### PR TITLE
Check validity of executable used for debugging by executing a python file

### DIFF
--- a/pythonFiles/printOne.py
+++ b/pythonFiles/printOne.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+print('1')


### PR DESCRIPTION
For #2531

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Has unit tests & system/integration tests
- [no] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
