### PR TITLE
Remove the 'TRAVIS' from 'TRAVIS_PYTHON_PATH' to suite other CI systems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_install: |
   npm install npm@latest -g
   npm install -g vsce
   npm install -g azure-cli
-  export TRAVIS_PYTHON_PATH=`which python`
+  export CI_PYTHON_PATH=`which python`
 install:
   - python -m pip install --upgrade -r requirements.txt
   - python -m pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -114,8 +114,8 @@ export const setPythonPathInWorkspaceRoot = async (pythonPath: string) => retryA
 export const resetGlobalPythonPathSetting = async () => retryAsync(restoreGlobalPythonPathSetting)();
 
 function getPythonPath(): string {
-    if (process.env.TRAVIS_PYTHON_PATH && fs.existsSync(process.env.TRAVIS_PYTHON_PATH)) {
-        return process.env.TRAVIS_PYTHON_PATH;
+    if (process.env.CI_PYTHON_PATH && fs.existsSync(process.env.CI_PYTHON_PATH)) {
+        return process.env.CI_PYTHON_PATH;
     }
     return 'python';
 }


### PR DESCRIPTION
Fixes #1945 

We will be using this variable in VSTS CI automation as well, feels better to not be using a different-CI-system moniker!

This pull request:
- [x] Has a title summarizes what is changing
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
