### PR TITLE
Add news entry for upstream fix #767

### DIFF
--- a/news/2 Fixes/767.md
+++ b/news/2 Fixes/767.md
@@ -1,0 +1,1 @@
+Ensure stepping out of debugged code does  not take user into `PTVSD` debugger code.

--- a/news/2 Fixes/767.md
+++ b/news/2 Fixes/767.md
@@ -1,1 +1,1 @@
-Ensure stepping out of debugged code does  not take user into `PTVSD` debugger code.
+Ensure stepping out of debugged code does not take user into `PTVSD` debugger code.


### PR DESCRIPTION
Fixes #767

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [n/a] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [n/a] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
