### PR TITLE
Include Python Language Server version in survey

### DIFF
--- a/news/1 Enhancements/2630.md
+++ b/news/1 Enhancements/2630.md
@@ -1,0 +1,1 @@
+Add Python Language Server version to the survey banner URL presented to some users.

--- a/src/client/languageServices/languageServerSurveyBanner.ts
+++ b/src/client/languageServices/languageServerSurveyBanner.ts
@@ -122,7 +122,8 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
 
     public async launchSurvey(): Promise<void> {
         const launchCounter = await this.getPythonLSLaunchCounter();
-        const lsVersion = await this.getPythonLSVersion();
+        let lsVersion: string = await this.getPythonLSVersion();
+        lsVersion = encodeURIComponent(lsVersion);
         this.browserService.launch(`https://www.research.net/r/LJZV9BZ?n=${launchCounter}&v=${lsVersion}`);
     }
 
@@ -134,7 +135,7 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
 
     private async getPythonLSVersion(fallback: string = 'unknown'): Promise<string> {
         const langServiceLatestFolder: FolderVersionPair | undefined = await this.lsService.getcurrentLanguageServerDirectory();
-        return langServiceLatestFolder ? langServiceLatestFolder.version.version : fallback;
+        return langServiceLatestFolder ? langServiceLatestFolder.version.raw : fallback;
     }
 
     private async getPythonLSLaunchCounter(): Promise<number> {

--- a/src/client/languageServices/languageServerSurveyBanner.ts
+++ b/src/client/languageServices/languageServerSurveyBanner.ts
@@ -7,8 +7,10 @@ import { inject, injectable } from 'inversify';
 import { getRandomBetween } from '../../utils/random';
 import { IApplicationShell } from '../common/application/types';
 import '../common/extensions';
-import { IBrowserService, IPersistentStateFactory,
-    IPythonExtensionBanner } from '../common/types';
+import {
+    IBrowserService, IPersistentStateFactory,
+    IPythonExtensionBanner
+} from '../common/types';
 
 // persistent state names, exported to make use of in testing
 export enum LSSurveyStateKeys {
@@ -33,15 +35,15 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
     private maxCompletionsBeforeShow: number;
     private isInitialized: boolean = false;
     private bannerMessage: string = 'Can you please take 2 minutes to tell us how the Python Language Server is working for you?';
-    private bannerLabels: string [] = [ 'Yes, take survey now', 'No, thanks'];
+    private bannerLabels: string[] = ['Yes, take survey now', 'No, thanks'];
 
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private persistentState: IPersistentStateFactory,
         @inject(IBrowserService) private browserService: IBrowserService,
+        //@inject(ILanguageServerFolderService) private lsService: ILanguageServerFolderService,
         showAfterMinimumEventsCount: number = 100,
-        showBeforeMaximumEventsCount: number = 500)
-    {
+        showBeforeMaximumEventsCount: number = 500) {
         this.minCompletionsBeforeShow = showAfterMinimumEventsCount;
         this.maxCompletionsBeforeShow = showBeforeMaximumEventsCount;
         this.initialize();
@@ -105,7 +107,7 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
             return false;
         }
 
-        if (! launchCounter) {
+        if (!launchCounter) {
             launchCounter = await this.getPythonLSLaunchCounter();
         }
         const threshold: number = await this.getPythonLSLaunchThresholdCounter();
@@ -119,13 +121,20 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
 
     public async launchSurvey(): Promise<void> {
         const launchCounter = await this.getPythonLSLaunchCounter();
-        this.browserService.launch(`https://www.research.net/r/LJZV9BZ?n=${launchCounter}`);
+        const lsVersion = await this.getPythonLSVersion();
+        this.browserService.launch(`https://www.research.net/r/LJZV9BZ?n=${launchCounter}&v=${lsVersion}`);
     }
 
     private async incrementPythonLanguageServiceLaunchCounter(): Promise<number> {
         const state = this.persistentState.createGlobalPersistentState<number>(LSSurveyStateKeys.ShowAttemptCounter, 0);
         await state.updateValue(state.value + 1);
         return state.value;
+    }
+
+    private async getPythonLSVersion(fallback: string = 'unknown'): Promise<string> {
+        // const langServiceLatestFolder: FolderVersionPair | undefined = await this.lsService.getLatestLanguageServerDirectory();
+        // return langServiceLatestFolder ? langServiceLatestFolder.version : fallback;
+        return fallback;
     }
 
     private async getPythonLSLaunchCounter(): Promise<number> {

--- a/src/client/languageServices/languageServerSurveyBanner.ts
+++ b/src/client/languageServices/languageServerSurveyBanner.ts
@@ -5,6 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { getRandomBetween } from '../../utils/random';
+import { FolderVersionPair, ILanguageServerFolderService } from '../activation/types';
 import { IApplicationShell } from '../common/application/types';
 import '../common/extensions';
 import {
@@ -41,7 +42,7 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
         @inject(IApplicationShell) private appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private persistentState: IPersistentStateFactory,
         @inject(IBrowserService) private browserService: IBrowserService,
-        //@inject(ILanguageServerFolderService) private lsService: ILanguageServerFolderService,
+        @inject(ILanguageServerFolderService) private lsService: ILanguageServerFolderService,
         showAfterMinimumEventsCount: number = 100,
         showBeforeMaximumEventsCount: number = 500) {
         this.minCompletionsBeforeShow = showAfterMinimumEventsCount;
@@ -132,9 +133,8 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
     }
 
     private async getPythonLSVersion(fallback: string = 'unknown'): Promise<string> {
-        // const langServiceLatestFolder: FolderVersionPair | undefined = await this.lsService.getLatestLanguageServerDirectory();
-        // return langServiceLatestFolder ? langServiceLatestFolder.version : fallback;
-        return fallback;
+        const langServiceLatestFolder: FolderVersionPair | undefined = await this.lsService.getcurrentLanguageServerDirectory();
+        return langServiceLatestFolder ? langServiceLatestFolder.version.version : fallback;
     }
 
     private async getPythonLSLaunchCounter(): Promise<number> {

--- a/src/test/unittests/banners/languageServerSurvey.unit.test.ts
+++ b/src/test/unittests/banners/languageServerSurvey.unit.test.ts
@@ -10,11 +10,14 @@ import * as typemoq from 'typemoq';
 import { IApplicationShell } from '../../../client/common/application/types';
 import { IBrowserService, IConfigurationService, IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
 import { LanguageServerSurveyBanner, LSSurveyStateKeys } from '../../../client/languageServices/languageServerSurveyBanner';
+//import { ILanguageServerFolderService } from '../../../client/activation/types';
 
 suite('Language Server Survey Banner', () => {
     let config: typemoq.IMock<IConfigurationService>;
     let appShell: typemoq.IMock<IApplicationShell>;
     let browser: typemoq.IMock<IBrowserService>;
+    //let lsService: typemoq.IMock<ILanguageServerFolderService>;
+
     const message = 'Can you please take 2 minutes to tell us how the Experimental Debugger is working for you?';
     const yes = 'Yes, take survey now';
     const no = 'No, thanks';
@@ -23,23 +26,24 @@ suite('Language Server Survey Banner', () => {
         config = typemoq.Mock.ofType<IConfigurationService>();
         appShell = typemoq.Mock.ofType<IApplicationShell>();
         browser = typemoq.Mock.ofType<IBrowserService>();
+        //lsService = typemoq.Mock.ofType<ILanguageServerFolderService>();
     });
     test('Is debugger enabled upon creation?', () => {
         const enabledValue: boolean = true;
         const attemptCounter: number = 0;
         const completionsCount: number = 0;
-        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 100, appShell.object, browser.object);
+        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 100, appShell.object, browser.object); //, lsService.object);
         expect(testBanner.enabled).to.be.equal(true, 'Sampling 100/100 should always enable the banner.');
     });
     test('Do not show banner when it is disabled', () => {
         appShell.setup(a => a.showInformationMessage(typemoq.It.isValue(message),
-                                                    typemoq.It.isValue(yes),
-                                                    typemoq.It.isValue(no)))
+            typemoq.It.isValue(yes),
+            typemoq.It.isValue(no)))
             .verifiable(typemoq.Times.never());
         const enabledValue: boolean = true;
         const attemptCounter: number = 0;
         const completionsCount: number = 0;
-        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object, browser.object);
+        const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object, browser.object); //, lsService.object);
         testBanner.showBanner().ignoreErrors();
     });
     test('shouldShowBanner must return false when Banner is implicitly disabled by sampling', () => {
@@ -51,12 +55,21 @@ suite('Language Server Survey Banner', () => {
     });
 });
 
-function preparePopup(attemptCounter: number, completionsCount: number, enabledValue: boolean, minCompletionCount: number, maxCompletionCount: number, appShell: IApplicationShell, browser: IBrowserService): LanguageServerSurveyBanner {
+function preparePopup(
+    attemptCounter: number,
+    completionsCount: number,
+    enabledValue: boolean,
+    minCompletionCount: number,
+    maxCompletionCount: number,
+    appShell: IApplicationShell,
+    browser: IBrowserService
+    //lsService: ILanguageServerFolderService
+): LanguageServerSurveyBanner {
+
     const myfactory: typemoq.IMock<IPersistentStateFactory> = typemoq.Mock.ofType<IPersistentStateFactory>();
     const enabledValState: typemoq.IMock<IPersistentState<boolean>> = typemoq.Mock.ofType<IPersistentState<boolean>>();
     const attemptCountState: typemoq.IMock<IPersistentState<number>> = typemoq.Mock.ofType<IPersistentState<number>>();
     const completionCountState: typemoq.IMock<IPersistentState<number>> = typemoq.Mock.ofType<IPersistentState<number>>();
-
     enabledValState.setup(a => a.updateValue(typemoq.It.isValue(true))).returns(() => {
         enabledValue = true;
         return Promise.resolve();
@@ -100,6 +113,7 @@ function preparePopup(attemptCounter: number, completionsCount: number, enabledV
         appShell,
         myfactory.object,
         browser,
+        //lsService,
         minCompletionCount,
         maxCompletionCount);
 }


### PR DESCRIPTION
For #2630

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
