### PR TITLE
Ensure callback function is bound to the right scope

### DIFF
--- a/news/2 Fixes/2281.md
+++ b/news/2 Fixes/2281.md
@@ -1,0 +1,1 @@
+Fix error when switching from new language server to the old `Jedi` language server.

--- a/src/client/activation/languageServer.ts
+++ b/src/client/activation/languageServer.ts
@@ -87,7 +87,7 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
 
         this.surveyBanner = services.get<IPythonExtensionBanner>(IPythonExtensionBanner, BANNER_NAME_LS_SURVEY);
 
-        (this.configuration.getSettings() as PythonSettings).addListener('change', this.onSettingsChanged);
+        (this.configuration.getSettings() as PythonSettings).addListener('change', this.onSettingsChanged.bind(this));
     }
 
     public async activate(): Promise<boolean> {
@@ -112,7 +112,7 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
         for (const d of this.disposables) {
             d.dispose();
         }
-        (this.configuration.getSettings() as PythonSettings).removeListener('change', this.onSettingsChanged);
+        (this.configuration.getSettings() as PythonSettings).removeListener('change', this.onSettingsChanged.bind(this));
     }
 
     private async startLanguageServer(clientOptions: LanguageClientOptions): Promise<boolean> {

--- a/src/client/unittests/pytest/services/argsService.ts
+++ b/src/client/unittests/pytest/services/argsService.ts
@@ -32,7 +32,7 @@ const OptionsWithoutArguments = ['--cache-clear', '--cache-show', '--collect-in-
     '--no-print-logs', '--noconftest', '--old-summary', '--pdb', '--pyargs', '-PyTest, Unittest-pyargs',
     '--quiet', '--runxfail', '--setup-only', '--setup-plan', '--setup-show', '--showlocals',
     '--strict', '--trace-config', '--verbose', '--version', '-h', '-l', '-q', '-s', '-v', '-x',
-    '--boxed', '--forked', '--looponfail', '--tx', '-d'];
+    '--boxed', '--forked', '--looponfail', '--trace', '--tx', '-d'];
 
 @injectable()
 export class ArgumentsService implements IArgumentsService {
@@ -92,7 +92,7 @@ export class ArgumentsService implements IArgumentsService {
                         '-l', '--showlocals',
                         '--no-print-logs',
                         '--debug',
-                        '--setup-only', '--setup-show', '--setup-plan'
+                        '--setup-only', '--setup-show', '--setup-plan', '--trace'
                     ]);
                     optionsWithArgsToRemove.push(...[
                         '-m', '--maxfail',
@@ -111,7 +111,7 @@ export class ArgumentsService implements IArgumentsService {
                 }
                 case TestFilter.debugAll:
                 case TestFilter.runAll: {
-                    optionsWithoutArgsToRemove.push('--collect-only');
+                    optionsWithoutArgsToRemove.push(...['--collect-only', '--trace']);
                     break;
                 }
                 case TestFilter.debugSpecific:
@@ -120,7 +120,8 @@ export class ArgumentsService implements IArgumentsService {
                         '--collect-only',
                         '--lf', '--last-failed',
                         '--ff', '--failed-first',
-                        '--nf', '--new-first'
+                        '--nf', '--new-first',
+                        '--trace'
                     ]);
                     optionsWithArgsToRemove.push(...[
                         '-k', '-m',


### PR DESCRIPTION
Fixes #2281

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
