### PR TITLE
Use a glob pattern to look for conda executables

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,7 +72,7 @@ init:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm ci
+  - npm i
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python -m pip install -U pip
   - pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/

--- a/news/3 Code Health/256.md
+++ b/news/3 Code Health/256.md
@@ -1,0 +1,1 @@
+Use a glob pattern to look for `conda` executables.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,8 +2648,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "1.2.4",
@@ -3262,7 +3261,6 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5269,7 +5267,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5278,8 +5275,7 @@
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
@@ -6895,7 +6891,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -7106,8 +7101,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -9440,8 +9434,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
             "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -1891,6 +1891,7 @@
         "fs-extra": "4.0.3",
         "fuzzy": "0.1.3",
         "get-port": "3.2.0",
+        "glob": "^7.1.2",
         "iconv-lite": "0.4.21",
         "inversify": "4.11.1",
         "line-by-line": "0.1.6",

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -4,6 +4,7 @@
 
 import { createHash } from 'crypto';
 import * as fs from 'fs-extra';
+import * as glob from 'glob';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { createDeferred } from '../helpers';
@@ -127,6 +128,16 @@ export class FileSystem implements IFileSystem {
                     const actual = createHash('sha512').update(`${stats.ctimeMs}-${stats.mtimeMs}`).digest('hex');
                     resolve(actual);
                 }
+            });
+        });
+    }
+    public search(globPattern: string): Promise<string[]> {
+        return new Promise<string[]>((resolve, reject) => {
+            glob(globPattern, (ex, files) => {
+                if (ex) {
+                    return reject(ex);
+                }
+                resolve(Array.isArray(files) ? files : []);
             });
         });
     }

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -47,4 +47,5 @@ export interface IFileSystem {
     copyFile(src: string, dest: string): Promise<void>;
     deleteFile(filename: string): Promise<void>;
     getFileHash(filePath: string): Promise<string | undefined>;
+    search(globPattern: string): Promise<string[]>;
 }

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -1,4 +1,3 @@
-import * as glob from 'glob';
 import { inject, injectable, named, optional } from 'inversify';
 import * as path from 'path';
 import { IFileSystem, IPlatformService } from '../../../common/platform/types';
@@ -182,11 +181,8 @@ export class CondaService implements ICondaService {
         return this.getCondaFileFromKnownLocations();
     }
     private async getCondaFileFromKnownLocations(): Promise<string> {
-        const condaFiles = await new Promise<string[]>(resolve => {
-            glob(untildify(CondaLocationsGlob), (_, files) => {
-                resolve(Array.isArray(files) ? files : []);
-            });
-        });
+        const condaFiles = await this.fileSystem.search(untildify(CondaLocationsGlob))
+            .catch<string[]>(() => []);
 
         const validCondaFiles = condaFiles.filter(condaPath => condaPath.length > 0);
         return validCondaFiles.length === 0 ? 'conda' : validCondaFiles[0];

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -81,6 +81,8 @@ suite('FileSystem', () => {
         const files = await fileSystem.search(path.join(__dirname, '*.js'));
         expect(files).to.be.array();
         expect(files.length).to.be.at.least(1);
-        expect(files).to.include(__filename);
+        const expectedFileName = __filename.replace(/\\/g, '/');
+        const fileName = files[0].replace(/\\/g, '/');
+        expect(fileName).to.equal(expectedFileName);
     });
 });

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -77,4 +77,10 @@ suite('FileSystem', () => {
         const fileContents = await fileSystem.readFile(fileToAppendTo);
         expect(fileContents).to.be.equal(dataToAppend);
     });
+    test('Test searching for files', async () => {
+        const files = await fileSystem.search(path.join(__dirname, '*.js'));
+        expect(files).to.be.array();
+        expect(files.length).to.be.at.least(1);
+        expect(files).to.include(__filename);
+    });
 });

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -12,7 +12,7 @@ process.env.IS_MULTI_ROOT_TEST = IS_MULTI_ROOT_TEST.toString();
 // If running on CI server and we're running the debugger tests, then ensure we only run debug tests.
 // We do this to ensure we only run debugger test, as debugger tests are very flaky on CI.
 // So the solution is to run them separately and first on CI.
-const grep = IS_CI_SERVER && IS_CI_SERVER_TEST_DEBUGGER ? 'Debug' : undefined;
+const grep = IS_CI_SERVER && IS_CI_SERVER_TEST_DEBUGGER ? 'Debug' : 'FileSystem';
 
 const testFilesSuffix = process.env.TEST_FILES_SUFFIX;
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -12,7 +12,7 @@ process.env.IS_MULTI_ROOT_TEST = IS_MULTI_ROOT_TEST.toString();
 // If running on CI server and we're running the debugger tests, then ensure we only run debug tests.
 // We do this to ensure we only run debugger test, as debugger tests are very flaky on CI.
 // So the solution is to run them separately and first on CI.
-const grep = IS_CI_SERVER && IS_CI_SERVER_TEST_DEBUGGER ? 'Debug' : 'FileSystem';
+const grep = IS_CI_SERVER && IS_CI_SERVER_TEST_DEBUGGER ? 'Debug' : undefined;
 
 const testFilesSuffix = process.env.TEST_FILES_SUFFIX;
 

--- a/src/test/interpreters/condaService.test.ts
+++ b/src/test/interpreters/condaService.test.ts
@@ -363,7 +363,8 @@ suite('Interpreters Conda Service', () => {
                 const expectedCondaLocation = untildify(knownLocation);
                 platformService.setup(p => p.isWindows).returns(() => false);
                 processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.reject(new Error('Not Found')));
-                fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isAny())).returns((file: string) => Promise.resolve(file === expectedCondaLocation));
+                fileSystem.setup(fs => fs.search(TypeMoq.It.isAny())).returns(() => Promise.resolve([expectedCondaLocation]));
+                fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(expectedCondaLocation))).returns(() => Promise.resolve(true));
 
                 const condaExe = await condaService.getCondaFile();
                 assert.equal(condaExe, expectedCondaLocation, 'Failed to identify');
@@ -373,6 +374,7 @@ suite('Interpreters Conda Service', () => {
     test('Must return \'conda\' if conda could not be found in known locations', async () => {
         platformService.setup(p => p.isWindows).returns(() => false);
         processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.reject(new Error('Not Found')));
+        fileSystem.setup(fs => fs.search(TypeMoq.It.isAny())).returns(() => Promise.resolve([]));
         fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isAny())).returns((file: string) => Promise.resolve(false));
 
         const condaExe = await condaService.getCondaFile();

--- a/src/test/interpreters/condaService.test.ts
+++ b/src/test/interpreters/condaService.test.ts
@@ -9,7 +9,7 @@ import { Architecture, IFileSystem, IPlatformService } from '../../client/common
 import { IProcessService, IProcessServiceFactory } from '../../client/common/process/types';
 import { ILogger, IPersistentStateFactory } from '../../client/common/types';
 import { IInterpreterLocatorService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
-import { CondaService, KNOWN_CONDA_LOCATIONS } from '../../client/interpreter/locators/services/condaService';
+import { CondaService } from '../../client/interpreter/locators/services/condaService';
 import { IServiceContainer } from '../../client/ioc/types';
 import { MockState } from './mocks';
 
@@ -356,17 +356,19 @@ suite('Interpreters Conda Service', () => {
         processService.verify(p => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
     });
 
-    KNOWN_CONDA_LOCATIONS.forEach(knownLocation => {
-        test(`Must return conda path from known location '${knownLocation}' (non windows)`, async () => {
-            const expectedCondaLocation = untildify(knownLocation);
-            platformService.setup(p => p.isWindows).returns(() => false);
-            processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.reject(new Error('Not Found')));
-            fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isAny())).returns((file: string) => Promise.resolve(file === expectedCondaLocation));
+    ['~/anaconda/bin/conda', '~/miniconda/bin/conda', '~/anaconda2/bin/conda',
+        '~/miniconda2/bin/conda', '~/anaconda3/bin/conda', '~/miniconda3/bin/conda']
+        .forEach(knownLocation => {
+            test(`Must return conda path from known location '${knownLocation}' (non windows)`, async () => {
+                const expectedCondaLocation = untildify(knownLocation);
+                platformService.setup(p => p.isWindows).returns(() => false);
+                processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.reject(new Error('Not Found')));
+                fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isAny())).returns((file: string) => Promise.resolve(file === expectedCondaLocation));
 
-            const condaExe = await condaService.getCondaFile();
-            assert.equal(condaExe, expectedCondaLocation, 'Failed to identify');
+                const condaExe = await condaService.getCondaFile();
+                assert.equal(condaExe, expectedCondaLocation, 'Failed to identify');
+            });
         });
-    });
 
     test('Must return \'conda\' if conda could not be found in known locations', async () => {
         platformService.setup(p => p.isWindows).returns(() => false);


### PR DESCRIPTION
Fixes #256

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
