### PR TITLE
Make 'F' error codes from flake8 be errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1353,7 +1353,7 @@
                 },
                 "python.linting.flake8CategorySeverity.F": {
                     "type": "string",
-                    "default": "Warning",
+                    "default": "Error",
                     "description": "Severity of Flake8 message type 'F'.",
                     "enum": [
                         "Hint",


### PR DESCRIPTION
Some are runtime errors (e.g. `break` outside of a loop), while others are just warnings (e.g. unused imports).

Reverts part of 7894ae68d2f9a4e016db342f8f05eccf6a709d33 to undo changes for #815 