### PR TITLE
Ensure we track activation results

### DIFF
--- a/src/test/common/terminals/activator/base.unit.test.ts
+++ b/src/test/common/terminals/activator/base.unit.test.ts
@@ -11,7 +11,7 @@ import { ITerminalActivator, ITerminalHelper } from '../../../../client/common/t
 import { noop } from '../../../../client/common/utils/misc';
 
 // tslint:disable:max-func-body-length no-any
-suite('Terminalx Base Activator', () => {
+suite('Terminal Base Activator', () => {
     let activator: ITerminalActivator;
     let helper: TypeMoq.IMock<ITerminalHelper>;
 

--- a/src/test/common/terminals/activator/base.unit.test.ts
+++ b/src/test/common/terminals/activator/base.unit.test.ts
@@ -4,12 +4,13 @@
 'use strict';
 
 import * as TypeMoq from 'typemoq';
+import { expect } from 'chai';
 import { Terminal } from 'vscode';
 import { BaseTerminalActivator } from '../../../../client/common/terminal/activator/base';
 import { ITerminalActivator, ITerminalHelper } from '../../../../client/common/terminal/types';
 import { noop } from '../../../../client/common/utils/misc';
 
-// tslint:disable-next-line:max-func-body-length
+// tslint:disable:max-func-body-length no-any
 suite('Terminalx Base Activator', () => {
     let activator: ITerminalActivator;
     let helper: TypeMoq.IMock<ITerminalHelper>;
@@ -18,7 +19,7 @@ suite('Terminalx Base Activator', () => {
         helper = TypeMoq.Mock.ofType<ITerminalHelper>();
         activator = new class extends BaseTerminalActivator {
             public waitForCommandToProcess() { noop(); return Promise.resolve(); }
-        }(helper.object);
+        }(helper.object) as any as ITerminalActivator;
     });
     [
         { commandCount: 1, preserveFocus: false },
@@ -69,6 +70,31 @@ suite('Terminalx Base Activator', () => {
             await activator.activateEnvironmentInTerminal(terminal.object, undefined, item.preserveFocus);
 
             terminal.verifyAll();
+        });
+        test(`Terminal is activated only once ${titleSuffix} (even when not waiting)`, async () => {
+            helper.setup(h => h.getTerminalShellPath()).returns(() => '');
+            helper.setup(h => h.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(activationCommands));
+            const terminal = TypeMoq.Mock.ofType<Terminal>();
+
+            terminal
+                .setup(t => t.show(TypeMoq.It.isValue(item.preserveFocus)))
+                .returns(() => undefined)
+                .verifiable(TypeMoq.Times.exactly(activationCommands.length));
+            activationCommands.forEach(cmd => {
+                terminal
+                    .setup(t => t.sendText(TypeMoq.It.isValue(cmd)))
+                    .returns(() => undefined)
+                    .verifiable(TypeMoq.Times.exactly(1));
+            });
+
+            const activated = await Promise.all([
+                activator.activateEnvironmentInTerminal(terminal.object, undefined, item.preserveFocus),
+                activator.activateEnvironmentInTerminal(terminal.object, undefined, item.preserveFocus),
+                activator.activateEnvironmentInTerminal(terminal.object, undefined, item.preserveFocus)
+            ]);
+
+            terminal.verifyAll();
+            expect(activated).to.deep.equal([true, true, true], 'Invalid values');
         });
     });
 });


### PR DESCRIPTION
For #2732

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [no] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
