### PR TITLE
Allow for the use of a proxy server during Python Language Server download

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,7 @@
             "sourceMaps": true,
             "args": [
                 "timeout=60000",
-                "grep=Activation - Downloader"
+                "grep="
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,7 @@
             "sourceMaps": true,
             "args": [
                 "timeout=60000",
-                "grep="
+                "grep=Activation - Downloader"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/news/1 Enhancements/2385.md
+++ b/news/1 Enhancements/2385.md
@@ -1,0 +1,1 @@
+Make use of the `http.proxy` field in settings.json when downloading the Python Language Server.

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -36,8 +36,8 @@ export class LanguageServerDownloader {
         private readonly fs: IFileSystem,
         private readonly platformData: PlatformData,
         readonly workspace: IWorkspaceService,
-        private requestHandler: IRequestWrapper | undefined,
-        private engineFolder: string) {
+        private engineFolder: string,
+        private requestHandler?: IRequestWrapper) {
 
         if (!this.requestHandler) {
             this.requestHandler = new RequestWithProxy(workspace.getConfiguration('http').get('proxy', ''));

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -6,12 +6,10 @@
 import * as path from 'path';
 import * as requestProgress from 'request-progress';
 import { ProgressLocation, window } from 'vscode';
-import { IWorkspaceService } from '../common/application/types';
 import { createDeferred } from '../common/helpers';
 import { IFileSystem } from '../common/platform/types';
 import { IExtensionContext, IOutputChannel } from '../common/types';
 import { PlatformData, PlatformName } from './platformData';
-import { RequestWithProxy } from './requestWithProxy';
 import { IDownloadFileService } from './types';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
@@ -34,14 +32,9 @@ export class LanguageServerDownloader {
         private readonly output: IOutputChannel,
         private readonly fs: IFileSystem,
         private readonly platformData: PlatformData,
-        readonly workspace: IWorkspaceService,
-        private engineFolder: string,
-        private requestHandler?: IDownloadFileService) {
-
-        if (!this.requestHandler) {
-            this.requestHandler = new RequestWithProxy(workspace.getConfiguration('http').get('proxy', ''));
-        }
-    }
+        private requestHandler: IDownloadFileService,
+        private engineFolder: string
+    ) { }
 
     public getDownloadUri() {
         const platformString = this.platformData.getPlatformName();
@@ -53,7 +46,6 @@ export class LanguageServerDownloader {
 
         let localTempFilePath = '';
         try {
-
             localTempFilePath = await this.downloadFile(downloadUri, 'Downloading Microsoft Python Language Server... ');
             await this.unpackArchive(context.extensionPath, localTempFilePath);
         } catch (err) {
@@ -84,7 +76,8 @@ export class LanguageServerDownloader {
             location: ProgressLocation.Window
         }, (progress) => {
 
-            requestProgress(this.requestHandler!.downloadFile(uri))
+            requestProgress(
+                this.requestHandler!.downloadFile(uri))
                 .on('progress', (state) => {
                     // https://www.npmjs.com/package/request-progress
                     const received = Math.round(state.size.transferred / 1024);

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -12,7 +12,7 @@ import { IFileSystem } from '../common/platform/types';
 import { IExtensionContext, IOutputChannel } from '../common/types';
 import { PlatformData, PlatformName } from './platformData';
 import { RequestWithProxy } from './requestWithProxy';
-import { IRequestWrapper } from './types';
+import { IDownloadFileService } from './types';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 const StreamZip = require('node-stream-zip');
@@ -36,7 +36,7 @@ export class LanguageServerDownloader {
         private readonly platformData: PlatformData,
         readonly workspace: IWorkspaceService,
         private engineFolder: string,
-        private requestHandler?: IRequestWrapper) {
+        private requestHandler?: IDownloadFileService) {
 
         if (!this.requestHandler) {
             this.requestHandler = new RequestWithProxy(workspace.getConfiguration('http').get('proxy', ''));
@@ -84,7 +84,7 @@ export class LanguageServerDownloader {
             location: ProgressLocation.Window
         }, (progress) => {
 
-            requestProgress(this.requestHandler!.downloadFileRequest(uri))
+            requestProgress(this.requestHandler!.downloadFile(uri))
                 .on('progress', (state) => {
                     // https://www.npmjs.com/package/request-progress
                     const received = Math.round(state.size.transferred / 1024);

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -3,7 +3,6 @@
 
 'use strict';
 
-import * as fileSystem from 'fs';
 import * as path from 'path';
 import * as requestProgress from 'request-progress';
 import { ProgressLocation, window } from 'vscode';
@@ -151,7 +150,7 @@ export class LanguageServerDownloader {
 
         // Set file to executable (nothing happens in Windows, as chmod has no definition there)
         const executablePath = path.join(installFolder, this.platformData.getEngineExecutableName());
-        fileSystem.chmodSync(executablePath, '0764'); // -rwxrw-r--
+        await this.fs.chmod(executablePath, '0764'); // -rwxrw-r--
 
         this.output.appendLine('done.');
     }

--- a/src/client/activation/languageServer.ts
+++ b/src/client/activation/languageServer.ts
@@ -137,7 +137,12 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
 
         const mscorlib = path.join(this.context.extensionPath, languageServerFolder, 'mscorlib.dll');
         if (!await this.fs.fileExists(mscorlib)) {
-            const downloader = new LanguageServerDownloader(this.services, languageServerFolder);
+            const downloader = new LanguageServerDownloader(
+                this.output,
+                this.fs,
+                this.platformData,
+                this.workspace,
+                languageServerFolder);
             await downloader.downloadLanguageServer(this.context);
             reporter.sendTelemetryEvent(PYTHON_LANGUAGE_SERVER_DOWNLOADED);
         }

--- a/src/client/activation/languageServer.ts
+++ b/src/client/activation/languageServer.ts
@@ -33,6 +33,7 @@ import { LanguageServerDownloader } from './downloader';
 import { InterpreterData, InterpreterDataService } from './interpreterDataService';
 import { PlatformData } from './platformData';
 import { ProgressReporting } from './progress';
+import { RequestWithProxy } from './requestWithProxy';
 import { IExtensionActivator } from './types';
 
 const PYTHON = 'python';
@@ -141,7 +142,7 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
                 this.output,
                 this.fs,
                 this.platformData,
-                this.workspace,
+                new RequestWithProxy(this.workspace.getConfiguration('http').get('proxy', '')),
                 languageServerFolder);
             await downloader.downloadLanguageServer(this.context);
             reporter.sendTelemetryEvent(PYTHON_LANGUAGE_SERVER_DOWNLOADED);

--- a/src/client/activation/languageServer.ts
+++ b/src/client/activation/languageServer.ts
@@ -142,7 +142,6 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
                 this.fs,
                 this.platformData,
                 this.workspace,
-                undefined,
                 languageServerFolder);
             await downloader.downloadLanguageServer(this.context);
             reporter.sendTelemetryEvent(PYTHON_LANGUAGE_SERVER_DOWNLOADED);

--- a/src/client/activation/languageServer.ts
+++ b/src/client/activation/languageServer.ts
@@ -142,6 +142,7 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
                 this.fs,
                 this.platformData,
                 this.workspace,
+                undefined,
                 languageServerFolder);
             await downloader.downloadLanguageServer(this.context);
             reporter.sendTelemetryEvent(PYTHON_LANGUAGE_SERVER_DOWNLOADED);

--- a/src/client/activation/platformData.ts
+++ b/src/client/activation/platformData.ts
@@ -24,7 +24,7 @@ export enum PlatformLSExecutables {
 
 export class PlatformData {
     constructor(private platform: IPlatformService, fs: IFileSystem) { }
-    public async getPlatformName(): Promise<PlatformName> {
+    public getPlatformName(): PlatformName {
         if (this.platform.isWindows) {
             return this.platform.is64bit ? PlatformName.Windows64Bit : PlatformName.Windows32Bit;
         }

--- a/src/client/activation/requestWithProxy.ts
+++ b/src/client/activation/requestWithProxy.ts
@@ -11,22 +11,18 @@ import { IDownloadFileService } from './types';
 export class RequestWithProxy implements IDownloadFileService {
     constructor(private proxyUri: string) { }
 
-    public get requestOptions(): request.CoreOptions {
+    public get requestOptions(): request.CoreOptions | undefined {
         if (this.proxyUri && this.proxyUri.length > 0) {
             return {
                 proxy: this.proxyUri
             };
         } else {
-            return {};
+            return;
         }
     }
 
     public downloadFile(uri: string): request.Request {
-        const requestOptions = this.requestOptions;
-        if (requestOptions) {
-            return request(uri, requestOptions);
-        } else {
-            return request(uri);
-        }
+        const requestOptions: request.CoreOptions | undefined = this.requestOptions;
+        return request(uri, requestOptions);
     }
 }

--- a/src/client/activation/requestWithProxy.ts
+++ b/src/client/activation/requestWithProxy.ts
@@ -11,20 +11,22 @@ import { IDownloadFileService } from './types';
 export class RequestWithProxy implements IDownloadFileService {
     constructor(private proxyUri: string) { }
 
-    public getRequestOptions(): request.CoreOptions | undefined {
+    public get requestOptions(): request.CoreOptions {
         if (this.proxyUri && this.proxyUri.length > 0) {
             return {
                 proxy: this.proxyUri
             };
+        } else {
+            return {};
         }
-        return;
     }
 
     public downloadFile(uri: string): request.Request {
-        const requestOptions = this.getRequestOptions();
+        const requestOptions = this.requestOptions;
         if (requestOptions) {
             return request(uri, requestOptions);
+        } else {
+            return request(uri);
         }
-        return request(uri);
     }
 }

--- a/src/client/activation/requestWithProxy.ts
+++ b/src/client/activation/requestWithProxy.ts
@@ -17,7 +17,7 @@ export class RequestWithProxy implements IRequestWrapper {
                 proxy: this.proxyUri
             };
         }
-        return undefined;
+        return;
     }
 
     public downloadFileRequest(uri: string): request.Request {

--- a/src/client/activation/requestWithProxy.ts
+++ b/src/client/activation/requestWithProxy.ts
@@ -4,11 +4,11 @@
 'use strict';
 
 import * as request from 'request';
-import { IRequestWrapper } from './types';
+import { IDownloadFileService } from './types';
 
 // Simple wrapper for request to allow for the use of a proxy server being
 // specified in the request options.
-export class RequestWithProxy implements IRequestWrapper {
+export class RequestWithProxy implements IDownloadFileService {
     constructor(private proxyUri: string) { }
 
     public getRequestOptions(): request.CoreOptions | undefined {
@@ -20,7 +20,7 @@ export class RequestWithProxy implements IRequestWrapper {
         return;
     }
 
-    public downloadFileRequest(uri: string): request.Request {
+    public downloadFile(uri: string): request.Request {
         const requestOptions = this.getRequestOptions();
         if (requestOptions) {
             return request(uri, requestOptions);

--- a/src/client/activation/requestWithProxy.ts
+++ b/src/client/activation/requestWithProxy.ts
@@ -23,7 +23,7 @@ export class RequestWithProxy implements IRequestWrapper {
     public downloadFileRequest(uri: string): request.Request {
         const requestOptions = this.getRequestOptions();
         if (requestOptions) {
-            return request(uri, requestOptions!);
+            return request(uri, requestOptions);
         }
         return request(uri);
     }

--- a/src/client/activation/requestWithProxy.ts
+++ b/src/client/activation/requestWithProxy.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as request from 'request';
+import { IRequestWrapper } from './types';
+
+// Simple wrapper for request to allow for the use of a proxy server being
+// specified in the request options.
+export class RequestWithProxy implements IRequestWrapper {
+    constructor(private proxyUri: string) { }
+
+    public getRequestOptions(): request.CoreOptions | undefined {
+        if (this.proxyUri && this.proxyUri.length > 0) {
+            return {
+                proxy: this.proxyUri
+            };
+        }
+        return undefined;
+    }
+
+    public downloadFileRequest(uri: string): request.Request {
+        const requestOptions = this.getRequestOptions();
+        if (requestOptions) {
+            return request(uri, requestOptions!);
+        }
+        return request(uri);
+    }
+}

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -21,6 +21,6 @@ export interface IExtensionActivator {
   deactivate(): Promise<void>;
 }
 
-export interface IRequestWrapper {
-  downloadFileRequest(uri: string): RequestResult;
+export interface IDownloadFileService {
+  downloadFile(uri: string): RequestResult;
 }

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+'use strict';
+
+import { Request as RequestResult } from 'request';
+
 export const IExtensionActivationService = Symbol('IExtensionActivationService');
 export interface IExtensionActivationService {
   activate(): Promise<void>;
@@ -15,4 +19,8 @@ export const IExtensionActivator = Symbol('IExtensionActivator');
 export interface IExtensionActivator {
   activate(): Promise<boolean>;
   deactivate(): Promise<void>;
+}
+
+export interface IRequestWrapper {
+  downloadFileRequest(uri: string): RequestResult;
 }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -3,6 +3,7 @@
 'use strict';
 
 import { createHash } from 'crypto';
+import * as fileSystem from 'fs';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import { inject, injectable } from 'inversify';
@@ -151,6 +152,9 @@ export class FileSystem implements IFileSystem {
                 resolve({ filePath: tmpFile, dispose: cleanupCallback });
             });
         });
+    }
 
+    public createWriteStream(filePath: string): fileSystem.WriteStream {
+        return fileSystem.createWriteStream(filePath);
     }
 }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -157,4 +157,15 @@ export class FileSystem implements IFileSystem {
     public createWriteStream(filePath: string): fileSystem.WriteStream {
         return fileSystem.createWriteStream(filePath);
     }
+
+    public chmod(filePath: string, mode: string): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            fileSystem.chmod(filePath, mode, (err: NodeJS.ErrnoException) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            });
+        });
+    }
 }

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -86,4 +86,5 @@ export interface IFileSystem {
     getFileHash(filePath: string): Promise<string | undefined>;
     search(globPattern: string): Promise<string[]>;
     createTemporaryFile(extension: string): Promise<TemporaryFile>;
+    createWriteStream(path: string): fs.WriteStream;
 }

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -87,4 +87,5 @@ export interface IFileSystem {
     search(globPattern: string): Promise<string[]>;
     createTemporaryFile(extension: string): Promise<TemporaryFile>;
     createWriteStream(path: string): fs.WriteStream;
+    chmod(path: string, mode: string): Promise<void>;
 }

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -12,6 +12,7 @@ import { WorkspaceConfiguration } from 'vscode';
 import { DownloadLinks, LanguageServerDownloader } from '../../client/activation/downloader';
 import { PlatformData, PlatformName } from '../../client/activation/platformData';
 import { RequestWithProxy } from '../../client/activation/requestWithProxy';
+import { IDownloadFileService } from '../../client/activation/types';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 import { IOutputChannel } from '../../client/common/types';
@@ -69,17 +70,5 @@ suite('Activation - Downloader', () => {
         setupPlatform({ linux: true, is64Bit: true });
         const link = languageServerDownloader.getDownloadUri();
         assert.equal(link, DownloadLinks[PlatformName.Linux64Bit]);
-    });
-    test('Supports download via proxy', async () => {
-        let proxyValue: string = 'https://myproxy.net:4242';
-        let requestWithProxy: RequestWithProxy = new RequestWithProxy(proxyValue);
-        let opts: request.CoreOptions | undefined = requestWithProxy.requestOptions;
-        assert.notEqual(opts, undefined, 'Expected to get options back from .getRequestOptions but got undefined');
-        assert.equal(opts!.proxy, proxyValue, `Expected to see proxy service uri set to "${proxyValue}" but got "${opts!.proxy}" instead.`);
-
-        proxyValue = '';
-        requestWithProxy = new RequestWithProxy(proxyValue);
-        opts = requestWithProxy.requestOptions;
-        assert.equal(opts, undefined, 'Expected to get no options back from .getRequestOptions but got some options anyway!');
     });
 });

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -35,9 +35,7 @@ suite('Activation - Downloader', () => {
             fs.object,
             platformData,
             workspace.object,
-            undefined,
-            ''
-        );
+            '');
 
     });
     type PlatformIdentifier = {

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -34,7 +34,7 @@ suite('Activation - Downloader', () => {
             output.object,
             fs.object,
             platformData,
-            workspace.object,
+            new RequestWithProxy(''),
             '');
 
     });
@@ -73,13 +73,13 @@ suite('Activation - Downloader', () => {
     test('Supports download via proxy', async () => {
         let proxyValue: string = 'https://myproxy.net:4242';
         let requestWithProxy: RequestWithProxy = new RequestWithProxy(proxyValue);
-        let opts: request.CoreOptions | undefined = requestWithProxy.getRequestOptions();
+        let opts: request.CoreOptions | undefined = requestWithProxy.requestOptions;
         assert.notEqual(opts, undefined, 'Expected to get options back from .getRequestOptions but got undefined');
         assert.equal(opts!.proxy, proxyValue, `Expected to see proxy service uri set to "${proxyValue}" but got "${opts!.proxy}" instead.`);
 
         proxyValue = '';
         requestWithProxy = new RequestWithProxy(proxyValue);
-        opts = requestWithProxy.getRequestOptions();
+        opts = requestWithProxy.requestOptions;
         assert.equal(opts, undefined, 'Expected to get no options back from .getRequestOptions but got some options anyway!');
     });
 });

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -34,6 +34,7 @@ suite('Activation - Downloader', () => {
             fs.object,
             platformData,
             workspace.object,
+            undefined,
             ''
         );
 
@@ -52,27 +53,27 @@ suite('Activation - Downloader', () => {
     }
     test('Windows 32Bit', async () => {
         setupPlatform({ windows: true });
-        const link = await languageServerDownloader.getDownloadUri();
+        const link = languageServerDownloader.getDownloadUri();
         assert.equal(link, DownloadLinks[PlatformName.Windows32Bit]);
     });
     test('Windows 64Bit', async () => {
         setupPlatform({ windows: true, is64Bit: true });
-        const link = await languageServerDownloader.getDownloadUri();
+        const link = languageServerDownloader.getDownloadUri();
         assert.equal(link, DownloadLinks[PlatformName.Windows64Bit]);
     });
     test('Mac 64Bit', async () => {
         setupPlatform({ mac: true, is64Bit: true });
-        const link = await languageServerDownloader.getDownloadUri();
+        const link = languageServerDownloader.getDownloadUri();
         assert.equal(link, DownloadLinks[PlatformName.Mac64Bit]);
     });
     test('Linux 64Bit', async () => {
         setupPlatform({ linux: true, is64Bit: true });
-        const link = await languageServerDownloader.getDownloadUri();
+        const link = languageServerDownloader.getDownloadUri();
         assert.equal(link, DownloadLinks[PlatformName.Linux64Bit]);
     });
     test('Download via proxy', async () => {
         setupPlatform({ linux: true, is64Bit: true });
         proxyValue = 'https://dereksproxy:3333';
-        const link = await languageServerDownloader.getDownloadUri();
+        const link = languageServerDownloader.getDownloadUri();
     });
 });

--- a/src/test/activation/requestWithProxy.unit.test.ts
+++ b/src/test/activation/requestWithProxy.unit.test.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as assert from 'assert';
+import * as request from 'request';
+import { RequestWithProxy } from '../../client/activation/requestWithProxy';
+
+suite('Activation - RequestWithProxy', () => {
+
+    test('Supports download via proxy', async () => {
+        let proxyValue: string = 'https://myproxy.net:4242';
+        let requestWithProxy: RequestWithProxy = new RequestWithProxy(proxyValue);
+        let opts: request.CoreOptions | undefined = requestWithProxy.requestOptions;
+        assert.notEqual(opts, undefined, 'Expected to get options back from .getRequestOptions but got undefined');
+        assert.equal(opts!.proxy, proxyValue, `Expected to see proxy service uri set to "${proxyValue}" but got "${opts!.proxy}" instead.`);
+
+        proxyValue = '';
+        requestWithProxy = new RequestWithProxy(proxyValue);
+        opts = requestWithProxy.requestOptions;
+        assert.equal(opts, undefined, 'Expected to get no options back from .getRequestOptions but got some options anyway!');
+    });
+});

--- a/src/test/common/platform/filesystem.unit.test.ts
+++ b/src/test/common/platform/filesystem.unit.test.ts
@@ -94,18 +94,15 @@ suite('FileSystem', () => {
         expect(tempFile.filePath).to.not.equal(tempFile2.filePath, 'Temp files must be unique, implementation of createTemporaryFile is off.');
     });
     test('Ensure writing to a temp file is supported via file stream', async () => {
-        const tempFile = await fileSystem.createTemporaryFile('.tmp');
-        expect(tempFile).to.be.an('TemporaryFile');
-        const writeStream = fileSystem.createWriteStream(tempFile.filePath);
-        const asyncPromise = new Promise<void>((resolve, reject) => {
+        await fileSystem.createTemporaryFile('.tmp').then((tf: TemporaryFile) => {
+            expect(tf).to.not.equal(undefined, 'Error trying to create a temporary file');
+            const writeStream = fileSystem.createWriteStream(tf.filePath);
             writeStream.write('hello', 'utf8', (err) => {
-                if (err) {
-                    return reject(err);
-                }
-                resolve();
+                expect(err).to.equal(undefined, `Failed to write to a temp file, error is ${err}`);
             });
+        }, (failReason) => {
+            expect(failReason).to.equal('No errors occured', `Failed to create a temporary file with error ${failReason}`);
         });
-        await asyncPromise;
     });
     test('Ensure chmod works against a temporary file', async () => {
         await fileSystem.createTemporaryFile('.tmp').then(async (fl: TemporaryFile) => {

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -580,18 +580,6 @@ export namespace vscMockExtHostedTypes {
             return edits ? edits.slice() : undefined;
         }
 
-        createFile(uri: vscUri.URI, options?: { overwrite?: boolean, ignoreIfExists?: boolean }): void {
-            return;
-        }
-
-        deleteFile(uri: vscUri.URI, options?: { recursive?: boolean, ignoreIfNotExists?: boolean }): void {
-            return;
-        }
-
-        renameFile(oldUri: vscUri.URI, newUri: vscUri.URI, options?: { overwrite?: boolean, ignoreIfExists?: boolean }): void {
-            return;
-        }
-
         entries(): [vscUri.URI, TextEdit[]][] {
             const res: [vscUri.URI, TextEdit[]][] = [];
             this._textEdits.forEach(value => res.push([value.uri, value.edits]));

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -580,6 +580,18 @@ export namespace vscMockExtHostedTypes {
             return edits ? edits.slice() : undefined;
         }
 
+        createFile(uri: vscUri.URI, options?: { overwrite?: boolean, ignoreIfExists?: boolean }): void {
+            return;
+        }
+
+        deleteFile(uri: vscUri.URI, options?: { recursive?: boolean, ignoreIfNotExists?: boolean }): void {
+            return;
+        }
+
+        renameFile(oldUri: vscUri.URI, newUri: vscUri.URI, options?: { overwrite?: boolean, ignoreIfExists?: boolean }): void {
+            return;
+        }
+
         entries(): [vscUri.URI, TextEdit[]][] {
             const res: [vscUri.URI, TextEdit[]][] = [];
             this._textEdits.forEach(value => res.push([value.uri, value.edits]));


### PR DESCRIPTION
Fixes #2385 

- [x] Title summarizes what is changing
- [x] Includes a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & [code coverage](https://codecov.io/gh/Microsoft/vscode-python) are not adversely affected (within reason)
- [x] Works on all [actively maintained versions of Python](https://devguide.python.org/#status-of-python-branches) (e.g. Python 2.7 & the latest Python 3 release)
- [x] Works on Windows 10, macOS, and Linux (e.g. considered file system case-sensitivity)
