### PR TITLE
Set focus to the terminal upon creation of a terminal using the Create Terminal command

### DIFF
--- a/news/1 Enhancements/1315.md
+++ b/news/1 Enhancements/1315.md
@@ -1,0 +1,1 @@
+Set focus to the terminal upon creation of a terminal using the `Python: Create Terminal` command.

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -11,14 +11,14 @@ import { ITerminalHelper, ITerminalService, TerminalShellType } from './types';
 @injectable()
 export class TerminalService implements ITerminalService, Disposable {
     private terminal?: Terminal;
-    private terminalShellType: TerminalShellType;
+    private terminalShellType!: TerminalShellType;
     private terminalClosed = new EventEmitter<void>();
     private terminalManager: ITerminalManager;
     private terminalHelper: ITerminalHelper;
     public get onDidCloseTerminal(): Event<void> {
         return this.terminalClosed.event;
     }
-    constructor( @inject(IServiceContainer) private serviceContainer: IServiceContainer,
+    constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer,
         private resource?: Uri,
         private title: string = 'Python') {
 
@@ -44,11 +44,11 @@ export class TerminalService implements ITerminalService, Disposable {
         this.terminal!.show(true);
         this.terminal!.sendText(text);
     }
-    public async show(): Promise<void> {
-        await this.ensureTerminal();
-        this.terminal!.show(true);
+    public async show(preserveFocus: boolean = true): Promise<void> {
+        await this.ensureTerminal(preserveFocus);
+        this.terminal!.show(preserveFocus);
     }
-    private async ensureTerminal(): Promise<void> {
+    private async ensureTerminal(preserveFocus: boolean = true): Promise<void> {
         if (this.terminal) {
             return;
         }
@@ -62,7 +62,7 @@ export class TerminalService implements ITerminalService, Disposable {
         const activationCommamnds = await this.terminalHelper.getEnvironmentActivationCommands(this.terminalShellType, this.resource);
         if (activationCommamnds) {
             for (const command of activationCommamnds!) {
-                this.terminal!.show(true);
+                this.terminal!.show(preserveFocus);
                 this.terminal!.sendText(command);
 
                 // Give the command some time to complete.
@@ -71,7 +71,7 @@ export class TerminalService implements ITerminalService, Disposable {
             }
         }
 
-        this.terminal!.show(true);
+        this.terminal!.show(preserveFocus);
     }
     private terminalCloseHandler(terminal: Terminal) {
         if (terminal === this.terminal) {

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -3,7 +3,6 @@
 // Licensed under the MIT License.
 
 import { Event, Terminal, Uri } from 'vscode';
-import { PythonInterpreter } from '../../interpreter/contracts';
 
 export enum TerminalShellType {
     powershell = 1,
@@ -19,7 +18,7 @@ export interface ITerminalService {
     readonly onDidCloseTerminal: Event<void>;
     sendCommand(command: string, args: string[]): Promise<void>;
     sendText(text: string): Promise<void>;
-    show(): Promise<void>;
+    show(preserveFocus?: boolean): Promise<void>;
 }
 
 export const ITerminalServiceFactory = Symbol('ITerminalServiceFactory');

--- a/src/client/providers/terminalProvider.ts
+++ b/src/client/providers/terminalProvider.ts
@@ -24,7 +24,7 @@ export class TerminalProvider implements Disposable {
     private async onCreateTerminal() {
         const terminalService = this.serviceContainer.get<ITerminalServiceFactory>(ITerminalServiceFactory);
         const activeResource = this.getActiveResource();
-        await terminalService.createTerminalService(activeResource, 'Python').show();
+        await terminalService.createTerminalService(activeResource, 'Python').show(false);
     }
     private getActiveResource(): Uri | undefined {
         const documentManager = this.serviceContainer.get<IDocumentManager>(IDocumentManager);

--- a/src/test/common/terminals/service.test.ts
+++ b/src/test/common/terminals/service.test.ts
@@ -114,6 +114,18 @@ suite('Terminal Service', () => {
         terminal.verify(t => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.exactly(2));
     });
 
+    test('Ensure terminal shown and focus is set to the Terminal', async () => {
+        terminalHelper.setup(helper => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
+        service = new TerminalService(mockServiceContainer.object);
+        terminalHelper.setup(h => h.getTerminalShellPath()).returns(() => '');
+        terminalHelper.setup(h => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+        terminalManager.setup(t => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+
+        await service.show(false);
+
+        terminal.verify(t => t.show(TypeMoq.It.isValue(false)), TypeMoq.Times.exactly(2));
+    });
+
     test('Ensure terminal is activated once after creation', async () => {
         service = new TerminalService(mockServiceContainer.object);
         terminalHelper.setup(h => h.getTerminalShellPath()).returns(() => '');

--- a/src/test/providers/terminal.test.ts
+++ b/src/test/providers/terminal.test.ts
@@ -68,7 +68,7 @@ suite('Terminal Provider', () => {
         terminalServiceFactory.setup(t => t.createTerminalService(TypeMoq.It.isValue(undefined), TypeMoq.It.isValue('Python'))).returns(() => terminalService.object);
 
         commandHandler!.call(terminalProvider);
-        terminalService.verify(t => t.show(), TypeMoq.Times.once());
+        terminalService.verify(t => t.show(false), TypeMoq.Times.once());
     });
 
     test('Ensure terminal creation does not use uri of the active documents which is untitled', () => {
@@ -94,7 +94,7 @@ suite('Terminal Provider', () => {
         terminalServiceFactory.setup(t => t.createTerminalService(TypeMoq.It.isValue(undefined), TypeMoq.It.isValue('Python'))).returns(() => terminalService.object);
 
         commandHandler!.call(terminalProvider);
-        terminalService.verify(t => t.show(), TypeMoq.Times.once());
+        terminalService.verify(t => t.show(false), TypeMoq.Times.once());
     });
 
     test('Ensure terminal creation uses uri of active document', () => {
@@ -122,7 +122,7 @@ suite('Terminal Provider', () => {
         terminalServiceFactory.setup(t => t.createTerminalService(TypeMoq.It.isValue(documentUri), TypeMoq.It.isValue('Python'))).returns(() => terminalService.object);
 
         commandHandler!.call(terminalProvider);
-        terminalService.verify(t => t.show(), TypeMoq.Times.once());
+        terminalService.verify(t => t.show(false), TypeMoq.Times.once());
     });
 
     test('Ensure terminal creation uses uri of active workspace', () => {
@@ -147,6 +147,6 @@ suite('Terminal Provider', () => {
         terminalServiceFactory.setup(t => t.createTerminalService(TypeMoq.It.isValue(workspaceUri), TypeMoq.It.isValue('Python'))).returns(() => terminalService.object);
 
         commandHandler!.call(terminalProvider);
-        terminalService.verify(t => t.show(), TypeMoq.Times.once());
+        terminalService.verify(t => t.show(false), TypeMoq.Times.once());
     });
 });


### PR DESCRIPTION
Fixes #1315

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
