### PR TITLE
 Close communication channel before exiting the test runner

### DIFF
--- a/news/2 Fixes/1529.md
+++ b/news/2 Fixes/1529.md
@@ -1,0 +1,1 @@
+Close communication channel before exiting the test runner.

--- a/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
+++ b/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
@@ -102,12 +102,20 @@ class _IpcChannel(object):
         self.seq = 0
         self.callback = callback
         self.lock = thread.allocate_lock()
+        self._closed = False
         # start the testing reader thread loop
         self.test_thread_id = thread.start_new_thread(self.readSocket, ())
 
+    def close(self):
+        self._closed = True
+
     def readSocket(self):
-        data = self.socket.recv(1024)
-        self.callback()
+        try:
+            data = self.socket.recv(1024)
+            self.callback()
+        except OSError:
+            if not self._closed:
+                raise
 
     def receive(self):
         pass
@@ -312,7 +320,9 @@ def main():
         else:
             runner = unittest.TextTestRunner(verbosity=opts.uvInt, resultclass=VsTestResult)
         result = runner.run(tests)
-        sys.exit(not result.wasSuccessful())
+        if _channel is not None:
+            _channel.close()
+        sys.exit(0 if result.wasSuccessful() else 1)
     finally:
         if cov is not None:
             cov.stop()

--- a/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
+++ b/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
@@ -322,7 +322,7 @@ def main():
         result = runner.run(tests)
         if _channel is not None:
             _channel.close()
-        sys.exit(0 if result.wasSuccessful() else 1)
+        sys.exit(not result.wasSuccessful())
     finally:
         if cov is not None:
             cov.stop()


### PR DESCRIPTION
Fixes #1529

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
