### PR TITLE
Enable jinja template debugging when debugging pyramid apps

### DIFF
--- a/news/1 Enhancements/1492.md
+++ b/news/1 Enhancements/1492.md
@@ -1,0 +1,1 @@
+Enable Jinja template debugging as a default behavior when debugging Pyramid applications.

--- a/package.json
+++ b/package.json
@@ -871,7 +871,8 @@
                             "args": [
                                 "^\"\\${workspaceFolder}/development.ini\""
                             ],
-                            "pyramid": true
+                            "pyramid": true,
+                            "jinja": true
                         }
                     },
                     {

--- a/src/client/debugger/configProviders/pythonV2Provider.ts
+++ b/src/client/debugger/configProviders/pythonV2Provider.ts
@@ -37,7 +37,8 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
         if (this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows) {
             this.debugOption(debugOptions, DebugOptions.FixFilePathCase);
         }
-        if (debugConfiguration.module && debugConfiguration.module.toUpperCase() === 'FLASK'
+        const isFlask = debugConfiguration.module && debugConfiguration.module.toUpperCase() === 'FLASK';
+        if ((debugConfiguration.pyramid || isFlask)
             && debugOptions.indexOf(DebugOptions.Jinja) === -1
             && debugConfiguration.jinja !== false) {
             this.debugOption(debugOptions, DebugOptions.Jinja);
@@ -57,6 +58,11 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
             this.debugOption(debugOptions, DebugOptions.Django);
         }
         if (debugConfiguration.jinja) {
+            this.debugOption(debugOptions, DebugOptions.Jinja);
+        }
+        if (debugConfiguration.pyramid
+            && debugOptions.indexOf(DebugOptions.Jinja) === -1
+            && debugConfiguration.jinja !== false) {
             this.debugOption(debugOptions, DebugOptions.Jinja);
         }
         if (debugConfiguration.redirectOutput || debugConfiguration.redirectOutput === undefined) {

--- a/src/test/debugger/configProvider/provider.test.ts
+++ b/src/test/debugger/configProvider/provider.test.ts
@@ -323,7 +323,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
             setupIoc(pythonPath, isWindows, isMac, isLinux);
             setupActiveEditor(pythonFile, PythonLanguage.language);
 
-            const execOutput = pyramidExists ? Promise.resolve({ stdout: pyramidFilePath }) : Promise.reject(new Error('No Module'));
+            const execOutput = pyramidExists ? Promise.resolve({ stdout: pyramidFilePath }) : Promise.reject('No Module');
             pythonExecutionService.setup(e => e.exec(TypeMoq.It.isValue(args), TypeMoq.It.isAny()))
                 .returns(() => execOutput)
                 .verifiable(TypeMoq.Times.exactly(addPyramidDebugOption ? 1 : 0));
@@ -337,13 +337,18 @@ import { IServiceContainer } from '../../../client/ioc/types';
             const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, options as any as DebugConfiguration);
             if (shouldWork) {
                 expect(debugConfig).to.have.property('program', pserveFilePath);
+
+                if (provider.debugType === 'pythonExperimental') {
+                    expect(debugConfig).to.have.property('debugOptions');
+                    expect((debugConfig as any).debugOptions).contains(DebugOptions.Jinja);
+                }
             } else {
                 expect(debugConfig!.program).to.be.not.equal(pserveFilePath);
             }
             pythonExecutionService.verifyAll();
             fileSystem.verifyAll();
             appShell.verifyAll();
-    }
+        }
         test('Program is set for Pyramid (windows)', async () => {
             await testPyramidConfiguration(true, false, false);
         });


### PR DESCRIPTION
Fixes #1492

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
