### PR TITLE
When debugging unit tests, use the envFile in settings

### DIFF
--- a/news/2 Fixes/1759.md
+++ b/news/2 Fixes/1759.md
@@ -1,0 +1,1 @@
+When debugging unit tests, use the `env` file configured in `settings.json` under `python.envFile`.

--- a/src/client/unittests/common/debugLauncher.ts
+++ b/src/client/unittests/common/debugLauncher.ts
@@ -26,13 +26,12 @@ export class DebugLauncher implements ITestDebugLauncher {
         }
 
         const cwd = cwdUri ? cwdUri.fsPath : workspaceFolder.uri.fsPath;
-        const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(Uri.file(cwd));
-        const useExperimentalDebugger = configurationService.unitTest.useExperimentalDebugger === true;
+        const configSettings = this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(Uri.file(cwd));
+        const useExperimentalDebugger = configSettings.unitTest.useExperimentalDebugger === true;
         const debugManager = this.serviceContainer.get<IDebugService>(IDebugService);
         const debuggerType = useExperimentalDebugger ? 'pythonExperimental' : 'python';
         const debugArgs = this.fixArgs(options.args, options.testProvider, useExperimentalDebugger);
         const program = this.getTestLauncherScript(options.testProvider, useExperimentalDebugger);
-
         return debugManager.startDebugging(workspaceFolder, {
             name: 'Debug Unit Test',
             type: debuggerType,
@@ -41,6 +40,7 @@ export class DebugLauncher implements ITestDebugLauncher {
             cwd,
             args: debugArgs,
             console: 'none',
+            envFile: configSettings.envFile,
             debugOptions: [DebugOptions.RedirectOutput]
         }).then(() => void (0));
     }

--- a/src/test/unittests/common/debugLauncher.test.ts
+++ b/src/test/unittests/common/debugLauncher.test.ts
@@ -27,6 +27,7 @@ suite('Unit Tests - Debug Launcher', () => {
     let debugLauncher: DebugLauncher;
     let debugService: TypeMoq.IMock<IDebugService>;
     let workspaceService: TypeMoq.IMock<IWorkspaceService>;
+    let settings: TypeMoq.IMock<IPythonSettings>;
     setup(async () => {
         const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         const configService = TypeMoq.Mock.ofType<IConfigurationService>();
@@ -38,7 +39,7 @@ suite('Unit Tests - Debug Launcher', () => {
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IWorkspaceService))).returns(() => workspaceService.object);
 
-        const settings = TypeMoq.Mock.ofType<IPythonSettings>();
+        settings = TypeMoq.Mock.ofType<IPythonSettings>();
         configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
 
         unitTestSettings = TypeMoq.Mock.ofType<IUnitTestSettings>();
@@ -51,10 +52,12 @@ suite('Unit Tests - Debug Launcher', () => {
         args: string[], console, debugOptions: DebugOptions[],
         testProvider: TestProvider, useExperimentalDebugger: boolean) {
 
+        const envFile = __filename;
+        settings.setup(p => p.envFile).returns(() => envFile);
         const debugArgs = testProvider === 'unittest' && useExperimentalDebugger ? args.filter(item => item !== '--debug') : args;
 
         debugService.setup(d => d.startDebugging(TypeMoq.It.isValue(workspaceFolder),
-            TypeMoq.It.isObjectWith({ name, type, request, program, cwd, args: debugArgs, console, debugOptions })))
+            TypeMoq.It.isObjectWith({ name, type, request, program, cwd, args: debugArgs, console, envFile, debugOptions })))
             .returns(() => Promise.resolve(undefined as any))
             .verifiable(TypeMoq.Times.once());
     }


### PR DESCRIPTION
Fixes #1759

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
