### PR TITLE
Add a Watson debug configuration for the experimental debugger.

### DIFF
--- a/news/1 Enhancements/1031.md
+++ b/news/1 Enhancements/1031.md
@@ -1,0 +1,1 @@
+Add a Watson debug configuration for the experimental debugger.

--- a/package.json
+++ b/package.json
@@ -787,6 +787,21 @@
                             "envFile": "^\"\\${workspaceFolder}/.env\"",
                             "debugOptions": []
                         }
+                    },
+                    {
+                        "label": "Python Experimental: Watson",
+                        "description": "%python.snippet.launch.watson.description%",
+                        "body": {
+                            "name": "Watson",
+                            "type": "pythonExperimental",
+                            "request": "launch",
+                            "program": "^\"\\${workspaceFolder}/console.py\"",
+                            "args": [
+                                "dev",
+                                "runserver",
+                                "--noreload=True"
+                            ]
+                        }
                     }
                 ],
                 "configurationAttributes": {


### PR DESCRIPTION
Fixes #1031

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
