### PR TITLE
Add isort CodeAction (sort imports on save)

### DIFF
--- a/news/1 Enhancements/156.md
+++ b/news/1 Enhancements/156.md
@@ -1,0 +1,1 @@
+Add support for the `editor.codeActionsOnSave.source.organizeImports` setting (thanks [Nathan Gaberel](https://github.com/n6g7)).

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -40,6 +40,7 @@ import { IServiceContainer, IServiceManager } from './ioc/types';
 import { LinterCommands } from './linters/linterCommands';
 import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
 import { ILintingEngine } from './linters/types';
+import { PythonCodeActionProvider } from './providers/codeActionsProvider';
 import { PythonFormattingEditProvider } from './providers/formatProvider';
 import { LinterProvider } from './providers/linterProvider';
 import { PythonRenameProvider } from './providers/renameProvider';
@@ -144,6 +145,8 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(new ReplProvider(serviceContainer));
     context.subscriptions.push(new TerminalProvider(serviceContainer));
     context.subscriptions.push(new WorkspaceSymbols(serviceContainer));
+
+    context.subscriptions.push(languages.registerCodeActionsProvider(PYTHON, new PythonCodeActionProvider()));
 
     type ConfigurationProvider = BaseConfigurationProvider<LaunchRequestArguments, AttachRequestArguments>;
     serviceContainer.getAll<ConfigurationProvider>(IDebugConfigurationProvider).forEach(debugConfig => {

--- a/src/client/providers/codeActionsProvider.ts
+++ b/src/client/providers/codeActionsProvider.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as vscode from 'vscode';
+
+export class PythonCodeActionProvider implements vscode.CodeActionProvider {
+    public provideCodeActions(document: vscode.TextDocument, range: vscode.Range, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeAction[]> {
+        const sortImports = new vscode.CodeAction(
+            'Sort imports on save',
+            vscode.CodeActionKind.SourceOrganizeImports
+        );
+        sortImports.command = {
+            title: 'Sort imports',
+            command: 'python.sortImports'
+        };
+
+        return [sortImports];
+    }
+}

--- a/src/test/providers/codeActionsProvider.test.ts
+++ b/src/test/providers/codeActionsProvider.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { CancellationToken, CodeActionContext, CodeActionKind, Range, TextDocument } from 'vscode';
+import { PythonCodeActionProvider } from '../../client/providers/codeActionsProvider';
+
+suite('CodeAction Provider', () => {
+    let codeActionsProvider: PythonCodeActionProvider;
+    let document: TypeMoq.IMock<TextDocument>;
+    let range: TypeMoq.IMock<Range>;
+    let context: TypeMoq.IMock<CodeActionContext>;
+    let token: TypeMoq.IMock<CancellationToken>;
+
+    setup(() => {
+        codeActionsProvider = new PythonCodeActionProvider();
+        document = TypeMoq.Mock.ofType<TextDocument>();
+        range = TypeMoq.Mock.ofType<Range>();
+        context = TypeMoq.Mock.ofType<CodeActionContext>();
+        token = TypeMoq.Mock.ofType<CancellationToken>();
+    });
+
+    test('Ensure it always returns a source.organizeImports CodeAction', async () => {
+        const codeActions = await codeActionsProvider.provideCodeActions(
+            document.object,
+            range.object,
+            context.object,
+            token.object
+        );
+
+        if (!codeActions) {
+            throw Error(`codeActionsProvider.provideCodeActions did not return an array (it returned ${codeActions})`);
+        }
+
+        const organizeImportsCodeAction = codeActions.filter(
+            codeAction => codeAction.kind === CodeActionKind.SourceOrganizeImports
+        );
+        expect(organizeImportsCodeAction).to.have.length(1);
+        expect(organizeImportsCodeAction[0].kind).to.eq(CodeActionKind.SourceOrganizeImports);
+    });
+});


### PR DESCRIPTION
Fixes #156 

This pull request:
- [X] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)

--------

This implements #156 (run `isort` on save) using [Code actions](https://code.visualstudio.com/updates/v1_23#_run-code-actions-on-save).

I'll add a news entry and make sure to check the remaining checkboxes above asap, in the meantime any feedback is welcome. :)