### PR TITLE
Include version info in ls telemetry

### DIFF
--- a/news/3 Code Health/2702.md
+++ b/news/3 Code Health/2702.md
@@ -1,0 +1,1 @@
+Include version of language server in telemetry.

--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -37,13 +37,15 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
 
     }
 
-    public async getDownloadUri() {
+    public async getDownloadInfo() {
         const lsFolderService = this.serviceContainer.get<ILanguageServerFolderService>(ILanguageServerFolderService);
-        return lsFolderService.getLatestLanguageServerVersion().then(info => info!.uri);
+        return lsFolderService.getLatestLanguageServerVersion().then(item => item!);
     }
 
     public async downloadLanguageServer(context: IExtensionContext): Promise<void> {
-        const downloadUri = await this.getDownloadUri();
+        const downloadInfo = await this.getDownloadInfo();
+        const downloadUri = downloadInfo.uri;
+        const version = downloadInfo.version.raw;
         const timer: StopWatch = new StopWatch();
         let success: boolean = true;
         let localTempFilePath = '';
@@ -59,7 +61,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             sendTelemetryEvent(
                 PYTHON_LANGUAGE_SERVER_DOWNLOADED,
                 timer.elapsedTime,
-                { success }
+                { success, version }
             );
         }
 
@@ -75,7 +77,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             sendTelemetryEvent(
                 PYTHON_LANGUAGE_SERVER_EXTRACTED,
                 timer.elapsedTime,
-                { success }
+                { success, version }
             );
             await this.fs.deleteFile(localTempFilePath);
         }

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -42,7 +42,7 @@ export interface ILanguageServerFolderService {
 export const ILanguageServerDownloader = Symbol('ILanguageServerDownloader');
 
 export interface ILanguageServerDownloader {
-  getDownloadUri(): Promise<string>;
+  getDownloadInfo(): Promise<NugetPackage>;
   downloadLanguageServer(context: IExtensionContext): Promise<void>;
 }
 

--- a/src/test/activation/downloader.unit.test.ts
+++ b/src/test/activation/downloader.unit.test.ts
@@ -5,7 +5,7 @@
 
 // tslint:disable:no-any
 
-import * as assert from 'assert';
+import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
 import { LanguageServerDownloader } from '../../client/activation/downloader';
 import { PlatformData } from '../../client/activation/platformData';
@@ -35,14 +35,15 @@ suite('Activation - Downloader', () => {
     });
 
     test('Get download uri', async () => {
+        const pkg = { uri: 'xyz' } as any;
         folderService
             .setup(f => f.getLatestLanguageServerVersion())
-            .returns(() => Promise.resolve({ uri: 'xyz' } as any))
+            .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const link = await languageServerDownloader.getDownloadUri();
+        const info = await languageServerDownloader.getDownloadInfo();
 
         folderService.verifyAll();
-        assert.equal(link, 'xyz');
+        expect(info).to.deep.equal(pkg);
     });
 });


### PR DESCRIPTION
For #2702

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
