### PR TITLE
Add PYTHONPATH to search paths used by the analysis engine

### DIFF
--- a/src/client/activation/analysis.ts
+++ b/src/client/activation/analysis.ts
@@ -12,6 +12,7 @@ import { IFileSystem, IPlatformService } from '../common/platform/types';
 import { IProcessService } from '../common/process/types';
 import { StopWatch } from '../common/stopWatch';
 import { IConfigurationService, IOutputChannel, IPythonSettings } from '../common/types';
+import { IEnvironmentVariablesProvider } from '../common/variables/types';
 import { IServiceContainer } from '../ioc/types';
 import { AnalysisEngineDownloader } from './downloader';
 import { InterpreterDataService } from './interpreterDataService';
@@ -175,8 +176,12 @@ export class AnalysisExtensionActivator implements IExtensionActivator {
                 searchPaths = `${searchPaths};${extraPaths.join(';')}`;
             }
         }
+
+        const envProvider = this.services.get<IEnvironmentVariablesProvider>(IEnvironmentVariablesProvider);
+        const pythonPath = (await envProvider.getEnvironmentVariables()).PYTHONPATH;
+
         // tslint:disable-next-line:no-string-literal
-        properties['SearchPaths'] = searchPaths;
+        properties['SearchPaths'] = `${searchPaths};${pythonPath ? pythonPath : ''}`;
 
         const selector: string[] = [PYTHON];
 

--- a/src/client/common/variables/types.ts
+++ b/src/client/common/variables/types.ts
@@ -39,5 +39,5 @@ export const IEnvironmentVariablesProvider = Symbol('IEnvironmentVariablesProvid
 
 export interface IEnvironmentVariablesProvider {
     onDidEnvironmentVariablesChange: Event<Uri | undefined>;
-    getEnvironmentVariables(resource?: Uri): Promise<EnvironmentVariables | undefined>;
+    getEnvironmentVariables(resource?: Uri): Promise<EnvironmentVariables>;
 }


### PR DESCRIPTION
Fixes #1327

This pull request:
- [x] Has a title summarizes what is changing
- [ ] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
