### PR TITLE
Update to latest Language Server

### DIFF
--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -20,7 +20,7 @@ const StreamZip = require('node-stream-zip');
 
 const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
 const downloadBaseFileName = 'Python-Language-Server';
-const downloadVersion = '0.1.0';
+const downloadVersion = '0.1.18204.3';
 const downloadFileExtension = '.nupkg';
 
 const DownloadLinks = {

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -18,12 +18,12 @@ import { PlatformData, PlatformName } from './platformData';
 // tslint:disable-next-line:no-require-imports no-var-requires
 const StreamZip = require('node-stream-zip');
 
-export const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
-export const downloadBaseFileName = 'Python-Language-Server';
-export const downloadVersion = '0.1.18204.3';
-export const downloadFileExtension = '.nupkg';
+const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
+const downloadBaseFileName = 'Python-Language-Server';
+const downloadVersion = '0.1.18204.3';
+const downloadFileExtension = '.nupkg';
 
-const DownloadLinks = {
+export const DownloadLinks = {
     [PlatformName.Windows32Bit]: `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows32Bit}.${downloadVersion}${downloadFileExtension}`,
     [PlatformName.Windows64Bit]: `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows64Bit}.${downloadVersion}${downloadFileExtension}`,
     [PlatformName.Linux64Bit]: `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Linux64Bit}.${downloadVersion}${downloadFileExtension}`,

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -18,10 +18,10 @@ import { PlatformData, PlatformName } from './platformData';
 // tslint:disable-next-line:no-require-imports no-var-requires
 const StreamZip = require('node-stream-zip');
 
-const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
-const downloadBaseFileName = 'Python-Language-Server';
-const downloadVersion = '0.1.18204.3';
-const downloadFileExtension = '.nupkg';
+export const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
+export const downloadBaseFileName = 'Python-Language-Server';
+export const downloadVersion = '0.1.18204.3';
+export const downloadFileExtension = '.nupkg';
 
 const DownloadLinks = {
     [PlatformName.Windows32Bit]: `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows32Bit}.${downloadVersion}${downloadFileExtension}`,

--- a/src/client/activation/platformData.ts
+++ b/src/client/activation/platformData.ts
@@ -41,7 +41,7 @@ export class PlatformData {
     public getEngineExecutableName(): string {
         return this.platform.isWindows
             ? 'Microsoft.Python.LanguageServer.exe'
-            : 'Microsoft.Python.LanguageServer.LanguageServer';
+            : 'Microsoft.Python.LanguageServer';
     }
 
     public async getExpectedHash(): Promise<string> {

--- a/src/client/activation/platformData.ts
+++ b/src/client/activation/platformData.ts
@@ -16,6 +16,12 @@ export enum PlatformName {
     Linux64Bit = 'linux-x64'
 }
 
+export enum PlatformLSExecutables {
+    Windows = 'Microsoft.Python.LanguageServer.exe',
+    MacOS = 'Microsoft.Python.LanguageServer',
+    Linux = 'Microsoft.Python.LanguageServer'
+}
+
 export class PlatformData {
     constructor(private platform: IPlatformService, fs: IFileSystem) { }
     public async getPlatformName(): Promise<PlatformName> {
@@ -39,9 +45,15 @@ export class PlatformData {
     }
 
     public getEngineExecutableName(): string {
-        return this.platform.isWindows
-            ? 'Microsoft.Python.LanguageServer.exe'
-            : 'Microsoft.Python.LanguageServer';
+        if (this.platform.isWindows) {
+            return PlatformLSExecutables.Windows;
+        } else if (this.platform.isLinux) {
+            return PlatformLSExecutables.Linux;
+        } else if (this.platform.isMac) {
+            return PlatformLSExecutables.MacOS;
+        } else {
+            return 'unknown-platform';
+        }
     }
 
     public async getExpectedHash(): Promise<string> {

--- a/src/client/interpreter/interpreterVersion.ts
+++ b/src/client/interpreter/interpreterVersion.ts
@@ -3,7 +3,7 @@ import '../common/extensions';
 import { IProcessServiceFactory } from '../common/process/types';
 import { IInterpreterVersionService } from './contracts';
 
-export const PIP_VERSION_REGEX = '\\d+\\.\\d+(\\.\\d+)';
+export const PIP_VERSION_REGEX = '^(\\d+\\.){1,2}\\d+$';
 
 @injectable()
 export class InterpreterVersionService implements IInterpreterVersionService {

--- a/src/client/interpreter/interpreterVersion.ts
+++ b/src/client/interpreter/interpreterVersion.ts
@@ -3,7 +3,7 @@ import '../common/extensions';
 import { IProcessServiceFactory } from '../common/process/types';
 import { IInterpreterVersionService } from './contracts';
 
-export const PIP_VERSION_REGEX = '^(\\d+\\.){1,2}\\d+$';
+export const PIP_VERSION_REGEX = '\\d+\\.\\d+(\\.\\d+)?';
 
 @injectable()
 export class InterpreterVersionService implements IInterpreterVersionService {

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -7,15 +7,11 @@
 
 import * as assert from 'assert';
 import * as TypeMoq from 'typemoq';
-import { LanguageServerDownloader } from '../../client/activation/downloader';
+import { downloadBaseFileName, downloadFileExtension, downloadUriPrefix, downloadVersion, LanguageServerDownloader } from '../../client/activation/downloader';
+import { PlatformName } from '../../client/activation/platformData';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 import { IOutputChannel } from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
-
-const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
-const downloadBaseFileName = 'Python-Language-Server';
-const downloadVersion = '0.1.0';
-const downloadFileExtension = '.nupkg';
 
 suite('Activation - Downloader', () => {
     let languageServerDownloader: LanguageServerDownloader;
@@ -48,21 +44,21 @@ suite('Activation - Downloader', () => {
     test('Windows 32Bit', async () => {
         setupPlatform({ windows: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-win-x86.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows32Bit}.${downloadVersion}${downloadFileExtension}`);
     });
     test('Windows 64Bit', async () => {
         setupPlatform({ windows: true, is64Bit: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-win-x64.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows64Bit}.${downloadVersion}${downloadFileExtension}`);
     });
     test('Mac 64Bit', async () => {
         setupPlatform({ mac: true, is64Bit: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-osx-x64.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Mac64Bit}.${downloadVersion}${downloadFileExtension}`);
     });
     test('Linux 64Bit', async () => {
         setupPlatform({ linux: true, is64Bit: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-linux-x64.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Linux64Bit}.${downloadVersion}${downloadFileExtension}`);
     });
 });

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -7,7 +7,7 @@
 
 import * as assert from 'assert';
 import * as TypeMoq from 'typemoq';
-import { downloadBaseFileName, downloadFileExtension, downloadUriPrefix, downloadVersion, LanguageServerDownloader } from '../../client/activation/downloader';
+import { DownloadLinks, LanguageServerDownloader } from '../../client/activation/downloader';
 import { PlatformName } from '../../client/activation/platformData';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 import { IOutputChannel } from '../../client/common/types';
@@ -44,21 +44,21 @@ suite('Activation - Downloader', () => {
     test('Windows 32Bit', async () => {
         setupPlatform({ windows: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows32Bit}.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, DownloadLinks[PlatformName.Windows32Bit]);
     });
     test('Windows 64Bit', async () => {
         setupPlatform({ windows: true, is64Bit: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Windows64Bit}.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, DownloadLinks[PlatformName.Windows64Bit]);
     });
     test('Mac 64Bit', async () => {
         setupPlatform({ mac: true, is64Bit: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Mac64Bit}.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, DownloadLinks[PlatformName.Mac64Bit]);
     });
     test('Linux 64Bit', async () => {
         setupPlatform({ linux: true, is64Bit: true });
         const link = await languageServerDownloader.getDownloadUri();
-        assert.equal(link, `${downloadUriPrefix}/${downloadBaseFileName}-${PlatformName.Linux64Bit}.${downloadVersion}${downloadFileExtension}`);
+        assert.equal(link, DownloadLinks[PlatformName.Linux64Bit]);
     });
 });

--- a/src/test/activation/platformData.unit.test.ts
+++ b/src/test/activation/platformData.unit.test.ts
@@ -4,7 +4,7 @@
 // tslint:disable:no-unused-variable
 import * as assert from 'assert';
 import * as TypeMoq from 'typemoq';
-import { PlatformData } from '../../client/activation/platformData';
+import { PlatformData, PlatformLSExecutables } from '../../client/activation/platformData';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 
 const testDataWinMac = [
@@ -24,8 +24,9 @@ const testDataLinux = [
 ];
 
 const testDataModuleName = [
-    { isWindows: true, expectedName: 'Microsoft.Python.LanguageServer.exe' },
-    { isWindows: false, expectedName: 'Microsoft.Python.LanguageServer.LanguageServer' }
+    { isWindows: true, isMac: false, isLinux: false, expectedName: PlatformLSExecutables.Windows },
+    { isWindows: false, isMac: true, isLinux: false, expectedName: PlatformLSExecutables.MacOS },
+    { isWindows: false, isMac: false, isLinux: true, expectedName: PlatformLSExecutables.Linux }
 ];
 
 // tslint:disable-next-line:max-func-body-length
@@ -70,6 +71,8 @@ suite('Activation - platform data', () => {
         for (const t of testDataModuleName) {
             const platformService = TypeMoq.Mock.ofType<IPlatformService>();
             platformService.setup(x => x.isWindows).returns(() => t.isWindows);
+            platformService.setup(x => x.isLinux).returns(() => t.isLinux);
+            platformService.setup(x => x.isMac).returns(() => t.isMac);
 
             const fs = TypeMoq.Mock.ofType<IFileSystem>();
             const pd = new PlatformData(platformService.object, fs.object);

--- a/src/test/interpreters/interpreterVersion.test.ts
+++ b/src/test/interpreters/interpreterVersion.test.ts
@@ -43,7 +43,7 @@ suite('Interpreters display version', () => {
         const pyVersion = await interpreterVersion.getVersion('INVALID_INTERPRETER', 'DEFAULT_TEST_VALUE');
         assert.equal(pyVersion, 'DEFAULT_TEST_VALUE', 'Incorrect version');
     });
-    test('Must return the pip Version', async () => {
+    test('Must return the pip Version.', async () => {
         const pythonProcess = await ioc.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory).create();
         const result = await pythonProcess.exec(PYTHON_PATH, ['-m', 'pip', '--version'], { cwd: __dirname, mergeStdOutErr: true });
         const output = result.stdout.splitLines()[0];
@@ -60,7 +60,7 @@ suite('Interpreters display version', () => {
         // tslint:disable-next-line:no-non-null-assertion
         await expect(pipVersionPromise).to.eventually.equal(matches![0].trim());
     });
-    test('Must throw an exceptionn when pip version cannot be determine', async () => {
+    test('Must throw an exception when pip version cannot be determined', async () => {
         const interpreterVersion = ioc.serviceContainer.get<IInterpreterVersionService>(IInterpreterVersionService);
         const pipVersionPromise = interpreterVersion.getPipVersion('INVALID_INTERPRETER');
         await expect(pipVersionPromise).to.be.rejectedWith();


### PR DESCRIPTION
- change the download version to latest build
- change the name of the executable bit of the LS

Fixes #2233

- [x] Title summarizes what is changing
- [x] Unnecessary. ~Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [x] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [x] `package-lock.json` has been regenerated if dependencies have changed
