### PR TITLE
Clicking 'Run Test' code lens for a test class should not run all tests in the file

### DIFF
--- a/news/2 Fixes/1472.md
+++ b/news/2 Fixes/1472.md
@@ -1,0 +1,1 @@
+Clicking the codelens `Run Test` on a test class should run that specific test class instead of all tests in the file.

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -9,7 +9,7 @@ type UnitTestParserOptions = TestDiscoveryOptions & { startDirectory: string };
 
 @injectable()
 export class TestsParser implements ITestsParser {
-    constructor( @inject(ITestsHelper) private testsHelper: ITestsHelper) { }
+    constructor(@inject(ITestsHelper) private testsHelper: ITestsHelper) { }
     public parse(content: string, options: UnitTestParserOptions): Tests {
         const testIds = this.getTestIds(content);
         let testsDirectory = options.cwd;
@@ -83,7 +83,7 @@ export class TestsParser implements ITestsParser {
                 suites: [] as TestSuite[],
                 isUnitTest: true,
                 isInstance: false,
-                nameToRun: classNameToRun,
+                nameToRun: `${path.parse(filePath).name}.${classNameToRun}`,
                 xmlName: '',
                 status: TestStatus.Idle,
                 time: 0


### PR DESCRIPTION
Fixes #1472
Note: I've created an issue to create **live** unit tests to test this scenario #1495)

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
