### PR TITLE
Allow for negative column numbers in messages returned by `pylint`

### DIFF
--- a/news/2 Fixes/1628.md
+++ b/news/2 Fixes/1628.md
@@ -1,0 +1,1 @@
+Allow for negative column numbers in messages returned by `pylint`.

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -33,7 +33,7 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
     public venvPath = '';
     public venvFolders: string[] = [];
     public devOptions: string[] = [];
-    public linting?: ILintingSettings;
+    public linting!: ILintingSettings;
     public formatting!: IFormattingSettings;
     public autoComplete?: IAutoCompleteSettings;
     public unitTest!: IUnitTestSettings;

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -103,7 +103,7 @@ export interface IPythonSettings {
     readonly jediPath: string;
     readonly jediMemoryLimit: number;
     readonly devOptions: string[];
-    readonly linting?: ILintingSettings;
+    readonly linting: ILintingSettings;
     readonly formatting: IFormattingSettings;
     readonly unitTest: IUnitTestSettings;
     readonly autoComplete?: IAutoCompleteSettings;


### PR DESCRIPTION
Fixes #1628

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
