### PR TITLE
Improvements to algorithm used to identify virtual environments

### DIFF
--- a/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
@@ -14,12 +14,14 @@ export abstract class BaseActivationCommandProvider implements ITerminalActivati
     constructor(protected readonly serviceContainer: IServiceContainer) { }
 
     public abstract isShellSupported(targetShell: TerminalShellType): boolean;
-    public abstract getActivationCommands(resource: Uri | undefined, targetShell: TerminalShellType): Promise<string[] | undefined>;
-
-    protected async findScriptFile(resource: Uri | undefined, scriptFileNames: string[]): Promise<string | undefined> {
-        const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
+    public getActivationCommands(resource: Uri | undefined, targetShell: TerminalShellType): Promise<string[] | undefined> {
         const pythonPath = this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings(resource).pythonPath;
+        return this.getActivationCommandsForInterpreter(pythonPath, targetShell);
+    }
+    public abstract getActivationCommandsForInterpreter(pythonPath: string, targetShell: TerminalShellType): Promise<string[] | undefined>;
 
+    protected async findScriptFile(pythonPath: string, scriptFileNames: string[]): Promise<string | undefined> {
+        const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
         for (const scriptFileName of scriptFileNames) {
             // Generate scripts are found in the same directory as the interpreter.
             const scriptFile = path.join(path.dirname(pythonPath), scriptFileName);

--- a/src/client/common/terminal/environmentActivationProviders/bash.ts
+++ b/src/client/common/terminal/environmentActivationProviders/bash.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { inject, injectable } from 'inversify';
-import { Uri } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
 import '../../extensions';
 import { TerminalShellType } from '../types';
@@ -23,8 +22,8 @@ export class Bash extends BaseActivationCommandProvider {
             targetShell === TerminalShellType.tcshell ||
             targetShell === TerminalShellType.fish;
     }
-    public async getActivationCommands(resource: Uri | undefined, targetShell: TerminalShellType): Promise<string[] | undefined> {
-        const scriptFile = await this.findScriptFile(resource, this.getScriptsInOrderOfPreference(targetShell));
+    public async getActivationCommandsForInterpreter(pythonPath: string, targetShell: TerminalShellType): Promise<string[] | undefined> {
+        const scriptFile = await this.findScriptFile(pythonPath, this.getScriptsInOrderOfPreference(targetShell));
         if (!scriptFile) {
             return;
         }

--- a/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
+++ b/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
@@ -3,7 +3,6 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { Uri } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
 import '../../extensions';
 import { IPlatformService } from '../../platform/types';
@@ -20,9 +19,9 @@ export class CommandPromptAndPowerShell extends BaseActivationCommandProvider {
             targetShell === TerminalShellType.powershell ||
             targetShell === TerminalShellType.powershellCore;
     }
-    public async getActivationCommands(resource: Uri | undefined, targetShell: TerminalShellType): Promise<string[] | undefined> {
+    public async getActivationCommandsForInterpreter(pythonPath, targetShell: TerminalShellType): Promise<string[] | undefined> {
         // Dependending on the target shell, look for the preferred script file.
-        const scriptFile = await this.findScriptFile(resource, this.getScriptsInOrderOfPreference(targetShell));
+        const scriptFile = await this.findScriptFile(pythonPath, this.getScriptsInOrderOfPreference(targetShell));
         if (!scriptFile) {
             return;
         }

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -57,4 +57,5 @@ export const ITerminalActivationCommandProvider = Symbol('ITerminalActivationCom
 export interface ITerminalActivationCommandProvider {
     isShellSupported(targetShell: TerminalShellType): boolean;
     getActivationCommands(resource: Uri | undefined, targetShell: TerminalShellType): Promise<string[] | undefined>;
+    getActivationCommandsForInterpreter?(pythonPath, targetShell: TerminalShellType): Promise<string[] | undefined>;
 }

--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -46,7 +46,7 @@ export class InterpreterHelper implements IInterpreterHelper {
     public async getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonInterpreter>> {
         let fileHash = await this.fs.getFileHash(pythonPath).catch(() => '');
         fileHash = fileHash ? fileHash : '';
-        const store = this.persistentFactory.createGlobalPersistentState<CachedPythonInterpreter>(`${pythonPath}.v1`, undefined, EXPITY_DURATION);
+        const store = this.persistentFactory.createGlobalPersistentState<CachedPythonInterpreter>(`${pythonPath}.v2`, undefined, EXPITY_DURATION);
         if (store.value && fileHash && store.value.fileHash === fileHash) {
             return store.value;
         }

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -127,7 +127,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
         let fileHash = await this.fs.getFileHash(pythonPath).catch(() => '');
         fileHash = fileHash ? fileHash : '';
-        const store = this.persistentStateFactory.createGlobalPersistentState<PythonInterpreter & { fileHash: string }>(`${pythonPath}.interpreter.details.v2`, undefined, EXPITY_DURATION);
+        const store = this.persistentStateFactory.createGlobalPersistentState<PythonInterpreter & { fileHash: string }>(`${pythonPath}.interpreter.details.v5`, undefined, EXPITY_DURATION);
         if (store.value && fileHash && store.value.fileHash === fileHash) {
             return store.value;
         }
@@ -151,10 +151,10 @@ export class InterpreterService implements Disposable, IInterpreterService {
                 type: type
             };
 
-            const virtualEnvName = await virtualEnvManager.getEnvironmentName(pythonPath, resource);
+            const envName = type === InterpreterType.Unknown ? undefined : await virtualEnvManager.getEnvironmentName(pythonPath, resource);
             interpreterInfo = {
                 ...(details as PythonInterpreter),
-                envName: virtualEnvName
+                envName
             };
             interpreterInfo.displayName = await this.getDisplayName(interpreterInfo, resource);
         }
@@ -172,7 +172,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
      * @memberof InterpreterService
      */
     public async getDisplayName(info: Partial<PythonInterpreter>, resource?: Uri): Promise<string> {
-        const store = this.persistentStateFactory.createGlobalPersistentState<string>(`${info.path}.interpreter.displayName.v3`, undefined, EXPITY_DURATION);
+        const store = this.persistentStateFactory.createGlobalPersistentState<string>(`${info.path}.interpreter.displayName.v5`, undefined, EXPITY_DURATION);
         if (store.value) {
             return store.value;
         }

--- a/src/client/interpreter/locators/services/cacheableLocatorService.ts
+++ b/src/client/interpreter/locators/services/cacheableLocatorService.ts
@@ -19,7 +19,7 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
     constructor(@unmanaged() name: string,
         @unmanaged() protected readonly serviceContainer: IServiceContainer,
         @unmanaged() private cachePerWorkspace: boolean = false) {
-        this.cacheKeyPrefix = `INTERPRETERS_CACHE_v1_${name}`;
+        this.cacheKeyPrefix = `INTERPRETERS_CACHE_v2_${name}`;
     }
     public abstract dispose();
     public async getInterpreters(resource?: Uri): Promise<PythonInterpreter[]> {

--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -3,19 +3,23 @@
 
 'use strict';
 
-// tslint:disable:max-func-body-length no-any
+// tslint:disable:max-func-body-length no-any max-classes-per-file
 
 import { expect } from 'chai';
 import * as typemoq from 'typemoq';
+import { ConfigurationChangeEvent } from 'vscode';
 import { InvalidPythonInterpreterDiagnostic, InvalidPythonInterpreterService } from '../../../../client/application/diagnostics/checks/pythonInterpreter';
 import { CommandOption, IDiagnosticsCommandFactory } from '../../../../client/application/diagnostics/commands/types';
 import { DiagnosticCodes } from '../../../../client/application/diagnostics/constants';
 import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../../../../client/application/diagnostics/promptHandler';
 import { IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService, IDiagnosticsService } from '../../../../client/application/diagnostics/types';
+import { IWorkspaceService } from '../../../../client/common/application/types';
 import { IPlatformService } from '../../../../client/common/platform/types';
-import { IConfigurationService, IPythonSettings } from '../../../../client/common/types';
+import { IConfigurationService, IDisposableRegistry, IPythonSettings } from '../../../../client/common/types';
 import { IInterpreterHelper, IInterpreterService, InterpreterType } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
+import { noop } from '../../../../utils/misc';
+import { sleep } from '../../../core';
 
 suite('Application Diagnostics - Checks Python Interpreter', () => {
     let diagnosticService: IDiagnosticsService;
@@ -26,9 +30,9 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
     let platformService: typemoq.IMock<IPlatformService>;
     let helper: typemoq.IMock<IInterpreterHelper>;
     const pythonPath = 'My Python Path in Settings';
-
-    setup(() => {
-        const serviceContainer = typemoq.Mock.ofType<IServiceContainer>();
+    let serviceContainer: typemoq.IMock<IServiceContainer>;
+    function createContainer() {
+        serviceContainer = typemoq.Mock.ofType<IServiceContainer>();
         messageHandler = typemoq.Mock.ofType<IDiagnosticHandlerService<MessageCommandPrompt>>();
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IDiagnosticHandlerService), typemoq.It.isValue(DiagnosticCommandPromptHandlerServiceId)))
             .returns(() => messageHandler.object);
@@ -50,242 +54,369 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
         helper = typemoq.Mock.ofType<IInterpreterHelper>();
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IInterpreterHelper)))
             .returns(() => helper.object);
+        serviceContainer.setup(s => s.get(typemoq.It.isValue(IDisposableRegistry)))
+            .returns(() => []);
+        return serviceContainer.object;
+    }
+    suite('Diagnostics', () => {
+        setup(() => {
+            diagnosticService = new class extends InvalidPythonInterpreterService {
+                protected addPythonPathChangedHandler() { noop(); }
+            }(createContainer());
+        });
 
-        diagnosticService = new InvalidPythonInterpreterService(serviceContainer.object);
-    });
+        test('Can handle InvalidPythonPathInterpreter diagnostics', async () => {
+            for (const code of [
+                DiagnosticCodes.NoPythonInterpretersDiagnostic,
+                DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic,
+                DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic
+            ]) {
+                const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
+                diagnostic.setup(d => d.code)
+                    .returns(() => code)
+                    .verifiable(typemoq.Times.atLeastOnce());
 
-    test('Can handle InvalidPythonPathInterpreter diagnostics', async () => {
-        for (const code of [
-            DiagnosticCodes.NoPythonInterpretersDiagnostic,
-            DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic,
-            DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic
-        ]) {
+                const canHandle = await diagnosticService.canHandle(diagnostic.object);
+                expect(canHandle).to.be.equal(true, `Should be able to handle ${code}`);
+                diagnostic.verifyAll();
+            }
+        });
+        test('Can not handle non-InvalidPythonPathInterpreter diagnostics', async () => {
             const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
             diagnostic.setup(d => d.code)
-                .returns(() => code)
+                .returns(() => 'Something Else')
                 .verifiable(typemoq.Times.atLeastOnce());
 
             const canHandle = await diagnosticService.canHandle(diagnostic.object);
-            expect(canHandle).to.be.equal(true, `Should be able to handle ${code}`);
+            expect(canHandle).to.be.equal(false, 'Invalid value');
             diagnostic.verifyAll();
-        }
+        });
+        test('Should return empty diagnostics if installer check is disabled', async () => {
+            settings
+                .setup(s => s.disableInstallationChecks)
+                .returns(() => true)
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose();
+            expect(diagnostics).to.be.deep.equal([]);
+            settings.verifyAll();
+        });
+        test('Should return diagnostics if there are no interpreters', async () => {
+            settings
+                .setup(s => s.disableInstallationChecks)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup(i => i.getInterpreters(typemoq.It.isAny()))
+                .returns(() => Promise.resolve([]))
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose();
+            expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic)]);
+            settings.verifyAll();
+            interpreterService.verifyAll();
+        });
+        test('Should return empty diagnostics if there are interpreters and platform is not mac', async () => {
+            settings
+                .setup(s => s.disableInstallationChecks)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup(i => i.getInterpreters(typemoq.It.isAny()))
+                .returns(() => Promise.resolve([{} as any]))
+                .verifiable(typemoq.Times.once());
+            platformService
+                .setup(i => i.isMac)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose();
+            expect(diagnostics).to.be.deep.equal([]);
+            settings.verifyAll();
+            interpreterService.verifyAll();
+            platformService.verifyAll();
+        });
+        test('Should return empty diagnostics if there are interpreters, platform is mac and selected interpreter is not default mac interpreter', async () => {
+            settings
+                .setup(s => s.disableInstallationChecks)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup(i => i.getInterpreters(typemoq.It.isAny()))
+                .returns(() => Promise.resolve([{} as any]))
+                .verifiable(typemoq.Times.once());
+            platformService
+                .setup(i => i.isMac)
+                .returns(() => true)
+                .verifiable(typemoq.Times.once());
+            helper
+                .setup(i => i.isMacDefaultPythonPath(typemoq.It.isAny()))
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose();
+            expect(diagnostics).to.be.deep.equal([]);
+            settings.verifyAll();
+            interpreterService.verifyAll();
+            platformService.verifyAll();
+            helper.verifyAll();
+        });
+        test('Should return diagnostic if there are no other interpreters, platform is mac and selected interpreter is default mac interpreter', async () => {
+            settings
+                .setup(s => s.disableInstallationChecks)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup(i => i.getInterpreters(typemoq.It.isAny()))
+                .returns(() => Promise.resolve([
+                    { path: pythonPath } as any,
+                    { path: pythonPath } as any
+                ]))
+                .verifiable(typemoq.Times.once());
+            platformService
+                .setup(i => i.isMac)
+                .returns(() => true)
+                .verifiable(typemoq.Times.once());
+            helper
+                .setup(i => i.isMacDefaultPythonPath(typemoq.It.isValue(pythonPath)))
+                .returns(() => true)
+                .verifiable(typemoq.Times.atLeastOnce());
+            interpreterService
+                .setup(i => i.getActiveInterpreter(typemoq.It.isAny()))
+                .returns(() => { return Promise.resolve({ type: InterpreterType.Unknown } as any); })
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose();
+            expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic)]);
+            settings.verifyAll();
+            interpreterService.verifyAll();
+            platformService.verifyAll();
+            helper.verifyAll();
+        });
+        test('Should return diagnostic if there are other interpreters, platform is mac and selected interpreter is default mac interpreter', async () => {
+            const nonMacStandardInterpreter = 'Non Mac Std Interpreter';
+            settings
+                .setup(s => s.disableInstallationChecks)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup(i => i.getInterpreters(typemoq.It.isAny()))
+                .returns(() => Promise.resolve([
+                    { path: pythonPath } as any,
+                    { path: pythonPath } as any,
+                    { path: nonMacStandardInterpreter } as any
+                ]))
+                .verifiable(typemoq.Times.once());
+            platformService
+                .setup(i => i.isMac)
+                .returns(() => true)
+                .verifiable(typemoq.Times.once());
+            helper
+                .setup(i => i.isMacDefaultPythonPath(typemoq.It.isValue(pythonPath)))
+                .returns(() => true)
+                .verifiable(typemoq.Times.atLeastOnce());
+            helper
+                .setup(i => i.isMacDefaultPythonPath(typemoq.It.isValue(nonMacStandardInterpreter)))
+                .returns(() => false)
+                .verifiable(typemoq.Times.atLeastOnce());
+            interpreterService
+                .setup(i => i.getActiveInterpreter(typemoq.It.isAny()))
+                .returns(() => { return Promise.resolve({ type: InterpreterType.Unknown } as any); })
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose();
+            expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic)]);
+            settings.verifyAll();
+            interpreterService.verifyAll();
+            platformService.verifyAll();
+            helper.verifyAll();
+        });
+        test('Handling no interpreters diagnostisc should return download link', async () => {
+            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic);
+            const cmd = {} as any as IDiagnosticCommand;
+            let messagePrompt: MessageCommandPrompt | undefined;
+            messageHandler
+                .setup(i => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
+                .callback((d, p: MessageCommandPrompt) => messagePrompt = p)
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
+                typemoq.It.isObjectWith<CommandOption<'launch', string>>({ type: 'launch' })))
+                .returns(() => cmd)
+                .verifiable(typemoq.Times.once());
+
+            await diagnosticService.handle([diagnostic]);
+
+            messageHandler.verifyAll();
+            commandFactory.verifyAll();
+            expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
+            expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Download', command: cmd }]);
+        });
+        test('Handling no interpreters diagnostisc should return select interpreter cmd', async () => {
+            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic);
+            const cmd = {} as any as IDiagnosticCommand;
+            let messagePrompt: MessageCommandPrompt | undefined;
+            messageHandler
+                .setup(i => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
+                .callback((d, p: MessageCommandPrompt) => messagePrompt = p)
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
+                typemoq.It.isObjectWith<CommandOption<'executeVSCCommand', string>>({ type: 'executeVSCCommand' })))
+                .returns(() => cmd)
+                .verifiable(typemoq.Times.once());
+
+            await diagnosticService.handle([diagnostic]);
+
+            messageHandler.verifyAll();
+            commandFactory.verifyAll();
+            expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
+            expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Select Python Interpreter', command: cmd }]);
+        });
+        test('Handling no interpreters diagnostisc should return download and learn links', async () => {
+            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic);
+            const cmdDownload = {} as any as IDiagnosticCommand;
+            const cmdLearn = {} as any as IDiagnosticCommand;
+            let messagePrompt: MessageCommandPrompt | undefined;
+            messageHandler
+                .setup(i => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
+                .callback((d, p: MessageCommandPrompt) => messagePrompt = p)
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
+                typemoq.It.isObjectWith<CommandOption<'launch', string>>({ type: 'launch', options: 'https://code.visualstudio.com/docs/python/python-tutorial#_prerequisites' })))
+                .returns(() => cmdLearn)
+                .verifiable(typemoq.Times.once());
+            commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
+                typemoq.It.isObjectWith<CommandOption<'launch', string>>({ type: 'launch', options: 'https://www.python.org/downloads' })))
+                .returns(() => cmdDownload)
+                .verifiable(typemoq.Times.once());
+
+            await diagnosticService.handle([diagnostic]);
+
+            messageHandler.verifyAll();
+            commandFactory.verifyAll();
+            expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
+            expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Learn more', command: cmdLearn }, { prompt: 'Download', command: cmdDownload }]);
+        });
     });
-    test('Can not handle non-InvalidPythonPathInterpreter diagnostics', async () => {
-        const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
-        diagnostic.setup(d => d.code)
-            .returns(() => 'Something Else')
-            .verifiable(typemoq.Times.atLeastOnce());
 
-        const canHandle = await diagnosticService.canHandle(diagnostic.object);
-        expect(canHandle).to.be.equal(false, 'Invalid value');
-        diagnostic.verifyAll();
-    });
-    test('Should return empty diagnostics if installer check is disabled', async () => {
-        settings
-            .setup(s => s.disableInstallationChecks)
-            .returns(() => true)
-            .verifiable(typemoq.Times.once());
+    suite('Change Handlers.', () => {
+        test('Add PythonPath handler is invoked', async () => {
+            let invoked = false;
+            diagnosticService = new class extends InvalidPythonInterpreterService {
+                protected addPythonPathChangedHandler() { invoked = true; }
+            }(createContainer());
 
-        const diagnostics = await diagnosticService.diagnose();
-        expect(diagnostics).to.be.deep.equal([]);
-        settings.verifyAll();
-    });
-    test('Should return diagnostics if there are no interpreters', async () => {
-        settings
-            .setup(s => s.disableInstallationChecks)
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
-        interpreterService
-            .setup(i => i.getInterpreters(typemoq.It.isAny()))
-            .returns(() => Promise.resolve([]))
-            .verifiable(typemoq.Times.once());
+            expect(invoked).to.be.equal(true, 'Not invoked');
+        });
+        test('Event Handler is registered and invoked', async () => {
+            let invoked = false;
+            let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
+            const workspaceService = { onDidChangeConfiguration: cb => callbackHandler = cb } as any;
+            const serviceContainerObject = createContainer();
+            serviceContainer.setup(s => s.get(typemoq.It.isValue(IWorkspaceService)))
+                .returns(() => workspaceService);
+            diagnosticService = new class extends InvalidPythonInterpreterService {
+                protected async onDidChangeConfiguration(_event: ConfigurationChangeEvent) { invoked = true; }
+            }(serviceContainerObject);
 
-        const diagnostics = await diagnosticService.diagnose();
-        expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic)]);
-        settings.verifyAll();
-        interpreterService.verifyAll();
-    });
-    test('Should return empty diagnostics if there are interpreters and platform is not mac', async () => {
-        settings
-            .setup(s => s.disableInstallationChecks)
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
-        interpreterService
-            .setup(i => i.getInterpreters(typemoq.It.isAny()))
-            .returns(() => Promise.resolve([{} as any]))
-            .verifiable(typemoq.Times.once());
-        platformService
-            .setup(i => i.isMac)
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
+            await callbackHandler({} as any);
+            expect(invoked).to.be.equal(true, 'Not invoked');
+        });
+        test('Event Handler is registered and not invoked', async () => {
+            let invoked = false;
+            const workspaceService = { onDidChangeConfiguration: noop } as any;
+            const serviceContainerObject = createContainer();
+            serviceContainer.setup(s => s.get(typemoq.It.isValue(IWorkspaceService)))
+                .returns(() => workspaceService);
+            diagnosticService = new class extends InvalidPythonInterpreterService {
+                protected async onDidChangeConfiguration(_event: ConfigurationChangeEvent) { invoked = true; }
+            }(serviceContainerObject);
 
-        const diagnostics = await diagnosticService.diagnose();
-        expect(diagnostics).to.be.deep.equal([]);
-        settings.verifyAll();
-        interpreterService.verifyAll();
-        platformService.verifyAll();
-    });
-    test('Should return empty diagnostics if there are interpreters, platform is mac and selected interpreter is not default mac interpreter', async () => {
-        settings
-            .setup(s => s.disableInstallationChecks)
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
-        interpreterService
-            .setup(i => i.getInterpreters(typemoq.It.isAny()))
-            .returns(() => Promise.resolve([{} as any]))
-            .verifiable(typemoq.Times.once());
-        platformService
-            .setup(i => i.isMac)
-            .returns(() => true)
-            .verifiable(typemoq.Times.once());
-        helper
-            .setup(i => i.isMacDefaultPythonPath(typemoq.It.isAny()))
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
+            expect(invoked).to.be.equal(false, 'Not invoked');
+        });
+        test('Diagnostics are checked when path changes', async () => {
+            const event = typemoq.Mock.ofType<ConfigurationChangeEvent>();
+            const workspaceService = typemoq.Mock.ofType<IWorkspaceService>();
+            const serviceContainerObject = createContainer();
+            let diagnoseInvocationCount = 0;
+            workspaceService
+                .setup(w => w.hasWorkspaceFolders)
+                .returns(() => true)
+                .verifiable(typemoq.Times.once());
+            workspaceService
+                .setup(w => w.workspaceFolders)
+                .returns(() => [{ uri: '' }] as any)
+                .verifiable(typemoq.Times.once());
+            serviceContainer.setup(s => s.get(typemoq.It.isValue(IWorkspaceService)))
+                .returns(() => workspaceService.object);
+            const diagnosticSvc = new class extends InvalidPythonInterpreterService {
+                constructor(item) {
+                    super(item);
+                    this.changeThrottleTimeout = 1;
+                }
+                public onDidChangeConfigurationEx = e => super.onDidChangeConfiguration(e);
+                public diagnose(): Promise<any> {
+                    diagnoseInvocationCount += 1;
+                    return Promise.resolve();
+                }
+            }(serviceContainerObject);
 
-        const diagnostics = await diagnosticService.diagnose();
-        expect(diagnostics).to.be.deep.equal([]);
-        settings.verifyAll();
-        interpreterService.verifyAll();
-        platformService.verifyAll();
-        helper.verifyAll();
-    });
-    test('Should return diagnostic if there are no other interpreters, platform is mac and selected interpreter is default mac interpreter', async () => {
-        settings
-            .setup(s => s.disableInstallationChecks)
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
-        interpreterService
-            .setup(i => i.getInterpreters(typemoq.It.isAny()))
-            .returns(() => Promise.resolve([
-                { path: pythonPath } as any,
-                { path: pythonPath } as any
-            ]))
-            .verifiable(typemoq.Times.once());
-        platformService
-            .setup(i => i.isMac)
-            .returns(() => true)
-            .verifiable(typemoq.Times.once());
-        helper
-            .setup(i => i.isMacDefaultPythonPath(typemoq.It.isValue(pythonPath)))
-            .returns(() => true)
-            .verifiable(typemoq.Times.atLeastOnce());
-        interpreterService
-            .setup(i => i.getActiveInterpreter(typemoq.It.isAny()))
-            .returns(() => { return Promise.resolve({ type: InterpreterType.Unknown } as any); })
-            .verifiable(typemoq.Times.once());
+            event
+                .setup(e => e.affectsConfiguration(typemoq.It.isValue('python.pythonPath'), typemoq.It.isAny()))
+                .returns(() => true)
+                .verifiable(typemoq.Times.atLeastOnce());
 
-        const diagnostics = await diagnosticService.diagnose();
-        expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic)]);
-        settings.verifyAll();
-        interpreterService.verifyAll();
-        platformService.verifyAll();
-        helper.verifyAll();
-    });
-    test('Should return diagnostic if there are other interpreters, platform is mac and selected interpreter is default mac interpreter', async () => {
-        const nonMacStandardInterpreter = 'Non Mac Std Interpreter';
-        settings
-            .setup(s => s.disableInstallationChecks)
-            .returns(() => false)
-            .verifiable(typemoq.Times.once());
-        interpreterService
-            .setup(i => i.getInterpreters(typemoq.It.isAny()))
-            .returns(() => Promise.resolve([
-                { path: pythonPath } as any,
-                { path: pythonPath } as any,
-                { path: nonMacStandardInterpreter } as any
-            ]))
-            .verifiable(typemoq.Times.once());
-        platformService
-            .setup(i => i.isMac)
-            .returns(() => true)
-            .verifiable(typemoq.Times.once());
-        helper
-            .setup(i => i.isMacDefaultPythonPath(typemoq.It.isValue(pythonPath)))
-            .returns(() => true)
-            .verifiable(typemoq.Times.atLeastOnce());
-        helper
-            .setup(i => i.isMacDefaultPythonPath(typemoq.It.isValue(nonMacStandardInterpreter)))
-            .returns(() => false)
-            .verifiable(typemoq.Times.atLeastOnce());
-        interpreterService
-            .setup(i => i.getActiveInterpreter(typemoq.It.isAny()))
-            .returns(() => { return Promise.resolve({ type: InterpreterType.Unknown } as any); })
-            .verifiable(typemoq.Times.once());
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            event.verifyAll();
+            await sleep(100);
+            expect(diagnoseInvocationCount).to.be.equal(1, 'Not invoked');
 
-        const diagnostics = await diagnosticService.diagnose();
-        expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic)]);
-        settings.verifyAll();
-        interpreterService.verifyAll();
-        platformService.verifyAll();
-        helper.verifyAll();
-    });
-    test('Handling no interpreters diagnostisc should return download link', async () => {
-        const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic);
-        const cmd = {} as any as IDiagnosticCommand;
-        let messagePrompt: MessageCommandPrompt | undefined;
-        messageHandler
-            .setup(i => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
-            .callback((d, p: MessageCommandPrompt) => messagePrompt = p)
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
-            typemoq.It.isObjectWith<CommandOption<'launch', string>>({ type: 'launch' })))
-            .returns(() => cmd)
-            .verifiable(typemoq.Times.once());
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            await sleep(100);
+            expect(diagnoseInvocationCount).to.be.equal(2, 'Not invoked');
+        });
+        test('Diagnostics are checked and throttled when path changes', async () => {
+            const event = typemoq.Mock.ofType<ConfigurationChangeEvent>();
+            const workspaceService = typemoq.Mock.ofType<IWorkspaceService>();
+            const serviceContainerObject = createContainer();
+            let diagnoseInvocationCount = 0;
+            workspaceService
+                .setup(w => w.hasWorkspaceFolders)
+                .returns(() => true)
+                .verifiable(typemoq.Times.once());
+            workspaceService
+                .setup(w => w.workspaceFolders)
+                .returns(() => [{ uri: '' }] as any)
+                .verifiable(typemoq.Times.once());
+            serviceContainer.setup(s => s.get(typemoq.It.isValue(IWorkspaceService)))
+                .returns(() => workspaceService.object);
+            const diagnosticSvc = new class extends InvalidPythonInterpreterService {
+                constructor(item) {
+                    super(item);
+                    this.changeThrottleTimeout = 100;
+                }
+                public onDidChangeConfigurationEx = e => super.onDidChangeConfiguration(e);
+                public diagnose(): Promise<any> {
+                    diagnoseInvocationCount += 1;
+                    return Promise.resolve();
+                }
+            }(serviceContainerObject);
 
-        await diagnosticService.handle([diagnostic]);
+            event
+                .setup(e => e.affectsConfiguration(typemoq.It.isValue('python.pythonPath'), typemoq.It.isAny()))
+                .returns(() => true)
+                .verifiable(typemoq.Times.atLeastOnce());
 
-        messageHandler.verifyAll();
-        commandFactory.verifyAll();
-        expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
-        expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Download', command: cmd }]);
-    });
-    test('Handling no interpreters diagnostisc should return select interpreter cmd', async () => {
-        const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic);
-        const cmd = {} as any as IDiagnosticCommand;
-        let messagePrompt: MessageCommandPrompt | undefined;
-        messageHandler
-            .setup(i => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
-            .callback((d, p: MessageCommandPrompt) => messagePrompt = p)
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
-            typemoq.It.isObjectWith<CommandOption<'executeVSCCommand', string>>({ type: 'executeVSCCommand' })))
-            .returns(() => cmd)
-            .verifiable(typemoq.Times.once());
-
-        await diagnosticService.handle([diagnostic]);
-
-        messageHandler.verifyAll();
-        commandFactory.verifyAll();
-        expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
-        expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Select Python Interpreter', command: cmd }]);
-    });
-    test('Handling no interpreters diagnostisc should return download and learn links', async () => {
-        const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic);
-        const cmdDownload = {} as any as IDiagnosticCommand;
-        const cmdLearn = {} as any as IDiagnosticCommand;
-        let messagePrompt: MessageCommandPrompt | undefined;
-        messageHandler
-            .setup(i => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
-            .callback((d, p: MessageCommandPrompt) => messagePrompt = p)
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
-            typemoq.It.isObjectWith<CommandOption<'launch', string>>({ type: 'launch', options: 'https://code.visualstudio.com/docs/python/python-tutorial#_prerequisites' })))
-            .returns(() => cmdLearn)
-            .verifiable(typemoq.Times.once());
-        commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
-            typemoq.It.isObjectWith<CommandOption<'launch', string>>({ type: 'launch', options: 'https://www.python.org/downloads' })))
-            .returns(() => cmdDownload)
-            .verifiable(typemoq.Times.once());
-
-        await diagnosticService.handle([diagnostic]);
-
-        messageHandler.verifyAll();
-        commandFactory.verifyAll();
-        expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
-        expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Learn more', command: cmdLearn }, { prompt: 'Download', command: cmdDownload }]);
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            await diagnosticSvc.onDidChangeConfigurationEx(event.object);
+            await sleep(500);
+            event.verifyAll();
+            expect(diagnoseInvocationCount).to.be.equal(1, 'Not invoked');
+        });
     });
 });

--- a/src/test/interpreters/virtualEnvs/index.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/index.unit.test.ts
@@ -8,17 +8,27 @@
 import { expect } from 'chai';
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
+import { Uri } from 'vscode';
+import { IWorkspaceService } from '../../../client/common/application/types';
+import { IFileSystem, IPlatformService } from '../../../client/common/platform/types';
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
+import { ITerminalActivationCommandProvider } from '../../../client/common/terminal/types';
 import { ICurrentProcess, IPathUtils } from '../../../client/common/types';
+import { InterpreterType, IPipEnvService } from '../../../client/interpreter/contracts';
 import { VirtualEnvironmentManager } from '../../../client/interpreter/virtualEnvs';
-import { IVirtualEnvironmentManager } from '../../../client/interpreter/virtualEnvs/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 
+// tslint:disable-next-line:max-func-body-length
 suite('Virtual Environment Manager', () => {
     let process: TypeMoq.IMock<ICurrentProcess>;
     let processService: TypeMoq.IMock<IProcessService>;
     let pathUtils: TypeMoq.IMock<IPathUtils>;
-    let virtualEnvMgr: IVirtualEnvironmentManager;
+    let virtualEnvMgr: VirtualEnvironmentManager;
+    let fs: TypeMoq.IMock<IFileSystem>;
+    let workspace: TypeMoq.IMock<IWorkspaceService>;
+    let pipEnvService: TypeMoq.IMock<IPipEnvService>;
+    let terminalActivation: TypeMoq.IMock<ITerminalActivationCommandProvider>;
+    let platformService: TypeMoq.IMock<IPlatformService>;
 
     setup(() => {
         const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
@@ -26,12 +36,22 @@ suite('Virtual Environment Manager', () => {
         processService = TypeMoq.Mock.ofType<IProcessService>();
         const processFactory = TypeMoq.Mock.ofType<IProcessServiceFactory>();
         pathUtils = TypeMoq.Mock.ofType<IPathUtils>();
+        fs = TypeMoq.Mock.ofType<IFileSystem>();
+        workspace = TypeMoq.Mock.ofType<IWorkspaceService>();
+        pipEnvService = TypeMoq.Mock.ofType<IPipEnvService>();
+        terminalActivation = TypeMoq.Mock.ofType<ITerminalActivationCommandProvider>();
+        platformService = TypeMoq.Mock.ofType<IPlatformService>();
 
         processService.setup(p => (p as any).then).returns(() => undefined);
         processFactory.setup(p => p.create(TypeMoq.It.isAny())).returns(() => Promise.resolve(processService.object));
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IProcessServiceFactory))).returns(() => processFactory.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICurrentProcess))).returns(() => process.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPathUtils))).returns(() => pathUtils.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IWorkspaceService))).returns(() => workspace.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPipEnvService))).returns(() => pipEnvService.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ITerminalActivationCommandProvider), TypeMoq.It.isAny())).returns(() => terminalActivation.object);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService), TypeMoq.It.isAny())).returns(() => platformService.object);
 
         virtualEnvMgr = new VirtualEnvironmentManager(serviceContainer.object);
     });
@@ -83,5 +103,171 @@ suite('Virtual Environment Manager', () => {
         process.verifyAll();
         processService.verifyAll();
         expect(pyenvRoot).to.equal(path.join('HOME', '.pyenv'));
+    });
+
+    test('Get Environment Type, detects venv', async () => {
+        const pythonPath = path.join('a', 'b', 'c', 'python');
+        const dir = path.dirname(pythonPath);
+
+        fs.setup(f => f.fileExists(TypeMoq.It.isValue(path.join(dir, 'pyvenv.cfg'))))
+            .returns(() => Promise.resolve(true))
+            .verifiable(TypeMoq.Times.once());
+
+        const isRecognized = await virtualEnvMgr.isVenvEnvironment(pythonPath);
+
+        expect(isRecognized).to.be.equal(true, 'invalid value');
+        fs.verifyAll();
+    });
+    test('Get Environment Type, does not detect venv incorrectly', async () => {
+        const pythonPath = path.join('a', 'b', 'c', 'python');
+        const dir = path.dirname(pythonPath);
+
+        fs.setup(f => f.fileExists(TypeMoq.It.isValue(path.join(dir, 'pyvenv.cfg'))))
+            .returns(() => Promise.resolve(false))
+            .verifiable(TypeMoq.Times.once());
+
+        const isRecognized = await virtualEnvMgr.isVenvEnvironment(pythonPath);
+
+        expect(isRecognized).to.be.equal(false, 'invalid value');
+        fs.verifyAll();
+    });
+
+    test('Get Environment Type, detects pyenv', async () => {
+        const pythonPath = path.join('py-env-root', 'b', 'c', 'python');
+
+        process.setup(p => p.env)
+            .returns(() => {
+                return { PYENV_ROOT: path.join('py-env-root', 'b') };
+            })
+            .verifiable(TypeMoq.Times.once());
+
+        const isRecognized = await virtualEnvMgr.isPyEnvEnvironment(pythonPath);
+
+        expect(isRecognized).to.be.equal(true, 'invalid value');
+        process.verifyAll();
+    });
+
+    test('Get Environment Type, does not detect pyenv incorrectly', async () => {
+        const pythonPath = path.join('a', 'b', 'c', 'python');
+
+        process.setup(p => p.env)
+            .returns(() => {
+                return { PYENV_ROOT: path.join('py-env-root', 'b') };
+            })
+            .verifiable(TypeMoq.Times.once());
+
+        const isRecognized = await virtualEnvMgr.isPyEnvEnvironment(pythonPath);
+
+        expect(isRecognized).to.be.equal(false, 'invalid value');
+        process.verifyAll();
+    });
+
+    test('Get Environment Type, detects pipenv', async () => {
+        const pythonPath = path.join('x', 'b', 'c', 'python');
+        workspace
+            .setup(w => w.hasWorkspaceFolders)
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+        const ws = [{ uri: Uri.file('x') }];
+        workspace
+            .setup(w => w.workspaceFolders)
+            .returns(() => ws as any)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+        pipEnvService
+            .setup(p => p.isRelatedPipEnvironment(TypeMoq.It.isAny(), TypeMoq.It.isValue(pythonPath)))
+            .returns(() => Promise.resolve(true))
+            .verifiable(TypeMoq.Times.once());
+
+        const isRecognized = await virtualEnvMgr.isPipEnvironment(pythonPath);
+
+        expect(isRecognized).to.be.equal(true, 'invalid value');
+        workspace.verifyAll();
+        pipEnvService.verifyAll();
+    });
+
+    test('Get Environment Type, does not detect pipenv incorrectly', async () => {
+        const pythonPath = path.join('x', 'b', 'c', 'python');
+        workspace
+            .setup(w => w.hasWorkspaceFolders)
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+        const ws = [{ uri: Uri.file('x') }];
+        workspace
+            .setup(w => w.workspaceFolders)
+            .returns(() => ws as any)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+        pipEnvService
+            .setup(p => p.isRelatedPipEnvironment(TypeMoq.It.isAny(), TypeMoq.It.isValue(pythonPath)))
+            .returns(() => Promise.resolve(false))
+            .verifiable(TypeMoq.Times.once());
+
+        const isRecognized = await virtualEnvMgr.isPipEnvironment(pythonPath);
+
+        expect(isRecognized).to.be.equal(false, 'invalid value');
+        workspace.verifyAll();
+        pipEnvService.verifyAll();
+    });
+
+    for (const isWindows of [true, false]) {
+        const testTitleSuffix = `(${isWindows ? 'On Windows' : 'Non-Windows'}})`;
+        test(`Get Environment Type, detects virtualenv ${testTitleSuffix}`, async () => {
+            const pythonPath = path.join('x', 'b', 'c', 'python');
+            terminalActivation
+                .setup(t => t.isShellSupported(TypeMoq.It.isAny()))
+                .returns(() => true)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+            terminalActivation
+                .setup(t => t.getActivationCommandsForInterpreter!(TypeMoq.It.isValue(pythonPath), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(['1']))
+                .verifiable(TypeMoq.Times.atLeastOnce());
+
+            const isRecognized = await virtualEnvMgr.isVirtualEnvironment(pythonPath);
+
+            expect(isRecognized).to.be.equal(true, 'invalid value');
+            terminalActivation.verifyAll();
+        });
+
+        test(`Get Environment Type, does not detect virtualenv incorrectly ${testTitleSuffix}`, async () => {
+            const pythonPath = path.join('x', 'b', 'c', 'python');
+            terminalActivation
+                .setup(t => t.isShellSupported(TypeMoq.It.isAny()))
+                .returns(() => true)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+            terminalActivation
+                .setup(t => t.getActivationCommandsForInterpreter!(TypeMoq.It.isValue(pythonPath), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve([]))
+                .verifiable(TypeMoq.Times.atLeastOnce());
+
+            let isRecognized = await virtualEnvMgr.isVirtualEnvironment(pythonPath);
+
+            expect(isRecognized).to.be.equal(false, 'invalid value');
+            terminalActivation.verifyAll();
+
+            terminalActivation.reset();
+            terminalActivation
+                .setup(t => t.isShellSupported(TypeMoq.It.isAny()))
+                .returns(() => false)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+            terminalActivation
+                .setup(t => t.getActivationCommandsForInterpreter!(TypeMoq.It.isValue(pythonPath), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve([]))
+                .verifiable(TypeMoq.Times.never());
+
+            isRecognized = await virtualEnvMgr.isVirtualEnvironment(pythonPath);
+
+            expect(isRecognized).to.be.equal(false, 'invalid value');
+            terminalActivation.verifyAll();
+        });
+    }
+    test('Get Environment Type, does not detect the type', async () => {
+        const pythonPath = path.join('x', 'b', 'c', 'python');
+        virtualEnvMgr.isPipEnvironment = () => Promise.resolve(false);
+        virtualEnvMgr.isPyEnvEnvironment = () => Promise.resolve(false);
+        virtualEnvMgr.isVenvEnvironment = () => Promise.resolve(false);
+        virtualEnvMgr.isVirtualEnvironment = () => Promise.resolve(false);
+
+        const envType = await virtualEnvMgr.getEnvironmentType(pythonPath);
+
+        expect(envType).to.be.equal(InterpreterType.Unknown);
     });
 });


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
