### PR TITLE
Add ability to disable the check on memory usage of language server (Jedi) process

### DIFF
--- a/news/2 Fixes/1036.md
+++ b/news/2 Fixes/1036.md
@@ -1,0 +1,5 @@
+Add ability to disable the check on memory usage of language server (Jedi) process.
+To turn off this check, add the following setting into your user or workspace settings (`settings.json`) file:
+```json
+"python.jediMemoryLimit": -1
+```

--- a/package.json
+++ b/package.json
@@ -1007,8 +1007,8 @@
                 },
                 "python.jediMemoryLimit": {
                     "type": "number",
-                    "default": "0",
-                    "description": "Memory limit for the Jedi completion engine in megabytes. Zero (default) means 1024 MB",
+                    "default": 0,
+                    "description": "Memory limit for the Jedi completion engine in megabytes. Zero (default) means 1024 MB. -1 means unlimited (disable memory limit check)",
                     "scope": "resource"
                 },
                 "python.sortImports.path": {

--- a/src/client/common/stopWatch.ts
+++ b/src/client/common/stopWatch.ts
@@ -8,4 +8,7 @@ export class StopWatch {
     public get elapsedTime() {
         return Date.now() - this.started;
     }
+    public reset(){
+        this.started = Date.now();
+    }
 }

--- a/src/client/debugger/Common/telemetry.ts
+++ b/src/client/debugger/Common/telemetry.ts
@@ -4,8 +4,8 @@
 // tslint:disable:no-function-expression no-any no-invalid-this no-use-before-declare
 
 import { DebugSession, StoppedEvent } from 'vscode-debugadapter';
+import { StopWatch } from '../../common/stopWatch';
 import { DEBUGGER_PERFORMANCE } from '../../telemetry/constants';
-import { StopWatch } from '../../telemetry/stopWatch';
 import { DebuggerPerformanceTelemetry } from '../../telemetry/types';
 import { TelemetryEvent } from './Contracts';
 

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -20,6 +20,7 @@ import { registerTypes as installerRegisterTypes } from './common/installer/serv
 import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
 import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
+import { StopWatch } from './common/stopWatch';
 import { GLOBAL_MEMENTO, IDisposableRegistry, ILogger, IMemento, IOutputChannel, IPersistentStateFactory, WORKSPACE_MEMENTO } from './common/types';
 import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
 import { BaseConfigurationProvider } from './debugger/configProviders/baseProvider';
@@ -53,7 +54,6 @@ import { activateUpdateSparkLibraryProvider } from './providers/updateSparkLibra
 import * as sortImports from './sortImports';
 import { sendTelemetryEvent } from './telemetry';
 import { EDITOR_LOAD } from './telemetry/constants';
-import { StopWatch } from './telemetry/stopWatch';
 import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionManager } from './terminals/types';
 import { BlockFormatProviders } from './typeFormatters/blockFormatProvider';

--- a/src/client/formatters/autoPep8Formatter.ts
+++ b/src/client/formatters/autoPep8Formatter.ts
@@ -1,10 +1,10 @@
 import * as vscode from 'vscode';
 import { Product } from '../common/installer/productInstaller';
+import { StopWatch } from '../common/stopWatch';
 import { IConfigurationService } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { sendTelemetryWhenDone } from '../telemetry';
 import { FORMAT } from '../telemetry/constants';
-import { StopWatch } from '../telemetry/stopWatch';
 import { BaseFormatter } from './baseFormatter';
 
 export class AutoPep8Formatter extends BaseFormatter {

--- a/src/client/formatters/yapfFormatter.ts
+++ b/src/client/formatters/yapfFormatter.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
+import { StopWatch } from '../common/stopWatch';
 import { IConfigurationService, Product } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { sendTelemetryWhenDone } from '../telemetry';
 import { FORMAT } from '../telemetry/constants';
-import { StopWatch } from '../telemetry/stopWatch';
 import { BaseFormatter } from './baseFormatter';
 
 export class YapfFormatter extends BaseFormatter {

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -1,10 +1,10 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { ConfigurationTarget, Uri, window } from 'vscode';
+import { StopWatch } from '../../common/stopWatch';
 import { IServiceContainer } from '../../ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { PYTHON_INTERPRETER } from '../../telemetry/constants';
-import { StopWatch } from '../../telemetry/stopWatch';
 import { PythonInterpreterTelemetry } from '../../telemetry/types';
 import { IInterpreterVersionService } from '../contracts';
 import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from './types';

--- a/src/client/linters/lintingEngine.ts
+++ b/src/client/linters/lintingEngine.ts
@@ -8,12 +8,12 @@ import * as vscode from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../common/application/types';
 import { LinterErrors, STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import { IFileSystem } from '../common/platform/types';
+import { StopWatch } from '../common/stopWatch';
 import { IConfigurationService, IOutputChannel } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { JupyterProvider } from '../jupyter/provider';
 import { sendTelemetryWhenDone } from '../telemetry';
 import { LINTING } from '../telemetry/constants';
-import { StopWatch } from '../telemetry/stopWatch';
 import { LinterTrigger, LintingTelemetry } from '../telemetry/types';
 import { ILinterInfo, ILinterManager, ILintingEngine, ILintMessage, LintMessageSeverity } from './types';
 
@@ -27,176 +27,176 @@ lintSeverityToVSSeverity.set(LintMessageSeverity.Warning, vscode.DiagnosticSever
 
 // tslint:disable-next-line:interface-name
 interface DocumentHasJupyterCodeCells {
-  // tslint:disable-next-line:callable-types
-  (doc: vscode.TextDocument, token: vscode.CancellationToken): Promise<Boolean>;
+    // tslint:disable-next-line:callable-types
+    (doc: vscode.TextDocument, token: vscode.CancellationToken): Promise<Boolean>;
 }
 
 @injectable()
 export class LintingEngine implements ILintingEngine {
-  private documentHasJupyterCodeCells: DocumentHasJupyterCodeCells;
-  private workspace: IWorkspaceService;
-  private documents: IDocumentManager;
-  private configurationService: IConfigurationService;
-  private linterManager: ILinterManager;
-  private diagnosticCollection: vscode.DiagnosticCollection;
-  private pendingLintings = new Map<string, vscode.CancellationTokenSource>();
-  private outputChannel: vscode.OutputChannel;
-  private fileSystem: IFileSystem;
+    private documentHasJupyterCodeCells: DocumentHasJupyterCodeCells;
+    private workspace: IWorkspaceService;
+    private documents: IDocumentManager;
+    private configurationService: IConfigurationService;
+    private linterManager: ILinterManager;
+    private diagnosticCollection: vscode.DiagnosticCollection;
+    private pendingLintings = new Map<string, vscode.CancellationTokenSource>();
+    private outputChannel: vscode.OutputChannel;
+    private fileSystem: IFileSystem;
 
-  constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
-    this.documentHasJupyterCodeCells = (a, b) => Promise.resolve(false);
-    this.documents = serviceContainer.get<IDocumentManager>(IDocumentManager);
-    this.workspace = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
-    this.configurationService = serviceContainer.get<IConfigurationService>(IConfigurationService);
-    this.outputChannel = serviceContainer.get<vscode.OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
-    this.linterManager = serviceContainer.get<ILinterManager>(ILinterManager);
-    this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
-    this.diagnosticCollection = vscode.languages.createDiagnosticCollection('python');
-  }
-
-  public get diagnostics(): vscode.DiagnosticCollection {
-    return this.diagnosticCollection;
-  }
-
-  public clearDiagnostics(document: vscode.TextDocument): void {
-    if (this.diagnosticCollection.has(document.uri)) {
-      this.diagnosticCollection.delete(document.uri);
-    }
-  }
-
-  public async lintOpenPythonFiles(): Promise<vscode.DiagnosticCollection> {
-    this.diagnosticCollection.clear();
-    const promises = this.documents.textDocuments.map(async document => await this.lintDocument(document, 'auto'));
-    await Promise.all(promises);
-    return this.diagnosticCollection;
-  }
-
-  public async lintDocument(document: vscode.TextDocument, trigger: LinterTrigger): Promise<void> {
-    this.diagnosticCollection.set(document.uri, []);
-
-    // Check if we need to lint this document
-    if (!await this.shouldLintDocument(document)) {
-      return;
+    constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
+        this.documentHasJupyterCodeCells = (a, b) => Promise.resolve(false);
+        this.documents = serviceContainer.get<IDocumentManager>(IDocumentManager);
+        this.workspace = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        this.configurationService = serviceContainer.get<IConfigurationService>(IConfigurationService);
+        this.outputChannel = serviceContainer.get<vscode.OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+        this.linterManager = serviceContainer.get<ILinterManager>(ILinterManager);
+        this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
+        this.diagnosticCollection = vscode.languages.createDiagnosticCollection('python');
     }
 
-    if (this.pendingLintings.has(document.uri.fsPath)) {
-      this.pendingLintings.get(document.uri.fsPath)!.cancel();
-      this.pendingLintings.delete(document.uri.fsPath);
+    public get diagnostics(): vscode.DiagnosticCollection {
+        return this.diagnosticCollection;
     }
 
-    const cancelToken = new vscode.CancellationTokenSource();
-    cancelToken.token.onCancellationRequested(() => {
-      if (this.pendingLintings.has(document.uri.fsPath)) {
-        this.pendingLintings.delete(document.uri.fsPath);
-      }
-    });
-
-    this.pendingLintings.set(document.uri.fsPath, cancelToken);
-    this.outputChannel.clear();
-
-    const promises: Promise<ILintMessage[]>[] = this.linterManager.getActiveLinters(document.uri)
-      .map(info => {
-        const stopWatch = new StopWatch();
-        const linter = this.linterManager.createLinter(info.product, this.outputChannel, this.serviceContainer, document.uri);
-        const promise = linter.lint(document, cancelToken.token);
-        this.sendLinterRunTelemetry(info, document.uri, promise, stopWatch, trigger);
-        return promise;
-      });
-
-    const hasJupyterCodeCells = await this.documentHasJupyterCodeCells(document, cancelToken.token);
-    // linters will resolve asynchronously - keep a track of all
-    // diagnostics reported as them come in.
-    let diagnostics: vscode.Diagnostic[] = [];
-    const settings = this.configurationService.getSettings(document.uri);
-
-    for (const p of promises) {
-      const msgs = await p;
-      if (cancelToken.token.isCancellationRequested) {
-        break;
-      }
-
-      if (this.isDocumentOpen(document.uri)) {
-        // Build the message and suffix the message with the name of the linter used.
-        for (const m of msgs) {
-          // Ignore magic commands from jupyter.
-          if (hasJupyterCodeCells && document.lineAt(m.line - 1).text.trim().startsWith('%') &&
-            (m.code === LinterErrors.pylint.InvalidSyntax ||
-              m.code === LinterErrors.prospector.InvalidSyntax ||
-              m.code === LinterErrors.flake8.InvalidSyntax)) {
-            continue;
-          }
-          diagnostics.push(this.createDiagnostics(m, document));
+    public clearDiagnostics(document: vscode.TextDocument): void {
+        if (this.diagnosticCollection.has(document.uri)) {
+            this.diagnosticCollection.delete(document.uri);
         }
-        // Limit the number of messages to the max value.
-        diagnostics = diagnostics.filter((value, index) => index <= settings.linting.maxNumberOfProblems);
-      }
-    }
-    // Set all diagnostics found in this pass, as this method always clears existing diagnostics.
-    this.diagnosticCollection.set(document.uri, diagnostics);
-  }
-
-  // tslint:disable-next-line:no-any
-  public async linkJupiterExtension(jupiter: vscode.Extension<any> | undefined): Promise<void> {
-    if (!jupiter) {
-      return;
-    }
-    if (!jupiter.isActive) {
-      await jupiter.activate();
-    }
-    // tslint:disable-next-line:no-unsafe-any
-    jupiter.exports.registerLanguageProvider(PYTHON.language, new JupyterProvider());
-    // tslint:disable-next-line:no-unsafe-any
-    this.documentHasJupyterCodeCells = jupiter.exports.hasCodeCells;
-  }
-
-  private sendLinterRunTelemetry(info: ILinterInfo, resource: vscode.Uri, promise: Promise<ILintMessage[]>, stopWatch: StopWatch, trigger: LinterTrigger): void {
-    const linterExecutablePathName = info.pathName(resource);
-    const properties: LintingTelemetry = {
-      tool: info.id,
-      hasCustomArgs: info.linterArgs(resource).length > 0,
-      trigger,
-      executableSpecified: linterExecutablePathName.length > 0
-    };
-    sendTelemetryWhenDone(LINTING, promise, stopWatch, properties);
-  }
-
-  private isDocumentOpen(uri: vscode.Uri): boolean {
-    return this.documents.textDocuments.some(document => document.uri.fsPath === uri.fsPath);
-  }
-
-  private createDiagnostics(message: ILintMessage, document: vscode.TextDocument): vscode.Diagnostic {
-    const position = new vscode.Position(message.line - 1, message.column);
-    const range = new vscode.Range(position, position);
-
-    const severity = lintSeverityToVSSeverity.get(message.severity!)!;
-    const diagnostic = new vscode.Diagnostic(range, `${message.code}:${message.message}`, severity);
-    diagnostic.code = message.code;
-    diagnostic.source = message.provider;
-    return diagnostic;
-  }
-
-  private async shouldLintDocument(document: vscode.TextDocument): Promise<boolean> {
-    if (!this.linterManager.isLintingEnabled(document.uri)) {
-      this.diagnosticCollection.set(document.uri, []);
-      return false;
     }
 
-    if (document.languageId !== PYTHON.language) {
-      return false;
+    public async lintOpenPythonFiles(): Promise<vscode.DiagnosticCollection> {
+        this.diagnosticCollection.clear();
+        const promises = this.documents.textDocuments.map(async document => await this.lintDocument(document, 'auto'));
+        await Promise.all(promises);
+        return this.diagnosticCollection;
     }
 
-    const workspaceFolder = this.workspace.getWorkspaceFolder(document.uri);
-    const workspaceRootPath = (workspaceFolder && typeof workspaceFolder.uri.fsPath === 'string') ? workspaceFolder.uri.fsPath : undefined;
-    const relativeFileName = typeof workspaceRootPath === 'string' ? path.relative(workspaceRootPath, document.fileName) : document.fileName;
+    public async lintDocument(document: vscode.TextDocument, trigger: LinterTrigger): Promise<void> {
+        this.diagnosticCollection.set(document.uri, []);
 
-    const settings = this.configurationService.getSettings(document.uri);
-    const ignoreMinmatches = settings.linting.ignorePatterns.map(pattern => new Minimatch(pattern));
-    if (ignoreMinmatches.some(matcher => matcher.match(document.fileName) || matcher.match(relativeFileName))) {
-      return false;
+        // Check if we need to lint this document
+        if (!await this.shouldLintDocument(document)) {
+            return;
+        }
+
+        if (this.pendingLintings.has(document.uri.fsPath)) {
+            this.pendingLintings.get(document.uri.fsPath)!.cancel();
+            this.pendingLintings.delete(document.uri.fsPath);
+        }
+
+        const cancelToken = new vscode.CancellationTokenSource();
+        cancelToken.token.onCancellationRequested(() => {
+            if (this.pendingLintings.has(document.uri.fsPath)) {
+                this.pendingLintings.delete(document.uri.fsPath);
+            }
+        });
+
+        this.pendingLintings.set(document.uri.fsPath, cancelToken);
+        this.outputChannel.clear();
+
+        const promises: Promise<ILintMessage[]>[] = this.linterManager.getActiveLinters(document.uri)
+            .map(info => {
+                const stopWatch = new StopWatch();
+                const linter = this.linterManager.createLinter(info.product, this.outputChannel, this.serviceContainer, document.uri);
+                const promise = linter.lint(document, cancelToken.token);
+                this.sendLinterRunTelemetry(info, document.uri, promise, stopWatch, trigger);
+                return promise;
+            });
+
+        const hasJupyterCodeCells = await this.documentHasJupyterCodeCells(document, cancelToken.token);
+        // linters will resolve asynchronously - keep a track of all
+        // diagnostics reported as them come in.
+        let diagnostics: vscode.Diagnostic[] = [];
+        const settings = this.configurationService.getSettings(document.uri);
+
+        for (const p of promises) {
+            const msgs = await p;
+            if (cancelToken.token.isCancellationRequested) {
+                break;
+            }
+
+            if (this.isDocumentOpen(document.uri)) {
+                // Build the message and suffix the message with the name of the linter used.
+                for (const m of msgs) {
+                    // Ignore magic commands from jupyter.
+                    if (hasJupyterCodeCells && document.lineAt(m.line - 1).text.trim().startsWith('%') &&
+                        (m.code === LinterErrors.pylint.InvalidSyntax ||
+                            m.code === LinterErrors.prospector.InvalidSyntax ||
+                            m.code === LinterErrors.flake8.InvalidSyntax)) {
+                        continue;
+                    }
+                    diagnostics.push(this.createDiagnostics(m, document));
+                }
+                // Limit the number of messages to the max value.
+                diagnostics = diagnostics.filter((value, index) => index <= settings.linting.maxNumberOfProblems);
+            }
+        }
+        // Set all diagnostics found in this pass, as this method always clears existing diagnostics.
+        this.diagnosticCollection.set(document.uri, diagnostics);
     }
-    if (document.uri.scheme !== 'file' || !document.uri.fsPath) {
-      return false;
+
+    // tslint:disable-next-line:no-any
+    public async linkJupiterExtension(jupiter: vscode.Extension<any> | undefined): Promise<void> {
+        if (!jupiter) {
+            return;
+        }
+        if (!jupiter.isActive) {
+            await jupiter.activate();
+        }
+        // tslint:disable-next-line:no-unsafe-any
+        jupiter.exports.registerLanguageProvider(PYTHON.language, new JupyterProvider());
+        // tslint:disable-next-line:no-unsafe-any
+        this.documentHasJupyterCodeCells = jupiter.exports.hasCodeCells;
     }
-    return await this.fileSystem.fileExistsAsync(document.uri.fsPath);
-  }
+
+    private sendLinterRunTelemetry(info: ILinterInfo, resource: vscode.Uri, promise: Promise<ILintMessage[]>, stopWatch: StopWatch, trigger: LinterTrigger): void {
+        const linterExecutablePathName = info.pathName(resource);
+        const properties: LintingTelemetry = {
+            tool: info.id,
+            hasCustomArgs: info.linterArgs(resource).length > 0,
+            trigger,
+            executableSpecified: linterExecutablePathName.length > 0
+        };
+        sendTelemetryWhenDone(LINTING, promise, stopWatch, properties);
+    }
+
+    private isDocumentOpen(uri: vscode.Uri): boolean {
+        return this.documents.textDocuments.some(document => document.uri.fsPath === uri.fsPath);
+    }
+
+    private createDiagnostics(message: ILintMessage, document: vscode.TextDocument): vscode.Diagnostic {
+        const position = new vscode.Position(message.line - 1, message.column);
+        const range = new vscode.Range(position, position);
+
+        const severity = lintSeverityToVSSeverity.get(message.severity!)!;
+        const diagnostic = new vscode.Diagnostic(range, `${message.code}:${message.message}`, severity);
+        diagnostic.code = message.code;
+        diagnostic.source = message.provider;
+        return diagnostic;
+    }
+
+    private async shouldLintDocument(document: vscode.TextDocument): Promise<boolean> {
+        if (!this.linterManager.isLintingEnabled(document.uri)) {
+            this.diagnosticCollection.set(document.uri, []);
+            return false;
+        }
+
+        if (document.languageId !== PYTHON.language) {
+            return false;
+        }
+
+        const workspaceFolder = this.workspace.getWorkspaceFolder(document.uri);
+        const workspaceRootPath = (workspaceFolder && typeof workspaceFolder.uri.fsPath === 'string') ? workspaceFolder.uri.fsPath : undefined;
+        const relativeFileName = typeof workspaceRootPath === 'string' ? path.relative(workspaceRootPath, document.fileName) : document.fileName;
+
+        const settings = this.configurationService.getSettings(document.uri);
+        const ignoreMinmatches = settings.linting.ignorePatterns.map(pattern => new Minimatch(pattern));
+        if (ignoreMinmatches.some(matcher => matcher.match(document.fileName) || matcher.match(relativeFileName))) {
+            return false;
+        }
+        if (document.uri.scheme !== 'file' || !document.uri.fsPath) {
+            return false;
+        }
+        return await this.fileSystem.fileExistsAsync(document.uri.fsPath);
+    }
 }

--- a/src/client/providers/simpleRefactorProvider.ts
+++ b/src/client/providers/simpleRefactorProvider.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
 import { PythonSettings } from '../common/configSettings';
 import { getTextEditsFromPatch } from '../common/editor';
+import { StopWatch } from '../common/stopWatch';
 import { IInstaller, Product } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { RefactorProxy } from '../refactor/proxy';
 import { sendTelemetryWhenDone } from '../telemetry';
 import { REFACTOR_EXTRACT_FUNCTION, REFACTOR_EXTRACT_VAR } from '../telemetry/constants';
-import { StopWatch } from '../telemetry/stopWatch';
 
 type RenameResponse = {
     results: [{ diff: string }];

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { StopWatch } from './stopWatch';
+import { StopWatch } from '../common/stopWatch';
 import { getTelemetryReporter } from './telemetry';
 import { TelemetryProperties } from './types';
 

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -30,7 +30,7 @@ export type CodeExecutionTelemetry = {
     scope: 'file' | 'selection';
 };
 export type DebuggerTelemetry = {
-    trigger: 'launch' | 'attach'
+    trigger: 'launch' | 'attach';
     console?: 'none' | 'integratedTerminal' | 'externalTerminal';
     debugOptions?: string;
     pyspark?: boolean;
@@ -41,14 +41,14 @@ export type DebuggerPerformanceTelemetry = {
     action: 'stepIn' | 'stepOut' | 'continue' | 'next' | 'launch';
 };
 export type TestRunTelemetry = {
-    tool: 'nosetest' | 'pytest' | 'unittest'
+    tool: 'nosetest' | 'pytest' | 'unittest';
     scope: 'currentFile' | 'all' | 'file' | 'class' | 'function' | 'failed';
     debugging: boolean;
     trigger: 'ui' | 'codelens' | 'commandpalette' | 'auto';
     failed: boolean;
 };
 export type TestDiscoverytTelemetry = {
-    tool: 'nosetest' | 'pytest' | 'unittest'
+    tool: 'nosetest' | 'pytest' | 'unittest';
     trigger: 'ui' | 'commandpalette';
     failed: boolean;
 };


### PR DESCRIPTION
Fixes #1036

@brettcannon @MikhailArkhipov 
Added the word Jedi in release notes to be specific (I don't want anyone looking back at these old change log entries to link this `language server` to our new `analysis engine`).

**Minor change: Moved `StopWatch` file into `common`.**

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
