### PR TITLE
Speed up githook by skipping commits not containing any `.ts` files

### DIFF
--- a/news/3 Code Health/1803.md
+++ b/news/3 Code Health/1803.md
@@ -1,0 +1,1 @@
+Speed up githook by skipping commits not containing any `.ts` files.


### PR DESCRIPTION
Fixes #1803

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
