### PR TITLE
Detect pipenv by looking for Pipfile, not pipfile

### DIFF
--- a/src/client/interpreter/locators/services/pipEnvService.ts
+++ b/src/client/interpreter/locators/services/pipEnvService.ts
@@ -69,7 +69,7 @@ export class PipEnvService extends CacheableLocatorService {
 
     private async getInterpreterPathFromPipenv(cwd: string): Promise<string | undefined> {
         // Quick check before actually running pipenv
-        if (!await this.fs.fileExistsAsync(path.join(cwd, 'pipfile'))) {
+        if (!await this.fs.fileExistsAsync(path.join(cwd, 'Pipfile'))) {
             return;
         }
         const venvFolder = await this.invokePipenv('--venv', cwd);


### PR DESCRIPTION
On platforms with case-sensitive filesystems, like Linux, these are not equivalent. pipenv [documents that the file should be called Pipfile][0] and [`Pipfile.find()` only finds files matching this exact case][1].

As a result, even if `pipenv --venv` in `cwd` would return success, it will never be run on Linux, and Code never detects the pipenv. (You can work around this with `touch pipfile`.) With this change, it's detected successfully. I believe there's no need to add a backwards-compatibility check for the old case, because on platforms where the old, incorrect check worked, so will the new, correct one.

[0]: https://docs.pipenv.org/basics/#example-pipfile-pipfile-lock
[1]: https://github.com/pypa/pipfile/blob/5acb9ac7/pipfile/api.py#L76-L85