### PR TITLE
Fix lock-threads config

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,3 +1,3 @@
-daysUntilLock:28
+daysUntilLock: 28
 lockComment: false
 only: issues


### PR DESCRIPTION
Spotted with Sentry.

```js
Error: YAMLException: end of the stream or a document separator is expected at line 2, column 12:
    lockComment: false
```
