### PR TITLE
Display banner once debugging has terminated

### DIFF
--- a/src/client/common/application/debugService.ts
+++ b/src/client/common/application/debugService.ts
@@ -9,10 +9,10 @@ import { IDebugService } from './types';
 
 @injectable()
 export class DebugService implements IDebugService {
-    public get onDidStartDebugSession(): Event<DebugSession>{
+    public get onDidStartDebugSession(): Event<DebugSession> {
         return debug.onDidStartDebugSession;
     }
-    public get onDidTerminateDebugSession(): Event<DebugSession>{
+    public get onDidTerminateDebugSession(): Event<DebugSession> {
         return debug.onDidTerminateDebugSession;
     }
     public startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration): Thenable<boolean> {

--- a/src/client/common/application/debugService.ts
+++ b/src/client/common/application/debugService.ts
@@ -12,6 +12,9 @@ export class DebugService implements IDebugService {
     public get onDidStartDebugSession(): Event<DebugSession>{
         return debug.onDidStartDebugSession;
     }
+    public get onDidTerminateDebugSession(): Event<DebugSession>{
+        return debug.onDidTerminateDebugSession;
+    }
     public startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration): Thenable<boolean> {
         return debug.startDebugging(folder, nameOrConfiguration);
     }

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -539,6 +539,11 @@ export interface IDebugService {
      * An [event](#Event) which fires when a new [debug session](#DebugSession) has been started.
      */
     onDidStartDebugSession: Event<DebugSession>;
+
+    /**
+     * An [event](#Event) which fires when a [debug session](#DebugSession) has terminated.
+     */
+    onDidTerminateDebugSession: Event<DebugSession>;
     /**
      * Start debugging by using either a named launch or named compound configuration,
      * or by directly passing a [DebugConfiguration](#DebugConfiguration).

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -39,10 +39,10 @@ export class ExperimentalDebuggerBanner implements IExperimentalDebuggerBanner {
             return;
         }
         const debuggerService = this.serviceContainer.get<IDebugService>(IDebugService);
-        const disposable = debuggerService.onDidStartDebugSession(async e => {
+        const disposable = debuggerService.onDidTerminateDebugSession(async e => {
             if (e.type === ExperimentalDebuggerType) {
                 const logger = this.serviceContainer.get<ILogger>(ILogger);
-                await this.onDebugSessionStarted()
+                await this.onDidTerminateDebugSession()
                     .catch(ex => logger.logError('Error in debugger Banner', ex));
             }
         });
@@ -114,7 +114,7 @@ export class ExperimentalDebuggerBanner implements IExperimentalDebuggerBanner {
         const num = parseInt(`0x${lastHexValue}`, 16);
         return isNaN(num) ? crypto.randomBytes(1).toString('hex').slice(-1) : lastHexValue;
     }
-    private async onDebugSessionStarted(): Promise<void> {
+    private async onDidTerminateDebugSession(): Promise<void> {
         if (!this.enabled) {
             return;
         }

--- a/src/test/debugger/banner.unit.test.ts
+++ b/src/test/debugger/banner.unit.test.ts
@@ -70,9 +70,9 @@ suite('Debugging - Banner', () => {
         browser.verifyAll();
     });
     test('Increment Debugger Launch Counter when debug session starts', async () => {
-        let onDidStartDebugSessionCb: (e: DebugSession) => Promise<void>;
-        debugService.setup(d => d.onDidStartDebugSession(typemoq.It.isAny()))
-            .callback(cb => onDidStartDebugSessionCb = cb)
+        let onDidTerminateDebugSessionCb: (e: DebugSession) => Promise<void>;
+        debugService.setup(d => d.onDidTerminateDebugSession(typemoq.It.isAny()))
+            .callback(cb => onDidTerminateDebugSessionCb = cb)
             .verifiable(typemoq.Times.once());
 
         const debuggerLaunchCounter = 1234;
@@ -84,7 +84,7 @@ suite('Debugging - Banner', () => {
             .verifiable(typemoq.Times.atLeastOnce());
 
         banner.initialize();
-        await onDidStartDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
+        await onDidTerminateDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
 
         launchCounterState.verifyAll();
         browser.verifyAll();
@@ -92,7 +92,7 @@ suite('Debugging - Banner', () => {
         showBannerState.verifyAll();
     });
     test('Do not Increment Debugger Launch Counter when debug session starts and Banner is disabled', async () => {
-        debugService.setup(d => d.onDidStartDebugSession(typemoq.It.isAny()))
+        debugService.setup(d => d.onDidTerminateDebugSession(typemoq.It.isAny()))
             .verifiable(typemoq.Times.never());
 
         const debuggerLaunchCounter = 1234;
@@ -147,11 +147,11 @@ suite('Debugging - Banner', () => {
         launchThresholdCounterState.verifyAll();
     });
     test('showBanner must be invoked when shouldShowBanner returns true', async () => {
-        let onDidStartDebugSessionCb: (e: DebugSession) => Promise<void>;
+        let onDidTerminateDebugSessionCb: (e: DebugSession) => Promise<void>;
         const currentLaunchCounter = 50;
 
-        debugService.setup(d => d.onDidStartDebugSession(typemoq.It.isAny()))
-            .callback(cb => onDidStartDebugSessionCb = cb)
+        debugService.setup(d => d.onDidTerminateDebugSession(typemoq.It.isAny()))
+            .callback(cb => onDidTerminateDebugSessionCb = cb)
             .verifiable(typemoq.Times.atLeastOnce());
         showBannerState.setup(s => s.value).returns(() => true)
             .verifiable(typemoq.Times.atLeastOnce());
@@ -166,7 +166,7 @@ suite('Debugging - Banner', () => {
         appShell.setup(a => a.showInformationMessage(typemoq.It.isValue(message), typemoq.It.isValue(yes), typemoq.It.isValue(no)))
             .verifiable(typemoq.Times.once());
         banner.initialize();
-        await onDidStartDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
+        await onDidTerminateDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
 
         appShell.verifyAll();
         showBannerState.verifyAll();
@@ -174,11 +174,11 @@ suite('Debugging - Banner', () => {
         launchThresholdCounterState.verifyAll();
     });
     test('showBanner must not be invoked the second time after dismissing the message', async () => {
-        let onDidStartDebugSessionCb: (e: DebugSession) => Promise<void>;
+        let onDidTerminateDebugSessionCb: (e: DebugSession) => Promise<void>;
         let currentLaunchCounter = 50;
 
-        debugService.setup(d => d.onDidStartDebugSession(typemoq.It.isAny()))
-            .callback(cb => onDidStartDebugSessionCb = cb)
+        debugService.setup(d => d.onDidTerminateDebugSession(typemoq.It.isAny()))
+            .callback(cb => onDidTerminateDebugSessionCb = cb)
             .verifiable(typemoq.Times.atLeastOnce());
         showBannerState.setup(s => s.value).returns(() => true)
             .verifiable(typemoq.Times.atLeastOnce());
@@ -193,10 +193,10 @@ suite('Debugging - Banner', () => {
             .returns(() => Promise.resolve(undefined))
             .verifiable(typemoq.Times.once());
         banner.initialize();
-        await onDidStartDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
-        await onDidStartDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
-        await onDidStartDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
-        await onDidStartDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
+        await onDidTerminateDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
+        await onDidTerminateDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
+        await onDidTerminateDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
+        await onDidTerminateDebugSessionCb!({ type: ExperimentalDebuggerType } as any);
 
         appShell.verifyAll();
         showBannerState.verifyAll();


### PR DESCRIPTION
Fixes #2008

This pull request:
- [x] Has a title summarizes what is changing
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
