### PR TITLE
Add debug configuration snippet for modules in Experimental debugger

### DIFF
--- a/news/1 Enhancements/2175.md
+++ b/news/1 Enhancements/2175.md
@@ -1,0 +1,1 @@
+Add debug configuration snippet for modules for the debugger.

--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
                             "name": "Python: Module",
                             "type": "python",
                             "request": "launch",
-                            "module": "module.name",
+                            "module": "enter-your-module-name-here",
                             "console": "integratedTerminal"
 
                         }
@@ -660,7 +660,7 @@
                         "name": "Python: Module",
                         "type": "python",
                         "request": "launch",
-                        "module": "module.name",
+                        "module": "enter-your-module-name-here",
                         "console": "integratedTerminal"
                     },
                     {

--- a/package.json
+++ b/package.json
@@ -818,7 +818,7 @@
                 },
                 "python.jediEnabled": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Enables Jedi as IntelliSense engine instead of Microsoft Python Analysis Engine.",
                     "scope": "resource"
                 },

--- a/package.json
+++ b/package.json
@@ -324,6 +324,18 @@
                         }
                     },
                     {
+                        "label": "Python: Module",
+                        "description": "%python.snippet.launch.module.description%",
+                        "body": {
+                            "name": "Python: Module",
+                            "type": "python",
+                            "request": "launch",
+                            "module": "module.name",
+                            "console": "integratedTerminal"
+
+                        }
+                    },
+                    {
                         "label": "Python: Django",
                         "description": "%python.snippet.launch.django.description%",
                         "body": {
@@ -645,6 +657,13 @@
                         "host": "localhost"
                     },
                     {
+                        "name": "Python: Module",
+                        "type": "python",
+                        "request": "launch",
+                        "module": "module.name",
+                        "console": "integratedTerminal"
+                    },
+                    {
                         "name": "Python: Django",
                         "type": "python",
                         "request": "launch",
@@ -799,7 +818,7 @@
                 },
                 "python.jediEnabled": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Enables Jedi as IntelliSense engine instead of Microsoft Python Analysis Engine.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
Fixes #2175

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
