### PR TITLE
Display all interpreters when a workspace contains a Pipfile

### DIFF
--- a/news/2 Fixes/1800.md
+++ b/news/2 Fixes/1800.md
@@ -1,0 +1,1 @@
+Fix to display all interpreters in the interpreter list when a workspace contains a `Pipfile`.

--- a/src/client/interpreter/locators/index.ts
+++ b/src/client/interpreter/locators/index.ts
@@ -31,12 +31,6 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
         this.platform = serviceContainer.get<IPlatformService>(IPlatformService);
     }
     public async getInterpreters(resource?: Uri): Promise<PythonInterpreter[]> {
-        // Pipenv always wins
-        const pipenv = this.serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, PIPENV_SERVICE);
-        const interpreters = await pipenv.getInterpreters(resource);
-        if (interpreters.length > 0) {
-            return interpreters;
-        }
         return this.getInterpretersPerResource(resource);
     }
     public dispose() {
@@ -87,6 +81,7 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
             locators.push(this.serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, KNOWN_PATH_SERVICE));
         }
         locators.push(this.serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, CURRENT_PATH_SERVICE));
+        locators.push(this.serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, PIPENV_SERVICE));
 
         return locators;
     }


### PR DESCRIPTION
Fixes #1800

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
