### PR TITLE
Update pvsc-dev-ext.py shebang

### DIFF
--- a/pvsc-dev-ext.py
+++ b/pvsc-dev-ext.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 


### PR DESCRIPTION
previously the python3 binary had to be in a prescriptive location, now it will use the python3 binary in the users path (wherever it is located)

