### PR TITLE
Relax path validations (ignore %)

### DIFF
--- a/src/client/application/diagnostics/applicationDiagnostics.ts
+++ b/src/client/application/diagnostics/applicationDiagnostics.ts
@@ -27,7 +27,7 @@ export class ApplicationDiagnostics implements IApplicationDiagnostics {
         const logger = this.serviceContainer.get<ILogger>(ILogger);
         const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
         diagnostics.forEach(item => {
-            const message = `Diagnostic Code: ${item.code}, Mesage: ${item.message}`;
+            const message = `Diagnostic Code: ${item.code}, Message: ${item.message}`;
             switch (item.severity) {
                 case DiagnosticSeverity.Error: {
                     logger.logError(message);

--- a/src/client/application/diagnostics/checks/envPathVariable.ts
+++ b/src/client/application/diagnostics/checks/envPathVariable.ts
@@ -16,7 +16,7 @@ import { DiagnosticCodes } from '../constants';
 import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../promptHandler';
 import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../types';
 
-const InvalidEnvPathVariableMessage = 'The environment variable \'{0}\' seems to have some paths containing characters (\';\', \'"\', \'%\' or \';;\').' +
+const InvalidEnvPathVariableMessage = 'The environment variable \'{0}\' seems to have some paths containing characters (\';\', \'"\' or \';;\').' +
     ' The existence of such characters are known to have caused the {1} extension to not load.';
 
 export class InvalidEnvironmentPathVariableDiagnostic extends BaseDiagnostic {
@@ -79,6 +79,6 @@ export class EnvironmentPathVariableDiagnosticsService extends BaseDiagnosticsSe
         const pathValue = currentProc.env[this.platform.pathVariableName];
         const pathSeparator = this.serviceContainer.get<IPathUtils>(IPathUtils).delimiter;
         const paths = pathValue.split(pathSeparator);
-        return paths.filter(item => item.indexOf('"') >= 0 || item.indexOf(';') >= 0 || item.indexOf('%') >= 0 || item.length === 0).length > 0;
+        return paths.filter(item => item.indexOf('"') >= 0 || item.indexOf(';') >= 0 || item.length === 0).length > 0;
     }
 }

--- a/src/client/application/diagnostics/checks/envPathVariable.ts
+++ b/src/client/application/diagnostics/checks/envPathVariable.ts
@@ -79,6 +79,6 @@ export class EnvironmentPathVariableDiagnosticsService extends BaseDiagnosticsSe
         const pathValue = currentProc.env[this.platform.pathVariableName];
         const pathSeparator = this.serviceContainer.get<IPathUtils>(IPathUtils).delimiter;
         const paths = pathValue.split(pathSeparator);
-        return paths.filter(item => item.indexOf('"') >= 0 || item.indexOf(';') >= 0 || item.length === 0).length > 0;
+        return paths.filter((item, index) => item.indexOf('"') >= 0 || item.indexOf(';') >= 0 || (item.length === 0 && index !== paths.length - 1)).length > 0;
     }
 }

--- a/src/client/application/diagnostics/checks/envPathVariable.ts
+++ b/src/client/application/diagnostics/checks/envPathVariable.ts
@@ -17,7 +17,7 @@ import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '.
 import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../types';
 
 const InvalidEnvPathVariableMessage = 'The environment variable \'{0}\' seems to have some paths containing characters (\';\', \'"\' or \';;\').' +
-    ' The existence of such characters are known to have caused the {1} extension to not load.';
+    ' The existence of such characters are known to have caused the {1} extension to not load. If the extension fails to load please modify your paths to remove these characters.';
 
 export class InvalidEnvironmentPathVariableDiagnostic extends BaseDiagnostic {
     constructor(message) {

--- a/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
+++ b/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
@@ -79,7 +79,7 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
         }
 
         for (const diagnostic of diagnostics) {
-            const message = `Diagnostic Code: ${diagnostic.code}, Mesage: ${diagnostic.message}`;
+            const message = `Diagnostic Code: ${diagnostic.code}, Message: ${diagnostic.message}`;
             switch (diagnostic.severity) {
                 case DiagnosticSeverity.Error: {
                     logger.setup(l => l.logError(message))

--- a/src/test/application/diagnostics/checks/envPathVariable.unit.test.ts
+++ b/src/test/application/diagnostics/checks/envPathVariable.unit.test.ts
@@ -133,6 +133,18 @@ suite('Application Diagnostics - Checks Env Path Variable', () => {
             expect(diagnostics[0].severity).to.be.equal(DiagnosticSeverity.Warning);
             expect(diagnostics[0].scope).to.be.equal(DiagnosticScope.Global);
         });
+        test('Should not return diagnostics for Windows if path ends with delimiter', async () => {
+            const paths = [
+                path.join('one', 'two', 'three'),
+                path.join('one', 'two', 'four')
+            ].join(pathDelimiter) + pathDelimiter;
+            platformService.setup(p => p.isWindows).returns(() => true);
+            procEnv.setup(env => env[pathVariableName]).returns(() => paths);
+
+            const diagnostics = await diagnosticService.diagnose();
+
+            expect(diagnostics).to.be.lengthOf(0);
+        });
     });
     test('Should display three options in message displayed with 2 commands', async () => {
         platformService.setup(p => p.isWindows).returns(() => true);

--- a/src/test/application/diagnostics/checks/envPathVariable.unit.test.ts
+++ b/src/test/application/diagnostics/checks/envPathVariable.unit.test.ts
@@ -114,7 +114,8 @@ suite('Application Diagnostics - Checks Env Path Variable', () => {
 
         expect(diagnostics).to.be.deep.equal([]);
     });
-    [';;', '"', '%'].forEach(invalidCharacter => {
+    // Note: On windows, when a path contains a `;` then Windows encloses the path within `"`.
+    [';;', '"'].forEach(invalidCharacter => {
         test(`Should return single diagnostics for Windows if path contains ${invalidCharacter}`, async () => {
             platformService.setup(p => p.isWindows).returns(() => true);
             const paths = [


### PR DESCRIPTION
Fixes #2005

This pull request:
- [x] Has a title summarizes what is changing
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
