### PR TITLE
Populate python.condaPath setting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1517,7 +1517,7 @@
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./out/test/standardTest.js && node ./out/test/multiRootTest.js",
-        "test:unittests": "node ./out/test/unittests.js grep='Feature Deprecation Manager Tests'",
+        "test:unittests": "node ./out/test/unittests.js",
         "testDebugger": "node ./out/test/debuggerTest.js",
         "testSingleWorkspace": "node ./out/test/standardTest.js",
         "testMultiWorkspace": "node ./out/test/multiRootTest.js",

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -128,6 +128,7 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
         this.venvPath = systemVariables.resolveAny(pythonSettings.get<string>('venvPath'))!;
         this.venvFolders = systemVariables.resolveAny(pythonSettings.get<string[]>('venvFolders'))!;
+        this.condaPath = systemVariables.resolveAny(pythonSettings.get<string>('condaPath'))!;
 
         this.downloadLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('downloadLanguageServer', true))!;
         this.jediEnabled = systemVariables.resolveAny(pythonSettings.get<boolean>('jediEnabled', true))!;

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -3,7 +3,10 @@
 import * as child_process from 'child_process';
 import { EventEmitter } from 'events';
 import * as path from 'path';
-import { ConfigurationTarget, DiagnosticSeverity, Disposable, Uri, workspace } from 'vscode';
+import {
+    ConfigurationTarget, DiagnosticSeverity, Disposable, Uri,
+    workspace, WorkspaceConfiguration
+} from 'vscode';
 import { sendTelemetryEvent } from '../telemetry';
 import { COMPLETION_ADD_BRACKETS, FORMAT_ON_TYPE } from '../telemetry/constants';
 import { isTestExecution } from './constants';
@@ -54,18 +57,22 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
     // tslint:disable-next-line:variable-name
     private _pythonPath = '';
 
-    constructor(workspaceFolder?: Uri) {
+    constructor(workspaceFolder?: Uri, initialize = true) {
         super();
         this.workspaceRoot = workspaceFolder ? workspaceFolder : Uri.file(__dirname);
-        this.disposables.push(workspace.onDidChangeConfiguration(() => {
-            this.initializeSettings();
+        if (initialize) {
+            this.disposables.push(workspace.onDidChangeConfiguration(() => {
+                const currentConfig = workspace.getConfiguration('python', this.workspaceRoot);
+                this.update(currentConfig);
 
-            // If workspace config changes, then we could have a cascading effect of on change events.
-            // Let's defer the change notification.
-            setTimeout(() => this.emit('change'), 1);
-        }));
+                // If workspace config changes, then we could have a cascading effect of on change events.
+                // Let's defer the change notification.
+                setTimeout(() => this.emit('change'), 1);
+            }));
 
-        this.initializeSettings();
+            const initialConfig = workspace.getConfiguration('python', this.workspaceRoot);
+            this.update(initialConfig);
+        }
     }
     // tslint:disable-next-line:function-name
     public static getInstance(resource?: Uri): PythonSettings {
@@ -111,10 +118,9 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         this.disposables = [];
     }
     // tslint:disable-next-line:cyclomatic-complexity max-func-body-length
-    private initializeSettings() {
+    public update(pythonSettings: WorkspaceConfiguration) {
         const workspaceRoot = this.workspaceRoot.fsPath;
         const systemVariables: SystemVariables = new SystemVariables(this.workspaceRoot ? this.workspaceRoot.fsPath : undefined);
-        const pythonSettings = workspace.getConfiguration('python', this.workspaceRoot);
 
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
         this.pythonPath = systemVariables.resolveAny(pythonSettings.get<string>('pythonPath'))!;

--- a/src/test/common/configSettings.unit.test.ts
+++ b/src/test/common/configSettings.unit.test.ts
@@ -85,6 +85,7 @@ suite('Python Settings', () => {
 
     test('condaPath updated', () => {
         const expected = new PythonSettings(undefined, false);
+        expected.pythonPath = 'python3';
         expected.condaPath = 'spam';
         initializeConfig(expected);
         config.setup(c => c.get<string>('condaPath'))

--- a/src/test/common/configSettings.unit.test.ts
+++ b/src/test/common/configSettings.unit.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
+import {
+    PythonSettings
+} from '../../client/common/configSettings';
+import {
+    IAnalysisSettings,
+    IAutoCompleteSettings,
+    IFormattingSettings,
+    ILintingSettings,
+    ISortImportSettings,
+    ITerminalSettings,
+    IUnitTestSettings,
+    IWorkspaceSymbolSettings
+} from '../../client/common/types';
+
+// tslint:disable-next-line:max-func-body-length
+suite('Python Settings', () => {
+    let config: TypeMoq.IMock<WorkspaceConfiguration>;
+
+    setup(() => {
+        config = TypeMoq.Mock.ofType<WorkspaceConfiguration>(undefined, TypeMoq.MockBehavior.Strict);
+    });
+
+    function initializeConfig(settings: PythonSettings) {
+        // string settings
+        for (const name of ['pythonPath', 'venvPath', 'condaPath', 'envFile']) {
+            config.setup(c => c.get<string>(name))
+                .returns(() => settings[name]);
+        }
+        if (settings.jediEnabled) {
+            config.setup(c => c.get<string>('jediPath'))
+                .returns(() => settings.jediPath);
+        }
+        for (const name of ['venvFolders']) {
+            config.setup(c => c.get<string[]>(name))
+                .returns(() => settings[name]);
+        }
+
+        // boolean settings
+        for (const name of ['downloadLanguageServer', 'jediEnabled']) {
+            config.setup(c => c.get<boolean>(name, true))
+                .returns(() => settings[name]);
+        }
+        for (const name of ['disableInstallationCheck', 'globalModuleInstallation']) {
+            config.setup(c => c.get<boolean>(name))
+                .returns(() => settings[name]);
+        }
+
+        // number settings
+        if (settings.jediEnabled) {
+            config.setup(c => c.get<number>('jediMemoryLimit'))
+                .returns(() => settings.jediMemoryLimit);
+        }
+
+        // "any" settings
+        // tslint:disable-next-line:no-any
+        config.setup(c => c.get<any[]>('devOptions'))
+            .returns(() => settings.devOptions);
+
+        // complex settings
+        config.setup(c => c.get<ILintingSettings>('linting'))
+            .returns(() => settings.linting);
+        config.setup(c => c.get<IAnalysisSettings>('analysis'))
+            .returns(() => settings.analysis);
+        config.setup(c => c.get<ISortImportSettings>('sortImports'))
+            .returns(() => settings.sortImports);
+        config.setup(c => c.get<IFormattingSettings>('formatting'))
+            .returns(() => settings.formatting);
+        config.setup(c => c.get<IAutoCompleteSettings>('autoComplete'))
+            .returns(() => settings.autoComplete);
+        config.setup(c => c.get<IWorkspaceSymbolSettings>('workspaceSymbols'))
+            .returns(() => settings.workspaceSymbols);
+        config.setup(c => c.get<IUnitTestSettings>('unitTest'))
+            .returns(() => settings.unitTest);
+        config.setup(c => c.get<ITerminalSettings>('terminal'))
+            .returns(() => settings.terminal);
+    }
+
+    test('condaPath', () => {
+        const expected = new PythonSettings(undefined, false);
+        expected.condaPath = 'spam';
+        initializeConfig(expected);
+        config.setup(c => c.get<string>('condaPath'))
+            .returns(() => expected.condaPath)
+            .verifiable(TypeMoq.Times.once());
+
+        const settings = new PythonSettings(undefined, false);
+        settings.update(config.object);
+
+        expect(settings.condaPath).to.be.equal(expected.condaPath);
+        config.verifyAll();
+    });
+});

--- a/src/test/common/configSettings.unit.test.ts
+++ b/src/test/common/configSettings.unit.test.ts
@@ -44,7 +44,7 @@ suite('Python Settings', () => {
         }
 
         // boolean settings
-        for (const name of ['downloadLanguageServer', 'jediEnabled']) {
+        for (const name of ['downloadLanguageServer', 'jediEnabled', 'autoUpdateLanguageServer']) {
             config.setup(c => c.get<boolean>(name, true))
                 .returns(() => settings[name]);
         }

--- a/src/test/common/configSettings.unit.test.ts
+++ b/src/test/common/configSettings.unit.test.ts
@@ -83,7 +83,7 @@ suite('Python Settings', () => {
             .returns(() => settings.terminal);
     }
 
-    test('condaPath', () => {
+    test('condaPath updated', () => {
         const expected = new PythonSettings(undefined, false);
         expected.condaPath = 'spam';
         initializeConfig(expected);


### PR DESCRIPTION
For #1944.  This is a follow-up to #2605.

Make sure `PythonSettings.condaPath` is populated from the VSC settings.

Note that I've added a unit test.