### PR TITLE
Disable problematic Debugger test.

### DIFF
--- a/src/test/debugger/capabilities.test.ts
+++ b/src/test/debugger/capabilities.test.ts
@@ -37,6 +37,9 @@ suite('Debugging - Capabilities', () => {
     let disposables: { dispose?: Function; destroy?: Function }[];
     let proc: ChildProcess;
     setup(async function () {
+        this.skip();
+        return;
+
         if (!IS_MULTI_ROOT_TEST || !TEST_DEBUGGER) {
             this.skip();
         }


### PR DESCRIPTION
For #2648

Found that the Debugger Capabilites test is failing in a way that takes down the enitre testing framework. Disabling the test suite for now until we can determine the root cause and fix it properly.


- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- ~Has unit tests & system/integration tests~
- ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
