### PR TITLE
Skip Multiple Linters system test due to unreliability (Symptom: executeCommand's await resolves prematurely).

### DIFF
--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -262,6 +262,7 @@ suite('Linting - General Tests', () => {
     test('Multiple linters', async function () {
         // tslint:disable-next-line:no-invalid-this
         this.skip();
+        return;
 
 //      Unreliable test being skipped until we can sort it out.
 //          - Fails about 1/3 of runs on Windows

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -261,7 +261,13 @@ suite('Linting - General Tests', () => {
     // tslint:disable-next-line:no-function-expression
     test('Multiple linters', async function () {
         // tslint:disable-next-line:no-invalid-this
-        this.timeout(40000);
+        this.skip();
+
+//      Unreliable test being skipped until we can sort it out.
+//          - Fails about 1/3 of runs on Windows
+//          - Symptom: lintingEngine::lintOpenPythonFiles returns values *after* command await resolves in lint.tests
+//          - lintOpenPythonFiles returns 3 sets of values, not what I expect (1).
+//          - Haven't yet found a way to await on this properly.
 
         await closeActiveWindows();
         const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));


### PR DESCRIPTION
Stop-gap measure for #2571

- Fails about 1/3 of runs *on Windows*, can't seem to repro on Linux.
- Symptom: lintingEngine::lintOpenPythonFiles returns values *after* command await resolves in lint.tests.
- lintOpenPythonFiles returns 3 sets of values, not what I expect (1).
- Haven't yet found a way to await on this properly.


- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Has~ **Skips** unit tests & system/integration tests
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
