### PR TITLE
WIP :bug: use map instead of filter to return a promise

### DIFF
--- a/src/client/interpreter/configuration/interpreterSelector.ts
+++ b/src/client/interpreter/configuration/interpreterSelector.ts
@@ -76,10 +76,7 @@ export class InterpreterSelector implements IInterpreterSelector {
 
     private async removeDuplicates(interpreters: PythonInterpreter[]): Promise<PythonInterpreter[]> {
         const result: PythonInterpreter[] = [];
-        await Promise.all(interpreters.filter(async x => {
-            x.realPath = await this.fileSystem.getRealPathAsync(x.path);
-            return true;
-        }));
+        await Promise.all(interpreters.map(async item => item.realPath = await this.fileSystem.getRealPathAsync(item.path)));
         interpreters.forEach(x => {
             if (result.findIndex(a => a.displayName === x.displayName
                 && a.type === x.type && this.fileSystem.arePathsSame(a.realPath!, x.realPath!)) < 0) {


### PR DESCRIPTION
Fix bug introduced in #831 
Selection of interpreters throws error. Not creating an issue for this, just tying it to the original issue that #831 resolved.
Using `map` to ensure a promise is returned.