### PR TITLE
Pin version of pylint to ensure pylint can be installed in python 2.7 on Travis

### DIFF
--- a/news/3 Code Health/2305.md
+++ b/news/3 Code Health/2305.md
@@ -1,0 +1,1 @@
+Pin version of `pylint` to `3.6.3` to allow ensure `pylint` gets installed on Travis with Pytnon2.7.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pep8
 prospector
 pydocstyle
 nose
-pytest
+pytest==3.6.3
 rope
 flask
 django


### PR DESCRIPTION
Fixes #2305

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
