### PR TITLE
Ensure workspace `pipenv` environment is not labeled as a `virtual env`

### DIFF
--- a/news/2 Fixes/2223.md
+++ b/news/2 Fixes/2223.md
@@ -1,0 +1,1 @@
+Ensure workspace `pipenv` environment is not labeled as a `virtual env`. 

--- a/src/client/common/installer/pythonInstallation.ts
+++ b/src/client/common/installer/pythonInstallation.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { IInterpreterLocatorService, IInterpreterService, INTERPRETER_LOCATOR_SERVICE, InterpreterType } from '../../interpreter/contracts';
+import { IInterpreterHelper, IInterpreterLocatorService, IInterpreterService, INTERPRETER_LOCATOR_SERVICE, InterpreterType } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { IApplicationShell } from '../application/types';
 import { IPlatformService } from '../platform/types';
@@ -24,8 +24,9 @@ export class PythonInstaller {
         const interpreters = await this.locator.getInterpreters();
         if (interpreters.length > 0) {
             const platform = this.serviceContainer.get<IPlatformService>(IPlatformService);
-            const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
-            if (platform.isMac && interpreterService.isMacDefaultPythonPath(settings.pythonPath)) {
+            const helper = this.serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
+            if (platform.isMac && helper.isMacDefaultPythonPath(settings.pythonPath)) {
+                const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
                 const interpreter = await interpreterService.getActiveInterpreter();
                 if (interpreter && interpreter.type === InterpreterType.Unknown) {
                     await this.shell.showWarningMessage('Selected interpreter is macOS system Python which is not recommended. Please select different interpreter');

--- a/src/client/common/installer/pythonInstallation.ts
+++ b/src/client/common/installer/pythonInstallation.ts
@@ -3,7 +3,6 @@
 'use strict';
 
 import { IInterpreterLocatorService, IInterpreterService, INTERPRETER_LOCATOR_SERVICE, InterpreterType } from '../../interpreter/contracts';
-import { isMacDefaultPythonPath } from '../../interpreter/locators/helpers';
 import { IServiceContainer } from '../../ioc/types';
 import { IApplicationShell } from '../application/types';
 import { IPlatformService } from '../platform/types';
@@ -25,8 +24,8 @@ export class PythonInstaller {
         const interpreters = await this.locator.getInterpreters();
         if (interpreters.length > 0) {
             const platform = this.serviceContainer.get<IPlatformService>(IPlatformService);
-            if (platform.isMac && isMacDefaultPythonPath(settings.pythonPath)) {
-                const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
+            const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
+            if (platform.isMac && interpreterService.isMacDefaultPythonPath(settings.pythonPath)) {
                 const interpreter = await interpreterService.getActiveInterpreter();
                 if (interpreter && interpreter.type === InterpreterType.Unknown) {
                     await this.shell.showWarningMessage('Selected interpreter is macOS system Python which is not recommended. Please select different interpreter');

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -78,9 +78,10 @@ export interface IInterpreterService {
     getInterpreters(resource?: Uri): Promise<PythonInterpreter[]>;
     autoSetInterpreter(): Promise<void>;
     getActiveInterpreter(resource?: Uri): Promise<PythonInterpreter | undefined>;
-    getInterpreterDetails(pythonPath: string): Promise<Partial<PythonInterpreter>>;
+    getInterpreterDetails(pythonPath: string): Promise<undefined | Partial<PythonInterpreter>>;
     refresh(): Promise<void>;
     initialize(): void;
+    isMacDefaultPythonPath(pythonPath: string): Boolean;
 }
 
 export const IInterpreterDisplay = Symbol('IInterpreterDisplay');
@@ -102,4 +103,9 @@ export interface IInterpreterHelper {
 export const IPipEnvService = Symbol('IPipEnvService');
 export interface IPipEnvService {
     isRelatedPipEnvironment(dir: string, pythonPath: string): Promise<boolean>;
+}
+
+export const IInterpreterLocatorHelper = Symbol('IInterpreterLocatorHelper');
+export interface IInterpreterLocatorHelper {
+    mergeInterpreters(interpreters: PythonInterpreter[]): PythonInterpreter[];
 }

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -81,7 +81,6 @@ export interface IInterpreterService {
     getInterpreterDetails(pythonPath: string): Promise<undefined | Partial<PythonInterpreter>>;
     refresh(): Promise<void>;
     initialize(): void;
-    isMacDefaultPythonPath(pythonPath: string): Boolean;
 }
 
 export const IInterpreterDisplay = Symbol('IInterpreterDisplay');
@@ -98,6 +97,7 @@ export const IInterpreterHelper = Symbol('IInterpreterHelper');
 export interface IInterpreterHelper {
     getActiveWorkspaceUri(): WorkspacePythonPath | undefined;
     getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonInterpreter>>;
+    isMacDefaultPythonPath(pythonPath: string): Boolean;
 }
 
 export const IPipEnvService = Symbol('IPipEnvService');

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -129,10 +129,6 @@ export class InterpreterService implements Disposable, IInterpreterService {
             type: type
         };
     }
-    public isMacDefaultPythonPath(pythonPath: string) {
-        return pythonPath === 'python' || pythonPath === '/usr/bin/python';
-    }
-
     private async shouldAutoSetInterpreter(): Promise<boolean> {
         const activeWorkspace = this.helper.getActiveWorkspaceUri();
         if (!activeWorkspace) {

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -53,7 +53,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
         if (!activeWorkspace) {
             return;
         }
-        // Check pipenv first
+        // Check pipenv first.
         const pipenvService = this.serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, PIPENV_SERVICE);
         let interpreters = await pipenvService.getInterpreters(activeWorkspace.folderUri);
         if (interpreters.length > 0) {
@@ -102,7 +102,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
         return this.getInterpreterDetails(fullyQualifiedPath, resource);
     }
-    public async getInterpreterDetails(pythonPath: string, resource?: Uri): Promise<PythonInterpreter> {
+    public async getInterpreterDetails(pythonPath: string, resource?: Uri): Promise<PythonInterpreter | undefined> {
         const interpreters = await this.getInterpreters(resource);
         const interpreter = interpreters.find(i => utils.arePathsSame(i.path, pythonPath));
 
@@ -116,7 +116,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
             virtualEnvManager.getEnvironmentName(pythonPath),
             virtualEnvManager.getEnvironmentType(pythonPath)
         ]);
-        if (details) {
+        if (!details) {
             return;
         }
         const dislayNameSuffix = virtualEnvName.length > 0 ? ` (${virtualEnvName})` : '';
@@ -129,6 +129,10 @@ export class InterpreterService implements Disposable, IInterpreterService {
             type: type
         };
     }
+    public isMacDefaultPythonPath(pythonPath: string) {
+        return pythonPath === 'python' || pythonPath === '/usr/bin/python';
+    }
+
     private async shouldAutoSetInterpreter(): Promise<boolean> {
         const activeWorkspace = this.helper.getActiveWorkspaceUri();
         if (!activeWorkspace) {

--- a/src/client/interpreter/locators/helpers.ts
+++ b/src/client/interpreter/locators/helpers.ts
@@ -4,7 +4,7 @@ import { getArchitectureDislayName } from '../../common/platform/registry';
 import { IFileSystem, IPlatformService } from '../../common/platform/types';
 import { fsReaddirAsync, IS_WINDOWS } from '../../common/utils';
 import { IServiceContainer } from '../../ioc/types';
-import { IInterpreterLocatorHelper, IInterpreterService, InterpreterType, PythonInterpreter } from '../contracts';
+import { IInterpreterHelper, IInterpreterLocatorHelper, InterpreterType, PythonInterpreter } from '../contracts';
 
 const CheckPythonInterpreterRegEx = IS_WINDOWS ? /^python(\d+(.\d+)?)?\.exe$/ : /^python(\d+(.\d+)?)?$/;
 
@@ -30,11 +30,11 @@ export function fixInterpreterDisplayName(item: PythonInterpreter) {
 export class InterpreterLocatorHelper implements IInterpreterLocatorHelper {
     private readonly platform: IPlatformService;
     private readonly fs: IFileSystem;
-    private readonly interpreterService: IInterpreterService;
+    private readonly helper: IInterpreterHelper;
 
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.platform = serviceContainer.get<IPlatformService>(IPlatformService);
-        this.interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
+        this.helper = serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
         this.fs = serviceContainer.get<IFileSystem>(IFileSystem);
     }
     public mergeInterpreters(interpreters: PythonInterpreter[]) {
@@ -43,7 +43,7 @@ export class InterpreterLocatorHelper implements IInterpreterLocatorHelper {
             .map(fixInterpreterDisplayName)
             .map(item => { item.path = path.normalize(item.path); return item; })
             .reduce<PythonInterpreter[]>((accumulator, current) => {
-                if (this.platform.isMac && this.interpreterService.isMacDefaultPythonPath(current.path)) {
+                if (this.platform.isMac && this.helper.isMacDefaultPythonPath(current.path)) {
                     return accumulator;
                 }
                 const currentVersion = Array.isArray(current.version_info) ? current.version_info.join('.') : undefined;

--- a/src/client/interpreter/locators/helpers.ts
+++ b/src/client/interpreter/locators/helpers.ts
@@ -1,7 +1,10 @@
+import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { getArchitectureDislayName } from '../../common/platform/registry';
+import { IFileSystem, IPlatformService } from '../../common/platform/types';
 import { fsReaddirAsync, IS_WINDOWS } from '../../common/utils';
-import { PythonInterpreter } from '../contracts';
+import { IServiceContainer } from '../../ioc/types';
+import { IInterpreterLocatorHelper, IInterpreterService, InterpreterType, PythonInterpreter } from '../contracts';
 
 const CheckPythonInterpreterRegEx = IS_WINDOWS ? /^python(\d+(.\d+)?)?\.exe$/ : /^python(\d+(.\d+)?)?$/;
 
@@ -23,7 +26,50 @@ export function fixInterpreterDisplayName(item: PythonInterpreter) {
     }
     return item;
 }
+@injectable()
+export class InterpreterLocatorHelper implements IInterpreterLocatorHelper {
+    private readonly platform: IPlatformService;
+    private readonly fs: IFileSystem;
+    private readonly interpreterService: IInterpreterService;
 
-export function isMacDefaultPythonPath(p: string) {
-    return p === 'python' || p === '/usr/bin/python';
+    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        this.platform = serviceContainer.get<IPlatformService>(IPlatformService);
+        this.interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
+        this.fs = serviceContainer.get<IFileSystem>(IFileSystem);
+    }
+    public mergeInterpreters(interpreters: PythonInterpreter[]) {
+        return interpreters
+            .map(item => { return { ...item }; })
+            .map(fixInterpreterDisplayName)
+            .map(item => { item.path = path.normalize(item.path); return item; })
+            .reduce<PythonInterpreter[]>((accumulator, current) => {
+                if (this.platform.isMac && this.interpreterService.isMacDefaultPythonPath(current.path)) {
+                    return accumulator;
+                }
+                const currentVersion = Array.isArray(current.version_info) ? current.version_info.join('.') : undefined;
+                const existingItem = accumulator.find(item => {
+                    if (this.fs.arePathsSame(item.path, current.path)) {
+                        return true;
+                    }
+                    // If same version and same base path, then ignore.
+                    // Could be Python 3.6 with path = python.exe, and Python 3.6 and path = python3.exe.
+                    if (Array.isArray(item.version_info) && item.version_info.join('.') === currentVersion &&
+                        item.path && current.path &&
+                        this.fs.arePathsSame(path.basename(item.path), path.basename(current.path))) {
+                        return true;
+                    }
+                    return false;
+                });
+                if (!existingItem) {
+                    accumulator.push(current);
+                } else {
+                    // Preserve type information.
+                    // Possible we identified environment as unknown, but a later provider has identified env type.
+                    if (existingItem.type === InterpreterType.Unknown && current.type !== InterpreterType.Unknown) {
+                        existingItem.type = current.type;
+                    }
+                }
+                return accumulator;
+            }, []);
+    }
 }

--- a/src/client/interpreter/locators/helpers.ts
+++ b/src/client/interpreter/locators/helpers.ts
@@ -48,14 +48,11 @@ export class InterpreterLocatorHelper implements IInterpreterLocatorHelper {
                 }
                 const currentVersion = Array.isArray(current.version_info) ? current.version_info.join('.') : undefined;
                 const existingItem = accumulator.find(item => {
-                    if (this.fs.arePathsSame(item.path, current.path)) {
-                        return true;
-                    }
                     // If same version and same base path, then ignore.
                     // Could be Python 3.6 with path = python.exe, and Python 3.6 and path = python3.exe.
                     if (Array.isArray(item.version_info) && item.version_info.join('.') === currentVersion &&
                         item.path && current.path &&
-                        this.fs.arePathsSame(path.basename(item.path), path.basename(current.path))) {
+                        this.fs.arePathsSame(path.dirname(item.path), path.dirname(current.path))) {
                         return true;
                     }
                     return false;

--- a/src/client/interpreter/locators/services/currentPathService.ts
+++ b/src/client/interpreter/locators/services/currentPathService.ts
@@ -35,9 +35,10 @@ export class CurrentPathService extends CacheableLocatorService {
             .then(listOfInterpreters => _.flatten(listOfInterpreters))
             .then(interpreters => interpreters.filter(item => item.length > 0))
             // tslint:disable-next-line:promise-function-async
-            .then(interpreters => Promise.all(interpreters.map(interpreter => this.getInterpreterDetails(interpreter, resource))));
+            .then(interpreters => Promise.all(interpreters.map(interpreter => this.getInterpreterDetails(interpreter, resource))))
+            .then(interpreters => interpreters.filter(item => !!item).map(item => item!));
     }
-    private async getInterpreterDetails(interpreter: string, resource?: Uri): Promise<PythonInterpreter> {
+    private async getInterpreterDetails(interpreter: string, resource?: Uri): Promise<PythonInterpreter | undefined> {
         return Promise.all([
             this.helper.getInterpreterInformation(interpreter),
             this.virtualEnvMgr.getEnvironmentName(interpreter),

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -15,6 +15,7 @@ import {
     ICondaService,
     IInterpreterDisplay,
     IInterpreterHelper,
+    IInterpreterLocatorHelper,
     IInterpreterLocatorService,
     IInterpreterService,
     IInterpreterVersionService,
@@ -33,6 +34,7 @@ import { ShebangCodeLensProvider } from './display/shebangCodeLensProvider';
 import { InterpreterHelper } from './helpers';
 import { InterpreterService } from './interpreterService';
 import { InterpreterVersionService } from './interpreterVersion';
+import { InterpreterLocatorHelper } from './locators/helpers';
 import { PythonInterpreterLocatorService } from './locators/index';
 import { CondaEnvFileService } from './locators/services/condaEnvFileService';
 import { CondaEnvService } from './locators/services/condaEnvService';
@@ -79,4 +81,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IInterpreterSelector>(IInterpreterSelector, InterpreterSelector);
     serviceManager.addSingleton<IShebangCodeLensProvider>(IShebangCodeLensProvider, ShebangCodeLensProvider);
     serviceManager.addSingleton<IInterpreterHelper>(IInterpreterHelper, InterpreterHelper);
+    serviceManager.addSingleton<IInterpreterLocatorHelper>(IInterpreterLocatorHelper, InterpreterLocatorHelper);
 }

--- a/src/test/configuration/interpreterSelector.unit.test.ts
+++ b/src/test/configuration/interpreterSelector.unit.test.ts
@@ -80,8 +80,6 @@ suite('Interpreters - selector', () => {
         const initial: PythonInterpreter[] = [
             { displayName: '1', path: 'c:/path1/path1', type: InterpreterType.Unknown },
             { displayName: '2', path: 'c:/path1/path1', type: InterpreterType.Unknown },
-            { displayName: '1', path: 'c:/path1/path1', type: InterpreterType.Unknown },
-            { displayName: '2', path: 'c:/path2/path2', type: InterpreterType.Unknown },
             { displayName: '2', path: 'c:/path2/path2', type: InterpreterType.Unknown },
             { displayName: '2 (virtualenv)', path: 'c:/path2/path2', type: InterpreterType.VirtualEnv },
             { displayName: '3', path: 'c:/path2/path2', type: InterpreterType.Unknown },

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { workspace } from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
-// import { IS_APPVEYOR, IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
-//     IS_TRAVIS, IS_VSTS, MOCHA_CI_PROPERTIES, MOCHA_CI_REPORTFILE,
-//     MOCHA_REPORTER_JUNIT } from './ciConstants';
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER, IS_TRAVIS } from './ciConstants';
 
 export const TEST_TIMEOUT = 25000;
@@ -14,11 +10,10 @@ export const IS_MULTI_ROOT_TEST = isMultitrootTest();
 // If running on CI server, then run debugger tests ONLY if the corresponding flag is enabled.
 export const TEST_DEBUGGER = IS_CI_SERVER ? IS_CI_SERVER_TEST_DEBUGGER : true;
 
-// export { IS_APPVEYOR, IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER,
-//     IS_TRAVIS, IS_VSTS, MOCHA_CI_PROPERTIES, MOCHA_CI_REPORTFILE,
-//     MOCHA_REPORTER_JUNIT };
-
 function isMultitrootTest() {
+    // tslint:disable-next-line:no-require-imports
+    const vscode = require('vscode');
+    const workspace = vscode.workspace;
     return Array.isArray(workspace.workspaceFolders) && workspace.workspaceFolders.length > 1;
 }
 

--- a/src/test/install/pythonInstallation.test.ts
+++ b/src/test/install/pythonInstallation.test.ts
@@ -7,9 +7,10 @@ import { Container } from 'inversify';
 import * as TypeMoq from 'typemoq';
 import { IApplicationShell } from '../../client/common/application/types';
 import { PythonInstaller } from '../../client/common/installer/pythonInstallation';
-import { Architecture, IPlatformService } from '../../client/common/platform/types';
-import { IPythonSettings } from '../../client/common/types';
-import { IInterpreterLocatorService, IInterpreterService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
+import { Architecture, IFileSystem, IPlatformService } from '../../client/common/platform/types';
+import { IPersistentStateFactory, IPythonSettings } from '../../client/common/types';
+import { IInterpreterHelper, IInterpreterLocatorService, IInterpreterService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
+import { InterpreterHelper } from '../../client/interpreter/helpers';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -56,7 +57,10 @@ class TestContext {
         interpreterService
             .setup(x => x.getActiveInterpreter(TypeMoq.It.isAny()))
             .returns(() => new Promise<PythonInterpreter>((resolve, reject) => resolve(activeInterpreter)));
-
+        const helper = new InterpreterHelper(this.serviceContainer);
+        this.serviceManager.addSingletonInstance<IFileSystem>(IFileSystem, TypeMoq.Mock.ofType<IFileSystem>().object);
+        this.serviceManager.addSingletonInstance<IPersistentStateFactory>(IPersistentStateFactory, TypeMoq.Mock.ofType<IPersistentStateFactory>().object);
+        this.serviceManager.addSingletonInstance<IInterpreterHelper>(IInterpreterHelper, helper);
         this.serviceManager.addSingletonInstance<IPlatformService>(IPlatformService, this.platform.object);
         this.serviceManager.addSingletonInstance<IApplicationShell>(IApplicationShell, this.appShell.object);
         this.serviceManager.addSingletonInstance<IInterpreterLocatorService>(IInterpreterLocatorService, this.locator.object);

--- a/src/test/install/pythonInstallation.unit.test.ts
+++ b/src/test/install/pythonInstallation.unit.test.ts
@@ -14,7 +14,6 @@ import { InterpreterHelper } from '../../client/interpreter/helpers';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../client/ioc/types';
-import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 
 const info: PythonInterpreter = {
     architecture: Architecture.Unknown,
@@ -57,9 +56,9 @@ class TestContext {
         interpreterService
             .setup(x => x.getActiveInterpreter(TypeMoq.It.isAny()))
             .returns(() => new Promise<PythonInterpreter>((resolve, reject) => resolve(activeInterpreter)));
-        const helper = new InterpreterHelper(this.serviceContainer);
         this.serviceManager.addSingletonInstance<IFileSystem>(IFileSystem, TypeMoq.Mock.ofType<IFileSystem>().object);
         this.serviceManager.addSingletonInstance<IPersistentStateFactory>(IPersistentStateFactory, TypeMoq.Mock.ofType<IPersistentStateFactory>().object);
+        const helper = new InterpreterHelper(this.serviceContainer);
         this.serviceManager.addSingletonInstance<IInterpreterHelper>(IInterpreterHelper, helper);
         this.serviceManager.addSingletonInstance<IPlatformService>(IPlatformService, this.platform.object);
         this.serviceManager.addSingletonInstance<IApplicationShell>(IApplicationShell, this.appShell.object);
@@ -74,13 +73,6 @@ class TestContext {
 
 // tslint:disable-next-line:max-func-body-length
 suite('Installation', () => {
-    suiteSetup(async () => {
-        await initialize();
-    });
-    setup(initializeTest);
-    suiteTeardown(closeActiveWindows);
-    teardown(closeActiveWindows);
-
     test('Disable checks', async () => {
         const c = new TestContext(false);
         let showErrorMessageCalled = false;

--- a/src/test/interpreters/locators/helpers.unit.test.ts
+++ b/src/test/interpreters/locators/helpers.unit.test.ts
@@ -11,7 +11,7 @@ import * as TypeMoq from 'typemoq';
 import { EnumEx } from '../../../client/common/enumUtils';
 import { Architecture, IFileSystem, IPlatformService } from '../../../client/common/platform/types';
 import { PythonVersionInfo } from '../../../client/common/process/types';
-import { IInterpreterLocatorHelper, IInterpreterService, InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
+import { IInterpreterHelper, IInterpreterLocatorHelper, InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
 import { InterpreterLocatorHelper } from '../../../client/interpreter/locators/helpers';
 import { IServiceContainer } from '../../../client/ioc/types';
 
@@ -26,15 +26,15 @@ suite('Interpreters - Locators Helper', () => {
     let platform: TypeMoq.IMock<IPlatformService>;
     let helper: IInterpreterLocatorHelper;
     let fs: TypeMoq.IMock<IFileSystem>;
-    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let interpreterServiceHelper: TypeMoq.IMock<IInterpreterHelper>;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         platform = TypeMoq.Mock.ofType<IPlatformService>();
         fs = TypeMoq.Mock.ofType<IFileSystem>();
-        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        interpreterServiceHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platform.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
-        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterService))).returns(() => interpreterService.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterHelper))).returns(() => interpreterServiceHelper.object);
 
         helper = new InterpreterLocatorHelper(serviceContainer.object);
     });
@@ -65,7 +65,7 @@ suite('Interpreters - Locators Helper', () => {
             interpreters.push(interpreter);
 
             // Treat 'mac' as as mac interpreter.
-            interpreterService
+            interpreterServiceHelper
                 .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isValue(interpreter.path)))
                 .returns(() => name === 'mac')
                 .verifiable(TypeMoq.Times.once());
@@ -75,7 +75,7 @@ suite('Interpreters - Locators Helper', () => {
 
         const items = helper.mergeInterpreters(interpreters);
 
-        interpreterService.verifyAll();
+        interpreterServiceHelper.verifyAll();
         platform.verifyAll();
         fs.verifyAll();
         expect(items).to.be.lengthOf(3);
@@ -83,7 +83,7 @@ suite('Interpreters - Locators Helper', () => {
     });
     EnumEx.getNamesAndValues<OS>(OS).forEach(os => {
         test(`Ensure duplicates are removed (same version and same interpreter directory on ${os.name})`, async () => {
-            interpreterService
+            interpreterServiceHelper
                 .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isAny()))
                 .returns(() => false);
             platform.setup(p => p.isWindows).returns(() => os.value === OS.Windows);
@@ -144,7 +144,7 @@ suite('Interpreters - Locators Helper', () => {
 
             const items = helper.mergeInterpreters(interpreters);
 
-            interpreterService.verifyAll();
+            interpreterServiceHelper.verifyAll();
             platform.verifyAll();
             fs.verifyAll();
             expect(items).to.be.lengthOf(expectedInterpreters.length);
@@ -153,7 +153,7 @@ suite('Interpreters - Locators Helper', () => {
     });
     EnumEx.getNamesAndValues<OS>(OS).forEach(os => {
         test(`Ensure interpreter types are identified from other locators (${os.name})`, async () => {
-            interpreterService
+            interpreterServiceHelper
                 .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isAny()))
                 .returns(() => false);
             platform.setup(p => p.isWindows).returns(() => os.value === OS.Windows);
@@ -189,7 +189,7 @@ suite('Interpreters - Locators Helper', () => {
 
             const items = helper.mergeInterpreters(interpreters);
 
-            interpreterService.verifyAll();
+            interpreterServiceHelper.verifyAll();
             platform.verifyAll();
             fs.verifyAll();
             expect(items).to.be.lengthOf(1);

--- a/src/test/interpreters/locators/helpers.unit.test.ts
+++ b/src/test/interpreters/locators/helpers.unit.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as TypeMoq from 'typemoq';
+import { EnumEx } from '../../../client/common/enumUtils';
+import { Architecture, IFileSystem, IPlatformService } from '../../../client/common/platform/types';
+import { PythonVersionInfo } from '../../../client/common/process/types';
+import { IInterpreterLocatorHelper, IInterpreterService, InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
+import { InterpreterLocatorHelper } from '../../../client/interpreter/locators/helpers';
+import { IServiceContainer } from '../../../client/ioc/types';
+
+enum OS {
+    Windows = 'Windows',
+    Linux = 'Linux',
+    Mac = 'Mac'
+}
+
+suite('Interpreters - Locators Helper', () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let platform: TypeMoq.IMock<IPlatformService>;
+    let helper: IInterpreterLocatorHelper;
+    let fs: TypeMoq.IMock<IFileSystem>;
+    let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        platform = TypeMoq.Mock.ofType<IPlatformService>();
+        fs = TypeMoq.Mock.ofType<IFileSystem>();
+        interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platform.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterService))).returns(() => interpreterService.object);
+
+        helper = new InterpreterLocatorHelper(serviceContainer.object);
+    });
+    test('Ensure default Mac interpreters are excluded from the list of interpreters', async () => {
+        platform.setup(p => p.isWindows).returns(() => false);
+        platform.setup(p => p.isLinux).returns(() => false);
+        platform
+            .setup(p => p.isMac).returns(() => true)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+        fs
+            .setup(f => f.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => false)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+
+        const interpreters: PythonInterpreter[] = [];
+        const macInterpreterPath = path.join('users', 'python', 'bin', 'mac');
+        ['conda', 'virtualenv', 'mac', 'pyenv'].forEach(name => {
+            const interpreter = {
+                architecture: Architecture.Unknown,
+                displayName: name,
+                path: path.join('users', 'python', 'bin', name),
+                sysPrefix: name,
+                sysVersion: name,
+                type: InterpreterType.Unknown,
+                version: name,
+                version_info: [0, 0, 0, 'alpha'] as PythonVersionInfo
+            };
+            interpreters.push(interpreter);
+
+            // Treat 'mac' as as mac interpreter.
+            interpreterService
+                .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isValue(interpreter.path)))
+                .returns(() => name === 'mac')
+                .verifiable(TypeMoq.Times.once());
+        });
+
+        const expectedInterpreters = interpreters.filter(item => item.path !== macInterpreterPath);
+
+        const items = helper.mergeInterpreters(interpreters);
+
+        interpreterService.verifyAll();
+        platform.verifyAll();
+        fs.verifyAll();
+        expect(items).to.be.lengthOf(3);
+        expect(items).to.be.deep.equal(expectedInterpreters);
+    });
+    EnumEx.getNamesAndValues<OS>(OS).forEach(os => {
+        test(`Ensure duplicates are removed (same version and same interpreter directory on ${os.name})`, async () => {
+            interpreterService
+                .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isAny()))
+                .returns(() => false);
+            platform.setup(p => p.isWindows).returns(() => os.value === OS.Windows);
+            platform.setup(p => p.isLinux).returns(() => os.value === OS.Linux);
+            platform.setup(p => p.isMac).returns(() => os.value === OS.Mac);
+            fs
+                .setup(f => f.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns((a, b) => {
+                    if (a === b && a === path.join('users', 'python', 'bin', '3.6')) {
+                        return true;
+                    }
+                    if (a === b && a === path.join('users', 'python', 'bin', '3.7')) {
+                        return true;
+                    }
+                    return false;
+                })
+                .verifiable(TypeMoq.Times.atLeastOnce());
+
+            const interpreters: PythonInterpreter[] = [];
+            const expectedInterpreters: PythonInterpreter[] = [];
+            // Unique python paths and versions.
+            ['3.6', '3.6', '2.7', '2.7'].forEach((name, index) => {
+                const interpreter = {
+                    architecture: Architecture.Unknown,
+                    displayName: name,
+                    path: path.join('users', `python${name}`, 'bin', name + index.toString()),
+                    sysPrefix: name,
+                    sysVersion: name,
+                    type: InterpreterType.Unknown,
+                    version: name,
+                    version_info: [3, parseInt(name.substr(-1), 10), 0, 'final'] as PythonVersionInfo
+                };
+                interpreters.push(interpreter);
+                expectedInterpreters.push(interpreter);
+            });
+            // These are duplicates.
+            ['3.6', '3.6', '3.7', '3.7'].forEach((name, index) => {
+                const interpreter = {
+                    architecture: Architecture.Unknown,
+                    displayName: name,
+                    path: path.join('users', 'python', 'bin', 'python.exe'),
+                    sysPrefix: name,
+                    sysVersion: name,
+                    type: InterpreterType.Unknown,
+                    version: name,
+                    version_info: [3, parseInt(name.substr(-1), 10), 0, 'final'] as PythonVersionInfo
+                };
+
+                const duplicateInterpreter = {
+                    architecture: Architecture.Unknown,
+                    displayName: name,
+                    path: path.join('users', 'python', 'bin', `python${name}.exe`),
+                    sysPrefix: name,
+                    sysVersion: name,
+                    type: InterpreterType.Unknown,
+                    version: name,
+                    version_info: [3, parseInt(name.substr(-1), 10), 0, 'final'] as PythonVersionInfo
+                };
+
+                interpreters.push(duplicateInterpreter);
+                interpreters.push(interpreter);
+                if (index % 2 === 1) {
+                    expectedInterpreters.push(interpreter);
+                }
+            });
+            // // Same versions but in the same directory.
+            // ['3.6', '2.7'].forEach(name => {
+            //     const interpreter = {
+            //         architecture: Architecture.Unknown,
+            //         displayName: name,
+            //         path: path.join('users', 'python', 'bin', '3.7'),
+            //         sysPrefix: name,
+            //         sysVersion: name,
+            //         type: InterpreterType.Unknown,
+            //         version: name,
+            //         version_info: [2, 7, 0, 'final'] as PythonVersionInfo
+            //     };
+            //     interpreters.push(interpreter);
+            //     expectedInterpreters.push(interpreter);
+            // });
+
+            const items = helper.mergeInterpreters(interpreters);
+
+            interpreterService.verifyAll();
+            platform.verifyAll();
+            fs.verifyAll();
+            expect(items).to.be.lengthOf(expectedInterpreters.length);
+            expect(items).to.be.deep.equal(expectedInterpreters);
+        });
+    });
+});

--- a/src/test/interpreters/locators/index.unit.test.ts
+++ b/src/test/interpreters/locators/index.unit.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { Uri } from 'vscode';
+import { EnumEx } from '../../../client/common/enumUtils';
+import { Architecture, IPlatformService } from '../../../client/common/platform/types';
+import { IDisposableRegistry } from '../../../client/common/types';
+import { CONDA_ENV_FILE_SERVICE, CONDA_ENV_SERVICE, CURRENT_PATH_SERVICE, GLOBAL_VIRTUAL_ENV_SERVICE, IInterpreterLocatorHelper, IInterpreterLocatorService, InterpreterType, KNOWN_PATH_SERVICE, PIPENV_SERVICE, PythonInterpreter, WINDOWS_REGISTRY_SERVICE, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
+import { PythonInterpreterLocatorService } from '../../../client/interpreter/locators';
+import { IServiceContainer } from '../../../client/ioc/types';
+
+enum OS {
+    Windows, Linux, Mac
+}
+
+suite('Interpreters - Locators Index', () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let platform: TypeMoq.IMock<IPlatformService>;
+    let helper: TypeMoq.IMock<IInterpreterLocatorHelper>;
+    let locator: IInterpreterLocatorService;
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        platform = TypeMoq.Mock.ofType<IPlatformService>();
+        helper = TypeMoq.Mock.ofType<IInterpreterLocatorHelper>();
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => []);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platform.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterLocatorHelper))).returns(() => helper.object);
+
+        locator = new PythonInterpreterLocatorService(serviceContainer.object);
+    });
+    [undefined, Uri.file('Something')].forEach(resource => {
+        EnumEx.getNamesAndValues<OS>(OS).forEach(os => {
+            const testSuffix = `(on ${os.name}, with${resource ? '' : 'out'} a resource)`;
+            test(`All Interpreter Sources are used ${testSuffix}`, async () => {
+                const locatorsTypes: string[] = [];
+                if (os.value === OS.Windows) {
+                    locatorsTypes.push(WINDOWS_REGISTRY_SERVICE);
+                }
+                platform.setup(p => p.isWindows).returns(() => os.value === OS.Windows);
+                platform.setup(p => p.isLinux).returns(() => os.value === OS.Linux);
+                platform.setup(p => p.isMac).returns(() => os.value === OS.Mac);
+
+                locatorsTypes.push(CONDA_ENV_SERVICE);
+                locatorsTypes.push(CONDA_ENV_FILE_SERVICE);
+                locatorsTypes.push(PIPENV_SERVICE);
+                locatorsTypes.push(GLOBAL_VIRTUAL_ENV_SERVICE);
+                locatorsTypes.push(WORKSPACE_VIRTUAL_ENV_SERVICE);
+
+                if (os.value !== OS.Windows) {
+                    locatorsTypes.push(KNOWN_PATH_SERVICE);
+                }
+                locatorsTypes.push(CURRENT_PATH_SERVICE);
+
+                const locatorsWithInterpreters = locatorsTypes.map(typeName => {
+                    const interpreter: PythonInterpreter = {
+                        architecture: Architecture.Unknown,
+                        displayName: typeName,
+                        path: typeName,
+                        sysPrefix: typeName,
+                        sysVersion: typeName,
+                        type: InterpreterType.Unknown,
+                        version: typeName,
+                        version_info: [0, 0, 0, 'alpha']
+                    };
+
+                    const typeLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
+                    typeLocator
+                        .setup(l => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                        .returns(() => Promise.resolve([interpreter]))
+                        .verifiable(TypeMoq.Times.once());
+
+                    serviceContainer
+                        .setup(c => c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(typeName)))
+                        .returns(() => typeLocator.object);
+
+                    return {
+                        type: typeName,
+                        locator: typeLocator,
+                        interpreters: [interpreter]
+                    };
+                });
+
+                helper
+                    .setup(h => h.mergeInterpreters(TypeMoq.It.isAny()))
+                    .returns(() => locatorsWithInterpreters.map(item => item.interpreters[0]))
+                    .verifiable(TypeMoq.Times.once());
+
+                await locator.getInterpreters(resource);
+
+                locatorsWithInterpreters.forEach(item => item.locator.verifyAll());
+                helper.verifyAll();
+            });
+            test(`Interpreter Sources are sorted correctly and merged ${testSuffix}`, async () => {
+                const locatorsTypes: string[] = [];
+                if (os.value === OS.Windows) {
+                    locatorsTypes.push(WINDOWS_REGISTRY_SERVICE);
+                }
+                platform.setup(p => p.isWindows).returns(() => os.value === OS.Windows);
+                platform.setup(p => p.isLinux).returns(() => os.value === OS.Linux);
+                platform.setup(p => p.isMac).returns(() => os.value === OS.Mac);
+
+                locatorsTypes.push(CONDA_ENV_SERVICE);
+                locatorsTypes.push(CONDA_ENV_FILE_SERVICE);
+                locatorsTypes.push(PIPENV_SERVICE);
+                locatorsTypes.push(GLOBAL_VIRTUAL_ENV_SERVICE);
+                locatorsTypes.push(WORKSPACE_VIRTUAL_ENV_SERVICE);
+
+                if (os.value !== OS.Windows) {
+                    locatorsTypes.push(KNOWN_PATH_SERVICE);
+                }
+                locatorsTypes.push(CURRENT_PATH_SERVICE);
+
+                const locatorsWithInterpreters = locatorsTypes.map(typeName => {
+                    const interpreter: PythonInterpreter = {
+                        architecture: Architecture.Unknown,
+                        displayName: typeName,
+                        path: typeName,
+                        sysPrefix: typeName,
+                        sysVersion: typeName,
+                        type: InterpreterType.Unknown,
+                        version: typeName,
+                        version_info: [0, 0, 0, 'alpha']
+                    };
+
+                    const typeLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
+                    typeLocator
+                        .setup(l => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                        .returns(() => Promise.resolve([interpreter]))
+                        .verifiable(TypeMoq.Times.once());
+
+                    serviceContainer
+                        .setup(c => c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(typeName)))
+                        .returns(() => typeLocator.object);
+
+                    return {
+                        type: typeName,
+                        locator: typeLocator,
+                        interpreters: [interpreter]
+                    };
+                });
+
+                const expectedInterpreters = locatorsWithInterpreters.map(item => item.interpreters[0]);
+                helper
+                    .setup(h => h.mergeInterpreters(TypeMoq.It.isAny()))
+                    .returns(() => expectedInterpreters)
+                    .verifiable(TypeMoq.Times.once());
+
+                const interpreters = await locator.getInterpreters(resource);
+
+                locatorsWithInterpreters.forEach(item => item.locator.verifyAll());
+                helper.verifyAll();
+                expect(interpreters).to.be.lengthOf(locatorsTypes.length);
+                expect(interpreters).to.be.deep.equal(expectedInterpreters);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #2223

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
