### PR TITLE
Update the downloaded Python language server nuget package filename.

### DIFF
--- a/news/2 Fixes/2362.md
+++ b/news/2 Fixes/2362.md
@@ -1,0 +1,1 @@
+Update the downloaded Python language server nuget package filename to 'Python-Language-Server-{OSType}.beta.nupkg'.

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -20,7 +20,7 @@ const StreamZip = require('node-stream-zip');
 
 const downloadUriPrefix = 'https://pvsc.blob.core.windows.net/python-language-server';
 const downloadBaseFileName = 'Python-Language-Server';
-const downloadVersion = '0.1.18204.3';
+const downloadVersion = 'beta';
 const downloadFileExtension = '.nupkg';
 
 export const DownloadLinks = {


### PR DESCRIPTION
Fixes #2362

- Coincides with addition to CI/CD pipeline where we copy the latest bits to a static file name.
- We need to use a *specific name* so we can just download it simply (going forward another scheme will be employed).
- We want the bits to be updatable, easily, until we get to the release stage for the LS.

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
