### PR TITLE
Disable the display of errors messages when rediscovering of tests fail in response to changes to files

### DIFF
--- a/news/1 Enhancements/704.md
+++ b/news/1 Enhancements/704.md
@@ -1,0 +1,1 @@
+Disable the display of errors messages when rediscovering of tests fail in response to changes to files.

--- a/news/1 Enhancements/704.md
+++ b/news/1 Enhancements/704.md
@@ -1,1 +1,1 @@
-Disable the display of errors messages when rediscovering of tests fail in response to changes to files.
+Disable the display of errors messages when rediscovering of tests fail in response to changes to files, e.g. don't show a message if there's a syntax error in the test code.

--- a/src/client/unittests/display/main.ts
+++ b/src/client/unittests/display/main.ts
@@ -11,9 +11,9 @@ export class TestResultDisplay {
     private discoverCounter = 0;
     private ticker = ['|', '/', '-', '|', '/', '-', '\\'];
     private progressTimeout;
-    private progressPrefix: string;
+    private progressPrefix!: string;
     // tslint:disable-next-line:no-any
-    constructor(private outputChannel: vscode.OutputChannel, private onDidChange?: vscode.EventEmitter<any>) {
+    constructor(private onDidChange?: vscode.EventEmitter<any>) {
         this.statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
     }
     public dispose() {
@@ -35,10 +35,10 @@ export class TestResultDisplay {
             // tslint:disable-next-line:no-empty
             .catch(() => { });
     }
-    public displayDiscoverStatus(testDiscovery: Promise<Tests>) {
+    public displayDiscoverStatus(testDiscovery: Promise<Tests>, quietMode: boolean = false) {
         this.displayProgress('Discovering Tests', 'Discovering Tests (Click to Stop)', constants.Commands.Tests_Ask_To_Stop_Discovery);
         return testDiscovery.then(tests => {
-            this.updateWithDiscoverSuccess(tests);
+            this.updateWithDiscoverSuccess(tests, quietMode);
             return tests;
         }).catch(reason => {
             this.updateWithDiscoverFailure(reason);
@@ -143,7 +143,7 @@ export class TestResultDisplay {
         return def.promise;
     }
 
-    private updateWithDiscoverSuccess(tests: Tests) {
+    private updateWithDiscoverSuccess(tests: Tests, quietMode: boolean = false) {
         this.clearProgressTicker();
         const haveTests = tests && (tests.testFunctions.length > 0);
         this.statusBar.text = '$(zap) Run Tests';
@@ -154,7 +154,7 @@ export class TestResultDisplay {
             this.onDidChange.fire();
         }
 
-        if (!haveTests) {
+        if (!haveTests && !quietMode) {
             vscode.window.showInformationMessage('No tests discovered, please check the configuration settings for the tests.', 'Disable Tests').then(item => {
                 if (item === 'Disable Tests') {
                     this.disableTests()


### PR DESCRIPTION
Fixes #704

@brettcannon 
* Please review news entry
* There are no unit tests for this as the code predates the use of IoC framework (i.e. difficult if not impossible to mock for testing).
* NOTE: We do have some integration tests though, but it won't test this issue.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
