### PR TITLE
Register test manager when using the new language server

### DIFF
--- a/news/2 Fixes/2186.md
+++ b/news/2 Fixes/2186.md
@@ -1,0 +1,1 @@
+Register test manager when using the new language server.

--- a/src/client/activation/languageServer.ts
+++ b/src/client/activation/languageServer.ts
@@ -11,7 +11,7 @@ import { isTestExecution, STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import { createDeferred, Deferred } from '../common/helpers';
 import { IFileSystem, IPlatformService } from '../common/platform/types';
 import { StopWatch } from '../common/stopWatch';
-import { IConfigurationService, IExtensionContext, IOutputChannel, IPythonSettings } from '../common/types';
+import { IConfigurationService, IExtensionContext, ILogger, IOutputChannel, IPythonSettings } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import {
     PYTHON_LANGUAGE_SERVER_DOWNLOADED,
@@ -19,6 +19,7 @@ import {
     PYTHON_LANGUAGE_SERVER_ERROR
 } from '../telemetry/constants';
 import { getTelemetryReporter } from '../telemetry/telemetry';
+import { IUnitTestManagementService } from '../unittests/types';
 import { LanguageServerDownloader } from './downloader';
 import { InterpreterData, InterpreterDataService } from './interpreterDataService';
 import { PlatformData } from './platformData';
@@ -89,6 +90,11 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
         if (!clientOptions) {
             return false;
         }
+
+        const testManagementService = this.services.get<IUnitTestManagementService>(IUnitTestManagementService);
+        testManagementService.activate()
+            .catch(ex => this.services.get<ILogger>(ILogger).logError('Failed to activate Unit Tests', ex));
+
         return this.startLanguageServer(clientOptions);
     }
 


### PR DESCRIPTION
Fixes #2186

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
