### PR TITLE
Renamed invalid property named `label` to `name` in `launch.json` file.

### DIFF
--- a/news/2 Fixes/1219.md
+++ b/news/2 Fixes/1219.md
@@ -1,0 +1,1 @@
+Renamed invalid property named `label` to `name` in `launch.json` file.

--- a/news/2 Fixes/1219.md
+++ b/news/2 Fixes/1219.md
@@ -1,1 +1,0 @@
-Renamed invalid property named `label` to `name` in `launch.json` file.

--- a/package.json
+++ b/package.json
@@ -990,7 +990,7 @@
                         ]
                     },
                     {
-                        "label": "Python Experimental: Flask",
+                        "name": "Python Experimental: Flask",
                         "type": "pythonExperimental",
                         "request": "launch",
                         "module": "flask",


### PR DESCRIPTION
Fixes #1219

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
