### PR TITLE
Change shortcut from ctrl+enter to shift+enter

### DIFF
--- a/.github/test_plan.md
+++ b/.github/test_plan.md
@@ -33,7 +33,7 @@
 - [ ] `Run Selection/Line in Python Terminal`
   - [ ] Right-click
   - [ ] Command
-  - [ ] `Ctrl-Enter`
+  - [ ] `Shift+Enter`
 
 #### Virtual environments
 


### PR DESCRIPTION
Fixes #2188

- [ ] Title summarizes what is changing
- [ ] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [ ] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [ ] `package-lock.json` has been regenerated if dependencies have changed
