### PR TITLE
Fix failing test on Mac when validating the path of a python interperter

### DIFF
--- a/news/3 Code Health/1957.md
+++ b/news/3 Code Health/1957.md
@@ -1,0 +1,1 @@
+Fix failing test on Mac when validating the path of a python interperter.


### PR DESCRIPTION
Fixes #1957

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
