### PR TITLE
News entry for jinja template debugging in the experimental debugger

### DIFF
--- a/news/1 Enhancements/1206.md
+++ b/news/1 Enhancements/1206.md
@@ -1,0 +1,7 @@
+Enable debugging of Jinja templates in the experimental debugger.
+This is made possible with the addition of the `jinja` setting in the `launch.json` file as follows:
+```json
+    "request": "launch or attach",
+    ...
+    "jinja": true
+```


### PR DESCRIPTION
Fixes #1206

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [n/a] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [n/a] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
