### PR TITLE
Add support for requirements.in (from pip-tools)

### DIFF
--- a/news/1 Enhancements/961.md
+++ b/news/1 Enhancements/961.md
@@ -1,2 +1,2 @@
-Enable syntax highlighting for `requirements.in` files used by
-[pip-tools](https://github.com/jazzband/pip-tools).
+Enable syntax highlighting for `requirements.in` files as used by
+e.g. [pip-tools](https://github.com/jazzband/pip-tools).

--- a/news/1 Enhancements/961.md
+++ b/news/1 Enhancements/961.md
@@ -1,0 +1,2 @@
+Enable syntax highlighting for `requirements.in` files used by
+[pip-tools](https://github.com/jazzband/pip-tools).

--- a/package.json
+++ b/package.json
@@ -1548,8 +1548,7 @@
                 "id": "pip-requirements",
                 "aliases": [
                     "pip requirements",
-                    "requirements.txt",
-                    "requirements.in"
+                    "requirements.txt"
                 ],
                 "filenames": [
                     "requirements.txt",

--- a/package.json
+++ b/package.json
@@ -1548,14 +1548,18 @@
                 "id": "pip-requirements",
                 "aliases": [
                     "pip requirements",
-                    "requirements.txt"
+                    "requirements.txt",
+                    "requirements.in"
                 ],
                 "filenames": [
-                    "requirements.txt"
+                    "requirements.txt",
+                    "requirements.in"
                 ],
                 "filenamePatterns": [
                     "*-requirements.txt",
-                    "requirements-*.txt"
+                    "requirements-*.txt",
+                    "*-requirements.in",
+                    "requirements-*.in"
                 ],
                 "configuration": "./languages/pip-requirements.json"
             },


### PR DESCRIPTION
[pip-tools](https://github.com/jazzband/pip-tools) provides a tool called `pip-compile` that takes a
`requirements.in` file with the same format used by `requirements.txt` to produce a "lock file"
(the usual `requirements.txt` file).

This commits enables the `pip-requirements` syntax for the aforementioned files.