### PR TITLE
Add support for ShowReturnValue Debugger setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ obj/**
 .pytest_cache
 tmp/**
 .python-version
-**/.vs/**
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ obj/**
 .pytest_cache
 tmp/**
 .python-version
+**/.vs/**

--- a/news/1 Enhancements/2463.md
+++ b/news/1 Enhancements/2463.md
@@ -1,0 +1,1 @@
+Added a debugger setting to show return values of functions while stepping.

--- a/package.json
+++ b/package.json
@@ -490,6 +490,11 @@
                                 "description": "Automatically stop after launch.",
                                 "default": false
                             },
+                            "showReturnValue": {
+                                "type": "boolean",
+                                "description": "Show return value of functions when stepping.",
+                                "default": false
+                            },
                             "console": {
                                 "enum": [
                                     "none",

--- a/src/client/debugger/debugAdapter/DebugClients/LocalDebugClient.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/LocalDebugClient.ts
@@ -20,7 +20,8 @@ import { DebugClientHelper } from './helper';
 const VALID_DEBUG_OPTIONS = [
     'RedirectOutput',
     'DebugStdLib',
-    'stopOnEntry',
+    'StopOnEntry',
+    'ShowReturnValue',
     'BreakOnSystemExitZero',
     'DjangoDebugging',
     'Django'];

--- a/src/client/debugger/extension/configProviders/baseProvider.ts
+++ b/src/client/debugger/extension/configProviders/baseProvider.ts
@@ -72,6 +72,9 @@ export abstract class BaseConfigurationProvider implements DebugConfigurationPro
         if (typeof debugConfiguration.stopOnEntry !== 'boolean') {
             debugConfiguration.stopOnEntry = false;
         }
+        if (typeof debugConfiguration.showReturnValue !== 'boolean') {
+            debugConfiguration.showReturnValue = false;
+        }
         if (!debugConfiguration.console) {
             debugConfiguration.console = 'integratedTerminal';
         }

--- a/src/client/debugger/extension/configProviders/pythonV2Provider.ts
+++ b/src/client/debugger/extension/configProviders/pythonV2Provider.ts
@@ -28,6 +28,9 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
         if (debugConfiguration.stopOnEntry) {
             this.debugOption(debugOptions, DebugOptions.StopOnEntry);
         }
+        if (debugConfiguration.showReturnValue) {
+            this.debugOption(debugOptions, DebugOptions.ShowReturnValue);
+        }
         if (debugConfiguration.django) {
             this.debugOption(debugOptions, DebugOptions.Django);
         }
@@ -136,7 +139,8 @@ export class PythonV2DebugConfigurationProvider extends BaseConfigurationProvide
             isSudo: !!debugConfiguration.sudo,
             jinja: !!debugConfiguration.jinja,
             pyramid: !!debugConfiguration.pyramid,
-            stopOnEntry: !!debugConfiguration.stopOnEntry
+            stopOnEntry: !!debugConfiguration.stopOnEntry,
+            showReturnValue: !!debugConfiguration.showReturnValue
         };
         sendTelemetryEvent(DEBUGGER, undefined, telemetryProps);
     }

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -17,7 +17,8 @@ export enum DebugOptions {
     FixFilePathCase = 'FixFilePathCase',
     WindowsClient = 'WindowsClient',
     UnixClient = 'UnixClient',
-    StopOnEntry = 'StopOnEntry'
+    StopOnEntry = 'StopOnEntry',
+    ShowReturnValue = 'ShowReturnValue'
 }
 
 // tslint:disable-next-line:interface-name
@@ -30,6 +31,7 @@ interface AdditionalLaunchDebugOptions {
     sudo?: boolean;
     pyramid?: boolean;
     stopOnEntry?: boolean;
+    showReturnValue?: boolean;
 }
 
 // tslint:disable-next-line:interface-name
@@ -50,6 +52,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
     pythonPath: string;
     // Automatically stop target after launch. If not specified, target does not stop.
     stopOnEntry?: boolean;
+    /** Show return values of functions while stepping. */
+    showReturnValue?: boolean;
     args: string[];
     cwd?: string;
     debugOptions?: DebugOptions[];

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -55,6 +55,7 @@ export type DebuggerTelemetryV2 = {
     isModule: boolean;
     isSudo: boolean;
     stopOnEntry: boolean;
+    showReturnValue: boolean;
     pyramid: boolean;
 };
 export type DebuggerPerformanceTelemetry = {

--- a/src/test/debugger/configProvider/provider.unit.test.ts
+++ b/src/test/debugger/configProvider/provider.unit.test.ts
@@ -270,8 +270,9 @@ suite('Debugging - Config Provider', () => {
 
         expect(debugConfig).to.have.property('console', 'integratedTerminal');
         expect(debugConfig).to.have.property('stopOnEntry', false);
+        expect(debugConfig).to.have.property('showReturnValue', false);
         expect(debugConfig).to.have.property('debugOptions');
-        expect((debugConfig as any).debugOptions).to.be.deep.equal(['RedirectOutput']);
+        expect((debugConfig as any).debugOptions).to.be.deep.equal([DebugOptions.RedirectOutput]);
     });
     test('Test defaults of python debugger', async () => {
         if ('python' === DebuggerTypeName) {
@@ -286,6 +287,7 @@ suite('Debugging - Config Provider', () => {
         const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, {} as DebugConfiguration);
 
         expect(debugConfig).to.have.property('stopOnEntry', false);
+        expect(debugConfig).to.have.property('showReturnValue', false);
         expect(debugConfig).to.have.property('debugOptions');
         expect((debugConfig as any).debugOptions).to.be.deep.equal([DebugOptions.RedirectOutput]);
     });
@@ -300,6 +302,7 @@ suite('Debugging - Config Provider', () => {
 
         expect(debugConfig).to.have.property('console', 'integratedTerminal');
         expect(debugConfig).to.have.property('stopOnEntry', false);
+        expect(debugConfig).to.have.property('showReturnValue', false);
         expect(debugConfig).to.have.property('debugOptions');
         expect((debugConfig as any).debugOptions).to.be.deep.equal([]);
     });

--- a/src/test/debugger/misc.test.ts
+++ b/src/test/debugger/misc.test.ts
@@ -56,13 +56,14 @@ suite(`Standard Debugging - Misc tests: ${debuggerType}`, () => {
             return new DebugClientEx(testAdapterFilePath, debuggerType, coverageDirectory, { cwd: EXTENSION_ROOT_DIR });
         }
     }
-    function buildLaunchArgs(pythonFile: string, stopOnEntry: boolean = false): LaunchRequestArguments {
+    function buildLaunchArgs(pythonFile: string, stopOnEntry: boolean = false, showReturnValue: boolean = false): LaunchRequestArguments {
         const env = { PYTHONPATH: PTVSD_PATH };
         // tslint:disable-next-line:no-unnecessary-local-variable
         const options = {
             program: path.join(debugFilesPath, pythonFile),
             cwd: debugFilesPath,
             stopOnEntry,
+            showReturnValue,
             debugOptions: [DebugOptions.RedirectOutput],
             pythonPath: PYTHON_PATH,
             args: [],

--- a/src/test/debugger/portAndHost.test.ts
+++ b/src/test/debugger/portAndHost.test.ts
@@ -44,11 +44,12 @@ suite(`Standard Debugging of ports and hosts: ${debuggerType}`, () => {
         } catch (ex) { }
     });
 
-    function buildLauncArgs(pythonFile: string, stopOnEntry: boolean = false, port?: number, host?: string): LaunchRequestArguments {
+    function buildLaunchArgs(pythonFile: string, stopOnEntry: boolean = false, port?: number, host?: string, showReturnValue: boolean = false): LaunchRequestArguments {
         return {
             program: path.join(debugFilesPath, pythonFile),
             cwd: debugFilesPath,
             stopOnEntry,
+            showReturnValue,
             logToFile: true,
             debugOptions: [DebugOptions.RedirectOutput],
             pythonPath: PYTHON_PATH,
@@ -64,7 +65,7 @@ suite(`Standard Debugging of ports and hosts: ${debuggerType}`, () => {
     async function testDebuggingWithProvidedPort(port?: number | undefined, host?: string | undefined) {
         await Promise.all([
             debugClient.configurationSequence(),
-            debugClient.launch(buildLauncArgs('startAndWait.py', false, port, host)),
+            debugClient.launch(buildLaunchArgs('startAndWait.py', false, port, host)),
             debugClient.waitForEvent('initialized')
         ]);
 

--- a/src/test/debugger/run.test.ts
+++ b/src/test/debugger/run.test.ts
@@ -40,12 +40,13 @@ suite('Run without Debugging', () => {
         } catch (ex) { }
         await sleep(1000);
     });
-    function buildLauncArgs(pythonFile: string, stopOnEntry: boolean = false): LaunchRequestArguments {
+    function buildLaunchArgs(pythonFile: string, stopOnEntry: boolean = false, showReturnValue: boolean = false): LaunchRequestArguments {
         // tslint:disable-next-line:no-unnecessary-local-variable
         return {
             program: path.join(debugFilesPath, pythonFile),
             cwd: debugFilesPath,
             stopOnEntry,
+            showReturnValue,
             noDebug: true,
             debugOptions: [DebugOptions.RedirectOutput],
             pythonPath: PYTHON_PATH,
@@ -62,7 +63,7 @@ suite('Run without Debugging', () => {
     test('Should run program to the end', async () => {
         await Promise.all([
             debugClient.configurationSequence(),
-            debugClient.launch(buildLauncArgs('simplePrint.py', false)),
+            debugClient.launch(buildLaunchArgs('simplePrint.py', false)),
             debugClient.waitForEvent('initialized'),
             debugClient.waitForEvent('terminated')
         ]);
@@ -70,7 +71,7 @@ suite('Run without Debugging', () => {
     test('test stderr output for Python', async () => {
         await Promise.all([
             debugClient.configurationSequence(),
-            debugClient.launch(buildLauncArgs('stdErrOutput.py', false)),
+            debugClient.launch(buildLaunchArgs('stdErrOutput.py', false)),
             debugClient.waitForEvent('initialized'),
             debugClient.assertOutput('stderr', 'error output'),
             debugClient.waitForEvent('terminated')
@@ -79,7 +80,7 @@ suite('Run without Debugging', () => {
     test('Test stdout output', async () => {
         await Promise.all([
             debugClient.configurationSequence(),
-            debugClient.launch(buildLauncArgs('stdOutOutput.py', false)),
+            debugClient.launch(buildLaunchArgs('stdOutOutput.py', false)),
             debugClient.waitForEvent('initialized'),
             debugClient.assertOutput('stdout', 'normal output'),
             debugClient.waitForEvent('terminated')
@@ -102,7 +103,7 @@ suite('Run without Debugging', () => {
         });
         await Promise.all([
             debugClient.configurationSequence(),
-            debugClient.launch(buildLauncArgs('sampleWithSleep.py', false)),
+            debugClient.launch(buildLaunchArgs('sampleWithSleep.py', false)),
             debugClient.waitForEvent('initialized'),
             processIdOutput
         ]);


### PR DESCRIPTION
For #2463 

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Unit tests & system/integration tests are added/updated
- [ ] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)

Result of setting `showReturnValue`: `true`
![image](https://user-images.githubusercontent.com/3840081/46770506-8f8ebf80-cca4-11e8-8485-92bcc1d87849.png)
