### PR TITLE
Improve reporting in VSTS CI

### DIFF
--- a/.mocha-reporter/mocha-vsts-reporter.js
+++ b/.mocha-reporter/mocha-vsts-reporter.js
@@ -1,0 +1,63 @@
+'use-strict';
+
+var mocha = require('mocha');
+var MochaJUnitReporter = require('mocha-junit-reporter');
+module.exports = MochaVstsReporter;
+
+function MochaVstsReporter(runner, options) {
+  MochaJUnitReporter.call(this, runner, options);
+  var INDENT_BASE = '  ';
+  var indenter = '';
+  var indentLevel = 0;
+  var passes = 0;
+  var failures = 0;
+  var skipped = 0;
+
+  runner.on('suite', function(suite){
+    if (suite.root === true){
+      console.log('Begin test run.............');
+      indentLevel++;
+      indenter = INDENT_BASE.repeat(indentLevel);
+    } else {
+      console.log('%sStart "%s"', indenter, suite.title);
+      indentLevel++;
+      indenter = INDENT_BASE.repeat(indentLevel);
+    }
+  });
+
+  runner.on('suite end', function(suite){
+    if (suite.root === true) {
+      indentLevel=0;
+      indenter = '';
+      console.log('.............End test run.');
+    } else {
+      console.log('%sEnd "%s"', indenter, suite.title);
+      indentLevel--;
+      indenter = INDENT_BASE.repeat(indentLevel);
+      // ##vso[task.setprogress]current operation
+    }
+  });
+  
+  runner.on('pass', function(test){
+    passes++;
+    console.log('%s✓ %s (%dms)', indenter, test.title, test.duration);
+  });
+
+  runner.on('pending', function(test){
+    skipped++;
+    console.log('%s- %s', indenter, test.title);
+    console.log('##vso[task.logissue type=warning;sourcepath=%s;]SKIPPED TEST %s :: %s', test.file, test.parent.title, test.title);
+  });
+
+  runner.on('fail', function(test, err){
+    failures++;
+    console.log('%s✖ %s -- error: %s', indenter, test.title, err.message);
+    console.log('##vso[task.logissue type=warning;sourcepath=%s;]SKIPPED TEST %s :: %s', test.file, test.parent.title, test.title);
+  });
+
+  runner.on('end', function(){
+    console.log('SUMMARY: %d/%d passed, %d skipped', passes, passes + failures, skipped);
+  });
+}
+
+mocha.utils.inherits(MochaVstsReporter, MochaJUnitReporter);

--- a/package.json
+++ b/package.json
@@ -1999,6 +1999,7 @@
         "typemoq": "^2.1.0",
         "typescript": "^2.9.1",
         "typescript-formatter": "^7.1.0",
+        "uuid": "^3.2.1",
         "vscode": "^1.1.5",
         "vscode-debugadapter-testsupport": "^1.27.0"
     },

--- a/src/test/ciConstants.ts
+++ b/src/test/ciConstants.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+//
+// Constants that pertain to CI processes/tests only. No dependencies on vscode!
+//
+
+export const IS_APPVEYOR = process.env.APPVEYOR === 'true';
+export const IS_TRAVIS = process.env.TRAVIS === 'true';
+export const IS_VSTS = process.env.TF_BUILD !== undefined;
+export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR || IS_VSTS;
+
+// Control JUnit-style output logging for reporting purposes.
+let reportJunit: boolean = false;
+if (IS_CI_SERVER && process.env.MOCHA_REPORTER_JUNIT !== undefined) {
+    reportJunit = process.env.MOCHA_REPORTER_JUNIT.toLowerCase() === 'true';
+}
+export const MOCHA_REPORTER_JUNIT: boolean = reportJunit;
+export const MOCHA_CI_REPORTFILE: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_REPORTFILE !== undefined ?
+                                            process.env.MOCHA_CI_REPORTFILE : './junit-out.xml';
+export const MOCHA_CI_PROPERTIES: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_PROPERTIES !== undefined ?
+                                            process.env.MOCHA_CI_PROPERTIES : '';
+
+export const IS_CI_SERVER_TEST_DEBUGGER = process.env.IS_CI_SERVER_TEST_DEBUGGER === '1';

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -3,28 +3,20 @@
 
 import { workspace } from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
-
-export const IS_APPVEYOR = process.env.APPVEYOR === 'true';
-export const IS_TRAVIS = process.env.TRAVIS === 'true';
-export const IS_VSTS = process.env.TF_BUILD !== undefined;
-export const IS_CI_SERVER = IS_TRAVIS || IS_APPVEYOR || IS_VSTS;
-
-// allow the CI server to specify JUnit output...
-let reportJunit: boolean = false;
-if (IS_CI_SERVER && process.env.MOCHA_REPORTER_JUNIT !== undefined) {
-    reportJunit = process.env.MOCHA_REPORTER_JUNIT.toLowerCase() === 'true';
-}
-export const MOCHA_REPORTER_JUNIT: boolean = reportJunit;
-export const MOCHA_CI_REPORTFILE: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_REPORTFILE !== undefined ?
-                                            process.env.MOCHA_CI_REPORTFILE : './junit-out.xml';
-export const MOCHA_CI_PROPERTIES: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_PROPERTIES !== undefined ?
-                                            process.env.MOCHA_CI_PROPERTIES : '';
+// import { IS_APPVEYOR, IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
+//     IS_TRAVIS, IS_VSTS, MOCHA_CI_PROPERTIES, MOCHA_CI_REPORTFILE,
+//     MOCHA_REPORTER_JUNIT } from './ciConstants';
+import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER, IS_TRAVIS } from './ciConstants';
 
 export const TEST_TIMEOUT = 25000;
 export const IS_MULTI_ROOT_TEST = isMultitrootTest();
-export const IS_CI_SERVER_TEST_DEBUGGER = process.env.IS_CI_SERVER_TEST_DEBUGGER === '1';
+
 // If running on CI server, then run debugger tests ONLY if the corresponding flag is enabled.
 export const TEST_DEBUGGER = IS_CI_SERVER ? IS_CI_SERVER_TEST_DEBUGGER : true;
+
+// export { IS_APPVEYOR, IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
+//     IS_TRAVIS, IS_VSTS, MOCHA_CI_PROPERTIES, MOCHA_CI_REPORTFILE,
+//     MOCHA_REPORTER_JUNIT };
 
 function isMultitrootTest() {
     return Array.isArray(workspace.workspaceFolders) && workspace.workspaceFolders.length > 1;

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -6,9 +6,10 @@ if ((Reflect as any).metadata === undefined) {
 
 import {
     IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
-    IS_MULTI_ROOT_TEST, IS_VSTS, MOCHA_CI_PROPERTIES,
+    IS_VSTS, MOCHA_CI_PROPERTIES,
     MOCHA_CI_REPORTFILE, MOCHA_REPORTER_JUNIT
-} from './constants';
+} from './ciConstants';
+import { IS_MULTI_ROOT_TEST } from './constants';
 import * as testRunner from './testRunner';
 
 process.env.VSC_PYTHON_CI_TEST = '1';

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -1,6 +1,5 @@
 // tslint:disable:no-string-literal
 
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
@@ -8,6 +7,7 @@ import { activated } from '../client/extension';
 import { clearPythonPathInWorkspaceFolder, PYTHON_PATH, resetGlobalPythonPathSetting, setPythonPathInWorkspaceRoot } from './common';
 
 export * from './constants';
+export * from './ciConstants';
 
 const dummyPythonFile = path.join(__dirname, '..', '..', 'src', 'test', 'pythonFiles', 'dummy.py');
 const multirootPath = path.join(__dirname, '..', '..', 'src', 'testMultiRootWkspc');


### PR DESCRIPTION
Extends functionality of mocha-junit-reporter and produces console output for VSTS to report alongside the JUnit style reports necessary for VSTS test pane.

Fixes #1907, supports #1985.

> Note: This has been tested in a PR on my personal repo here: d3r3kk/vscode-python#2, as well it has been reviewed by @DonJayamanne there as well.

This pull request:
- [x] Has a title summarizes what is changing
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
