### PR TITLE
Moved IExperimentalDebuggerBanner back into a debug dir

### DIFF
--- a/news/3 Code Health/2195.md
+++ b/news/3 Code Health/2195.md
@@ -1,0 +1,1 @@
+Revert change that moved IExperimentalDebuggerBanner into a common location.

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -268,16 +268,6 @@ export interface IBrowserService {
     launch(url: string): void;
 }
 
-export const IExperimentalDebuggerBanner = Symbol('IExperimentalDebuggerBanner');
-export interface IExperimentalDebuggerBanner {
-    enabled: boolean;
-    initialize(): void;
-    showBanner(): Promise<void>;
-    shouldShowBanner(): Promise<boolean>;
-    disable(): Promise<void>;
-    launchSurvey(): Promise<void>;
-}
-
 export const IPythonExtensionBanner = Symbol('IPythonExtensionBanner');
 export interface IPythonExtensionBanner {
     enabled: boolean;

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -38,3 +38,12 @@ export interface IProtocolMessageWriter {
 }
 
 export const IDebugConfigurationProvider = Symbol('DebugConfigurationProvider');
+export const IExperimentalDebuggerBanner = Symbol('IExperimentalDebuggerBanner');
+export interface IExperimentalDebuggerBanner {
+    enabled: boolean;
+    initialize(): void;
+    showBanner(): Promise<void>;
+    shouldShowBanner(): Promise<boolean>;
+    disable(): Promise<void>;
+    launchSurvey(): Promise<void>;
+}


### PR DESCRIPTION
Fixes #2195

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [x] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [x] `package-lock.json` has been regenerated if dependencies have changed
