### PR TITLE
Change keyboard shortcut for execSelectionInTerminal to Shit+Enter

### DIFF
--- a/news/2 Fixes/1875.md
+++ b/news/2 Fixes/1875.md
@@ -1,0 +1,1 @@
+Change keyboard shortcut for `Run Selection/Line in Python Terminal` to `Shit+Enter`.

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
         "keybindings": [
             {
                 "command": "python.execSelectionInTerminal",
-                "key": "ctrl+enter",
-                "when": "editorFocus && editorHasSelection && editorLangId == python"
+                "key": "shift+enter",
+                "when": "editorFocus && editorLangId == python"
             }
         ],
         "commands": [

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
                 {
                     "command": "python.execSelectionInTerminal",
                     "group": "Python",
-                    "when": "editorHasSelection && editorLangId == python"
+                    "when": "editorFocus && editorLangId == python"
                 },
                 {
                     "command": "python.execSelectionInDjangoShell",


### PR DESCRIPTION
Fixes #1875

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
