### PR TITLE
[WIP] Use symbol provider from new language server to place code lenses in tests

### DIFF
--- a/src/client/activation/jedi.ts
+++ b/src/client/activation/jedi.ts
@@ -16,12 +16,13 @@ import { PythonReferenceProvider } from '../providers/referenceProvider';
 import { PythonRenameProvider } from '../providers/renameProvider';
 import { PythonSignatureProvider } from '../providers/signatureProvider';
 import { PythonSymbolProvider } from '../providers/symbolProvider';
+import { ThrottledPythonSymbolProvider } from '../providers/throttledSymbolProvider';
 import { IUnitTestManagementService } from '../unittests/types';
 import { WorkspaceSymbols } from '../workspaceSymbols/main';
 import { IExtensionActivator } from './types';
 
 @injectable()
-export class JediExtensionActivator implements IExtensionActivator {
+export class ClassicExtensionActivator implements IExtensionActivator {
     private readonly context: IExtensionContext;
     private jediFactory?: JediFactory;
     private readonly documentSelector: DocumentFilter[];
@@ -50,7 +51,7 @@ export class JediExtensionActivator implements IExtensionActivator {
         const serviceContainer = this.serviceManager.get<IServiceContainer>(IServiceContainer);
         context.subscriptions.push(new WorkspaceSymbols(serviceContainer));
 
-        const symbolProvider = new PythonSymbolProvider(serviceContainer, jediFactory);
+        const symbolProvider = new ThrottledPythonSymbolProvider(serviceContainer, jediFactory);
         context.subscriptions.push(languages.registerDocumentSymbolProvider(this.documentSelector, symbolProvider));
 
         const pythonSettings = this.serviceManager.get<IConfigurationService>(IConfigurationService).getSettings();
@@ -60,7 +61,7 @@ export class JediExtensionActivator implements IExtensionActivator {
 
         const testManagementService = this.serviceManager.get<IUnitTestManagementService>(IUnitTestManagementService);
         testManagementService.activate()
-            .then(() => testManagementService.activateCodeLenses(symbolProvider))
+            .then(() => testManagementService.activateCodeLenses(new PythonSymbolProvider(serviceContainer, jediFactory)))
             .catch(ex => this.serviceManager.get<ILogger>(ILogger).logError('Failed to activate Unit Tests', ex));
 
         return true;

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -5,12 +5,12 @@
 
 import { IServiceManager } from '../ioc/types';
 import { ExtensionActivationService } from './activationService';
-import { JediExtensionActivator } from './jedi';
+import { ClassicExtensionActivator } from './jedi';
 import { LanguageServerExtensionActivator } from './languageServer';
 import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, ExtensionActivationService);
-    serviceManager.add<IExtensionActivator>(IExtensionActivator, JediExtensionActivator, ExtensionActivators.Jedi);
+    serviceManager.add<IExtensionActivator>(IExtensionActivator, ClassicExtensionActivator, ExtensionActivators.Jedi);
     serviceManager.add<IExtensionActivator>(IExtensionActivator, LanguageServerExtensionActivator, ExtensionActivators.DotNet);
 }

--- a/src/client/activation/symbolProvider.ts
+++ b/src/client/activation/symbolProvider.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { CancellationToken, DocumentSymbolProvider, SymbolInformation, TextDocument } from 'vscode';
+import { LanguageClient } from 'vscode-languageclient';
+
+export class SymbolProvider implements DocumentSymbolProvider {
+    constructor(private readonly languageClient: LanguageClient) {
+    }
+    public async provideDocumentSymbols(document: TextDocument, token: CancellationToken): Promise<SymbolInformation[]> {
+        const args = { textDocument: { uri: document.uri.toString() } };
+        return this.languageClient.sendRequest<SymbolInformation[]>('textDocument/documentSymbol', args, token);
+    }
+}

--- a/src/client/providers/symbolProvider.ts
+++ b/src/client/providers/symbolProvider.ts
@@ -1,7 +1,6 @@
 'use strict';
 
 import { CancellationToken, DocumentSymbolProvider, Location, Range, SymbolInformation, TextDocument, Uri } from 'vscode';
-import { createDeferred, Deferred } from '../common/helpers';
 import { IFileSystem } from '../common/platform/types';
 import { IServiceContainer } from '../ioc/types';
 import { JediFactory } from '../languageServices/jediProxyFactory';
@@ -10,60 +9,12 @@ import { SYMBOL } from '../telemetry/constants';
 import * as proxy from './jediProxy';
 
 export class PythonSymbolProvider implements DocumentSymbolProvider {
-    private debounceRequest: Map<string, { timer: NodeJS.Timer; deferred: Deferred<SymbolInformation[]> }>;
-    private readonly fs: IFileSystem;
-    public constructor(serviceContainer: IServiceContainer, private jediFactory: JediFactory, private readonly debounceTimeoutMs = 500) {
-        this.debounceRequest = new Map<string, { timer: NodeJS.Timer; deferred: Deferred<SymbolInformation[]> }>();
+    protected readonly fs: IFileSystem;
+    public constructor(serviceContainer: IServiceContainer, protected readonly jediFactory: JediFactory) {
         this.fs = serviceContainer.get<IFileSystem>(IFileSystem);
     }
     @captureTelemetry(SYMBOL)
     public provideDocumentSymbols(document: TextDocument, token: CancellationToken): Thenable<SymbolInformation[]> {
-        const key = `${document.uri.fsPath}`;
-        if (this.debounceRequest.has(key)) {
-            const item = this.debounceRequest.get(key)!;
-            clearTimeout(item.timer);
-            item.deferred.resolve([]);
-        }
-
-        const deferred = createDeferred<SymbolInformation[]>();
-        const timer = setTimeout(() => {
-            if (token.isCancellationRequested) {
-                return deferred.resolve([]);
-            }
-
-            const filename = document.fileName;
-            const cmd: proxy.ICommand<proxy.ISymbolResult> = {
-                command: proxy.CommandType.Symbols,
-                fileName: filename,
-                columnIndex: 0,
-                lineIndex: 0
-            };
-
-            if (document.isDirty) {
-                cmd.source = document.getText();
-            }
-
-            this.jediFactory.getJediProxyHandler<proxy.ISymbolResult>(document.uri).sendCommand(cmd, token)
-                .then(data => this.parseData(document, data))
-                .then(items => deferred.resolve(items))
-                .catch(ex => deferred.reject(ex));
-
-        }, this.debounceTimeoutMs);
-
-        token.onCancellationRequested(() => {
-            clearTimeout(timer);
-            deferred.resolve([]);
-            this.debounceRequest.delete(key);
-        });
-
-        // When a document is not saved on FS, we cannot uniquely identify it, so lets not debounce, but delay the symbol provider.
-        if (!document.isUntitled) {
-            this.debounceRequest.set(key, { timer, deferred });
-        }
-
-        return deferred.promise;
-    }
-    public provideDocumentSymbolsForInternalUse(document: TextDocument, token: CancellationToken): Thenable<SymbolInformation[]> {
         const filename = document.fileName;
 
         const cmd: proxy.ICommand<proxy.ISymbolResult> = {
@@ -80,7 +31,7 @@ export class PythonSymbolProvider implements DocumentSymbolProvider {
         return this.jediFactory.getJediProxyHandler<proxy.ISymbolResult>(document.uri).sendCommandNonCancellableCommand(cmd, token)
             .then(data => this.parseData(document, data));
     }
-    private parseData(document: TextDocument, data?: proxy.ISymbolResult): SymbolInformation[] {
+    protected parseData(document: TextDocument, data?: proxy.ISymbolResult): SymbolInformation[] {
         if (data) {
             const symbols = data.definitions.filter(sym => this.fs.arePathsSame(sym.fileName, document.fileName));
             return symbols.map(sym => {

--- a/src/client/providers/throttledSymbolProvider.ts
+++ b/src/client/providers/throttledSymbolProvider.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { CancellationToken, DocumentSymbolProvider, SymbolInformation, TextDocument } from 'vscode';
+import { createDeferred, Deferred } from '../common/helpers';
+import { IServiceContainer } from '../ioc/types';
+import { JediFactory } from '../languageServices/jediProxyFactory';
+import { captureTelemetry } from '../telemetry';
+import { SYMBOL } from '../telemetry/constants';
+import * as proxy from './jediProxy';
+import { PythonSymbolProvider } from './symbolProvider';
+
+export class ThrottledPythonSymbolProvider extends PythonSymbolProvider implements DocumentSymbolProvider {
+    private readonly debounceRequest: Map<string, { timer: NodeJS.Timer; deferred: Deferred<SymbolInformation[]> }>;
+    public constructor(serviceContainer: IServiceContainer, jediFactory: JediFactory, private readonly debounceTimeoutMs = 500) {
+        super(serviceContainer, jediFactory);
+        this.debounceRequest = new Map<string, { timer: NodeJS.Timer; deferred: Deferred<SymbolInformation[]> }>();
+    }
+    @captureTelemetry(SYMBOL)
+    public provideDocumentSymbols(document: TextDocument, token: CancellationToken): Thenable<SymbolInformation[]> {
+        const key = `${document.uri.fsPath}`;
+        if (this.debounceRequest.has(key)) {
+            const item = this.debounceRequest.get(key)!;
+            clearTimeout(item.timer);
+            item.deferred.resolve([]);
+        }
+
+        const deferred = createDeferred<SymbolInformation[]>();
+        const timer = setTimeout(() => {
+            if (token.isCancellationRequested) {
+                return deferred.resolve([]);
+            }
+
+            const filename = document.fileName;
+            const cmd: proxy.ICommand<proxy.ISymbolResult> = {
+                command: proxy.CommandType.Symbols,
+                fileName: filename,
+                columnIndex: 0,
+                lineIndex: 0
+            };
+
+            if (document.isDirty) {
+                cmd.source = document.getText();
+            }
+
+            this.jediFactory.getJediProxyHandler<proxy.ISymbolResult>(document.uri).sendCommand(cmd, token)
+                .then(data => this.parseData(document, data))
+                .then(items => deferred.resolve(items))
+                .catch(ex => deferred.reject(ex));
+
+        }, this.debounceTimeoutMs);
+
+        token.onCancellationRequested(() => {
+            clearTimeout(timer);
+            deferred.resolve([]);
+            this.debounceRequest.delete(key);
+        });
+
+        // When a document is not saved on FS, we cannot uniquely identify it, so lets not debounce, but delay the symbol provider.
+        if (!document.isUntitled) {
+            this.debounceRequest.set(key, { timer, deferred });
+        }
+
+        return deferred.promise;
+    }
+}

--- a/src/client/unittests/codeLenses/main.ts
+++ b/src/client/unittests/codeLenses/main.ts
@@ -1,11 +1,10 @@
 import * as vscode from 'vscode';
 import { PYTHON } from '../../common/constants';
-import { PythonSymbolProvider } from '../../providers/symbolProvider';
 import { ITestCollectionStorageService } from '../common/types';
 import { TestFileCodeLensProvider } from './testFiles';
 
 export function activateCodeLenses(onDidChange: vscode.EventEmitter<void>,
-    symboldProvider: PythonSymbolProvider, testCollectionStorage: ITestCollectionStorageService): vscode.Disposable {
+    symboldProvider: vscode.DocumentSymbolProvider, testCollectionStorage: ITestCollectionStorageService): vscode.Disposable {
 
     const disposables: vscode.Disposable[] = [];
     const codeLensProvider = new TestFileCodeLensProvider(onDidChange, symboldProvider, testCollectionStorage);

--- a/src/client/unittests/codeLenses/testFiles.ts
+++ b/src/client/unittests/codeLenses/testFiles.ts
@@ -2,9 +2,8 @@
 
 // tslint:disable:no-object-literal-type-assertion
 
-import { CancellationToken, CancellationTokenSource, CodeLens, CodeLensProvider, Event, EventEmitter, Position, Range, SymbolInformation, SymbolKind, TextDocument, Uri, workspace } from 'vscode';
+import { CancellationToken, CancellationTokenSource, CodeLens, CodeLensProvider, DocumentSymbolProvider, Event, EventEmitter, Position, Range, SymbolInformation, SymbolKind, TextDocument, Uri, workspace } from 'vscode';
 import * as constants from '../../common/constants';
-import { PythonSymbolProvider } from '../../providers/symbolProvider';
 import { CommandSource } from '../common/constants';
 import { ITestCollectionStorageService, TestFile, TestFunction, TestStatus, TestsToRun, TestSuite } from '../common/types';
 
@@ -16,7 +15,7 @@ type FunctionsAndSuites = {
 export class TestFileCodeLensProvider implements CodeLensProvider {
     // tslint:disable-next-line:variable-name
     constructor(private _onDidChange: EventEmitter<void>,
-        private symbolProvider: PythonSymbolProvider,
+        private symbolProvider: DocumentSymbolProvider,
         private testCollectionStorage: ITestCollectionStorageService) {
     }
 
@@ -45,7 +44,7 @@ export class TestFileCodeLensProvider implements CodeLensProvider {
             }
         }, constants.Delays.MaxUnitTestCodeLensDelay);
 
-        return this.getCodeLenses(document, token, this.symbolProvider);
+        return this.getCodeLenses(document, cancelTokenSrc.token, this.symbolProvider);
     }
 
     public resolveCodeLens(codeLens: CodeLens, token: CancellationToken): CodeLens | Thenable<CodeLens> {
@@ -53,7 +52,7 @@ export class TestFileCodeLensProvider implements CodeLensProvider {
         return Promise.resolve(codeLens);
     }
 
-    private async getCodeLenses(document: TextDocument, token: CancellationToken, symbolProvider: PythonSymbolProvider) {
+    private async getCodeLenses(document: TextDocument, token: CancellationToken, symbolProvider: DocumentSymbolProvider) {
         const wkspace = workspace.getWorkspaceFolder(document.uri);
         if (!wkspace) {
             return [];
@@ -68,13 +67,16 @@ export class TestFileCodeLensProvider implements CodeLensProvider {
         }
         const allFuncsAndSuites = getAllTestSuitesAndFunctionsPerFile(file);
 
-        return symbolProvider.provideDocumentSymbolsForInternalUse(document, token)
-            .then((symbols: SymbolInformation[]) => {
-                return symbols.filter(symbol => {
-                    return symbol.kind === SymbolKind.Function ||
-                        symbol.kind === SymbolKind.Method ||
-                        symbol.kind === SymbolKind.Class;
-                }).map(symbol => {
+        try {
+            const symbols = (await symbolProvider.provideDocumentSymbols(document, token)) as SymbolInformation[];
+            if (!symbols) {
+                return [];
+            }
+            return symbols!
+                .filter(symbol => symbol.kind === SymbolKind.Function ||
+                    symbol.kind === SymbolKind.Method ||
+                    symbol.kind === SymbolKind.Class)
+                .map(symbol => {
                     // This is bloody crucial, if the start and end columns are the same
                     // then vscode goes bonkers when ever you edit a line (start scrolling magically).
                     const range = new Range(symbol.location.range.start,
@@ -83,13 +85,15 @@ export class TestFileCodeLensProvider implements CodeLensProvider {
 
                     return this.getCodeLens(document.uri, allFuncsAndSuites,
                         range, symbol.name, symbol.kind, symbol.containerName);
-                }).reduce((previous, current) => previous.concat(current), []).filter(codeLens => codeLens !== null);
-            }, reason => {
-                if (token.isCancellationRequested) {
-                    return [];
-                }
-                return Promise.reject(reason);
-            });
+                })
+                .reduce((previous, current) => previous.concat(current), [])
+                .filter(codeLens => codeLens !== null);
+        } catch (reason) {
+            if (token.isCancellationRequested) {
+                return [];
+            }
+            return Promise.reject(reason);
+        }
     }
 
     private getCodeLens(file: Uri, allFuncsAndSuites: FunctionsAndSuites,
@@ -103,7 +107,7 @@ export class TestFileCodeLensProvider implements CodeLensProvider {
             case SymbolKind.Class: {
                 const cls = allFuncsAndSuites.suites.find(item => item.name === symbolName);
                 if (!cls) {
-                    return null;
+                    return [];
                 }
                 return [
                     new CodeLens(range, {
@@ -242,7 +246,7 @@ function getAllTestSuitesAndFunctionsPerFile(testFile: TestFile): FunctionsAndSu
     return all;
 }
 function getAllTestSuitesAndFunctions(testSuite: TestSuite): FunctionsAndSuites {
-    const all = { functions: [], suites: [] };
+    const all: { functions: TestFunction[]; suites: TestSuite[] } = { functions: [], suites: [] };
     testSuite.functions.forEach(fn => {
         all.functions.push(fn);
     });

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -9,7 +9,6 @@ import { ICommandManager, IDocumentManager, IWorkspaceService } from '../common/
 import * as constants from '../common/constants';
 import { IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
-import { PythonSymbolProvider } from '../providers/symbolProvider';
 import { UNITTEST_STOP, UNITTEST_VIEW_OUTPUT } from '../telemetry/constants';
 import { sendTelemetryEvent } from '../telemetry/index';
 import { activateCodeLenses } from './codeLenses/main';
@@ -51,7 +50,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         this.autoDiscoverTests()
             .catch(ex => this.serviceContainer.get<ILogger>(ILogger).logError('Failed to auto discover tests upon activation', ex));
     }
-    public async activateCodeLenses(symboldProvider: PythonSymbolProvider): Promise<void> {
+    public async activateCodeLenses(symboldProvider: vscode.DocumentSymbolProvider): Promise<void> {
         const testCollectionStorage = this.serviceContainer.get<ITestCollectionStorageService>(ITestCollectionStorageService);
         this.disposableRegistry.push(activateCodeLenses(this.onDidChange, symboldProvider, testCollectionStorage));
     }
@@ -314,7 +313,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         if (!settings.unitTest.autoTestDiscoverOnSaveEnabled) {
             return;
         }
-        this.discoverTestsForDocument(doc);
+        this.discoverTestsForDocument(doc).ignoreErrors();
     }
     private registerHandlers() {
         const documentManager = this.serviceContainer.get<IDocumentManager>(IDocumentManager);

--- a/src/client/unittests/types.ts
+++ b/src/client/unittests/types.ts
@@ -3,9 +3,8 @@
 
 'use strict';
 
-import { Disposable, Event, TextDocument, Uri } from 'vscode';
+import { Disposable, DocumentSymbolProvider, Event, TextDocument, Uri } from 'vscode';
 import { Product } from '../common/types';
-import { PythonSymbolProvider } from '../providers/symbolProvider';
 import { CommandSource } from './common/constants';
 import { FlattenedTestFunction, ITestManager, ITestResultsService, TestFile, TestFunction, TestRunOptions, Tests, TestsToRun, UnitTestProduct } from './common/types';
 
@@ -37,7 +36,7 @@ export interface ITestDisplay {
 export const IUnitTestManagementService = Symbol('IUnitTestManagementService');
 export interface IUnitTestManagementService {
     activate(): Promise<void>;
-    activateCodeLenses(symboldProvider: PythonSymbolProvider): Promise<void>;
+    activateCodeLenses(symboldProvider: DocumentSymbolProvider): Promise<void>;
     getTestManager(displayTestNotConfiguredMessage: boolean, resource?: Uri): Promise<ITestManager | undefined | void>;
     discoverTestsForDocument(doc: TextDocument): Promise<void>;
     autoDiscoverTests(): Promise<void>;

--- a/src/test/providers/symbolProvider.unit.test.ts
+++ b/src/test/providers/symbolProvider.unit.test.ts
@@ -12,7 +12,7 @@ import { IFileSystem } from '../../client/common/platform/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { JediFactory } from '../../client/languageServices/jediProxyFactory';
 import { IDefinition, ISymbolResult, JediProxyHandler } from '../../client/providers/jediProxy';
-import { PythonSymbolProvider } from '../../client/providers/symbolProvider';
+import { ThrottledPythonSymbolProvider } from '../../client/providers/throttledSymbolProvider';
 
 const assertArrays = require('chai-arrays');
 use(assertArrays);
@@ -69,35 +69,35 @@ suite('Symbol Provider', () => {
     }
 
     test('Ensure symbols are returned', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await testDocumentation(1, __filename, 1);
     });
     test('Ensure symbols are returned (for untitled documents)', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await testDocumentation(1, __filename, 1, undefined, true);
     });
     test('Ensure symbols are returned with a debounce of 100ms', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await testDocumentation(1, __filename, 1);
     });
     test('Ensure symbols are returned with a debounce of 100ms (for untitled documents)', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await testDocumentation(1, __filename, 1, undefined, true);
     });
     test('Ensure symbols are not returned when cancelled', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         const tokenSource = new CancellationTokenSource();
         tokenSource.cancel();
         await testDocumentation(1, __filename, 0, tokenSource.token);
     });
     test('Ensure symbols are not returned when cancelled (for untitled documents)', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         const tokenSource = new CancellationTokenSource();
         tokenSource.cancel();
         await testDocumentation(1, __filename, 0, tokenSource.token, true);
     });
     test('Ensure symbols are returned only for the last request', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
         await Promise.all([
             testDocumentation(1, __filename, 0),
             testDocumentation(2, __filename, 0),
@@ -105,7 +105,7 @@ suite('Symbol Provider', () => {
         ]);
     });
     test('Ensure symbols are returned for all the requests when the doc is untitled', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
         await Promise.all([
             testDocumentation(1, __filename, 1, undefined, true),
             testDocumentation(2, __filename, 1, undefined, true),
@@ -113,28 +113,28 @@ suite('Symbol Provider', () => {
         ]);
     });
     test('Ensure symbols are returned for multiple documents', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await Promise.all([
             testDocumentation(1, 'file1', 1),
             testDocumentation(2, 'file2', 1)
         ]);
     });
     test('Ensure symbols are returned for multiple untitled documents ', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await Promise.all([
             testDocumentation(1, 'file1', 1, undefined, true),
             testDocumentation(2, 'file2', 1, undefined, true)
         ]);
     });
     test('Ensure symbols are returned for multiple documents with a debounce of 100ms', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
         await Promise.all([
             testDocumentation(1, 'file1', 1),
             testDocumentation(2, 'file2', 1)
         ]);
     });
     test('Ensure symbols are returned for multiple untitled documents with a debounce of 100ms', async () => {
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 100);
         await Promise.all([
             testDocumentation(1, 'file1', 1, undefined, true),
             testDocumentation(2, 'file2', 1, undefined, true)
@@ -170,7 +170,7 @@ suite('Symbol Provider', () => {
             .returns(() => Promise.resolve(symbols.object))
             .verifiable(TypeMoq.Times.once());
 
-        provider = new PythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
+        provider = new ThrottledPythonSymbolProvider(serviceContainer.object, jediFactory.object, 0);
         await provider.provideDocumentSymbols(doc.object, new CancellationTokenSource().token);
 
         doc.verifyAll();


### PR DESCRIPTION
Fixes #1948

- [x] Title summarizes what is changing
- [ ] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [ ] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [ ] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [ ] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [ ] `package-lock.json` has been regenerated if dependencies have changed
