### PR TITLE
Ensure default mac interpreter is not removed from the list of interpreters

### DIFF
--- a/src/test/interpreters/locators/helpers.unit.test.ts
+++ b/src/test/interpreters/locators/helpers.unit.test.ts
@@ -39,49 +39,6 @@ suite('Interpreters - Locators Helper', () => {
 
         helper = new InterpreterLocatorHelper(serviceContainer.object);
     });
-    test('Ensure default Mac interpreters are excluded from the list of interpreters', async () => {
-        platform.setup(p => p.isWindows).returns(() => false);
-        platform.setup(p => p.isLinux).returns(() => false);
-        platform
-            .setup(p => p.isMac).returns(() => true)
-            .verifiable(TypeMoq.Times.atLeastOnce());
-        fs
-            .setup(f => f.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => false)
-            .verifiable(TypeMoq.Times.atLeastOnce());
-
-        const interpreters: PythonInterpreter[] = [];
-        const macInterpreterPath = path.join('users', 'python', 'bin', 'mac');
-        ['conda', 'virtualenv', 'mac', 'pyenv'].forEach(name => {
-            const interpreter = {
-                architecture: Architecture.Unknown,
-                displayName: name,
-                path: path.join('users', 'python', 'bin', name),
-                sysPrefix: name,
-                sysVersion: name,
-                type: InterpreterType.Unknown,
-                version: name,
-                version_info: [0, 0, 0, 'alpha'] as PythonVersionInfo
-            };
-            interpreters.push(interpreter);
-
-            // Treat 'mac' as as mac interpreter.
-            interpreterServiceHelper
-                .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isValue(interpreter.path)))
-                .returns(() => name === 'mac')
-                .verifiable(TypeMoq.Times.once());
-        });
-
-        const expectedInterpreters = interpreters.filter(item => item.path !== macInterpreterPath);
-
-        const items = helper.mergeInterpreters(interpreters);
-
-        interpreterServiceHelper.verifyAll();
-        platform.verifyAll();
-        fs.verifyAll();
-        expect(items).to.be.lengthOf(3);
-        expect(items).to.be.deep.equal(expectedInterpreters);
-    });
     getNamesAndValues<OS>(OS).forEach(os => {
         test(`Ensure duplicates are removed (same version and same interpreter directory on ${os.name})`, async () => {
             interpreterServiceHelper

--- a/src/test/interpreters/locators/helpers.unit.test.ts
+++ b/src/test/interpreters/locators/helpers.unit.test.ts
@@ -39,6 +39,48 @@ suite('Interpreters - Locators Helper', () => {
 
         helper = new InterpreterLocatorHelper(serviceContainer.object);
     });
+    test('Ensure default Mac interpreter is not excluded from the list of interpreters', async () => {
+        platform.setup(p => p.isWindows).returns(() => false);
+        platform.setup(p => p.isLinux).returns(() => false);
+        platform
+            .setup(p => p.isMac).returns(() => true)
+            .verifiable(TypeMoq.Times.never());
+        fs
+            .setup(f => f.arePathsSame(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => false)
+            .verifiable(TypeMoq.Times.atLeastOnce());
+
+        const interpreters: PythonInterpreter[] = [];
+        ['conda', 'virtualenv', 'mac', 'pyenv'].forEach(name => {
+            const interpreter = {
+                architecture: Architecture.Unknown,
+                displayName: name,
+                path: path.join('users', 'python', 'bin', name),
+                sysPrefix: name,
+                sysVersion: name,
+                type: InterpreterType.Unknown,
+                version: name,
+                version_info: [0, 0, 0, 'alpha'] as PythonVersionInfo
+            };
+            interpreters.push(interpreter);
+
+            // Treat 'mac' as as mac interpreter.
+            interpreterServiceHelper
+                .setup(i => i.isMacDefaultPythonPath(TypeMoq.It.isValue(interpreter.path)))
+                .returns(() => name === 'mac')
+                .verifiable(TypeMoq.Times.never());
+        });
+
+        const expectedInterpreters = interpreters.slice(0);
+
+        const items = helper.mergeInterpreters(interpreters);
+
+        interpreterServiceHelper.verifyAll();
+        platform.verifyAll();
+        fs.verifyAll();
+        expect(items).to.be.lengthOf(4);
+        expect(items).to.be.deep.equal(expectedInterpreters);
+    });
     getNamesAndValues<OS>(OS).forEach(os => {
         test(`Ensure duplicates are removed (same version and same interpreter directory on ${os.name})`, async () => {
             interpreterServiceHelper


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
