### PR TITLE
Only unregister unit test event listeners when **all** testing is complete

### DIFF
--- a/src/client/unittests/unittest/runner.ts
+++ b/src/client/unittests/unittest/runner.ts
@@ -116,7 +116,8 @@ export class TestManagerRunner implements ITestManagerRunner {
 
         // Test everything.
         if (testPaths.length === 0) {
-            await this.removeListenersAfter(runTestInternal());
+            const runTestPromise: Promise<void> = runTestInternal();
+            await this.removeListenersAfter(runTestPromise);
         }
 
         // Ok, the test runner can only work with one test at a time.

--- a/src/client/unittests/unittest/runner.ts
+++ b/src/client/unittests/unittest/runner.ts
@@ -147,15 +147,17 @@ export class TestManagerRunner implements ITestManagerRunner {
         return options.tests;
     }
 
-    // remove all the listeners from the server after all tests are complete
+    // remove all the listeners from the server after all tests are complete,
+    // and just pass the promise `after` through as we do not want to get in
+    // the way here.
     // tslint:disable-next-line:no-any
-    private async removeListenersAfter(after: Promise<any>): Promise<void> {
+    private async removeListenersAfter(after: Promise<any>): Promise<any> {
         return after.then(() => {
             this.server.removeAllListeners();
-            return;
-        }, (_) => {
+            return after;
+        }, (reason) => {
             this.server.removeAllListeners();
-            return;
+            return after;
         });
     }
 

--- a/src/client/unittests/unittest/runner.ts
+++ b/src/client/unittests/unittest/runner.ts
@@ -152,13 +152,9 @@ export class TestManagerRunner implements ITestManagerRunner {
     private async removeListenersAfter(after: Promise<any>): Promise<void> {
         return after.then(() => {
             this.server.removeAllListeners();
-            // tslint:disable-next-line:no-console
-            console.log('Removing listeners');
             return;
         }, (_) => {
             this.server.removeAllListeners();
-            // tslint:disable-next-line:no-console
-            console.log('Removing listeners (ERRPATH)');
             return;
         });
     }

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import { ConfigurationTarget, Uri, workspace } from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
-import { sleep } from '../client/common/core.utils';
 import { IS_MULTI_ROOT_TEST } from './initialize';
 export { sleep } from './core';
 
@@ -39,7 +38,7 @@ export async function updateSetting(setting: PythonSettingKeys, value: {} | unde
     // after invoking the update method. This issue has regressed a few times as well. This
     // delay is merely a backup to ensure it extension doesn't break the tests due to similar
     // regressions in VSC:
-    await sleep(2000);
+    // await sleep(2000);
     // ... please see issue #2356 and PR #2332 for a discussion on the matter
 
     PythonSettings.dispose();

--- a/src/test/unittests/debugger.test.ts
+++ b/src/test/unittests/debugger.test.ts
@@ -36,10 +36,8 @@ const defaultUnitTestArgs = [
 suite('Unit Tests - debugging', () => {
     let ioc: UnitTestIocContainer;
     const configTarget = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
-    suiteSetup(async function () {
+    suiteSetup(async () => {
         // Test disvovery is where the delay is, hence give 10 seconds (as we discover tests at least twice in each test).
-        // tslint:disable-next-line:no-invalid-this
-        this.timeout(10000);
         await initialize();
         await updateSetting('unitTest.unittestArgs', defaultUnitTestArgs, rootWorkspaceUri, configTarget);
         await updateSetting('unitTest.nosetestArgs', [], rootWorkspaceUri, configTarget);


### PR DESCRIPTION
*Addendum to* fixes for #2143

- Add test to ensure re-running failed tests count correctly
- We use promise-chains for 'queuing' up our tests when they span multiple files/suites/functions, add one last member to the chain that un-registers the event handlers.

- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (Still using the originally created news file)
- [x] Has unit tests & system/integration tests
