### PR TITLE
Changes to logic for determining download channel

### DIFF
--- a/src/client/activation/languageServerPackageService.ts
+++ b/src/client/activation/languageServerPackageService.ts
@@ -67,11 +67,11 @@ export class LanguageServerPackageService implements ILanguageServerPackageServi
             return settings.analysis.downloadChannel;
         }
 
-        const isReleaseOrAlpha = this.isReleaseOrAlphaVersionOfExtension();
-        return isReleaseOrAlpha ? 'stable' : 'beta';
+        const isReleaseOrSimilar = this.isReleaseOrSimilarVersionOfExtension();
+        return isReleaseOrSimilar ? 'stable' : 'beta';
     }
 
-    private isReleaseOrAlphaVersionOfExtension() {
+    private isReleaseOrSimilarVersionOfExtension() {
         const extensions = this.serviceContainer.get<IExtensions>(IExtensions);
         const extension = extensions.getExtension(PVSC_EXTENSION_ID);
         if (!extension || !extension.packageJSON || !extension.packageJSON.version) {
@@ -79,7 +79,9 @@ export class LanguageServerPackageService implements ILanguageServerPackageServi
             return true;
         }
         const version = parse(extension.packageJSON.version);
-        if (version && (version.prerelease.length === 0 || version.prerelease === ['alpha'])) {
+        if (version && (version.prerelease.length === 0 ||
+            version.prerelease === ['rc'] ||
+            version.prerelease === ['beta'])) {
             return true;
         }
         return false;

--- a/src/client/activation/languageServerPackageService.ts
+++ b/src/client/activation/languageServerPackageService.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import { parse } from 'semver';
 import { Architecture, OSType } from '../../utils/platform';
 import { PVSC_EXTENSION_ID } from '../common/constants';
-import { log, warn } from '../common/logger';
+import { log } from '../common/logger';
 import { INugetRepository, INugetService, NugetPackage } from '../common/nuget/types';
 import { IPlatformService } from '../common/platform/types';
 import { IConfigurationService, IExtensions, LanguageServerDownloadChannels } from '../common/types';
@@ -67,23 +67,14 @@ export class LanguageServerPackageService implements ILanguageServerPackageServi
             return settings.analysis.downloadChannel;
         }
 
-        const isReleaseOrSimilar = this.isReleaseOrSimilarVersionOfExtension();
-        return isReleaseOrSimilar ? 'stable' : 'beta';
+        const isAlphaVersion = this.isAlphaVersionOfExtension();
+        return isAlphaVersion ? 'beta' : 'stable';
     }
 
-    private isReleaseOrSimilarVersionOfExtension() {
+    private isAlphaVersionOfExtension() {
         const extensions = this.serviceContainer.get<IExtensions>(IExtensions);
-        const extension = extensions.getExtension(PVSC_EXTENSION_ID);
-        if (!extension || !extension.packageJSON || !extension.packageJSON.version) {
-            warn('Python Extension not found', PVSC_EXTENSION_ID);
-            return true;
-        }
-        const version = parse(extension.packageJSON.version);
-        if (version && (version.prerelease.length === 0 ||
-            version.prerelease === ['rc'] ||
-            version.prerelease === ['beta'])) {
-            return true;
-        }
-        return false;
+        const extension = extensions.getExtension(PVSC_EXTENSION_ID)!;
+        const version = parse(extension.packageJSON.version)!;
+        return version.prerelease === ['alpha'];
     }
 }

--- a/src/client/common/application/extensions.ts
+++ b/src/client/common/application/extensions.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { injectable } from 'inversify';
+import { Extension, extensions } from 'vscode';
+import { IExtensions } from '../types';
+
+@injectable()
+export class Extensions implements IExtensions {
+    // tslint:disable-next-line:no-any
+    public get all(): Extension<any>[] {
+        return extensions.all;
+    }
+
+    // tslint:disable-next-line:no-any
+    public getExtension(extensionId: any) {
+        return extensions.getExtension(extensionId);
+    }
+}

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -9,6 +9,7 @@ import { ApplicationShell } from './application/applicationShell';
 import { CommandManager } from './application/commandManager';
 import { DebugService } from './application/debugService';
 import { DocumentManager } from './application/documentManager';
+import { Extensions } from './application/extensions';
 import { TerminalManager } from './application/terminalManager';
 import {
     IApplicationEnvironment, IApplicationShell, ICommandManager,
@@ -41,15 +42,16 @@ import {
 } from './terminal/types';
 import {
     IBrowserService, IConfigurationService,
-    ICurrentProcess, IEditorUtils, IFeatureDeprecationManager,
-    IInstaller, ILogger,
-    IPathUtils, IPersistentStateFactory, IRandom, Is64Bit, IsWindows
+    ICurrentProcess, IEditorUtils, IExtensions,
+    IFeatureDeprecationManager, IInstaller,
+    ILogger, IPathUtils, IPersistentStateFactory, IRandom, Is64Bit, IsWindows
 } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingletonInstance<boolean>(IsWindows, IS_WINDOWS);
     serviceManager.addSingletonInstance<boolean>(Is64Bit, IS_64_BIT);
 
+    serviceManager.addSingleton<IExtensions>(IExtensions, Extensions);
     serviceManager.addSingleton<IRandom>(IRandom, Random);
     serviceManager.addSingleton<IPersistentStateFactory>(IPersistentStateFactory, PersistentStateFactory);
     serviceManager.addSingleton<ILogger>(ILogger, Logger);

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Socket } from 'net';
-import { ConfigurationTarget, DiagnosticSeverity, Disposable, ExtensionContext, OutputChannel, Uri, WorkspaceEdit } from 'vscode';
+import { ConfigurationTarget, DiagnosticSeverity, Disposable, Extension, ExtensionContext, OutputChannel, Uri, WorkspaceEdit } from 'vscode';
 import { EnvironmentVariables } from './variables/types';
 export const IOutputChannel = Symbol('IOutputChannel');
 export interface IOutputChannel extends OutputChannel { }
@@ -271,6 +271,32 @@ export interface ISocketServer extends Disposable {
 
 export const IExtensionContext = Symbol('ExtensionContext');
 export interface IExtensionContext extends ExtensionContext { }
+
+export const IExtensions = Symbol('IExtensions');
+export interface IExtensions {
+    /**
+     * All extensions currently known to the system.
+     */
+    // tslint:disable-next-line:no-any
+    readonly all: Extension<any>[];
+
+    /**
+     * Get an extension by its full identifier in the form of: `publisher.name`.
+     *
+     * @param extensionId An extension identifier.
+     * @return An extension or `undefined`.
+     */
+    // tslint:disable-next-line:no-any
+    getExtension(extensionId: string): Extension<any> | undefined;
+
+    /**
+     * Get an extension its full identifier in the form of: `publisher.name`.
+     *
+     * @param extensionId An extension identifier.
+     * @return An extension or `undefined`.
+     */
+    getExtension<T>(extensionId: string): Extension<T> | undefined;
+}
 
 export const IBrowserService = Symbol('IBrowserService');
 export interface IBrowserService {

--- a/src/test/activation/languageServerPackageService.test.ts
+++ b/src/test/activation/languageServerPackageService.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import * as typeMoq from 'typemoq';
 import { WorkspaceConfiguration } from 'vscode';
 import { LanguageServerPackageStorageContainers } from '../../client/activation/languageServerPackageRepository';
-import { DefaultLanguageServerDownloadChannel, LanguageServerPackageService } from '../../client/activation/languageServerPackageService';
+import { LanguageServerPackageService } from '../../client/activation/languageServerPackageService';
 import { IHttpClient } from '../../client/activation/types';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { HttpClient } from '../../client/common/net/httpClient';
@@ -69,7 +69,7 @@ suite('Language Server Package Service', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nugetService);
         const platformService = new PlatformService();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IPlatformService))).returns(() => platformService);
-        const defaultStorageChannel = LanguageServerPackageStorageContainers[DefaultLanguageServerDownloadChannel];
+        const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
         const nugetRepo = new AzureBlobStoreNugetRepository(serviceContainer.object, 'https://pvsc.blob.core.windows.net', defaultStorageChannel);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetRepository))).returns(() => nugetRepo);
         const lsPackageService = new LanguageServerPackageService(serviceContainer.object);

--- a/src/test/common/nuget/azureBobStoreRepository.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import { SemVer } from 'semver';
 import * as typeMoq from 'typemoq';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServerPackageRepository';
-import { DefaultLanguageServerDownloadChannel, LanguageServerPackageService } from '../../../client/activation/languageServerPackageService';
+import { LanguageServerPackageService } from '../../../client/activation/languageServerPackageService';
 import { IHttpClient } from '../../../client/activation/types';
 import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
 import { INugetService } from '../../../client/common/nuget/types';
@@ -27,7 +27,7 @@ suite('Nuget Azure Storage Repository', () => {
         const nugetService = typeMoq.Mock.ofType<INugetService>();
         nugetService.setup(n => n.getVersionFromPackageFileName(typeMoq.It.isAny())).returns(() => new SemVer('1.1.1'));
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nugetService.object);
-        const defaultStorageChannel = LanguageServerPackageStorageContainers[DefaultLanguageServerDownloadChannel];
+        const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
 
         repo = new AzureBlobStoreNugetRepository(serviceContainer.object, 'https://pvsc.blob.core.windows.net', defaultStorageChannel);
     });


### PR DESCRIPTION
For #2755

@brettcannon 	@d3r3kk 
The new logic is outlined in the issue.
Please review, @d3r3kk you two have reviewed this in the past.
@brettcannon you have been (need to be) across the requirements.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
