### PR TITLE
Ignore languageServer files from vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,7 +10,7 @@
 CODE_OF_CONDUCT.md
 CODING_STANDARDS.md
 CONTRIBUTING.md
-CONTRIBUTING - PYTHON_ANALYSIS.md
+CONTRIBUTING - LANGUAGE SERVER.md
 coverconfig.json
 gulpfile.js
 packageExtension.cmd
@@ -26,7 +26,7 @@ yarn.lock
 .nvm/**
 .vscode/**
 .vscode-test/**
-languageServer/publish*.*
+languageServer/**
 bin/**
 BuildOutput/**
 coverage/**

--- a/news/3 Code Health/2150.md
+++ b/news/3 Code Health/2150.md
@@ -1,0 +1,1 @@
+Ensure 'languageServer' directory is excluded from the build output.


### PR DESCRIPTION
Fixes #2150

This pull request:
- [x] Has a title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) is not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
