### PR TITLE
Fix installation of conda packages when conda environment has spaces

### DIFF
--- a/news/2 Fixes/2015.md
+++ b/news/2 Fixes/2015.md
@@ -1,0 +1,1 @@
+Fix installation of codna packages when conda environment contains spaces.

--- a/src/client/common/installer/condaInstaller.ts
+++ b/src/client/common/installer/condaInstaller.ts
@@ -65,11 +65,11 @@ export class CondaInstaller extends ModuleInstaller implements IModuleInstaller 
         if (info && info.name) {
             // If we have the name of the conda environment, then use that.
             args.push('--name');
-            args.push(info.name!);
+            args.push(info.name!.toCommandArgument());
         } else if (info && info.path) {
             // Else provide the full path to the environment path.
             args.push('--prefix');
-            args.push(info.path);
+            args.push(info.path.fileToCommandArgument());
         }
         args.push(moduleName);
         return {

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -43,7 +43,10 @@ suite('Module Installer', () => {
         proxyServers.forEach(proxyServer => {
             [undefined, Uri.file('/users/dev/xyz')].forEach(resource => {
                 // Conda info is relevant only for CondaInstaller.
-                const condaEnvs = installerClass === CondaInstaller ? [{ name: 'My-Env01', path: '' }, { name: '', path: '/conda/path' }] : [];
+                const condaEnvs = installerClass === CondaInstaller ? [
+                    { name: 'My-Env01', path: '' }, { name: '', path: path.join('conda', 'path') },
+                    { name: 'My-Env01 With Spaces', path: '' }, { name: '', path: path.join('conda with spaces', 'path') }
+                ] : [];
                 [undefined, ...condaEnvs].forEach(condaEnvInfo => {
                     const testProxySuffix = proxyServer.length === 0 ? 'without proxy info' : 'with proxy info';
                     const testCondaEnv = condaEnvInfo ? (condaEnvInfo.name ? 'without conda name' : 'with conda path') : 'without conda';
@@ -144,10 +147,10 @@ suite('Module Installer', () => {
                                                 const expectedArgs = ['install'];
                                                 if (condaEnvInfo && condaEnvInfo.name) {
                                                     expectedArgs.push('--name');
-                                                    expectedArgs.push(condaEnvInfo.name);
+                                                    expectedArgs.push(condaEnvInfo.name.toCommandArgument());
                                                 } else if (condaEnvInfo && condaEnvInfo.path) {
                                                     expectedArgs.push('--prefix');
-                                                    expectedArgs.push(condaEnvInfo.path);
+                                                    expectedArgs.push(condaEnvInfo.path.fileToCommandArgument());
                                                 }
                                                 expectedArgs.push('"pylint<2.0.0"');
                                                 await installModuleAndVerifyCommand(condaExecutable, expectedArgs);
@@ -176,10 +179,10 @@ suite('Module Installer', () => {
                                                 const expectedArgs = ['install'];
                                                 if (condaEnvInfo && condaEnvInfo.name) {
                                                     expectedArgs.push('--name');
-                                                    expectedArgs.push(condaEnvInfo.name);
+                                                    expectedArgs.push(condaEnvInfo.name.toCommandArgument());
                                                 } else if (condaEnvInfo && condaEnvInfo.path) {
                                                     expectedArgs.push('--prefix');
-                                                    expectedArgs.push(condaEnvInfo.path);
+                                                    expectedArgs.push(condaEnvInfo.path.fileToCommandArgument());
                                                 }
                                                 expectedArgs.push('pylint');
                                                 await installModuleAndVerifyCommand(condaExecutable, expectedArgs);
@@ -223,10 +226,10 @@ suite('Module Installer', () => {
                                     const expectedArgs = ['install'];
                                     if (condaEnvInfo && condaEnvInfo.name) {
                                         expectedArgs.push('--name');
-                                        expectedArgs.push(condaEnvInfo.name);
+                                        expectedArgs.push(condaEnvInfo.name.toCommandArgument());
                                     } else if (condaEnvInfo && condaEnvInfo.path) {
                                         expectedArgs.push('--prefix');
-                                        expectedArgs.push(condaEnvInfo.path);
+                                        expectedArgs.push(condaEnvInfo.path.fileToCommandArgument());
                                     }
                                     expectedArgs.push(moduleName);
                                     await installModuleAndVerifyCommand(condaExecutable, expectedArgs);


### PR DESCRIPTION
For #2015

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
