### PR TITLE
Capture stderr so it's available in check_returncode() exception for pvsc-dev-ext.py

### DIFF
--- a/news/1 Enhancements/2483.md
+++ b/news/1 Enhancements/2483.md
@@ -1,0 +1,2 @@
+The `pvsc-dev-ext.py` script now captures `stderr` for more informative exceptions
+when execution fails.

--- a/pvsc-dev-ext.py
+++ b/pvsc-dev-ext.py
@@ -32,7 +32,7 @@ class VSCode(enum.Enum):
 
 def run_command(command, cwd=None):
     """Run the specified command in a subprocess shell."""
-    cmd = subprocess.run(command, cwd=cwd, shell=True)
+    cmd = subprocess.run(command, cwd=cwd, stderr=subprocess.PIPE, shell=True)
     cmd.check_returncode()
 
 


### PR DESCRIPTION
Fixes #2483 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has unit tests & system/integration tests~
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
