### PR TITLE
Pass OS type to the debugger

### DIFF
--- a/news/3 Code Health/2128.md
+++ b/news/3 Code Health/2128.md
@@ -1,0 +1,1 @@
+Pass OS type to the debugger.

--- a/src/client/debugger/Common/Contracts.ts
+++ b/src/client/debugger/Common/Contracts.ts
@@ -41,7 +41,8 @@ export enum DebugOptions {
     Sudo = 'Sudo',
     Pyramid = 'Pyramid',
     FixFilePathCase = 'FixFilePathCase',
-    WindowsClient = 'WindowsClient'
+    WindowsClient = 'WindowsClient',
+    UnixClient = 'UnixClient'
 }
 
 export interface ExceptionHandling {

--- a/src/client/debugger/configProviders/pythonV2Provider.ts
+++ b/src/client/debugger/configProviders/pythonV2Provider.ts
@@ -82,6 +82,8 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
         }
         if (this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows) {
             this.debugOption(debugOptions, DebugOptions.WindowsClient);
+        } else {
+            this.debugOption(debugOptions, DebugOptions.UnixClient);
         }
 
         if (!debugConfiguration.pathMappings) {

--- a/src/test/debugger/configProvider/provider.attach.test.ts
+++ b/src/test/debugger/configProvider/provider.attach.test.ts
@@ -33,9 +33,13 @@ enum OS {
             let platformService: TypeMoq.IMock<IPlatformService>;
             let fileSystem: TypeMoq.IMock<IFileSystem>;
             const debugOptionsAvailable = [DebugOptions.RedirectOutput];
-            if (os.value === OS.Windows && provider.debugType === 'pythonExperimental') {
-                debugOptionsAvailable.push(DebugOptions.FixFilePathCase);
-                debugOptionsAvailable.push(DebugOptions.WindowsClient);
+            if (provider.debugType === 'pythonExperimental') {
+                if (os.value === OS.Windows) {
+                    debugOptionsAvailable.push(DebugOptions.FixFilePathCase);
+                    debugOptionsAvailable.push(DebugOptions.WindowsClient);
+                } else {
+                    debugOptionsAvailable.push(DebugOptions.UnixClient);
+                }
             }
             setup(() => {
                 serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();


### PR DESCRIPTION
Fixes #2128

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
