### PR TITLE
Fix unhandled promise rejections

### DIFF
--- a/src/test/interpreters/condaEnvFileService.test.ts
+++ b/src/test/interpreters/condaEnvFileService.test.ts
@@ -108,11 +108,11 @@ suite('Interpreters from Conda Environments Text File', () => {
         fileSystem.setup(fs => fs.fileExistsAsync(TypeMoq.It.isValue(environmentsFilePath))).returns(() => Promise.resolve(true));
         fileSystem.setup(fs => fs.readFile(TypeMoq.It.isValue(environmentsFilePath))).returns(() => Promise.resolve(interpreterPaths.join(EOL)));
 
-        AnacondaCompanyNames.forEach(async companyDisplayName => {
+        for (const _ of AnacondaCompanyNames){
             const interpreters = await condaFileProvider.getInterpreters();
 
             assert.equal(interpreters.length, 1, 'Incorrect number of entries');
             assert.equal(interpreters[0].displayName, `${AnacondaDisplayName} Mock Version (numpy)`, 'Incorrect display name');
-        });
+        }
     });
 });

--- a/src/test/interpreters/condaEnvFileService.test.ts
+++ b/src/test/interpreters/condaEnvFileService.test.ts
@@ -104,15 +104,20 @@ suite('Interpreters from Conda Environments Text File', () => {
         const interpreterPaths = [
             path.join(environmentsPath, 'conda', 'envs', 'numpy')
         ];
+        const pythonPath = path.join(interpreterPaths[0], 'pythonPath');
         condaService.setup(c => c.condaEnvironmentsFile).returns(() => environmentsFilePath);
+        condaService.setup(c => c.getInterpreterPath(TypeMoq.It.isAny())).returns(() => pythonPath);
+        fileSystem.setup(fs => fs.fileExistsAsync(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         fileSystem.setup(fs => fs.fileExistsAsync(TypeMoq.It.isValue(environmentsFilePath))).returns(() => Promise.resolve(true));
         fileSystem.setup(fs => fs.readFile(TypeMoq.It.isValue(environmentsFilePath))).returns(() => Promise.resolve(interpreterPaths.join(EOL)));
 
-        for (const _ of AnacondaCompanyNames){
+        for (const companyName of AnacondaCompanyNames) {
+            const versionWithCompanyName = `Mock Version :: ${companyName}`;
+            interpreterVersion.setup(c => c.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(versionWithCompanyName));
             const interpreters = await condaFileProvider.getInterpreters();
 
             assert.equal(interpreters.length, 1, 'Incorrect number of entries');
-            assert.equal(interpreters[0].displayName, `${AnacondaDisplayName} Mock Version (numpy)`, 'Incorrect display name');
+            assert.equal(interpreters[0].displayName, `${AnacondaDisplayName} Mock Version`, 'Incorrect display name');
         }
     });
 });

--- a/src/test/refactor/extension.refactor.extract.var.test.ts
+++ b/src/test/refactor/extension.refactor.extract.var.test.ts
@@ -101,13 +101,13 @@ suite('Variable Extraction', () => {
     test('Extract Variable', async () => {
         const startPos = new vscode.Position(234, 29);
         const endPos = new vscode.Position(234, 38);
-        testingVariableExtraction(false, startPos, endPos);
+        await testingVariableExtraction(false, startPos, endPos);
     });
 
     test('Extract Variable fails if whole string not selected', async () => {
         const startPos = new vscode.Position(234, 20);
         const endPos = new vscode.Position(234, 38);
-        testingVariableExtraction(true, startPos, endPos);
+        await testingVariableExtraction(true, startPos, endPos);
     });
 
     function testingVariableExtractionEndToEnd(shouldError: boolean, startPos: Position, endPos: Position) {

--- a/src/test/unittests/debugger.test.ts
+++ b/src/test/unittests/debugger.test.ts
@@ -77,25 +77,19 @@ suite('Unit Tests - debugging', () => {
 
         // This promise should never resolve nor reject.
         runningPromise
-           .then(() => 'Debugger stopped when it shouldn\'t have')
-           .catch(() => 'Debugger crashed when it shouldn\'t have')
-           // tslint:disable-next-line:no-floating-promises
-          .then(error => {
-                deferred.reject(error);
-          });
+           .then(() => deferred.reject('Debugger stopped when it shouldn\'t have'))
+           .catch(error => deferred.reject(error));
 
         mockDebugLauncher.launched
-                    // tslint:disable-next-line:no-unsafe-any
-                    .then((launched) => {
-                        if (launched) {
-                            deferred.resolve('');
-                        } else {
-                            deferred.reject('Debugger not launched');
-                        }
-                    })
-                    // tslint:disable-next-line:no-unsafe-any
-                    .catch(ex => deferred.reject(ex));
-        return await deferred.promise;
+            .then((launched) => {
+                if (launched) {
+                    deferred.resolve('');
+                } else {
+                    deferred.reject('Debugger not launched');
+                }
+            }) .catch(error => deferred.reject(error));
+
+        await deferred.promise;
     }
 
     test('Debugger should start (unittest)', async () => {

--- a/src/test/unittests/debugger.test.ts
+++ b/src/test/unittests/debugger.test.ts
@@ -94,7 +94,7 @@ suite('Unit Tests - debugging', () => {
 
     test('Debugger should start (unittest)', async () => {
         await updateSetting('unitTest.unittestArgs', ['-s=./tests', '-p=test_*.py'], rootWorkspaceUri, configTarget);
-        await testStartingDebugger('unittest');
+        await  testStartingDebugger('unittest');
     });
 
     test('Debugger should start (pytest)', async () => {
@@ -120,8 +120,10 @@ suite('Unit Tests - debugging', () => {
         const launched = await mockDebugLauncher.launched;
         assert.isTrue(launched, 'Debugger not launched');
 
-        await testManager.discoverTests(CommandSource.commandPalette, true, true, true);
+        const discoveryPromise = testManager.discoverTests(CommandSource.commandPalette, true, true, true);
         await expect(runningPromise).to.be.rejectedWith(CANCELLATION_REASON, 'Incorrect reason for ending the debugger');
+        ioc.dispose(); // will cancel test discovery
+        await expect(discoveryPromise).to.be.rejectedWith(CANCELLATION_REASON, 'Incorrect reason for ending the debugger');
     }
 
     test('Debugger should stop when user invokes a test discovery (unittest)', async () => {

--- a/src/test/unittests/stoppingDiscoverAndTest.test.ts
+++ b/src/test/unittests/stoppingDiscoverAndTest.test.ts
@@ -5,6 +5,7 @@ import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import {createDeferred} from '../../client/common/helpers';
 import { Product } from '../../client/common/types';
 import { CANCELLATION_REASON, CommandSource, UNITTEST_PROVIDER } from '../../client/unittests/common/constants';
 import { ITestDiscoveryService } from '../../client/unittests/common/types';
@@ -60,9 +61,28 @@ suite('Unit Tests Stopping Discovery and Runner', () => {
 
         const discoveryPromise = mockTestManager.discoverTests(CommandSource.auto);
         mockTestManager.discoveryDeferred.resolve(EmptyTests);
-        mockTestManager.runTest(CommandSource.ui);
+        const runningPromise = mockTestManager.runTest(CommandSource.ui);
+        const deferred = createDeferred<string>();
 
-        await expect(discoveryPromise).to.eventually.equal(EmptyTests);
+        // This promise should never resolve nor reject.
+        runningPromise
+            .then(() => 'Debugger stopped when it shouldn\'t have')
+            .catch(() => 'Debugger crashed when it shouldn\'t have')
+            // tslint:disable-next-line:no-floating-promises
+            .then(error => {
+                deferred.reject(error);
+            });
+
+       discoveryPromise.then(result => {
+            if (result === EmptyTests) {
+                deferred.resolve('');
+            } else {
+                deferred.reject('tests not empty');
+            }
+        }).catch(error => {
+            deferred.reject(error);
+        });
+        await deferred.promise;
     });
 
     test('Discovering tests should stop running tests', async () => {
@@ -75,7 +95,7 @@ suite('Unit Tests Stopping Discovery and Runner', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         // User manually discovering tests will kill the existing test runner.
-        mockTestManager.discoverTests(CommandSource.ui, true, false, true);
+        await mockTestManager.discoverTests(CommandSource.ui, true, false, true);
         await expect(runPromise).to.eventually.be.rejectedWith(CANCELLATION_REASON);
     });
 });

--- a/src/test/unittests/stoppingDiscoverAndTest.test.ts
+++ b/src/test/unittests/stoppingDiscoverAndTest.test.ts
@@ -66,12 +66,8 @@ suite('Unit Tests Stopping Discovery and Runner', () => {
 
         // This promise should never resolve nor reject.
         runningPromise
-            .then(() => 'Debugger stopped when it shouldn\'t have')
-            .catch(() => 'Debugger crashed when it shouldn\'t have')
-            // tslint:disable-next-line:no-floating-promises
-            .then(error => {
-                deferred.reject(error);
-            });
+            .then(() => Promise.reject('Debugger stopped when it shouldn\'t have'))
+            .catch(error =>  deferred.reject(error));
 
        discoveryPromise.then(result => {
             if (result === EmptyTests) {
@@ -79,9 +75,8 @@ suite('Unit Tests Stopping Discovery and Runner', () => {
             } else {
                 deferred.reject('tests not empty');
             }
-        }).catch(error => {
-            deferred.reject(error);
-        });
+        }).catch(error => deferred.reject(error));
+
         await deferred.promise;
     });
 


### PR DESCRIPTION
The tests fail because I unearthed one test that was silently failing, `'Must strip company name from version info'`.

Most uncaught rejections were from the promises of `testManager.runTest` and `testManager.discoverTests` getting killed when the test ended. They ought to be handled just to prevent this error, but otherwise there is not any code defect. 

Fixes #479, I would hope.

