### PR TITLE
Changed logic used to determine validity of debugger executable

### DIFF
--- a/pythonFiles/printOne.py
+++ b/pythonFiles/printOne.py
@@ -1,4 +1,0 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-print('1')

--- a/src/client/debugger/executableValidator.ts
+++ b/src/client/debugger/executableValidator.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { IFileSystem } from '../common/platform/types';
+import { IProcessServiceFactory } from '../common/process/types';
+import { IServiceContainer } from '../ioc/types';
+import { IExcutableValidator } from './types';
+
+@injectable()
+export class ExcutableValidator implements IExcutableValidator {
+    constructor(@inject(IServiceContainer) private readonly serviceContainer: IServiceContainer) { }
+    /**
+     * Checks the validity of the executable.
+     * Do not use `<python> --version` as the output in 2.7 comes in stderr.
+     * Do not use `<python> -c print('1')` as the executable could be pyspark.
+     * Use `<python> xyz.py` to check output as this is absolutely necessary for debugger to start.
+     * @param {string} exePath
+     * @returns {Promise<boolean>}
+     * @memberof DebuggerExcutableValidator
+     */
+    public async validateExecutable(exePath: string): Promise<boolean> {
+        const processFactory = this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
+        const processService = await processFactory.create();
+        const [valid, execuableExists] = await Promise.all([
+            processService.exec(exePath, ['-c', 'print("1")'])
+                .then(output => output.stdout.trim() === '1')
+                .catch(() => false),
+            fs.fileExists(exePath)
+        ]);
+
+        return valid || execuableExists;
+    }
+
+}

--- a/src/client/debugger/executableValidator.ts
+++ b/src/client/debugger/executableValidator.ts
@@ -15,8 +15,9 @@ export class ExcutableValidator implements IExcutableValidator {
     /**
      * Checks the validity of the executable.
      * Do not use `<python> --version` as the output in 2.7 comes in stderr.
-     * Do not use `<python> -c print('1')` as the executable could be pyspark.
-     * Use `<python> xyz.py` to check output as this is absolutely necessary for debugger to start.
+     * Check if either one of the following is true:
+     * 1. Use `<python> -c print('1')` as the executable could python.
+     * 2. Check if the executable file exists (in case of `spark-submit`)
      * @param {string} exePath
      * @returns {Promise<boolean>}
      * @memberof DebuggerExcutableValidator

--- a/src/client/debugger/serviceRegistry.ts
+++ b/src/client/debugger/serviceRegistry.ts
@@ -21,7 +21,8 @@ import { DebuggerProcessServiceFactory } from './Common/processServiceFactory';
 import { ProtocolLogger } from './Common/protocolLogger';
 import { ProtocolParser } from './Common/protocolParser';
 import { ProtocolMessageWriter } from './Common/protocolWriter';
-import { IDebuggerBanner, IDebugStreamProvider, IProtocolLogger, IProtocolMessageWriter, IProtocolParser } from './types';
+import { ExcutableValidator } from './executableValidator';
+import { IDebuggerBanner, IDebugStreamProvider, IExcutableValidator, IProtocolLogger, IProtocolMessageWriter, IProtocolParser } from './types';
 
 export function initializeIoc(): IServiceContainer {
     const cont = new Container();
@@ -43,6 +44,7 @@ function registerDebuggerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IProtocolMessageWriter>(IProtocolMessageWriter, ProtocolMessageWriter);
     serviceManager.addSingleton<IBufferDecoder>(IBufferDecoder, BufferDecoder);
     serviceManager.addSingleton<IProcessServiceFactory>(IProcessServiceFactory, DebuggerProcessServiceFactory);
+    serviceManager.addSingleton<IExcutableValidator>(IExcutableValidator, ExcutableValidator);
 }
 
 export function registerTypes(serviceManager: IServiceManager) {

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -42,3 +42,8 @@ export const IDebuggerBanner = Symbol('IDebuggerBanner');
 export interface IDebuggerBanner {
     initialize(): void;
 }
+
+export const IExcutableValidator = Symbol('IExcutableValidator');
+export interface IExcutableValidator {
+    validateExecutable(exePath: string): Promise<boolean>;
+}

--- a/src/test/debugger/excutableValidator.unit.test.ts
+++ b/src/test/debugger/excutableValidator.unit.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as typeMoq from 'typemoq';
+import { IFileSystem } from '../../client/common/platform/types';
+import { ExecutionResult, IProcessService, IProcessServiceFactory } from '../../client/common/process/types';
+import { ExcutableValidator } from '../../client/debugger/executableValidator';
+import { IServiceContainer } from '../../client/ioc/types';
+
+suite('Debugger Executable Validator', () => {
+    let fs: typeMoq.IMock<IFileSystem>;
+    let processService: typeMoq.IMock<IProcessService>;
+    let validator: ExcutableValidator;
+    setup(() => {
+        const serviceContainer = typeMoq.Mock.ofType<IServiceContainer>();
+        fs = typeMoq.Mock.ofType<IFileSystem>(undefined, typeMoq.MockBehavior.Strict);
+        processService = typeMoq.Mock.ofType<IProcessService>();
+        processService.setup((p: any) => p.then).returns(() => undefined);
+        const processFactory = typeMoq.Mock.ofType<IProcessServiceFactory>();
+        processFactory.setup(p => p.create()).returns(() => Promise.resolve(processService.object));
+
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(IProcessServiceFactory))).returns(() => processFactory.object);
+        validator = new ExcutableValidator(serviceContainer.object);
+    });
+
+    async function validate(pythonPath: string, expectedResult: boolean, fileExists: boolean, processOutput: ExecutionResult<string>) {
+        fs.setup(f => f.fileExists(typeMoq.It.isValue(pythonPath))).returns(() => Promise.resolve(fileExists));
+        processService.setup(p => p.exec(typeMoq.It.isValue(pythonPath), typeMoq.It.isValue(['-c', 'print("1")'])))
+            .returns(() => Promise.resolve(processOutput))
+            .verifiable(typeMoq.Times.once());
+
+        const isValid = await validator.validateExecutable(pythonPath);
+
+        expect(isValid).to.be.equal(expectedResult, 'Incorrect value');
+        fs.verifyAll();
+        processService.verifyAll();
+    }
+    test('Validate \'python\' command', async () => {
+        const pythonPath = 'python';
+        const output = { stdout: '1' };
+        await validate(pythonPath, true, false, output);
+    });
+
+    test('Validate \'python\' Executable with a valida path', async () => {
+        const pythonPath = path.join('a', 'b', 'bin', 'python');
+        const output = { stdout: '1' };
+        await validate(pythonPath, true, true, output);
+    });
+
+    test('Validate \'spark-submit\'', async () => {
+        const pythonPath = path.join('a', 'b', 'bin', 'spark-submit');
+        const output = { stderr: 'ex', stdout: '' };
+        await validate(pythonPath, true, true, output);
+    });
+
+    test('Validate invalid \'python\' command', async () => {
+        const pythonPath = path.join('python');
+        const output = { stderr: 'ex', stdout: '' };
+        await validate(pythonPath, false, false, output);
+    });
+
+    test('Validate invalid executable', async () => {
+        const pythonPath = path.join('a', 'b', 'bin', 'spark-submit');
+        const output = { stderr: 'ex', stdout: '' };
+        await validate(pythonPath, false, false, output);
+    });
+});


### PR DESCRIPTION
For #2351

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
