### PR TITLE
Use an existing method to identify the active interpreter

### DIFF
--- a/news/2 Fixes/1015.md
+++ b/news/2 Fixes/1015.md
@@ -1,0 +1,1 @@
+Use an existing method to identify the active interpreter.

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -45,10 +45,10 @@ export interface ICondaService {
     isCondaAvailable(): Promise<boolean>;
     getCondaVersion(): Promise<string | undefined>;
     getCondaInfo(): Promise<CondaInfo | undefined>;
-    getCondaEnvironments(ignoreCache: boolean): Promise<({ name: string, path: string }[]) | undefined>;
+    getCondaEnvironments(ignoreCache: boolean): Promise<({ name: string; path: string }[]) | undefined>;
     getInterpreterPath(condaEnvironmentPath: string): string;
     isCondaEnvironment(interpreterPath: string): Promise<boolean>;
-    getCondaEnvironment(interpreterPath: string): Promise<{ name: string, path: string } | undefined>;
+    getCondaEnvironment(interpreterPath: string): Promise<{ name: string; path: string } | undefined>;
 }
 
 export enum InterpreterType {

--- a/src/test/common/installer/installer.test.ts
+++ b/src/test/common/installer/installer.test.ts
@@ -14,7 +14,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
 use(chaiAsPromised);
 
 // tslint:disable-next-line:max-func-body-length
-suite('Module Installerx', () => {
+suite('Module Installer', () => {
     [undefined, Uri.file('resource')].forEach(resource => {
         EnumEx.getNamesAndValues<Product>(Product).forEach(product => {
             let disposables: Disposable[] = [];

--- a/src/test/common/installer/moduleInstaller.test.ts
+++ b/src/test/common/installer/moduleInstaller.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as path from 'path';
+import * as TypeMoq from 'typemoq';
+import { Disposable} from 'vscode';
+import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
+import { PipInstaller } from '../../../client/common/installer/pipInstaller';
+import { IInstallationChannelManager, IModuleInstaller } from '../../../client/common/installer/types';
+import { ITerminalService, ITerminalServiceFactory } from '../../../client/common/terminal/types';
+import { IConfigurationService, IDisposableRegistry, IPythonSettings } from '../../../client/common/types';
+import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { initialize } from '../../initialize';
+
+// tslint:disable-next-line:max-func-body-length
+suite('Module Installer', () => {
+    const pythonPath = path.join(__dirname, 'python');
+    suiteSetup(initialize);
+    [CondaInstaller, PipInstaller].forEach(installerClass => {
+        let disposables: Disposable[] = [];
+        let installer: IModuleInstaller;
+        let installationChannel: TypeMoq.IMock<IInstallationChannelManager>;
+        let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+        let terminalService: TypeMoq.IMock<ITerminalService>;
+        let pythonSettings: TypeMoq.IMock<IPythonSettings>;
+        let interpreterService: TypeMoq.IMock<IInterpreterService>;
+        setup(() => {
+            serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+
+            disposables = [];
+            serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IDisposableRegistry), TypeMoq.It.isAny())).returns(() => disposables);
+
+            installationChannel = TypeMoq.Mock.ofType<IInstallationChannelManager>();
+            serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInstallationChannelManager), TypeMoq.It.isAny())).returns(() => installationChannel.object);
+
+            const condaService = TypeMoq.Mock.ofType<ICondaService>();
+            condaService.setup(c => c.getCondaFile()).returns(() => Promise.resolve('conda'));
+            condaService.setup(c => c.getCondaEnvironment(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
+
+            const configService = TypeMoq.Mock.ofType<IConfigurationService>();
+            serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IConfigurationService), TypeMoq.It.isAny())).returns(() => configService);
+            pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+            pythonSettings.setup(p => p.pythonPath).returns(() => pythonPath);
+            configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+
+            terminalService = TypeMoq.Mock.ofType<ITerminalService>();
+            const terminalServiceFactory = TypeMoq.Mock.ofType<ITerminalServiceFactory>();
+            terminalServiceFactory.setup(f => f.getTerminalService(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => terminalService.object);
+            serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ITerminalServiceFactory), TypeMoq.It.isAny())).returns(() => terminalServiceFactory.object);
+
+            interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+            serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterService), TypeMoq.It.isAny())).returns(() => interpreterService.object);
+
+            installer = new installerClass(serviceContainer.object);
+        });
+        teardown(() => {
+            disposables.forEach(disposable => {
+                if (disposable) {
+                    disposable.dispose();
+                }
+            });
+        });
+        test(`Ensure getActiveInterperter is used (${installerClass.name})`, async () => {
+            if (installer.displayName !== 'Pip') {
+                return;
+            }
+            interpreterService.setup(i => i.getActiveInterpreter(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined)).verifiable();
+            try {
+                await installer.installModule('xyz');
+                // tslint:disable-next-line:no-empty
+            } catch { }
+            interpreterService.verifyAll();
+        });
+    });
+});

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -202,6 +202,8 @@ suite('Module Installer', () => {
         mockTerminalService
             .setup(t => t.sendCommand(TypeMoq.It.isAnyString(), TypeMoq.It.isAny()))
             .returns((cmd: string, args: string[]) => { argsSent = args; return Promise.resolve(void 0); });
+        // tslint:disable-next-line:no-any
+        interpreterService.setup(i => i.getActiveInterpreter(TypeMoq.It.isAny())).returns(() => Promise.resolve({ type: InterpreterType.Unknown } as any));
         await pipInstaller.installModule(moduleName);
 
         expect(argsSent.join(' ')).equal(`-m pip install -U ${moduleName} --user`, 'Invalid command sent to terminal for installation.');
@@ -225,7 +227,6 @@ suite('Module Installer', () => {
         mockTerminalService
             .setup(t => t.sendCommand(TypeMoq.It.isAnyString(), TypeMoq.It.isAny()))
             .returns((cmd: string, args: string[]) => { argsSent = args; return Promise.resolve(void 0); });
-
         await pipInstaller.installModule(moduleName);
 
         expect(argsSent.join(' ')).equal(`-m pip install -U ${moduleName}`, 'Invalid command sent to terminal for installation.');


### PR DESCRIPTION
Fixes #1015

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
