### PR TITLE
Coverage reporting in codecove & in VSTS (1st pass)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ bin/**
 obj/**
 .pytest_cache
 tmp/**
+.python-version

--- a/coverconfig.json
+++ b/coverconfig.json
@@ -11,7 +11,8 @@
         "json",
         "html",
         "lcov",
-        "lcovonly"
+        "lcovonly",
+        "cobertura"
     ],
     "verbose": false
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,9 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
+/* jshint node: true */
+/* jshint esversion: 6 */
+
 'use strict';
 
 const gulp = require('gulp');
@@ -118,7 +121,7 @@ gulp.task('cover:enable', () => {
 gulp.task('cover:disable', () => {
     return gulp.src("./coverconfig.json")
         .pipe(jeditor((json) => {
-            json.enabled = true;
+            json.enabled = false;
             return json;
         }))
         .pipe(gulp.dest("./out", { 'overwrite': true }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,7 @@ const os = require('os');
 const _ = require('lodash');
 const nativeDependencyChecker = require('node-has-native-dependencies');
 const flat = require('flat');
+const inlinesource = require('gulp-inline-source');
 
 /**
 * Hygiene works by creating cascading subsets of all our files and
@@ -125,6 +126,16 @@ gulp.task('cover:disable', () => {
             return json;
         }))
         .pipe(gulp.dest("./out", { 'overwrite': true }));
+});
+
+/**
+ * Inline CSS into the coverage report for better visualizations on
+ * the VSTS report page for code coverage.
+ */
+gulp.task('inlinesource', () => {
+    return gulp.src('./coverage/lcov-report/*.html')
+                .pipe(inlinesource({attribute: false}))
+                .pipe(gulp.dest('./coverage/lcov-report-inline'));
 });
 
 function hasNativeDependencies() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "python",
-    "version": "2018.6.0-beta",
+    "version": "2018.7.0-alpha",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1235,6 +1235,15 @@
             "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
             "dev": true
         },
+        "clap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+            "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3"
+            }
+        },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -1353,6 +1362,15 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "coa": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+            "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+            "dev": true,
+            "requires": {
+                "q": "^1.1.2"
+            }
         },
         "codecov": {
             "version": "3.0.2",
@@ -1523,6 +1541,25 @@
                         "amdefine": ">=0.0.4"
                     }
                 }
+            }
+        },
+        "css-tree": {
+            "version": "1.0.0-alpha25",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha25.tgz",
+            "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
+            "dev": true,
+            "requires": {
+                "mdn-data": "^1.0.0",
+                "source-map": "^0.5.3"
+            }
+        },
+        "csso": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-3.4.0.tgz",
+            "integrity": "sha1-V7J+9VPMy/WqlkxkF0hkHprxE/M=",
+            "dev": true,
+            "requires": {
+                "css-tree": "1.0.0-alpha25"
             }
         },
         "currently-unhandled": {
@@ -1930,6 +1967,49 @@
                 }
             }
         },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
+            },
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                }
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+            "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
         "dotenv": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
@@ -2070,6 +2150,12 @@
                     }
                 }
             }
+        },
+        "entities": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+            "dev": true
         },
         "error-ex": {
             "version": "1.3.1",
@@ -3975,6 +4061,31 @@
                 }
             }
         },
+        "gulp-inline-source": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/gulp-inline-source/-/gulp-inline-source-3.2.0.tgz",
+            "integrity": "sha512-Ky5SKDgM517QZ6Jw9rKhYz+ynX9T4sr72iUW2fbOhqzN74D37DzWZDZnbKLSwdlTbbqt7JFq/JmUmT12qroW+A==",
+            "dev": true,
+            "requires": {
+                "inline-source": "~5.2.6",
+                "plugin-error": "~1.0.1",
+                "through2": "~2.0.0"
+            },
+            "dependencies": {
+                "plugin-error": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+                    "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-colors": "^1.0.1",
+                        "arr-diff": "^4.0.0",
+                        "arr-union": "^3.1.0",
+                        "extend-shallow": "^3.0.2"
+                    }
+                }
+            }
+        },
         "gulp-json-editor": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/gulp-json-editor/-/gulp-json-editor-2.4.1.tgz",
@@ -5218,6 +5329,20 @@
             "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
             "dev": true
         },
+        "htmlparser2": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
         "http-cache-semantics": {
             "version": "3.8.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
@@ -5301,6 +5426,38 @@
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
             "dev": true
+        },
+        "inline-source": {
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/inline-source/-/inline-source-5.2.7.tgz",
+            "integrity": "sha512-RvMOGMXxAqqve4ld128B7TYyNR2aP1LB38dcSpWFmqXrhKPuey1+yFU6kFUgyH8IWX+gRZdWtHN4eQ9d0IpFZg==",
+            "dev": true,
+            "requires": {
+                "csso": "3.4.x",
+                "htmlparser2": "3.9.x",
+                "is-plain-obj": "1.1.x",
+                "object-assign": "4.1.x",
+                "svgo": "0.7.x",
+                "uglify-js": "3.3.x"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "uglify-js": {
+                    "version": "3.3.28",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
+                    "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "~2.15.0",
+                        "source-map": "~0.6.1"
+                    }
+                }
+            }
         },
         "interpret": {
             "version": "1.1.0",
@@ -6421,6 +6578,12 @@
                 "inherits": "^2.0.1"
             }
         },
+        "mdn-data": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+            "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+            "dev": true
+        },
         "memoizee": {
             "version": "0.4.12",
             "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.12.tgz",
@@ -7422,6 +7585,12 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
         "qs": {
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -8379,6 +8548,49 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
+        },
+        "svgo": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+            "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+            "dev": true,
+            "requires": {
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                    "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                    "dev": true
+                },
+                "csso": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+                    "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+                    "dev": true,
+                    "requires": {
+                        "clap": "^1.0.9",
+                        "source-map": "^0.5.3"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.7.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                    "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^2.6.0"
+                    }
+                }
+            }
         },
         "symbol-observable": {
             "version": "1.0.1",
@@ -9479,6 +9691,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
             "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+        },
+        "whet.extend": {
+            "version": "0.9.9",
+            "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
+            "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+            "dev": true
         },
         "which": {
             "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -1894,7 +1894,8 @@
         "clean": "gulp clean",
         "clean:ptvsd": "gulp clean:ptvsd",
         "cover:enable": "gulp cover:enable",
-        "debugger-coverage": "gulp debugger-coverage"
+        "debugger-coverage": "gulp debugger-coverage",
+        "cover:inlinesource": "gulp inlinesource"
     },
     "dependencies": {
         "arch": "2.1.0",
@@ -1978,6 +1979,7 @@
         "gulp-debounced-watch": "^1.0.4",
         "gulp-filter": "^5.1.0",
         "gulp-gitmodified": "^1.1.1",
+        "gulp-inline-source": "^3.2.0",
         "gulp-json-editor": "^2.2.2",
         "gulp-sourcemaps": "^2.6.4",
         "gulp-typescript": "^4.0.1",

--- a/src/test/ciConstants.ts
+++ b/src/test/ciConstants.ts
@@ -22,5 +22,6 @@ export const MOCHA_CI_REPORTFILE: string = MOCHA_REPORTER_JUNIT && process.env.M
                                             process.env.MOCHA_CI_REPORTFILE : './junit-out.xml';
 export const MOCHA_CI_PROPERTIES: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_PROPERTIES !== undefined ?
                                             process.env.MOCHA_CI_PROPERTIES : '';
-
+export const MOCHA_CI_REPORTER_ID: string = MOCHA_REPORTER_JUNIT && process.env.MOCHA_CI_REPORTER_ID !== undefined ?
+                                            process.env.MOCHA_CI_REPORTER_ID : 'mocha-junit-reporter';
 export const IS_CI_SERVER_TEST_DEBUGGER = process.env.IS_CI_SERVER_TEST_DEBUGGER === '1';

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -6,7 +6,7 @@ if ((Reflect as any).metadata === undefined) {
 
 import {
     IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
-    IS_VSTS, MOCHA_CI_PROPERTIES,
+    IS_VSTS, MOCHA_CI_PROPERTIES, MOCHA_CI_REPORTER_ID,
     MOCHA_CI_REPORTFILE, MOCHA_REPORTER_JUNIT
 } from './ciConstants';
 import { IS_MULTI_ROOT_TEST } from './constants';
@@ -42,7 +42,7 @@ if (IS_VSTS) {
 // 'MOCHA_REPORTER_JUNIT' is defined, further control is afforded
 // by other 'MOCHA_CI_...' variables. See constants.ts for info.
 if (MOCHA_REPORTER_JUNIT) {
-    options.reporter = 'mocha-junit-reporter';
+    options.reporter = MOCHA_CI_REPORTER_ID;
     options.reporterOptions = {
         mochaFile: MOCHA_CI_REPORTFILE,
         properties: MOCHA_CI_PROPERTIES

--- a/src/test/unittests.ts
+++ b/src/test/unittests.ts
@@ -12,7 +12,8 @@ import * as glob from 'glob';
 import * as Mocha from 'mocha';
 import * as path from 'path';
 import { MochaSetupOptions } from 'vscode/lib/testrunner';
-import { MOCHA_CI_REPORTFILE, MOCHA_REPORTER_JUNIT } from './ciConstants';
+import { MOCHA_CI_REPORTER_ID, MOCHA_CI_REPORTFILE,
+    MOCHA_REPORTER_JUNIT } from './ciConstants';
 import * as vscodeMoscks from './vscode-mock';
 
 export function runTests(testOptions?: { grep?: string; timeout?: number }) {
@@ -35,7 +36,7 @@ export function runTests(testOptions?: { grep?: string; timeout?: number }) {
             grep: undefined,
             ui: 'tdd',
             timeout,
-            reporter: '../../../.mocha-reporter/mocha-vsts-reporter.js',
+            reporter: MOCHA_CI_REPORTER_ID,
             reporterOptions: {
                 useColors: false,
                 mochaFile: MOCHA_CI_REPORTFILE,


### PR DESCRIPTION
This PR will enable code coverage in VSTS going forward, but doesn't complete the effort.
- Enables VSTS console logging for all tests (and allows us to set a different mocha report via env var)
- Enables Cobertura format coverage reporting in addition to the original report formats.
- Corrects logic in the `cover:disable` function.
- Embeds CSS in the HTML coverage report generated (needed for VSTS), but only when `cover:inlinesources` gulp function is called.

Some further info here: #2058


