### PR TITLE
Set this.entryResponse to undefined after we have sent it

### DIFF
--- a/src/client/debugger/Main.ts
+++ b/src/client/debugger/Main.ts
@@ -166,6 +166,7 @@ export class PythonDebugger extends LoggingDebugSession {
     private onPythonProcessLoaded(pyThread?: IPythonThread) {
         if (this.entryResponse) {
             this.sendResponse(this.entryResponse);
+            this.entryResponse = undefined;
         }
         this.debuggerLoadedPromiseResolve();
         if (this.launchArgs && !this.launchArgs.console) {


### PR DESCRIPTION
Fixes #

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
