### PR TITLE
Change using pserve-script.py instead of pserve.exe

### DIFF
--- a/src/client/debugger/configProviders/baseProvider.ts
+++ b/src/client/debugger/configProviders/baseProvider.ts
@@ -86,7 +86,7 @@ export abstract class BaseConfigurationProvider<L extends BaseLaunchRequestArgum
         if (debugConfiguration.debugOptions.indexOf(DebugOptions.Pyramid) >= 0) {
             const platformService = this.serviceContainer.get<IPlatformService>(IPlatformService);
             const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
-            const pserve = platformService.isWindows ? 'pserve.exe' : 'pserve';
+            const pserve = platformService.isWindows ? 'pserve-script.py' : 'pserve';
             if (fs.fileExistsSync(debugConfiguration.pythonPath)) {
                 debugConfiguration.program = path.join(path.dirname(debugConfiguration.pythonPath), pserve);
             } else {

--- a/src/test/debugger/configProvider/provider.test.ts
+++ b/src/test/debugger/configProvider/provider.test.ts
@@ -298,7 +298,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
         async function testPyramidConfiguration(isWindows: boolean, isLinux: boolean, isMac: boolean, addPyramidDebugOption: boolean = true, pythonPathExists = true, shouldWork = true) {
             const workspacePath = path.join('usr', 'development', 'wksp1');
             const pythonPath = path.join(workspacePath, 'env', 'bin', 'python');
-            const pserveExecutableName = isWindows ? 'pserve.exe' : 'pserve';
+            const pserveExecutableName = isWindows ? 'pserve-script.py' : 'pserve';
             const pservePath = pythonPathExists ? path.join(path.dirname(pythonPath), pserveExecutableName) : pserveExecutableName;
             const workspaceFolder = createMoqWorkspaceFolder(workspacePath);
             const pythonFile = 'xyz.py';


### PR DESCRIPTION
Fix #737

Fixes #

This pull request:
- [ ] Has a title summarizes what is changing
- [ ] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
