### PR TITLE
Ensure resource is passed into isInstalled method

### DIFF
--- a/news/3 Code Health/1893.md
+++ b/news/3 Code Health/1893.md
@@ -1,0 +1,1 @@
+Ensure workspace information is passed into installer when determining whether a product/tool is installed.


### PR DESCRIPTION
Fixes #1893
FYI: Line 77 is what has changed `return this.isInstalled(product, resource)`
The other changes are to remove the `import *`

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
