### PR TITLE
[WIP] Allow for specifying grep value in tests for CI and on command line

### DIFF
--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -11,7 +11,7 @@ export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR || IS_VSTS;
 
 // allow the CI server to specify JUnit output...
 let reportJunit: boolean = false;
-if (IS_CI_SERVER && process.env.MOCHA_REPORTER_JUNIT !== undefined) {
+if (process.env.MOCHA_REPORTER_JUNIT !== undefined) {
     reportJunit = process.env.MOCHA_REPORTER_JUNIT.toLowerCase() === 'true';
 }
 export const MOCHA_REPORTER_JUNIT: boolean = reportJunit;
@@ -19,6 +19,8 @@ export const MOCHA_CI_REPORTFILE: string = MOCHA_REPORTER_JUNIT && process.env.M
                                             process.env.MOCHA_CI_REPORTFILE : './junit-out.xml';
 export const MOCHA_CI_PROPERTIES: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_PROPERTIES !== undefined ?
                                             process.env.MOCHA_CI_PROPERTIES : '';
+export const MOCHA_CI_GREP: string = process.env.MOCHA_CI_GREP !== undefined ?
+                                            process.env.MOCHA_CI_GREP : '';
 
 export const TEST_TIMEOUT = 25000;
 export const IS_MULTI_ROOT_TEST = isMultitrootTest();

--- a/src/test/debugger/envVars.test.ts
+++ b/src/test/debugger/envVars.test.ts
@@ -103,7 +103,11 @@ suite('Resolving Environment Variables when Debugging', () => {
         }
     }
 
-    test('Confirm json environment variables exist when launched in external terminal', () => testJsonEnvVariables('externalTerminal', 2 + 2));
+    test('Confirm json environment variables exist when launched in external terminal', () => {
+        testJsonEnvVariables('externalTerminal', 2 + 2).catch((reason) => {
+            throw new Error(`Env Var Test broken: '${reason}'`);
+        });
+    });
 
     test('Confirm json environment variables exist when launched in intergrated terminal', () => testJsonEnvVariables('integratedTerminal', 2 + 2));
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -5,8 +5,9 @@ if ((Reflect as any).metadata === undefined) {
 }
 
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
-         IS_MULTI_ROOT_TEST, IS_VSTS, MOCHA_CI_PROPERTIES,
-         MOCHA_CI_REPORTFILE, MOCHA_REPORTER_JUNIT } from './constants';
+         IS_MULTI_ROOT_TEST, IS_VSTS, MOCHA_CI_GREP,
+         MOCHA_CI_PROPERTIES, MOCHA_CI_REPORTFILE,
+         MOCHA_REPORTER_JUNIT } from './constants';
 import * as testRunner from './testRunner';
 
 process.env.VSC_PYTHON_CI_TEST = '1';
@@ -15,7 +16,14 @@ process.env.IS_MULTI_ROOT_TEST = IS_MULTI_ROOT_TEST.toString();
 // If running on CI server and we're running the debugger tests, then ensure we only run debug tests.
 // We do this to ensure we only run debugger test, as debugger tests are very flaky on CI.
 // So the solution is to run them separately and first on CI.
-const grep = IS_CI_SERVER && IS_CI_SERVER_TEST_DEBUGGER ? 'Debug' : undefined;
+let grep: string | undefined;
+if (IS_CI_SERVER) {
+    if (IS_CI_SERVER_TEST_DEBUGGER) {
+        grep = 'Debug';
+    } else if (MOCHA_CI_GREP !== '') {
+        grep = MOCHA_CI_GREP;
+    }
+}
 const testFilesSuffix = process.env.TEST_FILES_SUFFIX;
 
 // You can directly control Mocha options by uncommenting the following lines.


### PR DESCRIPTION
Further to #1897 (allowing for us to diagnose/find problems with tests in CI but not locally faster)

>Note: This PR is going to be somewhat exploratory in that I would like to find the best way to correct some of our false-negative reports to do with `rejected promise not handled...` messages.

Setting environment variable `MOCHA_CI_GREP` to a test suite name will only run the tests in that suite.
Also: Removed the requirement that `IS_CI_SERVER` is `true` in order to make use of JUnit settings in mocha test runs. (We need to run it locally too in order to diagnose issues with CI when they arise).

This pull request:
- [x] Has a title summarizes what is changing
~~- [ ] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~~
~~- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)~~
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
