### PR TITLE
Prompt to reload VS Code when changing analysis engines

### DIFF
--- a/news/3 Code Health/1747.md
+++ b/news/3 Code Health/1747.md
@@ -1,0 +1,1 @@
+Prompt user to reload Visual Studio Code when toggling between the analysis engines.

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { ConfigurationChangeEvent, Disposable, OutputChannel, Uri } from 'vscode';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
+import { isPythonAnalysisEngineTest, STANDARD_OUTPUT_CHANNEL } from '../common/constants';
+import '../common/extensions';
+import { IConfigurationService, IDisposableRegistry, IOutputChannel, IPythonSettings } from '../common/types';
+import { IServiceContainer } from '../ioc/types';
+import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from './types';
+
+const jediEnabledSetting: keyof IPythonSettings = 'jediEnabled';
+
+type ActivatorInfo = { jedi: boolean; activator: IExtensionActivator };
+
+@injectable()
+export class ExtensionActivationService implements IExtensionActivationService, Disposable {
+    private currentActivator?: ActivatorInfo;
+    private readonly workspaceService: IWorkspaceService;
+    private readonly output: OutputChannel;
+    private readonly appShell: IApplicationShell;
+    constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
+        this.workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        this.output = this.serviceContainer.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+        this.appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+
+        const disposables = serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
+        disposables.push(this);
+        disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
+    }
+    public async activate(): Promise<void> {
+        if (this.currentActivator) {
+            return;
+        }
+
+        const jedi = this.useJedi();
+
+        const engineName = jedi ? 'classic analysis engine' : 'analysis engine';
+        this.output.appendLine(`Starting the ${engineName}.`);
+        const activatorName = jedi ? ExtensionActivators.Jedi : ExtensionActivators.DotNet;
+        const activator = this.serviceContainer.get<IExtensionActivator>(IExtensionActivator, activatorName);
+        this.currentActivator = { jedi, activator };
+
+        await activator.activate();
+    }
+    public dispose() {
+        if (this.currentActivator) {
+            this.currentActivator.activator.deactivate().ignoreErrors();
+        }
+    }
+    private async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
+        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders ? this.workspaceService.workspaceFolders!.map(workspace => workspace.uri) : [undefined];
+        if (workspacesUris.findIndex(uri => event.affectsConfiguration(`python.${jediEnabledSetting}`, uri)) === -1) {
+            return;
+        }
+        const jedi = this.useJedi();
+        if (this.currentActivator && this.currentActivator.jedi === jedi) {
+            return;
+        }
+
+        const item = await this.appShell.showInformationMessage('Please reload Visual Studio Code when switching between the analysis engines.', 'Reload');
+        if (item === 'Reload') {
+            this.serviceContainer.get<ICommandManager>(ICommandManager).executeCommand('workbench.action.reloadWindow');
+        }
+    }
+    private useJedi(): boolean {
+        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders ? this.workspaceService.workspaceFolders!.map(item => item.uri) : [undefined];
+        const configuraionService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const jediEnabledForAnyWorkspace = workspacesUris.filter(uri => configuraionService.getSettings(uri).jediEnabled).length > 0;
+        return !isPythonAnalysisEngineTest() && jediEnabledForAnyWorkspace;
+    }
+}

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -61,7 +61,7 @@ export class ExtensionActivationService implements IExtensionActivationService, 
             return;
         }
 
-        const item = await this.appShell.showInformationMessage('Please reload Visual Studio Code when switching between the analysis engines.', 'Reload');
+        const item = await this.appShell.showInformationMessage('Please reload the window switching between the analysis engines.', 'Reload');
         if (item === 'Reload') {
             this.serviceContainer.get<ICommandManager>(ICommandManager).executeCommand('workbench.action.reloadWindow');
         }

--- a/src/client/activation/analysis.ts
+++ b/src/client/activation/analysis.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { ExtensionContext, OutputChannel } from 'vscode';
 import { Message } from 'vscode-jsonrpc';
@@ -10,7 +11,7 @@ import { isTestExecution, STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import { createDeferred, Deferred } from '../common/helpers';
 import { IFileSystem, IPlatformService } from '../common/platform/types';
 import { StopWatch } from '../common/stopWatch';
-import { IConfigurationService, IOutputChannel, IPythonSettings } from '../common/types';
+import { IConfigurationService, IExtensionContext, IOutputChannel } from '../common/types';
 import { IEnvironmentVariablesProvider } from '../common/variables/types';
 import { IInterpreterService } from '../interpreter/contracts';
 import { IServiceContainer } from '../ioc/types';
@@ -43,6 +44,7 @@ class LanguageServerStartupErrorHandler implements ErrorHandler {
     }
 }
 
+@injectable()
 export class AnalysisExtensionActivator implements IExtensionActivator {
     private readonly configuration: IConfigurationService;
     private readonly appShell: IApplicationShell;
@@ -53,10 +55,11 @@ export class AnalysisExtensionActivator implements IExtensionActivator {
     private readonly interpreterService: IInterpreterService;
     private readonly disposables: Disposable[] = [];
     private languageClient: LanguageClient | undefined;
-    private context: ExtensionContext | undefined;
+    private readonly context: ExtensionContext;
     private interpreterHash: string = '';
 
-    constructor(private readonly services: IServiceContainer, pythonSettings: IPythonSettings) {
+    constructor(@inject(IServiceContainer) private readonly services: IServiceContainer) {
+        this.context = this.services.get<IExtensionContext>(IExtensionContext);
         this.configuration = this.services.get<IConfigurationService>(IConfigurationService);
         this.appShell = this.services.get<IApplicationShell>(IApplicationShell);
         this.output = this.services.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
@@ -65,15 +68,14 @@ export class AnalysisExtensionActivator implements IExtensionActivator {
         this.interpreterService = this.services.get<IInterpreterService>(IInterpreterService);
     }
 
-    public async activate(context: ExtensionContext): Promise<boolean> {
+    public async activate(): Promise<boolean> {
         this.sw.reset();
-        this.context = context;
-        const clientOptions = await this.getAnalysisOptions(context);
+        const clientOptions = await this.getAnalysisOptions(this.context);
         if (!clientOptions) {
             return false;
         }
         this.disposables.push(this.interpreterService.onDidChangeInterpreter(() => this.restartLanguageServer()));
-        return this.startLanguageServer(context, clientOptions);
+        return this.startLanguageServer(this.context, clientOptions);
     }
 
     public async deactivate(): Promise<void> {
@@ -94,7 +96,7 @@ export class AnalysisExtensionActivator implements IExtensionActivator {
         if (!idata || idata.hash !== this.interpreterHash) {
             this.interpreterHash = idata ? idata.hash : '';
             await this.deactivate();
-            await this.activate(this.context);
+            await this.activate();
         }
     }
 

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { IServiceManager } from '../ioc/types';
+import { ExtensionActivationService } from './activationService';
+import { AnalysisExtensionActivator } from './analysis';
+import { ClassicExtensionActivator } from './classic';
+import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from './types';
+
+export function registerTypes(serviceManager: IServiceManager) {
+    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, ExtensionActivationService);
+    serviceManager.add<IExtensionActivator>(IExtensionActivator, ClassicExtensionActivator, ExtensionActivators.Jedi);
+    serviceManager.add<IExtensionActivator>(IExtensionActivator, AnalysisExtensionActivator, ExtensionActivators.DotNet);
+}

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -1,9 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as vscode from 'vscode';
+export const IExtensionActivationService = Symbol('IExtensionActivationService');
+export interface IExtensionActivationService {
+  activate(): Promise<void>;
+}
 
+export enum ExtensionActivators {
+  Jedi = 'Jedi',
+  DotNet = 'DotNet'
+}
+
+export const IExtensionActivator = Symbol('IExtensionActivator');
 export interface IExtensionActivator {
-  activate(context: vscode.ExtensionContext): Promise<boolean>;
+  activate(): Promise<boolean>;
   deactivate(): Promise<void>;
 }

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -71,8 +71,7 @@ export namespace LinterErrors {
 export const STANDARD_OUTPUT_CHANNEL = 'STANDARD_OUTPUT_CHANNEL';
 
 export function isTestExecution(): boolean {
-    // tslint:disable-next-line:interface-name no-string-literal
-    return process.env['VSC_PYTHON_CI_TEST'] === '1';
+    return process.env.VSC_PYTHON_CI_TEST === '1';
 }
 export function isPythonAnalysisEngineTest(): boolean {
     return process.env.VSC_PYTHON_ANALYSIS === '1';

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -3,14 +3,16 @@
 // Licensed under the MIT License.
 
 import { Socket } from 'net';
-import { ConfigurationTarget, DiagnosticSeverity, Disposable, Uri } from 'vscode';
+import { ConfigurationTarget, DiagnosticSeverity, Disposable, ExtensionContext, OutputChannel, Uri } from 'vscode';
 
 import { EnvironmentVariables } from './variables/types';
 export const IOutputChannel = Symbol('IOutputChannel');
+export interface IOutputChannel extends OutputChannel { }
 export const IDocumentSymbolProvider = Symbol('IDocumentSymbolProvider');
 export const IsWindows = Symbol('IS_WINDOWS');
 export const Is64Bit = Symbol('Is64Bit');
 export const IDisposableRegistry = Symbol('IDiposableRegistry');
+export type IDisposableRegistry = Disposable[];
 export const IMemento = Symbol('IGlobalMemento');
 export const GLOBAL_MEMENTO = Symbol('IGlobalMemento');
 export const WORKSPACE_MEMENTO = Symbol('IWorkspaceMemento');
@@ -233,3 +235,6 @@ export interface ISocketServer extends Disposable {
     readonly client: Promise<Socket>;
     Start(options?: { port?: number; host?: string }): Promise<number>;
 }
+
+export const IExtensionContext = Symbol('ExtensionContext');
+export interface IExtensionContext extends ExtensionContext { }

--- a/src/client/formatters/baseFormatter.ts
+++ b/src/client/formatters/baseFormatter.ts
@@ -41,7 +41,6 @@ export abstract class BaseFormatter {
         return vscode.Uri.file(__dirname);
     }
     protected async provideDocumentFormattingEdits(document: vscode.TextDocument, options: vscode.FormattingOptions, token: vscode.CancellationToken, args: string[], cwd?: string): Promise<vscode.TextEdit[]> {
-        this.outputChannel.clear();
         if (typeof cwd !== 'string' || cwd.length === 0) {
             cwd = this.getWorkspaceUri(document).fsPath;
         }

--- a/src/client/ioc/serviceManager.ts
+++ b/src/client/ioc/serviceManager.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Container, interfaces } from 'inversify';
+import { Container, injectable, interfaces } from 'inversify';
 import { Abstract, IServiceManager, Newable } from './types';
 
 type identifier<T> = string | symbol | Newable<T> | Abstract<T>;
 
+@injectable()
 export class ServiceManager implements IServiceManager {
     constructor(private container: Container) { }
     // tslint:disable-next-line:no-any

--- a/src/client/linters/lintingEngine.ts
+++ b/src/client/linters/lintingEngine.ts
@@ -92,7 +92,6 @@ export class LintingEngine implements ILintingEngine {
         });
 
         this.pendingLintings.set(document.uri.fsPath, cancelToken);
-        this.outputChannel.clear();
 
         const promises: Promise<ILintMessage[]>[] = this.linterManager.getActiveLinters(document.uri)
             .map(info => {

--- a/src/test/activation/activationService.unit.test.ts
+++ b/src/test/activation/activationService.unit.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length
+
+import * as TypeMoq from 'typemoq';
+import { ConfigurationChangeEvent, Disposable } from 'vscode';
+import { ExtensionActivationService } from '../../client/activation/activationService';
+import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from '../../client/activation/types';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../client/common/application/types';
+import { isPythonAnalysisEngineTest } from '../../client/common/constants';
+import { IConfigurationService, IDisposableRegistry, IOutputChannel, IPythonSettings } from '../../client/common/types';
+import { IServiceContainer } from '../../client/ioc/types';
+
+suite('Activation - ActivationService', () => {
+    [true, false].forEach(jediIsEnabled => {
+        suite(`Jedi is ${jediIsEnabled ? 'dnabled' : 'disabled'}`, () => {
+            let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+            let pythonSettings: TypeMoq.IMock<IPythonSettings>;
+            let appShell: TypeMoq.IMock<IApplicationShell>;
+            let cmdManager: TypeMoq.IMock<ICommandManager>;
+            let workspaceService: TypeMoq.IMock<IWorkspaceService>;
+            setup(function () {
+                if (isPythonAnalysisEngineTest()) {
+                    // tslint:disable-next-line:no-invalid-this
+                    return this.skip();
+                }
+                serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+                appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+                workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
+                cmdManager = TypeMoq.Mock.ofType<ICommandManager>();
+                const configService = TypeMoq.Mock.ofType<IConfigurationService>();
+                pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+
+                workspaceService.setup(w => w.hasWorkspaceFolders).returns(() => false);
+                workspaceService.setup(w => w.workspaceFolders).returns(() => []);
+                configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+
+                const output = TypeMoq.Mock.ofType<IOutputChannel>();
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isAny())).returns(() => output.object);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IWorkspaceService))).returns(() => workspaceService.object);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IApplicationShell))).returns(() => appShell.object);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => []);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IConfigurationService))).returns(() => configService.object);
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICommandManager))).returns(() => cmdManager.object);
+            });
+
+            async function testActivation(activationService: IExtensionActivationService, activator: TypeMoq.IMock<IExtensionActivator>) {
+                activator
+                    .setup(a => a.activate()).returns(() => Promise.resolve(true))
+                    .verifiable(TypeMoq.Times.once());
+                const activatorName = jediIsEnabled ? ExtensionActivators.Jedi : ExtensionActivators.DotNet;
+                serviceContainer
+                    .setup(c => c.get(TypeMoq.It.isValue(IExtensionActivator), TypeMoq.It.isValue(activatorName)))
+                    .returns(() => activator.object)
+                    .verifiable(TypeMoq.Times.once());
+
+                await activationService.activate();
+
+                activator.verifyAll();
+                serviceContainer.verifyAll();
+            }
+            test('Activatory must be activated', async () => {
+                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                const activator = TypeMoq.Mock.ofType<IExtensionActivator>();
+                const activationService = new ExtensionActivationService(serviceContainer.object);
+
+                await testActivation(activationService, activator);
+            });
+            test('Activatory must be deactivated', async () => {
+                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                const activator = TypeMoq.Mock.ofType<IExtensionActivator>();
+                const activationService = new ExtensionActivationService(serviceContainer.object);
+
+                await testActivation(activationService, activator);
+
+                activator
+                    .setup(a => a.deactivate()).returns(() => Promise.resolve())
+                    .verifiable(TypeMoq.Times.once());
+
+                activationService.dispose();
+                activator.verifyAll();
+            });
+            test('Prompt user to reload VS Code when setting is toggled', async () => {
+                let callbackHandler!: (e: ConfigurationChangeEvent) => void;
+                let jediIsEnabledValueInSetting = jediIsEnabled;
+                workspaceService
+                    .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                    .callback(cb => callbackHandler = cb)
+                    .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
+                    .verifiable(TypeMoq.Times.once());
+
+                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabledValueInSetting);
+                const activator = TypeMoq.Mock.ofType<IExtensionActivator>();
+                const activationService = new ExtensionActivationService(serviceContainer.object);
+
+                workspaceService.verifyAll();
+                await testActivation(activationService, activator);
+
+                const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+                event.setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .returns(() => true)
+                    .verifiable(TypeMoq.Times.atLeastOnce());
+                appShell.setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isValue('Reload')))
+                    .returns(() => Promise.resolve('Reload'))
+                    .verifiable(TypeMoq.Times.once());
+
+                // Toggle the value in the setting and invoke the callback.
+                jediIsEnabledValueInSetting = !jediIsEnabledValueInSetting;
+                callbackHandler(event.object);
+
+                event.verifyAll();
+                appShell.verifyAll();
+            });
+            test('Do not prompt user to reload VS Code when setting is not toggled', async () => {
+                let callbackHandler!: (e: ConfigurationChangeEvent) => void;
+                workspaceService
+                    .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                    .callback(cb => callbackHandler = cb)
+                    .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
+                    .verifiable(TypeMoq.Times.once());
+
+                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                const activator = TypeMoq.Mock.ofType<IExtensionActivator>();
+                const activationService = new ExtensionActivationService(serviceContainer.object);
+
+                workspaceService.verifyAll();
+                await testActivation(activationService, activator);
+
+                const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+                event.setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .returns(() => true)
+                    .verifiable(TypeMoq.Times.atLeastOnce());
+                appShell.setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isValue('Reload')))
+                    .returns(() => Promise.resolve('Reload'))
+                    .verifiable(TypeMoq.Times.never());
+
+                // Invoke the config changed callback.
+                callbackHandler(event.object);
+
+                event.verifyAll();
+                appShell.verifyAll();
+            });
+            test('Do not prompt user to reload VS Code when setting is not changed', async () => {
+                let callbackHandler!: (e: ConfigurationChangeEvent) => void;
+                workspaceService
+                    .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                    .callback(cb => callbackHandler = cb)
+                    .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
+                    .verifiable(TypeMoq.Times.once());
+
+                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                const activator = TypeMoq.Mock.ofType<IExtensionActivator>();
+                const activationService = new ExtensionActivationService(serviceContainer.object);
+
+                workspaceService.verifyAll();
+                await testActivation(activationService, activator);
+
+                const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
+                event.setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .returns(() => false)
+                    .verifiable(TypeMoq.Times.atLeastOnce());
+                appShell.setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isValue('Reload')))
+                    .returns(() => Promise.resolve('Reload'))
+                    .verifiable(TypeMoq.Times.never());
+
+                // Invoke the config changed callback.
+                callbackHandler(event.object);
+
+                event.verifyAll();
+                appShell.verifyAll();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1747

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
