### PR TITLE
gh-2696: Add a unit test for the MyPy output regex.

### DIFF
--- a/news/2 Fixes/2696.md
+++ b/news/2 Fixes/2696.md
@@ -1,0 +1,1 @@
+Add a unit test for the MyPy output regex.

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -5,7 +5,7 @@ import { IServiceContainer } from '../ioc/types';
 import { BaseLinter } from './baseLinter';
 import { ILintMessage } from './types';
 
-const REGEX = '(?<file>.+):(?<line>\\d+): (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
+export const REGEX = '(?<file>.+):(?<line>\\d+): (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
 
 export class MyPy extends BaseLinter {
     constructor(outputChannel: OutputChannel, serviceContainer: IServiceContainer) {

--- a/src/test/linters/mypy.unit.test.ts
+++ b/src/test/linters/mypy.unit.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-object-literal-type-assertion
+
+import { expect } from 'chai';
+import { parseLine } from '../../client/linters/baseLinter';
+import { REGEX } from '../../client/linters/mypy';
+import { ILintMessage } from '../../client/linters/types';
+
+// This following is a real-world example. See gh=2380.
+// tslint:disable-next-line:no-multiline-string
+const output = `
+provider.pyi:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
+provider.pyi:11: error: Name 'not_declared_var' is not defined
+`;
+
+suite('Linting - MyPy', () => {
+    test('regex', async () => {
+        const lines = output.split('\n');
+        const tests: [string, ILintMessage][] = [
+            [lines[1], {
+                message: 'Incompatible types in assignment (expression has type "str", variable has type "int")',
+                column: 0,
+                line: 10,
+                type: 'error',
+                provider: 'mypy'
+             } as ILintMessage],
+            [lines[2], {
+                message: 'Name \'not_declared_var\' is not defined',
+                column: 0,
+                line: 11,
+                type: 'error',
+                provider: 'mypy'
+             } as ILintMessage]
+        ];
+        for (const [line, expected] of tests) {
+            const msg = parseLine(line, REGEX, 'mypy');
+
+            expect(msg).to.deep.equal(expected);
+        }
+    });
+});


### PR DESCRIPTION
(for #2696)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~~
- [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~~
