### PR TITLE
Add full path to activate for conda activate command in windows.

### DIFF
--- a/news/2 Fixes/2753.md
+++ b/news/2 Fixes/2753.md
@@ -1,0 +1,1 @@
+Use full path to activate command in conda environments on windows when python.condaPath is set.


### PR DESCRIPTION
For #2753

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
