### PR TITLE
Delete only the contents of directory pythonTools/experimental/ptvsd

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,7 @@ gulp.task('output:clean', () => del(['coverage', 'debug_coverage*']));
 
 gulp.task('cover:clean', () => del(['coverage', 'debug_coverage*']));
 
-gulp.task('clean:ptvsd', () => del(['coverage', 'pythonFiles/experimental/ptvsd*']));
+gulp.task('clean:ptvsd', () => del(['coverage', 'pythonFiles/experimental/ptvsd/*']));
 
 gulp.task('checkNativeDependencies', () => {
     if (hasNativeDependencies()) {


### PR DESCRIPTION
Fixes #2590
The gulp file ended up removing all files and folders starting with `ptvsd` in the  directory.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Has unit tests & system/integration tests
- [no] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
