### PR TITLE
Check if python executable is valid before attempting to start the language server

### DIFF
--- a/news/2 Fixes/1487.md
+++ b/news/2 Fixes/1487.md
@@ -1,0 +1,1 @@
+Check whether the selected python interpreter is valid before starting the language server. Failing to do so could result in the extension failing to load.

--- a/src/client/providers/jediProxy.ts
+++ b/src/client/providers/jediProxy.ts
@@ -309,7 +309,7 @@ export class JediProxy implements Disposable {
         }
         this.languageServerStarted = createDeferred<void>();
         const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(Uri.file(this.workspacePath));
-        // Check if the python path is valid
+        // Check if the python path is valid.
         if ((await pythonProcess.getExecutablePath().catch(() => '')).length === 0) {
             return;
         }

--- a/src/client/providers/jediProxy.ts
+++ b/src/client/providers/jediProxy.ts
@@ -305,10 +305,14 @@ export class JediProxy implements Disposable {
     // tslint:disable-next-line:max-func-body-length
     private async spawnProcess(cwd: string) {
         if (this.languageServerStarted && !this.languageServerStarted.completed) {
-            this.languageServerStarted.reject();
+            this.languageServerStarted.reject(new Error('Language Server not started.'));
         }
         this.languageServerStarted = createDeferred<void>();
         const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(Uri.file(this.workspacePath));
+        // Check if the python path is valid
+        if ((await pythonProcess.getExecutablePath().catch(() => '')).length === 0) {
+            return;
+        }
         const args = ['completion.py'];
         if (typeof this.pythonSettings.jediPath === 'string' && this.pythonSettings.jediPath.length > 0) {
             args.push('custom');
@@ -638,14 +642,14 @@ export class JediProxy implements Disposable {
         // Add support for paths relative to workspace.
         const extraPaths = this.pythonSettings.autoComplete ?
             this.pythonSettings.autoComplete.extraPaths.map(extraPath => {
-            if (path.isAbsolute(extraPath)) {
-                return extraPath;
-            }
-            if (typeof this.workspacePath !== 'string') {
-                return '';
-            }
-            return path.join(this.workspacePath, extraPath);
-        }) : [];
+                if (path.isAbsolute(extraPath)) {
+                    return extraPath;
+                }
+                if (typeof this.workspacePath !== 'string') {
+                    return '';
+                }
+                return path.join(this.workspacePath, extraPath);
+            }) : [];
 
         // Always add workspace path into extra paths.
         if (typeof this.workspacePath === 'string') {


### PR DESCRIPTION
Fixes #1487

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
