### PR TITLE
Fix MyPy linter message REGEX to handle any python extension

### DIFF
--- a/news/2 Fixes/2380.md
+++ b/news/2 Fixes/2380.md
@@ -1,0 +1,2 @@
+Fix the regex expression to match MyPy linter messages that expects the file name to have a .py extension, that isn't always the case, to catch any filename.
+E.g., .pyi files that describes interfaces wouldn't get the linter messages to Problems tab.

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -5,7 +5,7 @@ import { IServiceContainer } from '../ioc/types';
 import { BaseLinter } from './baseLinter';
 import { ILintMessage } from './types';
 
-const REGEX = '(?<file>.py):(?<line>\\d+): (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
+const REGEX = '(?<file>.+):(?<line>\\d+): (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
 
 export class MyPy extends BaseLinter {
     constructor(outputChannel: OutputChannel, serviceContainer: IServiceContainer) {


### PR DESCRIPTION
Fixes #2380 
The regex expression to match MyPy linter messages expects that the file name has a `.py` extension, that isn't always the case. E.g., `.pyi` files for describing interfaces.

- [X] Title summarizes what is changing
- [X] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [X] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [X] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
- [X] Dependencies are pinned (e.g. `"1.2.3"`, not `"^1.2.3"`)
- [X] `package-lock.json` has been regenerated if dependencies have changed
