### PR TITLE
Resolve debug configuration information in `launch.json` when debugging without opening a python file

### DIFF
--- a/news/2 Fixes/1098.md
+++ b/news/2 Fixes/1098.md
@@ -1,0 +1,1 @@
+Resolve debug configuration information in `launch.json` when debugging without opening a python file.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     ],
     "activationEvents": [
         "onLanguage:python",
+        "onDebugResolve:python",
         "onCommand:python.execInTerminal",
         "onCommand:python.sortImports",
         "onCommand:python.runtests",


### PR DESCRIPTION
Fixes #1098

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
N/A (this functionality can only be tested manually)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
