### PR TITLE
Upgrade Typscript to v2.8.3

### DIFF
--- a/news/3 Code Health/1604.md
+++ b/news/3 Code Health/1604.md
@@ -1,0 +1,1 @@
+- Update typescript package to 2.8.3

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
                 "path": "./snippets/python.json"
             }
         ],
-        "keybindings":[
+        "keybindings": [
             {
                 "command": "python.execSelectionInTerminal",
                 "key": "ctrl+enter",
@@ -1757,7 +1757,6 @@
                     "description": "Whether to re-build the tags file on start (defaults to true).",
                     "scope": "resource"
                 },
-
                 "python.workspaceSymbols.tagFilePath": {
                     "type": "string",
                     "default": "${workspaceFolder}/.vscode/tags",
@@ -1933,7 +1932,7 @@
         "tslint-eslint-rules": "^5.1.0",
         "tslint-microsoft-contrib": "^5.0.3",
         "typemoq": "^2.1.0",
-        "typescript": "^2.7.2",
+        "typescript": "2.8.3",
         "typescript-formatter": "^7.1.0",
         "vscode": "^1.1.5",
         "vscode-debugadapter-testsupport": "^1.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,9 +4568,9 @@ typescript-formatter@^7.1.0:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
+typescript@2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
Fixes #1604 

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
