### PR TITLE
Ensure Flask application is launched with multi-threading disabled in CI tests

### DIFF
--- a/news/2 Fixes/1535.md
+++ b/news/2 Fixes/1535.md
@@ -1,1 +1,1 @@
-Ensure Flask application is launched with multi-threading disabled, when run in unit tests.
+Ensure Flask application is launched with multi-threading disabled, when run in the CI tests.

--- a/news/2 Fixes/1535.md
+++ b/news/2 Fixes/1535.md
@@ -1,0 +1,1 @@
+Ensure Flask application is launched with multi-threading disabled, when run in unit tests.

--- a/src/test/debugger/web.framework.test.ts
+++ b/src/test/debugger/web.framework.test.ts
@@ -69,6 +69,7 @@ suite(`Django and Flask Debugging: ${debuggerType}`, () => {
             'run',
             '--no-debugger',
             '--no-reload',
+            '--without-threads',
             '--port',
             `${port}`
         ];


### PR DESCRIPTION
Fixes #1535

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
