### PR TITLE
Minor UI changes to the display names of the interpreters

### DIFF
--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -86,7 +86,7 @@ export class InterpreterHelper implements IInterpreterHelper {
                 return 'venv';
             }
             case InterpreterType.VirtualEnv: {
-                return 'virtualEnv';
+                return 'virtualenv';
             }
             default: {
                 return '';

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -172,7 +172,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
      * @memberof InterpreterService
      */
     public async getDisplayName(info: Partial<PythonInterpreter>, resource?: Uri): Promise<string> {
-        const store = this.persistentStateFactory.createGlobalPersistentState<string>(`${info.path}.interpreter.displayName.v2`, undefined, EXPITY_DURATION);
+        const store = this.persistentStateFactory.createGlobalPersistentState<string>(`${info.path}.interpreter.displayName.v3`, undefined, EXPITY_DURATION);
         if (store.value) {
             return store.value;
         }
@@ -194,7 +194,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
             info.envName = await virtualEnvMgr.getEnvironmentName(info.path, resource);
         }
         if (info.envName && info.envName.length > 0) {
-            envSuffixParts.push(info.envName);
+            envSuffixParts.push(`'${info.envName}'`);
         }
         if (info.type) {
             const interpreterHelper = this.serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -586,7 +586,7 @@ suite('Interpreters service', () => {
                                             interpreterInfo.envName = pipEnvName;
                                         }
                                         if (interpreterInfo.envName && interpreterInfo.envName.length > 0) {
-                                            envSuffixParts.push(interpreterInfo.envName);
+                                            envSuffixParts.push(`'${interpreterInfo.envName}'`);
                                         }
                                         if (interpreterInfo.type) {
                                             envSuffixParts.push(`${interpreterType!.name}_display`);


### PR DESCRIPTION
For #1351

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
