### PR TITLE
#1944: Support a new "python.condaPath" setting, in case conda not on PATH.

### DIFF
--- a/news/2 Fixes/1944.md
+++ b/news/2 Fixes/1944.md
@@ -1,0 +1,1 @@
+Add a new "python.condaPath" to use if conda not found on PATH.

--- a/package.json
+++ b/package.json
@@ -1247,6 +1247,12 @@
                     "description": "Path to Python, you can use a custom version of Python by modifying this setting to include the full path.",
                     "scope": "resource"
                 },
+                "python.condaPath": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to the conda executable to use for activation (version 4.4+).",
+                    "scope": "resource"
+                },
                 "python.sortImports.args": {
                     "type": "array",
                     "description": "Arguments passed in. Each argument is a separate item in the array.",

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -35,6 +35,7 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
     public envFile = '';
     public venvPath = '';
     public venvFolders: string[] = [];
+    public condaPath = '';
     public devOptions: string[] = [];
     public linting!: ILintingSettings;
     public formatting!: IFormattingSettings;

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -50,8 +50,9 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
                 `& cmd /k "activate ${envInfo.name.toCommandArgument().replace(/"/g, '""')} & ${powershellExe}"`
             ];
         } else if (targetShell === TerminalShellType.fish) {
+            const conda = await condaService.getCondaFile();
             // https://github.com/conda/conda/blob/be8c08c083f4d5e05b06bd2689d2cd0d410c2ffe/shell/etc/fish/conf.d/conda.fish#L18-L28
-            return [`conda activate ${envInfo.name.toCommandArgument()}`];
+            return [`${conda} activate ${envInfo.name.toCommandArgument()}`];
         } else if (isWindows) {
             return [`activate ${envInfo.name.toCommandArgument()}`];
         } else {

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -52,7 +52,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         } else if (targetShell === TerminalShellType.fish) {
             const conda = await condaService.getCondaFile();
             // https://github.com/conda/conda/blob/be8c08c083f4d5e05b06bd2689d2cd0d410c2ffe/shell/etc/fish/conf.d/conda.fish#L18-L28
-            return [`${conda} activate ${envInfo.name.toCommandArgument()}`];
+            return [`${conda.fileToCommandArgument()} activate ${envInfo.name.toCommandArgument()}`];
         } else if (isWindows) {
             return [`activate ${envInfo.name.toCommandArgument()}`];
         } else {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -125,6 +125,7 @@ export interface IPythonSettings {
     readonly pythonPath: string;
     readonly venvPath: string;
     readonly venvFolders: string[];
+    readonly condaPath: string;
     readonly downloadLanguageServer: boolean;
     readonly jediEnabled: boolean;
     readonly jediPath: string;

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { compareVersion } from '../../../../utils/version';
 import { IFileSystem, IPlatformService } from '../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../common/process/types';
-import { ILogger, IPersistentStateFactory } from '../../../common/types';
+import { IConfigurationService, ILogger, IPersistentStateFactory } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { CondaInfo, ICondaService, IInterpreterLocatorService, InterpreterType, PythonInterpreter, WINDOWS_REGISTRY_SERVICE } from '../../contracts';
 import { CondaHelper } from './condaHelper';
@@ -223,6 +223,12 @@ export class CondaService implements ICondaService {
      * Return the path to the "conda file", if there is one (in known locations).
      */
     private async getCondaFileImpl() {
+        const settings = this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings();
+        const setting = settings.condaPath;
+        if (setting && setting !== '') {
+            return setting;
+        }
+
         const isAvailable = await this.isCondaInCurrentPath();
         if (isAvailable) {
             return 'conda';

--- a/src/test/interpreters/condaService.unit.test.ts
+++ b/src/test/interpreters/condaService.unit.test.ts
@@ -41,9 +41,9 @@ suite('Interpreters Conda Service', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let procServiceFactory: TypeMoq.IMock<IProcessServiceFactory>;
     let logger: TypeMoq.IMock<ILogger>;
-    let condaPath: string;
+    let condaPathSetting: string;
     setup(async () => {
-        condaPath = '';
+        condaPathSetting = '';
         logger = TypeMoq.Mock.ofType<ILogger>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
@@ -62,7 +62,7 @@ suite('Interpreters Conda Service', () => {
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem), TypeMoq.It.isAny())).returns(() => fileSystem.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IConfigurationService), TypeMoq.It.isAny())).returns(() => config.object);
         config.setup(c => c.getSettings(TypeMoq.It.isValue(undefined))).returns(() => settings.object);
-        settings.setup(p => p.condaPath).returns(() => condaPath);
+        settings.setup(p => p.condaPath).returns(() => condaPathSetting);
         condaService = new CondaService(serviceContainer.object, registryInterpreterLocatorService.object);
 
         fileSystem.setup(fs => fs.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((p1, p2) => {
@@ -341,7 +341,7 @@ suite('Interpreters Conda Service', () => {
     });
 
     test('Must use \'python.condaPath\' setting if set', async () => {
-        condaPath = 'spam-spam-conda-spam-spam';
+        condaPathSetting = 'spam-spam-conda-spam-spam';
         // We ensure that conda would otherwise be found.
         processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version'])))
             .returns(() => Promise.resolve({ stdout: 'xyz' }))

--- a/src/test/interpreters/condaService.unit.test.ts
+++ b/src/test/interpreters/condaService.unit.test.ts
@@ -7,7 +7,7 @@ import * as TypeMoq from 'typemoq';
 import { FileSystem } from '../../client/common/platform/fileSystem';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
 import { IProcessService, IProcessServiceFactory } from '../../client/common/process/types';
-import { ILogger, IPersistentStateFactory } from '../../client/common/types';
+import { IConfigurationService, ILogger, IPersistentStateFactory, IPythonSettings } from '../../client/common/types';
 import { IInterpreterLocatorService, InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
 import { CondaService } from '../../client/interpreter/locators/services/condaService';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -35,6 +35,8 @@ suite('Interpreters Conda Service', () => {
     let platformService: TypeMoq.IMock<IPlatformService>;
     let condaService: CondaService;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
+    let config: TypeMoq.IMock<IConfigurationService>;
+    let settings: TypeMoq.IMock<IPythonSettings>;
     let registryInterpreterLocatorService: TypeMoq.IMock<IInterpreterLocatorService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let procServiceFactory: TypeMoq.IMock<IProcessServiceFactory>;
@@ -45,6 +47,8 @@ suite('Interpreters Conda Service', () => {
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         registryInterpreterLocatorService = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
+        config = TypeMoq.Mock.ofType<IConfigurationService>();
+        settings = TypeMoq.Mock.ofType<IPythonSettings>();
         procServiceFactory = TypeMoq.Mock.ofType<IProcessServiceFactory>();
         processService.setup((x: any) => x.then).returns(() => undefined);
         procServiceFactory.setup(p => p.create(TypeMoq.It.isAny())).returns(() => Promise.resolve(processService.object));
@@ -54,6 +58,9 @@ suite('Interpreters Conda Service', () => {
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService), TypeMoq.It.isAny())).returns(() => platformService.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ILogger), TypeMoq.It.isAny())).returns(() => logger.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem), TypeMoq.It.isAny())).returns(() => fileSystem.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IConfigurationService), TypeMoq.It.isAny())).returns(() => config.object);
+        config.setup(c => c.getSettings(TypeMoq.It.isValue(undefined))).returns(() => settings.object);
+        settings.setup(p => p.condaPath).returns(() => '');
         condaService = new CondaService(serviceContainer.object, registryInterpreterLocatorService.object);
 
         fileSystem.setup(fs => fs.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns((p1, p2) => {


### PR DESCRIPTION
(fixes #1944)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [x] ~~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~~
- [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~~
