### PR TITLE
[WIP] As default setting turn on new language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1259,7 +1259,7 @@
                 },
                 "python.jediEnabled": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Enables Jedi as IntelliSense engine instead of Microsoft Python Analysis Engine.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
Fixes #2114

* No news entry, as this is a setting we'd like enabled for developer build


- [x] Title summarizes what is changing
- [No] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
