### PR TITLE
Flag program in launch.json as an optional property

### DIFF
--- a/news/3 Code Health/1503.md
+++ b/news/3 Code Health/1503.md
@@ -1,0 +1,1 @@
+Flag `program` in `launch.json` configuration items as an optional attribute.

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -39,7 +39,7 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
     public unitTest?: IUnitTestSettings;
     public terminal!: ITerminalSettings;
     public sortImports?: ISortImportSettings;
-    public workspaceSymbols?: IWorkspaceSymbolSettings;
+    public workspaceSymbols!: IWorkspaceSymbolSettings;
     public disableInstallationChecks = false;
     public globalModuleInstallation = false;
 

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -108,7 +108,7 @@ export interface IPythonSettings {
     readonly autoComplete?: IAutoCompleteSettings;
     readonly terminal: ITerminalSettings;
     readonly sortImports?: ISortImportSettings;
-    readonly workspaceSymbols?: IWorkspaceSymbolSettings;
+    readonly workspaceSymbols: IWorkspaceSymbolSettings;
     readonly envFile: string;
     readonly disablePromptForFeatures: string[];
     readonly disableInstallationChecks: boolean;

--- a/src/client/debugger/Common/Contracts.ts
+++ b/src/client/debugger/Common/Contracts.ts
@@ -71,7 +71,7 @@ export interface BaseLaunchRequestArguments extends DebugProtocol.LaunchRequestA
     type?: DebuggerType;
     /** An absolute path to the program to debug. */
     module?: string;
-    program: string;
+    program?: string;
     pythonPath: string;
     /** Automatically stop target after launch. If not specified, target does not stop. */
     stopOnEntry?: boolean;

--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -92,7 +92,7 @@ export class PythonDebugger extends LoggingDebugSession {
     private startDebugServer(): Promise<IDebugServer> {
         let programDirectory = '';
         if ((this.launchArgs && this.launchArgs.program) || (this.attachArgs && this.attachArgs.localRoot)) {
-            programDirectory = this.launchArgs ? path.dirname(this.launchArgs.program) : this.attachArgs.localRoot;
+            programDirectory = (this.launchArgs && this.launchArgs.program) ? path.dirname(this.launchArgs.program) : this.attachArgs.localRoot;
         }
         if (this.launchArgs && typeof this.launchArgs.cwd === 'string' && this.launchArgs.cwd.length > 0 && this.launchArgs.cwd !== 'null') {
             programDirectory = this.launchArgs.cwd;
@@ -227,7 +227,7 @@ export class PythonDebugger extends LoggingDebugSession {
         }
         // Confirm the file exists
         if (typeof args.module !== 'string' || args.module.length === 0) {
-            if (!fs.existsSync(args.program)) {
+            if (!args.program || !fs.existsSync(args.program)) {
                 return this.sendErrorResponse(response, 2001, `File does not exist. "${args.program}"`);
             }
         }

--- a/src/client/workspaceSymbols/generator.ts
+++ b/src/client/workspaceSymbols/generator.ts
@@ -31,7 +31,7 @@ export class Generator implements vscode.Disposable {
         if (!this.pythonSettings.workspaceSymbols.enabled) {
             return;
         }
-        return await this.generateTags({ directory: this.workspaceFolder.fsPath });
+        return this.generateTags({ directory: this.workspaceFolder.fsPath });
     }
     private buildCmdArgs(): string[] {
         const exclusions = this.pythonSettings.workspaceSymbols.exclusionPatterns;
@@ -40,7 +40,7 @@ export class Generator implements vscode.Disposable {
         return [`--options=${this.optionsFile}`, '--languages=Python'].concat(excludes);
     }
     @captureTelemetry(WORKSPACE_SYMBOLS_BUILD)
-    private generateTags(source: { directory?: string, file?: string }): Promise<void> {
+    private generateTags(source: { directory?: string; file?: string }): Promise<void> {
         const tagFile = path.normalize(this.pythonSettings.workspaceSymbols.tagFilePath);
         const cmd = this.pythonSettings.workspaceSymbols.ctagsPath;
         const args = this.buildCmdArgs();


### PR DESCRIPTION
Fixes #1503
Also fix a few other linter warnings/errors.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
