### PR TITLE
Changed property name used to capture the trigger source of Unit Tests.

### DIFF
--- a/news/3 Code Health/1213.md
+++ b/news/3 Code Health/1213.md
@@ -1,0 +1,1 @@
+Changed property name used to capture the trigger source of Unit Tests.

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -44,7 +44,7 @@ export type TestRunTelemetry = {
     tool: 'nosetest' | 'pytest' | 'unittest';
     scope: 'currentFile' | 'all' | 'file' | 'class' | 'function' | 'failed';
     debugging: boolean;
-    trigger: 'ui' | 'codelens' | 'commandpalette' | 'auto';
+    triggeredBy: 'ui' | 'codelens' | 'commandpalette' | 'auto';
     failed: boolean;
 };
 export type TestDiscoverytTelemetry = {

--- a/src/client/unittests/common/managers/baseTestManager.ts
+++ b/src/client/unittests/common/managers/baseTestManager.ts
@@ -177,7 +177,7 @@ export abstract class BaseTestManager implements ITestManager {
             tool: this.testProvider,
             scope: 'all',
             debugging: debug === true,
-            trigger: cmdSource,
+            triggeredBy: cmdSource,
             failed: false
         };
         if (runFailedTests === true) {


### PR DESCRIPTION
Fixes #1213

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
