### PR TITLE
Enable on-type formatting from language server

### DIFF
--- a/news/1 Enhancements/2690.md
+++ b/news/1 Enhancements/2690.md
@@ -1,0 +1,1 @@
+Enable on-type formatting from language server

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -58,9 +58,6 @@ import { sendTelemetryEvent } from './telemetry';
 import { EDITOR_LOAD } from './telemetry/constants';
 import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionManager, ITerminalAutoActivation } from './terminals/types';
-import { BlockFormatProviders } from './typeFormatters/blockFormatProvider';
-import { OnTypeFormattingDispatcher } from './typeFormatters/dispatcher';
-import { OnEnterFormatter } from './typeFormatters/onEnterFormatter';
 import { TEST_OUTPUT_CHANNEL } from './unittests/common/constants';
 import { registerTypes as unitTestsRegisterTypes } from './unittests/serviceRegistry';
 
@@ -135,15 +132,6 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
         const formatProvider = new PythonFormattingEditProvider(context, serviceContainer);
         context.subscriptions.push(languages.registerDocumentFormattingEditProvider(PYTHON, formatProvider));
         context.subscriptions.push(languages.registerDocumentRangeFormattingEditProvider(PYTHON, formatProvider));
-    }
-
-    const onTypeDispatcher = new OnTypeFormattingDispatcher({
-        '\n': new OnEnterFormatter(),
-        ':': new BlockFormatProviders()
-    });
-    const onTypeTriggers = onTypeDispatcher.getTriggerCharacters();
-    if (onTypeTriggers) {
-        context.subscriptions.push(languages.registerOnTypeFormattingEditProvider(PYTHON, onTypeDispatcher, onTypeTriggers.first, ...onTypeTriggers.more));
     }
 
     const deprecationMgr = serviceContainer.get<IFeatureDeprecationManager>(IFeatureDeprecationManager);


### PR DESCRIPTION
For #2690.

Similar to #2612. Note that `:`-based formatting isn't implemented in language server yet (Microsoft/python-language-server#165), but it hasn't been enabled in the extension for anyone for a while now either (fixed in #2714/#2724).

Since line formatting is relatively new in language server, this likely shouldn't make it out into a release until the language server downloaded by default is new enough to include that functionality. I haven't been monitoring that side of things, so feel free to hold off on merging this until the right time.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
