### PR TITLE
Update travis script to use latest stable ptvsd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ script:
         bash <(curl -s https://codecov.io/bash);
     fi
   - npm run clean:ptvsd
-  - pip install -t ./pythonFiles/experimental/ptvsd ptvsd --pre --no-cache-dir;
+  - pip install -t ./pythonFiles/experimental/ptvsd ptvsd --no-cache-dir;
   - if [ $DEBUGGER_TEST_RELEASE == "true" ]; then
         npm run clean;
         npm run vscode:prepublish;

--- a/news/3 Code Health/2432.md
+++ b/news/3 Code Health/2432.md
@@ -1,0 +1,1 @@
+Only use the current stable version of PTVSD in CI builds/releases.


### PR DESCRIPTION
Fixes #2432

- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has unit tests & system/integration tests~
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
