### PR TITLE
Activate conda envs with fully qualified paths to activate script

### DIFF
--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -38,7 +38,7 @@ export function error(title: string = '', message: any) {
     new Logger().logError(`${title}, ${message}`);
 }
 // tslint:disable-next-line:no-any
-export function warn(title: string = '', message: any) {
+export function warn(title: string = '', message: any = '') {
     new Logger().logWarning(`${title}, ${message}`);
 }
 

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -3,7 +3,6 @@
 
 import { injectable } from 'inversify';
 import * as path from 'path';
-import { SemVer } from 'semver';
 import { Uri } from 'vscode';
 import { ICondaService } from '../../../interpreter/contracts';
 import { IServiceContainer } from '../../../ioc/types';
@@ -70,7 +69,6 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
                 default:
                     return this.getUnixCommands(
                         envInfo.name,
-                        await condaService.getCondaVersion(),
                         await condaService.getCondaFile()
                     );
             }
@@ -134,24 +132,12 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
 
     public async getUnixCommands(
         envName: string,
-        version: SemVer | undefined,
         conda: string
     ): Promise<string[] | undefined> {
-        // Conda changed how activation works in the 4.4.0 release, so
-        // we accommodate the two ways distinctly.
         const condaDir = path.dirname(conda);
-        if (version && version.compare('4.4.0') >= 0 && condaDir !== conda) {
-            const activateFile = path.join(condaDir, 'activate');
-            return [
-                `source ${activateFile.fileToCommandArgument()} ${envName.toCommandArgument()}`
-            ];
-        } else {
-            // tslint:disable-next-line:no-suspicious-comment
-            // TODO: Handle pre-4.4 case where "activate" script not on $PATH.
-            // (Locate script next to "conda" binary and use absolute path.
-            return [
-                `source activate ${envName.toCommandArgument()}`
-            ];
-        }
+        const activateFile = path.join(condaDir, 'activate');
+        return [
+            `source ${activateFile.fileToCommandArgument()} ${envName.toCommandArgument()}`
+        ];
     }
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -217,7 +217,7 @@ async function sendStartupTelemetry(activatedPromise: Promise<void>, serviceCont
         const condaLocator = serviceContainer.get<ICondaService>(ICondaService);
         const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         const [condaVersion, interpreter, interpreters] = await Promise.all([
-            condaLocator.getCondaVersion().catch(() => undefined),
+            condaLocator.getCondaVersion().then(ver => ver ? ver.raw : '').catch<string>(() => ''),
             interpreterService.getActiveInterpreter().catch<PythonInterpreter | undefined>(() => undefined),
             interpreterService.getInterpreters().catch<PythonInterpreter[]>(() => [])
         ]);

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -1,3 +1,4 @@
+import { SemVer } from 'semver';
 import { CodeLensProvider, ConfigurationTarget, Disposable, Event, TextDocument, Uri } from 'vscode';
 import { InterpreterInfomation } from '../common/process/types';
 
@@ -36,6 +37,7 @@ export type CondaInfo = {
     'sys.prefix'?: string;
     'python_version'?: string;
     default_prefix?: string;
+    conda_version?: string;
 };
 
 export const ICondaService = Symbol('ICondaService');
@@ -44,7 +46,7 @@ export interface ICondaService {
     readonly condaEnvironmentsFile: string | undefined;
     getCondaFile(): Promise<string>;
     isCondaAvailable(): Promise<boolean>;
-    getCondaVersion(): Promise<string | undefined>;
+    getCondaVersion(): Promise<SemVer | undefined>;
     getCondaInfo(): Promise<CondaInfo | undefined>;
     getCondaEnvironments(ignoreCache: boolean): Promise<({ name: string; path: string }[]) | undefined>;
     getInterpreterPath(condaEnvironmentPath: string): string;

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -1,6 +1,8 @@
 import { inject, injectable, named, optional } from 'inversify';
 import * as path from 'path';
+import { parse, SemVer } from 'semver';
 import { compareVersion } from '../../../../utils/version';
+import { warn } from '../../../common/logger';
 import { IFileSystem, IPlatformService } from '../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../common/process/types';
 import { IConfigurationService, ILogger, IPersistentStateFactory } from '../../../common/types';
@@ -71,19 +73,34 @@ export class CondaService implements ICondaService {
             return this.isAvailable;
         }
         return this.getCondaVersion()
-            .then(version => this.isAvailable = typeof version === 'string')
+            .then(version => this.isAvailable = version !== undefined)
             .catch(() => this.isAvailable = false);
     }
 
     /**
      * Return the conda version.
      */
-    public async getCondaVersion(): Promise<string | undefined> {
+    public async getCondaVersion(): Promise<SemVer | undefined> {
         const processService = await this.processServiceFactory.create();
-        return this.getCondaFile()
-            .then(condaFile => processService.exec(condaFile, ['--version'], {}))
-            .then(result => result.stdout.trim())
-            .catch(() => undefined);
+        const info = await this.getCondaInfo().catch<CondaInfo | undefined>(() => undefined);
+        let versionString: string;
+        if (info && info.conda_version) {
+            versionString = info.conda_version;
+        } else {
+            const stdOut = await this.getCondaFile()
+                .then(condaFile => processService.exec(condaFile, ['--version'], {}))
+                .then(result => result.stdout.trim())
+                .catch<string | undefined>(() => undefined);
+
+            versionString = (stdOut && stdOut.startsWith('conda ')) ? stdOut.substring('conda '.length).trim() : '';
+        }
+        const version = parse(versionString, true);
+        if (version) {
+            return version;
+        }
+        // Use a bogus version, at least to indicate the fact that a version was returned.
+        warn(`Unable to parse Version of Conda, ${versionString}`);
+        return new SemVer('0.0.1');
     }
 
     /**

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -83,7 +83,7 @@ export class CondaService implements ICondaService {
     public async getCondaVersion(): Promise<SemVer | undefined> {
         const processService = await this.processServiceFactory.create();
         const info = await this.getCondaInfo().catch<CondaInfo | undefined>(() => undefined);
-        let versionString: string;
+        let versionString: string | undefined;
         if (info && info.conda_version) {
             versionString = info.conda_version;
         } else {
@@ -92,7 +92,10 @@ export class CondaService implements ICondaService {
                 .then(result => result.stdout.trim())
                 .catch<string | undefined>(() => undefined);
 
-            versionString = (stdOut && stdOut.startsWith('conda ')) ? stdOut.substring('conda '.length).trim() : '';
+            versionString = (stdOut && stdOut.startsWith('conda ')) ? stdOut.substring('conda '.length).trim() : stdOut;
+        }
+        if (!versionString) {
+            return;
         }
         const version = parse(versionString, true);
         if (version) {

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -114,11 +114,11 @@ suite('Terminal Environment Activation conda', () => {
                 name: envName,
                 path: path.dirname(pythonPath)
             }));
-            condaService.setup(c => c.getCondaFile())
+        condaService.setup(c => c.getCondaFile())
             .returns(() => Promise.resolve(condaPath));
         condaService.setup(c => c.getCondaVersion())
             .returns(() => Promise.resolve(parse('4.3.1', true)!));
-        const expected = ['source activate EnvA'];
+        const expected = [`source ${path.join(path.dirname(condaPath), 'activate')} EnvA`];
 
         const provider = new CondaActivationCommandProvider(serviceContainer.object);
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -5,6 +5,7 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import { parse } from 'semver';
 import * as TypeMoq from 'typemoq';
 import { Disposable } from 'vscode';
 import '../../../client/common/extensions';
@@ -105,14 +106,18 @@ suite('Terminal Environment Activation conda', () => {
     test('Conda activation on bash uses "source" before 4.4.0', async () => {
         const envName = 'EnvA';
         const pythonPath = 'python3';
+        const condaPath = path.join('a', 'b', 'c', 'conda');
         platformService.setup(p => p.isWindows).returns(() => false);
+        condaService.reset();
         condaService.setup(c => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({
                 name: envName,
                 path: path.dirname(pythonPath)
             }));
+            condaService.setup(c => c.getCondaFile())
+            .returns(() => Promise.resolve(condaPath));
         condaService.setup(c => c.getCondaVersion())
-            .returns(() => Promise.resolve('4.3.1'));
+            .returns(() => Promise.resolve(parse('4.3.1', true)!));
         const expected = ['source activate EnvA'];
 
         const provider = new CondaActivationCommandProvider(serviceContainer.object);
@@ -124,15 +129,19 @@ suite('Terminal Environment Activation conda', () => {
     test('Conda activation on bash uses "conda" after 4.4.0', async () => {
         const envName = 'EnvA';
         const pythonPath = 'python3';
+        const condaPath = path.join('a', 'b', 'c', 'conda');
         platformService.setup(p => p.isWindows).returns(() => false);
+        condaService.reset();
         condaService.setup(c => c.getCondaEnvironment(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({
                 name: envName,
                 path: path.dirname(pythonPath)
             }));
+        condaService.setup(c => c.getCondaFile())
+            .returns(() => Promise.resolve(condaPath));
         condaService.setup(c => c.getCondaVersion())
-            .returns(() => Promise.resolve('4.4.0'));
-        const expected = [`${conda} activate EnvA`];
+            .returns(() => Promise.resolve(parse('4.4.0', true)!));
+        const expected = [`source ${path.join(path.dirname(condaPath), 'activate')} EnvA`];
 
         const provider = new CondaActivationCommandProvider(serviceContainer.object);
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);

--- a/src/test/common/terminals/activation.conda.unit.test.ts
+++ b/src/test/common/terminals/activation.conda.unit.test.ts
@@ -118,7 +118,7 @@ suite('Terminal Environment Activation conda', () => {
             .returns(() => Promise.resolve(condaPath));
         condaService.setup(c => c.getCondaVersion())
             .returns(() => Promise.resolve(parse('4.3.1', true)!));
-        const expected = [`source ${path.join(path.dirname(condaPath), 'activate')} EnvA`];
+        const expected = [`source ${path.join(path.dirname(condaPath), 'activate').fileToCommandArgument()} EnvA`];
 
         const provider = new CondaActivationCommandProvider(serviceContainer.object);
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);
@@ -141,7 +141,7 @@ suite('Terminal Environment Activation conda', () => {
             .returns(() => Promise.resolve(condaPath));
         condaService.setup(c => c.getCondaVersion())
             .returns(() => Promise.resolve(parse('4.4.0', true)!));
-        const expected = [`source ${path.join(path.dirname(condaPath), 'activate')} EnvA`];
+        const expected = [`source ${path.join(path.dirname(condaPath), 'activate').fileToCommandArgument()} EnvA`];
 
         const provider = new CondaActivationCommandProvider(serviceContainer.object);
         const activationCommands = await provider.getActivationCommands(undefined, TerminalShellType.bash);

--- a/src/test/interpreters/condaService.unit.test.ts
+++ b/src/test/interpreters/condaService.unit.test.ts
@@ -540,22 +540,25 @@ suite('Interpreters Conda Service', () => {
     });
 
     test('isAvailable will return true if conda is available', async () => {
-        processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.resolve({ stdout: 'xyz' }));
+        processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.resolve({ stdout: '4.4.4' }));
         const isAvailable = await condaService.isCondaAvailable();
         assert.equal(isAvailable, true);
     });
 
     test('isAvailable will return false if conda is not available', async () => {
+        condaService.getCondaFile = () => Promise.resolve('conda');
         processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.reject(new Error('not found')));
         fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isAny())).returns(() => Promise.resolve(false));
         fileSystem.setup(fs => fs.search(TypeMoq.It.isAny())).returns(() => Promise.resolve([]));
         platformService.setup(p => p.isWindows).returns(() => false);
-
+        condaService.getCondaInfo = () => Promise.reject('Not Found');
         const isAvailable = await condaService.isCondaAvailable();
         assert.equal(isAvailable, false);
     });
 
     test('Version info from conda process will be returned in getCondaVersion', async () => {
+        condaService.getCondaInfo = () => Promise.reject('Not Found');
+        condaService.getCondaFile = () => Promise.resolve('conda');
         const expectedVersion = parse('4.4.4')!.raw;
         processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.resolve({ stdout: '4.4.4' }));
 

--- a/src/test/interpreters/condaService.unit.test.ts
+++ b/src/test/interpreters/condaService.unit.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 import { expect } from 'chai';
 import { EOL } from 'os';
 import * as path from 'path';
+import { parse } from 'semver';
 import * as TypeMoq from 'typemoq';
 import { FileSystem } from '../../client/common/platform/fileSystem';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
@@ -555,11 +556,11 @@ suite('Interpreters Conda Service', () => {
     });
 
     test('Version info from conda process will be returned in getCondaVersion', async () => {
-        const expectedVersion = new Date().toString();
-        processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.resolve({ stdout: expectedVersion }));
+        const expectedVersion = parse('4.4.4')!.raw;
+        processService.setup(p => p.exec(TypeMoq.It.isValue('conda'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())).returns(() => Promise.resolve({ stdout: '4.4.4' }));
 
         const version = await condaService.getCondaVersion();
-        assert.equal(version, expectedVersion);
+        assert.equal(version!.raw, expectedVersion);
     });
 
     test('isCondaInCurrentPath will return true if conda is available', async () => {


### PR DESCRIPTION
For #1882

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
