### PR TITLE
Change the command used to install pip on AppVeyor to avoid installation errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - npm i -g yarn
   - yarn
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - pip install -U pip
+  - python -m pip install -U pip
   - pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/
   - python --version
   - python -m easy_install -U setuptools

--- a/news/3 Code Health/1107.md
+++ b/news/3 Code Health/1107.md
@@ -1,0 +1,1 @@
+Change the command used to install pip on AppVeyor to avoid installation errors.


### PR DESCRIPTION
Fixes #1107

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
