### PR TITLE
Add snippet for `if __name__ == "__main__":` block

### DIFF
--- a/news/1 Enhancements/2242.md
+++ b/news/1 Enhancements/2242.md
@@ -1,0 +1,2 @@
+Add a new simple snippet for `if __name__ == '__main__':` block. The snippet can be accessed by typing `__main__`
+(thanks [R S Nikhil Krishna](https://github.com/rsnk96/))

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -183,17 +183,6 @@
         ],
         "description": "Code snippet for a lambda statement"
     },
-    "if(main) with main()": {
-        "prefix": "if(main)",
-        "body": [
-            "def main():",
-            "\t${1:pass}",
-            "",
-            "if __name__ == '__main__':",
-            "\tmain()"
-        ],
-        "description": "Code snippet for a main function"
-    },
     "if(main)": {
         "prefix": "__main__",
         "body": [

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -200,7 +200,7 @@
             "if __name__ == '__main__':",
             "    ${1:pass}",
         ],
-        "description": "Code snippet for checking if program is being called or imported"
+        "description": "Code snippet for a `if __name__ == \"__main__\": ...` block"
     },
     "async/def": {
         "prefix": "async/def",

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -198,7 +198,7 @@
         "prefix": "__main__",
         "body": [
             "if __name__ == '__main__':",
-            "\t${1:pass}",
+            "    ${1:pass}",
         ],
         "description": "Code snippet for checking if program is being called or imported"
     },

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -197,7 +197,7 @@
     "if(main)": {
         "prefix": "__main__",
         "body": [
-            "if __name__ == '__main__':",
+            "if __name__ == \"__main__\":",
             "    ${1:pass}",
         ],
         "description": "Code snippet for a `if __name__ == \"__main__\": ...` block"

--- a/snippets/python.json
+++ b/snippets/python.json
@@ -183,7 +183,7 @@
         ],
         "description": "Code snippet for a lambda statement"
     },
-    "if(main)": {
+    "if(main) with main()": {
         "prefix": "if(main)",
         "body": [
             "def main():",
@@ -193,6 +193,14 @@
             "\tmain()"
         ],
         "description": "Code snippet for a main function"
+    },
+    "if(main)": {
+        "prefix": "__main__",
+        "body": [
+            "if __name__ == '__main__':",
+            "\t${1:pass}",
+        ],
+        "description": "Code snippet for checking if program is being called or imported"
     },
     "async/def": {
         "prefix": "async/def",


### PR DESCRIPTION
Added snippet to check if program is being run directly or imported without a separate `main()` function. (To address #2242 )

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
