### PR TITLE
Exclude news folder from extension

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -35,3 +35,4 @@ coverage/**
 CODE_OF_CONDUCT.md
 CODING_STANDARDS.md
 CONTRIBUTING.md
+news/**

--- a/news/3 Code Health/1020.md
+++ b/news/3 Code Health/1020.md
@@ -1,0 +1,1 @@
+Exclude 'news' folder from getting packaged into the extension.


### PR DESCRIPTION
Fixes #1020

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
