### PR TITLE
Give preference to python exec info over registry

### DIFF
--- a/news/2 Fixes/2563.md
+++ b/news/2 Fixes/2563.md
@@ -1,0 +1,1 @@
+Give preference to bitness information retrieved from Python interpreter over what's been retrieved from Windows Registry.

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -127,7 +127,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
         let fileHash = await this.fs.getFileHash(pythonPath).catch(() => '');
         fileHash = fileHash ? fileHash : '';
-        const store = this.persistentStateFactory.createGlobalPersistentState<PythonInterpreter & { fileHash: string }>(`${pythonPath}.interpreter.details.v1`, undefined, EXPITY_DURATION);
+        const store = this.persistentStateFactory.createGlobalPersistentState<PythonInterpreter & { fileHash: string }>(`${pythonPath}.interpreter.details.v2`, undefined, EXPITY_DURATION);
         if (store.value && fileHash && store.value.fileHash === fileHash) {
             return store.value;
         }
@@ -172,7 +172,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
      * @memberof InterpreterService
      */
     public async getDisplayName(info: Partial<PythonInterpreter>, resource?: Uri): Promise<string> {
-        const store = this.persistentStateFactory.createGlobalPersistentState<string>(`${info.path}.interpreter.displayName.v1`, undefined, EXPITY_DURATION);
+        const store = this.persistentStateFactory.createGlobalPersistentState<string>(`${info.path}.interpreter.displayName.v2`, undefined, EXPITY_DURATION);
         if (store.value) {
             return store.value;
         }

--- a/src/client/interpreter/locators/services/windowsRegistryService.ts
+++ b/src/client/interpreter/locators/services/windowsRegistryService.ts
@@ -129,7 +129,6 @@ export class WindowsRegistryService extends CacheableLocatorService {
                 // tslint:disable-next-line:prefer-type-cast no-object-literal-type-assertion
                 return {
                     ...(details as PythonInterpreter),
-                    architecture: arch,
                     path: executablePath,
                     version,
                     companyDisplayName: interpreterInfo.companyDisplayName,

--- a/src/test/interpreters/windowsRegistryService.unit.test.ts
+++ b/src/test/interpreters/windowsRegistryService.unit.test.ts
@@ -14,10 +14,11 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 // tslint:disable-next-line:max-func-body-length
 suite('Interpreters from Windows Registry (unit)', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         const stateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
-        const interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
+        interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         const pathUtils = TypeMoq.Mock.ofType<IPathUtils>();
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPersistentStateFactory))).returns(() => stateFactory.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterHelper))).returns(() => interpreterHelper.object);
@@ -57,6 +58,9 @@ suite('Interpreters from Windows Registry (unit)', () => {
         const registry = new MockRegistry(registryKeys, registryValues);
         const winRegistry = new WindowsRegistryService(registry, false, serviceContainer.object);
 
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
+
         const interpreters = await winRegistry.getInterpreters();
 
         assert.equal(interpreters.length, 1, 'Incorrect number of entries');
@@ -75,6 +79,9 @@ suite('Interpreters from Windows Registry (unit)', () => {
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
         const winRegistry = new WindowsRegistryService(registry, false, serviceContainer.object);
+
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
         const interpreters = await winRegistry.getInterpreters();
 
@@ -109,6 +116,8 @@ suite('Interpreters from Windows Registry (unit)', () => {
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
         const winRegistry = new WindowsRegistryService(registry, false, serviceContainer.object);
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
         const interpreters = await winRegistry.getInterpreters();
 
@@ -150,6 +159,8 @@ suite('Interpreters from Windows Registry (unit)', () => {
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
         const winRegistry = new WindowsRegistryService(registry, false, serviceContainer.object);
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
         const interpreters = await winRegistry.getInterpreters();
 
@@ -206,6 +217,8 @@ suite('Interpreters from Windows Registry (unit)', () => {
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
         const winRegistry = new WindowsRegistryService(registry, false, serviceContainer.object);
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
         const interpreters = await winRegistry.getInterpreters();
 
@@ -262,6 +275,8 @@ suite('Interpreters from Windows Registry (unit)', () => {
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
         const winRegistry = new WindowsRegistryService(registry, false, serviceContainer.object);
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
         const interpreters = await winRegistry.getInterpreters();
 


### PR DESCRIPTION
Fixes #2563

Fix - Give preference to bitness information retrieved from Python Interpreter (via Python code), over what's been retrieved from Win Registry.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
