### PR TITLE
Ensure default browser is launched on Windows for survey/information popups. [ALTERNATE]

### DIFF
--- a/news/2 Fixes/2252.md
+++ b/news/2 Fixes/2252.md
@@ -1,0 +1,1 @@
+﻿Fix issue with survey not opening in a browser for Windows users.

--- a/src/client/common/net/browser.ts
+++ b/src/client/common/net/browser.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-// tslint:disable:no-require-imports no-var-requires no-any unified-signatures
+// tslint:disable:no-require-imports no-var-requires
 const opn = require('opn');
 
 import { injectable } from 'inversify';

--- a/src/client/common/net/browser.ts
+++ b/src/client/common/net/browser.ts
@@ -1,30 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as child_process from 'child_process';
+'use strict';
+
+// tslint:disable:no-require-imports no-var-requires no-any unified-signatures
+const opn = require('opn');
+
 import { injectable } from 'inversify';
-import * as os from 'os';
 import { IBrowserService } from '../types';
 
 export function launch(url: string) {
-    let openCommand: string | undefined;
-    if (os.platform() === 'win32') {
-        openCommand = 'explorer';
-    } else if (os.platform() === 'darwin') {
-        openCommand = '/usr/bin/open';
-    } else {
-        openCommand = '/usr/bin/xdg-open';
-    }
-    if (!openCommand) {
-        console.error(`Unable to determine platform to launch the browser in the Python extension on platform '${os.platform()}'.`);
-        console.error(`Link is: ${url}`);
-    }
-    child_process.spawn(openCommand, [url]);
+    opn(url);
 }
 
 @injectable()
 export class BrowserService implements IBrowserService {
-    public launch(url: string): void{
+    public launch(url: string): void {
         launch(url);
     }
 }


### PR DESCRIPTION
Fixes #2252 (using a URL with a query string launches windows file explorer, not the default browser).
- Make use of `opn` within the `BrowserService`, fixing all potential uses across the extension.
*Please see my other PR #2358 for an alternate fix.*

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)

Note: No tests for this PR, as the issue is with how the OS interprets the string we are sending. I am not positive how I can test that one!

