### PR TITLE
Add support for breaking into the first line of code in the new debugger

### DIFF
--- a/news/2 Fixes/2299.md
+++ b/news/2 Fixes/2299.md
@@ -1,0 +1,1 @@
+Add support for breaking into the first line of code in the new debugger.

--- a/src/client/debugger/Common/Contracts.ts
+++ b/src/client/debugger/Common/Contracts.ts
@@ -43,7 +43,8 @@ export enum DebugOptions {
     Pyramid = 'Pyramid',
     FixFilePathCase = 'FixFilePathCase',
     WindowsClient = 'WindowsClient',
-    UnixClient = 'UnixClient'
+    UnixClient = 'UnixClient',
+    StopOnEntry = 'StopOnEntry'
 }
 
 export interface ExceptionHandling {
@@ -60,6 +61,7 @@ export interface AdditionalLaunchDebugOptions {
     debugStdLib?: boolean;
     sudo?: boolean;
     pyramid?: boolean;
+    stopOnEntry?: boolean;
 }
 
 export interface AdditionalAttachDebugOptions {

--- a/src/client/debugger/DebugClients/LocalDebugClient.ts
+++ b/src/client/debugger/DebugClients/LocalDebugClient.ts
@@ -2,6 +2,7 @@ import { ChildProcess, spawn } from 'child_process';
 import * as path from 'path';
 import { DebugSession, OutputEvent } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
+import { noop } from '../../common/core.utils';
 import { open } from '../../common/open';
 import { PathUtils } from '../../common/platform/pathUtils';
 import { CurrentProcess } from '../../common/process/currentProcess';
@@ -15,11 +16,11 @@ import { LocalDebugServerV2 } from '../DebugServers/LocalDebugServerV2';
 import { IDebugLauncherScriptProvider } from '../types';
 import { DebugClient, DebugType } from './DebugClient';
 import { DebugClientHelper } from './helper';
-import { noop } from '../../common/core.utils';
 
 const VALID_DEBUG_OPTIONS = [
     'RedirectOutput',
     'DebugStdLib',
+    'stopOnEntry',
     'BreakOnSystemExitZero',
     'DjangoDebugging',
     'Django'];

--- a/src/client/debugger/configProviders/pythonV2Provider.ts
+++ b/src/client/debugger/configProviders/pythonV2Provider.ts
@@ -25,6 +25,9 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
         if (debugConfiguration.debugStdLib) {
             this.debugOption(debugOptions, DebugOptions.DebugStdLib);
         }
+        if (debugConfiguration.stopOnEntry) {
+            this.debugOption(debugOptions, DebugOptions.StopOnEntry);
+        }
         if (debugConfiguration.django) {
             this.debugOption(debugOptions, DebugOptions.Django);
         }


### PR DESCRIPTION
Fixes #2299

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
