### PR TITLE
conditionally import reflect-metadata and fix run without debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.9.1 (18 December 2017)
+
+* Fixes the compatibility issue with the [Visual Studio Code Tools for AI
+](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.vscode-ai) extension by conditionally importing `reflect-metadata` [#432](https://github.com/Microsoft/vscode-python/issues/432)
+* Display runtime errors encountered when running a python program without debugging [#454](https://github.com/Microsoft/vscode-python/issues/454)
+
 ## Version 0.9.0 (14 December 2017)
 
 * Translated the commands to simplified Chinese [#240](https://github.com/Microsoft/vscode-python/pull/240) (thanks [Wai Sui kei](https://github.com/WaiSiuKei))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "python",
 	"displayName": "Python",
 	"description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"publisher": "ms-python",
 	"author": {
 		"name": "Microsoft Corporation"

--- a/pythonFiles/PythonTools/visualstudio_py_launcher_nodebug.py
+++ b/pythonFiles/PythonTools/visualstudio_py_launcher_nodebug.py
@@ -114,7 +114,7 @@ def handle_exception(exc_type, exc_value, exc_tb):
     tb = traceback.extract_tb(exc_tb)
     for i in [0, -1]:
         while tb:
-            frame_file = path.normcase(tb[i][0])
+            frame_file = os.path.normcase(tb[i][0])
             if not any(is_same_py_file(frame_file, f) for f in do_not_debug):
                 break
             del tb[i]

--- a/src/client/common/envFileParser.ts
+++ b/src/client/common/envFileParser.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs-extra';
-import 'reflect-metadata';
 import { PathUtils } from './platform/pathUtils';
 import { EnvironmentVariablesService } from './variables/environment';
 import { EnvironmentVariables } from './variables/types';

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -3,7 +3,6 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { ICondaLocatorService, IInterpreterLocatorService, INTERPRETER_LOCATOR_SERVICE, InterpreterType } from '../../interpreter/contracts';
 import { CONDA_RELATIVE_PY_PATH } from '../../interpreter/locators/services/conda';

--- a/src/client/common/installer/installer.ts
+++ b/src/client/common/installer/installer.ts
@@ -1,7 +1,6 @@
 import { inject, injectable, named } from 'inversify';
 import * as os from 'os';
 import * as path from 'path';
-import 'reflect-metadata';
 import { ConfigurationTarget, QuickPickItem, Uri, window, workspace } from 'vscode';
 import * as vscode from 'vscode';
 import { IFormatterHelper } from '../../formatters/types';

--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { IServiceContainer } from '../../ioc/types';
 import { PythonSettings } from '../configSettings';

--- a/src/client/common/installer/pipInstaller.ts
+++ b/src/client/common/installer/pipInstaller.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { Uri, workspace } from 'vscode';
 import { IServiceContainer } from '../../ioc/types';
 import { IPythonExecutionFactory } from '../process/types';

--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -1,5 +1,4 @@
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { ILogger } from './types';
 
 const PREFIX = 'Python Extension: ';

--- a/src/client/common/persistentState.ts
+++ b/src/client/common/persistentState.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
-import 'reflect-metadata';
 import { Memento } from 'vscode';
 import { GLOBAL_MEMENTO, IMemento, IPersistentState, IPersistentStateFactory, WORKSPACE_MEMENTO } from './types';
 

--- a/src/client/common/platform/pathUtils.ts
+++ b/src/client/common/platform/pathUtils.ts
@@ -1,5 +1,4 @@
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { IPathUtils, IsWindows } from '../types';
 import { NON_WINDOWS_PATH_VARIABLE_NAME, WINDOWS_PATH_VARIABLE_NAME } from './constants';
 

--- a/src/client/common/platform/registry.ts
+++ b/src/client/common/platform/registry.ts
@@ -1,5 +1,4 @@
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import * as Registry from 'winreg';
 import { Architecture, IRegistry, RegistryHive } from './types';
 

--- a/src/client/common/process/decoder.ts
+++ b/src/client/common/process/decoder.ts
@@ -3,7 +3,6 @@
 
 import * as iconv from 'iconv-lite';
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { DEFAULT_ENCODING } from './constants';
 import { IBufferDecoder } from './types';
 

--- a/src/client/common/process/proc.ts
+++ b/src/client/common/process/proc.ts
@@ -3,7 +3,6 @@
 
 import { spawn } from 'child_process';
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import * as Rx from 'rxjs';
 import { Disposable } from 'vscode';
 import { createDeferred } from '../helpers';

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { PythonSettings } from '../configSettings';
 import { IEnvironmentVariablesProvider } from '../variables/types';

--- a/src/client/common/process/pythonProcess.ts
+++ b/src/client/common/process/pythonProcess.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { ErrorUtils } from '../errors/errorUtils';
 import { ModuleNotInstalledError } from '../errors/moduleNotInstalledError';
 import { EnvironmentVariables } from '../variables/types';

--- a/src/client/common/process/serviceRegistry.ts
+++ b/src/client/common/process/serviceRegistry.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// tslint:disable-next-line:no-import-side-effect
-import 'reflect-metadata';
 import { IServiceManager } from '../../ioc/types';
 import { BufferDecoder } from './decoder';
 import { ProcessService } from './proc';

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import 'reflect-metadata';
 import { IServiceManager } from '../ioc/types';
 import { CondaInstaller } from './installer/condaInstaller';
 import { Installer } from './installer/installer';

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { Disposable, Terminal, Uri, window, workspace } from 'vscode';
 import { IServiceContainer } from '../../ioc/types';
 import { IDisposableRegistry, IsWindows } from '../types';

--- a/src/client/common/variables/environment.ts
+++ b/src/client/common/variables/environment.ts
@@ -4,7 +4,6 @@
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { IPathUtils } from '../types';
 import { EnvironmentVariables, IEnvironmentVariablesService } from './types';
 

--- a/src/client/common/variables/environmentVariablesProvider.ts
+++ b/src/client/common/variables/environmentVariablesProvider.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { Disposable, FileSystemWatcher, Uri, workspace } from 'vscode';
 import { PythonSettings } from '../configSettings';
 import { NON_WINDOWS_PATH_VARIABLE_NAME, WINDOWS_PATH_VARIABLE_NAME } from '../platform/constants';

--- a/src/client/common/variables/serviceRegistry.ts
+++ b/src/client/common/variables/serviceRegistry.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// tslint:disable-next-line:no-import-side-effect
-import 'reflect-metadata';
 import { IServiceManager } from '../../ioc/types';
 import { EnvironmentVariablesService } from './environment';
 import { EnvironmentVariablesProvider } from './environmentVariablesProvider';

--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -2,7 +2,6 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import 'reflect-metadata';
 import { DebugSession, Handles, InitializedEvent, OutputEvent, Scope, Source, StackFrame, StoppedEvent, TerminatedEvent, Thread } from "vscode-debugadapter";
 import { ThreadEvent } from "vscode-debugadapter";
 import { DebugProtocol } from "vscode-debugprotocol";

--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -1,5 +1,10 @@
 "use strict";
 
+// This line should always be right on top.
+if (Reflect.metadata === undefined) {
+    // tslint:disable-next-line:no-require-imports no-var-requires
+    require('reflect-metadata');
+}
 import * as fs from "fs";
 import * as path from "path";
 import { DebugSession, Handles, InitializedEvent, OutputEvent, Scope, Source, StackFrame, StoppedEvent, TerminatedEvent, Thread } from "vscode-debugadapter";

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -1,4 +1,9 @@
 'use strict';
+// This line should always be right on top.
+if (Reflect.metadata === undefined) {
+    // tslint:disable-next-line:no-require-imports no-var-requires
+    require('reflect-metadata');
+}
 import { Container } from 'inversify';
 import * as os from 'os';
 import * as vscode from 'vscode';

--- a/src/client/formatters/helper.ts
+++ b/src/client/formatters/helper.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { IFormattingSettings } from '../common/configSettings';
 import { Product } from '../common/types';
 import { FormatterId, FormatterSettingsPropertyNames, IFormatterHelper } from './types';

--- a/src/client/formatters/serviceRegistry.ts
+++ b/src/client/formatters/serviceRegistry.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import 'reflect-metadata';
 import { IServiceManager } from '../ioc/types';
 import { FormatterHelper } from './helper';
 import { IFormatterHelper } from './types';

--- a/src/client/interpreter/interpreterVersion.ts
+++ b/src/client/interpreter/interpreterVersion.ts
@@ -1,6 +1,5 @@
 import * as child_process from 'child_process';
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { getInterpreterVersion } from '../common/utils';
 import { IInterpreterVersionService } from './contracts';
 

--- a/src/client/interpreter/locators/services/KnownPathsService.ts
+++ b/src/client/interpreter/locators/services/KnownPathsService.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { fsExistsAsync, IS_WINDOWS } from '../../../common/utils';
 import { IInterpreterLocatorService, IInterpreterVersionService, IKnownSearchPathsForInterpreters, InterpreterType } from '../../contracts';

--- a/src/client/interpreter/locators/services/condaEnvFileService.ts
+++ b/src/client/interpreter/locators/services/condaEnvFileService.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { IS_WINDOWS } from '../../../common/configSettings';
 import {

--- a/src/client/interpreter/locators/services/condaEnvService.ts
+++ b/src/client/interpreter/locators/services/condaEnvService.ts
@@ -2,7 +2,6 @@ import * as child_process from 'child_process';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { VersionUtils } from '../../../common/versionUtils';
 import { ICondaLocatorService, IInterpreterLocatorService, IInterpreterVersionService, InterpreterType, PythonInterpreter } from '../../contracts';

--- a/src/client/interpreter/locators/services/condaLocator.ts
+++ b/src/client/interpreter/locators/services/condaLocator.ts
@@ -2,7 +2,6 @@ import * as child_process from 'child_process';
 import * as fs from 'fs-extra';
 import { inject, injectable, named, optional } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { IProcessService } from '../../../common/process/types';
 import { IsWindows } from '../../../common/types';
 import { VersionUtils } from '../../../common/versionUtils';

--- a/src/client/interpreter/locators/services/currentPathService.ts
+++ b/src/client/interpreter/locators/services/currentPathService.ts
@@ -2,7 +2,6 @@ import * as child_process from 'child_process';
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { PythonSettings } from '../../../common/configSettings';
 import { IInterpreterLocatorService, IInterpreterVersionService, InterpreterType } from '../../contracts';

--- a/src/client/interpreter/locators/services/virtualEnvService.ts
+++ b/src/client/interpreter/locators/services/virtualEnvService.ts
@@ -1,7 +1,6 @@
 import { inject, injectable } from 'inversify';
 import * as _ from 'lodash';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri, workspace } from 'vscode';
 import { fsReaddirAsync, IS_WINDOWS } from '../../../common/utils';
 import { IInterpreterLocatorService, IInterpreterVersionService, IKnownSearchPathsForVirtualEnvironments, InterpreterType, PythonInterpreter } from '../../contracts';

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import 'reflect-metadata';
 import { IsWindows } from '../common/types';
 import { IServiceManager } from '../ioc/types';
 import {

--- a/src/client/interpreter/virtualEnvs/venv.ts
+++ b/src/client/interpreter/virtualEnvs/venv.ts
@@ -1,6 +1,5 @@
 import { injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { fsExistsAsync } from '../../common/utils';
 import { InterpreterType } from '../contracts';
 import { IVirtualEnvironmentIdentifier } from './types';

--- a/src/client/interpreter/virtualEnvs/virtualEnv.ts
+++ b/src/client/interpreter/virtualEnvs/virtualEnv.ts
@@ -1,6 +1,5 @@
 import { injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { fsExistsAsync } from '../../common/utils';
 import { InterpreterType } from '../contracts';
 import { IVirtualEnvironmentIdentifier } from './types';

--- a/src/client/linters/helper.ts
+++ b/src/client/linters/helper.ts
@@ -1,6 +1,5 @@
 import { injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { ILintingSettings, PythonSettings } from '../common/configSettings';
 import { ExecutionInfo, Product } from '../common/types';

--- a/src/client/linters/serviceRegistry.ts
+++ b/src/client/linters/serviceRegistry.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import 'reflect-metadata';
 import { IServiceManager } from '../ioc/types';
 import { LinterHelper } from './helper';
 import { ILinterHelper } from './types';

--- a/src/client/unittests/common/debugLauncher.ts
+++ b/src/client/unittests/common/debugLauncher.ts
@@ -1,7 +1,6 @@
 import * as getFreePort from 'get-port';
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
-import 'reflect-metadata';
 import { debug, Uri, workspace } from 'vscode';
 import { PythonSettings } from '../../common/configSettings';
 import { IPythonExecutionFactory } from '../../common/process/types';

--- a/src/client/unittests/common/services/storageService.ts
+++ b/src/client/unittests/common/services/storageService.ts
@@ -1,5 +1,4 @@
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { Disposable, Uri, workspace } from 'vscode';
 import { IDisposableRegistry } from '../../../common/types';
 import { ITestCollectionStorageService, Tests } from './../types';

--- a/src/client/unittests/common/services/testResultsService.ts
+++ b/src/client/unittests/common/services/testResultsService.ts
@@ -1,5 +1,4 @@
 import { inject, injectable, named } from 'inversify';
-import 'reflect-metadata';
 import { TestResultResetVisitor } from './../testVisitors/resultResetVisitor';
 import { ITestResultsService, ITestVisitor, TestFile, TestFolder, Tests, TestStatus, TestSuite } from './../types';
 

--- a/src/client/unittests/common/services/workspaceTestManagerService.ts
+++ b/src/client/unittests/common/services/workspaceTestManagerService.ts
@@ -1,5 +1,4 @@
 import { inject, injectable, named } from 'inversify';
-import 'reflect-metadata';
 import { Disposable, OutputChannel, Uri, workspace } from 'vscode';
 import { IDisposableRegistry, IOutputChannel } from '../../../common/types';
 import { TEST_OUTPUT_CHANNEL } from './../constants';

--- a/src/client/unittests/common/testUtils.ts
+++ b/src/client/unittests/common/testUtils.ts
@@ -1,6 +1,5 @@
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import * as vscode from 'vscode';
 import { Uri, workspace } from 'vscode';
 import { window } from 'vscode';

--- a/src/client/unittests/common/testVisitors/flatteningVisitor.ts
+++ b/src/client/unittests/common/testVisitors/flatteningVisitor.ts
@@ -1,5 +1,4 @@
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { convertFileToPackage } from '../testUtils';
 import {
     FlattenedTestFunction,

--- a/src/client/unittests/common/testVisitors/folderGenerationVisitor.ts
+++ b/src/client/unittests/common/testVisitors/folderGenerationVisitor.ts
@@ -1,6 +1,5 @@
 import { injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { ITestVisitor, TestFile, TestFolder, TestFunction, TestSuite } from '../types';
 
 @injectable()

--- a/src/client/unittests/common/testVisitors/resultResetVisitor.ts
+++ b/src/client/unittests/common/testVisitors/resultResetVisitor.ts
@@ -1,5 +1,4 @@
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { ITestVisitor, TestFile, TestFolder, TestFunction, TestStatus, TestSuite } from '../types';
 
 @injectable()

--- a/src/client/unittests/nosetest/main.ts
+++ b/src/client/unittests/nosetest/main.ts
@@ -1,5 +1,4 @@
 import { inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { PythonSettings } from '../../common/configSettings';
 import { Product } from '../../common/types';

--- a/src/client/unittests/nosetest/services/discoveryService.ts
+++ b/src/client/unittests/nosetest/services/discoveryService.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable, named } from 'inversify';
-import 'reflect-metadata';
 import { CancellationTokenSource } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
 import { NOSETEST_PROVIDER } from '../../common/constants';

--- a/src/client/unittests/nosetest/services/parserService.ts
+++ b/src/client/unittests/nosetest/services/parserService.ts
@@ -4,7 +4,6 @@
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
 import * as path from 'path';
-import 'reflect-metadata';
 import { convertFileToPackage, extractBetweenDelimiters } from '../../common/testUtils';
 import { ITestsHelper, ITestsParser, ParserOptions, TestDiscoveryOptions, TestFile, TestFunction, Tests, TestStatus, TestSuite } from '../../common/types';
 

--- a/src/client/unittests/pytest/services/discoveryService.ts
+++ b/src/client/unittests/pytest/services/discoveryService.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable, named } from 'inversify';
-import 'reflect-metadata';
 import { CancellationTokenSource } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
 import { PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../common/constants';

--- a/src/client/unittests/pytest/services/parserService.ts
+++ b/src/client/unittests/pytest/services/parserService.ts
@@ -4,7 +4,6 @@
 import { inject, injectable } from 'inversify';
 import * as os from 'os';
 import * as path from 'path';
-import 'reflect-metadata';
 import { convertFileToPackage, extractBetweenDelimiters } from '../../common/testUtils';
 import { ITestsHelper, ITestsParser, ParserOptions, TestDiscoveryOptions, TestFile, TestFunction, Tests, TestStatus, TestSuite } from '../../common/types';
 

--- a/src/client/unittests/serviceRegistry.ts
+++ b/src/client/unittests/serviceRegistry.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { NOSETEST_PROVIDER, PYTEST_PROVIDER, UNITTEST_PROVIDER } from './common/constants';

--- a/src/client/unittests/unittest/services/discoveryService.ts
+++ b/src/client/unittests/unittest/services/discoveryService.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable, named } from 'inversify';
-import 'reflect-metadata';
 import { IServiceContainer } from '../../../ioc/types';
 import { UNITTEST_PROVIDER } from '../../common/constants';
 import { Options, run } from '../../common/runner';

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -3,7 +3,6 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import 'reflect-metadata';
 import { ITestsHelper, ITestsParser, TestDiscoveryOptions, TestFile, TestFunction, Tests, TestStatus, TestSuite } from '../../common/types';
 
 type UnitTestParserOptions = TestDiscoveryOptions & { startDirectory: string };

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';
 import * as testRunner from 'vscode/lib/testrunner';
 import { MochaSetupOptions } from 'vscode/lib/testrunner';
 import { IS_MULTI_ROOT_TEST } from './initialize';

--- a/src/test/mocks/proc.ts
+++ b/src/test/mocks/proc.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import { decorate, inject, injectable } from 'inversify';
-import 'reflect-metadata';
 import * as Rx from 'rxjs';
 import { Disposable } from 'vscode';
 import { ExecutionResult, IBufferDecoder, IProcessService, ObservableExecutionResult, Output, SpawnOptions } from '../../client/common/process/types';

--- a/src/test/mocks/terminalService.ts
+++ b/src/test/mocks/terminalService.ts
@@ -1,5 +1,4 @@
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { createDeferred, Deferred } from '../../client/common/helpers';
 import { ITerminalService } from '../../client/common/terminal/types';
 

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { Container } from 'inversify';
-import 'reflect-metadata';
 import { Disposable, Memento, OutputChannel } from 'vscode';
 import { STANDARD_OUTPUT_CHANNEL } from '../client/common/constants';
 import { BufferDecoder } from '../client/common/process/decoder';

--- a/src/test/unittests/mocks.ts
+++ b/src/test/unittests/mocks.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
 import { injectable } from 'inversify';
-import 'reflect-metadata';
 import { CancellationToken, Disposable, Uri } from 'vscode';
 import { createDeferred, Deferred } from '../../client/common/helpers';
 import { Product } from '../../client/common/types';

--- a/src/test/unittests/serviceRegistry.ts
+++ b/src/test/unittests/serviceRegistry.ts
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-import { MockUnitTestSocketServer } from './mocks';
-
-import 'reflect-metadata';
 import { Uri } from 'vscode';
 import { IServiceContainer } from '../../client/ioc/types';
 import { NOSETEST_PROVIDER, PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../client/unittests/common/constants';
@@ -28,6 +23,7 @@ import { TestManager as UnitTestTestManager } from '../../client/unittests/unitt
 import { TestDiscoveryService as UnitTestTestDiscoveryService } from '../../client/unittests/unittest/services/discoveryService';
 import { TestsParser as UnitTestTestsParser } from '../../client/unittests/unittest/services/parserService';
 import { IocContainer } from '../serviceRegistry';
+import { MockUnitTestSocketServer } from './mocks';
 
 export class UnitTestIocContainer extends IocContainer {
     constructor() {


### PR DESCRIPTION
* Conditionally import `reflect-metadata` (fixes #432)
    * Once within the extension  
    * Once within the debugger  
    * Once within the unittests  
* Fully qualify the `path` module (fixes #454)