### PR TITLE
Ignore test results when debugging unit tests

### DIFF
--- a/news/2 Fixes/1043.md
+++ b/news/2 Fixes/1043.md
@@ -1,0 +1,1 @@
+Ignore test results when debugging unit tests.

--- a/src/client/unittests/nosetest/runner.ts
+++ b/src/client/unittests/nosetest/runner.ts
@@ -77,7 +77,7 @@ export function runTest(serviceContainer: IServiceContainer, testResultsService:
             return run(serviceContainer, 'nosetest', runOptions);
         }
     }).then(() => {
-        return updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
+        return options.debug ? options.tests : updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
     }).then(result => {
         xmlLogFileCleanup();
         return result;

--- a/src/client/unittests/pytest/runner.ts
+++ b/src/client/unittests/pytest/runner.ts
@@ -52,7 +52,7 @@ export function runTest(serviceContainer: IServiceContainer, testResultsService:
             return run(serviceContainer, 'pytest', runOptions);
         }
     }).then(() => {
-        return updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
+        return options.debug ? options.tests : updateResultsFromLogFiles(options.tests, xmlLogFile, testResultsService);
     }).then(result => {
         xmlLogFileCleanup();
         return result;


### PR DESCRIPTION
Fixes #1043 
Cannot create unit tests as the components in the unit test code in the extension cannot be mocked.
This would be a separate engineering task