### PR TITLE
Possible issue with time.sleep()

### DIFF
--- a/src/test/pythonFiles/autocomp/doc.py
+++ b/src/test/pythonFiles/autocomp/doc.py
@@ -8,4 +8,4 @@ if os.path.exists(("/etc/hosts")):
 
 
 import time
-time.slee
+time.sleep(1)


### PR DESCRIPTION
I guess the author meant `time.sleep(x)` instead of `time.slee`. 
Not sure what the time should be here. So, keeping it at 1 second for now.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [x] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
