### PR TITLE
Launch flask in a debug environment with the Flask debug mode disabled

### DIFF
--- a/news/2 Fixes/2309.md
+++ b/news/2 Fixes/2309.md
@@ -1,0 +1,3 @@
+Ensure Flask debug configuration launches flask in a debug environment with the Flask debug mode disabled.
+This is necessary to ensure the custom debugger takes precedence over the interactive debugger, and live reloading is disabled.
+http://flask.pocoo.org/docs/1.0/api/#flask.Flask.debug

--- a/package.json
+++ b/package.json
@@ -348,7 +348,9 @@
                             "request": "launch",
                             "module": "flask",
                             "env": {
-                                "FLASK_APP": "app.py"
+                                "FLASK_APP": "app.py",
+                                "FLASK_ENV": "development",
+                                "FLASK_DEBUG": "0"
                             },
                             "args": [
                                 "run",


### PR DESCRIPTION
Fixes #2309

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [n/a] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [n/a] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [n/a] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [n/a] `package-lock.json` has been regenerated if dependencies have changed
