### PR TITLE
Updates to envvars for CI build to support VSTS automation

### DIFF
--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -6,7 +6,7 @@ import { PythonSettings } from '../client/common/configSettings';
 
 export const IS_APPVEYOR = process.env.APPVEYOR === 'true';
 export const IS_TRAVIS = process.env.TRAVIS === 'true';
-export const IS_VSTS = process.env.TF_BUILD === 'true';
+export const IS_VSTS = process.env.TF_BUILD !== undefined;
 export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR || IS_VSTS;
 export const TEST_TIMEOUT = 25000;
 export const IS_MULTI_ROOT_TEST = isMultitrootTest();

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// tslint:disable:no-string-literal
 import { workspace } from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
 
-export const IS_APPVEYOR = process.env['APPVEYOR'] === 'true';
-export const IS_TRAVIS = process.env['TRAVIS'] === 'true';
-export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR;
+export const IS_APPVEYOR = process.env.APPVEYOR === 'true';
+export const IS_TRAVIS = process.env.TRAVIS === 'true';
+export const IS_VSTS = process.env.TF_BUILD === 'true';
+export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR || IS_VSTS;
 export const TEST_TIMEOUT = 25000;
 export const IS_MULTI_ROOT_TEST = isMultitrootTest();
-export const IS_CI_SERVER_TEST_DEBUGGER = process.env['IS_CI_SERVER_TEST_DEBUGGER'] === '1';
+export const IS_CI_SERVER_TEST_DEBUGGER = process.env.IS_CI_SERVER_TEST_DEBUGGER === '1';
 // If running on CI server, then run debugger tests ONLY if the corresponding flag is enabled.
 export const TEST_DEBUGGER = IS_CI_SERVER ? IS_CI_SERVER_TEST_DEBUGGER : true;
 
@@ -19,4 +19,4 @@ function isMultitrootTest() {
 }
 
 export const IS_ANALYSIS_ENGINE_TEST =
-    !IS_TRAVIS && (process.env['VSC_PYTHON_ANALYSIS'] === '1' || !PythonSettings.getInstance().jediEnabled);
+    !IS_TRAVIS && (process.env.VSC_PYTHON_ANALYSIS === '1' || !PythonSettings.getInstance().jediEnabled);

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -3,7 +3,9 @@ if ((Reflect as any).metadata === undefined) {
     // tslint:disable-next-line:no-require-imports no-var-requires
     require('reflect-metadata');
 }
-import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER, IS_MULTI_ROOT_TEST } from './constants';
+
+import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
+         IS_MULTI_ROOT_TEST, IS_VSTS } from './constants';
 import * as testRunner from './testRunner';
 
 process.env.VSC_PYTHON_CI_TEST = '1';
@@ -13,7 +15,6 @@ process.env.IS_MULTI_ROOT_TEST = IS_MULTI_ROOT_TEST.toString();
 // We do this to ensure we only run debugger test, as debugger tests are very flaky on CI.
 // So the solution is to run them separately and first on CI.
 const grep = IS_CI_SERVER && IS_CI_SERVER_TEST_DEBUGGER ? 'Debug' : undefined;
-
 const testFilesSuffix = process.env.TEST_FILES_SUFFIX;
 
 // You can directly control Mocha options by uncommenting the following lines.
@@ -21,7 +22,7 @@ const testFilesSuffix = process.env.TEST_FILES_SUFFIX;
 // Hack, as retries is not supported as setting in tsd.
 const options: testRunner.SetupOptions & { retries: number } = {
     ui: 'tdd',
-    useColors: true,
+    useColors: !IS_VSTS,
     timeout: 25000,
     retries: 3,
     grep,


### PR DESCRIPTION
Extend const `IS_CI_SERVER` from `src/test/constants.ts` to include new constant `IS_VSTS`, represented by the environment variable `TF_BUILD` present on VSTS.
- Set `MochaOpts.useColor=false` to take into account VSTS's lack of support for this.

Helps #934

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
