### PR TITLE
Create and pass environment object to the jedi.Script API

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -33,6 +33,7 @@ class JediCompletion(object):
 
     def __init__(self):
         self.default_sys_path = sys.path
+        self.environment = jedi.api.environment.Environment(sys.prefix, sys.executable)
         self._input = io.open(sys.stdin.fileno(), encoding='utf-8')
         if (os.path.sep == '/') and (platform.uname()[2].find('Microsoft') > -1):
             # WSL; does not support UNC paths
@@ -563,11 +564,10 @@ class JediCompletion(object):
                     all_scopes=True),
                 request['id'])
 
-        environment = jedi.api.environment.Environment(sys.prefix, sys.executable)
         script = jedi.Script(
             source=request.get('source', None), line=request['line'] + 1,
             column=request['column'], path=request.get('path', ''),
-            sys_path=sys.path, environment=environment)
+            sys_path=sys.path, environment=self.environment)
 
         if lookup == 'definitions':
             defs = []

--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -150,7 +150,7 @@ class JediCompletion(object):
             except Exception:
                 sig["docstring"] = ''
                 sig["raw_docstring"] = ''
-                
+
             sig["name"] = signature.name
             sig["paramindex"] = signature.index
             sig["bracketstart"].append(signature.index)
@@ -199,7 +199,7 @@ class JediCompletion(object):
             }
             _completion['description'] = ''
             _completion['raw_docstring'] = ''
-            
+
             # we pass 'text' here only for fuzzy matcher
             if value:
                 _completion['snippet'] = '%s=${1:%s}$0' % (name, value)
@@ -223,7 +223,7 @@ class JediCompletion(object):
                     'type': self._get_definition_type(completion),
                     'raw_type': completion.type,
                     'rightLabel': self._additional_info(completion)
-                }                
+                }
             except Exception:
                 continue
 
@@ -231,7 +231,7 @@ class JediCompletion(object):
                 if c['text'] == _completion['text']:
                     c['type'] = _completion['type']
                     c['raw_type'] = _completion['raw_type']
-                               
+
             if any([c['text'].split('=')[0] == _completion['text']
                     for c in _completions]):
                 # ignore function arguments we already have
@@ -361,7 +361,7 @@ class JediCompletion(object):
                     definition = self._top_definition(definition)
                 definitionRange = {
                     'start_line': 0,
-                    'start_column': 0, 
+                    'start_column': 0,
                     'end_line': 0,
                     'end_column': 0
                 }
@@ -377,7 +377,7 @@ class JediCompletion(object):
                     container = parent.name if parent.type != 'module' else ''
                 except Exception:
                     container = ''
-                
+
                 try:
                     docstring = definition.docstring()
                     rawdocstring = definition.docstring(raw=True)
@@ -424,7 +424,7 @@ class JediCompletion(object):
                         container = parent.name if parent.type != 'module' else ''
                     except Exception:
                         container = ''
-                
+
                     try:
                         docstring = definition.docstring()
                         rawdocstring = definition.docstring(raw=True)
@@ -474,7 +474,7 @@ class JediCompletion(object):
                 'type': self._get_definition_type(definition),
                 'text': definition.name,
                 'description': description,
-                'docstring': description, 
+                'docstring': description,
                 'signature': signature
             }
             _definitions.append(_definition)
@@ -563,11 +563,12 @@ class JediCompletion(object):
                     all_scopes=True),
                 request['id'])
 
+        environment = jedi.api.environment.Environment(sys.prefix, sys.executable)
         script = jedi.Script(
             source=request.get('source', None), line=request['line'] + 1,
             column=request['column'], path=request.get('path', ''),
-            sys_path=sys.path)
-        
+            sys_path=sys.path, environment=environment)
+
         if lookup == 'definitions':
             defs = []
             try:
@@ -625,7 +626,7 @@ class JediCompletion(object):
             try:
                 rq = self._input.readline()
                 if len(rq) == 0:
-                    # Reached EOF - indication our parent process is gone. 
+                    # Reached EOF - indication our parent process is gone.
                     sys.stderr.write('Received EOF from the standard input,exiting' + '\n')
                     sys.stderr.flush()
                     return


### PR DESCRIPTION
Fixes #1532

No news entry as this issue resolves a bug in the latest version of Jedi included in this current release of VSC.

This pull request:
- [x] Has a title summarizes what is changing
- [n/a] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
