### PR TITLE
Fix Deprecated Option for Ctags

### DIFF
--- a/news/2 Fixes/793.md
+++ b/news/2 Fixes/793.md
@@ -1,0 +1,2 @@
+Have `ctags` use the `--extras` option instead of `--extra`.
+(thanks to [Brandy Sandrowicz](https://github.com/bsandrow))

--- a/resources/ctagOptions
+++ b/resources/ctagOptions
@@ -19,5 +19,5 @@
 --exclude=Builds
 --exclude=doc
 --fields=Knz
---extra=+f
+--extras=+f
 --append=no


### PR DESCRIPTION
Get rid of the `ctags` warning about using `--extras` (supported) instead of
`--extra` (deprecated).

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
