### PR TITLE
Prevent debugger stepping into js code, when debugging async TypeScript code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,10 @@
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ],
             "stopOnEntry": false,
+            "smartStep": true,
             "sourceMaps": true,
             "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
+                "${workspaceFolder}/out/**/*"
             ],
             "preLaunchTask": "Compile"
         },
@@ -23,6 +24,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/out/client/debugger/Main.js",
             "stopOnEntry": false,
+            "smartStep": true,
             "args": [
                 "--server=4711"
             ],
@@ -39,6 +41,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/out/client/debugger/mainV2.js",
             "stopOnEntry": false,
+            "smartStep": true,
             "args": [
                 "--server=4711"
             ],
@@ -78,8 +81,9 @@
             ],
             "stopOnEntry": false,
             "sourceMaps": true,
+            "smartStep": true,
             "outFiles": [
-                "${workspaceFolder}/out/**/*.js"
+                "${workspaceFolder}/out/**/*"
             ],
             "preLaunchTask": "Compile"
         },
@@ -94,6 +98,7 @@
                 "--extensionTestsPath=${workspaceFolder}/out/test"
             ],
             "stopOnEntry": false,
+            "smartStep": true,
             "sourceMaps": true,
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/news/3 Code Health/1090.md
+++ b/news/3 Code Health/1090.md
@@ -1,0 +1,1 @@
+Prevent debugger stepping into js code, when debugging async TypeScript code.


### PR DESCRIPTION
Fixes #1090

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
