### PR TITLE
Update vscode-extension-telemetry to 0.0.22

### DIFF
--- a/ThirdPartyNotices-Distribution.txt
+++ b/ThirdPartyNotices-Distribution.txt
@@ -8,7 +8,7 @@ Microsoft Python extension for Visual Studio Code incorporates third party mater
 1.   _pydev_calltip_util.py (for PyDev.Debugger) (https://github.com/fabioz/PyDev.Debugger/blob/master/_pydev_bundle/_pydev_calltip_util.py)
 2.   ajv 5.5.2 (https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz)
 3.   angular.io (for RxJS 5.5) (https://angular.io/)
-4.   applicationinsights 1.0.1 (https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz)
+4.   applicationinsights 1.0.5 (https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.5.tgz)
 5.   arch 2.1.0 (https://registry.npmjs.org/arch/-/arch-2.1.0.tgz)
 6.   asn1 0.2.3 (https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz)
 7.   assert-plus 1.0.0 (https://github.com/joyent/node-assert-plus/tree/v1.0.0)
@@ -126,7 +126,7 @@ Microsoft Python extension for Visual Studio Code incorporates third party mater
 119. verror 1.10.0 (https://registry.npmjs.org/verror/-/verror-1.10.0.tgz)
 120. vscode-debugadapter 1.28.0 (https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.28.0.tgz)
 121. vscode-debugprotocol 1.28.0 (https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.28.0.tgz)
-122. vscode-extension-telemetry 0.0.15 (https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.15.tgz)
+122. vscode-extension-telemetry 0.0.22 (https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz)
 123. vscode-jsonrpc 3.6.2 (https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.2.tgz)
 124. vscode-languageclient 4.4.0 (https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.0.tgz)
 125. vscode-languageserver 4.4.0 (https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.4.0.tgz)
@@ -203,7 +203,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========================================
 END OF angular.io NOTICES AND INFORMATION
 
-%% applicationinsights 1.0.1 NOTICES AND INFORMATION BEGIN HERE (https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz)
+%% applicationinsights 1.0.5 NOTICES AND INFORMATION BEGIN HERE (https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.5.tgz)
 =========================================
 ﻿The MIT License (MIT) 
 Copyright © Microsoft Corporation
@@ -3986,7 +3986,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 =========================================
 END OF vscode-debugprotocol NOTICES AND INFORMATION
 
-%% vscode-extension-telemetry 0.0.15 NOTICES AND INFORMATION BEGIN HERE (https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.15.tgz)
+%% vscode-extension-telemetry 0.0.22 NOTICES AND INFORMATION BEGIN HERE (https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz)
 =========================================
 vscode-extension-telemetry
 

--- a/news/3 Code Health/2745.md
+++ b/news/3 Code Health/2745.md
@@ -1,0 +1,1 @@
+Update `vscode-extension-telemetry` to `0.0.22`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -524,9 +524,9 @@
             }
         },
         "applicationinsights": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.1.tgz",
-            "integrity": "sha1-U0Rrgw/o1dYZ7uKieLMdPSUDCSc=",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.5.tgz",
+            "integrity": "sha512-T6V4ZyhikGKnuqYGbNz1q5+ORROutUp58UqfLLwHH+X1RkcnEU+gW15kIKWJ8zqGWbilhn6bONJa+T5en642mg==",
             "requires": {
                 "diagnostic-channel": "0.2.0",
                 "diagnostic-channel-publishers": "0.2.1",
@@ -9637,11 +9637,11 @@
             "integrity": "sha512-QM4J8A13jBY9I7OPWXN0ZO1cqydnD4co2j/O81jIj6em8VkmJT4VyJQkq4HmwJe3af+u9+7IYCIEDrowgvKxTA=="
         },
         "vscode-extension-telemetry": {
-            "version": "0.0.15",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.15.tgz",
-            "integrity": "sha512-Yf6dL9r2x2GISI1xh22XsAaydSTQG/4aBitu8sGBwGr42n2TyOsIXGtXSDgqQBNZgYD6+P1EHqrrzetn9ekWTQ==",
+            "version": "0.0.22",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.0.22.tgz",
+            "integrity": "sha512-6/xT3UG6nPcNbBT29RPRJ6uRplI0l1m5ZBX9VXV3XGWrINDvWw2Nk/84xMeWDF1zI1YoPCcjeD0u4gH2OIsrcA==",
             "requires": {
-                "applicationinsights": "1.0.1"
+                "applicationinsights": "1.0.5"
             }
         },
         "vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -1572,7 +1572,7 @@
         "untildify": "3.0.2",
         "vscode-debugadapter": "1.28.0",
         "vscode-debugprotocol": "1.28.0",
-        "vscode-extension-telemetry": "0.0.15",
+        "vscode-extension-telemetry": "0.0.22",
         "vscode-languageclient": "4.4.0",
         "vscode-languageserver": "4.4.0",
         "vscode-languageserver-protocol": "3.10.3",


### PR DESCRIPTION
For #2745 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
