### PR TITLE
Change the download links of the language server files

### DIFF
--- a/news/3 Code Health/2180.md
+++ b/news/3 Code Health/2180.md
@@ -1,0 +1,1 @@
+Change the download links of the language server files.

--- a/src/client/activation/platformData.ts
+++ b/src/client/activation/platformData.ts
@@ -9,20 +9,27 @@ import {
     language_server_win_x86_sha512
 } from './languageServerHashes';
 
+export enum PlatformName {
+    Windows32Bit = 'win-x86',
+    Windows64Bit = 'win-x64',
+    Mac64Bit = 'osx-x64',
+    Linux64Bit = 'linux-x64'
+}
+
 export class PlatformData {
     constructor(private platform: IPlatformService, fs: IFileSystem) { }
-    public async getPlatformName(): Promise<string> {
+    public async getPlatformName(): Promise<PlatformName> {
         if (this.platform.isWindows) {
-            return this.platform.is64bit ? 'win-x64' : 'win-x86';
+            return this.platform.is64bit ? PlatformName.Windows64Bit : PlatformName.Windows32Bit;
         }
         if (this.platform.isMac) {
-            return 'osx-x64';
+            return PlatformName.Mac64Bit;
         }
         if (this.platform.isLinux) {
             if (!this.platform.is64bit) {
                 throw new Error('Microsoft Python Language Server does not support 32-bit Linux.');
             }
-            return 'linux-x64';
+            return PlatformName.Linux64Bit;
         }
         throw new Error('Unknown OS platform.');
     }

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-unused-variable
+
+import * as assert from 'assert';
+import * as TypeMoq from 'typemoq';
+import { LanguageServerDownloader } from '../../client/activation/downloader';
+import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
+import { IOutputChannel } from '../../client/common/types';
+import { IServiceContainer } from '../../client/ioc/types';
+
+const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
+const downloadBaseFileName = 'Python-Language-Server';
+const downloadVersion = '0.1.0';
+const downloadFileExtension = '.nupkg';
+
+suite('Activation - Downloader', () => {
+    let languageServerDownloader: LanguageServerDownloader;
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let platformService: TypeMoq.IMock<IPlatformService>;
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        platformService = TypeMoq.Mock.ofType<IPlatformService>();
+        const fs = TypeMoq.Mock.ofType<IFileSystem>();
+        const output = TypeMoq.Mock.ofType<IOutputChannel>();
+
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isAny())).returns(() => output.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platformService.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
+
+        languageServerDownloader = new LanguageServerDownloader(serviceContainer.object, '');
+    });
+    type PlatformIdentifier = {
+        windows?: boolean;
+        mac?: boolean;
+        linux?: boolean;
+        is64Bit?: boolean;
+    };
+    function setupPlatform(platform: PlatformIdentifier) {
+        platformService.setup(x => x.isWindows).returns(() => platform.windows === true);
+        platformService.setup(x => x.isMac).returns(() => platform.mac === true);
+        platformService.setup(x => x.isLinux).returns(() => platform.linux === true);
+        platformService.setup(x => x.is64bit).returns(() => platform.is64Bit === true);
+    }
+    test('Windows 32Bit', async () => {
+        setupPlatform({ windows: true });
+        const link = await languageServerDownloader.getDownloadUri();
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-win-x86.${downloadVersion}${downloadFileExtension}`);
+    });
+    test('Windows 64Bit', async () => {
+        setupPlatform({ windows: true, is64Bit: true });
+        const link = await languageServerDownloader.getDownloadUri();
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-win-x64.${downloadVersion}${downloadFileExtension}`);
+    });
+    test('Mac 64Bit', async () => {
+        setupPlatform({ mac: true, is64Bit: true });
+        const link = await languageServerDownloader.getDownloadUri();
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-osx-x64.${downloadVersion}${downloadFileExtension}`);
+    });
+    test('Linux 64Bit', async () => {
+        setupPlatform({ linux: true, is64Bit: true });
+        const link = await languageServerDownloader.getDownloadUri();
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-linux-x64.${downloadVersion}${downloadFileExtension}`);
+    });
+});

--- a/src/test/activation/platformData.unit.test.ts
+++ b/src/test/activation/platformData.unit.test.ts
@@ -6,7 +6,6 @@ import * as assert from 'assert';
 import * as TypeMoq from 'typemoq';
 import { PlatformData } from '../../client/activation/platformData';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
-import { initialize } from '../initialize';
 
 const testDataWinMac = [
     { isWindows: true, is64Bit: true, expectedName: 'win-x64' },
@@ -31,8 +30,6 @@ const testDataModuleName = [
 
 // tslint:disable-next-line:max-func-body-length
 suite('Activation - platform data', () => {
-    suiteSetup(initialize);
-
     test('Name and hash (Windows/Mac)', async () => {
         for (const t of testDataWinMac) {
             const platformService = TypeMoq.Mock.ofType<IPlatformService>();
@@ -43,11 +40,11 @@ suite('Activation - platform data', () => {
             const fs = TypeMoq.Mock.ofType<IFileSystem>();
             const pd = new PlatformData(platformService.object, fs.object);
 
-            let actual = await pd.getPlatformName();
+            const actual = await pd.getPlatformName();
             assert.equal(actual, t.expectedName, `${actual} does not match ${t.expectedName}`);
 
-            actual = await pd.getExpectedHash();
-            assert.equal(actual, t.expectedName, `${actual} hash not match ${t.expectedName}`);
+            const actualHash = await pd.getExpectedHash();
+            assert.equal(actualHash, t.expectedName, `${actual} hash not match ${t.expectedName}`);
         }
     });
     test('Name and hash (Linux)', async () => {
@@ -62,10 +59,10 @@ suite('Activation - platform data', () => {
             fs.setup(x => x.readFile(TypeMoq.It.isAnyString())).returns(() => Promise.resolve(`NAME="name"\nID=${t.name}\nID_LIKE=debian`));
             const pd = new PlatformData(platformService.object, fs.object);
 
-            let actual = await pd.getPlatformName();
+            const actual = await pd.getPlatformName();
             assert.equal(actual, t.expectedName, `${actual} does not match ${t.expectedName}`);
 
-            actual = await pd.getExpectedHash();
+            const actualHash = await pd.getExpectedHash();
             assert.equal(actual, t.expectedName, `${actual} hash not match ${t.expectedName}`);
         }
     });


### PR DESCRIPTION
Fixes #2180

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
