### PR TITLE
Test existance and value of `MOCHA_REPORTER_JUNIT` during test runs

### DIFF
--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -12,13 +12,13 @@ export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR || IS_VSTS;
 // allow the CI server to specify JUnit output...
 let reportJunit: boolean = false;
 if (IS_CI_SERVER && process.env.MOCHA_REPORTER_JUNIT !== undefined) {
-    reportJunit = process.env.MOCHA_REPORTER_JUNIT.toString().toLowerCase() === 'true';
+    reportJunit = process.env.MOCHA_REPORTER_JUNIT.toLowerCase() === 'true';
 }
 export const MOCHA_REPORTER_JUNIT: boolean = reportJunit;
 export const MOCHA_CI_REPORTFILE: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_REPORTFILE !== undefined ?
-                                            process.env.MOCHA_CI_REPORTFILE.toString() : './junit-out.xml';
+                                            process.env.MOCHA_CI_REPORTFILE : './junit-out.xml';
 export const MOCHA_CI_PROPERTIES: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_PROPERTIES !== undefined ?
-                                            process.env.MOCHA_CI_PROPERTIES.toString() : '';
+                                            process.env.MOCHA_CI_PROPERTIES : '';
 
 export const TEST_TIMEOUT = 25000;
 export const IS_MULTI_ROOT_TEST = isMultitrootTest();


### PR DESCRIPTION
Allow junit reporting to be disabled at build queue time.

Fixes #1911

This pull request:
- [x] Has a title summarizes what is changing
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
