### PR TITLE
Fix colon-triggered block formatting

### DIFF
--- a/news/2 Fixes/2714.md
+++ b/news/2 Fixes/2714.md
@@ -1,0 +1,1 @@
+Fix colon-triggered block formatting

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -58,7 +58,9 @@ import { sendTelemetryEvent } from './telemetry';
 import { EDITOR_LOAD } from './telemetry/constants';
 import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionManager, ITerminalAutoActivation } from './terminals/types';
+import { BlockFormatProviders } from './typeFormatters/blockFormatProvider';
 import { OnTypeFormattingDispatcher } from './typeFormatters/dispatcher';
+import { OnEnterFormatter } from './typeFormatters/onEnterFormatter';
 import { TEST_OUTPUT_CHANNEL } from './unittests/common/constants';
 import { registerTypes as unitTestsRegisterTypes } from './unittests/serviceRegistry';
 
@@ -135,7 +137,10 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
         context.subscriptions.push(languages.registerDocumentRangeFormattingEditProvider(PYTHON, formatProvider));
     }
 
-    const onTypeDispatcher = new OnTypeFormattingDispatcher();
+    const onTypeDispatcher = new OnTypeFormattingDispatcher({
+        '\n': new OnEnterFormatter(),
+        ':': new BlockFormatProviders()
+    });
     const onTypeTriggers = onTypeDispatcher.getTriggerCharacters();
     if (onTypeTriggers) {
         context.subscriptions.push(languages.registerOnTypeFormattingEditProvider(PYTHON, onTypeDispatcher, onTypeTriggers.first, ...onTypeTriggers.more));

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -58,8 +58,7 @@ import { sendTelemetryEvent } from './telemetry';
 import { EDITOR_LOAD } from './telemetry/constants';
 import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionManager, ITerminalAutoActivation } from './terminals/types';
-import { BlockFormatProviders } from './typeFormatters/blockFormatProvider';
-import { OnEnterFormatter } from './typeFormatters/onEnterFormatter';
+import { OnTypeFormattingDispatcher } from './typeFormatters/dispatcher';
 import { TEST_OUTPUT_CHANNEL } from './unittests/common/constants';
 import { registerTypes as unitTestsRegisterTypes } from './unittests/serviceRegistry';
 
@@ -136,8 +135,11 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
         context.subscriptions.push(languages.registerDocumentRangeFormattingEditProvider(PYTHON, formatProvider));
     }
 
-    context.subscriptions.push(languages.registerOnTypeFormattingEditProvider(PYTHON, new BlockFormatProviders(), ':'));
-    context.subscriptions.push(languages.registerOnTypeFormattingEditProvider(PYTHON, new OnEnterFormatter(), '\n'));
+    const onTypeDispatcher = new OnTypeFormattingDispatcher();
+    const onTypeTriggers = onTypeDispatcher.getTriggerCharacters();
+    if (onTypeTriggers) {
+        context.subscriptions.push(languages.registerOnTypeFormattingEditProvider(PYTHON, onTypeDispatcher, onTypeTriggers.first, ...onTypeTriggers.more));
+    }
 
     const deprecationMgr = serviceContainer.get<IFeatureDeprecationManager>(IFeatureDeprecationManager);
     deprecationMgr.initialize();

--- a/src/client/typeFormatters/dispatcher.ts
+++ b/src/client/typeFormatters/dispatcher.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { CancellationToken, FormattingOptions, OnTypeFormattingEditProvider, Position, ProviderResult, TextDocument, TextEdit } from 'vscode';
+import { BlockFormatProviders } from './blockFormatProvider';
+import { OnEnterFormatter } from './onEnterFormatter';
+
+export class OnTypeFormattingDispatcher implements OnTypeFormattingEditProvider {
+    private readonly onEnterFormatter = new OnEnterFormatter();
+    private readonly blockFormatProviders = new BlockFormatProviders();
+
+    private readonly formatters: { [key: string]: OnTypeFormattingEditProvider } = {
+        '\n': this.onEnterFormatter,
+        ':': this.blockFormatProviders
+    };
+
+    public provideOnTypeFormattingEdits(document: TextDocument, position: Position, ch: string, options: FormattingOptions, cancellationToken: CancellationToken): ProviderResult<TextEdit[]> {
+        const formatter = this.formatters[ch];
+
+        if (formatter) {
+            return formatter.provideOnTypeFormattingEdits(document, position, ch, options, cancellationToken);
+        }
+
+        return [];
+    }
+
+    public getTriggerCharacters(): { first: string; more: string[] } | undefined {
+        const keys = Object.keys(this.formatters);
+
+        const first = keys.shift();
+
+        if (first) {
+            return {
+                first: first,
+                more: keys
+            };
+        }
+
+        return undefined;
+    }
+}

--- a/src/test/format/extension.dispatch.test.ts
+++ b/src/test/format/extension.dispatch.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as assert from 'assert';
+import * as TypeMoq from 'typemoq';
+import { CancellationToken, FormattingOptions, OnTypeFormattingEditProvider, Position, ProviderResult, TextDocument, TextEdit } from 'vscode';
+import { OnTypeFormattingDispatcher } from '../../client/typeFormatters/dispatcher';
+
+suite('Formatting - Dispatcher', () => {
+    const doc = TypeMoq.Mock.ofType<TextDocument>();
+    const pos = TypeMoq.Mock.ofType<Position>();
+    const opt = TypeMoq.Mock.ofType<FormattingOptions>();
+    const token = TypeMoq.Mock.ofType<CancellationToken>();
+    const edits = TypeMoq.Mock.ofType<ProviderResult<TextEdit[]>>();
+
+    test('No providers', async () => {
+        const dispatcher = new OnTypeFormattingDispatcher({});
+
+        const triggers = dispatcher.getTriggerCharacters();
+        assert.equal(triggers, undefined, 'Trigger was not undefined');
+
+        const result = await dispatcher.provideOnTypeFormattingEdits(doc.object, pos.object, '\n', opt.object, token.object);
+        assert.deepStrictEqual(result, [], 'Did not return an empty list of edits');
+    });
+
+    test('Single provider', () => {
+        const provider = setupProvider(doc.object, pos.object, ':', opt.object, token.object, edits.object);
+
+        const dispatcher = new OnTypeFormattingDispatcher({
+            ':': provider.object
+        });
+
+        const triggers = dispatcher.getTriggerCharacters();
+        assert.deepStrictEqual(triggers, { first: ':', more: [] }, 'Did not return correct triggers');
+
+        const result = dispatcher.provideOnTypeFormattingEdits(doc.object, pos.object, ':', opt.object, token.object);
+        assert.equal(result, edits.object, 'Did not return correct edits');
+
+        provider.verifyAll();
+    });
+
+    test('Two providers', () => {
+        const colonProvider = setupProvider(doc.object, pos.object, ':', opt.object, token.object, edits.object);
+
+        const doc2 = TypeMoq.Mock.ofType<TextDocument>();
+        const pos2 = TypeMoq.Mock.ofType<Position>();
+        const opt2 = TypeMoq.Mock.ofType<FormattingOptions>();
+        const token2 = TypeMoq.Mock.ofType<CancellationToken>();
+        const edits2 = TypeMoq.Mock.ofType<ProviderResult<TextEdit[]>>();
+
+        const newlineProvider = setupProvider(doc2.object, pos2.object, '\n', opt2.object, token2.object, edits2.object);
+
+        const dispatcher = new OnTypeFormattingDispatcher({
+            ':': colonProvider.object,
+            '\n': newlineProvider.object
+        });
+
+        const triggers = dispatcher.getTriggerCharacters();
+        assert.deepStrictEqual(triggers, { first: '\n', more: [':'] }, 'Did not return correct triggers');
+
+        const result = dispatcher.provideOnTypeFormattingEdits(doc.object, pos.object, ':', opt.object, token.object);
+        assert.equal(result, edits.object, 'Did not return correct editsfor colon provider');
+
+        const result2 = dispatcher.provideOnTypeFormattingEdits(doc2.object, pos2.object, '\n', opt2.object, token2.object);
+        assert.equal(result2, edits2.object, 'Did not return correct edits for newline provider');
+
+        colonProvider.verifyAll();
+        newlineProvider.verifyAll();
+    });
+
+    function setupProvider(document: TextDocument, position: Position, ch: string, options: FormattingOptions, cancellationToken: CancellationToken,
+        result: ProviderResult<TextEdit[]>): TypeMoq.IMock<OnTypeFormattingEditProvider> {
+        const provider = TypeMoq.Mock.ofType<OnTypeFormattingEditProvider>();
+        provider.setup(p => p.provideOnTypeFormattingEdits(document, position, ch, options, cancellationToken))
+            .returns(() => result)
+            .verifiable(TypeMoq.Times.once());
+        return provider;
+    }
+});


### PR DESCRIPTION
For #2714.

Open to suggestions for naming the added class (if "dispatcher" isn't a good choice). As mentioned in #2714, this doesn't contain tests for things outside of the specific added class (i.e. integration). I haven't written anything in TypeScript before, so let me know if something here is unidiomatic or wrong.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
