### PR TITLE
Decorate `EventEmitter` within a `try..catch`

### DIFF
--- a/news/3 Code Health/2196.md
+++ b/news/3 Code Health/2196.md
@@ -1,0 +1,1 @@
+Decorate `EventEmitter` within a `try..catch` to play nice with other extensions performing the same operation.

--- a/src/client/ioc/container.ts
+++ b/src/client/ioc/container.ts
@@ -3,11 +3,18 @@
 
 import { EventEmitter } from 'events';
 import { Container, decorate, injectable, interfaces } from 'inversify';
+import { noop } from '../common/core.utils';
 import { Abstract, IServiceContainer, Newable } from './types';
 
 // This needs to be done once, hence placed in a common location.
 // Used by UnitTestSockerServer and also the extension unit tests.
-decorate(injectable(), EventEmitter);
+// Place within try..catch, as this can only be done once. Possible another extesion
+// would perform this before our extension.
+try {
+    decorate(injectable(), EventEmitter);
+} catch {
+    noop();
+}
 
 @injectable()
 export class ServiceContainer implements IServiceContainer {

--- a/src/client/ioc/container.ts
+++ b/src/client/ioc/container.ts
@@ -3,7 +3,6 @@
 
 import { EventEmitter } from 'events';
 import { Container, decorate, injectable, interfaces } from 'inversify';
-import { noop } from '../common/core.utils';
 import { Abstract, IServiceContainer, Newable } from './types';
 
 // This needs to be done once, hence placed in a common location.
@@ -12,8 +11,8 @@ import { Abstract, IServiceContainer, Newable } from './types';
 // possible another extesion would perform this before our extension).
 try {
     decorate(injectable(), EventEmitter);
-} catch {
-    noop();
+} catch (ex) {
+    console.warn('Failed to decorate EventEmitter for DI (most likely already decorate by another Extension)', ex);
 }
 
 @injectable()

--- a/src/client/ioc/container.ts
+++ b/src/client/ioc/container.ts
@@ -8,8 +8,8 @@ import { Abstract, IServiceContainer, Newable } from './types';
 
 // This needs to be done once, hence placed in a common location.
 // Used by UnitTestSockerServer and also the extension unit tests.
-// Place within try..catch, as this can only be done once. Possible another extesion
-// would perform this before our extension.
+// Place within try..catch, as this can only be done once (it's
+// possible another extesion would perform this before our extension).
 try {
     decorate(injectable(), EventEmitter);
 } catch {

--- a/src/client/ioc/container.ts
+++ b/src/client/ioc/container.ts
@@ -12,7 +12,7 @@ import { Abstract, IServiceContainer, Newable } from './types';
 try {
     decorate(injectable(), EventEmitter);
 } catch (ex) {
-    console.warn('Failed to decorate EventEmitter for DI (most likely already decorate by another Extension)', ex);
+    console.warn('Failed to decorate EventEmitter for DI (possibly already decorated by another Extension)', ex);
 }
 
 @injectable()


### PR DESCRIPTION
Fixes #2196

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
