### PR TITLE
Add conditional clauses for the keyboard shortcut of the command python.execSelectionInTerminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,12 +241,12 @@
                 {
                     "command": "python.execSelectionInTerminal",
                     "group": "Python",
-                    "when": "editorTextFocus & editorHasSelection && editorLangId == python"
+                    "when": "editorHasSelection && editorLangId == python"
                 },
                 {
                     "command": "python.execSelectionInDjangoShell",
                     "group": "Python",
-                    "when": "editorTextFocus & editorHasSelection && editorLangId == python && python.isDjangoProject"
+                    "when": "editorHasSelection && editorLangId == python && python.isDjangoProject"
                 },
                 {
                     "when": "resourceLangId == python",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
         "keybindings":[
             {
                 "command": "python.execSelectionInTerminal",
-                "key": "ctrl+enter"
+                "key": "ctrl+enter",
+                "when": "editorTextFocus & editorHasSelection && editorLangId == python"    
             }
         ],
         "commands": [
@@ -240,12 +241,12 @@
                 {
                     "command": "python.execSelectionInTerminal",
                     "group": "Python",
-                    "when": "editorHasSelection && editorLangId == python"
+                    "when": "editorTextFocus & editorHasSelection && editorLangId == python"
                 },
                 {
                     "command": "python.execSelectionInDjangoShell",
                     "group": "Python",
-                    "when": "editorHasSelection && editorLangId == python && python.isDjangoProject"
+                    "when": "editorTextFocus & editorHasSelection && editorLangId == python && python.isDjangoProject"
                 },
                 {
                     "when": "resourceLangId == python",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
             {
                 "command": "python.execSelectionInTerminal",
                 "key": "ctrl+enter",
-                "when": "editorTextFocus & editorHasSelection && editorLangId == python"    
+                "when": "editorFocus && editorHasSelection && editorLangId == python"    
             }
         ],
         "commands": [


### PR DESCRIPTION
Fixes #1493

This pull request:
- [x] Has a title summarizes what is changing
- [n/a] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [n/a] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [n/a] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
