### PR TITLE
#1882: Use "conda activate" after 4.4.0.

### DIFF
--- a/news/2 Fixes/1882.md
+++ b/news/2 Fixes/1882.md
@@ -1,0 +1,1 @@
+Support "conda activate" after 4.4.0.

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -112,6 +112,8 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
         // Conda changed how activation works in the 4.4.0 release, so
         // we accommodate the two ways distinctly.
         if (version === '4.4.0' || compareVersion(version, '4.4.0') > 0) {
+            // Note that this requires the user to have already followed
+            // the conda instructions such that "conda" is on their $PATH.
             return [
                 `${conda.fileToCommandArgument()} activate ${envName.toCommandArgument()}`
             ];

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -3,18 +3,12 @@
 
 import { injectable } from 'inversify';
 import { Uri } from 'vscode';
-import { compareVersion } from '../../../../utils/version';
 import { ICondaService } from '../../../interpreter/contracts';
 import { IServiceContainer } from '../../../ioc/types';
 import '../../extensions';
 import { IPlatformService } from '../../platform/types';
 import { IConfigurationService } from '../../types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
-
-interface ICondaInfo {
-    name: string;
-    path: string;
-}
 
 /**
  * Support conda env activation (in the terminal).
@@ -44,48 +38,72 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
             return;
         }
 
-        // Conda changed how activation works in the 4.4.0 release, so
-        // we accommodate the two ways distinctly.
-        const versionStr = await condaService.getCondaVersion();
-        if (compareVersion(versionStr || '', '4.4.0') === 0) {
-            return this.getPre440(targetShell, condaService, envInfo);
-        } else {
-            return this.getCurrent(targetShell, condaService, envInfo);
-        }
-    }
+        if (this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows) {
+            switch (targetShell) {
+                case TerminalShellType.powershell:
+                case TerminalShellType.powershellCore:
+                    return this.getPowershellCommands(envInfo.name, targetShell);
 
-    private async getPre440(
-        targetShell: TerminalShellType,
-        condaService: ICondaService,
-        envInfo: ICondaInfo
-    ): Promise<string[] | undefined> {
-        return this.getCurrent(targetShell, condaService, envInfo);
-    }
+                // tslint:disable-next-line:no-suspicious-comment
+                // TODO: Do we really special-case fish on Windows?
+                case TerminalShellType.fish:
+                    return this.getFishCommands(envInfo.name, await condaService.getCondaFile());
 
-    private async getCurrent(
-        targetShell: TerminalShellType,
-        condaService: ICondaService,
-        envInfo: ICondaInfo
-    ): Promise<string[] | undefined> {
-        const isWindows = this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows;
-        if (targetShell === TerminalShellType.powershell || targetShell === TerminalShellType.powershellCore) {
-            if (!isWindows) {
-                return;
+                default:
+                    return this.getWindowsCommands(envInfo.name);
             }
-            // https://github.com/conda/conda/issues/626
-            // On windows, the solution is to go into cmd, then run the batch (.bat) file and go back into powershell.
-            const powershellExe = targetShell === TerminalShellType.powershell ? 'powershell' : 'pwsh';
-            return [
-                `& cmd /k "activate ${envInfo.name.toCommandArgument().replace(/"/g, '""')} & ${powershellExe}"`
-            ];
-        } else if (targetShell === TerminalShellType.fish) {
-            const conda = await condaService.getCondaFile();
-            // https://github.com/conda/conda/blob/be8c08c083f4d5e05b06bd2689d2cd0d410c2ffe/shell/etc/fish/conf.d/conda.fish#L18-L28
-            return [`${conda.fileToCommandArgument()} activate ${envInfo.name.toCommandArgument()}`];
-        } else if (isWindows) {
-            return [`activate ${envInfo.name.toCommandArgument()}`];
         } else {
-            return [`source activate ${envInfo.name.toCommandArgument()}`];
+            switch (targetShell) {
+                case TerminalShellType.powershell:
+                case TerminalShellType.powershellCore:
+                    return;
+
+                // tslint:disable-next-line:no-suspicious-comment
+                // TODO: What about pre-4.4.0?
+                case TerminalShellType.fish:
+                    return this.getFishCommands(envInfo.name, await condaService.getCondaFile());
+
+                default:
+                    return this.getUnixCommands(envInfo.name);
+            }
         }
+    }
+
+    private async getWindowsCommands(
+        envName: string
+    ): Promise<string[] | undefined> {
+        return [
+            `activate ${envName.toCommandArgument()}`
+        ];
+    }
+
+    private async getPowershellCommands(
+        envName: string,
+        targetShell: TerminalShellType
+    ): Promise<string[] | undefined> {
+        // https://github.com/conda/conda/issues/626
+        // On windows, the solution is to go into cmd, then run the batch (.bat) file and go back into powershell.
+        const powershellExe = targetShell === TerminalShellType.powershell ? 'powershell' : 'pwsh';
+        return [
+            `& cmd /k "activate ${envName.toCommandArgument().replace(/"/g, '""')} & ${powershellExe}"`
+        ];
+    }
+
+    private async getFishCommands(
+        envName: string,
+        conda: string
+    ): Promise<string[] | undefined> {
+        // https://github.com/conda/conda/blob/be8c08c083f4d5e05b06bd2689d2cd0d410c2ffe/shell/etc/fish/conf.d/conda.fish#L18-L28
+        return [
+            `${conda.fileToCommandArgument()} activate ${envName.toCommandArgument()}`
+        ];
+    }
+
+    private async getUnixCommands(
+        envName: string
+    ): Promise<string[] | undefined> {
+        return [
+            `source activate ${envName.toCommandArgument()}`
+        ];
     }
 }


### PR DESCRIPTION
(fixes #1882)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~~
- [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~~
