### PR TITLE
Log env info when the existence of pipenv cannot be determined

### DIFF
--- a/news/3 Code Health/1338.md
+++ b/news/3 Code Health/1338.md
@@ -1,0 +1,1 @@
+Log relevant environment information when the existence of `pipenv` cannot be determined.


### PR DESCRIPTION
Fixes #1338

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
