### PR TITLE
Reverted change that ended up considering symlinked interpreters as duplicate interpreter.

### DIFF
--- a/news/2 Fixes/1192.md
+++ b/news/2 Fixes/1192.md
@@ -1,1 +1,1 @@
-Display symlinked interpreters in interpreter list.
+Reverted change that ended up considering symlinked interpreters as duplicate interpreter.

--- a/news/2 Fixes/1192.md
+++ b/news/2 Fixes/1192.md
@@ -1,0 +1,1 @@
+Display symlinked interpreters in interpreter list.

--- a/src/client/interpreter/configuration/interpreterSelector.ts
+++ b/src/client/interpreter/configuration/interpreterSelector.ts
@@ -78,7 +78,7 @@ export class InterpreterSelector implements IInterpreterSelector {
         const result: PythonInterpreter[] = [];
         interpreters.forEach(x => {
             if (result.findIndex(a => a.displayName === x.displayName
-                && a.type === x.type && this.fileSystem.arePathsSame(a.path, x.path)) < 0) {
+                && a.type === x.type && this.fileSystem.arePathsSame(path.dirname(a.path), path.dirname(x.path))) < 0) {
                 result.push(x);
             }
         });

--- a/src/client/interpreter/configuration/interpreterSelector.ts
+++ b/src/client/interpreter/configuration/interpreterSelector.ts
@@ -76,10 +76,9 @@ export class InterpreterSelector implements IInterpreterSelector {
 
     private async removeDuplicates(interpreters: PythonInterpreter[]): Promise<PythonInterpreter[]> {
         const result: PythonInterpreter[] = [];
-        await Promise.all(interpreters.map(async item => item.realPath = await this.fileSystem.getRealPathAsync(item.path)));
         interpreters.forEach(x => {
             if (result.findIndex(a => a.displayName === x.displayName
-                && a.type === x.type && this.fileSystem.arePathsSame(a.realPath!, x.realPath!)) < 0) {
+                && a.type === x.type && this.fileSystem.arePathsSame(a.path, x.path)) < 0) {
                 result.push(x);
             }
         });

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -67,7 +67,6 @@ export type PythonInterpreter = {
     envName?: string;
     envPath?: string;
     cachedEntry?: boolean;
-    realPath?: string;
 };
 
 export type WorkspacePythonPath = {

--- a/src/test/configuration/interpreterSelector.test.ts
+++ b/src/test/configuration/interpreterSelector.test.ts
@@ -15,7 +15,7 @@ import { IServiceContainer } from '../../client/ioc/types';
 class InterpreterQuickPickItem implements IInterpreterQuickPickItem {
     public path: string;
     public label: string;
-    public description: string;
+    public description!: string;
     public detail?: string;
     constructor(l: string, p: string) {
         this.path = p;
@@ -24,7 +24,7 @@ class InterpreterQuickPickItem implements IInterpreterQuickPickItem {
 }
 
 // tslint:disable-next-line:max-func-body-length
-suite('Intepreters - selector', () => {
+suite('Interpreters - selector', () => {
     let serviceContainer: IServiceContainer;
     let workspace: TypeMoq.IMock<IWorkspaceService>;
     let appShell: TypeMoq.IMock<IApplicationShell>;
@@ -65,14 +65,14 @@ suite('Intepreters - selector', () => {
 
     test('Suggestions', async () => {
         const initial: PythonInterpreter[] = [
-            { displayName: '1', path: 'path1', type: InterpreterType.Unknown },
-            { displayName: '2', path: 'path1', type: InterpreterType.Unknown },
-            { displayName: '1', path: 'path1', type: InterpreterType.Unknown },
-            { displayName: '2', path: 'path2', type: InterpreterType.Unknown },
-            { displayName: '2', path: 'path2', type: InterpreterType.Unknown },
-            { displayName: '2 (virtualenv)', path: 'path2', type: InterpreterType.VirtualEnv },
-            { displayName: '3', path: 'path2', type: InterpreterType.Unknown },
-            { displayName: '4', path: 'path4', type: InterpreterType.Conda }
+            { displayName: '1', path: 'c:/path1/path1', type: InterpreterType.Unknown },
+            { displayName: '2', path: 'c:/path1/path1', type: InterpreterType.Unknown },
+            { displayName: '1', path: 'c:/path1/path1', type: InterpreterType.Unknown },
+            { displayName: '2', path: 'c:/path2/path2', type: InterpreterType.Unknown },
+            { displayName: '2', path: 'c:/path2/path2', type: InterpreterType.Unknown },
+            { displayName: '2 (virtualenv)', path: 'c:/path2/path2', type: InterpreterType.VirtualEnv },
+            { displayName: '3', path: 'c:/path2/path2', type: InterpreterType.Unknown },
+            { displayName: '4', path: 'c:/path4/path4', type: InterpreterType.Conda }
         ];
         interpreterService
             .setup(x => x.getInterpreters(TypeMoq.It.isAny()))
@@ -82,12 +82,12 @@ suite('Intepreters - selector', () => {
         const actual = await selector.getSuggestions();
 
         const expected: InterpreterQuickPickItem[] = [
-            new InterpreterQuickPickItem('1', 'path1'),
-            new InterpreterQuickPickItem('2', 'path1'),
-            new InterpreterQuickPickItem('2', 'path2'),
-            new InterpreterQuickPickItem('2 (virtualenv)', 'path2'),
-            new InterpreterQuickPickItem('3', 'path2'),
-            new InterpreterQuickPickItem('4', 'path4')
+            new InterpreterQuickPickItem('1', 'c:/path1/path1'),
+            new InterpreterQuickPickItem('2', 'c:/path1/path1'),
+            new InterpreterQuickPickItem('2', 'c:/path2/path2'),
+            new InterpreterQuickPickItem('2 (virtualenv)', 'c:/path2/path2'),
+            new InterpreterQuickPickItem('3', 'c:/path2/path2'),
+            new InterpreterQuickPickItem('4', 'c:/path4/path4')
         ];
 
         assert.equal(actual.length, expected.length, 'Suggestion lengths are different.');


### PR DESCRIPTION
Fixes #1192

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
