### PR TITLE
Resolve pythonPath before comparing it to shebang

### DIFF
--- a/src/client/interpreter/display/shebangCodeLensProvider.ts
+++ b/src/client/interpreter/display/shebangCodeLensProvider.ts
@@ -53,7 +53,9 @@ export class ShebangCodeLensProvider implements vscode.CodeLensProvider {
 
     private async createShebangCodeLens(document: TextDocument) {
         const shebang = await ShebangCodeLensProvider.detectShebang(document);
-        if (!shebang || shebang === settings.PythonSettings.getInstance(document.uri).pythonPath) {
+        const pythonPath = settings.PythonSettings.getInstance(document.uri).pythonPath;
+        const resolvedPythonPath = await ShebangCodeLensProvider.getFullyQualifiedPathToInterpreter(pythonPath);
+        if (!shebang || shebang === resolvedPythonPath) {
             return [];
         }
 


### PR DESCRIPTION
When comparing if the path to the Python interpreter from the shebang in a file and the pythonPath setting point to one and the same interpreter, resolve pythonPath to the path to the actual Python interpreter executable before the comparison.

This solves the problem of having _python.pythonPath_ set to a symlink to the actual Python interpreter and having a _/usr/bin/env_ shebang in a file, where both would actually point to the same interpreter, but the _Set as interpreter_ CodeLens would display anyway, because it wouldn't recognize that.

For example, on macOS, with Python is installed Homebrew,<code>#!/usr/bin/env&nbsp;python3</code> and <code>python.pythonPath:&nbsp;"/usr/local/bin/python3"</code> both actually point to the same interpreter and give <code>sys.executable&nbsp;==&nbsp;'/usr/local/opt/python3/bin/python3.6'</code>, but they would be treated as different interpreters.