### PR TITLE
Display documentation for auto completion items when addBrackets is true

### DIFF
--- a/news/2 Fixes/452.md
+++ b/news/2 Fixes/452.md
@@ -1,0 +1,1 @@
+Display documentation for auto completion items when the feature to automatically insert of brackets for selected item is turned on.

--- a/src/client/providers/completionProvider.ts
+++ b/src/client/providers/completionProvider.ts
@@ -7,13 +7,14 @@ import { JediFactory } from '../languageServices/jediProxyFactory';
 import { captureTelemetry } from '../telemetry';
 import { COMPLETION } from '../telemetry/constants';
 import { CompletionSource } from './completionSource';
+import { ItemInfoSource } from './itemInfoSource';
 
 export class PythonCompletionItemProvider implements vscode.CompletionItemProvider {
     private completionSource: CompletionSource;
     private configService: IConfigurationService;
 
     constructor(jediFactory: JediFactory, serviceContainer: IServiceContainer) {
-        this.completionSource = new CompletionSource(jediFactory);
+        this.completionSource = new CompletionSource(jediFactory, serviceContainer, new ItemInfoSource(jediFactory));
         this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
     }
 

--- a/src/client/providers/completionSource.ts
+++ b/src/client/providers/completionSource.ts
@@ -3,9 +3,10 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { PythonSettings } from '../common/configSettings';
+import { IConfigurationService } from '../common/types';
+import { IServiceContainer } from '../ioc/types';
 import { JediFactory } from '../languageServices/jediProxyFactory';
-import { ItemInfoSource, LanguageItemInfo } from './itemInfoSource';
+import { IItemInfoSource, LanguageItemInfo } from './itemInfoSource';
 import * as proxy from './jediProxy';
 import { isPositionInsideStringOrComment } from './providerUtilities';
 
@@ -25,11 +26,10 @@ class DocumentPosition {
 
 export class CompletionSource {
     private jediFactory: JediFactory;
-    private itemInfoSource: ItemInfoSource;
 
-    constructor(jediFactory: JediFactory) {
+    constructor(jediFactory: JediFactory, private serviceContainer: IServiceContainer,
+        private itemInfoSource: IItemInfoSource) {
         this.jediFactory = jediFactory;
-        this.itemInfoSource = new ItemInfoSource(jediFactory);
     }
 
     public async getVsCodeCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken)
@@ -53,7 +53,7 @@ export class CompletionSource {
         let insertText: string | undefined;
         if (typeof completionItem.insertText === 'string') {
             insertText = completionItem.insertText!;
-        } else if (completionItem instanceof vscode.SnippetString) {
+        } else if (completionItem.insertText instanceof vscode.SnippetString) {
             insertText = (completionItem.insertText! as vscode.SnippetString).value;
         }
         const itemText = insertText ? insertText : completionItem.label;
@@ -106,7 +106,9 @@ export class CompletionSource {
     private toVsCodeCompletion(documentPosition: DocumentPosition, item: proxy.IAutoCompleteItem, resource: vscode.Uri): vscode.CompletionItem {
         const completionItem = new vscode.CompletionItem(item.text);
         completionItem.kind = item.type;
-        if (PythonSettings.getInstance(resource).autoComplete.addBrackets === true &&
+        const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const pythonSettings = configurationService.getSettings(resource);
+        if (pythonSettings.autoComplete.addBrackets === true &&
             (item.kind === vscode.SymbolKind.Function || item.kind === vscode.SymbolKind.Method)) {
             completionItem.insertText = new vscode.SnippetString(item.text).appendText('(').appendTabstop().appendText(')');
         }

--- a/src/client/providers/completionSource.ts
+++ b/src/client/providers/completionSource.ts
@@ -50,7 +50,13 @@ export class CompletionSource {
         // Supply hover source with simulated document text where item in question was 'already typed'.
         const document = documentPosition.document;
         const position = documentPosition.position;
-        const itemText = completionItem.insertText ? completionItem.insertText : completionItem.label;
+        let insertText: string | undefined;
+        if (typeof completionItem.insertText === 'string') {
+            insertText = completionItem.insertText!;
+        } else if (completionItem instanceof vscode.SnippetString) {
+            insertText = (completionItem.insertText! as vscode.SnippetString).value;
+        }
+        const itemText = insertText ? insertText : completionItem.label;
         const wordRange = document.getWordRangeAtPosition(position);
 
         const leadingRange = wordRange !== undefined

--- a/src/test/providers/completionSource.test.ts
+++ b/src/test/providers/completionSource.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length no-any
+
+import * as TypeMoq from 'typemoq';
+import { CancellationTokenSource, CompletionItemKind, Position, SymbolKind, TextDocument, TextLine } from 'vscode';
+import { IAutoCompleteSettings, IConfigurationService, IPythonSettings } from '../../client/common/types';
+import { IServiceContainer } from '../../client/ioc/types';
+import { JediFactory } from '../../client/languageServices/jediProxyFactory';
+import { CompletionSource } from '../../client/providers/completionSource';
+import { IItemInfoSource } from '../../client/providers/itemInfoSource';
+import { IAutoCompleteItem, ICompletionResult, JediProxyHandler } from '../../client/providers/jediProxy';
+
+suite('Completion Provider', () => {
+    let completionSource: CompletionSource;
+    let jediHandler: TypeMoq.IMock<JediProxyHandler<ICompletionResult>>;
+    let autoCompleteSettings: TypeMoq.IMock<IAutoCompleteSettings>;
+    let itemInfoSource: TypeMoq.IMock<IItemInfoSource>;
+    setup(() => {
+        const jediFactory = TypeMoq.Mock.ofType(JediFactory);
+        jediHandler = TypeMoq.Mock.ofType<JediProxyHandler<ICompletionResult>>();
+        const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        const configService = TypeMoq.Mock.ofType<IConfigurationService>();
+        const pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+        autoCompleteSettings = TypeMoq.Mock.ofType<IAutoCompleteSettings>();
+        autoCompleteSettings = TypeMoq.Mock.ofType<IAutoCompleteSettings>();
+
+        jediFactory.setup(j => j.getJediProxyHandler(TypeMoq.It.isAny()))
+            .returns(() => jediHandler.object);
+        serviceContainer.setup(s => s.get(TypeMoq.It.isValue(IConfigurationService), TypeMoq.It.isAny()))
+            .returns(() => configService.object);
+        configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+        pythonSettings.setup(p => p.autoComplete).returns(() => autoCompleteSettings.object);
+        itemInfoSource = TypeMoq.Mock.ofType<IItemInfoSource>();
+        completionSource = new CompletionSource(jediFactory.object, serviceContainer.object, itemInfoSource.object);
+    });
+
+    async function testDocumentation(source: string, addBrackets: boolean) {
+        const doc = TypeMoq.Mock.ofType<TextDocument>();
+        const position = new Position(1, 1);
+        const token = new CancellationTokenSource().token;
+        const lineText = TypeMoq.Mock.ofType<TextLine>();
+        const completionResult = TypeMoq.Mock.ofType<ICompletionResult>();
+
+        const autoCompleteItems: IAutoCompleteItem[] = [{
+            description: 'description', kind: SymbolKind.Function,
+            raw_docstring: 'raw docstring',
+            rawType: CompletionItemKind.Function,
+            rightLabel: 'right label',
+            text: 'some text', type: CompletionItemKind.Function
+        }];
+
+        autoCompleteSettings.setup(a => a.addBrackets).returns(() => addBrackets);
+        doc.setup(d => d.fileName).returns(() => '');
+        doc.setup(d => d.getText(TypeMoq.It.isAny())).returns(() => source);
+        doc.setup(d => d.lineAt(TypeMoq.It.isAny())).returns(() => lineText.object);
+        doc.setup(d => d.offsetAt(TypeMoq.It.isAny())).returns(() => 0);
+        lineText.setup(l => l.text).returns(() => source);
+        completionResult.setup(c => c.requestId).returns(() => 1);
+        completionResult.setup(c => c.items).returns(() => autoCompleteItems);
+        completionResult.setup((c: any) => c.then).returns(() => undefined);
+        jediHandler.setup(j => j.sendCommand(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => {
+            return Promise.resolve(completionResult.object);
+        });
+
+        const expectedSource = `${source}${autoCompleteItems[0].text}${addBrackets ? '($)' : ''}`;
+        itemInfoSource.setup(i => i.getItemInfoFromText(TypeMoq.It.isAny(), TypeMoq.It.isAny(),
+            TypeMoq.It.isAny(), expectedSource, TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable(TypeMoq.Times.once());
+
+        const [item] = await completionSource.getVsCodeCompletionItems(doc.object, position, token);
+        await completionSource.getDocumentation(item, token);
+        itemInfoSource.verifyAll();
+    }
+
+    test('Ensure docs are provided when \'addBrackets\' setting is false', async () => {
+        const source = 'if True:\n    print("Hello")\n';
+        await testDocumentation(source, false);
+    });
+    test('Ensure docs are provided when \'addBrackets\' setting is true', async () => {
+        const source = 'if True:\n    print("Hello")\n';
+        await testDocumentation(source, true);
+    });
+
+});


### PR DESCRIPTION
Fixes #452

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
