### PR TITLE
Correct unittest discovery for n-depth test source trees

### DIFF
--- a/news/2 Fixes/2044.md
+++ b/news/2 Fixes/2044.md
@@ -1,0 +1,1 @@
+Store testId for files & suites during unittest discovery

--- a/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
+++ b/pythonFiles/PythonTools/visualstudio_py_testlauncher.py
@@ -1,16 +1,16 @@
 # Python Tools for Visual Studio
 # Copyright(c) Microsoft Corporation
 # All rights reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the License); you may not use
 # this file except in compliance with the License. You may obtain a copy of the
 # License at http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
 # OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY
 # IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
 # MERCHANTABLITY OR NON-INFRINGEMENT.
-# 
+#
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 
@@ -43,11 +43,11 @@ class _TestOutput(object):
     def flush(self):
         if self.old_out:
             self.old_out.flush()
-    
+
     def writelines(self, lines):
         for line in lines:
             self.write(line)
-    
+
     @property
     def encoding(self):
         return 'utf8'
@@ -58,13 +58,13 @@ class _TestOutput(object):
             self.old_out.write(value)
             # flush immediately, else things go wonky and out of order
             self.flush()
-    
+
     def isatty(self):
         return True
 
     def next(self):
         pass
-    
+
     @property
     def name(self):
         if self.is_stdout:
@@ -84,7 +84,7 @@ class _TestOutputBuffer(object):
         _channel.send_event('stdout' if self.is_stdout else 'stderr', content=data)
         self.buffer.write(data)
 
-    def flush(self): 
+    def flush(self):
         self.buffer.flush()
 
     def truncate(self, pos = None):
@@ -137,7 +137,7 @@ class VsTestResult(unittest.TextTestResult):
         super(VsTestResult, self).startTest(test)
         if _channel is not None:
             _channel.send_event(
-                name='start', 
+                name='start',
                 test = test.id()
             )
 
@@ -177,7 +177,7 @@ class VsTestResult(unittest.TextTestResult):
                 tb = ''.join(formatted)
                 message = str(trace[1])
             _channel.send_event(
-                name='result', 
+                name='result',
                 outcome=outcome,
                 traceback = tb,
                 message = message,
@@ -196,7 +196,7 @@ def stopTests():
 class ExitCommand(Exception):
     pass
 
-def signal_handler(signal, frame):    
+def signal_handler(signal, frame):
     raise ExitCommand()
 
 def main():
@@ -223,7 +223,7 @@ def main():
 
     if opts.debug:
         from ptvsd.visualstudio_py_debugger import DONT_DEBUG, DEBUG_ENTRYPOINTS, get_code
-    
+
     sys.path[0] = os.getcwd()
     if opts.result_port:
         try:
@@ -243,7 +243,7 @@ def main():
 
         pass
     elif opts.mixed_mode:
-        # For mixed-mode attach, there's no ptvsd and hence no wait_for_attach(), 
+        # For mixed-mode attach, there's no ptvsd and hence no wait_for_attach(),
         # so we have to use Win32 API in a loop to do the same thing.
         from time import sleep
         from ctypes import windll, c_char
@@ -278,43 +278,44 @@ def main():
                 opts.up = 'test*.py'
             tests = unittest.defaultTestLoader.discover(opts.us, opts.up)
         else:
-            # loadTestsFromNames doesn't work well (with duplicate file names or class names) 
+            # loadTestsFromNames doesn't work well (with duplicate file names or class names)
             # Easier approach is find the test suite and use that for running
             loader = unittest.TestLoader()
             # opts.us will be passed in
             suites = loader.discover(opts.us, pattern=os.path.basename(opts.testFile))
             suite = None
-            tests = None            
+            tests = None
             if opts.tests is None:
                 # Run everything in the test file
                 tests = suites
             else:
                 # Run a specific test class or test method
-                for suite in suites._tests:
-                    for cls in suite._tests:                        
+                for test_suite in suites._tests:
+                    for cls in test_suite._tests:
                         try:
                             for m in cls._tests:
                                 testId = m.id()
                                 if testId.startswith(opts.tests[0]):
                                     suite = cls
+                                    break
                                 if testId == opts.tests[0]:
                                     tests = m
                                     break
                         except Exception as err:
-                            errorMessage = traceback.format_exception()                            
+                            errorMessage = traceback.format_exception()
                             pass
                 if tests is None:
                     tests = suite
             if tests is None and suite is None:
                 _channel.send_event(
-                    name='error', 
+                    name='error',
                     outcome='',
                     traceback = '',
                     message = 'Failed to identify the test',
                     test = ''
                 )
         if opts.uvInt is None:
-            opts.uvInt = 0        
+            opts.uvInt = 0
         if opts.uf is not None:
             runner = unittest.TextTestRunner(verbosity=opts.uvInt, resultclass=VsTestResult, failfast=True)
         else:

--- a/src/client/unittests/common/types.ts
+++ b/src/client/unittests/common/types.ts
@@ -24,6 +24,8 @@ export type TestRunOptions = {
     debug?: boolean;
 };
 
+export type UnitTestParserOptions = TestDiscoveryOptions & { startDirectory: string };
+
 export type TestFolder = TestResult & {
     name: string;
     testFiles: TestFile[];

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -91,6 +91,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
             if (this.testResultDisplay) {
                 this.testResultDisplay.enabled = false;
             }
+            // tslint:disable-next-line:no-suspicious-comment
             // TODO: Why are we disposing, what happens when tests are enabled.
             if (this.workspaceTestManagerService) {
                 this.workspaceTestManagerService.dispose();

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -71,7 +71,7 @@ export class TestsParser implements ITestsParser {
                 fullPath: filePath,
                 functions: [],
                 suites: [],
-                nameToRun: suiteToRun,
+                nameToRun: `${suiteToRun}.${functionName}`,
                 xmlName: '',
                 status: TestStatus.Idle,
                 time: 0

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -18,7 +18,7 @@ export class TestsParser implements ITestsParser {
         }
         return this.parseTestIds(testsDirectory, testIds);
     }
-    public getTestIds(content: string): string[] {
+    private getTestIds(content: string): string[] {
         let startedCollecting = false;
         return content.split(/\r?\n/g)
             .map(line => {
@@ -32,7 +32,7 @@ export class TestsParser implements ITestsParser {
             })
             .filter(line => line.length > 0);
     }
-    public parseTestIds(rootDirectory: string, testIds: string[]): Tests {
+    private parseTestIds(rootDirectory: string, testIds: string[]): Tests {
         const testFiles: TestFile[] = [];
         testIds.forEach(testId => this.addTestId(rootDirectory, testId, testFiles));
 
@@ -44,13 +44,13 @@ export class TestsParser implements ITestsParser {
      * TestIds are fully qualified including the method names.
      * E.g. tone_test.Failing2Tests.test_failure
      * Where tone_test = folder, Failing2Tests = class/suite, test_failure = method.
-     * @public
+     * @private
      * @param {string} rootDirectory
      * @param {string[]} testIds
      * @returns {Tests}
      * @memberof TestsParser
      */
-    public addTestId(rootDirectory: string, testId: string, testFiles: TestFile[]) {
+    private addTestId(rootDirectory: string, testId: string, testFiles: TestFile[]) {
         const testIdParts = testId.split('.');
         // We must have a file, class and function name
         if (testIdParts.length <= 2) {

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -3,9 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { ITestsHelper, ITestsParser, TestDiscoveryOptions, TestFile, TestFunction, Tests, TestStatus } from '../../common/types';
-
-type UnitTestParserOptions = TestDiscoveryOptions & { startDirectory: string };
+import { ITestsHelper, ITestsParser, TestDiscoveryOptions, TestFile, TestFunction, Tests, TestStatus, UnitTestParserOptions } from '../../common/types';
 
 @injectable()
 export class TestsParser implements ITestsParser {
@@ -18,7 +16,7 @@ export class TestsParser implements ITestsParser {
         }
         return this.parseTestIds(testsDirectory, testIds);
     }
-    private getTestIds(content: string): string[] {
+    public getTestIds(content: string): string[] {
         let startedCollecting = false;
         return content.split(/\r?\n/g)
             .map(line => {
@@ -32,7 +30,7 @@ export class TestsParser implements ITestsParser {
             })
             .filter(line => line.length > 0);
     }
-    private parseTestIds(rootDirectory: string, testIds: string[]): Tests {
+    public parseTestIds(rootDirectory: string, testIds: string[]): Tests {
         const testFiles: TestFile[] = [];
         testIds.forEach(testId => this.addTestId(rootDirectory, testId, testFiles));
 
@@ -44,13 +42,13 @@ export class TestsParser implements ITestsParser {
      * TestIds are fully qualified including the method names.
      * E.g. tone_test.Failing2Tests.test_failure
      * Where tone_test = folder, Failing2Tests = class/suite, test_failure = method.
-     * @private
+     * @public
      * @param {string} rootDirectory
      * @param {string[]} testIds
      * @returns {Tests}
      * @memberof TestsParser
      */
-    private addTestId(rootDirectory: string, testId: string, testFiles: TestFile[]) {
+    public addTestId(rootDirectory: string, testId: string, testFiles: TestFile[]) {
         const testIdParts = testId.split('.');
         // We must have a file, class and function name
         if (testIdParts.length <= 2) {

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -3,7 +3,9 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { ITestsHelper, ITestsParser, TestDiscoveryOptions, TestFile, TestFunction, Tests, TestStatus, UnitTestParserOptions } from '../../common/types';
+import { ITestsHelper, ITestsParser, TestFile,
+    TestFunction, Tests, TestStatus,
+    UnitTestParserOptions } from '../../common/types';
 
 @injectable()
 export class TestsParser implements ITestsParser {

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -79,7 +79,7 @@ export class TestsParser implements ITestsParser {
         }
 
         // Check if we already have this test file
-        const classNameToRun = className;
+        const classNameToRun = `${path.parse(filePath).name}.${className}`;
         let testSuite = testFile.suites.find(cls => cls.nameToRun === classNameToRun);
         if (!testSuite) {
             testSuite = {
@@ -88,7 +88,7 @@ export class TestsParser implements ITestsParser {
                 suites: [],
                 isUnitTest: true,
                 isInstance: false,
-                nameToRun: `${path.parse(filePath).name}.${classNameToRun}`,
+                nameToRun: classNameToRun,
                 xmlName: '',
                 status: TestStatus.Idle,
                 time: 0

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -78,8 +78,10 @@ export class TestsParser implements ITestsParser {
             testFiles.push(testFile);
         }
 
-        // Check if we already have this test file
-        const classNameToRun = `${path.parse(filePath).name}.${className}`;
+        // Check if we already have this suite
+        const thePath: path.ParsedPath = path.parse(filePath);
+        const relativePath: string = thePath.dir.substring(rootDirectory.length + 1);
+        const classNameToRun: string = `${relativePath.replace(path.sep, '.')}.${thePath.name}.${className}`;
         let testSuite = testFile.suites.find(cls => cls.nameToRun === classNameToRun);
         if (!testSuite) {
             testSuite = {

--- a/src/client/unittests/unittest/services/parserService.ts
+++ b/src/client/unittests/unittest/services/parserService.ts
@@ -60,6 +60,7 @@ export class TestsParser implements ITestsParser {
         const paths = testIdParts.slice(0, testIdParts.length - 2);
         const filePath = `${path.join(rootDirectory, ...paths)}.py`;
         const functionName = testIdParts.pop()!;
+        const suiteToRun = testIdParts.join('.');
         const className = testIdParts.pop()!;
 
         // Check if we already have this test file
@@ -70,7 +71,7 @@ export class TestsParser implements ITestsParser {
                 fullPath: filePath,
                 functions: [],
                 suites: [],
-                nameToRun: `${className}.${functionName}`,
+                nameToRun: suiteToRun,
                 xmlName: '',
                 status: TestStatus.Idle,
                 time: 0
@@ -79,10 +80,8 @@ export class TestsParser implements ITestsParser {
         }
 
         // Check if we already have this suite
-        const thePath: path.ParsedPath = path.parse(filePath);
-        const relativePath: string = thePath.dir.substring(rootDirectory.length + 1);
-        const classNameToRun: string = `${relativePath.replace(path.sep, '.')}.${thePath.name}.${className}`;
-        let testSuite = testFile.suites.find(cls => cls.nameToRun === classNameToRun);
+        // nameToRun = testId - method name
+        let testSuite = testFile.suites.find(cls => cls.nameToRun === suiteToRun);
         if (!testSuite) {
             testSuite = {
                 name: className,
@@ -90,7 +89,7 @@ export class TestsParser implements ITestsParser {
                 suites: [],
                 isUnitTest: true,
                 isInstance: false,
-                nameToRun: classNameToRun,
+                nameToRun: suiteToRun,
                 xmlName: '',
                 status: TestStatus.Idle,
                 time: 0

--- a/src/client/unittests/unittest/socketServer.ts
+++ b/src/client/unittests/unittest/socketServer.ts
@@ -29,7 +29,7 @@ export class UnitTestSocketServer extends EventEmitter implements IUnitTestSocke
             this.server = undefined;
         }
     }
-    public start(options: { port?: number, host?: string } = { port: 0, host: 'localhost' }): Promise<number> {
+    public start(options: { port?: number; host?: string } = { port: 0, host: 'localhost' }): Promise<number> {
         this.startedDef = createDeferred<number>();
         this.server = net.createServer(this.connectionListener.bind(this));
         this.server!.maxConnections = MaxConnections;

--- a/src/test/unittests/unittest/unittest.discovery.test.ts
+++ b/src/test/unittests/unittest/unittest.discovery.test.ts
@@ -87,7 +87,7 @@ suite('Unit Tests - unittest - discovery with mocked process output', () => {
         assert.equal(tests.testFiles.length, 1, 'Incorrect number of test files');
         assert.equal(tests.testFunctions.length, 3, 'Incorrect number of test functions');
         assert.equal(tests.testSuites.length, 1, 'Incorrect number of test suites');
-        assert.equal(tests.testFiles.some(t => t.name === 'test_one.py' && t.nameToRun === 'Test_test1.test_A'), true, 'Test File not found');
+        assert.equal(tests.testFiles.some(t => t.name === 'test_one.py' && t.nameToRun === 'test_one.Test_test1.test_A'), true, 'Test File not found');
     });
 
     test('Discover Tests', async () => {
@@ -110,8 +110,8 @@ suite('Unit Tests - unittest - discovery with mocked process output', () => {
         assert.equal(tests.testFiles.length, 2, 'Incorrect number of test files');
         assert.equal(tests.testFunctions.length, 9, 'Incorrect number of test functions');
         assert.equal(tests.testSuites.length, 3, 'Incorrect number of test suites');
-        assert.equal(tests.testFiles.some(t => t.name === 'test_unittest_one.py' && t.nameToRun === 'Test_test1.test_A'), true, 'Test File not found');
-        assert.equal(tests.testFiles.some(t => t.name === 'test_unittest_two.py' && t.nameToRun === 'Test_test2.test_A2'), true, 'Test File not found');
+        assert.equal(tests.testFiles.some(t => t.name === 'test_unittest_one.py' && t.nameToRun === 'test_unittest_one.Test_test1.test_A'), true, 'Test File not found');
+        assert.equal(tests.testFiles.some(t => t.name === 'test_unittest_two.py' && t.nameToRun === 'test_unittest_two.Test_test2.test_A2'), true, 'Test File not found');
     });
 
     test('Discover Tests (pattern = *_test_*.py)', async () => {
@@ -127,7 +127,7 @@ suite('Unit Tests - unittest - discovery with mocked process output', () => {
         assert.equal(tests.testFiles.length, 1, 'Incorrect number of test files');
         assert.equal(tests.testFunctions.length, 2, 'Incorrect number of test functions');
         assert.equal(tests.testSuites.length, 1, 'Incorrect number of test suites');
-        assert.equal(tests.testFiles.some(t => t.name === 'unittest_three_test.py' && t.nameToRun === 'Test_test3.test_A'), true, 'Test File not found');
+        assert.equal(tests.testFiles.some(t => t.name === 'unittest_three_test.py' && t.nameToRun === 'unittest_three_test.Test_test3.test_A'), true, 'Test File not found');
     });
 
     test('Setting cwd should return tests', async () => {

--- a/src/test/unittests/unittest/unittest.discovery.unit.test.ts
+++ b/src/test/unittests/unittest/unittest.discovery.unit.test.ts
@@ -335,15 +335,216 @@ suite('Unit Tests - Unittest - Discovery', () => {
         expect(tests.testFunctions.length).to.be.equal(6);
         expect(tests.testSuites.length).to.be.equal(3);
         expect(tests.testFolders.length).to.be.equal(1);
+
+        // now ensure that each test function belongs within a single test suite...
+        tests.testFunctions.forEach(fn => {
+            if (fn.parentTestSuite) {
+                const testPrefix: boolean = fn.testFunction.nameToRun.startsWith(fn.parentTestSuite.nameToRun);
+                expect(testPrefix).to.equal(true,
+                    [`function ${fn.testFunction.name} has a parent suite ${fn.parentTestSuite.name}, `,
+                    `but the parent suite 'nameToRun' (${fn.parentTestSuite.nameToRun}) isn't the `,
+                    `prefix to the functions 'nameToRun' (${fn.testFunction.nameToRun})`].join(''));
+            }
+        });
     });
+    test('Ensure discovery resolves test files in n-depth directories', async () => {
+        const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
 
-    // no start directory given
-    // relative start directory given
-    // absolute start directory given
+        const testsParser: TestsParser = new TestsParser(testHelper);
 
-    // no content given
-    // corrupted/invalid content given
-    // correct content given
-    // incorrect content given (no tests in the given path)
+        const opts = typeMoq.Mock.ofType<UnitTestParserOptions>();
+        const token = typeMoq.Mock.ofType<CancellationToken>();
+        const wspace = typeMoq.Mock.ofType<Uri>();
+        opts.setup(o => o.token).returns(() => token.object);
+        opts.setup(o => o.workspaceFolder).returns(() => wspace.object);
+        token.setup(t => t.isCancellationRequested)
+            .returns(() => true);
+        opts.setup(o => o.cwd).returns(() => '/home/user/dev');
+        opts.setup(o => o.startDirectory).returns(() => '/home/user/dev/tests');
 
+        const discoveryOutput: string = ['start',
+            'apptests.debug.class_name.RootClassName.test_root',
+            'apptests.debug.class_name.RootClassName.test_root_other',
+            'apptests.debug.first.class_name.FirstLevelClassName.test_first',
+            'apptests.debug.first.class_name.FirstLevelClassName.test_first_other',
+            'apptests.debug.first.second.class_name.SecondLevelClassName.test_second',
+            'apptests.debug.first.second.class_name.SecondLevelClassName.test_second_other',
+            ''].join('\n');
+
+        const tests: Tests = testsParser.parse(discoveryOutput, opts.object);
+
+        expect(tests.testFiles.length).to.be.equal(3);
+        expect(tests.testFunctions.length).to.be.equal(6);
+        expect(tests.testSuites.length).to.be.equal(3);
+        expect(tests.testFolders.length).to.be.equal(1);
+
+        // now ensure that the 'nameToRun' for each test function begins with its file's a single test suite...
+        tests.testFunctions.forEach(fn => {
+            if (fn.parentTestSuite) {
+                const testPrefix: boolean = fn.testFunction.nameToRun.startsWith(fn.parentTestFile.nameToRun);
+                expect(testPrefix).to.equal(true,
+                    [`function ${fn.testFunction.name} was found in file ${fn.parentTestFile.name}, `,
+                    `but the parent file 'nameToRun' (${fn.parentTestFile.nameToRun}) isn't the `,
+                    `prefix to the functions 'nameToRun' (${fn.testFunction.nameToRun})`].join(''));
+            }
+        });
+    });
+    test('Ensure discovery resolves test suites in n-depth directories when no start directory is given', async () => {
+        const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
+
+        const testsParser: TestsParser = new TestsParser(testHelper);
+
+        const opts = typeMoq.Mock.ofType<UnitTestParserOptions>();
+        const token = typeMoq.Mock.ofType<CancellationToken>();
+        const wspace = typeMoq.Mock.ofType<Uri>();
+        opts.setup(o => o.token).returns(() => token.object);
+        opts.setup(o => o.workspaceFolder).returns(() => wspace.object);
+        token.setup(t => t.isCancellationRequested)
+            .returns(() => true);
+        opts.setup(o => o.cwd).returns(() => '/home/user/dev');
+        opts.setup(o => o.startDirectory).returns(() => '');
+
+        const discoveryOutput: string = ['start',
+            'apptests.debug.class_name.RootClassName.test_root',
+            'apptests.debug.class_name.RootClassName.test_root_other',
+            'apptests.debug.first.class_name.FirstLevelClassName.test_first',
+            'apptests.debug.first.class_name.FirstLevelClassName.test_first_other',
+            'apptests.debug.first.second.class_name.SecondLevelClassName.test_second',
+            'apptests.debug.first.second.class_name.SecondLevelClassName.test_second_other',
+            ''].join('\n');
+
+        const tests: Tests = testsParser.parse(discoveryOutput, opts.object);
+
+        expect(tests.testFiles.length).to.be.equal(3);
+        expect(tests.testFunctions.length).to.be.equal(6);
+        expect(tests.testSuites.length).to.be.equal(3);
+        expect(tests.testFolders.length).to.be.equal(1);
+
+        // now ensure that each test function belongs within a single test suite...
+        tests.testFunctions.forEach(fn => {
+            if (fn.parentTestSuite) {
+                const testPrefix: boolean = fn.testFunction.nameToRun.startsWith(fn.parentTestSuite.nameToRun);
+                expect(testPrefix).to.equal(true,
+                    [`function ${fn.testFunction.name} has a parent suite ${fn.parentTestSuite.name}, `,
+                    `but the parent suite 'nameToRun' (${fn.parentTestSuite.nameToRun}) isn't the `,
+                    `prefix to the functions 'nameToRun' (${fn.testFunction.nameToRun})`].join(''));
+            }
+        });
+    });
+    test('Ensure discovery resolves test suites in n-depth directories when a relative start directory is given', async () => {
+        const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
+
+        const testsParser: TestsParser = new TestsParser(testHelper);
+
+        const opts = typeMoq.Mock.ofType<UnitTestParserOptions>();
+        const token = typeMoq.Mock.ofType<CancellationToken>();
+        const wspace = typeMoq.Mock.ofType<Uri>();
+        opts.setup(o => o.token).returns(() => token.object);
+        opts.setup(o => o.workspaceFolder).returns(() => wspace.object);
+        token.setup(t => t.isCancellationRequested)
+            .returns(() => true);
+        opts.setup(o => o.cwd).returns(() => '/home/user/dev');
+        opts.setup(o => o.startDirectory).returns(() => './tests');
+
+        const discoveryOutput: string = ['start',
+            'apptests.debug.class_name.RootClassName.test_root',
+            'apptests.debug.class_name.RootClassName.test_root_other',
+            'apptests.debug.first.class_name.FirstLevelClassName.test_first',
+            'apptests.debug.first.class_name.FirstLevelClassName.test_first_other',
+            'apptests.debug.first.second.class_name.SecondLevelClassName.test_second',
+            'apptests.debug.first.second.class_name.SecondLevelClassName.test_second_other',
+            ''].join('\n');
+
+        const tests: Tests = testsParser.parse(discoveryOutput, opts.object);
+
+        expect(tests.testFiles.length).to.be.equal(3);
+        expect(tests.testFunctions.length).to.be.equal(6);
+        expect(tests.testSuites.length).to.be.equal(3);
+        expect(tests.testFolders.length).to.be.equal(1);
+
+        // now ensure that each test function belongs within a single test suite...
+        tests.testFunctions.forEach(fn => {
+            if (fn.parentTestSuite) {
+                const testPrefix: boolean = fn.testFunction.nameToRun.startsWith(fn.parentTestSuite.nameToRun);
+                expect(testPrefix).to.equal(true,
+                    [`function ${fn.testFunction.name} has a parent suite ${fn.parentTestSuite.name}, `,
+                    `but the parent suite 'nameToRun' (${fn.parentTestSuite.nameToRun}) isn't the `,
+                    `prefix to the functions 'nameToRun' (${fn.testFunction.nameToRun})`].join(''));
+            }
+        });
+    });
+    test('Ensure discovery will not fail with blank content' , async () => {
+        const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
+
+        const testsParser: TestsParser = new TestsParser(testHelper);
+
+        const opts = typeMoq.Mock.ofType<UnitTestParserOptions>();
+        const token = typeMoq.Mock.ofType<CancellationToken>();
+        const wspace = typeMoq.Mock.ofType<Uri>();
+        opts.setup(o => o.token).returns(() => token.object);
+        opts.setup(o => o.workspaceFolder).returns(() => wspace.object);
+        token.setup(t => t.isCancellationRequested)
+            .returns(() => true);
+        opts.setup(o => o.cwd).returns(() => '/home/user/dev');
+        opts.setup(o => o.startDirectory).returns(() => './tests');
+
+        const tests: Tests = testsParser.parse('', opts.object);
+
+        expect(tests.testFiles.length).to.be.equal(0);
+        expect(tests.testFunctions.length).to.be.equal(0);
+        expect(tests.testSuites.length).to.be.equal(0);
+        expect(tests.testFolders.length).to.be.equal(0);
+    });
+    test('Ensure discovery will not fail with corrupt content', async () => {
+        const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
+
+        const testsParser: TestsParser = new TestsParser(testHelper);
+
+        const opts = typeMoq.Mock.ofType<UnitTestParserOptions>();
+        const token = typeMoq.Mock.ofType<CancellationToken>();
+        const wspace = typeMoq.Mock.ofType<Uri>();
+        opts.setup(o => o.token).returns(() => token.object);
+        opts.setup(o => o.workspaceFolder).returns(() => wspace.object);
+        token.setup(t => t.isCancellationRequested)
+            .returns(() => true);
+        opts.setup(o => o.cwd).returns(() => '/home/user/dev');
+        opts.setup(o => o.startDirectory).returns(() => './tests');
+
+        const discoveryOutput: string = ['a;lskdjfa',
+            'allikbrilkpdbfkdfbalk;nfm',
+            '',
+            ';;h,spmn,nlikmslkjls.bmnl;klkjna;jdfngad,lmvnjkldfhb',
+            ''].join('\n');
+
+        const tests: Tests = testsParser.parse(discoveryOutput, opts.object);
+
+        expect(tests.testFiles.length).to.be.equal(0);
+        expect(tests.testFunctions.length).to.be.equal(0);
+        expect(tests.testSuites.length).to.be.equal(0);
+        expect(tests.testFolders.length).to.be.equal(0);
+    });
+    test('Ensure discovery resolves when no tests are found in the given path', async () => {
+        const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
+
+        const testsParser: TestsParser = new TestsParser(testHelper);
+
+        const opts = typeMoq.Mock.ofType<UnitTestParserOptions>();
+        const token = typeMoq.Mock.ofType<CancellationToken>();
+        const wspace = typeMoq.Mock.ofType<Uri>();
+        opts.setup(o => o.token).returns(() => token.object);
+        opts.setup(o => o.workspaceFolder).returns(() => wspace.object);
+        token.setup(t => t.isCancellationRequested)
+            .returns(() => true);
+        opts.setup(o => o.cwd).returns(() => '/home/user/dev');
+        opts.setup(o => o.startDirectory).returns(() => './tests');
+
+        const discoveryOutput: string = 'start';
+
+        const tests: Tests = testsParser.parse(discoveryOutput, opts.object);
+
+        expect(tests.testFiles.length).to.be.equal(0);
+        expect(tests.testFunctions.length).to.be.equal(0);
+        expect(tests.testSuites.length).to.be.equal(0);
+        expect(tests.testFolders.length).to.be.equal(0);
+    });
 });

--- a/src/test/unittests/unittest/unittest.test.ts
+++ b/src/test/unittests/unittest/unittest.test.ts
@@ -58,6 +58,6 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
         assert.equal(tests.testFiles.length, 1, 'Incorrect number of test files');
         assert.equal(tests.testFunctions.length, 3, 'Incorrect number of test functions');
         assert.equal(tests.testSuites.length, 1, 'Incorrect number of test suites');
-        assert.equal(tests.testFiles.some(t => t.name === 'test_one.py' && t.nameToRun === 'Test_test1.test_A'), true, 'Test File not found');
+        assert.equal(tests.testFiles.some(t => t.name === 'test_one.py' && t.nameToRun === 'test_one.Test_test1.test_A'), true, 'Test File not found');
     });
 });


### PR DESCRIPTION
Store full testId for files & suites during unittest discovery.

In testing the cause of the problem, I found that the testId for each test method must be prefixed by the testSuite or testFile 'nameToRun'. The testSuite/File nameToRun field was being inserted as the folderName.testClassFileName only, ignoring any further depth of the path to that testSuite/File.

Take for instance:
````
tests/
  app/
    suite1/
      test_suite1.py 
        [class TestSuite1]
          [function test_something]
````
The testFunction would have a 'nameToRun' field generated that would be:
`tests.app.suite1.test_suite1.TestSuite1.test_something`
However, the testSuite would get a 'nameToRun' field generated as such:
`test_suite1.TestSuite1`
And the testFile would get a 'nameToRun' field generated like so:
`TestSuite1.test_something`

The testSuite/testFile `nameToRun` must be the exact prefix to the testFunction's `nameToRun` in order for that testFunction to be selected for execution.

Fixes #2044

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
