### PR TITLE
Add new line separator for the message

### DIFF
--- a/src/client/debugger/mainV2.ts
+++ b/src/client/debugger/mainV2.ts
@@ -33,7 +33,7 @@ const killProcessTree = require('tree-kill');
 
 const DEBUGGER_CONNECT_TIMEOUT = 20000;
 const MIN_DEBUGGER_CONNECT_TIMEOUT = 5000;
-const InvalidPythonPathInDebuggerMessage = 'You need to select a Python interpreter before you start debugging. \nTip: click on "Select Python Environment" in the status bar.';
+const InvalidPythonPathInDebuggerMessage = 'You need to select a Python interpreter before you start debugging. \n\nTip: click on "Select Python Environment" in the status bar.';
 
 /**
  * Primary purpose of this class is to perform the handshake with VS Code and launch PTVSD process.


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- ~[no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- ~[no] Unit tests & system/integration tests are added/updated~
- ~[no] Any new/changed dependencies in [`package.json`]~(https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)~
- ~[no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
