### PR TITLE
Add test for windows in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ const tslint = require('tslint');
 const relative = require('relative');
 const ts = require('gulp-typescript');
 const cp = require('child_process');
+const spawn = require('cross-spawn');
 const colors = require('colors/safe');
 const gitmodified = require('gulp-gitmodified');
 const path = require('path');
@@ -128,7 +129,7 @@ function hasNativeDependencies() {
     if (!Array.isArray(nativeDependencies) || nativeDependencies.length === 0) {
         return false;
     }
-    const dependencies = JSON.parse(cp.spawnSync('npm', ['ls', '--json', '--prod']).stdout.toString());
+    const dependencies = JSON.parse(spawn.sync('npm', ['ls', '--json', '--prod']).stdout.toString());
     const jsonProperties = Object.keys(flat.flatten(dependencies));
     nativeDependencies = _.flatMap(nativeDependencies, item => path.dirname(item.substring(item.indexOf('node_modules') + 'node_modules'.length)).split(path.sep))
         .filter(item => item.length > 0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,6 +1460,19 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            }
+        },
         "crypt": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
@@ -6683,6 +6696,12 @@
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
             "dev": true
         },
+        "nice-try": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+            "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+            "dev": true
+        },
         "nise": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
@@ -7137,6 +7156,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
             "dev": true
         },
         "path-parse": {
@@ -7851,6 +7876,21 @@
                     }
                 }
             }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
         },
         "shortid": {
             "version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -1954,6 +1954,7 @@
         "chai-as-promised": "^7.1.1",
         "codecov": "^3.0.0",
         "colors": "^1.2.1",
+        "cross-spawn": "^6.0.5",
         "debounce": "^1.1.0",
         "decache": "^4.4.0",
         "del": "^3.0.0",


### PR DESCRIPTION
Get around a problem with paths in Win32 affecting our gulpfile

Fixes #1928 

This pull request:
- [x] Has a title summarizes what is changing
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
