### PR TITLE
Preserve formatting of operators used in return type annotations

### DIFF
--- a/news/2 Fixes/1442.md
+++ b/news/2 Fixes/1442.md
@@ -1,0 +1,1 @@
+Preserve formatting of `->` in return annotation when the feature format as you type (the setting `editor.formatOnType`) is enabled.

--- a/src/client/language/tokenizer.ts
+++ b/src/client/language/tokenizer.ts
@@ -262,7 +262,6 @@ export class Tokenizer implements ITokenizer {
         const nextChar = this.cs.nextChar;
         switch (this.cs.currentChar) {
             case Char.Plus:
-            case Char.Hyphen:
             case Char.Ampersand:
             case Char.Bar:
             case Char.Caret:
@@ -271,6 +270,9 @@ export class Tokenizer implements ITokenizer {
                 length = nextChar === Char.Equal ? 2 : 1;
                 break;
 
+            case Char.Hyphen:
+                length = nextChar === Char.Greater ? 2 : 1;
+                break;
             case Char.Asterisk:
                 if (nextChar === Char.Asterisk) {
                     length = this.cs.lookAhead(2) === Char.Equal ? 3 : 2;

--- a/src/test/format/extension.lineFormatter.test.ts
+++ b/src/test/format/extension.lineFormatter.test.ts
@@ -85,4 +85,20 @@ suite('Formatting - line formatter', () => {
         const actual = formatter.formatLine('foo( *a, ** b, ! c)');
         assert.equal(actual, 'foo(*a, **b, !c)');
     });
+    test('Negative Operator', () => {
+        const actual = formatter.formatLine('return 1-2');
+        assert.equal(actual, 'return 1 - 2');
+    });
+    test('Negative Operator as args', () => {
+        const actual = formatter.formatLine('foo(1-2)');
+        assert.equal(actual, 'foo(1 - 2)');
+    });
+    test('Return annotation', () => {
+        const actual = formatter.formatLine('def foo(a: int) -> bool:');
+        assert.equal(actual, 'def foo(a: int) -> bool:');
+    });
+    test('Return annotation (and some parts are formatted)', () => {
+        const actual = formatter.formatLine('def foo(a:int)->bool:');
+        assert.equal(actual, 'def foo(a: int) -> bool:');
+    });
 });


### PR DESCRIPTION
Fixes #1442

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
