### PR TITLE
[Discussion] [VS Live Share] Restrict language services to file/untitled schemes

### DIFF
--- a/src/client/activation/classic.ts
+++ b/src/client/activation/classic.ts
@@ -20,10 +20,8 @@ import { TEST_OUTPUT_CHANNEL } from '../unittests/common/constants';
 import * as tests from '../unittests/main';
 import { IExtensionActivator } from './types';
 
-const PYTHON: DocumentFilter = { language: 'python' };
-
 export class ClassicExtensionActivator implements IExtensionActivator {
-    constructor(private serviceManager: IServiceManager, private pythonSettings: IPythonSettings) {
+    constructor(private serviceManager: IServiceManager, private pythonSettings: IPythonSettings, private documentSelector: DocumentFilter[]) {
     }
 
     public async activate(context: ExtensionContext): Promise<boolean> {
@@ -35,20 +33,20 @@ export class ClassicExtensionActivator implements IExtensionActivator {
         context.subscriptions.push(...activateGoToObjectDefinitionProvider(jediFactory));
 
         context.subscriptions.push(jediFactory);
-        context.subscriptions.push(languages.registerRenameProvider(PYTHON, new PythonRenameProvider(this.serviceManager)));
+        context.subscriptions.push(languages.registerRenameProvider(this.documentSelector, new PythonRenameProvider(this.serviceManager)));
         const definitionProvider = new PythonDefinitionProvider(jediFactory);
 
-        context.subscriptions.push(languages.registerDefinitionProvider(PYTHON, definitionProvider));
-        context.subscriptions.push(languages.registerHoverProvider(PYTHON, new PythonHoverProvider(jediFactory)));
-        context.subscriptions.push(languages.registerReferenceProvider(PYTHON, new PythonReferenceProvider(jediFactory)));
-        context.subscriptions.push(languages.registerCompletionItemProvider(PYTHON, new PythonCompletionItemProvider(jediFactory, this.serviceManager), '.'));
-        context.subscriptions.push(languages.registerCodeLensProvider(PYTHON, this.serviceManager.get<IShebangCodeLensProvider>(IShebangCodeLensProvider)));
+        context.subscriptions.push(languages.registerDefinitionProvider(this.documentSelector, definitionProvider));
+        context.subscriptions.push(languages.registerHoverProvider(this.documentSelector, new PythonHoverProvider(jediFactory)));
+        context.subscriptions.push(languages.registerReferenceProvider(this.documentSelector, new PythonReferenceProvider(jediFactory)));
+        context.subscriptions.push(languages.registerCompletionItemProvider(this.documentSelector, new PythonCompletionItemProvider(jediFactory, this.serviceManager), '.'));
+        context.subscriptions.push(languages.registerCodeLensProvider(this.documentSelector, this.serviceManager.get<IShebangCodeLensProvider>(IShebangCodeLensProvider)));
 
         const symbolProvider = new PythonSymbolProvider(jediFactory);
-        context.subscriptions.push(languages.registerDocumentSymbolProvider(PYTHON, symbolProvider));
+        context.subscriptions.push(languages.registerDocumentSymbolProvider(this.documentSelector, symbolProvider));
 
         if (this.pythonSettings.devOptions.indexOf('DISABLE_SIGNATURE') === -1) {
-            context.subscriptions.push(languages.registerSignatureHelpProvider(PYTHON, new PythonSignatureProvider(jediFactory), '(', ','));
+            context.subscriptions.push(languages.registerSignatureHelpProvider(this.documentSelector, new PythonSignatureProvider(jediFactory), '(', ','));
         }
 
         const unitTestOutChannel = this.serviceManager.get<OutputChannel>(IOutputChannel, TEST_OUTPUT_CHANNEL);

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -60,7 +60,7 @@ const activationDeferred = createDeferred<void>();
 export const activated = activationDeferred.promise;
 
 const PYTHON_LANGUAGE = 'python';
-const PYTHON: DocumentFilter = [
+const PYTHON: DocumentFilter[] = [
     { scheme: 'file', language: PYTHON_LANGUAGE },
     { scheme: 'untitled', language: PYTHON_LANGUAGE }
 ];
@@ -110,7 +110,7 @@ export async function activate(context: ExtensionContext) {
 
     // Enable indentAction
     // tslint:disable-next-line:no-non-null-assertion
-    languages.setLanguageConfiguration(PYTHON_LANGUAGE, {
+    languages.setLanguageConfiguration(PYTHON_LANGUAGE!, {
         onEnterRules: [
             {
                 beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async)\b.*/,

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -58,7 +58,12 @@ import { WorkspaceSymbols } from './workspaceSymbols/main';
 
 const activationDeferred = createDeferred<void>();
 export const activated = activationDeferred.promise;
-const PYTHON: DocumentFilter = { language: 'python' };
+
+const PYTHON_LANGUAGE = 'python';
+const PYTHON: DocumentFilter = [
+    { scheme: 'file', language: PYTHON_LANGUAGE },
+    { scheme: 'untitled', language: PYTHON_LANGUAGE }
+];
 
 // tslint:disable-next-line:max-func-body-length
 export async function activate(context: ExtensionContext) {
@@ -77,7 +82,7 @@ export async function activate(context: ExtensionContext) {
 
     const activator: IExtensionActivator = IS_ANALYSIS_ENGINE_TEST || !pythonSettings.jediEnabled
         ? new AnalysisExtensionActivator(serviceManager, pythonSettings)
-        : new ClassicExtensionActivator(serviceManager, pythonSettings);
+        : new ClassicExtensionActivator(serviceManager, pythonSettings, PYTHON);
 
     await activator.activate(context);
 
@@ -105,7 +110,7 @@ export async function activate(context: ExtensionContext) {
 
     // Enable indentAction
     // tslint:disable-next-line:no-non-null-assertion
-    languages.setLanguageConfiguration(PYTHON.language!, {
+    languages.setLanguageConfiguration(PYTHON_LANGUAGE, {
         onEnterRules: [
             {
                 beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async)\b.*/,


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](aka.ms/vsls) adding support for "guests" to receive remote language services for Python, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Python extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

If someone joins a Python project using Live Share, and doesn't have the Python extension installed, then they will automatically receive language services from the host (which is awesome! 🎉), so this PR is simply an optimization for the case where collaborating developers both have the Python extension installed. Additionally, this wouldn't impact the "local" Python development experience.

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*

// CC @DonJayamanne 