### PR TITLE
Added missing setting into package.json (for intellisense)

### DIFF
--- a/package.json
+++ b/package.json
@@ -733,6 +733,12 @@
                     "description": "Specifies paths to local typeshed repository clone(s) for the Python language server.",
                     "scope": "resource"
                 },
+                "python.autoUpdateLanguageServer": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Automatically update the language server.",
+                    "scope": "application"
+                },
                 "python.disableInstallationCheck": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
For #2580

This setting is used in code, and it works. However it wasn't added into `package.json`, hence it isn't discoverable to users.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
