### PR TITLE
Report Microsoft Python language server version to console during startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -57,7 +57,7 @@
             }
         },
         {
-            "name": "Tests (Sigle Workspace, VS Code, *.test.ts)",
+            "name": "Tests (Single Workspace, VS Code, *.test.ts)",
             "type": "extensionHost",
             "request": "launch",
             "runtimeExecutable": "${execPath}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -129,7 +129,7 @@
             ]
         },
         {
-            "name": "Unit Tests (without VS Ccode, *.unit.test.ts)",
+            "name": "Unit Tests (without VS Code, *.unit.test.ts)",
             "type": "node",
             "request": "launch",
             "program": "${workspaceFolder}/out/test/unittests.js",

--- a/news/1 Enhancements/2687.md
+++ b/news/1 Enhancements/2687.md
@@ -1,0 +1,1 @@
+Report the Microsoft Python language server version during language server initialization.

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -15,18 +15,18 @@ import {
 } from '../common/application/types';
 import { isLanguageServerTest, STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import '../common/extensions';
-import { NugetPackage } from '../common/nuget/types';
 import { IPlatformService } from '../common/platform/types';
 import {
     IConfigurationService, IDisposableRegistry,
-    ILogger, IOutputChannel, IPythonSettings
+    IOutputChannel, IPythonSettings
 } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { PYTHON_LANGUAGE_SERVER_PLATFORM_NOT_SUPPORTED } from '../telemetry/constants';
 import { getTelemetryReporter } from '../telemetry/telemetry';
 import {
-    ExtensionActivators, IExtensionActivationService,
-    IExtensionActivator, ILanguageServerFolderService
+    ExtensionActivators, FolderVersionPair,
+    IExtensionActivationService, IExtensionActivator,
+    ILanguageServerFolderService
 } from './types';
 
 const jediEnabledSetting: keyof IPythonSettings = 'jediEnabled';
@@ -98,15 +98,10 @@ export class ExtensionActivationService implements IExtensionActivationService, 
 
         if (!isJedi) {
             let msplVersion: string = '';
-            try {
-                const lsFolderService = this.serviceContainer.get<ILanguageServerFolderService>(ILanguageServerFolderService);
-                const msplPackage: NugetPackage | undefined = await lsFolderService.getLatestLanguageServerVersion();
-                if (msplPackage && msplPackage.version) {
-                    msplVersion = ` (${msplPackage.version.raw})`;
-                }
-            } catch (ex) {
-                const log: ILogger = this.serviceContainer.get<ILogger>(ILogger);
-                log.logInformation('Cannot determine Microsoft Python language server version.', ex);
+            const lsFolderService = this.serviceContainer.get<ILanguageServerFolderService>(ILanguageServerFolderService);
+            const msplPackage: FolderVersionPair | undefined = await lsFolderService.getCurrentLanguageServerDirectory();
+            if (msplPackage && msplPackage.version) {
+                msplVersion = ` (${msplPackage.version.raw})`;
             }
             outputLine = `Starting Microsoft Python language server${msplVersion}.`;
         }

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -4,17 +4,30 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { ConfigurationChangeEvent, Disposable, OutputChannel, Uri } from 'vscode';
+import {
+    ConfigurationChangeEvent, Disposable,
+    OutputChannel, Uri
+} from 'vscode';
 import { OSDistro, OSType } from '../../utils/platform';
-import { IApplicationShell, ICommandManager, IWorkspaceService } from '../common/application/types';
+import {
+    IApplicationShell, ICommandManager,
+    IWorkspaceService
+} from '../common/application/types';
 import { isLanguageServerTest, STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import '../common/extensions';
+import { NugetPackage } from '../common/nuget/types';
 import { IPlatformService } from '../common/platform/types';
-import { IConfigurationService, IDisposableRegistry, IOutputChannel, IPythonSettings } from '../common/types';
+import {
+    IConfigurationService, IDisposableRegistry,
+    ILogger, IOutputChannel, IPythonSettings
+} from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { PYTHON_LANGUAGE_SERVER_PLATFORM_NOT_SUPPORTED } from '../telemetry/constants';
 import { getTelemetryReporter } from '../telemetry/telemetry';
-import { ExtensionActivators, IExtensionActivationService, IExtensionActivator } from './types';
+import {
+    ExtensionActivators, IExtensionActivationService,
+    IExtensionActivator, ILanguageServerFolderService
+} from './types';
 
 const jediEnabledSetting: keyof IPythonSettings = 'jediEnabled';
 const LS_MIN_OS_VERSIONS: [OSType, OSDistro, string][] = [
@@ -38,6 +51,7 @@ export class ExtensionActivationService implements IExtensionActivationService, 
     private readonly workspaceService: IWorkspaceService;
     private readonly output: OutputChannel;
     private readonly appShell: IApplicationShell;
+
     constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
         this.workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.output = this.serviceContainer.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
@@ -47,6 +61,7 @@ export class ExtensionActivationService implements IExtensionActivationService, 
         disposables.push(this);
         disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
     }
+
     public async activate(): Promise<void> {
         if (this.currentActivator) {
             return;
@@ -62,19 +77,43 @@ export class ExtensionActivationService implements IExtensionActivationService, 
             jedi = true;
         }
 
-        const engineName = jedi ? 'Jedi Python language engine' : 'Microsoft Python language server';
-        this.output.appendLine(`Starting ${engineName}.`);
+        await this.logStartup(jedi);
+
         const activatorName = jedi ? ExtensionActivators.Jedi : ExtensionActivators.DotNet;
         const activator = this.serviceContainer.get<IExtensionActivator>(IExtensionActivator, activatorName);
         this.currentActivator = { jedi, activator };
 
         await activator.activate();
     }
+
     public dispose() {
         if (this.currentActivator) {
             this.currentActivator.activator.deactivate().ignoreErrors();
         }
     }
+
+    // write a descriptive text message to output to help us diagnose user issues.
+    private async logStartup(isJedi: boolean): Promise<void> {
+        let outputLine: string = 'Starting Jedi Python language engine.';
+
+        if (!isJedi) {
+            let msplVersion: string = '';
+            try {
+                const lsFolderService = this.serviceContainer.get<ILanguageServerFolderService>(ILanguageServerFolderService);
+                const msplPackage: NugetPackage | undefined = await lsFolderService.getLatestLanguageServerVersion();
+                if (msplPackage && msplPackage.version) {
+                    msplVersion = ` (${msplPackage.version.raw})`;
+                }
+            } catch (ex) {
+                const log: ILogger = this.serviceContainer.get<ILogger>(ILogger);
+                log.logInformation('Cannot determine Microsoft Python language server version.', ex);
+            }
+            outputLine = `Starting Microsoft Python language server${msplVersion}.`;
+        }
+
+        this.output.appendLine(outputLine);
+    }
+
     private async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
         const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders ? this.workspaceService.workspaceFolders!.map(workspace => workspace.uri) : [undefined];
         if (workspacesUris.findIndex(uri => event.affectsConfiguration(`python.${jediEnabledSetting}`, uri)) === -1) {

--- a/src/client/activation/languageServerFolderService.ts
+++ b/src/client/activation/languageServerFolderService.ts
@@ -22,7 +22,7 @@ export class LanguageServerFolderService implements ILanguageServerFolderService
 
     @log('Get language server folder name')
     public async getLanguageServerFolderName(): Promise<string> {
-        const currentFolder = await this.getcurrentLanguageServerDirectory();
+        const currentFolder = await this.getCurrentLanguageServerDirectory();
         let serverVersion: NugetPackage | undefined;
 
         const configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
@@ -45,7 +45,7 @@ export class LanguageServerFolderService implements ILanguageServerFolderService
         const lsPackageService = this.serviceContainer.get<ILanguageServerPackageService>(ILanguageServerPackageService);
         return lsPackageService.getLatestNugetPackageVersion();
     }
-    public async getcurrentLanguageServerDirectory(): Promise<FolderVersionPair | undefined> {
+    public async getCurrentLanguageServerDirectory(): Promise<FolderVersionPair | undefined> {
         const dirs = await this.getExistingLanguageServerDirectories();
         if (dirs.length === 0) {
             return;

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -36,7 +36,7 @@ export const ILanguageServerFolderService = Symbol('ILanguageServerFolderService
 export interface ILanguageServerFolderService {
   getLanguageServerFolderName(): Promise<string>;
   getLatestLanguageServerVersion(): Promise<NugetPackage | undefined>;
-  getcurrentLanguageServerDirectory(): Promise<FolderVersionPair | undefined>;
+  getCurrentLanguageServerDirectory(): Promise<FolderVersionPair | undefined>;
 }
 
 export const ILanguageServerDownloader = Symbol('ILanguageServerDownloader');

--- a/src/client/languageServices/languageServerSurveyBanner.ts
+++ b/src/client/languageServices/languageServerSurveyBanner.ts
@@ -134,7 +134,7 @@ export class LanguageServerSurveyBanner implements IPythonExtensionBanner {
     }
 
     private async getPythonLSVersion(fallback: string = 'unknown'): Promise<string> {
-        const langServiceLatestFolder: FolderVersionPair | undefined = await this.lsService.getcurrentLanguageServerDirectory();
+        const langServiceLatestFolder: FolderVersionPair | undefined = await this.lsService.getCurrentLanguageServerDirectory();
         return langServiceLatestFolder ? langServiceLatestFolder.version.raw : fallback;
     }
 

--- a/src/test/activation/languageServerActivation.unit.test.ts
+++ b/src/test/activation/languageServerActivation.unit.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length
+
+import { SemVer } from 'semver';
+import * as TypeMoq from 'typemoq';
+import {
+    ExtensionActivationService
+} from '../../client/activation/activationService';
+import {
+    FolderVersionPair, IExtensionActivator, ILanguageServerFolderService
+} from '../../client/activation/types';
+import {
+    IApplicationShell, IWorkspaceService
+} from '../../client/common/application/types';
+import { IPlatformInfo, IPlatformService } from '../../client/common/platform/types';
+import {
+    IDisposableRegistry, ILogger, IOutputChannel
+} from '../../client/common/types';
+import { IServiceContainer } from '../../client/ioc/types';
+import { OSDistro, OSType } from '../../utils/platform';
+
+suite('ActivationService - Microsoft Python language service', () => {
+
+    function setupMocks(): [
+        TypeMoq.IMock<IServiceContainer>,
+        TypeMoq.IMock<ILanguageServerFolderService>,
+        TypeMoq.IMock<IOutputChannel>,
+        TypeMoq.IMock<ILogger>
+    ] {
+        const serviceContainerMock = TypeMoq.Mock.ofType<IServiceContainer>();
+
+        const workspaceServiceMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+        workspaceServiceMock.setup(w => w.workspaceFolders).returns(() => []);
+
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(IWorkspaceService),
+            TypeMoq.It.isAny())
+        ).returns(() => workspaceServiceMock.object);
+
+        const platformInfoMock = TypeMoq.Mock.ofType<IPlatformInfo>();
+        platformInfoMock.setup(pim => pim.type).returns(() => OSType.Windows);
+        platformInfoMock.setup(pim => pim.version).returns(() => new SemVer('10.0.0'));
+        platformInfoMock.setup(pim => pim.distro).returns(() => OSDistro.Unknown);
+
+        const platformServiceMock = TypeMoq.Mock.ofType<IPlatformService>();
+        platformServiceMock.setup(psm => psm.info).returns(() => platformInfoMock.object);
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(IPlatformService),
+            TypeMoq.It.isAny())
+        ).returns(() => platformServiceMock.object);
+
+        const outputMock = TypeMoq.Mock.ofType<IOutputChannel>();
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(IOutputChannel),
+            TypeMoq.It.isAny())
+        ).returns(() => outputMock.object);
+
+        const loggerMock = TypeMoq.Mock.ofType<ILogger>();
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(ILogger),
+            TypeMoq.It.isAny())
+        ).returns(() => loggerMock.object);
+
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(IApplicationShell),
+            TypeMoq.It.isAny())
+        ).returns(() => appShellMock.object);
+
+        const disposableRegistryMock = TypeMoq.Mock.ofType<IDisposableRegistry>();
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(IDisposableRegistry),
+            TypeMoq.It.isAny())
+        ).returns(() => disposableRegistryMock.object);
+
+        const extensionActivatorMock = TypeMoq.Mock.ofType<IExtensionActivator>();
+        extensionActivatorMock.setup(eam => eam.activate())
+            .returns(() => Promise.resolve(true));
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(IExtensionActivator),
+            TypeMoq.It.isAny())
+        ).returns(() => extensionActivatorMock.object);
+
+        const langFolderServiceMock = TypeMoq.Mock.ofType<ILanguageServerFolderService>();
+        serviceContainerMock.setup(scm => scm.get(
+            TypeMoq.It.isValue(ILanguageServerFolderService),
+            TypeMoq.It.isAny())
+        ).returns(() => langFolderServiceMock.object);
+
+        return [serviceContainerMock, langFolderServiceMock, outputMock, loggerMock];
+    }
+
+    test('MPLS issues the version correctly when it is present', async () => {
+        // Set expectations:
+        const testVer: string = '1.2.3';
+        const testSemVer: SemVer = new SemVer(testVer);
+        const expectedString: string = `Starting Microsoft Python language server (${testVer}).`;
+
+        // Arrange/setup mocks:
+        const [serviceContainerMock, langFolderServiceMock, outputMock] = setupMocks();
+        langFolderServiceMock.setup(lfsm => lfsm.getCurrentLanguageServerDirectory())
+            .returns(() => {
+                const mplsFolderVer: FolderVersionPair = {
+                    path: '',
+                    version: testSemVer
+                };
+                return Promise.resolve(mplsFolderVer);
+            });
+        outputMock.setup(om => om.appendLine(TypeMoq.It.isValue(expectedString)))
+            .verifiable(TypeMoq.Times.once());
+
+        // Verify: ensure we actually logged the expected line.
+        const activationServiceMock = new ExtensionActivationService(serviceContainerMock.object);
+        await activationServiceMock.activate();
+        outputMock.verifyAll();
+    });
+
+    test('MPLS issues no version correctly when it is not present', async () => {
+        // Set expectations:
+        const expectedString: string = 'Starting Microsoft Python language server.';
+
+        // Arrange/setup mocks:
+        const [serviceContainerMock, langFolderServiceMock, outputMock] = setupMocks();
+        langFolderServiceMock.setup(lfsm => lfsm.getCurrentLanguageServerDirectory())
+            .returns(() => Promise.resolve(undefined));
+        outputMock.setup(om => om.appendLine(TypeMoq.It.isValue(expectedString)))
+            .verifiable(TypeMoq.Times.once());
+
+        // Verify: ensure we actually logged the expected line.
+        const activationService = new ExtensionActivationService(serviceContainerMock.object);
+        await activationService.activate();
+        outputMock.verifyAll();
+    });
+
+    test('Does not throw when errors occur getting the current MPLS version', async () => {
+        // Set expectations:
+        const expectedString: string = 'Starting Microsoft Python language server.';
+        const expectedLogMsg: string = 'Failed to obtain current MPLS version during activation.';
+
+        // Arrange/setup mocks:
+        const [serviceContainerMock, langFolderServiceMock, outputMock, loggerMock] = setupMocks();
+        langFolderServiceMock.setup(lfsm => lfsm.getCurrentLanguageServerDirectory())
+            .returns(() =>
+                Promise.reject('Test for handling unknown errors.')
+            );
+        loggerMock.setup(lm => lm.logInformation(
+            TypeMoq.It.isValue(expectedLogMsg),
+            TypeMoq.It.isAny()
+        )).verifiable(TypeMoq.Times.once());
+        outputMock.setup(om => om.appendLine(TypeMoq.It.isValue(expectedString)))
+            .verifiable(TypeMoq.Times.once());
+
+        // Verify: ensure we actually logged the expected line.
+        const activationService = new ExtensionActivationService(serviceContainerMock.object);
+        await activationService.activate();
+        outputMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+
+});

--- a/src/test/activation/languageServerFolderService.unit.test.ts
+++ b/src/test/activation/languageServerFolderService.unit.test.ts
@@ -14,7 +14,7 @@ import { ILanguageServerPackageService } from '../../client/activation/types';
 import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
 import { NugetPackage } from '../../client/common/nuget/types';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
-import { IConfigurationService,  IPythonSettings } from '../../client/common/types';
+import { IConfigurationService, IPythonSettings } from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
 const languageServerFolder = 'languageServer';
@@ -82,7 +82,7 @@ suite('Language Server Folder Service', () => {
         });
         lsFolderService.getExistingLanguageServerDirectories = () => Promise.resolve(expectedFolders as any);
 
-        const latestFolder = await lsFolderService.getcurrentLanguageServerDirectory();
+        const latestFolder = await lsFolderService.getCurrentLanguageServerDirectory();
 
         expect(latestFolder!.path).to.be.equal(path.join(root, 'languageServer.3.9.1'));
         expect(latestFolder!.version.raw).to.be.equal('3.9.1');
@@ -90,7 +90,7 @@ suite('Language Server Folder Service', () => {
     test('Get latest language server folder name from nuget package version when there is no local folder', async () => {
         const pkg: NugetPackage = { package: 'abc', version: new SemVer('1.1.1'), uri: 'xyz' };
         settings.setup(s => s.autoUpdateLanguageServer).returns(() => true).verifiable(typeMoq.Times.once());
-        lsFolderService.getcurrentLanguageServerDirectory = () => Promise.resolve(undefined);
+        lsFolderService.getCurrentLanguageServerDirectory = () => Promise.resolve(undefined);
         lsFolderService.getLatestLanguageServerVersion = () => Promise.resolve(pkg);
 
         const folderName = await lsFolderService.getLanguageServerFolderName();
@@ -101,7 +101,7 @@ suite('Language Server Folder Service', () => {
         const pkg: NugetPackage = { package: 'abc', version: new SemVer('1.1.1'), uri: 'xyz' };
         const existingFolder = { path: path.join('1', '2', 'abc'), version: new SemVer('1.1.1') };
         settings.setup(s => s.autoUpdateLanguageServer).returns(() => true).verifiable(typeMoq.Times.once());
-        lsFolderService.getcurrentLanguageServerDirectory = () => Promise.resolve(existingFolder);
+        lsFolderService.getCurrentLanguageServerDirectory = () => Promise.resolve(existingFolder);
         lsFolderService.getLatestLanguageServerVersion = () => Promise.resolve(pkg);
 
         const folderName = await lsFolderService.getLanguageServerFolderName();
@@ -113,7 +113,7 @@ suite('Language Server Folder Service', () => {
         const pkg: NugetPackage = { package: 'abc', version: new SemVer('2.1.1'), uri: 'xyz' };
         const existingFolder = { path: path.join('1', '2', 'abc'), version: new SemVer('1.1.1') };
         settings.setup(s => s.autoUpdateLanguageServer).returns(() => true).verifiable(typeMoq.Times.once());
-        lsFolderService.getcurrentLanguageServerDirectory = () => Promise.resolve(existingFolder);
+        lsFolderService.getCurrentLanguageServerDirectory = () => Promise.resolve(existingFolder);
         lsFolderService.getLatestLanguageServerVersion = () => Promise.resolve(pkg);
 
         const folderName = await lsFolderService.getLanguageServerFolderName();
@@ -125,7 +125,7 @@ suite('Language Server Folder Service', () => {
         const pkg: NugetPackage = { package: 'abc', version: new SemVer('2.1.1'), uri: 'xyz' };
         const existingFolder = { path: path.join('1', '2', 'abc'), version: new SemVer('1.1.1') };
         settings.setup(s => s.autoUpdateLanguageServer).returns(() => false).verifiable(typeMoq.Times.once());
-        lsFolderService.getcurrentLanguageServerDirectory = () => Promise.resolve(existingFolder);
+        lsFolderService.getCurrentLanguageServerDirectory = () => Promise.resolve(existingFolder);
         lsFolderService.getLatestLanguageServerVersion = () => Promise.resolve(pkg);
 
         const folderName = await lsFolderService.getLanguageServerFolderName();

--- a/src/test/unittests/banners/languageServerSurvey.unit.test.ts
+++ b/src/test/unittests/banners/languageServerSurvey.unit.test.ts
@@ -81,7 +81,7 @@ suite('Language Server Survey Banner', () => {
             // language service will get asked for the current Language
             // Server directory installed. This in turn will give the tested
             // code the version via the .version member of lsFolder.
-            lsService.setup(f => f.getcurrentLanguageServerDirectory())
+            lsService.setup(f => f.getCurrentLanguageServerDirectory())
                 .returns(() => {
                     return Promise.resolve(lsFolder);
                 })
@@ -98,7 +98,7 @@ suite('Language Server Survey Banner', () => {
                     return a === expectedUri;
                 }))
             )
-            .verifiable(typemoq.Times.once());
+                .verifiable(typemoq.Times.once());
 
             const testBanner: LanguageServerSurveyBanner = preparePopup(attemptCounter, completionsCount, enabledValue, 0, 0, appShell.object, browser.object, lsService.object);
             await testBanner.launchSurvey();


### PR DESCRIPTION
For #2687 

To aid in resolving user issues with the MPLS.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
