### PR TITLE
Updates for 2018.8.0 final release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2018.8.0-rc (30 August 2018)
+## 2018.8.0 (04 September 2018)
 
 ### Thanks
 
@@ -74,6 +74,8 @@ part of!
 
 1. Fix debugger issue that prevented users from copying the value of a variable from the Variables debugger window.
    ([#1398](https://github.com/Microsoft/vscode-python/issues/1398))
+1. Enable code lenses for tests when using the new language server.
+   ([#1948](https://github.com/Microsoft/vscode-python/issues/1948))
 1. Fix null reference exception in the language server causing server initialization to fail. The exception happened when search paths contained a folder that did not exist.
    ([#2017](https://github.com/Microsoft/vscode-python/issues/2017))
 1. Language server now populates document outline with all symbols instead of just top-level ones.
@@ -118,6 +120,8 @@ part of!
    ([#2309](https://github.com/Microsoft/vscode-python/issues/2309))
 1. Language server now correctly merges data from typeshed and the Python library.
    ([#2345](https://github.com/Microsoft/vscode-python/issues/2345))
+1. Fix pytest >= 3.7 test discovery.
+   ([#2347](https://github.com/Microsoft/vscode-python/issues/2347))
 1. Update the downloaded Python language server nuget package filename to
    `Python-Language-Server-{OSType}.beta.nupkg`.
    ([#2362](https://github.com/Microsoft/vscode-python/issues/2362))
@@ -144,11 +148,6 @@ part of!
    ([#2307](https://github.com/Microsoft/vscode-python/issues/2307))
 1. Only use the current stable version of PTVSD in CI builds/releases.
    ([#2432](https://github.com/Microsoft/vscode-python/issues/2432))
-
-
-
-
-
 
 
 ## 2018.7.1 (23 July 2018)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,8 +191,8 @@ To create a release _build_, the following steps should be followed:
    is up-to-date (the only update should be the version number if
    `package-lock.json` has been kept up-to-date otherwise)
 1. Update [`CHANGELOG.md`](https://github.com/Microsoft/vscode-python/blob/master/CHANGELOG.md)
-   - If this is the first release after a final release, then create a new section,
-     Otherwise update version and date in section header
+   - If this is the first release **after** a final release, then create a new section,
+     otherwise update the version and date in section header
    - Run [`news`](https://github.com/Microsoft/vscode-python/tree/master/news)
      (typically `python3 news | code-insiders -`; add `--final` if this
      is a final release)
@@ -207,7 +207,8 @@ To create a release _build_, the following steps should be followed:
 1. Update [`ThirdPartyNotices-Repository.txt`](https://github.com/Microsoft/vscode-python/blob/master/ThirdPartyNotices-Repository.txt)
    and register any changes with OSPO
 
-You can then download the development build `.vsix` for releasing.
+Once the above changes have been merged into `master` you can then download the
+development build `.vsix` for releasing.
 
 ## Development Build
 

--- a/news/1 Enhancements/1865.md
+++ b/news/1 Enhancements/1865.md
@@ -1,1 +1,0 @@
-Improved language server startup time by 40%.

--- a/news/1 Enhancements/2119.md
+++ b/news/1 Enhancements/2119.md
@@ -1,2 +1,0 @@
-Add pip dependency support to the conda `environment.yml` YAML schema support
-(thanks [Mark Edwards](https://github.com/markedwards)).

--- a/news/1 Enhancements/2203.md
+++ b/news/1 Enhancements/2203.md
@@ -1,1 +1,0 @@
-Added a German translation. (thanks to [bschley](https://github.com/bschley) and by means of [berndverst](https://github.com/berndverst) and [croth1](https://github.com/croth1) for the reviews)

--- a/news/1 Enhancements/2270.md
+++ b/news/1 Enhancements/2270.md
@@ -1,4 +1,0 @@
-The new setting `python.analysis.diagnosticPublishDelay` allows you to control
-when language server publishes diagnostics. Default is 1 second after the user
-activity, such a typing, ceases. If diagnostic is clear (i.e. errors got fixed),
-the publishing is immediate.

--- a/news/1 Enhancements/2384.md
+++ b/news/1 Enhancements/2384.md
@@ -1,1 +1,0 @@
-Language server now supports hierarchical document outline per language server protocol 4.4+ and VS Code 1.26+.

--- a/news/1 Enhancements/2385.md
+++ b/news/1 Enhancements/2385.md
@@ -1,1 +1,0 @@
-Make use of the `http.proxy` field in `settings.json` when downloading the Python Language Server.

--- a/news/2 Fixes/1398.md
+++ b/news/2 Fixes/1398.md
@@ -1,1 +1,0 @@
-Fix debugger issue that prevented users from copying the value of a variable from the Variables debugger window.

--- a/news/2 Fixes/1948.md
+++ b/news/2 Fixes/1948.md
@@ -1,1 +1,0 @@
-Enable code lenses for tests when using the new language server.

--- a/news/2 Fixes/2017.md
+++ b/news/2 Fixes/2017.md
@@ -1,1 +1,0 @@
-Fix null reference exception in the language server causing server initialization to fail. The exception happened when search paths contained a folder that did not exist.

--- a/news/2 Fixes/2050.md
+++ b/news/2 Fixes/2050.md
@@ -1,1 +1,0 @@
-Language server now populates document outline with all symbols instead of just top-level ones.

--- a/news/2 Fixes/2143.md
+++ b/news/2 Fixes/2143.md
@@ -1,1 +1,0 @@
-Ensure test count values in the status bar represent the correct number of tests that were discovered and run.

--- a/news/2 Fixes/2179.md
+++ b/news/2 Fixes/2179.md
@@ -1,1 +1,0 @@
-Fixed issue in the language server when documentation for a function always produced "Documentation is still being calculated, please try again soon".

--- a/news/2 Fixes/2198.md
+++ b/news/2 Fixes/2198.md
@@ -1,2 +1,0 @@
-Change linter message parsing so it respects `python.linting.maxNumberOfProblems`.
-(thanks [Scott Saponas](https://github.com/saponas/))

--- a/news/2 Fixes/2207.md
+++ b/news/2 Fixes/2207.md
@@ -1,1 +1,0 @@
-Fixed language server issue when it could enter infinite loop reloading modules.

--- a/news/2 Fixes/2223.md
+++ b/news/2 Fixes/2223.md
@@ -1,1 +1,0 @@
-Ensure workspace `pipenv` environment is not labeled as a `virtual env`. 

--- a/news/2 Fixes/2224.md
+++ b/news/2 Fixes/2224.md
@@ -1,1 +1,0 @@
-Improve reliability of document outline population with language server.

--- a/news/2 Fixes/2240.md
+++ b/news/2 Fixes/2240.md
@@ -1,2 +1,0 @@
-Language server now correctly handles `with` statement when `__enter__` is
-declared in a base class.

--- a/news/2 Fixes/2241.md
+++ b/news/2 Fixes/2241.md
@@ -1,1 +1,0 @@
-Fix `visualstudio_py_testLauncher` to stop breaking out of test discovery too soon.

--- a/news/2 Fixes/2245.md
+++ b/news/2 Fixes/2245.md
@@ -1,1 +1,0 @@
-Notify the user when the language server does not support their platform.

--- a/news/2 Fixes/2252.md
+++ b/news/2 Fixes/2252.md
@@ -1,1 +1,0 @@
-Fix issue with survey not opening in a browser for Windows users.

--- a/news/2 Fixes/2253.md
+++ b/news/2 Fixes/2253.md
@@ -1,1 +1,0 @@
-Correct banner survey question text to reference the Python Language Server.

--- a/news/2 Fixes/2262.md
+++ b/news/2 Fixes/2262.md
@@ -1,1 +1,0 @@
-Fixed issue in the language server when typing dot under certain conditions produced null reference exception.

--- a/news/2 Fixes/2281.md
+++ b/news/2 Fixes/2281.md
@@ -1,1 +1,0 @@
-Fix error when switching from new language server to the old `Jedi` language server.

--- a/news/2 Fixes/2284.md
+++ b/news/2 Fixes/2284.md
@@ -1,1 +1,0 @@
-Unpin Pylint from < 2.0 (prospector was upgraded and isn't stuck on that any longer)

--- a/news/2 Fixes/2299.md
+++ b/news/2 Fixes/2299.md
@@ -1,1 +1,0 @@
-Add support for breaking into the first line of code in the new debugger.

--- a/news/2 Fixes/2300.md
+++ b/news/2 Fixes/2300.md
@@ -1,1 +1,0 @@
-Show the debugger survey banner for only a subset of users.

--- a/news/2 Fixes/2309.md
+++ b/news/2 Fixes/2309.md
@@ -1,3 +1,0 @@
-Ensure Flask debug configuration launches flask in a debug environment with the Flask debug mode disabled.
-This is necessary to ensure the custom debugger takes precedence over the interactive debugger, and live reloading is disabled.
-http://flask.pocoo.org/docs/1.0/api/#flask.Flask.debug

--- a/news/2 Fixes/2345.md
+++ b/news/2 Fixes/2345.md
@@ -1,1 +1,0 @@
-Language server now correctly merges data from typeshed and the Python library.

--- a/news/2 Fixes/2347.md
+++ b/news/2 Fixes/2347.md
@@ -1,1 +1,0 @@
-Fix pytest >= 3.7 test discovery.

--- a/news/2 Fixes/2362.md
+++ b/news/2 Fixes/2362.md
@@ -1,2 +1,0 @@
-Update the downloaded Python language server nuget package filename to
-`Python-Language-Server-{OSType}.beta.nupkg`.

--- a/news/2 Fixes/2405.md
+++ b/news/2 Fixes/2405.md
@@ -1,1 +1,0 @@
-Added setting to control language server log output. Default is now 'error' so there should be much less noise in the output.

--- a/news/2 Fixes/688.md
+++ b/news/2 Fixes/688.md
@@ -1,1 +1,0 @@
-Fix `experimental` debugger when debugging Python files with Unicode characters in the file path.

--- a/news/2 Fixes/767.md
+++ b/news/2 Fixes/767.md
@@ -1,1 +1,0 @@
-Ensure stepping out of debugged code does not take user into `PTVSD` debugger code.

--- a/news/3 Code Health/2195.md
+++ b/news/3 Code Health/2195.md
@@ -1,1 +1,0 @@
-Revert change that moved IExperimentalDebuggerBanner into a common location.

--- a/news/3 Code Health/2196.md
+++ b/news/3 Code Health/2196.md
@@ -1,1 +1,0 @@
-Decorate `EventEmitter` within a `try..catch` to play nice with other extensions performing the same operation.

--- a/news/3 Code Health/2266.md
+++ b/news/3 Code Health/2266.md
@@ -1,1 +1,0 @@
-Change the default interpreter to favor Python 3 over Python 2.

--- a/news/3 Code Health/2267.md
+++ b/news/3 Code Health/2267.md
@@ -1,1 +1,0 @@
-Deprecate command `Python: Build Workspace Symbols` when using the language server.

--- a/news/3 Code Health/2305.md
+++ b/news/3 Code Health/2305.md
@@ -1,1 +1,0 @@
-Pin version of `pylint` to `3.6.3` to allow ensure `pylint` gets installed on Travis with Pytnon2.7.

--- a/news/3 Code Health/2307.md
+++ b/news/3 Code Health/2307.md
@@ -1,1 +1,0 @@
-Remove some of the debugger tests and fix some minor debugger issues.

--- a/news/3 Code Health/2432.md
+++ b/news/3 Code Health/2432.md
@@ -1,1 +1,0 @@
-Only use the current stable version of PTVSD in CI builds/releases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "python",
-    "version": "2018.8.0-rc",
+    "version": "2018.8.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2796,12 +2796,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2816,17 +2818,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2943,7 +2948,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2955,6 +2961,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2969,6 +2976,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2976,12 +2984,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.2.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.1",
                         "yallist": "^3.0.0"
@@ -3000,6 +3010,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3080,7 +3091,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3092,6 +3104,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3213,6 +3226,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
-    "version": "2018.8.0-rc",
+    "version": "2018.8.0",
     "publisher": "ms-python",
     "author": {
         "name": "Microsoft Corporation"


### PR DESCRIPTION
Part of #2199 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has unit tests & system/integration tests~
- [x] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
