### PR TITLE
Fixes issue while trying to run / debug a pyramid application

### DIFF
--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -22,6 +22,7 @@ import { DebugClient } from "./DebugClients/DebugClient";
 import { CreateAttachDebugClient, CreateLaunchDebugClient } from "./DebugClients/DebugFactory";
 import { BaseDebugServer } from "./DebugServers/BaseDebugServer";
 import { PythonProcess } from "./PythonProcess";
+import { IS_WINDOWS } from '../../../common/utils';
 
 const CHILD_ENUMEARATION_TIMEOUT = 5000;
 
@@ -214,11 +215,15 @@ export class PythonDebugger extends DebugSession {
         catch (ex) {
         }
         if (Array.isArray(args.debugOptions) && args.debugOptions.indexOf("Pyramid") >= 0) {
+            let pserve = "pserve";
+            if (IS_WINDOWS) {
+                pserve = "pserve.exe";
+            }
             if (fs.existsSync(args.pythonPath)) {
-                args.program = path.join(path.dirname(args.pythonPath), "pserve");
+                args.program = path.join(path.dirname(args.pythonPath), pserve);
             }
             else {
-                args.program = "pserve";
+                args.program = pserve;
             }
         }
         // Confirm the file exists

--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -22,7 +22,7 @@ import { DebugClient } from "./DebugClients/DebugClient";
 import { CreateAttachDebugClient, CreateLaunchDebugClient } from "./DebugClients/DebugFactory";
 import { BaseDebugServer } from "./DebugServers/BaseDebugServer";
 import { PythonProcess } from "./PythonProcess";
-import { IS_WINDOWS } from '../../../common/utils';
+import { IS_WINDOWS } from './Common/Utils';
 
 const CHILD_ENUMEARATION_TIMEOUT = 5000;
 
@@ -215,10 +215,7 @@ export class PythonDebugger extends DebugSession {
         catch (ex) {
         }
         if (Array.isArray(args.debugOptions) && args.debugOptions.indexOf("Pyramid") >= 0) {
-            let pserve = "pserve";
-            if (IS_WINDOWS) {
-                pserve = "pserve.exe";
-            }
+            const pserve = IS_WINDOWS ? "pserve.exe" : "pserve";
             if (fs.existsSync(args.pythonPath)) {
                 args.program = path.join(path.dirname(args.pythonPath), pserve);
             }


### PR DESCRIPTION
The debugger tries to find `pserve` on all platforms but on windows the correct file name should be `pserve.exe`.
  
Fixes #519 