### PR TITLE
Change property name used to track versions in telemetry 

### DIFF
--- a/src/client/activation/downloader.ts
+++ b/src/client/activation/downloader.ts
@@ -45,7 +45,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
     public async downloadLanguageServer(context: IExtensionContext): Promise<void> {
         const downloadInfo = await this.getDownloadInfo();
         const downloadUri = downloadInfo.uri;
-        const version = downloadInfo.version.raw;
+        const lsVersion = downloadInfo.version.raw;
         const timer: StopWatch = new StopWatch();
         let success: boolean = true;
         let localTempFilePath = '';
@@ -61,7 +61,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             sendTelemetryEvent(
                 PYTHON_LANGUAGE_SERVER_DOWNLOADED,
                 timer.elapsedTime,
-                { success, version }
+                { success, lsVersion }
             );
         }
 
@@ -77,7 +77,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             sendTelemetryEvent(
                 PYTHON_LANGUAGE_SERVER_EXTRACTED,
                 timer.elapsedTime,
-                { success, version }
+                { success, lsVersion }
             );
             await this.fs.deleteFile(localTempFilePath);
         }

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -50,7 +50,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
                 .catch<string>(() => '');
             const [info, pipVersion] = await Promise.all([infoPromise, pipVersionPromise]);
             if (info) {
-                telemtryProperties.version = info.version;
+                telemtryProperties.pyVersion = info.version;
             }
             if (pipVersion) {
                 telemtryProperties.pipVersion = pipVersion;

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -17,6 +17,7 @@ export type FormatTelemetry = {
 
 export type LanguageServerTelemetry = {
     success: boolean;
+    lsVersion: string;
 };
 
 export type LinterTrigger = 'auto' | 'save';
@@ -30,7 +31,7 @@ export type LintingTelemetry = {
 export type PythonInterpreterTelemetry = {
     trigger: 'ui' | 'shebang' | 'load';
     failed: boolean;
-    version?: string;
+    pyVersion?: string;
     pipVersion?: string;
 };
 export type CodeExecutionTelemetry = {

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -17,7 +17,7 @@ export type FormatTelemetry = {
 
 export type LanguageServerTelemetry = {
     success: boolean;
-    lsVersion: string;
+    lsVersion?: string;
 };
 
 export type LinterTrigger = 'auto' | 'save';


### PR DESCRIPTION
For #2702

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [no] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
