### PR TITLE
Ensure navigation to definitons follows imports and is transparent to decoration

### DIFF
--- a/news/2 Fixes/1638.md
+++ b/news/2 Fixes/1638.md
@@ -1,0 +1,1 @@
+Ensure navigation to definitons follows imports but not decoration ([#1638](https://github.com/Microsoft/vscode-python/issues/1638); thanks [Peter Law](https://github.com/PeterJCLaw))

--- a/news/2 Fixes/1638.md
+++ b/news/2 Fixes/1638.md
@@ -1,1 +1,1 @@
-Ensure navigation to definitons follows imports but not decoration ([#1638](https://github.com/Microsoft/vscode-python/issues/1638); thanks [Peter Law](https://github.com/PeterJCLaw))
+Ensure navigation to definitons follows imports and is transparent to decoration ([#1638](https://github.com/Microsoft/vscode-python/issues/1638); thanks [Peter Law](https://github.com/PeterJCLaw))

--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -570,21 +570,7 @@ class JediCompletion(object):
             sys_path=sys.path, environment=self.environment)
 
         if lookup == 'definitions':
-            defs = []
-            try:
-                defs = self._get_definitionsx(script.goto_definitions(follow_imports=False), request['id'])
-            except:
-                pass
-            try:
-                if len(defs) == 0:
-                    defs = self._get_definitionsx(script.goto_definitions(), request['id'])
-            except:
-                pass
-            try:
-                if len(defs) == 0:
-                    defs = self._get_definitionsx(script.goto_assignments(), request['id'])
-            except:
-                pass
+            defs = self._get_definitionsx(script.goto_assignments(follow_imports=True), request['id'])
             return json.dumps({'id': request['id'], 'results': defs})
         if lookup == 'tooltip':
             if jediPreview:

--- a/src/test/definitions/navigation.test.ts
+++ b/src/test/definitions/navigation.test.ts
@@ -1,0 +1,70 @@
+// Licensed under the MIT License.
+
+'use strict';
+import * as assert from 'assert';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { closeActiveWindows, initialize, initializeTest } from '../initialize';
+
+const decoratorsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonFiles', 'definition', 'navigation');
+const fileDefinitions = path.join(decoratorsPath, 'definitions.py');
+const fileUsages = path.join(decoratorsPath, 'usages.py');
+
+// tslint:disable-next-line:max-func-body-length
+suite('Definition Navigation', () => {
+    suiteSetup(initialize);
+    setup(initializeTest);
+    suiteTeardown(closeActiveWindows);
+    teardown(closeActiveWindows);
+
+    const assertFile = (expectedLocation: string, location: vscode.Uri) => {
+        const relLocation = vscode.workspace.asRelativePath(location);
+        const expectedRelLocation = vscode.workspace.asRelativePath(expectedLocation);
+        assert.equal(expectedRelLocation, relLocation, 'Position is in wrong file');
+    };
+
+    const formatPosition = (position: vscode.Position) => {
+        return `${position.line},${position.character}`;
+    };
+
+    const assertRange = (expectedRange: vscode.Range, range: vscode.Range) => {
+        assert.equal(formatPosition(expectedRange.start), formatPosition(range.start), 'Start position is incorrect');
+        assert.equal(formatPosition(expectedRange.end), formatPosition(range.end), 'End position is incorrect');
+    };
+
+    const buildTest = (startFile: string, startPosition: vscode.Position, expectedFile: string, expectedRange: vscode.Range) => {
+        return async () => {
+            const textDocument = await vscode.workspace.openTextDocument(startFile);
+            await vscode.window.showTextDocument(textDocument);
+            assert(vscode.window.activeTextEditor, 'No active editor');
+
+            const locations = await vscode.commands.executeCommand<vscode.Location[]>('vscode.executeDefinitionProvider', textDocument.uri, startPosition);
+            assert.equal(1, locations!.length, 'Wrong number of results');
+
+            const def = locations![0];
+            assertFile(expectedFile, def.uri);
+            assertRange(expectedRange, def.range!);
+        };
+    };
+
+    test('From own definition', buildTest(
+        fileDefinitions,
+        new vscode.Position(2, 6),
+        fileDefinitions,
+        new vscode.Range(2, 0, 11, 17)
+    ));
+
+    test('Nested function', buildTest(
+        fileDefinitions,
+        new vscode.Position(11, 16),
+        fileDefinitions,
+        new vscode.Range(6, 4, 10, 16)
+    ));
+
+    test('Decorator usage', buildTest(
+        fileDefinitions,
+        new vscode.Position(13, 1),
+        fileDefinitions,
+        new vscode.Range(2, 0, 11, 17)
+    ));
+});

--- a/src/test/definitions/navigation.test.ts
+++ b/src/test/definitions/navigation.test.ts
@@ -67,4 +67,60 @@ suite('Definition Navigation', () => {
         fileDefinitions,
         new vscode.Range(2, 0, 11, 17)
     ));
+
+    test('Function decorated by stdlib', buildTest(
+        fileDefinitions,
+        new vscode.Position(29, 6),
+        fileDefinitions,
+        new vscode.Range(21, 0, 27, 17)
+    ));
+
+    test('Function decorated by local decorator', buildTest(
+        fileDefinitions,
+        new vscode.Position(30, 6),
+        fileDefinitions,
+        new vscode.Range(14, 0, 18, 7)
+    ));
+
+    test('Module imported decorator usage', buildTest(
+        fileUsages,
+        new vscode.Position(3, 15),
+        fileDefinitions,
+        new vscode.Range(2, 0, 11, 17)
+    ));
+
+    test('Module imported function decorated by stdlib', buildTest(
+        fileUsages,
+        new vscode.Position(11, 19),
+        fileDefinitions,
+        new vscode.Range(21, 0, 27, 17)
+    ));
+
+    test('Module imported function decorated by local decorator', buildTest(
+        fileUsages,
+        new vscode.Position(12, 19),
+        fileDefinitions,
+        new vscode.Range(14, 0, 18, 7)
+    ));
+
+    test('Specifically imported decorator usage', buildTest(
+        fileUsages,
+        new vscode.Position(7, 1),
+        fileDefinitions,
+        new vscode.Range(2, 0, 11, 17)
+    ));
+
+    test('Specifically imported function decorated by stdlib', buildTest(
+        fileUsages,
+        new vscode.Position(14, 6),
+        fileDefinitions,
+        new vscode.Range(21, 0, 27, 17)
+    ));
+
+    test('Specifically imported function decorated by local decorator', buildTest(
+        fileUsages,
+        new vscode.Position(15, 6),
+        fileDefinitions,
+        new vscode.Range(14, 0, 18, 7)
+    ));
 });

--- a/src/test/pythonFiles/definition/navigation/definitions.py
+++ b/src/test/pythonFiles/definition/navigation/definitions.py
@@ -1,0 +1,31 @@
+from contextlib import contextmanager
+
+def my_decorator(fn):
+    """
+    This is my decorator.
+    """
+    def wrapper(*args, **kwargs):
+        """
+        This is the wrapper.
+        """
+        return 42
+    return wrapper
+
+@my_decorator
+def thing(arg):
+    """
+    Thing which is decorated.
+    """
+    pass
+
+@contextmanager
+def my_context_manager():
+    """
+    This is my context manager.
+    """
+    print("before")
+    yield
+    print("after")
+
+with my_context_manager():
+    thing(19)

--- a/src/test/pythonFiles/definition/navigation/usages.py
+++ b/src/test/pythonFiles/definition/navigation/usages.py
@@ -1,0 +1,16 @@
+import definitions
+from .definitions import my_context_manager, my_decorator, thing
+
+@definitions.my_decorator
+def one():
+    pass
+
+@my_decorator
+def two():
+    pass
+
+with definitions.my_context_manager():
+    definitions.thing(19)
+
+with my_context_manager():
+    thing(19)


### PR DESCRIPTION
Fixes #1638

It turns out that there are three mechanisms for getting definitions of a symbol from [`jedi`](https://github.com/davidhalter/jedi):
- `goto_definitions`: follows all imports and considers the actual value of the target symbol (so returns the wrapped version of a decorated function)
- `goto_assignments`: considers the original assignments of a symbol, meaning that it ignores decoration, but doesn't follow import by default
- `goto_assignments(follow_imports=True)`: behaves like `goto_assignments`, but doesn't consider an import to be an assignment and so follows to the original assignment

It's the latter behaviour that is what I'd find most useful from an IDE.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (only tested under Python 2.7, but there's no reason it should be different elsewhere)
- [x] Works on Windows 10, macOS, and Linux (only tested on Linux, but there's no reason it shouldn't work elsewhere)
