### PR TITLE
Fix indentation when function contains type hints

### DIFF
--- a/news/2 Fixes/1461.md
+++ b/news/2 Fixes/1461.md
@@ -1,0 +1,1 @@
+Fix indentation when function contains type hints.

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -104,10 +104,6 @@ export async function activate(context: ExtensionContext) {
     languages.setLanguageConfiguration(PYTHON_LANGUAGE, {
         onEnterRules: [
             {
-                beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except)\b.*:\s*\S+/,
-                action: { indentAction: IndentAction.None }
-            },
-            {
                 beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async)\b.*:\s*/,
                 action: { indentAction: IndentAction.Indent }
             },


### PR DESCRIPTION
Fixes #1461

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
