### PR TITLE
Remove explicit initialization of PYTHONPATH with workspace for dbg test

### DIFF
--- a/news/3 Code Health/1465.md
+++ b/news/3 Code Health/1465.md
@@ -1,0 +1,1 @@
+Remove explicit initialization of PYTHONPATH with the current workspace path in unit testing of modules with the experimental debugger.

--- a/src/test/debugger/module.test.ts
+++ b/src/test/debugger/module.test.ts
@@ -38,7 +38,7 @@ suite(`Module Debugging - Misc tests: ${debuggerType}`, () => {
     function buildLauncArgs(): LaunchRequestArguments {
         const env = {};
         // tslint:disable-next-line:no-string-literal
-        env['PYTHONPATH'] = `.${path.delimiter}${PTVSD_PATH}`;
+        env['PYTHONPATH'] = PTVSD_PATH;
 
         // tslint:disable-next-line:no-unnecessary-local-variable
         const options: LaunchRequestArguments = {

--- a/src/test/debugger/module.test.ts
+++ b/src/test/debugger/module.test.ts
@@ -36,8 +36,6 @@ suite(`Module Debugging - Misc tests: ${debuggerType}`, () => {
         await sleep(1000);
     });
     function buildLaunchArgs(): LaunchRequestArguments {
-        const env = { PYTHONPATH: PTVSD_PATH };
-
         // tslint:disable-next-line:no-unnecessary-local-variable
         const options: LaunchRequestArguments = {
             module: 'mymod',
@@ -46,7 +44,7 @@ suite(`Module Debugging - Misc tests: ${debuggerType}`, () => {
             debugOptions: [DebugOptions.RedirectOutput],
             pythonPath: PYTHON_PATH,
             args: [],
-            env,
+            env: { PYTHONPATH: `${PTVSD_PATH}` },
             envFile: '',
             logToFile: false,
             type: debuggerType

--- a/src/test/debugger/module.test.ts
+++ b/src/test/debugger/module.test.ts
@@ -35,10 +35,8 @@ suite(`Module Debugging - Misc tests: ${debuggerType}`, () => {
         } catch (ex) { }
         await sleep(1000);
     });
-    function buildLauncArgs(): LaunchRequestArguments {
-        const env = {};
-        // tslint:disable-next-line:no-string-literal
-        env['PYTHONPATH'] = PTVSD_PATH;
+    function buildLaunchArgs(): LaunchRequestArguments {
+        const env = { PYTHONPATH: PTVSD_PATH };
 
         // tslint:disable-next-line:no-unnecessary-local-variable
         const options: LaunchRequestArguments = {
@@ -60,7 +58,7 @@ suite(`Module Debugging - Misc tests: ${debuggerType}`, () => {
     test('Test stdout output', async () => {
         await Promise.all([
             debugClient.configurationSequence(),
-            debugClient.launch(buildLauncArgs()),
+            debugClient.launch(buildLaunchArgs()),
             debugClient.waitForEvent('initialized'),
             debugClient.assertOutput('stdout', 'Hello world!'),
             debugClient.waitForEvent('exited'),


### PR DESCRIPTION
Fixes #1465

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
