### PR TITLE
Ensure debugger breaks on `assert` failures

### DIFF
--- a/news/2 Fixes/1194.md
+++ b/news/2 Fixes/1194.md
@@ -1,0 +1,1 @@
+Ensure debugger breaks on `assert` failures.

--- a/src/client/debugger/PythonProcessCallbackHandler.ts
+++ b/src/client/debugger/PythonProcessCallbackHandler.ts
@@ -259,7 +259,7 @@ export class PythonProcessCallbackHandler extends EventEmitter {
             return;
         }
 
-        if (typeName && desc) {
+        if (typeName || desc) {
             let ex: IPythonException = {
                 TypeName: typeName,
                 Description: desc

--- a/src/test/debugger/misc.test.ts
+++ b/src/test/debugger/misc.test.ts
@@ -439,6 +439,42 @@ let testCounter = 0;
             const pauseLocation = { path: path.join(debugFilesPath, 'sample3WithEx.py'), line: 5 };
             await debugClient.assertStoppedLocation('exception', pauseLocation);
         });
+        test('Test pausing on assert failures', async () => {
+            const pauseLocation = { path: path.join(debugFilesPath, 'sampleWithAssertEx.py'), line: 1 };
+
+            function waitToStopDueToException() {
+                return new Promise((resolve, reject) => {
+                    debugClient.once('stopped', (event: DebugProtocol.StoppedEvent) => {
+                        if (event.body.reason === 'exception' &&
+                            event.body.text && event.body.text!.startsWith('AssertionError')) {
+                            resolve();
+                        } else {
+                            reject(new Error('Stopped for some other reason'));
+                        }
+                    });
+                    setTimeout(() => {
+                        reject(new Error(`waitToStopDueToException not received after ${debugClient.defaultTimeout} ms`));
+                    }, debugClient.defaultTimeout);
+                });
+            }
+
+            function setBreakpointFilter(): Promise<any> {
+                if (debuggerType === 'python') {
+                    return Promise.resolve();
+                } else {
+                    return debugClient.waitForEvent('initialized')
+                        .then(() => debugClient.setExceptionBreakpointsRequest({ filters: ['uncaught'] }))
+                        .then(() => debugClient.configurationDoneRequest());
+                }
+            }
+            await Promise.all([
+                debugClient.configurationSequence(),
+                setBreakpointFilter(),
+                debugClient.launch(buildLauncArgs('sampleWithAssertEx.py', false)),
+                waitToStopDueToException(),
+                debugClient.assertStoppedLocation('exception', pauseLocation)
+            ]);
+        });
         test('Test multi-threaded debugging', async function () {
             if (debuggerType !== 'python') {
                 // See GitHub issue #1250

--- a/src/test/pythonFiles/debugging/sampleWithAssertEx.py
+++ b/src/test/pythonFiles/debugging/sampleWithAssertEx.py
@@ -1,0 +1,1 @@
+assert False


### PR DESCRIPTION
Fixes #1194

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
