### PR TITLE
Ensure the prompt to install missing packages is displayed only once

### DIFF
--- a/news/2 Fixes/980
+++ b/news/2 Fixes/980
@@ -1,0 +1,1 @@
+Ensure the prompt to install missing packages is not displayed more than once.

--- a/src/client/linters/errorHandlers/notInstalled.ts
+++ b/src/client/linters/errorHandlers/notInstalled.ts
@@ -1,5 +1,4 @@
 import { OutputChannel, Uri } from 'vscode';
-import { isNotInstalledError } from '../../common/helpers';
 import { IPythonExecutionFactory } from '../../common/process/types';
 import { ExecutionInfo, Product } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
 import { ConfigurationTarget, Uri } from 'vscode';
-import { IApplicationShell } from '../../client/common/application/types';
+import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import { ConfigurationService } from '../../client/common/configuration/service';
 import { EnumEx } from '../../client/common/enumUtils';
 import { createDeferred } from '../../client/common/helpers';
@@ -57,6 +57,10 @@ suite('Installer', () => {
 
         ioc.serviceManager.addSingletonInstance<IApplicationShell>(IApplicationShell, TypeMoq.Mock.ofType<IApplicationShell>().object);
         ioc.serviceManager.addSingleton<IConfigurationService>(IConfigurationService, ConfigurationService);
+
+        const workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
+        workspaceService.setup(w => w.getWorkspaceFolder(TypeMoq.It.isAny())).returns(() => undefined);
+        ioc.serviceManager.addSingletonInstance<IWorkspaceService>(IWorkspaceService, workspaceService.object);
 
         ioc.registerMockProcessTypes();
         ioc.serviceManager.addSingletonInstance<boolean>(IsWindows, false);


### PR DESCRIPTION
Fixes #980

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
