### PR TITLE
Fixes issue that causes linter to fail when file path contains spaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2018.3.1 (29 Mar 2018)
+
+### Fixes
+
+1. Fixes issue that causes linter to fail when file path contains spaces.
+([#1239](https://github.com/Microsoft/vscode-python/issues/1239))
+
 ## 2018.3.0 (28 Mar 2018)
 
 ### Enhancements
@@ -829,4 +836,3 @@ the following people who contributed code:
 
 ## Version 0.0.3
 * Added support for debugging using PDB
-

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
-    "version": "2018.3.0",
+    "version": "2018.4.0-alpha",
     "publisher": "ms-python",
     "author": {
         "name": "Microsoft Corporation"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
-    "version": "2018.4.0-alpha",
+    "version": "2018.3.1",
     "publisher": "ms-python",
     "author": {
         "name": "Microsoft Corporation"

--- a/src/client/linters/flake8.ts
+++ b/src/client/linters/flake8.ts
@@ -13,7 +13,7 @@ export class Flake8 extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const messages = await this.run(['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath.fileToCommandArgument()], document, cancellation);
+        const messages = await this.run(['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath], document, cancellation);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.flake8CategorySeverity);
         });

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -13,7 +13,7 @@ export class MyPy extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const messages = await this.run([document.uri.fsPath.fileToCommandArgument()], document, cancellation, REGEX);
+        const messages = await this.run([document.uri.fsPath], document, cancellation, REGEX);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.mypyCategorySeverity);
             msg.code = msg.type;

--- a/src/client/linters/pep8.ts
+++ b/src/client/linters/pep8.ts
@@ -13,7 +13,7 @@ export class Pep8 extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const messages = await this.run(['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath.fileToCommandArgument()], document, cancellation);
+        const messages = await this.run(['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', document.uri.fsPath], document, cancellation);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.pep8CategorySeverity);
         });

--- a/src/client/linters/prospector.ts
+++ b/src/client/linters/prospector.ts
@@ -28,7 +28,7 @@ export class Prospector extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        return this.run(['--absolute-paths', '--output-format=json', document.uri.fsPath.fileToCommandArgument()], document, cancellation);
+        return this.run(['--absolute-paths', '--output-format=json', document.uri.fsPath], document, cancellation);
     }
     protected async parseMessages(output: string, document: TextDocument, token: CancellationToken, regEx: string) {
         let parsedData: IProspectorResponse;

--- a/src/client/linters/pydocstyle.ts
+++ b/src/client/linters/pydocstyle.ts
@@ -13,7 +13,7 @@ export class PyDocStyle extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const messages = await this.run([document.uri.fsPath.fileToCommandArgument()], document, cancellation);
+        const messages = await this.run([document.uri.fsPath], document, cancellation);
         // All messages in pep8 are treated as warnings for now.
         messages.forEach(msg => {
             msg.severity = LintMessageSeverity.Warning;

--- a/src/client/linters/pylama.ts
+++ b/src/client/linters/pylama.ts
@@ -14,7 +14,7 @@ export class PyLama extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const messages = await this.run(['--format=parsable', document.uri.fsPath.fileToCommandArgument()], document, cancellation, REGEX);
+        const messages = await this.run(['--format=parsable', document.uri.fsPath], document, cancellation, REGEX);
         // All messages in pylama are treated as warnings for now.
         messages.forEach(msg => {
             msg.severity = LintMessageSeverity.Warning;

--- a/src/client/linters/pylint.ts
+++ b/src/client/linters/pylint.ts
@@ -70,7 +70,7 @@ export class Pylint extends BaseLinter {
             '--msg-template=\'{line},{column},{category},{msg_id}:{msg}\'',
             '--reports=n',
             '--output-format=text',
-            uri.fsPath.fileToCommandArgument()
+            uri.fsPath
         ];
         const messages = await this.run(minArgs.concat(args), document, cancellation);
         messages.forEach(msg => {

--- a/src/test/linters/lint.args.test.ts
+++ b/src/test/linters/lint.args.test.ts
@@ -110,32 +110,32 @@ suite('Linting - Arguments', () => {
     [Uri.file(path.join('users', 'development path to', 'one.py')), Uri.file(path.join('users', 'development', 'one.py'))].forEach(fileUri => {
         test(`Flake8 (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
             const linter = new Flake8(outputChannel.object, serviceContainer);
-            const expectedArgs = ['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', fileUri.fsPath.fileToCommandArgument()];
+            const expectedArgs = ['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', fileUri.fsPath];
             await testLinter(linter, fileUri, expectedArgs);
         });
         test(`Pep8 (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
             const linter = new Pep8(outputChannel.object, serviceContainer);
-            const expectedArgs = ['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', fileUri.fsPath.fileToCommandArgument()];
+            const expectedArgs = ['--format=%(row)d,%(col)d,%(code).1s,%(code)s:%(text)s', fileUri.fsPath];
             await testLinter(linter, fileUri, expectedArgs);
         });
         test(`Prospector (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
             const linter = new Prospector(outputChannel.object, serviceContainer);
-            const expectedArgs = ['--absolute-paths', '--output-format=json', fileUri.fsPath.fileToCommandArgument()];
+            const expectedArgs = ['--absolute-paths', '--output-format=json', fileUri.fsPath];
             await testLinter(linter, fileUri, expectedArgs);
         });
         test(`Pylama (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
             const linter = new PyLama(outputChannel.object, serviceContainer);
-            const expectedArgs = ['--format=parsable', fileUri.fsPath.fileToCommandArgument()];
+            const expectedArgs = ['--format=parsable', fileUri.fsPath];
             await testLinter(linter, fileUri, expectedArgs);
         });
         test(`MyPy (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
             const linter = new MyPy(outputChannel.object, serviceContainer);
-            const expectedArgs = [fileUri.fsPath.fileToCommandArgument()];
+            const expectedArgs = [fileUri.fsPath];
             await testLinter(linter, fileUri, expectedArgs);
         });
         test(`Pydocstyle (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
             const linter = new PyDocStyle(outputChannel.object, serviceContainer);
-            const expectedArgs = [fileUri.fsPath.fileToCommandArgument()];
+            const expectedArgs = [fileUri.fsPath];
             await testLinter(linter, fileUri, expectedArgs);
         });
         test(`Pylint (${fileUri.fsPath.indexOf(' ') > 0 ? 'with spaces' : 'without spaces'})`, async () => {
@@ -144,7 +144,7 @@ suite('Linting - Arguments', () => {
 
             let invoked = false;
             (linter as any).run = (args, doc, token) => {
-                expect(args[args.length - 1]).to.equal(fileUri.fsPath.fileToCommandArgument());
+                expect(args[args.length - 1]).to.equal(fileUri.fsPath);
                 invoked = true;
                 return Promise.resolve([]);
             };


### PR DESCRIPTION
Fixes #1239

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
