### PR TITLE
Specifying a particular unittest to debug does not work with custom loaders

### DIFF
--- a/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
+++ b/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
@@ -269,7 +269,7 @@ def main():
                 cov.start()
             except:
                 pass
-        if opts.tests is None and opts.testFile is None:
+        if opts.testFile is None:
             if opts.us is None:
                 opts.us = '.'
             if opts.up is None:
@@ -280,30 +280,29 @@ def main():
             # Easier approach is find the test suite and use that for running
             loader = unittest.TestLoader()
             # opts.us will be passed in
-            suites = loader.discover(opts.us, pattern=os.path.basename(opts.testFile))
-            suite = None
-            tests = None            
-            if opts.tests is None:
-                # Run everything in the test file
-                tests = suites
-            else:
-                # Run a specific test class or test method
-                for suite in suites._tests:
-                    for cls in suite._tests:                        
-                        try:
-                            for m in cls._tests:
-                                testId = m.id()
-                                if testId.startswith(opts.tests[0]):
-                                    suite = cls
-                                if testId == opts.tests[0]:
-                                    tests = m
-                                    break
-                        except Exception as err:
-                            errorMessage = traceback.format_exception()                            
-                            pass
-                if tests is None:
-                    tests = suite
-            if tests is None and suite is None:
+            tests = loader.discover(opts.us, pattern=os.path.basename(opts.testFile))
+        
+        if not opts.tests is None:
+            suites = tests
+            test_suite = None
+            tests = None
+            # Run a specific test class or test method
+            for suite in suites._tests:
+                for cls in suite._tests:                        
+                    try:
+                        for m in cls._tests:
+                            testId = m.id()
+                            if testId.startswith(opts.tests[0]):
+                                test_suite = cls
+                            if testId == opts.tests[0]:
+                                tests = m
+                                break
+                    except Exception as err:
+                        errorMessage = traceback.format_exception()                            
+                        pass
+            if tests is None:
+                tests = test_suite
+            if tests is None:
                 _channel.send_event(
                     name='error', 
                     outcome='',

--- a/src/client/unittests/unittest/runner.ts
+++ b/src/client/unittests/unittest/runner.ts
@@ -128,16 +128,14 @@ export async function runTest(serviceContainer: IServiceContainer, testManager: 
         }
         if (Array.isArray(options.testsToRun!.testSuite)) {
             options.testsToRun!.testSuite!.forEach(testSuite => {
-                const testFileName = options.tests.testSuites.find(t => t.testSuite === testSuite)!.parentTestFile.fullPath;
                 // tslint:disable-next-line:prefer-type-cast no-any
-                promise = promise.then(() => runTestInternal(testFileName, testSuite.nameToRun) as Promise<any>);
+                promise = promise.then(() => runTestInternal('', testSuite.nameToRun) as Promise<any>);
             });
         }
         if (Array.isArray(options.testsToRun!.testFunction)) {
             options.testsToRun!.testFunction!.forEach(testFn => {
-                const testFileName = options.tests.testFunctions.find(t => t.testFunction === testFn)!.parentTestFile.fullPath;
                 // tslint:disable-next-line:prefer-type-cast no-any
-                promise = promise.then(() => runTestInternal(testFileName, testFn.nameToRun) as Promise<any>);
+                promise = promise.then(() => runTestInternal('', testFn.nameToRun) as Promise<any>);
             });
         }
         // tslint:disable-next-line:prefer-type-cast no-any


### PR DESCRIPTION
Fix issue #670 

**Note**: this could have a speed impact as it is no longer limiting which files the unittest discovery engine is actually importing when a particular test method is specified. If this is a concern, it can be fixed by trying to find the test to run using the current mechanism and if that fails, try to filter all of the tests using the new mechanism.