### PR TITLE
Prefix display name with 'Python' only if not already prefixed

### DIFF
--- a/news/2 Fixes/1651.md
+++ b/news/2 Fixes/1651.md
@@ -1,0 +1,1 @@
+Ensure the display name of an interpreter does not get prefixed twice with the words `Python`.

--- a/src/client/interpreter/locators/helpers.ts
+++ b/src/client/interpreter/locators/helpers.ts
@@ -18,7 +18,8 @@ export function fixInterpreterDisplayName(item: PythonInterpreter) {
     if (!item.displayName) {
         const arch = getArchitectureDislayName(item.architecture);
         const version = typeof item.version === 'string' ? item.version : '';
-        item.displayName = ['Python', version, arch].filter(namePart => namePart.length > 0).join(' ').trim();
+        const prefix = version.toUpperCase().startsWith('PYTHON') ? '' : 'Python';
+        item.displayName = [prefix, version, arch].filter(namePart => namePart.length > 0).join(' ').trim();
     }
     return item;
 }

--- a/src/test/interpreters/helper.test.ts
+++ b/src/test/interpreters/helper.test.ts
@@ -7,6 +7,7 @@ import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
 import { ConfigurationTarget, TextDocument, TextEditor, Uri } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
+import { Architecture } from '../../client/common/platform/types';
 import { InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../client/interpreter/helpers';
 import { fixInterpreterDisplayName } from '../../client/interpreter/locators/helpers';
@@ -91,7 +92,11 @@ suite('Interpreters Display Helper', () => {
         const interpreter: PythonInterpreter = {
             path: '',
             type: InterpreterType.Unknown,
-            version: 'Something'
+            version: 'Something',
+            sysPrefix: '',
+            architecture: Architecture.Unknown,
+            sysVersion: '',
+            version_info: [0, 0, 0, 'alpha']
         };
         const expectedDisplayName = `Python ${interpreter.version!}`;
         expect(fixInterpreterDisplayName(interpreter)).to.have.property('displayName', expectedDisplayName);
@@ -100,7 +105,11 @@ suite('Interpreters Display Helper', () => {
         const interpreter: PythonInterpreter = {
             path: '',
             type: InterpreterType.Unknown,
-            version: 'Python Something'
+            version: 'Python Something',
+            sysPrefix: '',
+            architecture: Architecture.Unknown,
+            sysVersion: '',
+            version_info: [0, 0, 0, 'alpha']
         };
         expect(fixInterpreterDisplayName(interpreter)).to.have.property('displayName', interpreter.version);
     });

--- a/src/test/interpreters/helper.test.ts
+++ b/src/test/interpreters/helper.test.ts
@@ -7,7 +7,9 @@ import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
 import { ConfigurationTarget, TextDocument, TextEditor, Uri } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
+import { InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../client/interpreter/helpers';
+import { fixInterpreterDisplayName } from '../../client/interpreter/locators/helpers';
 import { IServiceContainer } from '../../client/ioc/types';
 
 // tslint:disable-next-line:max-func-body-length
@@ -84,5 +86,22 @@ suite('Interpreters Display Helper', () => {
         expect(workspace).to.be.not.equal(undefined, 'incorrect value');
         expect(workspace!.folderUri).to.be.equal(documentWorkspaceFolderUri);
         expect(workspace!.configTarget).to.be.equal(ConfigurationTarget.WorkspaceFolder);
+    });
+    test('Ensure Python prefix is added to displayName', () => {
+        const interpreter: PythonInterpreter = {
+            path: '',
+            type: InterpreterType.Unknown,
+            version: 'Something'
+        };
+        const expectedDisplayName = `Python ${interpreter.version!}`;
+        expect(fixInterpreterDisplayName(interpreter)).to.have.property('displayName', expectedDisplayName);
+    });
+    test('Ensure Python prefix is not added to displayName', () => {
+        const interpreter: PythonInterpreter = {
+            path: '',
+            type: InterpreterType.Unknown,
+            version: 'Python Something'
+        };
+        expect(fixInterpreterDisplayName(interpreter)).to.have.property('displayName', interpreter.version);
     });
 });


### PR DESCRIPTION
Fixes #1651

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
