### PR TITLE
Deprecate the use of the setting `python.autoComplete.preloadModules`

### DIFF
--- a/.github/test_plan.md
+++ b/.github/test_plan.md
@@ -149,7 +149,6 @@ foo = 42  # Marked as a blacklisted name.
 Please also test for general accuracy on the most "interesting" code you can find.
 
 - [ ] `"python.autoComplete.extraPaths"` works
-- [ ] `"python.autoComplete.preloadModules"` works (e.g. listing `numpy` should visibly speed up completing on the module's contents)
 - [ ] `"python.autocomplete.addBrackets": true` causes auto-completion of functions to append `()`
 
 #### [Formatting](https://code.visualstudio.com/docs/python/editing#_formatting)

--- a/news/2 Fixes/1704.md
+++ b/news/2 Fixes/1704.md
@@ -1,0 +1,1 @@
+Deprecate the use of the setting `python.autoComplete.preloadModules`. Recommendation is to utilize the new language server (change the setting `"python.jediEnabled" = false`).

--- a/package.json
+++ b/package.json
@@ -718,15 +718,6 @@
                     "description": "List of paths to libraries and the like that need to be imported by auto complete engine. E.g. when using Google App SDK, the paths are not in system path, hence need to be added into this list.",
                     "scope": "resource"
                 },
-                "python.autoComplete.preloadModules": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "default": [],
-                    "description": "Comma delimited list of modules preloaded to speed up Auto Complete (e.g. add Numpy, Pandas, etc, items slow to load when autocompleting).",
-                    "scope": "resource"
-                },
                 "python.autoComplete.showAdvancedMembers": {
                     "type": "boolean",
                     "default": true,
@@ -1526,7 +1517,7 @@
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./out/test/standardTest.js && node ./out/test/multiRootTest.js",
-        "test:unittests": "node ./out/test/unittests.js",
+        "test:unittests": "node ./out/test/unittests.js grep='Feature Deprecation Manager Tests'",
         "testDebugger": "node ./out/test/debuggerTest.js",
         "testSingleWorkspace": "node ./out/test/standardTest.js",
         "testMultiWorkspace": "node ./out/test/multiRootTest.js",

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -245,7 +245,6 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         this.autoComplete = this.autoComplete ? this.autoComplete : {
             extraPaths: [],
             addBrackets: false,
-            preloadModules: [],
             showAdvancedMembers: false,
             typeshedPaths: []
         };

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -226,7 +226,6 @@ export interface IFormattingSettings {
 export interface IAutoCompleteSettings {
     readonly addBrackets: boolean;
     readonly extraPaths: string[];
-    readonly preloadModules: string[];
     readonly showAdvancedMembers: boolean;
     readonly typeshedPaths: string[];
 }

--- a/src/client/providers/jediProxy.ts
+++ b/src/client/providers/jediProxy.ts
@@ -348,12 +348,6 @@ export class JediProxy implements Disposable {
             args.push('custom');
             args.push(this.pythonSettings.jediPath);
         }
-        if (this.pythonSettings.autoComplete &&
-            Array.isArray(this.pythonSettings.autoComplete.preloadModules) &&
-            this.pythonSettings.autoComplete.preloadModules.length > 0) {
-            const modules = this.pythonSettings.autoComplete.preloadModules.filter(m => m.trim().length > 0).join(',');
-            args.push(modules);
-        }
         const result = pythonProcess.execObservable(args, { cwd });
         this.proc = result.proc;
         this.languageServerStarted.resolve();


### PR DESCRIPTION
For #1704

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has unit tests & system/integration tests
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
