### PR TITLE
Add tests for log points in the experimental debugger

### DIFF
--- a/news/3 Code Health/1582.md
+++ b/news/3 Code Health/1582.md
@@ -1,0 +1,1 @@
+Add tests for log points in the experimental debugger.

--- a/src/test/debugger/misc.test.ts
+++ b/src/test/debugger/misc.test.ts
@@ -467,7 +467,7 @@ let testCounter = 0;
             await Promise.all([
                 debugClient.configurationSequence(),
                 setBreakpointFilter(),
-                debugClient.launch(buildLauncArgs('sampleWithAssertEx.py', false)),
+                debugClient.launch(buildLaunchArgs('sampleWithAssertEx.py', false)),
                 waitToStopDueToException(),
                 debugClient.assertStoppedLocation('exception', pauseLocation)
             ]);
@@ -616,7 +616,6 @@ let testCounter = 0;
             if (debuggerType !== 'pythonExperimental') {
                 return this.skip();
             }
-            this.retries(0);
             const breakpointLocation = { path: path.join(debugFilesPath, 'logMessage.py'), line: 4 };
             const breakpointArgs: DebugProtocol.SetBreakpointsArguments = {
                 lines: [breakpointLocation.line],

--- a/src/test/debugger/misc.test.ts
+++ b/src/test/debugger/misc.test.ts
@@ -612,5 +612,28 @@ let testCounter = 0;
                 debugClient.waitForEvent('terminated')
             ]);
         });
+        test('Test Logpoints', async function () {
+            if (debuggerType !== 'pythonExperimental') {
+                return this.skip();
+            }
+            this.retries(0);
+            const breakpointLocation = { path: path.join(debugFilesPath, 'logMessage.py'), line: 4 };
+            const breakpointArgs: DebugProtocol.SetBreakpointsArguments = {
+                lines: [breakpointLocation.line],
+                breakpoints: [{ line: breakpointLocation.line, logMessage: 'Sum of {a} and {b} is 3' }],
+                source: { path: breakpointLocation.path }
+            };
+            await Promise.all([
+                debugClient.launch(buildLaunchArgs('logMessage.py', false)),
+                debugClient.waitForEvent('initialized')
+                    .then(() => debugClient.setBreakpointsRequest(breakpointArgs))
+                    .then(() => debugClient.configurationDoneRequest())
+                    .then(() => debugClient.threadsRequest()),
+                debugClient.waitForEvent('thread')
+                    .then(() => debugClient.threadsRequest()),
+                debugClient.assertOutput('stdout', 'Sum of 1 and 2 is 3'),
+                debugClient.waitForEvent('terminated')
+            ]);
+        });
     });
 });

--- a/src/test/pythonFiles/debugging/logMessage.py
+++ b/src/test/pythonFiles/debugging/logMessage.py
@@ -1,0 +1,4 @@
+import time
+a = 1
+b = 2
+c = a + b


### PR DESCRIPTION
Fixes #1582
Was not added in previous release as this was purely a PTSVD change.
Adding tests in VSC to ensure we do not regress.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
