### PR TITLE
Debug specific unittest test ends up running all failed tests

### DIFF
--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -158,7 +158,7 @@ async function selectAndRunTestMethod(cmdSource: CommandSource, resource: Uri, d
         return;
     }
     // tslint:disable-next-line:prefer-type-cast
-    await runTestsImpl(cmdSource, testManager.workspaceFolder, { testFunction: [selectedTestFn.testFunction] } as TestsToRun, debug);
+    await runTestsImpl(cmdSource, testManager.workspaceFolder, { testFunction: [selectedTestFn.testFunction] } as TestsToRun, false, debug);
 }
 async function selectAndRunTestFile(cmdSource: CommandSource) {
     const testManager = await getTestManager(true);


### PR DESCRIPTION
Fix issue #669 

Function call was missing a parameter causing unexpected behavior.