### PR TITLE
Add path mappings for remote debugging when attaching to the localhost

### DIFF
--- a/news/2 Fixes/1829.md
+++ b/news/2 Fixes/1829.md
@@ -1,0 +1,1 @@
+Automatically add path mappings for remote debugging when attaching to the localhost.


### PR DESCRIPTION
Fixes #1829

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
