### PR TITLE
Handle config:python.pythonPath when validating path when debugging

### DIFF
--- a/src/client/application/diagnostics/types.ts
+++ b/src/client/application/diagnostics/types.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { DiagnosticSeverity } from 'vscode';
+import { DiagnosticSeverity, Uri } from 'vscode';
 
 export enum DiagnosticScope {
     Global = 'Global',
@@ -23,6 +23,10 @@ export interface IDiagnosticsService {
     diagnose(): Promise<IDiagnostic[]>;
     canHandle(diagnostic: IDiagnostic): Promise<boolean>;
     handle(diagnostics: IDiagnostic[]): Promise<void>;
+}
+
+export interface IInvalidPythonPathInDebuggerService extends IDiagnosticsService {
+    validatePythonPath(pythonPath?: string, resource?: Uri): Promise<boolean>;
 }
 
 export const IDiagnosticFilterService = Symbol('IDiagnosticFilterService');

--- a/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
@@ -3,20 +3,26 @@
 
 'use strict';
 
+// tslint:disable:no-invalid-template-strings max-func-body-length
+
 import { expect } from 'chai';
+import * as path from 'path';
 import * as typemoq from 'typemoq';
 import { InvalidPythonPathInDebuggerService } from '../../../../client/application/diagnostics/checks/invalidPythonPathInDebugger';
 import { CommandOption, IDiagnosticsCommandFactory } from '../../../../client/application/diagnostics/commands/types';
 import { DiagnosticCodes } from '../../../../client/application/diagnostics/constants';
 import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../../../../client/application/diagnostics/promptHandler';
-import { IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService, IDiagnosticsService } from '../../../../client/application/diagnostics/types';
+import { IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService, IInvalidPythonPathInDebuggerService } from '../../../../client/application/diagnostics/types';
+import { IConfigurationService, IPythonSettings } from '../../../../client/common/types';
+import { IInterpreterHelper } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
 
-// tslint:disable-next-line:max-func-body-length
 suite('Application Diagnostics - Checks Python Path in debugger', () => {
-    let diagnosticService: IDiagnosticsService;
+    let diagnosticService: IInvalidPythonPathInDebuggerService;
     let messageHandler: typemoq.IMock<IDiagnosticHandlerService<MessageCommandPrompt>>;
     let commandFactory: typemoq.IMock<IDiagnosticsCommandFactory>;
+    let configService: typemoq.IMock<IConfigurationService>;
+    let helper: typemoq.IMock<IInterpreterHelper>;
     setup(() => {
         const serviceContainer = typemoq.Mock.ofType<IServiceContainer>();
         messageHandler = typemoq.Mock.ofType<IDiagnosticHandlerService<MessageCommandPrompt>>();
@@ -25,6 +31,12 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         commandFactory = typemoq.Mock.ofType<IDiagnosticsCommandFactory>();
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IDiagnosticsCommandFactory)))
             .returns(() => commandFactory.object);
+        configService = typemoq.Mock.ofType<IConfigurationService>();
+        serviceContainer.setup(s => s.get(typemoq.It.isValue(IConfigurationService)))
+            .returns(() => configService.object);
+        helper = typemoq.Mock.ofType<IInterpreterHelper>();
+        serviceContainer.setup(s => s.get(typemoq.It.isValue(IInterpreterHelper)))
+            .returns(() => helper.object);
 
         diagnosticService = new InvalidPythonPathInDebuggerService(serviceContainer.object);
     });
@@ -71,5 +83,95 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         diagnostic.verifyAll();
         commandFactory.verifyAll();
         messageHandler.verifyAll();
+    });
+    test('Ensure we get python path from config when path = ${config:python.pythonPath}', async () => {
+        const pythonPath = '${config:python.pythonPath}';
+
+        const settings = typemoq.Mock.ofType<IPythonSettings>();
+        settings
+            .setup(s => s.pythonPath)
+            .returns(() => 'p')
+            .verifiable(typemoq.Times.once());
+        configService
+            .setup(c => c.getSettings(typemoq.It.isAny()))
+            .returns(() => settings.object)
+            .verifiable(typemoq.Times.once());
+        helper
+            .setup(h => h.getInterpreterInformation(typemoq.It.isValue('p')))
+            .returns(() => Promise.resolve({}))
+            .verifiable(typemoq.Times.once());
+
+        const valid = await diagnosticService.validatePythonPath(pythonPath);
+
+        settings.verifyAll();
+        configService.verifyAll();
+        helper.verifyAll();
+        expect(valid).to.be.equal(true, 'not valid');
+    });
+    test('Ensure we get python path from config when path = undefined', async () => {
+        const pythonPath = undefined;
+
+        const settings = typemoq.Mock.ofType<IPythonSettings>();
+        settings
+            .setup(s => s.pythonPath)
+            .returns(() => 'p')
+            .verifiable(typemoq.Times.once());
+        configService
+            .setup(c => c.getSettings(typemoq.It.isAny()))
+            .returns(() => settings.object)
+            .verifiable(typemoq.Times.once());
+        helper
+            .setup(h => h.getInterpreterInformation(typemoq.It.isValue('p')))
+            .returns(() => Promise.resolve({}))
+            .verifiable(typemoq.Times.once());
+
+        const valid = await diagnosticService.validatePythonPath(pythonPath);
+
+        settings.verifyAll();
+        configService.verifyAll();
+        helper.verifyAll();
+        expect(valid).to.be.equal(true, 'not valid');
+    });
+    test('Ensure we do get python path from config when path is provided', async () => {
+        const pythonPath = path.join('a', 'b');
+
+        const settings = typemoq.Mock.ofType<IPythonSettings>();
+        configService
+            .setup(c => c.getSettings(typemoq.It.isAny()))
+            .returns(() => settings.object)
+            .verifiable(typemoq.Times.never());
+        helper
+            .setup(h => h.getInterpreterInformation(typemoq.It.isValue(pythonPath)))
+            .returns(() => Promise.resolve({}))
+            .verifiable(typemoq.Times.once());
+
+        const valid = await diagnosticService.validatePythonPath(pythonPath);
+
+        configService.verifyAll();
+        helper.verifyAll();
+        expect(valid).to.be.equal(true, 'not valid');
+    });
+    test('Ensure diagnosics are handled when path is invalid', async () => {
+        const pythonPath = path.join('a', 'b');
+        helper
+            .setup(h => h.getInterpreterInformation(pythonPath))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable(typemoq.Times.once());
+
+        const mockDiagnostics = typemoq.Mock.ofInstance(diagnosticService);
+        mockDiagnostics
+            .setup(s => s.handle(typemoq.It.isAny()))
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.once());
+        helper
+            .setup(h => h.getInterpreterInformation(typemoq.It.isValue(pythonPath)))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable(typemoq.Times.once());
+
+        const valid = await mockDiagnostics.object.validatePythonPath(pythonPath);
+
+        helper.verifyAll();
+        mockDiagnostics.verifyAll();
+        expect(valid).to.be.equal(false, 'should be invalid');
     });
 });


### PR DESCRIPTION
Fixes #2587 (fixes bug introduced by #2552)

* The `launch.json` can contain the value `$config:python.pythonPath}` as the value for the python path. We need to account for this value when validating the python path before debugging.
* Also moved validation code into a separate method of the diagnostics class.


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
