### PR TITLE
 Move service registrations from debug adapter host to extension host

### DIFF
--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -8,9 +8,14 @@ import { ExtensionActivationService } from './activationService';
 import { JediExtensionActivator } from './jedi';
 import { LanguageServerExtensionActivator } from './languageServer';
 import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from './types';
+import { IPythonExtensionBanner, BANNER_NAME_LS_SURVEY, BANNER_NAME_PROPOSE_LS } from '../common/types';
+import { LanguageServerSurveyBanner } from '../languageServices/languageServerSurveyBanner';
+import { ProposeLanguageServerBanner } from '../languageServices/proposeLanguageServerBanner';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, ExtensionActivationService);
     serviceManager.add<IExtensionActivator>(IExtensionActivator, JediExtensionActivator, ExtensionActivators.Jedi);
     serviceManager.add<IExtensionActivator>(IExtensionActivator, LanguageServerExtensionActivator, ExtensionActivators.DotNet);
+    serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, LanguageServerSurveyBanner, BANNER_NAME_LS_SURVEY);
+    serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, ProposeLanguageServerBanner, BANNER_NAME_PROPOSE_LS);
 }

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -3,14 +3,14 @@
 
 'use strict';
 
+import { BANNER_NAME_LS_SURVEY, BANNER_NAME_PROPOSE_LS, IPythonExtensionBanner } from '../common/types';
 import { IServiceManager } from '../ioc/types';
+import { LanguageServerSurveyBanner } from '../languageServices/languageServerSurveyBanner';
+import { ProposeLanguageServerBanner } from '../languageServices/proposeLanguageServerBanner';
 import { ExtensionActivationService } from './activationService';
 import { JediExtensionActivator } from './jedi';
 import { LanguageServerExtensionActivator } from './languageServer';
 import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from './types';
-import { IPythonExtensionBanner, BANNER_NAME_LS_SURVEY, BANNER_NAME_PROPOSE_LS } from '../common/types';
-import { LanguageServerSurveyBanner } from '../languageServices/languageServerSurveyBanner';
-import { ProposeLanguageServerBanner } from '../languageServices/proposeLanguageServerBanner';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, ExtensionActivationService);

--- a/src/client/debugger/serviceRegistry.ts
+++ b/src/client/debugger/serviceRegistry.ts
@@ -9,13 +9,10 @@ import { FileSystem } from '../common/platform/fileSystem';
 import { PlatformService } from '../common/platform/platformService';
 import { IFileSystem, IPlatformService } from '../common/platform/types';
 import { CurrentProcess } from '../common/process/currentProcess';
-import { BANNER_NAME_LS_SURVEY, BANNER_NAME_PROPOSE_LS, ICurrentProcess,
-    IExperimentalDebuggerBanner, IPythonExtensionBanner, ISocketServer } from '../common/types';
+import { ICurrentProcess, IExperimentalDebuggerBanner, ISocketServer } from '../common/types';
 import { ServiceContainer } from '../ioc/container';
 import { ServiceManager } from '../ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
-import { LanguageServerSurveyBanner } from '../languageServices/languageServerSurveyBanner';
-import { ProposeLanguageServerBanner } from '../languageServices/proposeLanguageServerBanner';
 import { ExperimentalDebuggerBanner } from './banner';
 import { DebugStreamProvider } from './Common/debugStreamProvider';
 import { ProtocolLogger } from './Common/protocolLogger';
@@ -45,6 +42,4 @@ function registerDebuggerTypes(serviceManager: IServiceManager) {
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExperimentalDebuggerBanner>(IExperimentalDebuggerBanner, ExperimentalDebuggerBanner);
-    serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, LanguageServerSurveyBanner, BANNER_NAME_LS_SURVEY);
-    serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, ProposeLanguageServerBanner, BANNER_NAME_PROPOSE_LS);
 }


### PR DESCRIPTION
Fixes #2191

- [x] Title summarizes what is changing
- [n/a] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
