### PR TITLE
Show the debugger survey banner for only a subset of users.

### DIFF
--- a/news/2 Fixes/2300.md
+++ b/news/2 Fixes/2300.md
@@ -1,0 +1,1 @@
+Show the debugger survey banner for only a subset of users.

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -27,8 +27,6 @@ export class DebuggerBannerConfig {
     public sampleSizePerHundred: number = 10;  // 10%
 }
 
-const defaultConfig = new DebuggerBannerConfig();
-
 @injectable()
 export class DebuggerBanner implements IDebuggerBanner {
     private initialized?: boolean;
@@ -36,7 +34,7 @@ export class DebuggerBanner implements IDebuggerBanner {
 
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
-        private config: DebuggerBannerConfig = defaultConfig,
+        private config: DebuggerBannerConfig = new DebuggerBannerConfig(),
         // The following is only used during testing and will not be
         // passed in normally (hence the underscore).
         _randInt: RandIntFunc = getRandomBetween)

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -37,18 +37,18 @@ export class DebuggerBanner implements IDebuggerBanner {
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
         private config: DebuggerBannerConfig = defaultConfig,
-        _randInt: RandIntFunc | null = getRandomBetween)
+        // The following is only used during testing and will not be
+        // passed in normally (hence the underscore).
+        _randInt: RandIntFunc = getRandomBetween)
     {
         if (!this.enabled) {
             return;
         }
 
-        if (_randInt !== null) {
-            // Only show the banner to a subset of users.  (see GH-2300)
-            const randomSample: number = _randInt(0, 100);
-            if (randomSample >= this.config.sampleSizePerHundred) {
-                this.disable().ignoreErrors();
-            }
+        // Only show the banner to a subset of users.  (see GH-2300)
+        const randomSample: number = _randInt(0, 100);
+        if (randomSample >= this.config.sampleSizePerHundred) {
+            this.disable().ignoreErrors();
         }
     }
 

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -62,10 +62,6 @@ export class DebuggerBanner implements IDebuggerBanner {
         }
     }
 
-    public async launchSurvey(): Promise<void> {
-        return this._action();
-    }
-
     // "enabled" state
 
     public get enabled(): boolean {
@@ -149,6 +145,7 @@ export class DebuggerBanner implements IDebuggerBanner {
 
     // debugger-specific functionality
 
+    // Launch the survey.
     private async _action(): Promise<void> {
         const debuggerLaunchCounter = await this.getGetDebuggerLaunchCounter();
         const browser = this.serviceContainer.get<IBrowserService>(IBrowserService);

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -21,10 +21,14 @@ export enum PersistentStateKeys {
     DebuggerLaunchThresholdCounter = 'DebuggerLaunchThresholdCounter'
 }
 
+type IsUserSelectedFunc = () => boolean;
 type RandIntFunc = (min: number, max: number) => number;
 
-export class DebuggerBannerConfig {
-    public sampleSizePerHundred: number = 10;  // 10%
+const sampleSizePerHundred: number = 10;  // 10%
+
+export function isUserSelected(randInt: RandIntFunc = getRandomBetween): boolean {
+    const randomSample: number = randInt(0, 100);
+    return randomSample < sampleSizePerHundred;
 }
 
 @injectable()
@@ -34,18 +38,16 @@ export class DebuggerBanner implements IDebuggerBanner {
 
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
-        private config: DebuggerBannerConfig = new DebuggerBannerConfig(),
         // The following is only used during testing and will not be
         // passed in normally (hence the underscore).
-        _randInt: RandIntFunc = getRandomBetween)
+        _isUserSelected: IsUserSelectedFunc = isUserSelected)
     {
         if (!this.enabled) {
             return;
         }
 
         // Only show the banner to a subset of users.  (see GH-2300)
-        const randomSample: number = _randInt(0, 100);
-        if (randomSample >= this.config.sampleSizePerHundred) {
+        if (!_isUserSelected()) {
             this.disable().ignoreErrors();
         }
     }

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -33,7 +33,7 @@ export function isUserSelected(state: IPersistentState<MaybeBool>, randInt: Rand
     if (selected === undefined) {
         const randomSample: number = randInt(0, 100);
         selected = randomSample < sampleSizePerHundred;
-        state.updateValue(selected);
+        state.updateValue(selected).ignoreErrors();
     }
     return selected;
 }
@@ -54,6 +54,9 @@ export class DebuggerBanner implements IDebuggerBanner {
         }
 
         // Only show the banner to a subset of users.  (see GH-2300)
+        // In order to avoid selecting the user *every* time they start
+        // the extension, we store their selection in the persistence
+        // layer.
         const persist = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         const key = PersistentStateKeys.DebuggerUserSelected;
         const state = persist.createGlobalPersistentState<MaybeBool>(key, undefined);

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -33,10 +33,7 @@ const defaultConfig = new DebuggerBannerConfig();
 export class DebuggerBanner implements IDebuggerBanner {
     private initialized?: boolean;
     private disabledInCurrentSession?: boolean;
-    public get enabled(): boolean {
-        const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
-        return factory.createGlobalPersistentState<boolean>(PersistentStateKeys.ShowBanner, true).value;
-    }
+
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
         @inject(DebuggerBannerConfig) private config: DebuggerBannerConfig = defaultConfig,
@@ -54,6 +51,7 @@ export class DebuggerBanner implements IDebuggerBanner {
             }
         }
     }
+
     public initialize() {
         if (this.initialized) {
             return;
@@ -64,17 +62,35 @@ export class DebuggerBanner implements IDebuggerBanner {
         if (!this.enabled) {
             return;
         }
-        const debuggerService = this.serviceContainer.get<IDebugService>(IDebugService);
-        const disposable = debuggerService.onDidTerminateDebugSession(async e => {
-            if (e.type === DebuggerTypeName) {
-                const logger = this.serviceContainer.get<ILogger>(ILogger);
-                await this.onDidTerminateDebugSession()
-                    .catch(ex => logger.logError('Error in debugger Banner', ex));
-            }
-        });
 
-        this.serviceContainer.get<Disposable[]>(IDisposableRegistry).push(disposable);
+        this._initialize();
     }
+
+    public async launchSurvey(): Promise<void> {
+        return this._action();
+    }
+
+    // "enabled" state
+
+    public get enabled(): boolean {
+        const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
+        return factory.createGlobalPersistentState<boolean>(PersistentStateKeys.ShowBanner, true).value;
+    }
+
+    public async disable(): Promise<void> {
+        const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
+        await factory.createGlobalPersistentState<boolean>(PersistentStateKeys.ShowBanner, false).updateValue(false);
+    }
+
+    // showing banner
+
+    public async shouldShowBanner(): Promise<boolean> {
+        if (!this.enabled || this.disabledInCurrentSession) {
+            return false;
+        }
+        return this.passedThreshold();
+    }
+
     public async showBanner(): Promise<void> {
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         const yes = 'Yes, take survey now';
@@ -83,7 +99,7 @@ export class DebuggerBanner implements IDebuggerBanner {
         switch (response) {
             case yes:
                 {
-                    await this.launchSurvey();
+                    await this._action();
                     await this.disable();
                     break;
                 }
@@ -97,33 +113,26 @@ export class DebuggerBanner implements IDebuggerBanner {
             }
         }
     }
-    public async shouldShowBanner(): Promise<boolean> {
-        if (!this.enabled || this.disabledInCurrentSession) {
-            return false;
-        }
+
+    // persistent counter
+
+    private async passedThreshold(): Promise<boolean> {
         const [threshold, debuggerCounter] = await Promise.all([this.getDebuggerLaunchThresholdCounter(), this.getGetDebuggerLaunchCounter()]);
         return debuggerCounter >= threshold;
     }
 
-    public async disable(): Promise<void> {
-        const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
-        await factory.createGlobalPersistentState<boolean>(PersistentStateKeys.ShowBanner, false).updateValue(false);
-    }
-    public async launchSurvey(): Promise<void> {
-        const debuggerLaunchCounter = await this.getGetDebuggerLaunchCounter();
-        const browser = this.serviceContainer.get<IBrowserService>(IBrowserService);
-        browser.launch(`https://www.research.net/r/N7B25RV?n=${debuggerLaunchCounter}`);
-    }
     private async incrementDebuggerLaunchCounter(): Promise<void> {
         const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         const state = factory.createGlobalPersistentState<number>(PersistentStateKeys.DebuggerLaunchCounter, 0);
         await state.updateValue(state.value + 1);
     }
+
     private async getGetDebuggerLaunchCounter(): Promise<number> {
         const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         const state = factory.createGlobalPersistentState<number>(PersistentStateKeys.DebuggerLaunchCounter, 0);
         return state.value;
     }
+
     private async getDebuggerLaunchThresholdCounter(): Promise<number> {
         const factory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         const state = factory.createGlobalPersistentState<number | undefined>(PersistentStateKeys.DebuggerLaunchThresholdCounter, undefined);
@@ -134,12 +143,34 @@ export class DebuggerBanner implements IDebuggerBanner {
         }
         return state.value!;
     }
+
     private getRandomHex() {
         const appEnv = this.serviceContainer.get<IApplicationEnvironment>(IApplicationEnvironment);
         const lastHexValue = appEnv.machineId.slice(-1);
         const num = parseInt(`0x${lastHexValue}`, 16);
         return isNaN(num) ? crypto.randomBytes(1).toString('hex').slice(-1) : lastHexValue;
     }
+
+    // debugger-specific functionality
+
+    private _initialize() {
+        const debuggerService = this.serviceContainer.get<IDebugService>(IDebugService);
+        const disposable = debuggerService.onDidTerminateDebugSession(async e => {
+            if (e.type === DebuggerTypeName) {
+                const logger = this.serviceContainer.get<ILogger>(ILogger);
+                await this.onDidTerminateDebugSession()
+                    .catch(ex => logger.logError('Error in debugger Banner', ex));
+            }
+        });
+        this.serviceContainer.get<Disposable[]>(IDisposableRegistry).push(disposable);
+    }
+
+    private async _action(): Promise<void> {
+        const debuggerLaunchCounter = await this.getGetDebuggerLaunchCounter();
+        const browser = this.serviceContainer.get<IBrowserService>(IBrowserService);
+        browser.launch(`https://www.research.net/r/N7B25RV?n=${debuggerLaunchCounter}`);
+    }
+
     private async onDidTerminateDebugSession(): Promise<void> {
         if (!this.enabled) {
             return;

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -12,7 +12,7 @@ import { IBrowserService, IDisposableRegistry,
     ILogger, IPersistentStateFactory } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { DebuggerTypeName } from './Common/constants';
-import { IExperimentalDebuggerBanner } from './types';
+import { IDebuggerBanner } from './types';
 
 export enum PersistentStateKeys {
     ShowBanner = 'ShowBanner',
@@ -21,7 +21,7 @@ export enum PersistentStateKeys {
 }
 
 @injectable()
-export class ExperimentalDebuggerBanner implements IExperimentalDebuggerBanner {
+export class DebuggerBanner implements IDebuggerBanner {
     private initialized?: boolean;
     private disabledInCurrentSession?: boolean;
     public get enabled(): boolean {

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -36,7 +36,7 @@ export class DebuggerBanner implements IDebuggerBanner {
 
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
-        @inject(DebuggerBannerConfig) private config: DebuggerBannerConfig = defaultConfig,
+        private config: DebuggerBannerConfig = defaultConfig,
         _randInt: RandIntFunc | null = getRandomBetween)
     {
         if (!this.enabled) {

--- a/src/client/debugger/banner.ts
+++ b/src/client/debugger/banner.ts
@@ -22,14 +22,13 @@ export enum PersistentStateKeys {
     DebuggerLaunchThresholdCounter = 'DebuggerLaunchThresholdCounter'
 }
 
-type MaybeBool = boolean | undefined;
-type IsUserSelectedFunc = (state: IPersistentState<MaybeBool>) => boolean;
+type IsUserSelectedFunc = (state: IPersistentState<boolean | undefined>) => boolean;
 type RandIntFunc = (min: number, max: number) => number;
 
 const sampleSizePerHundred: number = 10;  // 10%
 
-export function isUserSelected(state: IPersistentState<MaybeBool>, randInt: RandIntFunc = getRandomBetween): boolean {
-    let selected: MaybeBool = state.value;
+export function isUserSelected(state: IPersistentState<boolean | undefined>, randInt: RandIntFunc = getRandomBetween): boolean {
+    let selected = state.value;
     if (selected === undefined) {
         const randomSample: number = randInt(0, 100);
         selected = randomSample < sampleSizePerHundred;
@@ -59,7 +58,7 @@ export class DebuggerBanner implements IDebuggerBanner {
         // layer.
         const persist = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         const key = PersistentStateKeys.DebuggerUserSelected;
-        const state = persist.createGlobalPersistentState<MaybeBool>(key, undefined);
+        const state = persist.createGlobalPersistentState<boolean | undefined>(key, undefined);
         if (!_isUserSelected(state)) {
             this.disable().ignoreErrors();
         }

--- a/src/client/debugger/serviceRegistry.ts
+++ b/src/client/debugger/serviceRegistry.ts
@@ -13,12 +13,12 @@ import { ICurrentProcess, ISocketServer } from '../common/types';
 import { ServiceContainer } from '../ioc/container';
 import { ServiceManager } from '../ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
-import { ExperimentalDebuggerBanner } from './banner';
+import { DebuggerBanner } from './banner';
 import { DebugStreamProvider } from './Common/debugStreamProvider';
 import { ProtocolLogger } from './Common/protocolLogger';
 import { ProtocolParser } from './Common/protocolParser';
 import { ProtocolMessageWriter } from './Common/protocolWriter';
-import { IDebugStreamProvider, IExperimentalDebuggerBanner, IProtocolLogger, IProtocolMessageWriter, IProtocolParser } from './types';
+import { IDebuggerBanner, IDebugStreamProvider, IProtocolLogger, IProtocolMessageWriter, IProtocolParser } from './types';
 
 export function initializeIoc(): IServiceContainer {
     const cont = new Container();
@@ -41,5 +41,5 @@ function registerDebuggerTypes(serviceManager: IServiceManager) {
 }
 
 export function registerTypes(serviceManager: IServiceManager) {
-    serviceManager.addSingleton<IExperimentalDebuggerBanner>(IExperimentalDebuggerBanner, ExperimentalDebuggerBanner);
+    serviceManager.addSingleton<IDebuggerBanner>(IDebuggerBanner, DebuggerBanner);
 }

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -40,5 +40,6 @@ export interface IProtocolMessageWriter {
 export const IDebugConfigurationProvider = Symbol('DebugConfigurationProvider');
 export const IDebuggerBanner = Symbol('IDebuggerBanner');
 export interface IDebuggerBanner {
-    initialize(): void;
+    enabled: boolean;
+    onDidTerminateDebugSession(): Promise<void>;
 }

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -40,10 +40,5 @@ export interface IProtocolMessageWriter {
 export const IDebugConfigurationProvider = Symbol('DebugConfigurationProvider');
 export const IDebuggerBanner = Symbol('IDebuggerBanner');
 export interface IDebuggerBanner {
-    enabled: boolean;
     initialize(): void;
-    showBanner(): Promise<void>;
-    shouldShowBanner(): Promise<boolean>;
-    disable(): Promise<void>;
-    launchSurvey(): Promise<void>;
 }

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -38,8 +38,8 @@ export interface IProtocolMessageWriter {
 }
 
 export const IDebugConfigurationProvider = Symbol('DebugConfigurationProvider');
-export const IExperimentalDebuggerBanner = Symbol('IExperimentalDebuggerBanner');
-export interface IExperimentalDebuggerBanner {
+export const IDebuggerBanner = Symbol('IDebuggerBanner');
+export interface IDebuggerBanner {
     enabled: boolean;
     initialize(): void;
     showBanner(): Promise<void>;

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -34,7 +34,7 @@ import { AttachRequestArguments, LaunchRequestArguments } from './debugger/Commo
 import { BaseConfigurationProvider } from './debugger/configProviders/baseProvider';
 import { registerTypes as debugConfigurationRegisterTypes } from './debugger/configProviders/serviceRegistry';
 import { registerTypes as debuggerRegisterTypes } from './debugger/serviceRegistry';
-import { IDebugConfigurationProvider, IExperimentalDebuggerBanner } from './debugger/types';
+import { IDebugConfigurationProvider, IDebuggerBanner } from './debugger/types';
 import { registerTypes as formattersRegisterTypes } from './formatters/serviceRegistry';
 import { IInterpreterSelector } from './interpreter/configuration/types';
 import { ICondaService, IInterpreterService, PythonInterpreter } from './interpreter/contracts';
@@ -159,7 +159,7 @@ export async function activate(context: ExtensionContext) {
         context.subscriptions.push(debug.registerDebugConfigurationProvider(debugConfig.debugType, debugConfig));
     });
 
-    serviceContainer.get<IExperimentalDebuggerBanner>(IExperimentalDebuggerBanner).initialize();
+    serviceContainer.get<IDebuggerBanner>(IDebuggerBanner).initialize();
     activationDeferred.resolve();
 }
 

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -15,7 +15,7 @@ import { registerTypes as activationRegisterTypes } from './activation/serviceRe
 import { IExtensionActivationService } from './activation/types';
 import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { IApplicationDiagnostics } from './application/types';
-import { IWorkspaceService } from './common/application/types';
+import { IDebugService, IWorkspaceService } from './common/application/types';
 import { PythonSettings } from './common/configSettings';
 import { PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { FeatureDeprecationManager } from './common/featureDeprecationManager';
@@ -30,6 +30,7 @@ import { GLOBAL_MEMENTO, IConfigurationService, IDisposableRegistry,
     IExtensionContext, ILogger, IMemento, IOutputChannel,
     IPersistentStateFactory, WORKSPACE_MEMENTO } from './common/types';
 import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
+import { injectDebuggerBanner } from './debugger/banner';
 import { AttachRequestArguments, LaunchRequestArguments } from './debugger/Common/Contracts';
 import { BaseConfigurationProvider } from './debugger/configProviders/baseProvider';
 import { registerTypes as debugConfigurationRegisterTypes } from './debugger/configProviders/serviceRegistry';
@@ -159,7 +160,12 @@ export async function activate(context: ExtensionContext) {
         context.subscriptions.push(debug.registerDebugConfigurationProvider(debugConfig.debugType, debugConfig));
     });
 
-    serviceContainer.get<IDebuggerBanner>(IDebuggerBanner).initialize();
+    const banner = serviceContainer.get<IDebuggerBanner>(IDebuggerBanner);
+    const debuggerService = serviceContainer.get<IDebugService>(IDebugService);
+    const disposables = serviceContainer.get<Disposable[]>(IDisposableRegistry);
+    const logger = serviceContainer.get<ILogger>(ILogger);
+    injectDebuggerBanner(banner, debuggerService, disposables, logger);
+
     activationDeferred.resolve();
 }
 

--- a/src/test/debugger/banner.unit.test.ts
+++ b/src/test/debugger/banner.unit.test.ts
@@ -13,7 +13,6 @@ import { IBrowserService, IDisposableRegistry,
     ILogger, IPersistentState, IPersistentStateFactory } from '../../client/common/types';
 import { DebuggerBanner, isUserSelected, PersistentStateKeys } from '../../client/debugger/banner';
 import { DebuggerTypeName } from '../../client/debugger/Common/constants';
-import { IDebuggerBanner } from '../../client/debugger/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
 function neverSelected(p: IPersistentState<boolean | undefined>): boolean {
@@ -42,7 +41,7 @@ suite('Debugging - Banner', () => {
     let showBannerState: typemoq.IMock<IPersistentState<boolean>>;
     let debugService: typemoq.IMock<IDebugService>;
     let appShell: typemoq.IMock<IApplicationShell>;
-    let banner: IDebuggerBanner;
+    let banner: DebuggerBanner;
     const message = 'Can you please take 2 minutes to tell us how the Debugger is working for you?';
     const yes = 'Yes, take survey now';
     const no = 'No thanks';

--- a/src/test/debugger/banner.unit.test.ts
+++ b/src/test/debugger/banner.unit.test.ts
@@ -11,9 +11,9 @@ import { DebugSession } from 'vscode';
 import { IApplicationShell, IDebugService } from '../../client/common/application/types';
 import { IBrowserService, IDisposableRegistry,
     ILogger, IPersistentState, IPersistentStateFactory } from '../../client/common/types';
-import { ExperimentalDebuggerBanner, PersistentStateKeys } from '../../client/debugger/banner';
+import { DebuggerBanner, PersistentStateKeys } from '../../client/debugger/banner';
 import { DebuggerTypeName } from '../../client/debugger/Common/constants';
-import { IExperimentalDebuggerBanner } from '../../client/debugger/types';
+import { IDebuggerBanner } from '../../client/debugger/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
 suite('Debugging - Banner', () => {
@@ -24,7 +24,7 @@ suite('Debugging - Banner', () => {
     let showBannerState: typemoq.IMock<IPersistentState<boolean>>;
     let debugService: typemoq.IMock<IDebugService>;
     let appShell: typemoq.IMock<IApplicationShell>;
-    let banner: IExperimentalDebuggerBanner;
+    let banner: IDebuggerBanner;
     const message = 'Can you please take 2 minutes to tell us how the Debugger is working for you?';
     const yes = 'Yes, take survey now';
     const no = 'No thanks';
@@ -57,7 +57,7 @@ suite('Debugging - Banner', () => {
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IDisposableRegistry))).returns(() => []);
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IApplicationShell))).returns(() => appShell.object);
 
-        banner = new ExperimentalDebuggerBanner(serviceContainer.object);
+        banner = new DebuggerBanner(serviceContainer.object);
     });
     test('Browser is displayed when launching service along with debugger launch counter', async () => {
         const debuggerLaunchCounter = 1234;

--- a/src/test/debugger/banner.unit.test.ts
+++ b/src/test/debugger/banner.unit.test.ts
@@ -57,7 +57,10 @@ suite('Debugging - Banner', () => {
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IDisposableRegistry))).returns(() => []);
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IApplicationShell))).returns(() => appShell.object);
 
-        banner = new DebuggerBanner(serviceContainer.object, undefined, null);
+        function alwaysZero(min: number, max: number): number {
+            return 0;
+        }
+        banner = new DebuggerBanner(serviceContainer.object, undefined, alwaysZero);
     });
     test('Browser is displayed when launching service along with debugger launch counter', async () => {
         const debuggerLaunchCounter = 1234;

--- a/src/test/debugger/banner.unit.test.ts
+++ b/src/test/debugger/banner.unit.test.ts
@@ -127,8 +127,10 @@ suite('Debugging - Banner', () => {
         launchCounterState.setup(l => l.value).returns(() => debuggerLaunchCounter).verifiable(typemoq.Times.once());
         browser.setup(b => b.launch(typemoq.It.isValue(`https://www.research.net/r/N7B25RV?n=${debuggerLaunchCounter}`)))
             .verifiable(typemoq.Times.once());
+        appShell.setup(a => a.showInformationMessage(typemoq.It.isValue(message), typemoq.It.isValue(yes), typemoq.It.isValue(no)))
+            .returns(() => Promise.resolve(yes));
 
-        await banner.launchSurvey();
+        await banner.showBanner();
 
         launchCounterState.verifyAll();
         browser.verifyAll();


### PR DESCRIPTION
(fixes #2300)

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [x] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [x] `package-lock.json` has been regenerated if dependencies have changed
