### PR TITLE
Mention Black as option for code formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ contributors (if you would like to contribute a translation, see the
   + Ability to include custom module paths (e.g. include paths for libraries like Google App Engine, etc.; use the setting `python.autoComplete.extraPaths = []`)
 * Code formatting
   + Auto formatting of code upon saving changes (default to 'Off')
-  + Use either [yapf](https://pypi.io/project/yapf/), [autopep8](https://pypi.io/project/autopep8/) or [black](https://pypi.io/project/black/) for code formatting (defaults to autopep8)
+  + Use either [yapf](https://pypi.org/project/yapf/), [autopep8](https://pypi.org/project/autopep8/), or [Black](https://pypi.org/project/black/) for code formatting (defaults to autopep8)
 * Linting
-  + Support for multiple linters with custom settings (default is [Pylint](https://pypi.org/project/pylint/), but [Prospector](https://pypi.org/project/prospector/), [Flake8](https://pypi.io/project/flake8/), [pylama](https://github.com/klen/pylama), [pydocstyle](https://pypi.org/project/pydocstyle/), and [mypy](https://pypi.org/project/mypy/) are also supported)
+  + Support for multiple linters with custom settings (default is [Pylint](https://pypi.org/project/pylint/), but [Prospector](https://pypi.org/project/prospector/), [Flake8](https://pypi.org/project/flake8/), [pylama](https://github.com/klen/pylama), [pydocstyle](https://pypi.org/project/pydocstyle/), and [mypy](https://pypi.org/project/mypy/) are also supported)
 * Debugging
   + Watch window
   + Evaluate expressions
@@ -87,7 +87,7 @@ contributors (if you would like to contribute a translation, see the
   + Debugging in the integrated or external terminal window
   + Debugging as sudo
 * Unit testing
-  + Support for [unittest](https://docs.python.org/3/library/unittest.html#module-unittest), [pytest](https://pypi.io/project/pytest/), and [nose](https://pypi.io/project/nose/)
+  + Support for [unittest](https://docs.python.org/3/library/unittest.html#module-unittest), [pytest](https://pypi.org/project/pytest/), and [nose](https://pypi.org/project/nose/)
   + Ability to run all failed tests, individual tests
   + Debugging unit tests
 * Snippets

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ contributors (if you would like to contribute a translation, see the
   + Ability to include custom module paths (e.g. include paths for libraries like Google App Engine, etc.; use the setting `python.autoComplete.extraPaths = []`)
 * Code formatting
   + Auto formatting of code upon saving changes (default to 'Off')
-  + Use either [yapf](https://pypi.io/project/yapf/) or [autopep8](https://pypi.io/project/autopep8/) for code formatting (defaults to autopep8)
+  + Use either [yapf](https://pypi.io/project/yapf/), [autopep8](https://pypi.io/project/autopep8/) or [black](https://pypi.io/project/black/) for code formatting (defaults to autopep8)
 * Linting
   + Support for multiple linters with custom settings (default is [Pylint](https://pypi.org/project/pylint/), but [Prospector](https://pypi.org/project/prospector/), [Flake8](https://pypi.io/project/flake8/), [pylama](https://github.com/klen/pylama), [pydocstyle](https://pypi.org/project/pydocstyle/), and [mypy](https://pypi.org/project/mypy/) are also supported)
 * Debugging


### PR DESCRIPTION
Readme only mentioned yapf and autopep8 but black is also supported in latest release.

Fixes #
black was missing from list of supported formatters.

This pull request:
- [x] Has a title summarizes what is changing
- [ ] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
