### PR TITLE
Create a new API to retrieve interpreter details with the ability to cache the details

### DIFF
--- a/news/3 Code Health/1569.md
+++ b/news/3 Code Health/1569.md
@@ -1,0 +1,1 @@
+Create a new API to retrieve interpreter details with the ability to cache the details.

--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import json
+import sys
+
+obj = {}
+obj["versionInfo"] = sys.version_info[:4]
+obj["sysPrefix"] = sys.prefix
+obj["version"] = sys.version
+obj["is64Bit"] = sys.maxsize > 2**32
+
+print(json.dumps(obj))

--- a/src/client/activation/interpreterDataService.ts
+++ b/src/client/activation/interpreterDataService.ts
@@ -33,7 +33,7 @@ export class InterpreterDataService {
 
   public async getInterpreterData(resource?: Uri): Promise<InterpreterData | undefined> {
     const executionFactory = this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
-    const execService = await executionFactory.create(resource);
+    const execService = await executionFactory.create({ resource });
 
     const interpreterPath = await execService.getExecutablePath();
     if (interpreterPath.length === 0) {

--- a/src/client/common/installer/channelManager.ts
+++ b/src/client/common/installer/channelManager.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { QuickPickItem, Uri } from 'vscode';
+import { Uri } from 'vscode';
 import { IInterpreterService, InterpreterType } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { IApplicationShell } from '../application/types';
@@ -34,9 +34,9 @@ export class InstallationChannelManager implements IInstallationChannelManager {
                 label: `Install using ${installer.displayName}`,
                 description: '',
                 installer
-            } as QuickPickItem & { installer: IModuleInstaller };
+            };
         });
-        const selection = await appShell.showQuickPick(options, { matchOnDescription: true, matchOnDetail: true, placeHolder });
+        const selection = await appShell.showQuickPick<typeof options[0]>(options, { matchOnDescription: true, matchOnDetail: true, placeHolder });
         return selection ? selection.installer : undefined;
     }
 

--- a/src/client/common/installer/pipInstaller.ts
+++ b/src/client/common/installer/pipInstaller.ts
@@ -38,7 +38,7 @@ export class PipInstaller extends ModuleInstaller implements IModuleInstaller {
     }
     private isPipAvailable(resource?: Uri): Promise<boolean> {
         const pythonExecutionFactory = this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
-        return pythonExecutionFactory.create(resource)
+        return pythonExecutionFactory.create({ resource })
             .then(proc => proc.isModuleInstalled('pip'))
             .catch(() => false);
     }

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -74,7 +74,7 @@ abstract class BaseInstaller {
 
         const isModule = typeof moduleName === 'string' && moduleName.length > 0 && path.basename(executableName) === executableName;
         if (isModule) {
-            const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(resource);
+            const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource });
             return pythonProcess.isModuleInstalled(executableName);
         } else {
             const process = await this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory).create(resource);

--- a/src/client/common/persistentState.ts
+++ b/src/client/common/persistentState.ts
@@ -8,25 +8,38 @@ import { Memento } from 'vscode';
 import { GLOBAL_MEMENTO, IMemento, IPersistentState, IPersistentStateFactory, WORKSPACE_MEMENTO } from './types';
 
 class PersistentState<T> implements IPersistentState<T>{
-    constructor(private storage: Memento, private key: string, private defaultValue: T) { }
+    constructor(private storage: Memento, private key: string, private defaultValue?: T, private expiryDurationMs?: number) { }
 
     public get value(): T {
-        return this.storage.get<T>(this.key, this.defaultValue);
+        if (this.expiryDurationMs) {
+            const cachedData = this.storage.get<{ data?: T; expiry?: number }>(this.key, { data: this.defaultValue! });
+            if (!cachedData || !cachedData.expiry || cachedData.expiry < Date.now()) {
+                return this.defaultValue!;
+            } else {
+                return cachedData.data!;
+            }
+        } else {
+            return this.storage.get<T>(this.key, this.defaultValue!);
+        }
     }
 
     public async updateValue(newValue: T): Promise<void> {
-        await this.storage.update(this.key, newValue);
+        if (this.expiryDurationMs) {
+            await this.storage.update(this.key, { data: newValue, expiry: Date.now() + this.expiryDurationMs });
+        } else {
+            await this.storage.update(this.key, newValue);
+        }
     }
 }
 
 @injectable()
 export class PersistentStateFactory implements IPersistentStateFactory {
-    constructor( @inject(IMemento) @named(GLOBAL_MEMENTO) private globalState: Memento,
+    constructor(@inject(IMemento) @named(GLOBAL_MEMENTO) private globalState: Memento,
         @inject(IMemento) @named(WORKSPACE_MEMENTO) private workspaceState: Memento) { }
-    public createGlobalPersistentState<T>(key: string, defaultValue: T): IPersistentState<T> {
-        return new PersistentState<T>(this.globalState, key, defaultValue);
+    public createGlobalPersistentState<T>(key: string, defaultValue?: T, expiryDurationMs?: number): IPersistentState<T> {
+        return new PersistentState<T>(this.globalState, key, defaultValue, expiryDurationMs);
     }
-    public createWorkspacePersistentState<T>(key: string, defaultValue: T): IPersistentState<T> {
-        return new PersistentState<T>(this.workspaceState, key, defaultValue);
+    public createWorkspacePersistentState<T>(key: string, defaultValue?: T, expiryDurationMs?: number): IPersistentState<T> {
+        return new PersistentState<T>(this.workspaceState, key, defaultValue, expiryDurationMs);
     }
 }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 
+import { createHash } from 'crypto';
 import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
@@ -116,5 +117,17 @@ export class FileSystem implements IFileSystem {
         const deferred = createDeferred<void>();
         fs.unlink(filename, err => err ? deferred.reject(err) : deferred.resolve());
         return deferred.promise;
+    }
+    public getFileHash(filePath: string): Promise<string | undefined> {
+        return new Promise<string | undefined>(resolve => {
+            fs.lstat(filePath, (err, stats) => {
+                if (err) {
+                    resolve();
+                } else {
+                    const actual = createHash('sha512').update(`${stats.ctimeMs}-${stats.mtimeMs}`).digest('hex');
+                    resolve(actual);
+                }
+            });
+        });
     }
 }

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -46,4 +46,5 @@ export interface IFileSystem {
     getRealPath(path: string): Promise<string>;
     copyFile(src: string, dest: string): Promise<void>;
     deleteFile(filename: string): Promise<void>;
+    getFileHash(filePath: string): Promise<string | undefined>;
 }

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -4,17 +4,21 @@
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { IServiceContainer } from '../../ioc/types';
+import { IConfigurationService } from '../types';
 import { PythonExecutionService } from './pythonProcess';
-import { IProcessServiceFactory, IPythonExecutionFactory, IPythonExecutionService } from './types';
+import { ExecutionFactoryCreationOptions, IProcessServiceFactory, IPythonExecutionFactory, IPythonExecutionService } from './types';
 
 @injectable()
 export class PythonExecutionFactory implements IPythonExecutionFactory {
+    private readonly configService: IConfigurationService;
     private processServiceFactory: IProcessServiceFactory;
     constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
         this.processServiceFactory = serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
     }
-    public async create(resource?: Uri): Promise<IPythonExecutionService> {
-        const processService = await this.processServiceFactory.create(resource);
-        return new PythonExecutionService(this.serviceContainer, processService, resource);
+    public async create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService> {
+        const pythonPath = options.pythonPath ? options.pythonPath : this.configService.getSettings(options.resource).pythonPath;
+        const processService = await this.processServiceFactory.create(options.resource);
+        return new PythonExecutionService(this.serviceContainer, processService, pythonPath);
     }
 }

--- a/src/client/common/process/pythonToolService.ts
+++ b/src/client/common/process/pythonToolService.ts
@@ -15,7 +15,7 @@ export class PythonToolExecutionService implements IPythonToolExecutionService {
             throw new Error('Environment variables are not supported');
         }
         if (executionInfo.moduleName && executionInfo.moduleName.length > 0) {
-            const pythonExecutionService = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(resource);
+            const pythonExecutionService = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource });
             return pythonExecutionService.execModuleObservable(executionInfo.moduleName, executionInfo.args, options);
         } else {
             const processService = await this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory).create(resource);
@@ -27,7 +27,7 @@ export class PythonToolExecutionService implements IPythonToolExecutionService {
             throw new Error('Environment variables are not supported');
         }
         if (executionInfo.moduleName && executionInfo.moduleName.length > 0) {
-            const pythonExecutionService = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(resource);
+            const pythonExecutionService = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource });
             return pythonExecutionService.execModule(executionInfo.moduleName!, executionInfo.args, options);
         } else {
             const processService = await this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory).create(resource);

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -4,6 +4,7 @@
 import { ChildProcess, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
 import { Observable } from 'rxjs/Observable';
 import { CancellationToken, Uri } from 'vscode';
+import { Architecture } from '../platform/types';
 import { ExecutionInfo } from '../types';
 import { EnvironmentVariables } from '../variables/types';
 
@@ -46,14 +47,28 @@ export interface IProcessServiceFactory {
 }
 
 export const IPythonExecutionFactory = Symbol('IPythonExecutionFactory');
-
+export type ExecutionFactoryCreationOptions = {
+    resource?: Uri;
+    pythonPath?: string;
+};
 export interface IPythonExecutionFactory {
-    create(resource?: Uri): Promise<IPythonExecutionService>;
+    create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService>;
 }
-
+export type ReleaseLevel = 'alpha' | 'beta' | 'candidate' | 'final';
+// tslint:disable-next-line:interface-name
+export type PythonVersionInfo = [number, number, number, ReleaseLevel];
+export type InterpreterInfomation = {
+    path: string;
+    version: string;
+    sysVersion: string;
+    architecture: Architecture;
+    version_info: PythonVersionInfo;
+    sysPrefix: string;
+};
 export const IPythonExecutionService = Symbol('IPythonExecutionService');
 
 export interface IPythonExecutionService {
+    getInterpreterInformation(): Promise<InterpreterInfomation | undefined>;
     getExecutablePath(): Promise<string>;
     isModuleInstalled(moduleName: string): Promise<boolean>;
 

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -23,8 +23,8 @@ export interface IPersistentState<T> {
 export const IPersistentStateFactory = Symbol('IPersistentStateFactory');
 
 export interface IPersistentStateFactory {
-    createGlobalPersistentState<T>(key: string, defaultValue: T): IPersistentState<T>;
-    createWorkspacePersistentState<T>(key: string, defaultValue: T): IPersistentState<T>;
+    createGlobalPersistentState<T>(key: string, defaultValue?: T, expiryDurationMs?: number): IPersistentState<T>;
+    createWorkspacePersistentState<T>(key: string, defaultValue?: T, expiryDurationMs?: number): IPersistentState<T>;
 }
 
 export type ExecutionInfo = {

--- a/src/client/debugger/configProviders/configurationProviderUtils.ts
+++ b/src/client/debugger/configProviders/configurationProviderUtils.ts
@@ -24,7 +24,7 @@ export class ConfigurationProviderUtils implements IConfigurationProviderUtils {
     }
     public async getPyramidStartupScriptFilePath(resource?: Uri): Promise<string | undefined> {
         try {
-            const executionService = await this.executionFactory.create(resource);
+            const executionService = await this.executionFactory.create({ resource });
             const output = await executionService.exec(['-c', 'import pyramid;print(pyramid.__file__)'], { throwOnStdErr: true });
             const pserveFilePath = path.join(path.dirname(output.stdout.trim()), 'scripts', PSERVE_SCRIPT_FILE_NAME);
             return await this.fs.fileExists(pserveFilePath) ? pserveFilePath : undefined;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -1,5 +1,5 @@
 import { CodeLensProvider, ConfigurationTarget, Disposable, Event, TextDocument, Uri } from 'vscode';
-import { Architecture } from '../common/platform/types';
+import { InterpreterInfomation } from '../common/process/types';
 
 export const INTERPRETER_LOCATOR_SERVICE = 'IInterpreterLocatorService';
 export const WINDOWS_REGISTRY_SERVICE = 'WindowsRegistryService';
@@ -10,7 +10,6 @@ export const KNOWN_PATH_SERVICE = 'KnownPathsService';
 export const GLOBAL_VIRTUAL_ENV_SERVICE = 'VirtualEnvService';
 export const WORKSPACE_VIRTUAL_ENV_SERVICE = 'WorkspaceVirtualEnvService';
 export const PIPENV_SERVICE = 'PipEnvService';
-
 export const IInterpreterVersionService = Symbol('IInterpreterVersionService');
 export interface IInterpreterVersionService {
     getVersion(pythonPath: string, defaultValue: string): Promise<string>;
@@ -54,15 +53,14 @@ export interface ICondaService {
 export enum InterpreterType {
     Unknown = 1,
     Conda = 2,
-    VirtualEnv = 4
+    VirtualEnv = 4,
+    PipEnv = 8,
+    Pyenv = 16,
+    Venv = 32
 }
-
-export type PythonInterpreter = {
-    path: string;
+export type PythonInterpreter = InterpreterInfomation & {
     companyDisplayName?: string;
     displayName?: string;
-    version?: string;
-    architecture?: Architecture;
     type: InterpreterType;
     envName?: string;
     envPath?: string;
@@ -80,6 +78,7 @@ export interface IInterpreterService {
     getInterpreters(resource?: Uri): Promise<PythonInterpreter[]>;
     autoSetInterpreter(): Promise<void>;
     getActiveInterpreter(resource?: Uri): Promise<PythonInterpreter | undefined>;
+    getInterpreterDetails(pythonPath: string): Promise<Partial<PythonInterpreter>>;
     refresh(): Promise<void>;
     initialize(): void;
 }
@@ -97,4 +96,10 @@ export interface IShebangCodeLensProvider extends CodeLensProvider {
 export const IInterpreterHelper = Symbol('IInterpreterHelper');
 export interface IInterpreterHelper {
     getActiveWorkspaceUri(): WorkspacePythonPath | undefined;
+    getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonInterpreter>>;
+}
+
+export const IPipEnvService = Symbol('IPipEnvService');
+export interface IPipEnvService {
+    isRelatedPipEnvironment(dir: string, pythonPath: string): Promise<boolean>;
 }

--- a/src/client/interpreter/locators/index.ts
+++ b/src/client/interpreter/locators/index.ts
@@ -49,6 +49,8 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
 
         // tslint:disable-next-line:underscore-consistent-invocation
         return _.flatten(listOfInterpreters)
+            .filter(item => !!item)
+            .map(item => item!)
             .map(fixInterpreterDisplayName)
             .map(item => { item.path = path.normalize(item.path); return item; })
             .reduce<PythonInterpreter[]>((accumulator, current) => {

--- a/src/client/interpreter/locators/index.ts
+++ b/src/client/interpreter/locators/index.ts
@@ -70,6 +70,9 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
     private getLocators(): IInterpreterLocatorService[] {
         const locators: IInterpreterLocatorService[] = [];
         // The order of the services is important.
+        // The order is important because the data sources at the bottom of the list do not contain all,
+        //  the information about the interpreters (e.g. type, environment name, etc).
+        // This way, the items returned from the top of the list will win, when we combine the items returned.
         if (this.platform.isWindows) {
             locators.push(this.serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, WINDOWS_REGISTRY_SERVICE));
         }

--- a/src/client/interpreter/locators/services/KnownPathsService.ts
+++ b/src/client/interpreter/locators/services/KnownPathsService.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { fsExistsAsync, IS_WINDOWS } from '../../../common/utils';
 import { IServiceContainer } from '../../../ioc/types';
-import { IInterpreterVersionService, IKnownSearchPathsForInterpreters, InterpreterType, PythonInterpreter } from '../../contracts';
+import { IInterpreterHelper, IKnownSearchPathsForInterpreters, InterpreterType, PythonInterpreter } from '../../contracts';
 import { lookForInterpretersInDirectory } from '../helpers';
 import { CacheableLocatorService } from './cacheableLocatorService';
 
@@ -13,8 +13,8 @@ const untildify = require('untildify');
 
 @injectable()
 export class KnownPathsService extends CacheableLocatorService {
-    public constructor( @inject(IKnownSearchPathsForInterpreters) private knownSearchPaths: string[],
-        @inject(IInterpreterVersionService) private versionProvider: IInterpreterVersionService,
+    public constructor(@inject(IKnownSearchPathsForInterpreters) private knownSearchPaths: string[],
+        @inject(IInterpreterHelper) private helper: IInterpreterHelper,
         @inject(IServiceContainer) serviceContainer: IServiceContainer) {
         super('KnownPathsService', serviceContainer);
     }
@@ -29,17 +29,19 @@ export class KnownPathsService extends CacheableLocatorService {
             // tslint:disable-next-line:underscore-consistent-invocation
             .then(listOfInterpreters => _.flatten(listOfInterpreters))
             .then(interpreters => interpreters.filter(item => item.length > 0))
-            .then(interpreters => Promise.all(interpreters.map(interpreter => this.getInterpreterDetails(interpreter))));
+            .then(interpreters => Promise.all(interpreters.map(interpreter => this.getInterpreterDetails(interpreter))))
+            .then(interpreters => interpreters.filter(interpreter => !interpreter).map(interpreter => interpreter!));
     }
-    private getInterpreterDetails(interpreter: string) {
-        return this.versionProvider.getVersion(interpreter, path.basename(interpreter))
-            .then(displayName => {
-                return {
-                    displayName,
-                    path: interpreter,
-                    type: InterpreterType.Unknown
-                };
-            });
+    private async getInterpreterDetails(interpreter: string) {
+        const details = await this.helper.getInterpreterInformation(interpreter);
+        if (!details) {
+            return;
+        }
+        return {
+            ...(details as PythonInterpreter),
+            path: interpreter,
+            type: InterpreterType.Unknown
+        };
     }
     private getInterpretersInDirectory(dir: string) {
         return fsExistsAsync(dir)

--- a/src/client/interpreter/locators/services/KnownPathsService.ts
+++ b/src/client/interpreter/locators/services/KnownPathsService.ts
@@ -30,7 +30,7 @@ export class KnownPathsService extends CacheableLocatorService {
             .then(listOfInterpreters => _.flatten(listOfInterpreters))
             .then(interpreters => interpreters.filter(item => item.length > 0))
             .then(interpreters => Promise.all(interpreters.map(interpreter => this.getInterpreterDetails(interpreter))))
-            .then(interpreters => interpreters.filter(interpreter => !interpreter).map(interpreter => interpreter!));
+            .then(interpreters => interpreters.filter(interpreter => !!interpreter).map(interpreter => interpreter!));
     }
     private async getInterpreterDetails(interpreter: string) {
         const details = await this.helper.getInterpreterInformation(interpreter);

--- a/src/client/interpreter/locators/services/baseVirtualEnvService.ts
+++ b/src/client/interpreter/locators/services/baseVirtualEnvService.ts
@@ -40,7 +40,7 @@ export class BaseVirtualEnvService extends CacheableLocatorService {
             .then(dirs => Promise.all(dirs.map(lookForInterpretersInDirectory)))
             .then(pathsWithInterpreters => _.flatten(pathsWithInterpreters))
             .then(interpreters => Promise.all(interpreters.map(interpreter => this.getVirtualEnvDetails(interpreter))))
-            .then(interpreters => interpreters.filter(interpreter => !interpreter).map(interpreter => interpreter!))
+            .then(interpreters => interpreters.filter(interpreter => !!interpreter).map(interpreter => interpreter!))
             .catch((err) => {
                 console.error('Python Extension (lookForInterpretersInVenvs):', err);
                 // Ignore exceptions.
@@ -65,7 +65,7 @@ export class BaseVirtualEnvService extends CacheableLocatorService {
                     return '';
                 }));
     }
-    private async getVirtualEnvDetails(interpreter: string): Promise<PythonInterpreter> {
+    private async getVirtualEnvDetails(interpreter: string): Promise<PythonInterpreter | undefined> {
         return Promise.all([
             this.helper.getInterpreterInformation(interpreter),
             this.virtualEnvMgr.getEnvironmentName(interpreter),

--- a/src/client/interpreter/locators/services/baseVirtualEnvService.ts
+++ b/src/client/interpreter/locators/services/baseVirtualEnvService.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { IFileSystem, IPlatformService } from '../../../common/platform/types';
 import { IServiceContainer } from '../../../ioc/types';
-import { IInterpreterVersionService, InterpreterType, IVirtualEnvironmentsSearchPathProvider, PythonInterpreter } from '../../contracts';
+import { IInterpreterHelper, IVirtualEnvironmentsSearchPathProvider, PythonInterpreter } from '../../contracts';
 import { IVirtualEnvironmentManager } from '../../virtualEnvs/types';
 import { lookForInterpretersInDirectory } from '../helpers';
 import { CacheableLocatorService } from './cacheableLocatorService';
@@ -12,7 +12,7 @@ import { CacheableLocatorService } from './cacheableLocatorService';
 @injectable()
 export class BaseVirtualEnvService extends CacheableLocatorService {
     private readonly virtualEnvMgr: IVirtualEnvironmentManager;
-    private readonly versionProvider: IInterpreterVersionService;
+    private readonly helper: IInterpreterHelper;
     private readonly fileSystem: IFileSystem;
     public constructor(@unmanaged() private searchPathsProvider: IVirtualEnvironmentsSearchPathProvider,
         @unmanaged() serviceContainer: IServiceContainer,
@@ -20,7 +20,7 @@ export class BaseVirtualEnvService extends CacheableLocatorService {
         @unmanaged() cachePerWorkspace: boolean = false) {
         super(name, serviceContainer, cachePerWorkspace);
         this.virtualEnvMgr = serviceContainer.get<IVirtualEnvironmentManager>(IVirtualEnvironmentManager);
-        this.versionProvider = serviceContainer.get<IInterpreterVersionService>(IInterpreterVersionService);
+        this.helper = serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
         this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
     }
     // tslint:disable-next-line:no-empty
@@ -30,16 +30,17 @@ export class BaseVirtualEnvService extends CacheableLocatorService {
     }
     private async suggestionsFromKnownVenvs(resource?: Uri) {
         const searchPaths = this.searchPathsProvider.getSearchPaths(resource);
-        return Promise.all(searchPaths.map(dir => this.lookForInterpretersInVenvs(dir)))
+        return Promise.all(searchPaths.map(dir => this.lookForInterpretersInVenvs(dir, resource)))
             .then(listOfInterpreters => _.flatten(listOfInterpreters));
     }
-    private async lookForInterpretersInVenvs(pathToCheck: string) {
+    private async lookForInterpretersInVenvs(pathToCheck: string, resource?: Uri) {
         return this.fileSystem.getSubDirectories(pathToCheck)
             .then(subDirs => Promise.all(this.getProspectiveDirectoriesForLookup(subDirs)))
             .then(dirs => dirs.filter(dir => dir.length > 0))
             .then(dirs => Promise.all(dirs.map(lookForInterpretersInDirectory)))
             .then(pathsWithInterpreters => _.flatten(pathsWithInterpreters))
             .then(interpreters => Promise.all(interpreters.map(interpreter => this.getVirtualEnvDetails(interpreter))))
+            .then(interpreters => interpreters.filter(interpreter => !interpreter).map(interpreter => interpreter!))
             .catch((err) => {
                 console.error('Python Extension (lookForInterpretersInVenvs):', err);
                 // Ignore exceptions.
@@ -66,15 +67,20 @@ export class BaseVirtualEnvService extends CacheableLocatorService {
     }
     private async getVirtualEnvDetails(interpreter: string): Promise<PythonInterpreter> {
         return Promise.all([
-            this.versionProvider.getVersion(interpreter, path.basename(interpreter)),
-            this.virtualEnvMgr.getEnvironmentName(interpreter)
+            this.helper.getInterpreterInformation(interpreter),
+            this.virtualEnvMgr.getEnvironmentName(interpreter),
+            this.virtualEnvMgr.getEnvironmentType(interpreter)
         ])
-            .then(([displayName, virtualEnvName]) => {
+            .then(([details, virtualEnvName, type]) => {
+                if (!details) {
+                    return;
+                }
                 const virtualEnvSuffix = virtualEnvName.length ? virtualEnvName : this.getVirtualEnvironmentRootDirectory(interpreter);
                 return {
-                    displayName: `${displayName} (${virtualEnvSuffix})`.trim(),
-                    path: interpreter,
-                    type: virtualEnvName.length > 0 ? InterpreterType.VirtualEnv : InterpreterType.Unknown
+                    ...(details as PythonInterpreter),
+                    displayName: `${details.version!} (${virtualEnvSuffix})`.trim(),
+                    envName: virtualEnvName,
+                    type: type
                 };
             });
     }

--- a/src/client/interpreter/locators/services/pipEnvService.ts
+++ b/src/client/interpreter/locators/services/pipEnvService.ts
@@ -65,6 +65,7 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
         }
         return {
             ...(details as PythonInterpreter),
+            displayName: `${details.version} (${execName})`,
             path: interpreterPath,
             type: InterpreterType.PipEnv
         };

--- a/src/client/interpreter/locators/services/pipEnvService.ts
+++ b/src/client/interpreter/locators/services/pipEnvService.ts
@@ -9,17 +9,16 @@ import { IFileSystem } from '../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../common/process/types';
 import { ICurrentProcess } from '../../../common/types';
 import { IEnvironmentVariablesProvider } from '../../../common/variables/types';
-import { getPythonExecutable } from '../../../debugger/Common/Utils';
 import { IServiceContainer } from '../../../ioc/types';
-import { IInterpreterVersionService, InterpreterType, PythonInterpreter } from '../../contracts';
+import { IInterpreterHelper, InterpreterType, IPipEnvService, PythonInterpreter } from '../../contracts';
 import { CacheableLocatorService } from './cacheableLocatorService';
 
 const execName = 'pipenv';
 const pipEnvFileNameVariable = 'PIPENV_PIPFILE';
 
 @injectable()
-export class PipEnvService extends CacheableLocatorService {
-    private readonly versionService: IInterpreterVersionService;
+export class PipEnvService extends CacheableLocatorService implements IPipEnvService {
+    private readonly helper: IInterpreterHelper;
     private readonly processServiceFactory: IProcessServiceFactory;
     private readonly workspace: IWorkspaceService;
     private readonly fs: IFileSystem;
@@ -27,7 +26,7 @@ export class PipEnvService extends CacheableLocatorService {
 
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         super('PipEnvService', serviceContainer);
-        this.versionService = this.serviceContainer.get<IInterpreterVersionService>(IInterpreterVersionService);
+        this.helper = this.serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
         this.processServiceFactory = this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         this.workspace = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
@@ -35,6 +34,14 @@ export class PipEnvService extends CacheableLocatorService {
     }
     // tslint:disable-next-line:no-empty
     public dispose() { }
+    public async isRelatedPipEnvironment(dir: string, pythonPath: string): Promise<boolean> {
+        // In PipEnv, the name of the cwd is used as a prefix in the virtual env.
+        if (pythonPath.indexOf(`${path.sep}${path.basename(dir)}-`) === -1) {
+            return false;
+        }
+        const envName = await this.getInterpreterPathFromPipenv(dir, true);
+        return !!envName;
+    }
     protected getInterpretersImplementation(resource?: Uri): Promise<PythonInterpreter[]> {
         const pipenvCwd = this.getPipenvWorkingDirectory(resource);
         if (!pipenvCwd) {
@@ -52,13 +59,14 @@ export class PipEnvService extends CacheableLocatorService {
             return;
         }
 
-        const pythonExecutablePath = getPythonExecutable(interpreterPath);
-        const ver = await this.versionService.getVersion(pythonExecutablePath, '');
+        const details = await this.helper.getInterpreterInformation(interpreterPath);
+        if (!details) {
+            return;
+        }
         return {
-            path: pythonExecutablePath,
-            displayName: `${ver} (${execName})`,
-            type: InterpreterType.VirtualEnv,
-            version: ver
+            ...(details as PythonInterpreter),
+            path: interpreterPath,
+            type: InterpreterType.PipEnv
         };
     }
 
@@ -72,13 +80,25 @@ export class PipEnvService extends CacheableLocatorService {
         return wsFolder ? wsFolder.uri.fsPath : this.workspace.rootPath;
     }
 
-    private async getInterpreterPathFromPipenv(cwd: string): Promise<string | undefined> {
+    private async getInterpreterPathFromPipenv(cwd: string, ignoreErrors = false): Promise<string | undefined> {
         // Quick check before actually running pipenv
         if (!await this.checkIfPipFileExists(cwd)) {
             return;
         }
-        const venvFolder = await this.invokePipenv('--venv', cwd);
-        return venvFolder && await this.fs.directoryExists(venvFolder) ? venvFolder : undefined;
+        try {
+            const pythonPath = await this.invokePipenv('--py', cwd);
+            // TODO: Why do we need to do this?
+            return pythonPath && await this.fs.fileExists(pythonPath) ? pythonPath : undefined;
+            // tslint:disable-next-line:no-empty
+        } catch (error) {
+            console.error(error);
+            if (ignoreErrors) {
+                return;
+            }
+            const errorMessage = error.message || error;
+            const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+            appShell.showWarningMessage(`Workspace contains pipfile but attempt to run 'pipenv --py' failed with ${errorMessage}. Make sure pipenv is on the PATH.`);
+        }
     }
     private async checkIfPipFileExists(cwd: string): Promise<boolean> {
         const currentProcess = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -20,6 +20,7 @@ import {
     IInterpreterVersionService,
     IKnownSearchPathsForInterpreters,
     INTERPRETER_LOCATOR_SERVICE,
+    IPipEnvService,
     IShebangCodeLensProvider,
     IVirtualEnvironmentsSearchPathProvider,
     KNOWN_PATH_SERVICE,
@@ -61,6 +62,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, GlobalVirtualEnvService, GLOBAL_VIRTUAL_ENV_SERVICE);
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, WorkspaceVirtualEnvService, WORKSPACE_VIRTUAL_ENV_SERVICE);
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
+    serviceManager.addSingleton<IInterpreterLocatorService>(IPipEnvService, PipEnvService);
 
     const isWindows = serviceManager.get<boolean>(IsWindows);
     if (isWindows) {

--- a/src/client/interpreter/virtualEnvs/index.ts
+++ b/src/client/interpreter/virtualEnvs/index.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
-import { IProcessService, IProcessServiceFactory } from '../../common/process/types';
+import { IProcessServiceFactory } from '../../common/process/types';
 import { IServiceContainer } from '../../ioc/types';
 import { InterpreterType, IPipEnvService } from '../contracts';
 import { IVirtualEnvironmentManager } from './types';
@@ -19,7 +19,7 @@ export class VirtualEnvironmentManager implements IVirtualEnvironmentManager {
     private pipEnvService: IPipEnvService;
     private fs: IFileSystem;
     private pyEnvRoot?: string;
-    private workspaceService?: IWorkspaceService;
+    private workspaceService: IWorkspaceService;
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.processServiceFactory = serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         this.fs = serviceContainer.get<IFileSystem>(IFileSystem);
@@ -46,13 +46,13 @@ export class VirtualEnvironmentManager implements IVirtualEnvironmentManager {
         const dir = path.dirname(pythonPath);
         const pyEnvCfgFiles = PYENVFILES.map(file => path.join(dir, file));
         for (const file of pyEnvCfgFiles) {
-            if (await this.fs.fileExistsAsync(file)) {
+            if (await this.fs.fileExists(file)) {
                 return InterpreterType.Venv;
             }
         }
 
         const pyEnvRoot = await this.getPyEnvRoot(resource);
-        if (pythonPath.startsWith(pyEnvRoot)) {
+        if (pyEnvRoot && pythonPath.startsWith(pyEnvRoot)) {
             return InterpreterType.Pyenv;
         }
 

--- a/src/client/interpreter/virtualEnvs/index.ts
+++ b/src/client/interpreter/virtualEnvs/index.ts
@@ -2,26 +2,84 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { IProcessServiceFactory } from '../../common/process/types';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { IWorkspaceService } from '../../common/application/types';
+import { IFileSystem } from '../../common/platform/types';
+import { IProcessService, IProcessServiceFactory } from '../../common/process/types';
 import { IServiceContainer } from '../../ioc/types';
+import { InterpreterType, IPipEnvService } from '../contracts';
 import { IVirtualEnvironmentManager } from './types';
+
+const PYENVFILES = ['pyvenv.cfg', path.join('..', 'pyvenv.cfg')];
 
 @injectable()
 export class VirtualEnvironmentManager implements IVirtualEnvironmentManager {
     private processServiceFactory: IProcessServiceFactory;
+    private pipEnvService: IPipEnvService;
+    private fs: IFileSystem;
+    private pyEnvRoot?: string;
+    private workspaceService?: IWorkspaceService;
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.processServiceFactory = serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        this.fs = serviceContainer.get<IFileSystem>(IFileSystem);
+        this.pipEnvService = serviceContainer.get<IPipEnvService>(IPipEnvService);
+        this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
     }
     public async getEnvironmentName(pythonPath: string): Promise<string> {
         // https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv
         // hasattr(sys, 'real_prefix') works for virtualenv while
         // '(hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix))' works for venv
-        const code = 'import sys\nif hasattr(sys, "real_prefix"):\n  print("virtualenv")\nelif hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix:\n  print("venv")';
-        const processService = await this.processServiceFactory.create();
-        const output = await processService.exec(pythonPath, ['-c', code]);
-        if (output.stdout.length > 0) {
-            return output.stdout.trim();
+        try {
+            const processService = await this.processServiceFactory.create();
+            const code = 'import sys\nif hasattr(sys, "real_prefix"):\n  print("virtualenv")\nelif hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix:\n  print("venv")';
+            const output = await processService.exec(pythonPath, ['-c', code]);
+            if (output.stdout.length > 0) {
+                return output.stdout.trim();
+            }
+        } catch {
+            // do nothing.
         }
         return '';
+    }
+    public async getEnvironmentType(pythonPath: string, resource?: Uri): Promise<InterpreterType> {
+        const dir = path.dirname(pythonPath);
+        const pyEnvCfgFiles = PYENVFILES.map(file => path.join(dir, file));
+        for (const file of pyEnvCfgFiles) {
+            if (await this.fs.fileExistsAsync(file)) {
+                return InterpreterType.Venv;
+            }
+        }
+
+        const pyEnvRoot = await this.getPyEnvRoot(resource);
+        if (pythonPath.startsWith(pyEnvRoot)) {
+            return InterpreterType.Pyenv;
+        }
+
+        const defaultWorkspaceUri = this.workspaceService.hasWorkspaceFolders ? this.workspaceService.workspaceFolders![0].uri : undefined;
+        const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
+        const workspaceUri = workspaceFolder ? workspaceFolder.uri : defaultWorkspaceUri;
+        if (workspaceUri && this.pipEnvService.isRelatedPipEnvironment(pythonPath, workspaceUri.fsPath)) {
+            return InterpreterType.PipEnv;
+        }
+
+        if ((await this.getEnvironmentName(pythonPath)).length > 0) {
+            return InterpreterType.VirtualEnv;
+        }
+
+        // Lets not try to determine whether this is a conda environment or not.
+        return InterpreterType.Unknown;
+    }
+    private async getPyEnvRoot(resource?: Uri): Promise<string | undefined> {
+        if (this.pyEnvRoot) {
+            return this.pyEnvRoot;
+        }
+        try {
+            const processService = await this.processServiceFactory.create(resource);
+            const output = await processService.exec('pyenv', ['root']);
+            return this.pyEnvRoot = output.stdout.trim();
+        } catch {
+            return;
+        }
     }
 }

--- a/src/client/interpreter/virtualEnvs/types.ts
+++ b/src/client/interpreter/virtualEnvs/types.ts
@@ -1,7 +1,11 @@
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { Uri } from 'vscode';
+import { InterpreterType } from '../contracts';
 export const IVirtualEnvironmentManager = Symbol('VirtualEnvironmentManager');
 export interface IVirtualEnvironmentManager {
     getEnvironmentName(pythonPath: string): Promise<string>;
+    getEnvironmentType(pythonPath: string, resource?: Uri): Promise<InterpreterType>;
 }

--- a/src/client/linters/errorHandlers/notInstalled.ts
+++ b/src/client/linters/errorHandlers/notInstalled.ts
@@ -11,10 +11,10 @@ export class NotInstalledErrorHandler extends BaseErrorHandler {
         super(product, outputChannel, serviceContainer);
     }
     public async handleError(error: Error, resource: Uri, execInfo: ExecutionInfo): Promise<boolean> {
-        const pythonExecutionService = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(resource);
+        const pythonExecutionService = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource });
         const isModuleInstalled = await pythonExecutionService.isModuleInstalled(execInfo.moduleName!);
         if (isModuleInstalled) {
-            return this.nextHandler ? await this.nextHandler.handleError(error, resource, execInfo) : false;
+            return this.nextHandler ? this.nextHandler.handleError(error, resource, execInfo) : false;
         }
 
         this.installer.promptToInstall(this.product, resource)

--- a/src/client/providers/importSortProvider.ts
+++ b/src/client/providers/importSortProvider.ts
@@ -38,7 +38,7 @@ export class PythonImportSortProvider {
             const processService = await this.processServiceFactory.create(document.uri);
             promise = processService.exec(isort, args, { throwOnStdErr: true });
         } else {
-            promise = this.pythonExecutionFactory.create(document.uri)
+            promise = this.pythonExecutionFactory.create({ resource: document.uri })
                 .then(executionService => executionService.exec([importScript].concat(args), { throwOnStdErr: true }));
         }
 

--- a/src/client/providers/jediProxy.ts
+++ b/src/client/providers/jediProxy.ts
@@ -330,7 +330,7 @@ export class JediProxy implements Disposable {
             this.languageServerStarted.reject(new Error('Language Server not started.'));
         }
         this.languageServerStarted = createDeferred<void>();
-        const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(Uri.file(this.workspacePath));
+        const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource: Uri.file(this.workspacePath) });
         // Check if the python path is valid.
         if ((await pythonProcess.getExecutablePath().catch(() => '')).length === 0) {
             return;
@@ -606,7 +606,7 @@ export class JediProxy implements Disposable {
 
     private async getPathFromPythonCommand(args: string[]): Promise<string> {
         try {
-            const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(Uri.file(this.workspacePath));
+            const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource: Uri.file(this.workspacePath) });
             const result = await pythonProcess.exec(args, { cwd: this.workspacePath });
             const lines = result.stdout.trim().splitLines();
             if (lines.length === 0) {

--- a/src/client/refactor/proxy.ts
+++ b/src/client/refactor/proxy.ts
@@ -106,7 +106,7 @@ export class RefactorProxy extends Disposable {
         });
     }
     private async initialize(pythonPath: string): Promise<void> {
-        const pythonProc = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(Uri.file(this.workspaceRoot));
+        const pythonProc = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource: Uri.file(this.workspaceRoot) });
         this.initialized = createDeferred<void>();
         const args = ['refactor.py', this.workspaceRoot];
         const cwd = path.join(this._extensionDir, 'pythonFiles');

--- a/src/client/unittests/common/runner.ts
+++ b/src/client/unittests/common/runner.ts
@@ -3,15 +3,14 @@ import { CancellationToken, OutputChannel, Uri } from 'vscode';
 import { PythonSettings } from '../../common/configSettings';
 import { ErrorUtils } from '../../common/errors/errorUtils';
 import { ModuleNotInstalledError } from '../../common/errors/moduleNotInstalledError';
-import { IPythonToolExecutionService } from '../../common/process/types';
 import {
     IPythonExecutionFactory,
     IPythonExecutionService,
+    IPythonToolExecutionService,
     ObservableExecutionResult,
     SpawnOptions
 } from '../../common/process/types';
-import { IPythonSettings } from '../../common/types';
-import { ExecutionInfo } from '../../common/types';
+import { ExecutionInfo, IPythonSettings } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { NOSETEST_PROVIDER, PYTEST_PROVIDER, UNITTEST_PROVIDER } from './constants';
 import { ITestsHelper, TestProvider } from './types';
@@ -36,7 +35,7 @@ export async function run(serviceContainer: IServiceContainer, testProvider: Tes
     if (!testExecutablePath && testProvider === UNITTEST_PROVIDER) {
         // Unit tests have a special way of being executed
         const pythonServiceFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
-        pythonExecutionServicePromise = pythonServiceFactory.create(options.workspaceFolder);
+        pythonExecutionServicePromise = pythonServiceFactory.create({ resource: options.workspaceFolder });
         promise = pythonExecutionServicePromise.then(executionService => executionService.execObservable(options.args, { ...spawnOptions }));
     } else {
         const pythonToolsExecutionService = serviceContainer.get<IPythonToolExecutionService>(IPythonToolExecutionService);

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -27,6 +27,19 @@ import { MockProcessService } from '../mocks/proc';
 import { UnitTestIocContainer } from '../unittests/serviceRegistry';
 import { closeActiveWindows, initializeTest } from './../initialize';
 
+const info: PythonInterpreter = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    type: InterpreterType.Unknown,
+    version: '',
+    version_info: [0, 0, 0, 'alpha'],
+    sysPrefix: '',
+    sysVersion: ''
+};
+
 // tslint:disable-next-line:max-func-body-length
 suite('Module Installer', () => {
     let ioc: UnitTestIocContainer;
@@ -91,7 +104,7 @@ suite('Module Installer', () => {
     async function getCurrentPythonPath(): Promise<string> {
         const pythonPath = PythonSettings.getInstance(workspaceUri).pythonPath;
         if (path.basename(pythonPath) === pythonPath) {
-            const pythonProc = await ioc.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(workspaceUri);
+            const pythonProc = await ioc.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource: workspaceUri });
             return pythonProc.getExecutablePath().catch(() => pythonPath);
         } else {
             return pythonPath;
@@ -133,7 +146,7 @@ suite('Module Installer', () => {
         ioc.serviceManager.addSingletonInstance<IModuleInstaller>(IModuleInstaller, new MockModuleInstaller('mock', true));
         const pythonPath = await getCurrentPythonPath();
         const mockInterpreterLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
-        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ architecture: Architecture.Unknown, companyDisplayName: '', displayName: '', envName: '', path: pythonPath, type: InterpreterType.Conda, version: '' }]));
+        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ ...info, architecture: Architecture.Unknown, companyDisplayName: '', displayName: '', envName: '', path: pythonPath, type: InterpreterType.Conda, version: '' }]));
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, mockInterpreterLocator.object, INTERPRETER_LOCATOR_SERVICE);
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, TypeMoq.Mock.ofType<IInterpreterLocatorService>().object, PIPENV_SERVICE);
 
@@ -189,11 +202,12 @@ suite('Module Installer', () => {
     test('Validate pip install arguments', async () => {
         const interpreterPath = await getCurrentPythonPath();
         const mockInterpreterLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
-        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ path: interpreterPath, type: InterpreterType.Unknown }]));
+        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ ...info, path: interpreterPath, type: InterpreterType.Unknown }]));
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, mockInterpreterLocator.object, INTERPRETER_LOCATOR_SERVICE);
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, TypeMoq.Mock.ofType<IInterpreterLocatorService>().object, PIPENV_SERVICE);
 
         const interpreter: PythonInterpreter = {
+            ...info,
             type: InterpreterType.Unknown,
             path: PYTHON_PATH
         };
@@ -220,7 +234,7 @@ suite('Module Installer', () => {
     test('Validate Conda install arguments', async () => {
         const interpreterPath = await getCurrentPythonPath();
         const mockInterpreterLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
-        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ path: interpreterPath, type: InterpreterType.Conda }]));
+        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ ...info, path: interpreterPath, type: InterpreterType.Conda }]));
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, mockInterpreterLocator.object, INTERPRETER_LOCATOR_SERVICE);
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, TypeMoq.Mock.ofType<IInterpreterLocatorService>().object, PIPENV_SERVICE);
 
@@ -242,7 +256,7 @@ suite('Module Installer', () => {
 
     test('Validate pipenv install arguments', async () => {
         const mockInterpreterLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
-        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ path: 'interpreterPath', type: InterpreterType.VirtualEnv }]));
+        mockInterpreterLocator.setup(p => p.getInterpreters(TypeMoq.It.isAny())).returns(() => Promise.resolve([{ ...info, path: 'interpreterPath', type: InterpreterType.VirtualEnv }]));
         ioc.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, mockInterpreterLocator.object, PIPENV_SERVICE);
 
         const moduleName = 'xyz';

--- a/src/test/common/process/pythonProc.simple.multiroot.test.ts
+++ b/src/test/common/process/pythonProc.simple.multiroot.test.ts
@@ -83,7 +83,7 @@ suite('PythonExecutableService', () => {
     test('Importing without a valid PYTHONPATH should fail', async () => {
         await configService.updateSettingAsync('envFile', 'someInvalidFile.env', workspace4PyFile, ConfigurationTarget.WorkspaceFolder);
         pythonExecFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
-        const pythonExecService = await pythonExecFactory.create(workspace4PyFile);
+        const pythonExecService = await pythonExecFactory.create({ resource: workspace4PyFile });
         const promise = pythonExecService.exec([workspace4PyFile.fsPath], { cwd: path.dirname(workspace4PyFile.fsPath), throwOnStdErr: true });
 
         await expect(promise).to.eventually.be.rejectedWith(StdErrError);
@@ -91,14 +91,14 @@ suite('PythonExecutableService', () => {
 
     test('Importing with a valid PYTHONPATH from .env file should succeed', async () => {
         await configService.updateSettingAsync('envFile', undefined, workspace4PyFile, ConfigurationTarget.WorkspaceFolder);
-        const pythonExecService = await pythonExecFactory.create(workspace4PyFile);
+        const pythonExecService = await pythonExecFactory.create({ resource: workspace4PyFile });
         const promise = pythonExecService.exec([workspace4PyFile.fsPath], { cwd: path.dirname(workspace4PyFile.fsPath), throwOnStdErr: true });
 
         await expect(promise).to.eventually.have.property('stdout', `Hello${EOL}`);
     });
 
     test('Known modules such as \'os\' and \'sys\' should be deemed \'installed\'', async () => {
-        const pythonExecService = await pythonExecFactory.create(workspace4PyFile);
+        const pythonExecService = await pythonExecFactory.create({ resource: workspace4PyFile });
         const osModuleIsInstalled = pythonExecService.isModuleInstalled('os');
         const sysModuleIsInstalled = pythonExecService.isModuleInstalled('sys');
         await expect(osModuleIsInstalled).to.eventually.equal(true, 'os module is not installed');
@@ -106,7 +106,7 @@ suite('PythonExecutableService', () => {
     });
 
     test('Unknown modules such as \'xyzabc123\' be deemed \'not installed\'', async () => {
-        const pythonExecService = await pythonExecFactory.create(workspace4PyFile);
+        const pythonExecService = await pythonExecFactory.create({ resource: workspace4PyFile });
         const randomModuleName = `xyz123${new Date().getSeconds()}`;
         const randomModuleIsInstalled = pythonExecService.isModuleInstalled(randomModuleName);
         await expect(randomModuleIsInstalled).to.eventually.equal(false, `Random module '${randomModuleName}' is installed`);
@@ -119,7 +119,7 @@ suite('PythonExecutableService', () => {
                 resolve(stdout.trim());
             });
         });
-        const pythonExecService = await pythonExecFactory.create(workspace4PyFile);
+        const pythonExecService = await pythonExecFactory.create({ resource: workspace4PyFile });
         const executablePath = await pythonExecService.getExecutablePath();
         expect(executablePath).to.equal(expectedExecutablePath, 'Executable paths are not the same');
     });

--- a/src/test/configuration/interpreterSelector.test.ts
+++ b/src/test/configuration/interpreterSelector.test.ts
@@ -5,12 +5,25 @@ import * as assert from 'assert';
 import { Container } from 'inversify';
 import * as TypeMoq from 'typemoq';
 import { IApplicationShell, ICommandManager, IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
-import { IFileSystem } from '../../client/common/platform/types';
+import { Architecture, IFileSystem } from '../../client/common/platform/types';
 import { IInterpreterQuickPickItem, InterpreterSelector } from '../../client/interpreter/configuration/interpreterSelector';
 import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../client/ioc/types';
+
+const info: PythonInterpreter = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    type: InterpreterType.Unknown,
+    version: '',
+    version_info: [0, 0, 0, 'alpha'],
+    sysPrefix: '',
+    sysVersion: ''
+};
 
 class InterpreterQuickPickItem implements IInterpreterQuickPickItem {
     public path: string;
@@ -73,7 +86,7 @@ suite('Interpreters - selector', () => {
             { displayName: '2 (virtualenv)', path: 'c:/path2/path2', type: InterpreterType.VirtualEnv },
             { displayName: '3', path: 'c:/path2/path2', type: InterpreterType.Unknown },
             { displayName: '4', path: 'c:/path4/path4', type: InterpreterType.Conda }
-        ];
+        ].map(item => { return { ...info, ...item }; });
         interpreterService
             .setup(x => x.getInterpreters(TypeMoq.It.isAny()))
             .returns(() => new Promise((resolve) => resolve(initial)));

--- a/src/test/format/extension.format.test.ts
+++ b/src/test/format/extension.format.test.ts
@@ -36,7 +36,7 @@ suite('Formatting', () => {
             fs.copySync(originalUnformattedFile, file, { overwrite: true });
         });
         fs.ensureDirSync(path.dirname(autoPep8FileToFormat));
-        const pythonProcess = await ioc.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(vscode.Uri.file(workspaceRootPath));
+        const pythonProcess = await ioc.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource: vscode.Uri.file(workspaceRootPath) });
         const py2 = await ioc.getPythonMajorVersion(vscode.Uri.parse(originalUnformattedFile)) === 2;
         const yapf = pythonProcess.execModule('yapf', [originalUnformattedFile], { cwd: workspaceRootPath });
         const autoPep8 = pythonProcess.execModule('autopep8', [originalUnformattedFile], { cwd: workspaceRootPath });
@@ -113,7 +113,7 @@ suite('Formatting', () => {
     }
 
     test('AutoPep8', async () => testFormatting(new AutoPep8Formatter(ioc.serviceContainer), formattedAutoPep8, autoPep8FileToFormat, 'autopep8.output'));
-    test('Black', async function() {
+    test('Black', async function () {
         if (await ioc.getPythonMajorVersion(vscode.Uri.parse(blackFileToFormat)) === 2) {
             // tslint:disable-next-line:no-invalid-this
             return this.skip();

--- a/src/test/install/channelManager.channels.test.ts
+++ b/src/test/install/channelManager.channels.test.ts
@@ -8,11 +8,25 @@ import { QuickPickOptions } from 'vscode';
 import { IApplicationShell } from '../../client/common/application/types';
 import { InstallationChannelManager } from '../../client/common/installer/channelManager';
 import { IModuleInstaller } from '../../client/common/installer/types';
+import { Architecture } from '../../client/common/platform/types';
 import { Product } from '../../client/common/types';
 import { IInterpreterLocatorService, InterpreterType, PIPENV_SERVICE, PythonInterpreter } from '../../client/interpreter/contracts';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../client/ioc/types';
+
+const info: PythonInterpreter = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    type: InterpreterType.Unknown,
+    version: '',
+    version_info: [0, 0, 0, 'alpha'],
+    sysPrefix: '',
+    sysVersion: ''
+};
 
 // tslint:disable-next-line:max-func-body-length
 suite('Installation - installation channels', () => {
@@ -55,6 +69,7 @@ suite('Installation - installation channels', () => {
         const pipenvInstaller = mockInstaller(true, 'pipenv', 10);
 
         const interpreter: PythonInterpreter = {
+            ...info,
             path: 'pipenv',
             type: InterpreterType.VirtualEnv
         };

--- a/src/test/install/channelManager.messages.test.ts
+++ b/src/test/install/channelManager.messages.test.ts
@@ -6,12 +6,25 @@ import { Container } from 'inversify';
 import * as TypeMoq from 'typemoq';
 import { IApplicationShell } from '../../client/common/application/types';
 import { InstallationChannelManager } from '../../client/common/installer/channelManager';
-import { IPlatformService } from '../../client/common/platform/types';
+import { Architecture, IPlatformService } from '../../client/common/platform/types';
 import { Product } from '../../client/common/types';
 import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../client/ioc/types';
+
+const info: PythonInterpreter = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    type: InterpreterType.Unknown,
+    version: '',
+    version_info: [0, 0, 0, 'alpha'],
+    sysPrefix: '',
+    sysVersion: ''
+};
 
 // tslint:disable-next-line:max-func-body-length
 suite('Installation - channel messages', () => {
@@ -132,6 +145,7 @@ suite('Installation - channel messages', () => {
         verify: (c: InstallationChannelManager, m: string, u: string) => void): Promise<void> {
 
         const activeInterpreter: PythonInterpreter = {
+            ...info,
             type: interpreterType,
             path: ''
         };

--- a/src/test/install/pythonInstallation.test.ts
+++ b/src/test/install/pythonInstallation.test.ts
@@ -7,14 +7,26 @@ import { Container } from 'inversify';
 import * as TypeMoq from 'typemoq';
 import { IApplicationShell } from '../../client/common/application/types';
 import { PythonInstaller } from '../../client/common/installer/pythonInstallation';
-import { IPlatformService } from '../../client/common/platform/types';
+import { Architecture, IPlatformService } from '../../client/common/platform/types';
 import { IPythonSettings } from '../../client/common/types';
-import { IInterpreterLocatorService, IInterpreterService } from '../../client/interpreter/contracts';
-import { InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
+import { IInterpreterLocatorService, IInterpreterService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../client/ioc/types';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
+
+const info: PythonInterpreter = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    type: InterpreterType.Unknown,
+    version: '',
+    version_info: [0, 0, 0, 'alpha'],
+    sysPrefix: '',
+    sysVersion: ''
+};
 
 class TestContext {
     public serviceManager: ServiceManager;
@@ -36,6 +48,7 @@ class TestContext {
         this.settings = TypeMoq.Mock.ofType<IPythonSettings>();
 
         const activeInterpreter: PythonInterpreter = {
+            ...info,
             type: InterpreterType.Unknown,
             path: ''
         };
@@ -116,6 +129,7 @@ suite('Installation', () => {
         c.appShell.setup(x => x.showWarningMessage(TypeMoq.It.isAnyString())).callback(() => called = true);
         c.settings.setup(x => x.pythonPath).returns(() => 'python');
         const interpreter: PythonInterpreter = {
+            ...info,
             path: 'python',
             type: InterpreterType.Unknown
         };

--- a/src/test/interpreters/condaEnvService.test.ts
+++ b/src/test/interpreters/condaEnvService.test.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import { IFileSystem } from '../../client/common/platform/types';
 import { ILogger, IPersistentStateFactory } from '../../client/common/types';
-import { ICondaService, IInterpreterVersionService, InterpreterType } from '../../client/interpreter/contracts';
+import { ICondaService, InterpreterType } from '../../client/interpreter/contracts';
+import { InterpreterHelper } from '../../client/interpreter/helpers';
 import { AnacondaCompanyName, AnacondaDisplayName } from '../../client/interpreter/locators/services/conda';
 import { CondaEnvService } from '../../client/interpreter/locators/services/condaEnvService';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -14,12 +15,12 @@ import { MockState } from './mocks';
 const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonFiles', 'environments');
 
 // tslint:disable-next-line:max-func-body-length
-suite('Interpreters from Conda Environments', () => {
+suite('Interpreters from Conda Environmentsx', () => {
     let ioc: UnitTestIocContainer;
     let logger: TypeMoq.IMock<ILogger>;
     let condaProvider: CondaEnvService;
     let condaService: TypeMoq.IMock<ICondaService>;
-    let interpreterVersion: TypeMoq.IMock<IInterpreterVersionService>;
+    let interpreterHelper: TypeMoq.IMock<InterpreterHelper>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     suiteSetup(initialize);
     setup(async () => {
@@ -32,9 +33,9 @@ suite('Interpreters from Conda Environments', () => {
         stateFactory.setup(s => s.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => state);
 
         condaService = TypeMoq.Mock.ofType<ICondaService>();
-        interpreterVersion = TypeMoq.Mock.ofType<IInterpreterVersionService>();
+        interpreterHelper = TypeMoq.Mock.ofType<InterpreterHelper>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
-        condaProvider = new CondaEnvService(condaService.object, interpreterVersion.object, logger.object, serviceContainer.object, fileSystem.object);
+        condaProvider = new CondaEnvService(condaService.object, interpreterHelper.object, logger.object, serviceContainer.object, fileSystem.object);
     });
     teardown(() => ioc.dispose());
     function initializeDI() {
@@ -65,7 +66,7 @@ suite('Interpreters from Conda Environments', () => {
             const pythonPath = isWindows ? path.join(validPath, 'python.exe') : path.join(validPath, 'bin', 'python');
             fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         });
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
 
         const interpreters = await condaProvider.parseCondaInfo(info);
         assert.equal(interpreters.length, 2, 'Incorrect number of entries');
@@ -102,7 +103,7 @@ suite('Interpreters from Conda Environments', () => {
             const pythonPath = isWindows ? path.join(validPath, 'python.exe') : path.join(validPath, 'bin', 'python');
             fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         });
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
         condaService.setup(c => c.getCondaFile()).returns(() => Promise.resolve('conda'));
         condaService.setup(c => c.getCondaInfo()).returns(() => Promise.resolve(info));
         condaService.setup(c => c.getCondaEnvironments(TypeMoq.It.isAny())).returns(() => Promise.resolve([
@@ -147,7 +148,7 @@ suite('Interpreters from Conda Environments', () => {
             const pythonPath = isWindows ? path.join(validPath, 'python.exe') : path.join(validPath, 'bin', 'python');
             fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         });
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
 
         const interpreters = await condaProvider.parseCondaInfo(info);
         assert.equal(interpreters.length, 1, 'Incorrect number of entries');
@@ -171,7 +172,7 @@ suite('Interpreters from Conda Environments', () => {
             default_prefix: '',
             'sys.version': '3.6.1 |Anaonda 4.4.0 (64-bit)| (default, May 11 2017, 13:25:24) [MSC v.1900 64 bit (AMD64)]'
         };
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
         condaService.setup(c => c.getCondaInfo()).returns(() => Promise.resolve(info));
         condaService.setup(c => c.getCondaEnvironments(TypeMoq.It.isAny())).returns(() => Promise.resolve([
             { name: 'base', path: environmentsPath },
@@ -185,7 +186,7 @@ suite('Interpreters from Conda Environments', () => {
             const pythonPath = isWindows ? path.join(validPath, 'python.exe') : path.join(validPath, 'bin', 'python');
             fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         });
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve(undefined));
         fileSystem.setup(fs => fs.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((p1: string, p2: string) => isWindows ? p1 === p2 : p1.toUpperCase() === p2.toUpperCase());
 
         const interpreters = await condaProvider.getInterpreters();
@@ -215,7 +216,7 @@ suite('Interpreters from Conda Environments', () => {
             const pythonPath = isWindows ? path.join(validPath, 'python.exe') : path.join(validPath, 'bin', 'python');
             fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         });
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
 
         const interpreters = await condaProvider.parseCondaInfo(info);
         assert.equal(interpreters.length, 1, 'Incorrect number of entries');
@@ -245,7 +246,7 @@ suite('Interpreters from Conda Environments', () => {
             const pythonPath = isWindows ? path.join(validPath, 'python.exe') : path.join(validPath, 'bin', 'python');
             fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
         });
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
         condaService.setup(c => c.getCondaFile()).returns(() => Promise.resolve('conda'));
         condaService.setup(c => c.getCondaInfo()).returns(() => Promise.resolve(info));
         condaService.setup(c => c.getCondaEnvironments(TypeMoq.It.isAny())).returns(() => Promise.resolve([
@@ -280,7 +281,7 @@ suite('Interpreters from Conda Environments', () => {
         });
         const pythonPath = isWindows ? path.join(info.default_prefix, 'python.exe') : path.join(info.default_prefix, 'bin', 'python');
         fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(true));
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
 
         const interpreters = await condaProvider.parseCondaInfo(info);
         assert.equal(interpreters.length, 1, 'Incorrect number of entries');
@@ -308,7 +309,7 @@ suite('Interpreters from Conda Environments', () => {
             path.join(environmentsPath, 'path3', 'three.exe')]
         };
         const validPaths = info.envs.filter((_, index) => index % 2 === 0);
-        interpreterVersion.setup(i => i.getVersion(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((_p, defaultValue) => Promise.resolve(defaultValue));
+        interpreterHelper.setup(i => i.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ version: '' }));
         validPaths.forEach(envPath => {
             condaService.setup(c => c.getInterpreterPath(TypeMoq.It.isValue(envPath))).returns(environmentPath => {
                 return isWindows ? path.join(environmentPath, 'python.exe') : path.join(environmentPath, 'bin', 'python');

--- a/src/test/interpreters/helper.test.ts
+++ b/src/test/interpreters/helper.test.ts
@@ -28,7 +28,7 @@ suite('Interpreters Display Helper', () => {
     });
     test('getActiveWorkspaceUri should return undefined if there are no workspaces', () => {
         workspaceService.setup(w => w.workspaceFolders).returns(() => []);
-
+        documentManager.setup(doc => doc.activeTextEditor).returns(() => undefined);
         const workspace = helper.getActiveWorkspaceUri();
         expect(workspace).to.be.equal(undefined, 'incorrect value');
     });

--- a/src/test/interpreters/interpreterService.test.ts
+++ b/src/test/interpreters/interpreterService.test.ts
@@ -9,7 +9,7 @@ import * as TypeMoq from 'typemoq';
 import { ConfigurationTarget, Disposable, TextDocument, TextEditor, Uri, WorkspaceConfiguration } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
 import { noop } from '../../client/common/core.utils';
-import { IFileSystem } from '../../client/common/platform/types';
+import { Architecture, IFileSystem } from '../../client/common/platform/types';
 import { IConfigurationService, IDisposableRegistry } from '../../client/common/types';
 import { IPythonPathUpdaterServiceManager } from '../../client/interpreter/configuration/types';
 import {
@@ -26,6 +26,19 @@ import {
 import { InterpreterService } from '../../client/interpreter/interpreterService';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
+
+const info: PythonInterpreter = {
+    architecture: Architecture.Unknown,
+    companyDisplayName: '',
+    displayName: '',
+    envName: '',
+    path: '',
+    type: InterpreterType.Unknown,
+    version: '',
+    version_info: [0, 0, 0, 'alpha'],
+    sysPrefix: '',
+    sysVersion: ''
+};
 
 // tslint:disable-next-line:max-func-body-length
 suite('Interpreters service', () => {
@@ -85,6 +98,7 @@ suite('Interpreters service', () => {
             return { key: 'python' };
         });
         const interpreter: PythonInterpreter = {
+            ...info,
             path: path.join(path.sep, 'folder', 'py1', 'bin', 'python.exe'),
             type: InterpreterType.Unknown
         };
@@ -107,6 +121,7 @@ suite('Interpreters service', () => {
             return { key: 'python', workspaceValue: 'python' };
         });
         const interpreter: PythonInterpreter = {
+            ...info,
             path: 'python',
             type: InterpreterType.VirtualEnv
         };
@@ -120,6 +135,7 @@ suite('Interpreters service', () => {
             return { key: 'python', workspaceValue: 'elsewhere' };
         });
         const interpreter: PythonInterpreter = {
+            ...info,
             path: 'elsewhere',
             type: InterpreterType.Unknown
         };
@@ -135,6 +151,7 @@ suite('Interpreters service', () => {
         });
         const intPath = path.join(path.sep, 'root', 'under', 'bin', 'python.exe');
         const interpreter: PythonInterpreter = {
+            ...info,
             path: intPath,
             type: InterpreterType.Unknown
         };

--- a/src/test/interpreters/virtualEnvManager.test.ts
+++ b/src/test/interpreters/virtualEnvManager.test.ts
@@ -6,12 +6,14 @@
 import { expect } from 'chai';
 import { Container } from 'inversify';
 import * as TypeMoq from 'typemoq';
+import { IWorkspaceService } from '../../client/common/application/types';
 import { FileSystem } from '../../client/common/platform/fileSystem';
 import { PlatformService } from '../../client/common/platform/platformService';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 import { BufferDecoder } from '../../client/common/process/decoder';
 import { ProcessService } from '../../client/common/process/proc';
 import { IBufferDecoder, IProcessService, IProcessServiceFactory } from '../../client/common/process/types';
+import { IPipEnvService } from '../../client/interpreter/contracts';
 import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
@@ -37,7 +39,9 @@ suite('Virtual environment manager', () => {
     serviceManager.addSingletonInstance<IProcessServiceFactory>(IProcessServiceFactory, processServiceFactory.object);
     serviceManager.addSingleton<IBufferDecoder>(IBufferDecoder, BufferDecoder);
     serviceManager.addSingleton<IFileSystem>(IFileSystem, FileSystem);
-    serviceManager.addSingleton<IPlatformService>(IFileSystem, PlatformService);
+    serviceManager.addSingleton<IPlatformService>(IPlatformService, PlatformService);
+    serviceManager.addSingletonInstance<IPipEnvService>(IPipEnvService, TypeMoq.Mock.ofType<IPipEnvService>().object);
+    serviceManager.addSingletonInstance<IWorkspaceService>(IWorkspaceService, TypeMoq.Mock.ofType<IWorkspaceService>().object);
     const venvManager = new VirtualEnvironmentManager(serviceContainer);
     const name = await venvManager.getEnvironmentName(PYTHON_PATH);
     const result = name === '' || name === 'venv' || name === 'virtualenv';
@@ -50,6 +54,9 @@ suite('Virtual environment manager', () => {
     processService.setup((x: any) => x.then).returns(() => undefined);
     processServiceFactory.setup(f => f.create(TypeMoq.It.isAny())).returns(() => Promise.resolve(processService.object));
     serviceManager.addSingletonInstance<IProcessServiceFactory>(IProcessServiceFactory, processServiceFactory.object);
+    serviceManager.addSingletonInstance<IFileSystem>(IFileSystem, TypeMoq.Mock.ofType<IFileSystem>().object);
+    serviceManager.addSingletonInstance<IPipEnvService>(IPipEnvService, TypeMoq.Mock.ofType<IPipEnvService>().object);
+    serviceManager.addSingletonInstance<IWorkspaceService>(IWorkspaceService, TypeMoq.Mock.ofType<IWorkspaceService>().object);
 
     const venvManager = new VirtualEnvironmentManager(serviceContainer);
     processService

--- a/src/test/interpreters/virtualEnvManager.test.ts
+++ b/src/test/interpreters/virtualEnvManager.test.ts
@@ -6,6 +6,9 @@
 import { expect } from 'chai';
 import { Container } from 'inversify';
 import * as TypeMoq from 'typemoq';
+import { FileSystem } from '../../client/common/platform/fileSystem';
+import { PlatformService } from '../../client/common/platform/platformService';
+import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 import { BufferDecoder } from '../../client/common/process/decoder';
 import { ProcessService } from '../../client/common/process/proc';
 import { IBufferDecoder, IProcessService, IProcessServiceFactory } from '../../client/common/process/types';
@@ -33,6 +36,8 @@ suite('Virtual environment manager', () => {
     processServiceFactory.setup(f => f.create(TypeMoq.It.isAny())).returns(() => Promise.resolve(new ProcessService(new BufferDecoder(), process.env as any)));
     serviceManager.addSingletonInstance<IProcessServiceFactory>(IProcessServiceFactory, processServiceFactory.object);
     serviceManager.addSingleton<IBufferDecoder>(IBufferDecoder, BufferDecoder);
+    serviceManager.addSingleton<IFileSystem>(IFileSystem, FileSystem);
+    serviceManager.addSingleton<IPlatformService>(IFileSystem, PlatformService);
     const venvManager = new VirtualEnvironmentManager(serviceContainer);
     const name = await venvManager.getEnvironmentName(PYTHON_PATH);
     const result = name === '' || name === 'venv' || name === 'virtualenv';

--- a/src/test/interpreters/windowsRegistryService.test.ts
+++ b/src/test/interpreters/windowsRegistryService.test.ts
@@ -4,6 +4,7 @@ import * as TypeMoq from 'typemoq';
 import { Architecture, RegistryHive } from '../../client/common/platform/types';
 import { IPersistentStateFactory } from '../../client/common/types';
 import { IS_WINDOWS } from '../../client/debugger/Common/Utils';
+import { IInterpreterHelper } from '../../client/interpreter/contracts';
 import { WindowsRegistryService } from '../../client/interpreter/locators/services/windowsRegistryService';
 import { IServiceContainer } from '../../client/ioc/types';
 import { initialize, initializeTest } from '../initialize';
@@ -18,8 +19,12 @@ suite('Interpreters from Windows Registry', () => {
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         const stateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
+        const interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPersistentStateFactory))).returns(() => stateFactory.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterHelper))).returns(() => interpreterHelper.object);
         const state = new MockState(undefined);
+        // tslint:disable-next-line:no-empty no-any
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({} as any));
         stateFactory.setup(s => s.createGlobalPersistentState(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => state);
         return initializeTest();
     });
@@ -182,7 +187,7 @@ suite('Interpreters from Windows Registry', () => {
                 { key: '\\Software\\Python', hive: RegistryHive.HKLM, arch: Architecture.x86, values: ['A'] },
                 { key: '\\Software\\Python\\Company A', hive: RegistryHive.HKLM, arch: Architecture.x86, values: ['Another Tag'] }
             ];
-            const registryValues: { key: string, hive: RegistryHive, arch?: Architecture, value: string, name?: string }[] = [
+            const registryValues: { key: string; hive: RegistryHive; arch?: Architecture; value: string; name?: string }[] = [
                 { key: '\\Software\\Python\\Company One', hive: RegistryHive.HKCU, arch: Architecture.x86, value: 'Display Name for Company One', name: 'DisplayName' },
                 { key: '\\Software\\Python\\Company One\\Tag1\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'conda', 'envs', 'numpy') },
                 { key: '\\Software\\Python\\Company One\\Tag1\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'conda', 'envs', 'numpy', 'python.exe'), name: 'ExecutablePath' },
@@ -241,7 +246,7 @@ suite('Interpreters from Windows Registry', () => {
                 { key: '\\Software\\Python', hive: RegistryHive.HKLM, arch: Architecture.x86, values: ['A'] },
                 { key: '\\Software\\Python\\Company A', hive: RegistryHive.HKLM, arch: Architecture.x86, values: ['Another Tag'] }
             ];
-            const registryValues: { key: string, hive: RegistryHive, arch?: Architecture, value: string, name?: string }[] = [
+            const registryValues: { key: string; hive: RegistryHive; arch?: Architecture; value: string; name?: string }[] = [
                 { key: '\\Software\\Python\\Company One', hive: RegistryHive.HKCU, arch: Architecture.x86, value: 'Display Name for Company One', name: 'DisplayName' },
                 { key: '\\Software\\Python\\Company One\\Tag1\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'conda', 'envs', 'numpy') },
                 { key: '\\Software\\Python\\Company One\\Tag1\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'conda', 'envs', 'numpy', 'python.exe'), name: 'ExecutablePath' },

--- a/src/test/unittests/serviceRegistry.ts
+++ b/src/test/unittests/serviceRegistry.ts
@@ -32,7 +32,7 @@ export class UnitTestIocContainer extends IocContainer {
         super();
     }
     public getPythonMajorVersion(resource: Uri) {
-        return this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create(resource)
+        return this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource })
             .then(pythonProcess => pythonProcess.exec(['-c', 'import sys;print(sys.version_info[0])'], {}))
             .then(output => parseInt(output.stdout.trim(), 10));
     }


### PR DESCRIPTION
Fixes #1569
Partial work for #1351 
This PR introduced about to get interpreter info and cache it. The information built will be used to build the display name and used in analysis engine (separate PR).
So, this PR focuses on being backwards compatible.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
