### PR TITLE
Fix debugger issue that causes the debugger to hang and silently exit

### DIFF
--- a/news/2 Fixes/459.md
+++ b/news/2 Fixes/459.md
@@ -1,0 +1,1 @@
+Fix debugger issue that causes the debugger to hang and silently exit stepping over a line of code instantiating an ITK vector object.


### PR DESCRIPTION
Fixes #459

@brettcannon @MikhailArkhipov 
This PR needs to be merged into the current release as it contains a fix that will be shipped with the next version of PTVSD.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
