### PR TITLE
moduleInstaller: use fs.access instead of open

### DIFF
--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -55,15 +55,9 @@ export abstract class ModuleInstaller {
     protected abstract getExecutionInfo(moduleName: string, resource?: vscode.Uri): Promise<ExecutionInfo>;
 
     private async isPathWritableAsync(directoryPath: string): Promise<boolean> {
-        const filePath = `${directoryPath}${path.sep}___vscpTest___`;
         return new Promise<boolean>(resolve => {
-            fs.open(filePath, fs.constants.O_CREAT | fs.constants.O_RDWR, (error, fd) => {
-                if (!error) {
-                    fs.close(fd, (e) => {
-                        fs.unlink(filePath);
-                    });
-                }
-                return resolve(!error);
+            fs.access(directoryPath, (error) =>  {
+                resolve(!error);
             });
         });
     }

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -23,7 +23,7 @@ import { rootWorkspaceUri } from '../common';
 import { MockModuleInstaller } from '../mocks/moduleInstaller';
 import { MockProcessService } from '../mocks/proc';
 import { UnitTestIocContainer } from '../unittests/serviceRegistry';
-import { closeActiveWindows, initializeTest } from './../initialize';
+import { closeActiveWindows, initializeTest, IS_MULTI_ROOT_TEST } from './../initialize';
 
 // tslint:disable-next-line:max-func-body-length
 suite('Module Installer', () => {
@@ -32,7 +32,7 @@ suite('Module Installer', () => {
     let condaService: TypeMoq.IMock<ICondaService>;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
 
-    const workspaceUri = Uri.file(path.join(__dirname, '..', '..', '..', 'src', 'test'));
+    const workspaceUri =  Uri.file(path.join(__dirname, '..', '..', '..', 'src', 'test'));
     suiteSetup(initializeTest);
     setup(async () => {
         initializeDI();
@@ -160,16 +160,22 @@ suite('Module Installer', () => {
         await expect(condaInstaller.isSupported()).to.eventually.equal(true, 'Conda is not supported');
     });
 
-    suite('Global Installation', () => {
+    suite('Global Module Installation', () => {
 
         setup(async () => {
             const configService = ioc.serviceManager.get<IConfigurationService>(IConfigurationService);
-            await configService.updateSettingAsync('globalModuleInstallation', true, rootWorkspaceUri, ConfigurationTarget.Workspace);
+            const configTarget = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
+            const multirootPath = path.join(__dirname, '..', '..', '..', 'src', 'testMultiRootWkspc');
+            const settingsUri = IS_MULTI_ROOT_TEST  ? Uri.file(multirootPath) : rootWorkspaceUri ;
+            await configService.updateSettingAsync('globalModuleInstallation', true, settingsUri, configTarget);
         });
 
         teardown(async () => {
             const configService = ioc.serviceManager.get<IConfigurationService>(IConfigurationService);
-            await configService.updateSettingAsync('globalModuleInstallation', false, rootWorkspaceUri, ConfigurationTarget.Workspace);
+            const configTarget = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
+            const multirootPath = path.join(__dirname, '..', '..', '..', 'src', 'testMultiRootWkspc');
+            const settingsUri = IS_MULTI_ROOT_TEST  ? Uri.file(multirootPath) : rootWorkspaceUri ;
+            await configService.updateSettingAsync('globalModuleInstallation', false, settingsUri, configTarget);
         });
 
         test('Validate global pip install arguments', async () => {


### PR DESCRIPTION
Hello, this is my first pull request here! Fixes #610.

I'm not sure about whether there are unit tests covering this change. I validated this by checking that installing a global module (pylint) through the extension works properly when prompted to install. 

The only place where `isPathWritableAsync` is used is when installing a global extension,
 so that should suffice (https://github.com/Microsoft/vscode-python/blob/master/src/client/common/installer/moduleInstaller.ts#L42).