### PR TITLE
Always display dunder variables when using new language server

### DIFF
--- a/news/2 Fixes/2013.md
+++ b/news/2 Fixes/2013.md
@@ -1,0 +1,1 @@
+Ensure dunder variables are always displayed in code completion when using the new language server.

--- a/package.json
+++ b/package.json
@@ -1169,7 +1169,7 @@
                 },
                 "python.autoComplete.showAdvancedMembers": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Controls appearance of methods with double underscores in the completion list.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
Fixes #2013

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
