### PR TITLE
Change error message displayed when path to a tool is invalid

### DIFF
--- a/news/2 Fixes/1064.md
+++ b/news/2 Fixes/1064.md
@@ -1,0 +1,1 @@
+Modified to change error message displayed when path to a tool (`linter`, `formatter`, etc) is invalid.

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -148,7 +148,7 @@ export class FormatterInstaller extends BaseInstaller {
             message = `Path to the ${productName} formatter is invalid (${executable})`;
         }
 
-        const item = await this.appShell.showErrorMessage(message, ...useOptions);
+        const item = await this.appShell.showErrorMessage(message, ...options);
         if (item === yesChoice) {
             return this.install(product, resource);
         } else if (typeof item === 'string') {

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -1,44 +1,36 @@
+// tslint:disable:max-classes-per-file max-classes-per-file
+
 import { inject, injectable, named } from 'inversify';
 import * as os from 'os';
-import * as path from 'path';
 import { OutputChannel, Uri } from 'vscode';
 import '../../common/extensions';
-import { IFormatterHelper } from '../../formatters/types';
 import { IServiceContainer } from '../../ioc/types';
 import { ILinterManager } from '../../linters/types';
-import { ITestsHelper } from '../../unittests/common/types';
 import { IApplicationShell, IWorkspaceService } from '../application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../constants';
 import { IPlatformService } from '../platform/types';
 import { IProcessServiceFactory, IPythonExecutionFactory } from '../process/types';
 import { ITerminalServiceFactory } from '../terminal/types';
-import { IConfigurationService, IInstaller, ILogger, InstallerResponse, IOutputChannel, ModuleNamePurpose, Product } from '../types';
+import { IConfigurationService, IInstaller, ILogger, InstallerResponse, IOutputChannel, ModuleNamePurpose, Product, ProductType } from '../types';
 import { ProductNames } from './productNames';
-import { IInstallationChannelManager } from './types';
+import { IInstallationChannelManager, IProductPathService, IProductService } from './types';
 
 export { Product } from '../types';
 
 const CTagsInsllationScript = os.platform() === 'darwin' ? 'brew install ctags' : 'sudo apt-get install exuberant-ctags';
 
-enum ProductType {
-    Linter,
-    Formatter,
-    TestFramework,
-    RefactoringLibrary,
-    WorkspaceSymbols
-}
-
-// tslint:disable-next-line:max-classes-per-file
 export abstract class BaseInstaller {
     private static readonly PromptPromises = new Map<string, Promise<InstallerResponse>>();
-    protected appShell: IApplicationShell;
-    protected configService: IConfigurationService;
+    protected readonly appShell: IApplicationShell;
+    protected readonly configService: IConfigurationService;
     private readonly workspaceService: IWorkspaceService;
+    private readonly productService: IProductService;
 
     constructor(protected serviceContainer: IServiceContainer, protected outputChannel: OutputChannel) {
         this.appShell = serviceContainer.get<IApplicationShell>(IApplicationShell);
         this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
         this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+        this.productService = serviceContainer.get<IProductService>(IProductService);
     }
 
     public promptToInstall(product: Product, resource?: Uri): Promise<InstallerResponse> {
@@ -82,16 +74,10 @@ export abstract class BaseInstaller {
         if (product === Product.unittest) {
             return true;
         }
-        let moduleName: string | undefined;
-        try {
-            moduleName = translateProductToModule(product, ModuleNamePurpose.run);
-            // tslint:disable-next-line:no-empty
-        } catch { }
-
-        // User may have customized the module name or provided the fully qualifieid path.
+        // User may have customized the module name or provided the fully qualified path.
         const executableName = this.getExecutableNameFromSettings(product, resource);
 
-        const isModule = typeof moduleName === 'string' && moduleName.length > 0 && path.basename(executableName) === executableName;
+        const isModule = this.isExecutableAModule(product, resource);
         if (isModule) {
             const pythonProcess = await this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource });
             return pythonProcess.isModuleInstalled(executableName);
@@ -104,7 +90,14 @@ export abstract class BaseInstaller {
     }
     protected abstract promptToInstallImplementation(product: Product, resource?: Uri): Promise<InstallerResponse>;
     protected getExecutableNameFromSettings(product: Product, resource?: Uri): string {
-        throw new Error('getExecutableNameFromSettings is not supported on this object');
+        const productType = this.productService.getProductType(product);
+        const productPathService = this.serviceContainer.get<IProductPathService>(IProductPathService, productType);
+        return productPathService.getExecutableNameFromSettings(product, resource);
+    }
+    protected isExecutableAModule(product: Product, resource?: Uri): Boolean {
+        const productType = this.productService.getProductType(product);
+        const productPathService = this.serviceContainer.get<IProductPathService>(IProductPathService, productType);
+        return productPathService.isExecutableAModule(product, resource);
     }
 }
 
@@ -133,11 +126,6 @@ export class CTagsInstaller extends BaseInstaller {
         const item = await this.appShell.showErrorMessage('Install CTags to enable Python workspace symbols?', 'Yes', 'No');
         return item === 'Yes' ? this.install(product, resource) : InstallerResponse.Ignore;
     }
-
-    protected getExecutableNameFromSettings(product: Product, resource?: Uri): string {
-        const settings = this.configService.getSettings(resource);
-        return settings.workspaceSymbols.ctagsPath;
-    }
 }
 
 export class FormatterInstaller extends BaseInstaller {
@@ -151,7 +139,16 @@ export class FormatterInstaller extends BaseInstaller {
         const useOptions = formatterNames.map((name) => `Use ${name}`);
         const yesChoice = 'Yes';
 
-        const item = await this.appShell.showErrorMessage(`Formatter ${productName} is not installed. Install?`, yesChoice, ...useOptions);
+        const options = [...useOptions];
+        let message = `Formatter ${productName} is not installed. Install?`;
+        if (this.isExecutableAModule(product, resource)) {
+            options.splice(0, 0, yesChoice);
+        } else {
+            const executable = this.getExecutableNameFromSettings(product, resource);
+            message = `Path to the ${productName} formatter is invalid (${executable})`;
+        }
+
+        const item = await this.appShell.showErrorMessage(message, yesChoice, ...useOptions);
         if (item === yesChoice) {
             return this.install(product, resource);
         } else if (typeof item === 'string') {
@@ -167,16 +164,8 @@ export class FormatterInstaller extends BaseInstaller {
 
         return InstallerResponse.Ignore;
     }
-
-    protected getExecutableNameFromSettings(product: Product, resource?: Uri): string {
-        const settings = this.configService.getSettings(resource);
-        const formatHelper = this.serviceContainer.get<IFormatterHelper>(IFormatterHelper);
-        const settingsPropNames = formatHelper.getSettingsPropertyNames(product);
-        return settings.formatting[settingsPropNames.pathName] as string;
-    }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class LinterInstaller extends BaseInstaller {
     protected async promptToInstallImplementation(product: Product, resource?: Uri): Promise<InstallerResponse> {
         const productName = ProductNames.get(product)!;
@@ -184,8 +173,16 @@ export class LinterInstaller extends BaseInstaller {
         const disableAllLinting = 'Disable linting';
         const disableThisLinter = `Disable ${productName}`;
 
-        const response = await this.appShell
-            .showErrorMessage(`Linter ${productName} is not installed.`, install, disableThisLinter, disableAllLinting);
+        const options = [disableThisLinter, disableAllLinting];
+        let message = `Linter ${productName} is not installed.`;
+        if (this.isExecutableAModule(product, resource)) {
+            options.splice(0, 0, install);
+        } else {
+            const executable = this.getExecutableNameFromSettings(product, resource);
+            message = `Path to the ${productName} linter is invalid (${executable})`;
+        }
+
+        const response = await this.appShell.showErrorMessage(message, ...options);
         if (response === install) {
             return this.install(product, resource);
         }
@@ -199,66 +196,41 @@ export class LinterInstaller extends BaseInstaller {
         }
         return InstallerResponse.Ignore;
     }
-    protected getExecutableNameFromSettings(product: Product, resource?: Uri): string {
-        const linterManager = this.serviceContainer.get<ILinterManager>(ILinterManager);
-        return linterManager.getLinterInfo(product).pathName(resource);
-    }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class TestFrameworkInstaller extends BaseInstaller {
     protected async promptToInstallImplementation(product: Product, resource?: Uri): Promise<InstallerResponse> {
         const productName = ProductNames.get(product)!;
-        const item = await this.appShell.showErrorMessage(`Test framework ${productName} is not installed. Install?`, 'Yes', 'No');
-        return item === 'Yes' ? this.install(product, resource) : InstallerResponse.Ignore;
-    }
 
-    protected getExecutableNameFromSettings(product: Product, resource?: Uri): string {
-        const testHelper = this.serviceContainer.get<ITestsHelper>(ITestsHelper);
-        const settingsPropNames = testHelper.getSettingsPropertyNames(product);
-        if (!settingsPropNames.pathName) {
-            // E.g. in the case of UnitTests we don't allow customizing the paths.
-            return translateProductToModule(product, ModuleNamePurpose.run);
+        const options: string[] = [];
+        let message = `Test framework ${productName} is not installed. Install?`;
+        if (this.isExecutableAModule(product, resource)) {
+            options.push(...['Yes', 'No']);
+        } else {
+            const executable = this.getExecutableNameFromSettings(product, resource);
+            message = `Path to the ${productName} test framework is invalid (${executable})`;
         }
-        const settings = this.configService.getSettings(resource);
-        return settings.unitTest[settingsPropNames.pathName] as string;
+
+        const item = await this.appShell.showErrorMessage(message, ...options);
+        return item === 'Yes' ? this.install(product, resource) : InstallerResponse.Ignore;
     }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 export class RefactoringLibraryInstaller extends BaseInstaller {
     protected async promptToInstallImplementation(product: Product, resource?: Uri): Promise<InstallerResponse> {
         const productName = ProductNames.get(product)!;
         const item = await this.appShell.showErrorMessage(`Refactoring library ${productName} is not installed. Install?`, 'Yes', 'No');
         return item === 'Yes' ? this.install(product, resource) : InstallerResponse.Ignore;
     }
-    protected getExecutableNameFromSettings(product: Product, resource?: Uri): string {
-        return translateProductToModule(product, ModuleNamePurpose.run);
-    }
 }
 
-// tslint:disable-next-line:max-classes-per-file
 @injectable()
 export class ProductInstaller implements IInstaller {
-    private ProductTypes = new Map<Product, ProductType>();
+    private readonly productService: IProductService;
 
     constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer,
         @inject(IOutputChannel) @named(STANDARD_OUTPUT_CHANNEL) private outputChannel: OutputChannel) {
-        this.ProductTypes.set(Product.flake8, ProductType.Linter);
-        this.ProductTypes.set(Product.mypy, ProductType.Linter);
-        this.ProductTypes.set(Product.pep8, ProductType.Linter);
-        this.ProductTypes.set(Product.prospector, ProductType.Linter);
-        this.ProductTypes.set(Product.pydocstyle, ProductType.Linter);
-        this.ProductTypes.set(Product.pylama, ProductType.Linter);
-        this.ProductTypes.set(Product.pylint, ProductType.Linter);
-        this.ProductTypes.set(Product.ctags, ProductType.WorkspaceSymbols);
-        this.ProductTypes.set(Product.nosetest, ProductType.TestFramework);
-        this.ProductTypes.set(Product.pytest, ProductType.TestFramework);
-        this.ProductTypes.set(Product.unittest, ProductType.TestFramework);
-        this.ProductTypes.set(Product.autopep8, ProductType.Formatter);
-        this.ProductTypes.set(Product.black, ProductType.Formatter);
-        this.ProductTypes.set(Product.yapf, ProductType.Formatter);
-        this.ProductTypes.set(Product.rope, ProductType.RefactoringLibrary);
+        this.productService = serviceContainer.get<IProductService>(IProductService);
     }
 
     // tslint:disable-next-line:no-empty
@@ -275,9 +247,8 @@ export class ProductInstaller implements IInstaller {
     public translateProductToModuleName(product: Product, purpose: ModuleNamePurpose): string {
         return translateProductToModule(product, purpose);
     }
-
     private createInstaller(product: Product): BaseInstaller {
-        const productType = this.ProductTypes.get(product)!;
+        const productType = this.productService.getProductType(product);
         switch (productType) {
             case ProductType.Formatter:
                 return new FormatterInstaller(this.serviceContainer, this.outputChannel);

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -148,7 +148,7 @@ export class FormatterInstaller extends BaseInstaller {
             message = `Path to the ${productName} formatter is invalid (${executable})`;
         }
 
-        const item = await this.appShell.showErrorMessage(message, yesChoice, ...useOptions);
+        const item = await this.appShell.showErrorMessage(message, ...useOptions);
         if (item === yesChoice) {
             return this.install(product, resource);
         } else if (typeof item === 'string') {

--- a/src/client/common/installer/productPath.ts
+++ b/src/client/common/installer/productPath.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-classes-per-file
+
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { IFormatterHelper } from '../../formatters/types';
+import { IServiceContainer } from '../../ioc/types';
+import { ILinterManager } from '../../linters/types';
+import { ITestsHelper } from '../../unittests/common/types';
+import { IConfigurationService, IInstaller, ModuleNamePurpose, Product } from '../types';
+import { IProductPathService } from './types';
+
+@injectable()
+abstract class BaseProductPathsService implements IProductPathService {
+    protected readonly configService: IConfigurationService;
+    protected readonly productInstaller: IInstaller;
+    constructor(@inject(IServiceContainer) protected serviceContainer: IServiceContainer) {
+        this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
+        this.productInstaller = serviceContainer.get<IInstaller>(IInstaller);
+    }
+    public abstract getExecutableNameFromSettings(product: Product, resource?: Uri): string;
+    public isExecutableAModule(product: Product, resource?: Uri): Boolean {
+        let moduleName: string | undefined;
+        try {
+            moduleName = this.productInstaller.translateProductToModuleName(product, ModuleNamePurpose.run);
+            // tslint:disable-next-line:no-empty
+        } catch { }
+
+        // User may have customized the module name or provided the fully qualifieid path.
+        const executableName = this.getExecutableNameFromSettings(product, resource);
+
+        return typeof moduleName === 'string' && moduleName.length > 0 && path.basename(executableName) === executableName;
+    }
+}
+
+@injectable()
+export class CTagsProductPathService extends BaseProductPathsService {
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        super(serviceContainer);
+    }
+    public getExecutableNameFromSettings(_: Product, resource?: Uri): string {
+        const settings = this.configService.getSettings(resource);
+        return settings.workspaceSymbols.ctagsPath;
+    }
+}
+
+@injectable()
+export class FormatterProductPathService extends BaseProductPathsService {
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        super(serviceContainer);
+    }
+    public getExecutableNameFromSettings(product: Product, resource?: Uri): string {
+        const settings = this.configService.getSettings(resource);
+        const formatHelper = this.serviceContainer.get<IFormatterHelper>(IFormatterHelper);
+        const settingsPropNames = formatHelper.getSettingsPropertyNames(product);
+        return settings.formatting[settingsPropNames.pathName] as string;
+    }
+}
+
+@injectable()
+export class LinterProductPathService extends BaseProductPathsService {
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        super(serviceContainer);
+    }
+    public getExecutableNameFromSettings(product: Product, resource?: Uri): string {
+        const linterManager = this.serviceContainer.get<ILinterManager>(ILinterManager);
+        return linterManager.getLinterInfo(product).pathName(resource);
+    }
+}
+
+@injectable()
+export class TestFrameworkProductPathService extends BaseProductPathsService {
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        super(serviceContainer);
+    }
+    public getExecutableNameFromSettings(product: Product, resource?: Uri): string {
+        const testHelper = this.serviceContainer.get<ITestsHelper>(ITestsHelper);
+        const settingsPropNames = testHelper.getSettingsPropertyNames(product);
+        if (!settingsPropNames.pathName) {
+            // E.g. in the case of UnitTests we don't allow customizing the paths.
+            return this.productInstaller.translateProductToModuleName(product, ModuleNamePurpose.run);
+        }
+        const settings = this.configService.getSettings(resource);
+        return settings.unitTest[settingsPropNames.pathName] as string;
+    }
+}
+
+@injectable()
+export class RefactoringLibraryProductPathService extends BaseProductPathsService {
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        super(serviceContainer);
+    }
+    public getExecutableNameFromSettings(product: Product, _?: Uri): string {
+        return this.productInstaller.translateProductToModuleName(product, ModuleNamePurpose.run);
+    }
+}

--- a/src/client/common/installer/productService.ts
+++ b/src/client/common/installer/productService.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { injectable } from 'inversify';
+import { Product, ProductType } from '../types';
+import { IProductService } from './types';
+
+@injectable()
+export class ProductService implements IProductService {
+    private ProductTypes = new Map<Product, ProductType>();
+
+    constructor() {
+        this.ProductTypes.set(Product.flake8, ProductType.Linter);
+        this.ProductTypes.set(Product.mypy, ProductType.Linter);
+        this.ProductTypes.set(Product.pep8, ProductType.Linter);
+        this.ProductTypes.set(Product.prospector, ProductType.Linter);
+        this.ProductTypes.set(Product.pydocstyle, ProductType.Linter);
+        this.ProductTypes.set(Product.pylama, ProductType.Linter);
+        this.ProductTypes.set(Product.pylint, ProductType.Linter);
+        this.ProductTypes.set(Product.ctags, ProductType.WorkspaceSymbols);
+        this.ProductTypes.set(Product.nosetest, ProductType.TestFramework);
+        this.ProductTypes.set(Product.pytest, ProductType.TestFramework);
+        this.ProductTypes.set(Product.unittest, ProductType.TestFramework);
+        this.ProductTypes.set(Product.autopep8, ProductType.Formatter);
+        this.ProductTypes.set(Product.black, ProductType.Formatter);
+        this.ProductTypes.set(Product.yapf, ProductType.Formatter);
+        this.ProductTypes.set(Product.rope, ProductType.RefactoringLibrary);
+    }
+    public getProductType(product: Product): ProductType {
+        return this.ProductTypes.get(product)!;
+    }
+}

--- a/src/client/common/installer/serviceRegistry.ts
+++ b/src/client/common/installer/serviceRegistry.ts
@@ -3,15 +3,25 @@
 'use strict';
 
 import { IServiceManager } from '../../ioc/types';
+import { ProductType } from '../types';
 import { InstallationChannelManager } from './channelManager';
 import { CondaInstaller } from './condaInstaller';
 import { PipEnvInstaller } from './pipEnvInstaller';
 import { PipInstaller } from './pipInstaller';
-import { IInstallationChannelManager, IModuleInstaller } from './types';
+import { CTagsProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from './productPath';
+import { ProductService } from './productService';
+import { IInstallationChannelManager, IModuleInstaller, IProductPathService, IProductService } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, CondaInstaller);
     serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PipInstaller);
     serviceManager.addSingleton<IModuleInstaller>(IModuleInstaller, PipEnvInstaller);
     serviceManager.addSingleton<IInstallationChannelManager>(IInstallationChannelManager, InstallationChannelManager);
+
+    serviceManager.addSingleton<IProductService>(IProductService, ProductService);
+    serviceManager.addSingleton<IProductPathService>(IProductPathService, CTagsProductPathService, ProductType.WorkspaceSymbols);
+    serviceManager.addSingleton<IProductPathService>(IProductPathService, FormatterProductPathService, ProductType.Formatter);
+    serviceManager.addSingleton<IProductPathService>(IProductPathService, LinterProductPathService, ProductType.Linter);
+    serviceManager.addSingleton<IProductPathService>(IProductPathService, TestFrameworkProductPathService, ProductType.TestFramework);
+    serviceManager.addSingleton<IProductPathService>(IProductPathService, RefactoringLibraryProductPathService, ProductType.RefactoringLibrary);
 }

--- a/src/client/common/installer/types.ts
+++ b/src/client/common/installer/types.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Uri } from 'vscode';
-import { Product } from '../types';
+import { Product, ProductType } from '../types';
 
 export const IModuleInstaller = Symbol('IModuleInstaller');
 export interface IModuleInstaller {
@@ -22,4 +22,13 @@ export interface IInstallationChannelManager {
     getInstallationChannel(product: Product, resource?: Uri): Promise<IModuleInstaller | undefined>;
     getInstallationChannels(resource?: Uri): Promise<IModuleInstaller[]>;
     showNoInstallersMessage(): void;
+}
+export const IProductService = Symbol('IProductService');
+export interface IProductService {
+    getProductType(product: Product): ProductType;
+}
+export const IProductPathService = Symbol('IProductPathService');
+export interface IProductPathService {
+    getExecutableNameFromSettings(product: Product, resource?: Uri): string;
+    isExecutableAModule(product: Product, resource?: Uri): Boolean;
 }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -50,6 +50,14 @@ export enum InstallerResponse {
     Ignore
 }
 
+export enum ProductType {
+    Linter,
+    Formatter,
+    TestFramework,
+    RefactoringLibrary,
+    WorkspaceSymbols
+}
+
 export enum Product {
     pytest = 1,
     nosetest = 2,

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -51,11 +51,11 @@ export enum InstallerResponse {
 }
 
 export enum ProductType {
-    Linter,
-    Formatter,
-    TestFramework,
-    RefactoringLibrary,
-    WorkspaceSymbols
+    Linter = 'Linter',
+    Formatter = 'Formatter',
+    TestFramework = 'TestFramework',
+    RefactoringLibrary = 'RefactoringLibrary',
+    WorkspaceSymbols = 'WorkspaceSymbols'
 }
 
 export enum Product {

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -7,13 +7,15 @@ import { EnumEx } from '../../client/common/enumUtils';
 import { createDeferred } from '../../client/common/helpers';
 import { InstallationChannelManager } from '../../client/common/installer/channelManager';
 import { ProductInstaller } from '../../client/common/installer/productInstaller';
-import { IInstallationChannelManager, IModuleInstaller } from '../../client/common/installer/types';
+import { CTagsProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from '../../client/common/installer/productPath';
+import { ProductService } from '../../client/common/installer/productService';
+import { IInstallationChannelManager, IModuleInstaller, IProductPathService, IProductService } from '../../client/common/installer/types';
 import { Logger } from '../../client/common/logger';
 import { PersistentStateFactory } from '../../client/common/persistentState';
 import { PathUtils } from '../../client/common/platform/pathUtils';
 import { CurrentProcess } from '../../client/common/process/currentProcess';
 import { IProcessServiceFactory } from '../../client/common/process/types';
-import { IConfigurationService, ICurrentProcess, IInstaller, ILogger, IPathUtils, IPersistentStateFactory, IsWindows, ModuleNamePurpose, Product } from '../../client/common/types';
+import { IConfigurationService, ICurrentProcess, IInstaller, ILogger, IPathUtils, IPersistentStateFactory, IsWindows, ModuleNamePurpose, Product, ProductType } from '../../client/common/types';
 import { rootWorkspaceUri, updateSetting } from '../common';
 import { MockModuleInstaller } from '../mocks/moduleInstaller';
 import { MockProcessService } from '../mocks/proc';
@@ -65,6 +67,12 @@ suite('Installer', () => {
 
         ioc.registerMockProcessTypes();
         ioc.serviceManager.addSingletonInstance<boolean>(IsWindows, false);
+        ioc.serviceManager.addSingletonInstance<IProductService>(IProductService, new ProductService());
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, CTagsProductPathService, ProductType.WorkspaceSymbols);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, FormatterProductPathService, ProductType.Formatter);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, LinterProductPathService, ProductType.Linter);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, TestFrameworkProductPathService, ProductType.TestFramework);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, RefactoringLibraryProductPathService, ProductType.RefactoringLibrary);
     }
     async function resetSettings() {
         await updateSetting('linting.pylintEnabled', true, rootWorkspaceUri, ConfigurationTarget.Workspace);

--- a/src/test/common/installer/installer.invalidPath.unit.test.ts
+++ b/src/test/common/installer/installer.invalidPath.unit.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as path from 'path';
+import * as TypeMoq from 'typemoq';
+import { OutputChannel } from 'vscode';
+import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
+import { EnumEx } from '../../../client/common/enumUtils';
+import '../../../client/common/extensions';
+import { ProductInstaller } from '../../../client/common/installer/productInstaller';
+import { ProductService } from '../../../client/common/installer/productService';
+import { IProductPathService, IProductService } from '../../../client/common/installer/types';
+import { Product } from '../../../client/common/types';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { Uri } from '../../vscode-mock';
+
+use(chaiAsPromised);
+
+suite('Module Installer - Invalid Paths', () => {
+    [undefined, Uri.file('resource')].forEach(resource => {
+        ['moduleName', path.join('users', 'dev', 'tool', 'executable')].forEach(pathToExecutable => {
+            const isExecutableAModule = path.basename(pathToExecutable) === pathToExecutable;
+
+            EnumEx.getNamesAndValues<Product>(Product).forEach(product => {
+                let installer: ProductInstaller;
+                let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+                let app: TypeMoq.IMock<IApplicationShell>;
+                let workspaceService: TypeMoq.IMock<IWorkspaceService>;
+                let productPathService: TypeMoq.IMock<IProductPathService>;
+                setup(() => {
+                    serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+                    const outputChannel = TypeMoq.Mock.ofType<OutputChannel>();
+
+                    serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IProductService), TypeMoq.It.isAny())).returns(() => new ProductService());
+                    app = TypeMoq.Mock.ofType<IApplicationShell>();
+                    serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IApplicationShell), TypeMoq.It.isAny())).returns(() => app.object);
+                    workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
+                    serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IWorkspaceService), TypeMoq.It.isAny())).returns(() => workspaceService.object);
+
+                    productPathService = TypeMoq.Mock.ofType<IProductPathService>();
+                    serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IProductPathService), TypeMoq.It.isAny())).returns(() => productPathService.object);
+
+                    installer = new ProductInstaller(serviceContainer.object, outputChannel.object);
+                });
+
+                switch (product.value) {
+                    case Product.isort:
+                    case Product.ctags:
+                    case Product.rope:
+                    case Product.unittest: {
+                        return;
+                    }
+                    default: {
+                        test(`Ensure invalid path message is ${isExecutableAModule ? 'not displayed' : 'displayed'} ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                            // If the path to executable is a module, then we won't display error message indicating path is invalid.
+
+                            productPathService
+                                .setup(p => p.getExecutableNameFromSettings(TypeMoq.It.isAny(), TypeMoq.It.isValue(resource)))
+                                .returns(() => pathToExecutable)
+                                .verifiable(TypeMoq.Times.atLeast(isExecutableAModule ? 0 : 1));
+                            productPathService
+                                .setup(p => p.isExecutableAModule(TypeMoq.It.isAny(), TypeMoq.It.isValue(resource)))
+                                .returns(() => isExecutableAModule)
+                                .verifiable(TypeMoq.Times.atLeastOnce());
+                            const anyParams = [0, 1, 2, 3, 4, 5].map(() => TypeMoq.It.isAny());
+                            app.setup(a => a.showErrorMessage(TypeMoq.It.isAny(), ...anyParams))
+                                .callback(message => {
+                                    if (!isExecutableAModule) {
+                                        expect(message).contains(pathToExecutable);
+                                    }
+                                })
+                                .returns(() => Promise.resolve(undefined))
+                                .verifiable(TypeMoq.Times.exactly(1));
+
+                            await installer.promptToInstall(product.value, resource);
+                            productPathService.verifyAll();
+                        });
+                    }
+                }
+            });
+        });
+    });
+});

--- a/src/test/common/installer/installer.invalidPath.unit.test.ts
+++ b/src/test/common/installer/installer.invalidPath.unit.test.ts
@@ -7,7 +7,7 @@ import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
-import { OutputChannel } from 'vscode';
+import { OutputChannel, Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { EnumEx } from '../../../client/common/enumUtils';
 import '../../../client/common/extensions';
@@ -16,7 +16,6 @@ import { ProductService } from '../../../client/common/installer/productService'
 import { IProductPathService, IProductService } from '../../../client/common/installer/types';
 import { Product } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { Uri } from '../../vscode-mock';
 
 use(chaiAsPromised);
 

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -6,7 +6,7 @@
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as TypeMoq from 'typemoq';
-import { Disposable, OutputChannel, WorkspaceFolder } from 'vscode';
+import { Disposable, OutputChannel, Uri, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { EnumEx } from '../../../client/common/enumUtils';
 import '../../../client/common/extensions';
@@ -16,7 +16,6 @@ import { ProductService } from '../../../client/common/installer/productService'
 import { IInstallationChannelManager, IModuleInstaller, IProductPathService, IProductService } from '../../../client/common/installer/types';
 import { IDisposableRegistry, ILogger, InstallerResponse, ModuleNamePurpose, Product } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { Uri } from '../../vscode-mock';
 
 use(chaiAsPromised);
 

--- a/src/test/common/installer/moduleInstaller.test.ts
+++ b/src/test/common/installer/moduleInstaller.test.ts
@@ -16,7 +16,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { initialize } from '../../initialize';
 
 // tslint:disable-next-line:max-func-body-length
-suite('Module Installer', () => {
+suite('Module Installerx', () => {
     const pythonPath = path.join(__dirname, 'python');
     suiteSetup(initialize);
     [CondaInstaller, PipInstaller].forEach(installerClass => {

--- a/src/test/common/installer/productPath.unit.test.ts
+++ b/src/test/common/installer/productPath.unit.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length no-invalid-this
+
+import { fail } from 'assert';
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as TypeMoq from 'typemoq';
+import { OutputChannel } from 'vscode';
+import { EnumEx } from '../../../client/common/enumUtils';
+import '../../../client/common/extensions';
+import { ProductInstaller } from '../../../client/common/installer/productInstaller';
+import { CTagsProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from '../../../client/common/installer/productPath';
+import { ProductService } from '../../../client/common/installer/productService';
+import { IProductService } from '../../../client/common/installer/types';
+import { IConfigurationService, IFormattingSettings, IInstaller, IPythonSettings, IUnitTestSettings, IWorkspaceSymbolSettings, ModuleNamePurpose, Product, ProductType } from '../../../client/common/types';
+import { IFormatterHelper } from '../../../client/formatters/types';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { ILinterInfo, ILinterManager } from '../../../client/linters/types';
+import { ITestsHelper } from '../../../client/unittests/common/types';
+import { Uri } from '../../vscode-mock';
+
+use(chaiAsPromised);
+
+suite('Product Path', () => {
+    [undefined, Uri.file('resource')].forEach(resource => {
+        EnumEx.getNamesAndValues<Product>(Product).forEach(product => {
+            let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+            let formattingSettings: TypeMoq.IMock<IFormattingSettings>;
+            let unitTestSettings: TypeMoq.IMock<IUnitTestSettings>;
+            let workspaceSymnbolSettings: TypeMoq.IMock<IWorkspaceSymbolSettings>;
+            let configService: TypeMoq.IMock<IConfigurationService>;
+            let productInstaller: ProductInstaller;
+            setup(() => {
+                serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+                configService = TypeMoq.Mock.ofType<IConfigurationService>();
+                formattingSettings = TypeMoq.Mock.ofType<IFormattingSettings>();
+                unitTestSettings = TypeMoq.Mock.ofType<IUnitTestSettings>();
+                workspaceSymnbolSettings = TypeMoq.Mock.ofType<IWorkspaceSymbolSettings>();
+
+                productInstaller = new ProductInstaller(serviceContainer.object, TypeMoq.Mock.ofType<OutputChannel>().object);
+                const pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+                pythonSettings.setup(p => p.formatting).returns(() => formattingSettings.object);
+                pythonSettings.setup(p => p.unitTest).returns(() => unitTestSettings.object);
+                pythonSettings.setup(p => p.workspaceSymbols).returns(() => workspaceSymnbolSettings.object);
+                configService.setup(s => s.getSettings(TypeMoq.It.isValue(resource)))
+                    .returns(() => pythonSettings.object);
+                serviceContainer.setup(s => s.get(TypeMoq.It.isValue(IConfigurationService), TypeMoq.It.isAny()))
+                    .returns(() => configService.object);
+                serviceContainer.setup(s => s.get(TypeMoq.It.isValue(IInstaller), TypeMoq.It.isAny()))
+                    .returns(() => productInstaller);
+
+                serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IProductService), TypeMoq.It.isAny())).returns(() => new ProductService());
+            });
+
+            if (product.value === Product.isort) {
+                return;
+            }
+            const productType = new ProductService().getProductType(product.value);
+            switch (productType) {
+                case ProductType.Formatter: {
+                    test(`Ensure path is returned for ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                        const productPathService = new FormatterProductPathService(serviceContainer.object);
+                        const formatterHelper = TypeMoq.Mock.ofType<IFormatterHelper>();
+                        const expectedPath = 'Some Path';
+                        serviceContainer.setup(s => s.get(TypeMoq.It.isValue(IFormatterHelper), TypeMoq.It.isAny()))
+                            .returns(() => formatterHelper.object);
+                        formattingSettings.setup(f => f.autopep8Path)
+                            .returns(() => expectedPath)
+                            .verifiable(TypeMoq.Times.atLeastOnce());
+                        formatterHelper.setup(f => f.getSettingsPropertyNames(TypeMoq.It.isValue(product.value)))
+                            .returns(() => {
+                                return {
+                                    pathName: 'autopep8Path',
+                                    argsName: 'autopep8Args'
+                                };
+                            })
+                            .verifiable(TypeMoq.Times.once());
+
+                        const value = productPathService.getExecutableNameFromSettings(product.value, resource);
+                        expect(value).to.be.equal(expectedPath);
+                        formattingSettings.verifyAll();
+                        formatterHelper.verifyAll();
+                    });
+                    break;
+                }
+                case ProductType.Linter: {
+                    test(`Ensure path is returned for ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                        const productPathService = new LinterProductPathService(serviceContainer.object);
+                        const linterManager = TypeMoq.Mock.ofType<ILinterManager>();
+                        const linterInfo = TypeMoq.Mock.ofType<ILinterInfo>();
+                        const expectedPath = 'Some Path';
+                        serviceContainer.setup(s => s.get(TypeMoq.It.isValue(ILinterManager), TypeMoq.It.isAny()))
+                            .returns(() => linterManager.object);
+                        linterInfo.setup(l => l.pathName(TypeMoq.It.isValue(resource)))
+                            .returns(() => expectedPath)
+                            .verifiable(TypeMoq.Times.once());
+                        linterManager.setup(l => l.getLinterInfo(TypeMoq.It.isValue(product.value)))
+                            .returns(() => linterInfo.object)
+                            .verifiable(TypeMoq.Times.once());
+
+                        const value = productPathService.getExecutableNameFromSettings(product.value, resource);
+                        expect(value).to.be.equal(expectedPath);
+                        linterInfo.verifyAll();
+                        linterManager.verifyAll();
+                    });
+                }
+                case ProductType.RefactoringLibrary: {
+                    test(`Ensure path is returned for ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                        const productPathService = new RefactoringLibraryProductPathService(serviceContainer.object);
+
+                        const value = productPathService.getExecutableNameFromSettings(product.value, resource);
+                        const moduleName = productInstaller.translateProductToModuleName(product.value, ModuleNamePurpose.run);
+                        expect(value).to.be.equal(moduleName);
+                    });
+                    break;
+                }
+                case ProductType.WorkspaceSymbols: {
+                    test(`Ensure path is returned for ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                        const productPathService = new CTagsProductPathService(serviceContainer.object);
+                        const expectedPath = 'Some Path';
+                        workspaceSymnbolSettings.setup(w => w.ctagsPath)
+                            .returns(() => expectedPath)
+                            .verifiable(TypeMoq.Times.atLeastOnce());
+
+                        const value = productPathService.getExecutableNameFromSettings(product.value, resource);
+                        expect(value).to.be.equal(expectedPath);
+                        workspaceSymnbolSettings.verifyAll();
+                    });
+                    break;
+                }
+                case ProductType.TestFramework: {
+                    test(`Ensure path is returned for ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                        const productPathService = new TestFrameworkProductPathService(serviceContainer.object);
+                        const testHelper = TypeMoq.Mock.ofType<ITestsHelper>();
+                        const expectedPath = 'Some Path';
+                        serviceContainer.setup(s => s.get(TypeMoq.It.isValue(ITestsHelper), TypeMoq.It.isAny()))
+                            .returns(() => testHelper.object);
+                        testHelper.setup(t => t.getSettingsPropertyNames(TypeMoq.It.isValue(product.value)))
+                            .returns(() => {
+                                return {
+                                    argsName: 'autoTestDiscoverOnSaveEnabled',
+                                    enabledName: 'autoTestDiscoverOnSaveEnabled',
+                                    pathName: 'nosetestPath'
+                                };
+                            })
+                            .verifiable(TypeMoq.Times.once());
+                        unitTestSettings.setup(u => u.nosetestPath)
+                            .returns(() => expectedPath)
+                            .verifiable(TypeMoq.Times.atLeastOnce());
+
+                        const value = productPathService.getExecutableNameFromSettings(product.value, resource);
+                        expect(value).to.be.equal(expectedPath);
+                        testHelper.verifyAll();
+                        unitTestSettings.verifyAll();
+                    });
+                    test(`Ensure module name is returned for ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
+                        const productPathService = new TestFrameworkProductPathService(serviceContainer.object);
+                        const testHelper = TypeMoq.Mock.ofType<ITestsHelper>();
+                        serviceContainer.setup(s => s.get(TypeMoq.It.isValue(ITestsHelper), TypeMoq.It.isAny()))
+                            .returns(() => testHelper.object);
+                        testHelper.setup(t => t.getSettingsPropertyNames(TypeMoq.It.isValue(product.value)))
+                            .returns(() => {
+                                return {
+                                    argsName: 'autoTestDiscoverOnSaveEnabled',
+                                    enabledName: 'autoTestDiscoverOnSaveEnabled',
+                                    pathName: undefined
+                                };
+                            })
+                            .verifiable(TypeMoq.Times.once());
+
+                        const value = productPathService.getExecutableNameFromSettings(product.value, resource);
+                        const moduleName = productInstaller.translateProductToModuleName(product.value, ModuleNamePurpose.run);
+                        expect(value).to.be.equal(moduleName);
+                        testHelper.verifyAll();
+                    });
+                    break;
+                }
+                default: {
+                    test(`No tests for Product Path of this Product Type ${product.name}`, () => {
+                        fail('No tests for Product Path of this Product Type');
+                    });
+                }
+            }
+        });
+    });
+});

--- a/src/test/common/installer/productPath.unit.test.ts
+++ b/src/test/common/installer/productPath.unit.test.ts
@@ -9,7 +9,7 @@ import { fail } from 'assert';
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as TypeMoq from 'typemoq';
-import { OutputChannel } from 'vscode';
+import { OutputChannel, Uri } from 'vscode';
 import { EnumEx } from '../../../client/common/enumUtils';
 import '../../../client/common/extensions';
 import { ProductInstaller } from '../../../client/common/installer/productInstaller';
@@ -21,7 +21,6 @@ import { IFormatterHelper } from '../../../client/formatters/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { ILinterInfo, ILinterManager } from '../../../client/linters/types';
 import { ITestsHelper } from '../../../client/unittests/common/types';
-import { Uri } from '../../vscode-mock';
 
 use(chaiAsPromised);
 

--- a/src/test/linters/lint.multiroot.test.ts
+++ b/src/test/linters/lint.multiroot.test.ts
@@ -2,15 +2,19 @@ import * as assert from 'assert';
 import * as path from 'path';
 import { CancellationTokenSource, ConfigurationTarget, OutputChannel, Uri, workspace } from 'vscode';
 import { PythonSettings } from '../../client/common/configSettings';
-import { IConfigurationService, IOutputChannel, Product } from '../../client/common/types';
+import { CTagsProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from '../../client/common/installer/productPath';
+import { ProductService } from '../../client/common/installer/productService';
+import { IProductPathService, IProductService } from '../../client/common/installer/types';
+import { IConfigurationService, IOutputChannel, Product, ProductType } from '../../client/common/types';
 import { ILinter, ILinterManager } from '../../client/linters/types';
 import { TEST_OUTPUT_CHANNEL } from '../../client/unittests/common/constants';
 import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } from '../initialize';
 import { UnitTestIocContainer } from '../unittests/serviceRegistry';
 
+// tslint:disable:max-func-body-length no-invalid-this
+
 const multirootPath = path.join(__dirname, '..', '..', '..', 'src', 'testMultiRootWkspc');
 
-// tslint:disable-next-line:max-func-body-length
 suite('Multiroot Linting', () => {
     const pylintSetting = 'linting.pylintEnabled';
     const flake8Setting = 'linting.flake8Enabled';
@@ -18,7 +22,6 @@ suite('Multiroot Linting', () => {
     let ioc: UnitTestIocContainer;
     suiteSetup(function () {
         if (!IS_MULTI_ROOT_TEST) {
-            // tslint:disable-next-line:no-invalid-this
             this.skip();
         }
         return initialize();
@@ -41,6 +44,13 @@ suite('Multiroot Linting', () => {
         ioc.registerLinterTypes();
         ioc.registerVariableTypes();
         ioc.registerPlatformTypes();
+        ioc.serviceManager.addSingletonInstance<IProductService>(IProductService, new ProductService());
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, CTagsProductPathService, ProductType.WorkspaceSymbols);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, FormatterProductPathService, ProductType.Formatter);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, LinterProductPathService, ProductType.Linter);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, TestFrameworkProductPathService, ProductType.TestFramework);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, RefactoringLibraryProductPathService, ProductType.RefactoringLibrary);
+
     }
 
     async function createLinter(product: Product, resource?: Uri): Promise<ILinter> {

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -123,7 +123,6 @@ suite('Linting', () => {
         ioc.registerLinterTypes();
         ioc.registerVariableTypes();
         ioc.registerPlatformTypes();
-        ioc.serviceManager.addSingletonInstance<IProductService>(IProductService, new ProductService());
         linterManager = new LinterManager(ioc.serviceContainer);
         configService = ioc.serviceContainer.get<IConfigurationService>(IConfigurationService);
         ioc.serviceManager.addSingletonInstance<IProductService>(IProductService, new ProductService());

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -6,7 +6,10 @@ import * as vscode from 'vscode';
 import { ICommandManager } from '../../client/common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../client/common/constants';
 import { Product } from '../../client/common/installer/productInstaller';
-import { IConfigurationService, IOutputChannel } from '../../client/common/types';
+import { CTagsProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from '../../client/common/installer/productPath';
+import { ProductService } from '../../client/common/installer/productService';
+import { IProductPathService, IProductService } from '../../client/common/installer/types';
+import { IConfigurationService, IOutputChannel, ProductType } from '../../client/common/types';
 import { LinterManager } from '../../client/linters/linterManager';
 import { ILinterManager, ILintMessage, LintMessageSeverity } from '../../client/linters/types';
 import { deleteFile, PythonSettingKeys, rootWorkspaceUri } from '../common';
@@ -120,9 +123,15 @@ suite('Linting', () => {
         ioc.registerLinterTypes();
         ioc.registerVariableTypes();
         ioc.registerPlatformTypes();
-
+        ioc.serviceManager.addSingletonInstance<IProductService>(IProductService, new ProductService());
         linterManager = new LinterManager(ioc.serviceContainer);
         configService = ioc.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        ioc.serviceManager.addSingletonInstance<IProductService>(IProductService, new ProductService());
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, CTagsProductPathService, ProductType.WorkspaceSymbols);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, FormatterProductPathService, ProductType.Formatter);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, LinterProductPathService, ProductType.Linter);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, TestFrameworkProductPathService, ProductType.TestFramework);
+        ioc.serviceManager.addSingleton<IProductPathService>(IProductPathService, RefactoringLibraryProductPathService, ProductType.RefactoringLibrary);
     }
 
     async function resetSettings() {


### PR DESCRIPTION
Fixes #1064

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
