### PR TITLE
Ensure default browser is launched on Windows for survey/information popups.

### DIFF
--- a/news/2 Fixes/2252.md
+++ b/news/2 Fixes/2252.md
@@ -1,0 +1,1 @@
+﻿Fix issue with survey not opening in a browser for Windows users.

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -8,8 +8,7 @@ import { inject, injectable } from 'inversify';
 import { Disposable } from 'vscode';
 import { IApplicationEnvironment, IApplicationShell, IDebugService } from '../common/application/types';
 import '../common/extensions';
-import { IBrowserService, IDisposableRegistry,
-    ILogger, IPersistentStateFactory } from '../common/types';
+import { IDisposableRegistry, ILogger, IPersistentStateFactory } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { DebuggerTypeName } from './Common/constants';
 import { IExperimentalDebuggerBanner } from './types';
@@ -86,8 +85,8 @@ export class ExperimentalDebuggerBanner implements IExperimentalDebuggerBanner {
     }
     public async launchSurvey(): Promise<void> {
         const debuggerLaunchCounter = await this.getGetDebuggerLaunchCounter();
-        const browser = this.serviceContainer.get<IBrowserService>(IBrowserService);
-        browser.launch(`https://www.research.net/r/N7B25RV?n=${debuggerLaunchCounter}`);
+        const appShell: IApplicationShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+        appShell.openUrl(`https://www.research.net/r/N7B25RV?n=${debuggerLaunchCounter}`);
     }
     private async incrementDebuggerLaunchCounter(): Promise<void> {
         const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);

--- a/src/client/languageServices/languageServerSurveyBanner.ts
+++ b/src/client/languageServices/languageServerSurveyBanner.ts
@@ -6,8 +6,7 @@
 import { inject, injectable } from 'inversify';
 import { IApplicationShell } from '../common/application/types';
 import '../common/extensions';
-import { IBrowserService, IPersistentStateFactory,
-    IPythonExtensionBanner } from '../common/types';
+import { IPersistentStateFactory, IPythonExtensionBanner } from '../common/types';
 import { getRandomBetween } from '../common/utils';
 
 // persistent state names, exported to make use of in testing
@@ -33,15 +32,13 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
     private maxCompletionsBeforeShow: number;
     private isInitialized: boolean = false;
     private bannerMessage: string = 'Can you please take 2 minutes to tell us how the Python Language Server is working for you?';
-    private bannerLabels: string [] = [ 'Yes, take survey now', 'No, thanks'];
+    private bannerLabels: string[] = ['Yes, take survey now', 'No, thanks'];
 
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private persistentState: IPersistentStateFactory,
-        @inject(IBrowserService) private browserService: IBrowserService,
         showAfterMinimumEventsCount: number = 100,
-        showBeforeMaximumEventsCount: number = 500)
-    {
+        showBeforeMaximumEventsCount: number = 500) {
         this.minCompletionsBeforeShow = showAfterMinimumEventsCount;
         this.maxCompletionsBeforeShow = showBeforeMaximumEventsCount;
         this.initialize();
@@ -105,7 +102,7 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
             return false;
         }
 
-        if (! launchCounter) {
+        if (!launchCounter) {
             launchCounter = await this.getPythonLSLaunchCounter();
         }
         const threshold: number = await this.getPythonLSLaunchThresholdCounter();
@@ -117,9 +114,13 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
         await this.persistentState.createGlobalPersistentState<boolean>(LSSurveyStateKeys.ShowBanner, false).updateValue(false);
     }
 
+    public async enable(): Promise<void> {
+        await this.persistentState.createGlobalPersistentState<boolean>(LSSurveyStateKeys.ShowBanner, true).updateValue(true);
+    }
+
     public async launchSurvey(): Promise<void> {
         const launchCounter = await this.getPythonLSLaunchCounter();
-        this.browserService.launch(`https://www.research.net/r/LJZV9BZ?n=${launchCounter}`);
+        this.appShell.openUrl(`https://www.research.net/r/LJZV9BZ?n=${launchCounter}`);
     }
 
     private async incrementPythonLanguageServiceLaunchCounter(): Promise<number> {

--- a/src/test/unittests/banners/languageServerSurvey.unit.test.ts
+++ b/src/test/unittests/banners/languageServerSurvey.unit.test.ts
@@ -8,13 +8,12 @@
 import { expect } from 'chai';
 import * as typemoq from 'typemoq';
 import { IApplicationShell } from '../../../client/common/application/types';
-import { IBrowserService, IConfigurationService, IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
+import { IConfigurationService, IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
 import { LanguageServerSurveyBanner, LSSurveyStateKeys } from '../../../client/languageServices/languageServerSurveyBanner';
 
 suite('Language Server Survey Banner', () => {
     let config: typemoq.IMock<IConfigurationService>;
     let appShell: typemoq.IMock<IApplicationShell>;
-    let browser: typemoq.IMock<IBrowserService>;
     const message = 'Can you please take 2 minutes to tell us how the Experimental Debugger is working for you?';
     const yes = 'Yes, take survey now';
     const no = 'No, thanks';
@@ -22,36 +21,35 @@ suite('Language Server Survey Banner', () => {
     setup(() => {
         config = typemoq.Mock.ofType<IConfigurationService>();
         appShell = typemoq.Mock.ofType<IApplicationShell>();
-        browser = typemoq.Mock.ofType<IBrowserService>();
     });
     test('Is debugger enabled upon creation?', () => {
         const enabledValue: boolean = true;
         const attemptCounter: number = 0;
         const completionsCount: number = 0;
-        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 100, appShell.object, browser.object);
+        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 100, appShell.object);
         expect(testBanner.enabled).to.be.equal(true, 'Sampling 100/100 should always enable the banner.');
     });
     test('Do not show banner when it is disabled', () => {
         appShell.setup(a => a.showInformationMessage(typemoq.It.isValue(message),
-                                                    typemoq.It.isValue(yes),
-                                                    typemoq.It.isValue(no)))
+            typemoq.It.isValue(yes),
+            typemoq.It.isValue(no)))
             .verifiable(typemoq.Times.never());
         const enabledValue: boolean = true;
         const attemptCounter: number = 0;
         const completionsCount: number = 0;
-        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object, browser.object);
+        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object);
         testBanner.showBanner().ignoreErrors();
     });
     test('shouldShowBanner must return false when Banner is implicitly disabled by sampling', () => {
         const enabledValue: boolean = true;
         const attemptCounter: number = 0;
         const completionsCount: number = 0;
-        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object, browser.object);
+        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object);
         expect(testBanner.enabled).to.be.equal(false, 'We implicitly disabled the banner, it should never show.');
     });
 });
 
-function preparePopup(attemptCounter: number, completionsCount: number, enabledValue: boolean, minCompletionCount: number, maxCompletionCount: number, appShell: IApplicationShell, browser: IBrowserService): LanguageServerSurveyBanner {
+function preparePopup(attemptCounter: number, completionsCount: number, enabledValue: boolean, minCompletionCount: number, maxCompletionCount: number, appShell: IApplicationShell): LanguageServerSurveyBanner {
     const myfactory: typemoq.IMock<IPersistentStateFactory> = typemoq.Mock.ofType<IPersistentStateFactory>();
     const enabledValState: typemoq.IMock<IPersistentState<boolean>> = typemoq.Mock.ofType<IPersistentState<boolean>>();
     const attemptCountState: typemoq.IMock<IPersistentState<number>> = typemoq.Mock.ofType<IPersistentState<number>>();
@@ -99,7 +97,6 @@ function preparePopup(attemptCounter: number, completionsCount: number, enabledV
     return new LanguageServerSurveyBanner(
         appShell,
         myfactory.object,
-        browser,
         minCompletionCount,
         maxCompletionCount);
 }


### PR DESCRIPTION
Fixes #2252 (using a URL with a query string launches windows file explorer, not the default browser).
- make use of appShell, which already has opn integrated
*Please see my other PR for an alternate, perhaps more simple fix.*

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)

Note: No tests for this PR, as the issue is with how the OS interprets the string we are sending. I am not positive how I can test that one!