### PR TITLE
Ensure relative paths to interpreters are prefixed with './' in settings.json

### DIFF
--- a/news/2 Fixes/2744.md
+++ b/news/2 Fixes/2744.md
@@ -1,0 +1,1 @@
+Ensure relative paths to python interpreters in `python.pythonPath` of `settings.json` are prefixed with `./` or `.\\` (depending on the OS).

--- a/src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
+++ b/src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
@@ -14,7 +14,7 @@ export class WorkspaceFolderPythonPathUpdaterService implements IPythonPathUpdat
             return;
         }
         if (pythonPath.startsWith(this.workspaceFolder.fsPath)) {
-            pythonPath = path.relative(this.workspaceFolder.fsPath, pythonPath);
+            pythonPath = path.join('.', path.relative(this.workspaceFolder.fsPath, pythonPath));
         }
         await pythonConfig.update('pythonPath', pythonPath, ConfigurationTarget.WorkspaceFolder);
     }

--- a/src/client/interpreter/configuration/services/workspaceUpdaterService.ts
+++ b/src/client/interpreter/configuration/services/workspaceUpdaterService.ts
@@ -14,7 +14,7 @@ export class WorkspacePythonPathUpdaterService implements IPythonPathUpdaterServ
             return;
         }
         if (pythonPath.startsWith(this.workspace.fsPath)) {
-            pythonPath = path.relative(this.workspace.fsPath, pythonPath);
+            pythonPath = path.join('.', path.relative(this.workspace.fsPath, pythonPath));
         }
         await pythonConfig.update('pythonPath', pythonPath, false);
     }

--- a/src/test/interpreters/pythonPathUpdater.test.ts
+++ b/src/test/interpreters/pythonPathUpdater.test.ts
@@ -80,7 +80,7 @@ suite('Python Path Settings Updater', () => {
             const workspaceFolder = Uri.file(workspaceFolderPath);
             const updater = updaterServiceFactory.getWorkspaceFolderPythonPathConfigurationService(workspaceFolder);
             const pythonPath = Uri.file(path.join(workspaceFolderPath, 'env', 'bin', 'python')).fsPath;
-            const expectedPythonPath = path.join('env', 'bin', 'python');
+            const expectedPythonPath = path.join('.', 'env', 'bin', 'python');
             const workspaceConfig = setupConfigProvider(workspaceFolder);
             workspaceConfig.setup(w => w.inspect(TypeMoq.It.isValue('pythonPath'))).returns(() => undefined);
 
@@ -120,7 +120,7 @@ suite('Python Path Settings Updater', () => {
             const workspaceFolder = Uri.file(workspaceFolderPath);
             const updater = updaterServiceFactory.getWorkspacePythonPathConfigurationService(workspaceFolder);
             const pythonPath = Uri.file(path.join(workspaceFolderPath, 'env', 'bin', 'python')).fsPath;
-            const expectedPythonPath = path.join('env', 'bin', 'python');
+            const expectedPythonPath = path.join('.', 'env', 'bin', 'python');
             const workspaceConfig = setupConfigProvider(workspaceFolder);
             workspaceConfig.setup(w => w.inspect(TypeMoq.It.isValue('pythonPath'))).returns(() => undefined);
 


### PR DESCRIPTION
For #2744

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
