### PR TITLE
Change keymapping for run selection/line in Python terminal

### DIFF
--- a/news/2 Fixes/2068.md
+++ b/news/2 Fixes/2068.md
@@ -1,0 +1,1 @@
+Change keyboard shortcut for `Run Selection/Line in Python Terminal` to `Ctrl+Shift+Enter`.

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
         "keybindings": [
             {
                 "command": "python.execSelectionInTerminal",
-                "key": "alt+shift+enter",
-                "when": "editorFocus && editorLangId == python"
+                "key": "shift+enter",
+                "when": "editorFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed"
             }
         ],
         "commands": [

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "keybindings": [
             {
                 "command": "python.execSelectionInTerminal",
-                "key": "shift+enter",
+                "key": "alt+shift+enter",
                 "when": "editorFocus && editorLangId == python"
             }
         ],


### PR DESCRIPTION
Fixes #2068

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
