### PR TITLE
Change default port in experimental debugger to 5678

### DIFF
--- a/news/2 Fixes/2146.md
+++ b/news/2 Fixes/2146.md
@@ -1,0 +1,1 @@
+Change the default port used in remote debugging using `Experimental` debugger to `5678`.

--- a/package.json
+++ b/package.json
@@ -901,7 +901,7 @@
                             "name": "Attach (Remote Debug)",
                             "type": "pythonExperimental",
                             "request": "attach",
-                            "port": 3000,
+                            "port": 5678,
                             "host": "localhost"
                         }
                     }
@@ -1101,7 +1101,7 @@
                         "name": "Python Experimental: Attach",
                         "type": "pythonExperimental",
                         "request": "attach",
-                        "port": 3000,
+                        "port": 5678,
                         "host": "localhost"
                     },
                     {


### PR DESCRIPTION
Fixes #2146

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
