### PR TITLE
Use PYTHONPATH variable as additional search paths for python modules

### DIFF
--- a/news/2 Fixes/2518.md
+++ b/news/2 Fixes/2518.md
@@ -1,0 +1,1 @@
+Provide paths form `PYTHONPATH` environment variable to the language server, as additional search locations of Python modules.

--- a/src/client/activation/interpreterDataService.ts
+++ b/src/client/activation/interpreterDataService.ts
@@ -104,7 +104,7 @@ export class InterpreterDataService {
   }
 
   private async getSearchPaths(execService: IPythonExecutionService): Promise<string> {
-    const result = await execService.exec(['-c', 'import sys; print(sys.path);'], {});
+    const result = await execService.exec(['-c', 'import sys; import os; print(sys.path + os.getenv("PYTHONPATH", "").split(os.pathsep));'], {});
     if (!result.stdout) {
       throw Error('Unable to determine Python interpreter search paths.');
     }

--- a/src/test/activation/languageServer.unit.test.ts
+++ b/src/test/activation/languageServer.unit.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as TypeMoq from 'typemoq';
+import { LanguageServerExtensionActivator } from '../../client/activation/languageServer';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../client/common/application/types';
+import { IPlatformService } from '../../client/common/platform/types';
+import { IConfigurationService, IDisposableRegistry, IExtensionContext, IFeatureDeprecationManager, IOutputChannel, IPathUtils, IPythonSettings } from '../../client/common/types';
+import { IEnvironmentVariablesProvider } from '../../client/common/variables/types';
+import { IServiceContainer } from '../../client/ioc/types';
+
+suite('Language Server', () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let pythonSettings: TypeMoq.IMock<IPythonSettings>;
+    let appShell: TypeMoq.IMock<IApplicationShell>;
+    let cmdManager: TypeMoq.IMock<ICommandManager>;
+    let workspaceService: TypeMoq.IMock<IWorkspaceService>;
+    let platformService: TypeMoq.IMock<IPlatformService>;
+    let languageServer: LanguageServerExtensionActivator;
+    let extensionContext: TypeMoq.IMock<IExtensionContext>;
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        extensionContext = TypeMoq.Mock.ofType<IExtensionContext>();
+        appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+        workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
+        cmdManager = TypeMoq.Mock.ofType<ICommandManager>();
+        platformService = TypeMoq.Mock.ofType<IPlatformService>();
+        const configService = TypeMoq.Mock.ofType<IConfigurationService>();
+        pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+
+        workspaceService.setup(w => w.hasWorkspaceFolders).returns(() => false);
+        workspaceService.setup(w => w.workspaceFolders).returns(() => []);
+        configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+
+        const output = TypeMoq.Mock.ofType<IOutputChannel>();
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isAny())).returns(() => output.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IWorkspaceService))).returns(() => workspaceService.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IApplicationShell))).returns(() => appShell.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => []);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IConfigurationService))).returns(() => configService.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICommandManager))).returns(() => cmdManager.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platformService.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IExtensionContext))).returns(() => extensionContext.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFeatureDeprecationManager))).returns(() => TypeMoq.Mock.ofType<IFeatureDeprecationManager>().object);
+
+        languageServer = new LanguageServerExtensionActivator(serviceContainer.object);
+    });
+
+    test('Must get PYTHONPATH from env vars provider', async () => {
+        const pathDelimiter = 'x';
+        const pythonPathVar = ['A', 'B', '1'];
+        const envVarsProvider = TypeMoq.Mock.ofType<IEnvironmentVariablesProvider>();
+        const pathUtils = TypeMoq.Mock.ofType<IPathUtils>();
+        extensionContext.setup(e => e.extensionPath).returns(() => path.join('a', 'b', 'c'));
+        pathUtils.setup(p => p.delimiter).returns(() => pathDelimiter);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IEnvironmentVariablesProvider))).returns(() => envVarsProvider.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPathUtils))).returns(() => pathUtils.object);
+        envVarsProvider
+            .setup(p => p.getEnvironmentVariables())
+            .returns(() => { return Promise.resolve({ PYTHONPATH: pythonPathVar.join(pathDelimiter) }); })
+            .verifiable(TypeMoq.Times.once());
+
+        const options = await languageServer.getAnalysisOptions();
+
+        expect(options!).not.to.equal(undefined, 'options cannot be undefined');
+        expect(options!.initializationOptions).not.to.equal(undefined, 'initializationOptions cannot be undefined');
+        expect(options!.initializationOptions!.searchPaths).to.include.members(pythonPathVar);
+    });
+});


### PR DESCRIPTION
Fixes #2518

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
