### PR TITLE
WIP - Unit tests to ensure attaching twice to a remote debugger fails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "out": true, // set this to true to hide the "out" folder with the compiled JS files
         "**/*.pyc": true,
         "**/__pycache__": true,
-        "node_modules": true,
+        "node_modules": false,
         ".vscode-test": true,
         "**/.mypy_cache/**": true,
         "**/.ropeproject/**": true
@@ -14,7 +14,7 @@
         "coverage": true
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "tslint.enable": false, // We will run our own linting in gulp (& git commit hooks), else tslint extension just complains about unmodified files
+    "tslint.enable": true, // We will run our own linting in gulp (& git commit hooks), else tslint extension just complains about unmodified files
     "python.linting.enabled": false,
     "python.unitTest.promptToConfigure": false,
     "python.workspaceSymbols.enabled": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
         "out": true, // set this to true to hide the "out" folder with the compiled JS files
         "**/*.pyc": true,
         "**/__pycache__": true,
-        "node_modules": false,
+        "node_modules": true,
         ".vscode-test": true,
         "**/.mypy_cache/**": true,
         "**/.ropeproject/**": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
         "coverage": true
     },
     "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "tslint.enable": true,
+    "tslint.enable": false, // We will run our own linting in gulp (& git commit hooks), else tslint extension just complains about unmodified files
     "python.linting.enabled": false,
     "python.unitTest.promptToConfigure": false,
     "python.workspaceSymbols.enabled": false,

--- a/news/1 Enhancements/1229.md
+++ b/news/1 Enhancements/1229.md
@@ -1,0 +1,2 @@
+Add prelimnary support for remote debugging using the experimental debugger.
+Attach to a Python program started using the command `python -m ptvsd --server --port 9091 --file pythonFile.py`

--- a/package.json
+++ b/package.json
@@ -1035,7 +1035,7 @@
                     },
                     {
                         "name": "Python Experimental: Attach",
-                        "type": "python",
+                        "type": "pythonExperimental",
                         "request": "pythonExperimental",
                         "localRoot": "${workspaceFolder}",
                         "remoteRoot": "${workspaceFolder}",

--- a/package.json
+++ b/package.json
@@ -963,6 +963,53 @@
                                 "default": false
                             }
                         }
+                    },
+                    "attach": {
+                        "required": [
+                            "port",
+                            "remoteRoot"
+                        ],
+                        "properties": {
+                            "localRoot": {
+                                "type": "string",
+                                "description": "Local source root that corrresponds to the 'remoteRoot'.",
+                                "default": "${workspaceFolder}"
+                            },
+                            "remoteRoot": {
+                                "type": "string",
+                                "description": "The source root of the remote host.",
+                                "default": ""
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": "Debug port to attach",
+                                "default": 0
+                            },
+                            "host": {
+                                "type": "string",
+                                "description": "IP Address of the of remote server (default is localhost or use 127.0.0.1).",
+                                "default": "localhost"
+                            },
+                            "debugOptions": {
+                                "type": "array",
+                                "description": "Advanced options, view read me for further details.",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "RedirectOutput",
+                                        "DebugStdLib",
+                                        "Django",
+                                        "Jinja"
+                                    ]
+                                },
+                                "default": []
+                            },
+                            "logToFile": {
+                                "type": "boolean",
+                                "description": "Enable logging of debugger events to a log file.",
+                                "default": false
+                            }
+                        }
                     }
                 },
                 "initialConfigurations": [

--- a/package.json
+++ b/package.json
@@ -874,6 +874,19 @@
                                 "Pyramid"
                             ]
                         }
+                    },
+                    {
+                        "label": "%python.snippet.launch.attach.label%",
+                        "description": "%python.snippet.launch.attach.description%",
+                        "body": {
+                            "name": "Attach (Remote Debug)",
+                            "type": "pythonExperimental",
+                            "request": "attach",
+                            "localRoot": "^\"\\${workspaceFolder}\"",
+                            "remoteRoot": "^\"\\${workspaceFolder}\"",
+                            "port": 3000,
+                            "host": "localhost"
+                        }
                     }
                 ],
                 "configurationAttributes": {
@@ -1019,6 +1032,15 @@
                         "request": "launch",
                         "program": "${file}",
                         "console": "integratedTerminal"
+                    },
+                    {
+                        "name": "Python Experimental: Attach",
+                        "type": "python",
+                        "request": "pythonExperimental",
+                        "localRoot": "${workspaceFolder}",
+                        "remoteRoot": "${workspaceFolder}",
+                        "port": 3000,
+                        "host": "localhost"
                     },
                     {
                         "name": "Python Experimental: Django",

--- a/package.json
+++ b/package.json
@@ -876,7 +876,7 @@
                         }
                     },
                     {
-                        "label": "%python.snippet.launch.attach.label%",
+                        "label": "Python Experimental: Attach",
                         "description": "%python.snippet.launch.attach.description%",
                         "body": {
                             "name": "Attach (Remote Debug)",

--- a/src/client/debugger/Common/Contracts.ts
+++ b/src/client/debugger/Common/Contracts.ts
@@ -72,6 +72,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 }
 
 export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
+    type?: DebuggerType;
     /** An absolute path to local directory with source. */
     localRoot: string;
     remoteRoot: string;

--- a/src/client/debugger/DebugClients/RemoteDebugClient.ts
+++ b/src/client/debugger/DebugClients/RemoteDebugClient.ts
@@ -2,19 +2,25 @@ import { DebugSession } from 'vscode-debugadapter';
 import { AttachRequestArguments, IPythonProcess } from '../Common/Contracts';
 import { BaseDebugServer } from '../DebugServers/BaseDebugServer';
 import { RemoteDebugServer } from '../DebugServers/RemoteDebugServer';
+import { RemoteDebugServerV2 } from '../DebugServers/RemoteDebugServerv2';
 import { DebugClient, DebugType } from './DebugClient';
 
 export class RemoteDebugClient extends DebugClient<AttachRequestArguments> {
-    private pythonProcess: IPythonProcess;
+    private pythonProcess?: IPythonProcess;
     private debugServer?: BaseDebugServer;
     // tslint:disable-next-line:no-any
-    constructor(args: any, debugSession: DebugSession) {
+    constructor(args: AttachRequestArguments, debugSession: DebugSession) {
         super(args, debugSession);
     }
 
     public CreateDebugServer(pythonProcess?: IPythonProcess): BaseDebugServer {
-        this.pythonProcess = pythonProcess!;
-        this.debugServer = new RemoteDebugServer(this.debugSession, this.pythonProcess!, this.args);
+        if (this.args.type === 'pythonExperimental') {
+            // tslint:disable-next-line:no-any
+            this.debugServer = new RemoteDebugServerV2(this.debugSession, undefined as any, this.args);
+        } else {
+            this.pythonProcess = pythonProcess!;
+            this.debugServer = new RemoteDebugServer(this.debugSession, this.pythonProcess!, this.args);
+        }
         return this.debugServer!;
     }
     public get DebugType(): DebugType {

--- a/src/client/debugger/DebugServers/RemoteDebugServerv2.ts
+++ b/src/client/debugger/DebugServers/RemoteDebugServerv2.ts
@@ -31,10 +31,18 @@ export class RemoteDebugServerV2 extends BaseDebugServer {
                 (<any>options).host = this.args.host;
             }
             try {
+                let connected = false;
                 const socket = connect(options, () => {
+                    connected = true;
                     this.socket = socket;
                     this.clientSocket.resolve(socket);
                     resolve(options);
+                });
+                socket.on('error', ex => {
+                    if (connected) {
+                        return;
+                    }
+                    reject(ex);
                 });
             } catch (ex) {
                 reject(ex);

--- a/src/client/debugger/DebugServers/RemoteDebugServerv2.ts
+++ b/src/client/debugger/DebugServers/RemoteDebugServerv2.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:quotemark ordered-imports no-any no-empty curly member-ordering one-line max-func-body-length no-var-self prefer-const cyclomatic-complexity prefer-template
+
+import { DebugSession } from "vscode-debugadapter";
+import { IPythonProcess, IDebugServer, AttachRequestArguments } from "../Common/Contracts";
+import { connect, Socket } from "net";
+import { BaseDebugServer } from "./BaseDebugServer";
+
+export class RemoteDebugServerV2 extends BaseDebugServer {
+    private args: AttachRequestArguments;
+    private socket?: Socket;
+    constructor(debugSession: DebugSession, pythonProcess: IPythonProcess, args: AttachRequestArguments) {
+        super(debugSession, pythonProcess);
+        this.args = args;
+    }
+
+    public Stop() {
+        if (this.socket) {
+            this.socket.destroy();
+        }
+    }
+    public Start(): Promise<IDebugServer> {
+        return new Promise<IDebugServer>((resolve, reject) => {
+            let portNumber = this.args.port;
+            let options = { port: portNumber! };
+            if (typeof this.args.host === "string" && this.args.host.length > 0) {
+                (<any>options).host = this.args.host;
+            }
+            try {
+                const socket = connect(options, () => {
+                    this.socket = socket;
+                    this.clientSocket.resolve(socket);
+                    resolve(options);
+                });
+            } catch (ex) {
+                reject(ex);
+            }
+        });
+    }
+}

--- a/src/client/debugger/configProviders/pythonV2Provider.ts
+++ b/src/client/debugger/configProviders/pythonV2Provider.ts
@@ -8,15 +8,15 @@ import { Uri } from 'vscode';
 import { IPlatformService } from '../../common/platform/types';
 import { IServiceContainer } from '../../ioc/types';
 import { DebugOptions } from '../Common/Contracts';
-import { BaseConfigurationProvider, PythonDebugConfiguration } from './baseProvider';
+import { BaseConfigurationProvider, PythonAttachDebugConfiguration, PythonLaunchDebugConfiguration } from './baseProvider';
 
 @injectable()
 export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvider {
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         super('pythonExperimental', serviceContainer);
     }
-    protected provideDefaults(workspaceFolder: Uri, debugConfiguration: PythonDebugConfiguration): void {
-        super.provideDefaults(workspaceFolder, debugConfiguration);
+    protected provideLaunchDefaults(workspaceFolder: Uri, debugConfiguration: PythonLaunchDebugConfiguration): void {
+        super.provideLaunchDefaults(workspaceFolder, debugConfiguration);
 
         debugConfiguration.stopOnEntry = false;
         debugConfiguration.debugOptions = Array.isArray(debugConfiguration.debugOptions) ? debugConfiguration.debugOptions : [];
@@ -28,6 +28,16 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
         if (debugConfiguration.module && debugConfiguration.module.toUpperCase() === 'FLASK'
             && debugConfiguration.debugOptions.indexOf(DebugOptions.Jinja) === -1) {
             debugConfiguration.debugOptions.push(DebugOptions.Jinja);
+        }
+    }
+    protected provideAttachDefaults(workspaceFolder: Uri, debugConfiguration: PythonAttachDebugConfiguration): void {
+        super.provideAttachDefaults(workspaceFolder, debugConfiguration);
+
+        debugConfiguration.debugOptions = Array.isArray(debugConfiguration.debugOptions) ? debugConfiguration.debugOptions : [];
+
+        // Add PTVSD specific flags.
+        if (this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows) {
+            debugConfiguration.debugOptions.push(DebugOptions.FixFilePathCase);
         }
     }
 }

--- a/src/test/debugger/attach.again.ptvsd.test.ts
+++ b/src/test/debugger/attach.again.ptvsd.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-invalid-this max-func-body-length no-empty no-increment-decrement
+
+import { expect } from 'chai';
+import { ChildProcess, spawn } from 'child_process';
+import * as getFreePort from 'get-port';
+import * as path from 'path';
+import { DebugClient } from 'vscode-debugadapter-testsupport';
+import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
+import '../../client/common/extensions';
+import { IS_WINDOWS } from '../../client/common/platform/constants';
+import { sleep } from '../common';
+import { initialize, IS_APPVEYOR, IS_MULTI_ROOT_TEST, TEST_DEBUGGER } from '../initialize';
+import { DEBUGGER_TIMEOUT } from './common/constants';
+import { DebugClientEx } from './debugClient';
+
+const fileToDebug = path.join(EXTENSION_ROOT_DIR, 'src', 'testMultiRootWkspc', 'workspace5', 'remoteDebugger-start-with-ptvsd.re-attach.py');
+const ptvsdPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'experimental', 'ptvsd');
+const DEBUG_ADAPTER = path.join(EXTENSION_ROOT_DIR, 'out', 'client', 'debugger', 'mainV2.js');
+
+suite('Attach Debugger - detach and again again - Experimental', () => {
+    let debugClient: DebugClient;
+    let procToKill: ChildProcess;
+    suiteSetup(initialize);
+
+    setup(async function () {
+        if (!IS_MULTI_ROOT_TEST || !TEST_DEBUGGER) {
+            this.skip();
+        }
+        await startDebugger();
+    });
+    teardown(async () => {
+        // Wait for a second before starting another test (sometimes, sockets take a while to get closed).
+        await sleep(1000);
+        try {
+            await debugClient.stop().catch(() => { });
+        } catch (ex) { }
+        if (procToKill) {
+            try {
+                procToKill.kill();
+            } catch { }
+        }
+    });
+    async function startDebugger() {
+        await sleep(1000);
+        debugClient = createDebugAdapter();
+        debugClient.defaultTimeout = DEBUGGER_TIMEOUT;
+        await debugClient.start();
+    }
+    /**
+     * Creates the debug aimport { AttachRequestArguments } from '../../client/debugger/Common/Contracts';
+     * We do not need to support code coverage on AppVeyor, lets use the standard test adapter.
+     * @returns {DebugClient}
+     */
+    function createDebugAdapter(): DebugClient {
+        if (IS_WINDOWS) {
+            return new DebugClient('node', DEBUG_ADAPTER, 'pythonExperimental');
+        } else {
+            const coverageDirectory = path.join(EXTENSION_ROOT_DIR, 'debug_coverage_attach_ptvsd');
+            return new DebugClientEx(DEBUG_ADAPTER, 'pythonExperimental', coverageDirectory, { cwd: EXTENSION_ROOT_DIR });
+        }
+    }
+    async function startRemoteProcess() {
+        const port = await getFreePort({ host: 'localhost', port: 9091 });
+        const customEnv = { ...process.env };
+
+        // Set the path for PTVSD to be picked up.
+        // tslint:disable-next-line:no-string-literal
+        customEnv['PYTHONPATH'] = ptvsdPath;
+        const pythonArgs = ['-m', 'ptvsd', '--server', '--port', `${port}`, '--file', fileToDebug.fileToCommandArgument()];
+        procToKill = spawn('python', pythonArgs, { env: customEnv, cwd: path.dirname(fileToDebug) });
+        // wait for socket server to start.
+        await sleep(1000);
+        return port;
+    }
+
+    async function waitForDebuggerCondfigurationDone(port: number) {
+        // Send initialize, attach
+        const initializePromise = debugClient.initializeRequest({
+            adapterID: 'pythonExperimental',
+            linesStartAt1: true,
+            columnsStartAt1: true,
+            supportsRunInTerminalRequest: true,
+            pathFormat: 'path',
+            supportsVariableType: true,
+            supportsVariablePaging: true
+        });
+        const attachPromise = debugClient.attachRequest({
+            localRoot: path.dirname(fileToDebug),
+            remoteRoot: path.dirname(fileToDebug),
+            type: 'pythonExperimental',
+            port: port,
+            host: 'localhost',
+            logToFile: false,
+            debugOptions: ['RedirectOutput']
+        });
+
+        await Promise.all([
+            initializePromise,
+            attachPromise,
+            debugClient.waitForEvent('initialized')
+        ]);
+
+        await debugClient.configurationDoneRequest();
+    }
+    async function testAttaching(port: number) {
+        await waitForDebuggerCondfigurationDone(port);
+        let threads = await debugClient.threadsRequest();
+        expect(threads).to.be.not.equal(undefined, 'no threads response');
+        expect(threads.body.threads).to.be.lengthOf(1);
+
+        await debugClient.setExceptionBreakpointsRequest({ filters: [] });
+        const breakpointLocation = { path: fileToDebug, column: 1, line: 7 };
+        await debugClient.setBreakpointsRequest({
+            lines: [breakpointLocation.line],
+            breakpoints: [{ line: breakpointLocation.line, column: breakpointLocation.column }],
+            source: { path: breakpointLocation.path }
+        });
+
+        await debugClient.assertStoppedLocation('breakpoint', breakpointLocation);
+        await debugClient.setBreakpointsRequest({ lines: [], breakpoints: [], source: { path: breakpointLocation.path } });
+
+        threads = await debugClient.threadsRequest();
+        expect(threads).to.be.not.equal(undefined, 'no threads response');
+        expect(threads.body.threads).to.be.lengthOf(1);
+
+        await debugClient.continueRequest({ threadId: threads.body.threads[0].id });
+    }
+
+    test('Confirm we are able to attach, detach and attach to a running program', async function () {
+        this.timeout(20000);
+        // Lets skip this test on AppVeyor (very flaky on AppVeyor).
+        if (IS_APPVEYOR) {
+            return;
+        }
+
+        const port = await startRemoteProcess();
+        await testAttaching(port);
+        await debugClient.disconnectRequest({});
+        await startDebugger();
+        await testAttaching(port);
+
+        const terminatedPromise = debugClient.waitForEvent('terminated');
+        procToKill.kill();
+        await terminatedPromise;
+    });
+});

--- a/src/test/debugger/attach.again.ptvsd.test.ts
+++ b/src/test/debugger/attach.again.ptvsd.test.ts
@@ -23,7 +23,8 @@ const ptvsdPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'experimental', '
 const DEBUG_ADAPTER = path.join(EXTENSION_ROOT_DIR, 'out', 'client', 'debugger', 'mainV2.js');
 
 suite('Attach Debugger - detach and again again - Experimental', () => {
-    let debugClient: DebugClient;
+    let debugClient1: DebugClient;
+    let debugClient2: DebugClient;
     let procToKill: ChildProcess;
     suiteSetup(initialize);
 
@@ -31,13 +32,19 @@ suite('Attach Debugger - detach and again again - Experimental', () => {
         if (!IS_MULTI_ROOT_TEST || !TEST_DEBUGGER) {
             this.skip();
         }
-        await startDebugger();
     });
     teardown(async () => {
         // Wait for a second before starting another test (sometimes, sockets take a while to get closed).
         await sleep(1000);
         try {
-            await debugClient.stop().catch(() => { });
+            if (debugClient1) {
+                await debugClient1.disconnectRequest();
+            }
+        } catch (ex) { }
+        try {
+            if (debugClient2) {
+                await debugClient2.disconnectRequest();
+            }
         } catch (ex) { }
         if (procToKill) {
             try {
@@ -47,9 +54,10 @@ suite('Attach Debugger - detach and again again - Experimental', () => {
     });
     async function startDebugger() {
         await sleep(1000);
-        debugClient = createDebugAdapter();
+        const debugClient = createDebugAdapter();
         debugClient.defaultTimeout = DEBUGGER_TIMEOUT;
         await debugClient.start();
+        return debugClient;
     }
     /**
      * Creates the debug aimport { AttachRequestArguments } from '../../client/debugger/Common/Contracts';
@@ -78,7 +86,7 @@ suite('Attach Debugger - detach and again again - Experimental', () => {
         return port;
     }
 
-    async function waitForDebuggerCondfigurationDone(port: number) {
+    async function waitForDebuggerCondfigurationDone(debugClient: DebugClient, port: number) {
         // Send initialize, attach
         const initializePromise = debugClient.initializeRequest({
             adapterID: 'pythonExperimental',
@@ -107,8 +115,8 @@ suite('Attach Debugger - detach and again again - Experimental', () => {
 
         await debugClient.configurationDoneRequest();
     }
-    async function testAttaching(port: number) {
-        await waitForDebuggerCondfigurationDone(port);
+    async function testAttaching(debugClient: DebugClient, port: number) {
+        await waitForDebuggerCondfigurationDone(debugClient, port);
         let threads = await debugClient.threadsRequest();
         expect(threads).to.be.not.equal(undefined, 'no threads response');
         expect(threads.body.threads).to.be.lengthOf(1);
@@ -138,14 +146,55 @@ suite('Attach Debugger - detach and again again - Experimental', () => {
             return;
         }
 
+        let debugClient = debugClient1 = await startDebugger();
+
         const port = await startRemoteProcess();
-        await testAttaching(port);
+        await testAttaching(debugClient, port);
         await debugClient.disconnectRequest({});
-        await startDebugger();
-        await testAttaching(port);
+        debugClient = await startDebugger();
+        await testAttaching(debugClient, port);
 
         const terminatedPromise = debugClient.waitForEvent('terminated');
         procToKill.kill();
         await terminatedPromise;
+    });
+
+    test('Confirm we are unable to attach if already attached to a running program', async function () {
+        this.timeout(200000);
+        // Lets skip this test on AppVeyor (very flaky on AppVeyor).
+        if (IS_APPVEYOR) {
+            return;
+        }
+
+        debugClient1 = await startDebugger();
+
+        const port = await startRemoteProcess();
+        await testAttaching(debugClient1, port);
+
+        debugClient2 = await startDebugger();
+        // Send initialize, attach
+        const initializePromise = debugClient2.initializeRequest({
+            adapterID: 'pythonExperimental',
+            linesStartAt1: true,
+            columnsStartAt1: true,
+            supportsRunInTerminalRequest: true,
+            pathFormat: 'path',
+            supportsVariableType: true,
+            supportsVariablePaging: true
+        });
+
+        const attachMustFail = 'A debugger is already attached to this process';
+        const attachPromise = debugClient2.attachRequest({
+            localRoot: path.dirname(fileToDebug),
+            remoteRoot: path.dirname(fileToDebug),
+            type: 'pythonExperimental',
+            port: port,
+            host: 'localhost',
+            logToFile: true,
+            debugOptions: ['RedirectOutput']
+        }).catch(() => Promise.resolve(attachMustFail));
+        // tslint:disable-next-line:no-unused-variable
+        const [_, attachResponse] = await Promise.all([initializePromise, attachPromise]);
+        expect(attachResponse).to.be.equal(attachMustFail);
     });
 });

--- a/src/test/debugger/attach.ptvsd.test.ts
+++ b/src/test/debugger/attach.ptvsd.test.ts
@@ -61,7 +61,8 @@ suite('Attach Debugger -Experimental', () => {
             return new DebugClientEx(DEBUG_ADAPTER, 'pythonExperimental', coverageDirectory, { cwd: EXTENSION_ROOT_DIR });
         }
     }
-    test('Confirm we are able to attach to a running program', async () => {
+    test('Confirm we are able to attach to a running program', async function () {
+        this.timeout(20000);
         // Lets skip this test on AppVeyor (very flaky on AppVeyor).
         if (IS_APPVEYOR) {
             return;

--- a/src/test/debugger/attach.ptvsd.test.ts
+++ b/src/test/debugger/attach.ptvsd.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-invalid-this max-func-body-length no-empty no-increment-decrement
+
+import { expect } from 'chai';
+import { ChildProcess, spawn } from 'child_process';
+import * as getFreePort from 'get-port';
+import * as path from 'path';
+import { DebugClient } from 'vscode-debugadapter-testsupport';
+import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
+import '../../client/common/extensions';
+import { IS_WINDOWS } from '../../client/common/platform/constants';
+import { sleep } from '../common';
+import { initialize, IS_APPVEYOR, IS_MULTI_ROOT_TEST, TEST_DEBUGGER } from '../initialize';
+import { DEBUGGER_TIMEOUT } from './common/constants';
+import { DebugClientEx } from './debugClient';
+
+const fileToDebug = path.join(EXTENSION_ROOT_DIR, 'src', 'testMultiRootWkspc', 'workspace5', 'remoteDebugger-start-with-ptvsd.py');
+const ptvsdPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'experimental', 'ptvsd');
+const DEBUG_ADAPTER = path.join(EXTENSION_ROOT_DIR, 'out', 'client', 'debugger', 'mainV2.js');
+
+suite('Attach Debugger -Experimental', () => {
+    let debugClient: DebugClient;
+    let procToKill: ChildProcess;
+    suiteSetup(initialize);
+
+    setup(async function () {
+        if (!IS_MULTI_ROOT_TEST || !TEST_DEBUGGER) {
+            this.skip();
+        }
+        await sleep(1000);
+        debugClient = createDebugAdapter();
+        debugClient.defaultTimeout = DEBUGGER_TIMEOUT;
+        await debugClient.start();
+    });
+    teardown(async () => {
+        // Wait for a second before starting another test (sometimes, sockets take a while to get closed).
+        await sleep(1000);
+        try {
+            await debugClient.stop().catch(() => { });
+        } catch (ex) { }
+        if (procToKill) {
+            try {
+                procToKill.kill();
+            } catch { }
+        }
+    });
+    /**
+     * Creates the debug aimport { AttachRequestArguments } from '../../client/debugger/Common/Contracts';
+     * We do not need to support code coverage on AppVeyor, lets use the standard test adapter.
+     * @returns {DebugClient}
+     */
+    function createDebugAdapter(): DebugClient {
+        if (IS_WINDOWS) {
+            return new DebugClient('node', DEBUG_ADAPTER, 'pythonExperimental');
+        } else {
+            const coverageDirectory = path.join(EXTENSION_ROOT_DIR, 'debug_coverage_attach_ptvsd');
+            return new DebugClientEx(DEBUG_ADAPTER, 'pythonExperimental', coverageDirectory, { cwd: EXTENSION_ROOT_DIR });
+        }
+    }
+    test('Confirm we are able to attach to a running program', async () => {
+        // Lets skip this test on AppVeyor (very flaky on AppVeyor).
+        if (IS_APPVEYOR) {
+            return;
+        }
+
+        const port = await getFreePort({ host: 'localhost', port: 3000 });
+        const customEnv = { ...process.env };
+
+        // Set the path for PTVSD to be picked up.
+        // tslint:disable-next-line:no-string-literal
+        customEnv['PYTHONPATH'] = ptvsdPath;
+        const pythonArgs = ['-m', 'ptvsd', '--server', '--port', `${port}`, '--file', fileToDebug.fileToCommandArgument()];
+        procToKill = spawn('python', pythonArgs, { env: customEnv, cwd: path.dirname(fileToDebug) });
+
+        // Send initialize, attach
+        const initializePromise = debugClient.initializeRequest({
+            adapterID: 'pythonExperimental',
+            linesStartAt1: true,
+            columnsStartAt1: true,
+            supportsRunInTerminalRequest: true,
+            pathFormat: 'path',
+            supportsVariableType: true,
+            supportsVariablePaging: true
+        });
+        const attachPromise = debugClient.attachRequest({
+            localRoot: path.dirname(fileToDebug),
+            remoteRoot: path.dirname(fileToDebug),
+            type: 'pythonExperimental',
+            port: port,
+            host: 'localhost',
+            logToFile: true,
+            debugOptions: ['RedirectOutput']
+        });
+
+        await Promise.all([
+            initializePromise,
+            attachPromise,
+            debugClient.waitForEvent('initialized')
+        ]);
+
+        await debugClient.configurationDoneRequest();
+
+        const stdOutPromise = debugClient.assertOutput('stdout', 'this is stdout');
+        const stdErrPromise = debugClient.assertOutput('stderr', 'this is stderr');
+
+        const breakpointLocation = { path: fileToDebug, column: 1, line: 12 };
+        const breakpointPromise = debugClient.setBreakpointsRequest({
+            lines: [breakpointLocation.line],
+            breakpoints: [{ line: breakpointLocation.line, column: breakpointLocation.column }],
+            source: { path: breakpointLocation.path }
+        });
+        const exceptionBreakpointPromise = debugClient.setExceptionBreakpointsRequest({ filters: [] });
+        await Promise.all([
+            breakpointPromise,
+            exceptionBreakpointPromise,
+            stdOutPromise, stdErrPromise
+        ]);
+
+        await debugClient.assertStoppedLocation('breakpoint', breakpointLocation);
+
+        const threads = await debugClient.threadsRequest();
+        expect(threads).to.be.not.equal(undefined, 'no threads response');
+        expect(threads.body.threads).to.be.lengthOf(1);
+
+        await Promise.all([
+            debugClient.continueRequest({ threadId: threads.body.threads[0].id }),
+            debugClient.assertOutput('stdout', 'this is print'),
+            debugClient.waitForEvent('exited'),
+            debugClient.waitForEvent('terminated')
+        ]);
+    });
+});

--- a/src/test/debugger/common/constants.ts
+++ b/src/test/debugger/common/constants.ts
@@ -4,4 +4,4 @@
 'use strict';
 
 // Sometimes PTVSD can take a while for thread & other events to be reported.
-export const DEBUGGER_TIMEOUT = 10000;
+export const DEBUGGER_TIMEOUT = 20000;

--- a/src/test/debugger/configProvider/provider.attach.test.ts
+++ b/src/test/debugger/configProvider/provider.attach.test.ts
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length no-invalid-template-strings no-any no-object-literal-type-assertion
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as TypeMoq from 'typemoq';
+import { DebugConfiguration, DebugConfigurationProvider, TextDocument, TextEditor, Uri, WorkspaceFolder } from 'vscode';
+import { IDocumentManager, IWorkspaceService } from '../../../client/common/application/types';
+import { PythonLanguage } from '../../../client/common/constants';
+import { EnumEx } from '../../../client/common/enumUtils';
+import { IFileSystem, IPlatformService } from '../../../client/common/platform/types';
+import { PythonDebugConfigurationProvider, PythonV2DebugConfigurationProvider } from '../../../client/debugger';
+import { DebugOptions } from '../../../client/debugger/Common/Contracts';
+import { IServiceContainer } from '../../../client/ioc/types';
+
+enum OS {
+    Windows,
+    Mac,
+    Linux
+}
+[
+    { debugType: 'pythonExperimental', class: PythonV2DebugConfigurationProvider },
+    { debugType: 'python', class: PythonDebugConfigurationProvider }
+].forEach(provider => {
+    EnumEx.getNamesAndValues(OS).forEach(os => {
+        suite(`Debugging - Config Provider attach, ${provider.debugType}, OS = ${os.name}`, () => {
+            let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+            let debugProvider: DebugConfigurationProvider;
+            let platformService: TypeMoq.IMock<IPlatformService>;
+            let fileSystem: TypeMoq.IMock<IFileSystem>;
+            const debugOptionsAvailable = [DebugOptions.RedirectOutput];
+            if (os.value === OS.Windows && provider.debugType === 'pythonExperimental') {
+                debugOptionsAvailable.push(DebugOptions.FixFilePathCase);
+            }
+            setup(() => {
+                serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+                platformService = TypeMoq.Mock.ofType<IPlatformService>();
+                fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platformService.object);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fileSystem.object);
+                platformService.setup(p => p.isWindows).returns(() => os.value === OS.Windows);
+                platformService.setup(p => p.isMac).returns(() => os.value === OS.Mac);
+                platformService.setup(p => p.isLinux).returns(() => os.value === OS.Linux);
+                debugProvider = new provider.class(serviceContainer.object);
+            });
+            function createMoqWorkspaceFolder(folderPath: string) {
+                const folder = TypeMoq.Mock.ofType<WorkspaceFolder>();
+                folder.setup(f => f.uri).returns(() => Uri.file(folderPath));
+                return folder.object;
+            }
+            function setupActiveEditor(fileName: string | undefined, languageId: string) {
+                const documentManager = TypeMoq.Mock.ofType<IDocumentManager>();
+                if (fileName) {
+                    const textEditor = TypeMoq.Mock.ofType<TextEditor>();
+                    const document = TypeMoq.Mock.ofType<TextDocument>();
+                    document.setup(d => d.languageId).returns(() => languageId);
+                    document.setup(d => d.fileName).returns(() => fileName);
+                    textEditor.setup(t => t.document).returns(() => document.object);
+                    documentManager.setup(d => d.activeTextEditor).returns(() => textEditor.object);
+                } else {
+                    documentManager.setup(d => d.activeTextEditor).returns(() => undefined);
+                }
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IDocumentManager))).returns(() => documentManager.object);
+            }
+            function setupWorkspaces(folders: string[]) {
+                const workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
+                const workspaceFolders = folders.map(createMoqWorkspaceFolder);
+                workspaceService.setup(w => w.workspaceFolders).returns(() => workspaceFolders);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IWorkspaceService))).returns(() => workspaceService.object);
+            }
+            test('Defaults should be returned when an empty object is passed with a Workspace Folder and active file', async () => {
+                const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+                const pythonFile = 'xyz.py';
+
+                setupActiveEditor(pythonFile, PythonLanguage.language);
+
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { request: 'attach' } as DebugConfiguration);
+
+                expect(Object.keys(debugConfig!)).to.have.lengthOf.above(3);
+                expect(debugConfig).to.have.property('request', 'attach');
+                expect(debugConfig).to.have.property('localRoot');
+                expect(debugConfig!.localRoot!.toLowerCase()).to.be.equal(__dirname.toLowerCase());
+                expect(debugConfig).to.have.property('debugOptions').deep.equal(debugOptionsAvailable);
+            });
+            test('Defaults should be returned when an empty object is passed without Workspace Folder, no workspaces and active file', async () => {
+                const pythonFile = 'xyz.py';
+
+                setupActiveEditor(pythonFile, PythonLanguage.language);
+                setupWorkspaces([]);
+
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, { request: 'attach' } as DebugConfiguration);
+                const filePath = Uri.file(path.dirname('')).fsPath;
+
+                expect(Object.keys(debugConfig!)).to.have.lengthOf.least(3);
+                expect(debugConfig).to.have.property('request', 'attach');
+                expect(debugConfig).to.have.property('localRoot');
+                expect(debugConfig).to.have.property('host', 'localhost');
+                expect(debugConfig!.localRoot!.toLowerCase()).to.be.equal(filePath.toLowerCase());
+                expect(debugConfig).to.have.property('debugOptions').deep.equal(debugOptionsAvailable);
+            });
+            test('Defaults should be returned when an empty object is passed without Workspace Folder, no workspaces and no active file', async () => {
+                setupActiveEditor(undefined, PythonLanguage.language);
+                setupWorkspaces([]);
+
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, { request: 'attach' } as DebugConfiguration);
+
+                expect(Object.keys(debugConfig!)).to.have.lengthOf.least(3);
+                expect(debugConfig).to.have.property('request', 'attach');
+                expect(debugConfig).to.not.have.property('localRoot');
+                expect(debugConfig).to.have.property('host', 'localhost');
+                expect(debugConfig).to.have.property('debugOptions').deep.equal(debugOptionsAvailable);
+            });
+            test('Defaults should be returned when an empty object is passed without Workspace Folder, no workspaces and non python file', async () => {
+                const activeFile = 'xyz.js';
+
+                setupActiveEditor(activeFile, 'javascript');
+                setupWorkspaces([]);
+
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, { request: 'attach' } as DebugConfiguration);
+
+                expect(Object.keys(debugConfig!)).to.have.lengthOf.least(3);
+                expect(debugConfig).to.have.property('request', 'attach');
+                expect(debugConfig).to.not.have.property('localRoot');
+                expect(debugConfig).to.have.property('host', 'localhost');
+                expect(debugConfig).to.have.property('debugOptions').deep.equal(debugOptionsAvailable);
+            });
+            test('Defaults should be returned when an empty object is passed without Workspace Folder, with a workspace and an active python file', async () => {
+                const activeFile = 'xyz.py';
+                setupActiveEditor(activeFile, PythonLanguage.language);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
+
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, { request: 'attach' } as DebugConfiguration);
+                const filePath = Uri.file(defaultWorkspace).fsPath;
+
+                expect(Object.keys(debugConfig!)).to.have.lengthOf.least(3);
+                expect(debugConfig).to.have.property('request', 'attach');
+                expect(debugConfig).to.have.property('localRoot');
+                expect(debugConfig).to.have.property('host', 'localhost');
+                expect(debugConfig!.localRoot!.toLowerCase()).to.be.equal(filePath.toLowerCase());
+                expect(debugConfig).to.have.property('debugOptions').deep.equal(debugOptionsAvailable);
+            });
+            test('Ensure \'localRoot\' is left unaltered', async () => {
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+                setupActiveEditor(activeFile, PythonLanguage.language);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
+
+                const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, request: 'attach' } as any as DebugConfiguration);
+
+                expect(debugConfig).to.have.property('localRoot', localRoot);
+            });
+            test('Ensure \'remoteRoot\' is left unaltered', async () => {
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+                setupActiveEditor(activeFile, PythonLanguage.language);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
+
+                const remoteRoot = `Debug_PythonPath_${new Date().toString()}`;
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { remoteRoot, request: 'attach' } as any as DebugConfiguration);
+
+                expect(debugConfig).to.have.property('remoteRoot', remoteRoot);
+            });
+            test('Ensure \'port\' is left unaltered', async () => {
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+                setupActiveEditor(activeFile, PythonLanguage.language);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
+
+                const port = 12341234;
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { port, request: 'attach' } as any as DebugConfiguration);
+
+                expect(debugConfig).to.have.property('port', port);
+            });
+            test('Ensure \'debugOptions\' are left unaltered', async () => {
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+                setupActiveEditor(activeFile, PythonLanguage.language);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
+
+                const debugOptions = debugOptionsAvailable.slice().concat(DebugOptions.Jinja, DebugOptions.Sudo);
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { debugOptions, request: 'attach' } as any as DebugConfiguration);
+
+                expect(debugConfig).to.have.property('debugOptions').to.be.deep.equal(debugOptions);
+            });
+        });
+    });
+});

--- a/src/test/debugger/misc.test.ts
+++ b/src/test/debugger/misc.test.ts
@@ -3,8 +3,7 @@
 
 // tslint:disable:no-suspicious-comment max-func-body-length no-invalid-this no-var-requires no-require-imports no-any
 
-import { expect, use } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 import * as path from 'path';
 import { ThreadEvent } from 'vscode-debugadapter';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
@@ -21,8 +20,6 @@ import { DEBUGGER_TIMEOUT } from './common/constants';
 import { DebugClientEx } from './debugClient';
 
 const isProcessRunning = require('is-running') as (number) => boolean;
-
-use(chaiAsPromised);
 
 const debugFilesPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonFiles', 'debugging');
 
@@ -446,13 +443,19 @@ let testCounter = 0;
             await debugClient.assertStoppedLocation('exception', pauseLocation);
         });
         test('Test multi-threaded debugging', async function () {
-            this.timeout(20000);
-
+            if (debuggerType !== 'python') {
+                // See GitHub issue #1250
+                this.skip();
+                return;
+            }
             await Promise.all([
                 debugClient.configurationSequence(),
                 debugClient.launch(buildLauncArgs('multiThread.py', false)),
                 debugClient.waitForEvent('initialized')
             ]);
+
+            // Add a delay for debugger to start (sometimes it takes a long time for new debugger to break).
+            await sleep(3000);
             const pythonFile = path.join(debugFilesPath, 'multiThread.py');
             const breakpointLocation = { path: pythonFile, column: 1, line: 11 };
             await debugClient.setBreakpointsRequest({
@@ -461,8 +464,49 @@ let testCounter = 0;
                 source: { path: breakpointLocation.path }
             });
 
-            // hit breakpoint.
             await debugClient.assertStoppedLocation('breakpoint', breakpointLocation);
+            const threads = await debugClient.threadsRequest();
+            expect(threads.body.threads).of.lengthOf(2, 'incorrect number of threads');
+            for (const thread of threads.body.threads) {
+                expect(thread.id).to.be.lessThan(MAX_SIGNED_INT32 + 1, 'ThreadId is not an integer');
+            }
+        });
+        test('Test multi-threaded debugging', async function () {
+            this.timeout(30000);
+            await Promise.all([
+                debugClient.launch(buildLauncArgs('multiThread.py', false)),
+                debugClient.waitForEvent('initialized')
+            ]);
+
+            const pythonFile = path.join(debugFilesPath, 'multiThread.py');
+            const breakpointLocation = { path: pythonFile, column: 1, line: 11 };
+            const breakpointRequestArgs = {
+                lines: [breakpointLocation.line],
+                breakpoints: [{ line: breakpointLocation.line, column: breakpointLocation.column }],
+                source: { path: breakpointLocation.path }
+            };
+
+            function waitForStoppedEventFromTwoThreads() {
+                return new Promise((resolve, reject) => {
+                    let numberOfStops = 0;
+                    debugClient.addListener('stopped', (event: DebugProtocol.StoppedEvent) => {
+                        numberOfStops += 1;
+                        if (numberOfStops < 2) {
+                            return;
+                        }
+                        resolve(event);
+                    });
+                    setTimeout(() => reject(new Error('Timeout waiting for two threads to stop at breakpoint')), DEBUGGER_TIMEOUT);
+                });
+            }
+
+            await Promise.all([
+                debugClient.setBreakpointsRequest(breakpointRequestArgs),
+                debugClient.setExceptionBreakpointsRequest({ filters: [] }),
+                debugClient.configurationDoneRequest(),
+                waitForStoppedEventFromTwoThreads(),
+                debugClient.assertStoppedLocation('breakpoint', breakpointLocation)
+            ]);
 
             const threads = await debugClient.threadsRequest();
             expect(threads.body.threads).of.lengthOf(2, 'incorrect number of threads');

--- a/src/test/debugger/misc.test.ts
+++ b/src/test/debugger/misc.test.ts
@@ -445,7 +445,9 @@ let testCounter = 0;
             const pauseLocation = { path: path.join(debugFilesPath, 'sample3WithEx.py'), line: 5 };
             await debugClient.assertStoppedLocation('exception', pauseLocation);
         });
-        test('Test multi-threaded debugging', async () => {
+        test('Test multi-threaded debugging', async function () {
+            this.timeout(20000);
+
             await Promise.all([
                 debugClient.configurationSequence(),
                 debugClient.launch(buildLauncArgs('multiThread.py', false)),

--- a/src/test/pythonFiles/debugging/multiThread.py
+++ b/src/test/pythonFiles/debugging/multiThread.py
@@ -4,7 +4,7 @@ import time
 
 def bar():
     time.sleep(2)
-    print("abcdef")
+    print('bar')
 
 def foo(x):
     while True:

--- a/src/testMultiRootWkspc/workspace5/remoteDebugger-start-with-ptvsd.py
+++ b/src/testMultiRootWkspc/workspace5/remoteDebugger-start-with-ptvsd.py
@@ -1,0 +1,14 @@
+import sys
+import time
+time.sleep(2)
+sys.stdout.write('this is stdout')
+sys.stdout.flush()
+sys.stderr.write('this is stderr')
+sys.stderr.flush()
+# Give the debugger some time to add a breakpoint.
+time.sleep(5)
+for i in range(1):
+    time.sleep(0.5)
+    pass
+
+print('this is print')

--- a/src/testMultiRootWkspc/workspace5/remoteDebugger-start-with-ptvsd.re-attach.py
+++ b/src/testMultiRootWkspc/workspace5/remoteDebugger-start-with-ptvsd.re-attach.py
@@ -1,0 +1,9 @@
+import sys
+import time
+# Give the debugger some time to add a breakpoint.
+time.sleep(5)
+for i in range(10000):
+    time.sleep(0.5)
+    pass
+
+print('bye')


### PR DESCRIPTION
Fixes #1269

This pull request:
- [ ] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
