### PR TITLE
Pylint not enabled by default, can be easily enabled for workspaces that have it available.

### DIFF
--- a/news/1 Enhancements/974.md
+++ b/news/1 Enhancements/974.md
@@ -1,0 +1,1 @@
+Pylint is no longer enabled by default. Users that have not configured pylint but who have installed it in their workspace will be asked if they'd like to enable it.

--- a/package.json
+++ b/package.json
@@ -1257,7 +1257,7 @@
                 },
                 "python.linting.pylintEnabled": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Whether to lint Python files using pylint.",
                     "scope": "resource"
                 },

--- a/package.json
+++ b/package.json
@@ -1257,7 +1257,7 @@
                 },
                 "python.linting.pylintEnabled": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Whether to lint Python files using pylint.",
                     "scope": "resource"
                 },

--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -86,10 +86,6 @@ export abstract class BaseLinter implements ILinter {
         return this._info;
     }
 
-    public isLinterExecutableSpecified(resource: vscode.Uri) {
-        const executablePath = this.info.pathName(resource);
-        return path.basename(executablePath).length > 0 && path.basename(executablePath) !== executablePath;
-    }
     public async lint(document: vscode.TextDocument, cancellation: vscode.CancellationToken): Promise<ILintMessage[]> {
         this._pythonSettings = this.configService.getSettings(document.uri);
         return this.runLinter(document, cancellation);

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -6,7 +6,7 @@
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../common/application/types';
-import { error as traceError } from '../common/logger';
+import { traceError } from '../common/logger';
 import { IInstaller, Product } from '../common/types';
 import { IAvailableLinterActivator, ILinterInfo } from './types';
 

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { IApplicationShell, IWorkspaceService } from '../common/application/types';
+import { error as traceError } from '../common/logger';
+import { IInstaller, Product } from '../common/types';
+import { IAvailableLinterActivator, ILinterInfo } from './types';
+
+@injectable()
+export class AvailableLinterActivator implements IAvailableLinterActivator {
+    constructor(
+        @inject(IApplicationShell) private appShell: IApplicationShell,
+        @inject(IInstaller) private installer: IInstaller,
+        @inject(IWorkspaceService) private workspaceConfig: IWorkspaceService
+    ) { }
+
+    /**
+     * Check if it is possible to enable an otherwise-unconfigured linter in
+     * the current workspace, and if so ask the user if they want that linter
+     * configured explicitly.
+     *
+     * @param linterInfo The linter to check installation status.
+     * @param resource Context for the operation (required when in multi-root workspaces).
+     *
+     * @returns true if configuration was updated in any way, false otherwise.
+     */
+    public async promptIfLinterAvailable(linterInfo: ILinterInfo, resource?: Uri): Promise<boolean> {
+
+        // Has the linter in question has been configured explicitly? If so, no need to continue.
+        if (!this.isLinterUsingDefaultConfiguration(linterInfo, resource)) {
+            return false;
+        }
+
+        // Is the linter available in the current workspace?
+        if (await this.isLinterAvailable(linterInfo.product, resource)) {
+
+            // great, it is - ask the user if they'd like to enable it.
+            return this.promptToConfigureAvailableLinter(linterInfo);
+        }
+        return false;
+    }
+
+    /**
+     * Raise a dialog asking the user if they would like to explicitly configure a
+     * linter or not in their current workspace.
+     *
+     * @param linterInfo The linter to ask the user to enable or not.
+     *
+     * @returns true if the user requested a configuration change, false otherwise.
+     */
+    public async promptToConfigureAvailableLinter(linterInfo: ILinterInfo): Promise<boolean> {
+        type ConfigureLinterMessage = {
+            enabled: boolean;
+            title: string;
+        };
+
+        const optButtons: ConfigureLinterMessage[] = [
+            {
+                title: `Enable ${linterInfo.id}`,
+                enabled: true
+            },
+            {
+                title: `Disable ${linterInfo.id}`,
+                enabled: false
+            }
+        ];
+        const pick = await this.appShell.showInformationMessage(`Linter ${linterInfo.id} is available but not enabled.`, ...optButtons);
+        if (pick) {
+            await linterInfo.enableAsync(pick.enabled);
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if the linter itself is available in the workspace's Python environment or
+     * not.
+     *
+     * @param linterProduct Linter to check in the current workspace environment.
+     * @param resource Context information for workspace.
+     */
+    public async isLinterAvailable(linterProduct: Product, resource?: Uri): Promise<boolean | undefined> {
+        return this.installer.isInstalled(linterProduct, resource)
+            .catch((reason) => {
+                // report and continue, assume the linter is unavailable.
+                traceError(`[WARNING]: Failed to discover if linter ${linterProduct} is installed.`, reason);
+                return false;
+            });
+    }
+
+    /**
+     * Check if the given linter has been configured by the user in this workspace or not.
+     *
+     * @param linterInfo Linter to check for configuration status.
+     * @param resource Context information.
+     *
+     * @returns true if the linter has not been configured at the user, workspace, or workspace-folder scope. false otherwise.
+     */
+    public isLinterUsingDefaultConfiguration(linterInfo: ILinterInfo, resource?: Uri) {
+        const ws = this.workspaceConfig.getConfiguration('python.linting', resource);
+        const pe = ws!.inspect(linterInfo.enabledSettingName);
+        return (pe!.globalValue === undefined && pe!.workspaceValue === undefined && pe!.workspaceFolderValue === undefined);
+    }
+}

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -30,7 +30,7 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      */
     public async promptIfLinterAvailable(linterInfo: ILinterInfo, resource?: Uri): Promise<boolean> {
         // Has the feature been enabled yet?
-        if (!this.isFeatureEnabled()) {
+        if (!this.isFeatureEnabled) {
             return false;
         }
 
@@ -120,7 +120,7 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      *
      * @returns true if the global default for python.jediEnabled is false.
      */
-    public isFeatureEnabled(): boolean {
+    public get isFeatureEnabled(): boolean {
         const ws = this.workspaceConfig.getConfiguration('python');
         const jediEnabled = ws!.inspect('jediEnabled');
         return (!jediEnabled || jediEnabled.defaultValue === false);

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../common/application/types';
 import { traceError } from '../common/logger';
-import { IInstaller, Product } from '../common/types';
+import { IConfigurationService, IInstaller, Product } from '../common/types';
 import { IAvailableLinterActivator, ILinterInfo } from './types';
 
 @injectable()
@@ -15,7 +15,8 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
         @inject(IInstaller) private installer: IInstaller,
-        @inject(IWorkspaceService) private workspaceConfig: IWorkspaceService
+        @inject(IWorkspaceService) private workspaceConfig: IWorkspaceService,
+        @inject(IConfigurationService) private configService: IConfigurationService
     ) { }
 
     /**
@@ -121,8 +122,6 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * @returns true if the global default for python.jediEnabled is false.
      */
     public get isFeatureEnabled(): boolean {
-        const ws = this.workspaceConfig.getConfiguration('python');
-        const jediEnabled = ws!.inspect('jediEnabled');
-        return (!jediEnabled || jediEnabled.defaultValue === false);
+        return !this.configService.getSettings().jediEnabled;
     }
 }

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -29,6 +29,10 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * @returns true if configuration was updated in any way, false otherwise.
      */
     public async promptIfLinterAvailable(linterInfo: ILinterInfo, resource?: Uri): Promise<boolean> {
+        // Has the feature been enabled yet?
+        if (!this.isFeatureEnabled()) {
+            return false;
+        }
 
         // Has the linter in question has been configured explicitly? If so, no need to continue.
         if (!this.isLinterUsingDefaultConfiguration(linterInfo, resource)) {
@@ -101,9 +105,24 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      *
      * @returns true if the linter has not been configured at the user, workspace, or workspace-folder scope. false otherwise.
      */
-    public isLinterUsingDefaultConfiguration(linterInfo: ILinterInfo, resource?: Uri) {
+    public isLinterUsingDefaultConfiguration(linterInfo: ILinterInfo, resource?: Uri): boolean {
         const ws = this.workspaceConfig.getConfiguration('python.linting', resource);
         const pe = ws!.inspect(linterInfo.enabledSettingName);
         return (pe!.globalValue === undefined && pe!.workspaceValue === undefined && pe!.workspaceFolderValue === undefined);
+    }
+
+    /**
+     * Check if this feature is enabled yet.
+     *
+     * This is a feature of the vscode-python extension that will become enabled once the
+     * Python Language Server becomes the default, replacing Jedi as the default. Testing
+     * the global default setting for `"python.jediEnabled": false` enables it.
+     *
+     * @returns true if the global default for python.jediEnabled is false.
+     */
+    public isFeatureEnabled(): boolean {
+        const ws = this.workspaceConfig.getConfiguration('python');
+        const jediEnabled = ws!.inspect('jediEnabled');
+        return (!jediEnabled || jediEnabled.defaultValue === false);
     }
 }

--- a/src/client/linters/linterCommands.ts
+++ b/src/client/linters/linterCommands.ts
@@ -28,7 +28,7 @@ export class LinterCommands implements vscode.Disposable {
     public async setLinterAsync(): Promise<void> {
         const linters = this.linterManager.getAllLinterInfos();
         const suggestions = linters.map(x => x.id).sort();
-        const activeLinters = this.linterManager.getActiveLinters(this.settingsUri);
+        const activeLinters = await this.linterManager.getActiveLinters(false, this.settingsUri);
 
         let current: string;
         switch (activeLinters.length) {
@@ -64,7 +64,7 @@ export class LinterCommands implements vscode.Disposable {
 
     public async enableLintingAsync(): Promise<void> {
         const options = ['on', 'off'];
-        const current = this.linterManager.isLintingEnabled(this.settingsUri) ? options[0] : options[1];
+        const current = await this.linterManager.isLintingEnabled(false, this.settingsUri) ? options[0] : options[1];
 
         const quickPickOptions: vscode.QuickPickOptions = {
             matchOnDetail: true,

--- a/src/client/linters/linterCommands.ts
+++ b/src/client/linters/linterCommands.ts
@@ -28,7 +28,7 @@ export class LinterCommands implements vscode.Disposable {
     public async setLinterAsync(): Promise<void> {
         const linters = this.linterManager.getAllLinterInfos();
         const suggestions = linters.map(x => x.id).sort();
-        const activeLinters = await this.linterManager.getActiveLinters(false, this.settingsUri);
+        const activeLinters = await this.linterManager.getActiveLinters(true, this.settingsUri);
 
         let current: string;
         switch (activeLinters.length) {
@@ -64,7 +64,7 @@ export class LinterCommands implements vscode.Disposable {
 
     public async enableLintingAsync(): Promise<void> {
         const options = ['on', 'off'];
-        const current = await this.linterManager.isLintingEnabled(false, this.settingsUri) ? options[0] : options[1];
+        const current = await this.linterManager.isLintingEnabled(true, this.settingsUri) ? options[0] : options[1];
 
         const quickPickOptions: vscode.QuickPickOptions = {
             matchOnDetail: true,

--- a/src/client/linters/linterManager.ts
+++ b/src/client/linters/linterManager.ts
@@ -74,9 +74,9 @@ export class LinterManager implements ILinterManager {
         throw new Error('Invalid linter');
     }
 
-    public async isLintingEnabled(checkAvailable: boolean, resource?: Uri): Promise<boolean> {
+    public async isLintingEnabled(silent: boolean, resource?: Uri): Promise<boolean> {
         const settings = this.configService.getSettings(resource);
-        const activeLintersPresent = await this.getActiveLinters(checkAvailable, resource);
+        const activeLintersPresent = await this.getActiveLinters(silent, resource);
         return (settings.linting[this.lintingEnabledSettingName] as boolean) && activeLintersPresent.length > 0;
     }
 
@@ -185,8 +185,8 @@ export class LinterManager implements ILinterManager {
         return (pe!.globalValue === undefined && pe!.workspaceValue === undefined && pe!.workspaceFolderValue === undefined);
     }
 
-    public async getActiveLinters(checkAvailable: boolean, resource?: Uri): Promise<ILinterInfo[]> {
-        if (checkAvailable) {
+    public async getActiveLinters(silent: boolean, resource?: Uri): Promise<ILinterInfo[]> {
+        if (silent) {
             // only ask the user if they'd like to enable pylint when it is available... others may follow.
             const pylintInfo = this.linters.find((linter: ILinterInfo) => linter.id === 'pylint');
             if (pylintInfo) {

--- a/src/client/linters/linterManager.ts
+++ b/src/client/linters/linterManager.ts
@@ -5,16 +5,10 @@
 
 import { inject, injectable } from 'inversify';
 import {
-    CancellationToken, OutputChannel,
-    TextDocument, Uri
+    CancellationToken, OutputChannel, TextDocument, Uri
 } from 'vscode';
-import { IApplicationShell, IWorkspaceService } from '../common/application/types';
-import { STANDARD_OUTPUT_CHANNEL } from '../common/constants';
-import { LinterInstaller } from '../common/installer/productInstaller';
-import { error as traceError } from '../common/logger';
 import {
-    IConfigurationService, ILogger,
-    IOutputChannel, Product
+    IConfigurationService, ILogger, Product
 } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { Bandit } from './bandit';
@@ -27,8 +21,7 @@ import { PyDocStyle } from './pydocstyle';
 import { PyLama } from './pylama';
 import { Pylint } from './pylint';
 import {
-    ILinter, ILinterInfo,
-    ILinterManager, ILintMessage
+    IAvailableLinterActivator, ILinter, ILinterInfo, ILinterManager, ILintMessage
 } from './types';
 
 class DisabledLinter implements ILinter {
@@ -84,120 +77,15 @@ export class LinterManager implements ILinterManager {
         await this.configService.updateSetting(`linting.${this.lintingEnabledSettingName}`, enable, resource);
     }
 
-    /**
-     * Check if it is possible to enable an otherwise-unconfigured linter in
-     * the current workspace, and if so ask the user if they want that linter
-     * configured explicitly.
-     *
-     * @param linterInfo The linter to check installation status.
-     * @param resource Context for the operation (required when in multi-root workspaces).
-     *
-     * @returns true if configuration was updated in any way, false otherwise.
-     */
-    public async promptUserIfLinterAvailable(linterInfo: ILinterInfo, resource?: Uri): Promise<boolean> {
-        // if we've already checked during this session, don't bother again
-        if (!this.checkedForInstalledLinters) {
-            this.checkedForInstalledLinters = true;
-        } else {
-            return false;
-        }
-
-        // If linting is disabled, we are finished.
-        if (!await this.isLintingEnabled(false, resource)) {
-            return false;
-        }
-
-        // Has the linter in question has been configured explicitly? If so, no need to continue.
-        if (!this.isLinterUsingDefaultConfiguration(linterInfo, resource)) {
-            return false;
-        }
-
-        // Is the linter available in the current workspace?
-        if (await this.isLinterAvailable(linterInfo.product, resource)) {
-            // ...ask the user if they would like to enable it.
-            return this.notifyUserAndConfigureLinter(linterInfo);
-        } else {
-            return false;
-        }
-
-    }
-
-    /// Raise a dialog asking the user if they would like to explicitly configure a linter or not.
-    /// Return true if a config change was made.
-    public async notifyUserAndConfigureLinter(linterInfo: ILinterInfo): Promise<boolean> {
-        const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-
-        type ConfigureLinterMessage = {
-            enabled: boolean;
-            title: string;
-        };
-
-        const optButtons: ConfigureLinterMessage[] = [
-            {
-                title: `Enable ${linterInfo.id}`,
-                enabled: true
-            },
-            {
-                title: `Disable ${linterInfo.id}`,
-                enabled: false
-            }
-        ];
-        const pick = await appShell.showInformationMessage(`Linter ${linterInfo.id} is available but not enabled.`, ...optButtons);
-        if (pick) {
-            await linterInfo.enableAsync(pick.enabled);
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Check if the linter itself is available in the workspace's Python environment or
-     * not.
-     *
-     * @param linterProduct Linter to check in the current workspace environment.
-     * @param resource Context information for workspace.
-     */
-    public async isLinterAvailable(linterProduct: Product, resource?: Uri): Promise<boolean | undefined> {
-        const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
-        const linterInstaller = new LinterInstaller(this.serviceContainer, outputChannel);
-
-        return linterInstaller.isInstalled(linterProduct, resource)
-            .catch((reason) => {
-                // report and continue, assume the linter is unavailable.
-                traceError(`[WARNING]: Failed to discover if linter ${linterProduct} is installed.`, reason);
-                return false;
-            });
-    }
-
-    /**
-     * Check if the given linter has been configured by the user in this workspace or not.
-     *
-     * @param linterInfo Linter to check for configuration status.
-     * @param resource Context information.
-     *
-     * @returns true if the linter has not been configured at the user, workspace, or workspace-folder scope. false otherwise.
-     */
-    public isLinterUsingDefaultConfiguration(linterInfo: ILinterInfo, resource?: Uri) {
-        const workspaceConfig = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
-        const ws = workspaceConfig.getConfiguration('python.linting', resource);
-        const pe = ws!.inspect(linterInfo.enabledSettingName);
-        return (pe!.globalValue === undefined && pe!.workspaceValue === undefined && pe!.workspaceFolderValue === undefined);
-    }
-
     public async getActiveLinters(silent: boolean, resource?: Uri): Promise<ILinterInfo[]> {
-        if (silent) {
-            // only ask the user if they'd like to enable pylint when it is available... others may follow.
-            const pylintInfo = this.linters.find((linter: ILinterInfo) => linter.id === 'pylint');
-            if (pylintInfo) {
-                await this.promptUserIfLinterAvailable(pylintInfo, resource);
-            }
+        if (!silent) {
+            await this.enableUnconfiguredLinters(resource);
         }
         return this.linters.filter(x => x.isEnabled(resource));
     }
 
     public async setActiveLintersAsync(products: Product[], resource?: Uri): Promise<void> {
-        const active = await this.getActiveLinters(false, resource);
+        const active = await this.getActiveLinters(true, resource);
         for (const x of active) {
             await x.enableAsync(false, resource);
         }
@@ -211,7 +99,7 @@ export class LinterManager implements ILinterManager {
     }
 
     public async createLinter(product: Product, outputChannel: OutputChannel, serviceContainer: IServiceContainer, resource?: Uri): Promise<ILinter> {
-        if (!await this.isLintingEnabled(false, resource)) {
+        if (!await this.isLintingEnabled(true, resource)) {
             return new DisabledLinter(this.configService);
         }
         const error = 'Linter manager: Unknown linter';
@@ -237,5 +125,25 @@ export class LinterManager implements ILinterManager {
                 break;
         }
         throw new Error(error);
+    }
+
+    private async enableUnconfiguredLinters(resource?: Uri): Promise<boolean> {
+        // if we've already checked during this session, don't bother again
+        if (this.checkedForInstalledLinters) {
+            return false;
+        }
+        this.checkedForInstalledLinters = true;
+
+        // only check & ask the user if they'd like to enable pylint
+        const pylintInfo = this.linters.find(
+            (linter: ILinterInfo) => linter.id === 'pylint'
+        );
+
+        // If linting is disabled, don't bother checking further.
+        if (pylintInfo && await this.isLintingEnabled(true, resource)) {
+            const activator = this.serviceContainer.get<IAvailableLinterActivator>(IAvailableLinterActivator);
+            return activator.promptIfLinterAvailable(pylintInfo, resource);
+        }
+        return false;
     }
 }

--- a/src/client/linters/linterManager.ts
+++ b/src/client/linters/linterManager.ts
@@ -127,7 +127,7 @@ export class LinterManager implements ILinterManager {
         throw new Error(error);
     }
 
-    private async enableUnconfiguredLinters(resource?: Uri): Promise<boolean> {
+    protected async enableUnconfiguredLinters(resource?: Uri): Promise<boolean> {
         // if we've already checked during this session, don't bother again
         if (this.checkedForInstalledLinters) {
             return false;

--- a/src/client/linters/linterManager.ts
+++ b/src/client/linters/linterManager.ts
@@ -186,19 +186,14 @@ export class LinterManager implements ILinterManager {
     }
 
     public async getActiveLinters(checkAvailable: boolean, resource?: Uri): Promise<ILinterInfo[]> {
-        let activeLinters = this.linters.filter(x => x.isEnabled(resource));
-
         if (checkAvailable) {
             // only ask the user if they'd like to enable pylint when it is available... others may follow.
             const pylintInfo = this.linters.find((linter: ILinterInfo) => linter.id === 'pylint');
             if (pylintInfo) {
-                const change = await this.promptUserIfLinterAvailable(pylintInfo, resource);
-                if (change) {
-                    activeLinters = this.linters.filter(x => x.isEnabled(resource));
-                }
+                await this.promptUserIfLinterAvailable(pylintInfo, resource);
             }
         }
-        return activeLinters;
+        return this.linters.filter(x => x.isEnabled(resource));
     }
 
     public async setActiveLintersAsync(products: Product[], resource?: Uri): Promise<void> {

--- a/src/client/linters/linterManager.ts
+++ b/src/client/linters/linterManager.ts
@@ -81,13 +81,7 @@ export class LinterManager implements ILinterManager {
         if (!silent) {
             await this.enableUnconfiguredLinters(resource);
         }
-        return this.linters.filter(x => {
-            let enabled = x.isEnabled(resource);
-            if (x.id === 'pylint') {
-                enabled = enabled === true;
-            }
-            return enabled === true;
-        });
+        return this.linters.filter(x => x.isEnabled(resource));
     }
 
     public async setActiveLintersAsync(products: Product[], resource?: Uri): Promise<void> {

--- a/src/client/linters/lintingEngine.ts
+++ b/src/client/linters/lintingEngine.ts
@@ -95,7 +95,7 @@ export class LintingEngine implements ILintingEngine {
 
         this.pendingLintings.set(document.uri.fsPath, cancelToken);
 
-        const activeLinters = await this.linterManager.getActiveLinters(true, document.uri);
+        const activeLinters = await this.linterManager.getActiveLinters(false, document.uri);
         const promises: Promise<ILintMessage[]>[] = activeLinters
             .map(async (info: ILinterInfo) => {
                 const stopWatch = new StopWatch();
@@ -183,7 +183,7 @@ export class LintingEngine implements ILintingEngine {
     }
 
     private async shouldLintDocument(document: vscode.TextDocument): Promise<boolean> {
-        if (!await this.linterManager.isLintingEnabled(true, document.uri)) {
+        if (!await this.linterManager.isLintingEnabled(false, document.uri)) {
             this.diagnosticCollection.set(document.uri, []);
             return false;
         }

--- a/src/client/linters/lintingEngine.ts
+++ b/src/client/linters/lintingEngine.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+'use strict';
+
 import { inject, injectable } from 'inversify';
 import { Minimatch } from 'minimatch';
 import * as path from 'path';
@@ -93,10 +95,16 @@ export class LintingEngine implements ILintingEngine {
 
         this.pendingLintings.set(document.uri.fsPath, cancelToken);
 
-        const promises: Promise<ILintMessage[]>[] = this.linterManager.getActiveLinters(document.uri)
-            .map(info => {
+        const activeLinters = await this.linterManager.getActiveLinters(true, document.uri);
+        const promises: Promise<ILintMessage[]>[] = activeLinters
+            .map(async (info: ILinterInfo) => {
                 const stopWatch = new StopWatch();
-                const linter = this.linterManager.createLinter(info.product, this.outputChannel, this.serviceContainer, document.uri);
+                const linter = await this.linterManager.createLinter(
+                    info.product,
+                    this.outputChannel,
+                    this.serviceContainer,
+                    document.uri
+                );
                 const promise = linter.lint(document, cancelToken.token);
                 this.sendLinterRunTelemetry(info, document.uri, promise, stopWatch, trigger);
                 return promise;
@@ -175,7 +183,7 @@ export class LintingEngine implements ILintingEngine {
     }
 
     private async shouldLintDocument(document: vscode.TextDocument): Promise<boolean> {
-        if (!this.linterManager.isLintingEnabled(document.uri)) {
+        if (!await this.linterManager.isLintingEnabled(true, document.uri)) {
             this.diagnosticCollection.set(document.uri, []);
             return false;
         }

--- a/src/client/linters/serviceRegistry.ts
+++ b/src/client/linters/serviceRegistry.ts
@@ -2,11 +2,15 @@
 // Licensed under the MIT License.
 
 import { IServiceManager } from '../ioc/types';
+import { AvailableLinterActivator } from './linterAvailability';
 import { LinterManager } from './linterManager';
 import { LintingEngine } from './lintingEngine';
-import { ILinterManager, ILintingEngine } from './types';
+import {
+    IAvailableLinterActivator, ILinterManager, ILintingEngine
+} from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ILintingEngine>(ILintingEngine, LintingEngine);
     serviceManager.addSingleton<ILinterManager>(ILinterManager, LinterManager);
+    serviceManager.add<IAvailableLinterActivator>(IAvailableLinterActivator, AvailableLinterActivator);
 }

--- a/src/client/linters/types.ts
+++ b/src/client/linters/types.ts
@@ -35,8 +35,8 @@ export const ILinterManager = Symbol('ILinterManager');
 export interface ILinterManager {
     getAllLinterInfos(): ILinterInfo[];
     getLinterInfo(product: Product): ILinterInfo;
-    getActiveLinters(checkAvailable: boolean, resource?: vscode.Uri): Promise<ILinterInfo[]>;
-    isLintingEnabled(checkAvailable: boolean, resource?: vscode.Uri): Promise<boolean>;
+    getActiveLinters(silent: boolean, resource?: vscode.Uri): Promise<ILinterInfo[]>;
+    isLintingEnabled(silent: boolean, resource?: vscode.Uri): Promise<boolean>;
     enableLintingAsync(enable: boolean, resource?: vscode.Uri): Promise<void>;
     setActiveLintersAsync(products: Product[], resource?: vscode.Uri): Promise<void>;
     createLinter(product: Product, outputChannel: vscode.OutputChannel, serviceContainer: IServiceContainer, resource?: vscode.Uri): Promise<ILinter>;

--- a/src/client/linters/types.ts
+++ b/src/client/linters/types.ts
@@ -31,6 +31,11 @@ export interface ILinter {
     lint(document: vscode.TextDocument, cancellation: vscode.CancellationToken): Promise<ILintMessage[]>;
 }
 
+export const IAvailableLinterActivator = Symbol('IAvailableLinterActivator');
+export interface IAvailableLinterActivator {
+    promptIfLinterAvailable(linter: ILinterInfo, resource?: vscode.Uri): Promise<boolean>;
+}
+
 export const ILinterManager = Symbol('ILinterManager');
 export interface ILinterManager {
     getAllLinterInfos(): ILinterInfo[];

--- a/src/client/linters/types.ts
+++ b/src/client/linters/types.ts
@@ -19,7 +19,7 @@ export interface ILinterInfo {
     readonly argsSettingName: string;
     readonly enabledSettingName: string;
     readonly configFileNames: string[];
-    enableAsync(flag: boolean, resource?: vscode.Uri): Promise<void>;
+    enableAsync(enabled: boolean, resource?: vscode.Uri): Promise<void>;
     isEnabled(resource?: vscode.Uri): boolean;
     pathName(resource?: vscode.Uri): string;
     linterArgs(resource?: vscode.Uri): string[];
@@ -35,11 +35,11 @@ export const ILinterManager = Symbol('ILinterManager');
 export interface ILinterManager {
     getAllLinterInfos(): ILinterInfo[];
     getLinterInfo(product: Product): ILinterInfo;
-    getActiveLinters(resource?: vscode.Uri): ILinterInfo[];
-    isLintingEnabled(resource?: vscode.Uri): boolean;
+    getActiveLinters(checkAvailable: boolean, resource?: vscode.Uri): Promise<ILinterInfo[]>;
+    isLintingEnabled(checkAvailable: boolean, resource?: vscode.Uri): Promise<boolean>;
     enableLintingAsync(enable: boolean, resource?: vscode.Uri): Promise<void>;
     setActiveLintersAsync(products: Product[], resource?: vscode.Uri): Promise<void>;
-    createLinter(product: Product, outputChannel: vscode.OutputChannel, serviceContainer: IServiceContainer, resource?: vscode.Uri): ILinter;
+    createLinter(product: Product, outputChannel: vscode.OutputChannel, serviceContainer: IServiceContainer, resource?: vscode.Uri): Promise<ILinter>;
 }
 
 export interface ILintMessage {

--- a/src/client/providers/linterProvider.ts
+++ b/src/client/providers/linterProvider.ts
@@ -8,10 +8,10 @@ import {
     ConfigurationTarget, Disposable, ExtensionContext,
     TextDocument, Uri, workspace
 } from 'vscode';
-import '../../../typings/extensions';
 import { IDocumentManager } from '../common/application/types';
 import { ConfigSettingMonitor } from '../common/configSettingMonitor';
 import { isTestExecution } from '../common/constants';
+import '../common/extensions';
 import { IFileSystem } from '../common/platform/types';
 import { IConfigurationService } from '../common/types';
 import { IInterpreterService } from '../interpreter/contracts';

--- a/src/client/providers/linterProvider.ts
+++ b/src/client/providers/linterProvider.ts
@@ -89,7 +89,7 @@ export class LinterProvider implements Disposable {
             return;
         }
 
-        const linters = await this.linterManager.getActiveLinters(true, document.uri);
+        const linters = await this.linterManager.getActiveLinters(false, document.uri);
         const fileName = path.basename(document.uri.fsPath).toLowerCase();
         const watchers = linters.filter((info) => info.configFileNames.indexOf(fileName) >= 0);
         if (watchers.length > 0) {

--- a/src/client/providers/linterProvider.ts
+++ b/src/client/providers/linterProvider.ts
@@ -85,7 +85,7 @@ export class LinterProvider implements Disposable {
     private async onDocumentSaved(document: TextDocument): Promise<void> {
         const settings = this.configuration.getSettings(document.uri);
         if (document.languageId === 'python' && settings.linting.enabled && settings.linting.lintOnSave) {
-            this.engine.lintDocument(document, 'save').ignoreErrors();
+            await this.engine.lintDocument(document, 'save');
             return;
         }
 

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -124,6 +124,7 @@ export async function deleteDirectory(dir: string) {
         await fs.remove(dir);
     }
 }
+
 export async function deleteFile(file: string) {
     const exists = await fs.pathExists(file);
     if (exists) {

--- a/src/test/common/configSettings.multiroot.test.ts
+++ b/src/test/common/configSettings.multiroot.test.ts
@@ -7,178 +7,178 @@ import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } fr
 
 const multirootPath = path.join(__dirname, '..', '..', '..', 'src', 'testMultiRootWkspc');
 
-if (IS_MULTI_ROOT_TEST) {
-
-    // tslint:disable-next-line:max-func-body-length
-    suite('Multiroot Config Settings', () => {
-        suiteSetup(async () => {
-            await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
-            await initialize();
-        });
-        setup(initializeTest);
-        suiteTeardown(closeActiveWindows);
-        teardown(async () => {
-            await closeActiveWindows();
-            await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
-            await initializeTest();
-        });
-
-        async function enableDisableLinterSetting(resource: Uri, configTarget: ConfigurationTarget, setting: string, enabled: boolean | undefined): Promise<void> {
-            const settings = workspace.getConfiguration('python.linting', resource);
-            const cfgValue = settings.inspect<boolean>(setting);
-            if (configTarget === ConfigurationTarget.Workspace && cfgValue && cfgValue.workspaceValue === enabled) {
-                return;
-            }
-            if (configTarget === ConfigurationTarget.WorkspaceFolder && cfgValue && cfgValue.workspaceFolderValue === enabled) {
-                return;
-            }
-            await settings.update(setting, enabled, configTarget);
-            PythonSettings.dispose();
+// tslint:disable-next-line:max-func-body-length
+suite('Multiroot Config Settings', () => {
+    suiteSetup(async function () {
+        if (!IS_MULTI_ROOT_TEST) {
+            // tslint:disable-next-line:no-invalid-this
+            this.skip();
         }
-
-        test('Workspace folder should inherit Python Path from workspace root', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            let settings = workspace.getConfiguration('python', workspaceUri);
-            const pythonPath = `x${new Date().getTime()}`;
-            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-            const value = settings.inspect('pythonPath');
-            if (value && typeof value.workspaceFolderValue === 'string') {
-                await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
-            }
-            settings = workspace.getConfiguration('python', workspaceUri);
-            PythonSettings.dispose();
-            const cfgSetting = PythonSettings.getInstance(workspaceUri);
-            assert.equal(cfgSetting.pythonPath, pythonPath, 'Python Path not inherited from workspace');
-        });
-
-        test('Workspace folder should not inherit Python Path from workspace root', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            const settings = workspace.getConfiguration('python', workspaceUri);
-            const pythonPath = `x${new Date().getTime()}`;
-            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-            const privatePythonPath = `x${new Date().getTime()}`;
-            await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
-
-            const cfgSetting = PythonSettings.getInstance(workspaceUri);
-            assert.equal(cfgSetting.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
-        });
-
-        test('Workspace folder should inherit Python Path from workspace root when opening a document', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-            const settings = workspace.getConfiguration('python', workspaceUri);
-            const pythonPath = `x${new Date().getTime()}`;
-            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-            // Update workspace folder to something else so it gets refreshed.
-            await settings.update('pythonPath', `x${new Date().getTime()}`, ConfigurationTarget.WorkspaceFolder);
-            await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
-
-            const document = await workspace.openTextDocument(fileToOpen);
-            const cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(cfg.pythonPath, pythonPath, 'Python Path not inherited from workspace');
-        });
-
-        test('Workspace folder should not inherit Python Path from workspace root when opening a document', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-            const settings = workspace.getConfiguration('python', workspaceUri);
-            const pythonPath = `x${new Date().getTime()}`;
-            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-            const privatePythonPath = `x${new Date().getTime()}`;
-            await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
-
-            const document = await workspace.openTextDocument(fileToOpen);
-            const cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(cfg.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
-        });
-
-        test('Enabling/Disabling Pylint in root should be reflected in config settings', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', undefined);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-            let settings = PythonSettings.getInstance(workspaceUri);
-            assert.equal(settings.linting.pylintEnabled, true, 'Pylint not enabled when it should be');
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-            settings = PythonSettings.getInstance(workspaceUri);
-            assert.equal(settings.linting.pylintEnabled, false, 'Pylint enabled when it should not be');
-        });
-
-        test('Enabling/Disabling Pylint in root and workspace should be reflected in config settings', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-
-            let cfgSetting = PythonSettings.getInstance(workspaceUri);
-            assert.equal(cfgSetting.linting.pylintEnabled, false, 'Workspace folder pylint setting is true when it should not be');
-            PythonSettings.dispose();
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-
-            cfgSetting = PythonSettings.getInstance(workspaceUri);
-            assert.equal(cfgSetting.linting.pylintEnabled, true, 'Workspace folder pylint setting is false when it should not be');
-        });
-
-        test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
-            let document = await workspace.openTextDocument(fileToOpen);
-            let cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
-            PythonSettings.dispose();
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
-            document = await workspace.openTextDocument(fileToOpen);
-            cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
-        });
-
-        test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
-            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
-            let document = await workspace.openTextDocument(fileToOpen);
-            let cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
-            PythonSettings.dispose();
-
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
-            document = await workspace.openTextDocument(fileToOpen);
-            cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
-        });
-
-        // tslint:disable-next-line:no-invalid-template-strings
-        test('${workspaceFolder} variable in settings should be replaced with the right value', async () => {
-            const workspace2Uri = Uri.file(path.join(multirootPath, 'workspace2'));
-            let fileToOpen = path.join(workspace2Uri.fsPath, 'file.py');
-
-            let document = await workspace.openTextDocument(fileToOpen);
-            let cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace2Uri.fsPath, 'ctags file path for workspace2 is incorrect');
-            assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace2.tags.file', 'ctags file name for workspace2 is incorrect');
-            PythonSettings.dispose();
-
-            const workspace3Uri = Uri.file(path.join(multirootPath, 'workspace3'));
-            fileToOpen = path.join(workspace3Uri.fsPath, 'file.py');
-
-            document = await workspace.openTextDocument(fileToOpen);
-            cfg = PythonSettings.getInstance(document.uri);
-            assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace3Uri.fsPath, 'ctags file path for workspace3 is incorrect');
-            assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace3.tags.file', 'ctags file name for workspace3 is incorrect');
-            PythonSettings.dispose();
-        });
+        await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
+        await initialize();
+    });
+    setup(initializeTest);
+    suiteTeardown(closeActiveWindows);
+    teardown(async () => {
+        await closeActiveWindows();
+        await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
+        await initializeTest();
     });
 
-}
+    async function enableDisableLinterSetting(resource: Uri, configTarget: ConfigurationTarget, setting: string, enabled: boolean | undefined): Promise<void> {
+        const settings = workspace.getConfiguration('python.linting', resource);
+        const cfgValue = settings.inspect<boolean>(setting);
+        if (configTarget === ConfigurationTarget.Workspace && cfgValue && cfgValue.workspaceValue === enabled) {
+            return;
+        }
+        if (configTarget === ConfigurationTarget.WorkspaceFolder && cfgValue && cfgValue.workspaceFolderValue === enabled) {
+            return;
+        }
+        await settings.update(setting, enabled, configTarget);
+        PythonSettings.dispose();
+    }
+
+    test('Workspace folder should inherit Python Path from workspace root', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        let settings = workspace.getConfiguration('python', workspaceUri);
+        const pythonPath = `x${new Date().getTime()}`;
+        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+        const value = settings.inspect('pythonPath');
+        if (value && typeof value.workspaceFolderValue === 'string') {
+            await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
+        }
+        settings = workspace.getConfiguration('python', workspaceUri);
+        PythonSettings.dispose();
+        const cfgSetting = PythonSettings.getInstance(workspaceUri);
+        assert.equal(cfgSetting.pythonPath, pythonPath, 'Python Path not inherited from workspace');
+    });
+
+    test('Workspace folder should not inherit Python Path from workspace root', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        const settings = workspace.getConfiguration('python', workspaceUri);
+        const pythonPath = `x${new Date().getTime()}`;
+        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+        const privatePythonPath = `x${new Date().getTime()}`;
+        await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
+
+        const cfgSetting = PythonSettings.getInstance(workspaceUri);
+        assert.equal(cfgSetting.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
+    });
+
+    test('Workspace folder should inherit Python Path from workspace root when opening a document', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+        const settings = workspace.getConfiguration('python', workspaceUri);
+        const pythonPath = `x${new Date().getTime()}`;
+        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+        // Update workspace folder to something else so it gets refreshed.
+        await settings.update('pythonPath', `x${new Date().getTime()}`, ConfigurationTarget.WorkspaceFolder);
+        await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
+
+        const document = await workspace.openTextDocument(fileToOpen);
+        const cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(cfg.pythonPath, pythonPath, 'Python Path not inherited from workspace');
+    });
+
+    test('Workspace folder should not inherit Python Path from workspace root when opening a document', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+        const settings = workspace.getConfiguration('python', workspaceUri);
+        const pythonPath = `x${new Date().getTime()}`;
+        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+        const privatePythonPath = `x${new Date().getTime()}`;
+        await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
+
+        const document = await workspace.openTextDocument(fileToOpen);
+        const cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(cfg.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
+    });
+
+    test('Enabling/Disabling Pylint in root should be reflected in config settings', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', undefined);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+        let settings = PythonSettings.getInstance(workspaceUri);
+        assert.equal(settings.linting.pylintEnabled, true, 'Pylint not enabled when it should be');
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+        settings = PythonSettings.getInstance(workspaceUri);
+        assert.equal(settings.linting.pylintEnabled, false, 'Pylint enabled when it should not be');
+    });
+
+    test('Enabling/Disabling Pylint in root and workspace should be reflected in config settings', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+
+        let cfgSetting = PythonSettings.getInstance(workspaceUri);
+        assert.equal(cfgSetting.linting.pylintEnabled, false, 'Workspace folder pylint setting is true when it should not be');
+        PythonSettings.dispose();
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+
+        cfgSetting = PythonSettings.getInstance(workspaceUri);
+        assert.equal(cfgSetting.linting.pylintEnabled, true, 'Workspace folder pylint setting is false when it should not be');
+    });
+
+    test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
+        let document = await workspace.openTextDocument(fileToOpen);
+        let cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
+        PythonSettings.dispose();
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
+        document = await workspace.openTextDocument(fileToOpen);
+        cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
+    });
+
+    test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
+        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
+        let document = await workspace.openTextDocument(fileToOpen);
+        let cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
+        PythonSettings.dispose();
+
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
+        document = await workspace.openTextDocument(fileToOpen);
+        cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
+    });
+
+    // tslint:disable-next-line:no-invalid-template-strings
+    test('${workspaceFolder} variable in settings should be replaced with the right value', async () => {
+        const workspace2Uri = Uri.file(path.join(multirootPath, 'workspace2'));
+        let fileToOpen = path.join(workspace2Uri.fsPath, 'file.py');
+
+        let document = await workspace.openTextDocument(fileToOpen);
+        let cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace2Uri.fsPath, 'ctags file path for workspace2 is incorrect');
+        assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace2.tags.file', 'ctags file name for workspace2 is incorrect');
+        PythonSettings.dispose();
+
+        const workspace3Uri = Uri.file(path.join(multirootPath, 'workspace3'));
+        fileToOpen = path.join(workspace3Uri.fsPath, 'file.py');
+
+        document = await workspace.openTextDocument(fileToOpen);
+        cfg = PythonSettings.getInstance(document.uri);
+        assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace3Uri.fsPath, 'ctags file path for workspace3 is incorrect');
+        assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace3.tags.file', 'ctags file name for workspace3 is incorrect');
+        PythonSettings.dispose();
+    });
+});

--- a/src/test/common/configSettings.multiroot.test.ts
+++ b/src/test/common/configSettings.multiroot.test.ts
@@ -7,178 +7,178 @@ import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } fr
 
 const multirootPath = path.join(__dirname, '..', '..', '..', 'src', 'testMultiRootWkspc');
 
-// tslint:disable-next-line:max-func-body-length
-suite('Multiroot Config Settings', () => {
-    suiteSetup(async function () {
-        if (!IS_MULTI_ROOT_TEST) {
-            // tslint:disable-next-line:no-invalid-this
-            this.skip();
-        }
-        await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
-        await initialize();
-    });
-    setup(initializeTest);
-    suiteTeardown(closeActiveWindows);
-    teardown(async () => {
-        await closeActiveWindows();
-        await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
-        await initializeTest();
-    });
+if (IS_MULTI_ROOT_TEST) {
 
-    async function enableDisableLinterSetting(resource: Uri, configTarget: ConfigurationTarget, setting: string, enabled: boolean | undefined): Promise<void> {
-        const settings = workspace.getConfiguration('python.linting', resource);
-        const cfgValue = settings.inspect<boolean>(setting);
-        if (configTarget === ConfigurationTarget.Workspace && cfgValue && cfgValue.workspaceValue === enabled) {
-            return;
-        }
-        if (configTarget === ConfigurationTarget.WorkspaceFolder && cfgValue && cfgValue.workspaceFolderValue === enabled) {
-            return;
-        }
-        await settings.update(setting, enabled, configTarget);
-        PythonSettings.dispose();
-    }
+    // tslint:disable-next-line:max-func-body-length
+    suite('Multiroot Config Settings', () => {
+        suiteSetup(async () => {
+            await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
+            await initialize();
+        });
+        setup(initializeTest);
+        suiteTeardown(closeActiveWindows);
+        teardown(async () => {
+            await closeActiveWindows();
+            await clearPythonPathInWorkspaceFolder(Uri.file(path.join(multirootPath, 'workspace1')));
+            await initializeTest();
+        });
 
-    test('Workspace folder should inherit Python Path from workspace root', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        let settings = workspace.getConfiguration('python', workspaceUri);
-        const pythonPath = `x${new Date().getTime()}`;
-        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-        const value = settings.inspect('pythonPath');
-        if (value && typeof value.workspaceFolderValue === 'string') {
+        async function enableDisableLinterSetting(resource: Uri, configTarget: ConfigurationTarget, setting: string, enabled: boolean | undefined): Promise<void> {
+            const settings = workspace.getConfiguration('python.linting', resource);
+            const cfgValue = settings.inspect<boolean>(setting);
+            if (configTarget === ConfigurationTarget.Workspace && cfgValue && cfgValue.workspaceValue === enabled) {
+                return;
+            }
+            if (configTarget === ConfigurationTarget.WorkspaceFolder && cfgValue && cfgValue.workspaceFolderValue === enabled) {
+                return;
+            }
+            await settings.update(setting, enabled, configTarget);
+            PythonSettings.dispose();
+        }
+
+        test('Workspace folder should inherit Python Path from workspace root', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            let settings = workspace.getConfiguration('python', workspaceUri);
+            const pythonPath = `x${new Date().getTime()}`;
+            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+            const value = settings.inspect('pythonPath');
+            if (value && typeof value.workspaceFolderValue === 'string') {
+                await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
+            }
+            settings = workspace.getConfiguration('python', workspaceUri);
+            PythonSettings.dispose();
+            const cfgSetting = PythonSettings.getInstance(workspaceUri);
+            assert.equal(cfgSetting.pythonPath, pythonPath, 'Python Path not inherited from workspace');
+        });
+
+        test('Workspace folder should not inherit Python Path from workspace root', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            const settings = workspace.getConfiguration('python', workspaceUri);
+            const pythonPath = `x${new Date().getTime()}`;
+            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+            const privatePythonPath = `x${new Date().getTime()}`;
+            await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
+
+            const cfgSetting = PythonSettings.getInstance(workspaceUri);
+            assert.equal(cfgSetting.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
+        });
+
+        test('Workspace folder should inherit Python Path from workspace root when opening a document', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+            const settings = workspace.getConfiguration('python', workspaceUri);
+            const pythonPath = `x${new Date().getTime()}`;
+            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+            // Update workspace folder to something else so it gets refreshed.
+            await settings.update('pythonPath', `x${new Date().getTime()}`, ConfigurationTarget.WorkspaceFolder);
             await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
-        }
-        settings = workspace.getConfiguration('python', workspaceUri);
-        PythonSettings.dispose();
-        const cfgSetting = PythonSettings.getInstance(workspaceUri);
-        assert.equal(cfgSetting.pythonPath, pythonPath, 'Python Path not inherited from workspace');
+
+            const document = await workspace.openTextDocument(fileToOpen);
+            const cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(cfg.pythonPath, pythonPath, 'Python Path not inherited from workspace');
+        });
+
+        test('Workspace folder should not inherit Python Path from workspace root when opening a document', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+            const settings = workspace.getConfiguration('python', workspaceUri);
+            const pythonPath = `x${new Date().getTime()}`;
+            await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
+            const privatePythonPath = `x${new Date().getTime()}`;
+            await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
+
+            const document = await workspace.openTextDocument(fileToOpen);
+            const cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(cfg.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
+        });
+
+        test('Enabling/Disabling Pylint in root should be reflected in config settings', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', undefined);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+            let settings = PythonSettings.getInstance(workspaceUri);
+            assert.equal(settings.linting.pylintEnabled, true, 'Pylint not enabled when it should be');
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+            settings = PythonSettings.getInstance(workspaceUri);
+            assert.equal(settings.linting.pylintEnabled, false, 'Pylint enabled when it should not be');
+        });
+
+        test('Enabling/Disabling Pylint in root and workspace should be reflected in config settings', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+
+            let cfgSetting = PythonSettings.getInstance(workspaceUri);
+            assert.equal(cfgSetting.linting.pylintEnabled, false, 'Workspace folder pylint setting is true when it should not be');
+            PythonSettings.dispose();
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+
+            cfgSetting = PythonSettings.getInstance(workspaceUri);
+            assert.equal(cfgSetting.linting.pylintEnabled, true, 'Workspace folder pylint setting is false when it should not be');
+        });
+
+        test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
+            let document = await workspace.openTextDocument(fileToOpen);
+            let cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
+            PythonSettings.dispose();
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
+            document = await workspace.openTextDocument(fileToOpen);
+            cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
+        });
+
+        test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
+            const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
+            const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
+            let document = await workspace.openTextDocument(fileToOpen);
+            let cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
+            PythonSettings.dispose();
+
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
+            await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
+            document = await workspace.openTextDocument(fileToOpen);
+            cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
+        });
+
+        // tslint:disable-next-line:no-invalid-template-strings
+        test('${workspaceFolder} variable in settings should be replaced with the right value', async () => {
+            const workspace2Uri = Uri.file(path.join(multirootPath, 'workspace2'));
+            let fileToOpen = path.join(workspace2Uri.fsPath, 'file.py');
+
+            let document = await workspace.openTextDocument(fileToOpen);
+            let cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace2Uri.fsPath, 'ctags file path for workspace2 is incorrect');
+            assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace2.tags.file', 'ctags file name for workspace2 is incorrect');
+            PythonSettings.dispose();
+
+            const workspace3Uri = Uri.file(path.join(multirootPath, 'workspace3'));
+            fileToOpen = path.join(workspace3Uri.fsPath, 'file.py');
+
+            document = await workspace.openTextDocument(fileToOpen);
+            cfg = PythonSettings.getInstance(document.uri);
+            assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace3Uri.fsPath, 'ctags file path for workspace3 is incorrect');
+            assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace3.tags.file', 'ctags file name for workspace3 is incorrect');
+            PythonSettings.dispose();
+        });
     });
 
-    test('Workspace folder should not inherit Python Path from workspace root', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        const settings = workspace.getConfiguration('python', workspaceUri);
-        const pythonPath = `x${new Date().getTime()}`;
-        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-        const privatePythonPath = `x${new Date().getTime()}`;
-        await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
-
-        const cfgSetting = PythonSettings.getInstance(workspaceUri);
-        assert.equal(cfgSetting.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
-    });
-
-    test('Workspace folder should inherit Python Path from workspace root when opening a document', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-        const settings = workspace.getConfiguration('python', workspaceUri);
-        const pythonPath = `x${new Date().getTime()}`;
-        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-        // Update workspace folder to something else so it gets refreshed.
-        await settings.update('pythonPath', `x${new Date().getTime()}`, ConfigurationTarget.WorkspaceFolder);
-        await settings.update('pythonPath', undefined, ConfigurationTarget.WorkspaceFolder);
-
-        const document = await workspace.openTextDocument(fileToOpen);
-        const cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(cfg.pythonPath, pythonPath, 'Python Path not inherited from workspace');
-    });
-
-    test('Workspace folder should not inherit Python Path from workspace root when opening a document', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-        const settings = workspace.getConfiguration('python', workspaceUri);
-        const pythonPath = `x${new Date().getTime()}`;
-        await settings.update('pythonPath', pythonPath, ConfigurationTarget.Workspace);
-        const privatePythonPath = `x${new Date().getTime()}`;
-        await settings.update('pythonPath', privatePythonPath, ConfigurationTarget.WorkspaceFolder);
-
-        const document = await workspace.openTextDocument(fileToOpen);
-        const cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(cfg.pythonPath, privatePythonPath, 'Python Path for workspace folder is incorrect');
-    });
-
-    test('Enabling/Disabling Pylint in root should be reflected in config settings', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', undefined);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-        let settings = PythonSettings.getInstance(workspaceUri);
-        assert.equal(settings.linting.pylintEnabled, true, 'Pylint not enabled when it should be');
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-        settings = PythonSettings.getInstance(workspaceUri);
-        assert.equal(settings.linting.pylintEnabled, false, 'Pylint enabled when it should not be');
-    });
-
-    test('Enabling/Disabling Pylint in root and workspace should be reflected in config settings', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-
-        let cfgSetting = PythonSettings.getInstance(workspaceUri);
-        assert.equal(cfgSetting.linting.pylintEnabled, false, 'Workspace folder pylint setting is true when it should not be');
-        PythonSettings.dispose();
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-
-        cfgSetting = PythonSettings.getInstance(workspaceUri);
-        assert.equal(cfgSetting.linting.pylintEnabled, true, 'Workspace folder pylint setting is false when it should not be');
-    });
-
-    test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
-        let document = await workspace.openTextDocument(fileToOpen);
-        let cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
-        PythonSettings.dispose();
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
-        document = await workspace.openTextDocument(fileToOpen);
-        cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
-    });
-
-    test('Enabling/Disabling Pylint in root should be reflected in config settings when opening a document', async () => {
-        const workspaceUri = Uri.file(path.join(multirootPath, 'workspace1'));
-        const fileToOpen = path.join(multirootPath, 'workspace1', 'file.py');
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', false);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', true);
-        let document = await workspace.openTextDocument(fileToOpen);
-        let cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(cfg.linting.pylintEnabled, true, 'Pylint should be enabled in workspace');
-        PythonSettings.dispose();
-
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.Workspace, 'pylintEnabled', true);
-        await enableDisableLinterSetting(workspaceUri, ConfigurationTarget.WorkspaceFolder, 'pylintEnabled', false);
-        document = await workspace.openTextDocument(fileToOpen);
-        cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(cfg.linting.pylintEnabled, false, 'Pylint should not be enabled in workspace');
-    });
-
-    // tslint:disable-next-line:no-invalid-template-strings
-    test('${workspaceFolder} variable in settings should be replaced with the right value', async () => {
-        const workspace2Uri = Uri.file(path.join(multirootPath, 'workspace2'));
-        let fileToOpen = path.join(workspace2Uri.fsPath, 'file.py');
-
-        let document = await workspace.openTextDocument(fileToOpen);
-        let cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace2Uri.fsPath, 'ctags file path for workspace2 is incorrect');
-        assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace2.tags.file', 'ctags file name for workspace2 is incorrect');
-        PythonSettings.dispose();
-
-        const workspace3Uri = Uri.file(path.join(multirootPath, 'workspace3'));
-        fileToOpen = path.join(workspace3Uri.fsPath, 'file.py');
-
-        document = await workspace.openTextDocument(fileToOpen);
-        cfg = PythonSettings.getInstance(document.uri);
-        assert.equal(path.dirname(cfg.workspaceSymbols.tagFilePath), workspace3Uri.fsPath, 'ctags file path for workspace3 is incorrect');
-        assert.equal(path.basename(cfg.workspaceSymbols.tagFilePath), 'workspace3.tags.file', 'ctags file name for workspace3 is incorrect');
-        PythonSettings.dispose();
-    });
-});
+}

--- a/src/test/linters/lint.commands.test.ts
+++ b/src/test/linters/lint.commands.test.ts
@@ -30,7 +30,7 @@ suite('Linting - Linter Selector', () => {
         initializeServices();
     });
     suiteTeardown(closeActiveWindows);
-    teardown(async () => await closeActiveWindows());
+    teardown(async () => closeActiveWindows());
 
     function initializeServices() {
         const cont = new Container();
@@ -105,7 +105,7 @@ suite('Linting - Linter Selector', () => {
         assert.equal(options!.matchOnDescription, true, 'Quick pick options are incorrect');
         assert.equal(options!.matchOnDetail, true, 'Quick pick options are incorrect');
         assert.equal(options!.placeHolder, `current: ${current}`, 'Quick pick current option is incorrect');
-        assert.equal(lm.isLintingEnabled(undefined), enable, 'Linting selector did not change linting on/off flag');
+        assert.equal(await lm.isLintingEnabled(false, undefined), enable, 'Linting selector did not change linting on/off flag');
     }
 
     async function selectLinterAsync(products: Product[]): Promise<void> {
@@ -129,7 +129,7 @@ suite('Linting - Linter Selector', () => {
         await lm.setActiveLintersAsync(products);
 
         let current: string;
-        let activeLinters = lm.getActiveLinters();
+        let activeLinters = await lm.getActiveLinters(false);
         switch (activeLinters.length) {
             case 0:
                 current = 'none';
@@ -154,7 +154,7 @@ suite('Linting - Linter Selector', () => {
         assert.equal(options!.matchOnDetail, true, 'Quick pick options are incorrect');
         assert.equal(options!.placeHolder, `current: ${current}`, 'Quick pick current option is incorrect');
 
-        activeLinters = lm.getActiveLinters();
+        activeLinters = await lm.getActiveLinters(false);
         assert.equal(activeLinters.length, 1, 'Linting selector did not change active linter');
         assert.equal(activeLinters[0].product, Product.pylint, 'Linting selector did not change to pylint');
 

--- a/src/test/linters/lint.commands.test.ts
+++ b/src/test/linters/lint.commands.test.ts
@@ -105,7 +105,7 @@ suite('Linting - Linter Selector', () => {
         assert.equal(options!.matchOnDescription, true, 'Quick pick options are incorrect');
         assert.equal(options!.matchOnDetail, true, 'Quick pick options are incorrect');
         assert.equal(options!.placeHolder, `current: ${current}`, 'Quick pick current option is incorrect');
-        assert.equal(await lm.isLintingEnabled(false, undefined), enable, 'Linting selector did not change linting on/off flag');
+        assert.equal(await lm.isLintingEnabled(true, undefined), enable, 'Linting selector did not change linting on/off flag');
     }
 
     async function selectLinterAsync(products: Product[]): Promise<void> {
@@ -129,7 +129,7 @@ suite('Linting - Linter Selector', () => {
         await lm.setActiveLintersAsync(products);
 
         let current: string;
-        let activeLinters = await lm.getActiveLinters(false);
+        let activeLinters = await lm.getActiveLinters(true);
         switch (activeLinters.length) {
             case 0:
                 current = 'none';
@@ -154,7 +154,7 @@ suite('Linting - Linter Selector', () => {
         assert.equal(options!.matchOnDetail, true, 'Quick pick options are incorrect');
         assert.equal(options!.placeHolder, `current: ${current}`, 'Quick pick current option is incorrect');
 
-        activeLinters = await lm.getActiveLinters(false);
+        activeLinters = await lm.getActiveLinters(true);
         assert.equal(activeLinters.length, 1, 'Linting selector did not change active linter');
         assert.equal(activeLinters[0].product, Product.pylint, 'Linting selector did not change to pylint');
 

--- a/src/test/linters/lint.manager.test.ts
+++ b/src/test/linters/lint.manager.test.ts
@@ -81,15 +81,15 @@ suite('Linting - Manager', () => {
 
     test('Enable/disable linting', async () => {
         await lm.enableLintingAsync(false);
-        assert.equal(lm.isLintingEnabled(false), false, 'Linting not disabled');
+        assert.equal(lm.isLintingEnabled(true), false, 'Linting not disabled');
         await lm.enableLintingAsync(true);
-        assert.equal(lm.isLintingEnabled(false), true, 'Linting not enabled');
+        assert.equal(lm.isLintingEnabled(true), true, 'Linting not enabled');
     });
 
     test('Set single linter', async () => {
         for (const linter of lm.getAllLinterInfos()) {
             await lm.setActiveLintersAsync([linter.product]);
-            const selected = await lm.getActiveLinters(false);
+            const selected = await lm.getActiveLinters(true);
             assert.notEqual(selected.length, 0, 'Current linter is undefined');
             assert.equal(linter!.id, selected![0].id, `Selected linter ${selected} does not match requested ${linter.id}`);
         }
@@ -97,18 +97,18 @@ suite('Linting - Manager', () => {
 
     test('Set multiple linters', async () => {
         await lm.setActiveLintersAsync([Product.flake8, Product.pydocstyle]);
-        const selected = await lm.getActiveLinters(false);
+        const selected = await lm.getActiveLinters(true);
         assert.equal(selected.length, 2, 'Selected linters lengths does not match');
         assert.equal(Product.flake8, selected[0].product, `Selected linter ${selected[0].id} does not match requested 'flake8'`);
         assert.equal(Product.pydocstyle, selected[1].product, `Selected linter ${selected[1].id} does not match requested 'pydocstyle'`);
     });
 
     test('Try setting unsupported linter', async () => {
-        const before = await lm.getActiveLinters(false);
+        const before = await lm.getActiveLinters(true);
         assert.notEqual(before, undefined, 'Current/before linter is undefined');
 
         await lm.setActiveLintersAsync([Product.nosetest]);
-        const after = await lm.getActiveLinters(false);
+        const after = await lm.getActiveLinters(true);
         assert.notEqual(after, undefined, 'Current/after linter is undefined');
 
         assert.equal(after![0].id, before![0].id, 'Should not be able to set unsupported linter');

--- a/src/test/linters/lint.manager.test.ts
+++ b/src/test/linters/lint.manager.test.ts
@@ -81,15 +81,15 @@ suite('Linting - Manager', () => {
 
     test('Enable/disable linting', async () => {
         await lm.enableLintingAsync(false);
-        assert.equal(lm.isLintingEnabled(), false, 'Linting not disabled');
+        assert.equal(lm.isLintingEnabled(false), false, 'Linting not disabled');
         await lm.enableLintingAsync(true);
-        assert.equal(lm.isLintingEnabled(), true, 'Linting not enabled');
+        assert.equal(lm.isLintingEnabled(false), true, 'Linting not enabled');
     });
 
     test('Set single linter', async () => {
         for (const linter of lm.getAllLinterInfos()) {
             await lm.setActiveLintersAsync([linter.product]);
-            const selected = lm.getActiveLinters();
+            const selected = await lm.getActiveLinters(false);
             assert.notEqual(selected.length, 0, 'Current linter is undefined');
             assert.equal(linter!.id, selected![0].id, `Selected linter ${selected} does not match requested ${linter.id}`);
         }
@@ -97,18 +97,18 @@ suite('Linting - Manager', () => {
 
     test('Set multiple linters', async () => {
         await lm.setActiveLintersAsync([Product.flake8, Product.pydocstyle]);
-        const selected = lm.getActiveLinters();
+        const selected = await lm.getActiveLinters(false);
         assert.equal(selected.length, 2, 'Selected linters lengths does not match');
         assert.equal(Product.flake8, selected[0].product, `Selected linter ${selected[0].id} does not match requested 'flake8'`);
         assert.equal(Product.pydocstyle, selected[1].product, `Selected linter ${selected[1].id} does not match requested 'pydocstyle'`);
     });
 
     test('Try setting unsupported linter', async () => {
-        const before = lm.getActiveLinters();
+        const before = await lm.getActiveLinters(false);
         assert.notEqual(before, undefined, 'Current/before linter is undefined');
 
         await lm.setActiveLintersAsync([Product.nosetest]);
-        const after = lm.getActiveLinters();
+        const after = await lm.getActiveLinters(false);
         assert.notEqual(after, undefined, 'Current/after linter is undefined');
 
         assert.equal(after![0].id, before![0].id, 'Should not be able to set unsupported linter');

--- a/src/test/linters/lint.manager.test.ts
+++ b/src/test/linters/lint.manager.test.ts
@@ -81,9 +81,9 @@ suite('Linting - Manager', () => {
 
     test('Enable/disable linting', async () => {
         await lm.enableLintingAsync(false);
-        assert.equal(lm.isLintingEnabled(true), false, 'Linting not disabled');
+        assert.equal(await lm.isLintingEnabled(true), false, 'Linting not disabled');
         await lm.enableLintingAsync(true);
-        assert.equal(lm.isLintingEnabled(true), true, 'Linting not enabled');
+        assert.equal(await lm.isLintingEnabled(true), true, 'Linting not enabled');
     });
 
     test('Set single linter', async () => {

--- a/src/test/linters/lint.manager.unit.test.ts
+++ b/src/test/linters/lint.manager.unit.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { Uri } from 'vscode';
+import { IConfigurationService, IPythonSettings } from '../../client/common/types';
+import { IServiceContainer } from '../../client/ioc/types';
+import { LinterManager } from '../../client/linters/linterManager';
+
+// setup class instance
+class TestLinterManager extends LinterManager {
+    public enableUnconfiguredLintersCallCount: number = 0;
+
+    protected async enableUnconfiguredLinters(resource?: Uri): Promise<boolean> {
+        this.enableUnconfiguredLintersCallCount += 1;
+        return false;
+    }
+}
+
+function getServiceContainerMockForLinterManagerTests(): TypeMoq.IMock<IServiceContainer> {
+    // setup test mocks
+    const serviceContainerMock = TypeMoq.Mock.ofType<IServiceContainer>();
+    const configMock = TypeMoq.Mock.ofType<IConfigurationService>();
+    const pythonSettingsMock = TypeMoq.Mock.ofType<IPythonSettings>();
+    configMock.setup(cm => cm.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettingsMock.object);
+    serviceContainerMock.setup(c => c.get(IConfigurationService)).returns(() => configMock.object);
+
+    return serviceContainerMock;
+}
+
+// tslint:disable-next-line:max-func-body-length
+suite('Lint Manager Unit Tests', () => {
+
+    test('Linter manager isLintingEnabled checks availability when silent = false.', async () => {
+        // set expectations
+        const expectedCallCount = 1;
+        const silentFlag = false;
+
+        // get setup
+        const serviceContainerMock = getServiceContainerMockForLinterManagerTests();
+
+        // make the call
+        const lm = new TestLinterManager(serviceContainerMock.object);
+        await lm.isLintingEnabled(silentFlag);
+
+        // test expectations
+        expect(lm.enableUnconfiguredLintersCallCount).to.equal(expectedCallCount);
+    });
+
+    test('Linter manager isLintingEnabled does not check availability when silent = true.', async () => {
+        // set expectations
+        const expectedCallCount = 0;
+        const silentFlag = true;
+
+        // get setup
+        const serviceContainerMock = getServiceContainerMockForLinterManagerTests();
+
+        // make the call
+        const lm: TestLinterManager = new TestLinterManager(serviceContainerMock.object);
+        await lm.isLintingEnabled(silentFlag);
+
+        // test expectations
+        expect(lm.enableUnconfiguredLintersCallCount).to.equal(expectedCallCount);
+    });
+
+    test('Linter manager getActiveLinters checks availability when silent = false.', async () => {
+        // set expectations
+        const expectedCallCount = 1;
+        const silentFlag = false;
+
+        // get setup
+        const serviceContainerMock = getServiceContainerMockForLinterManagerTests();
+
+        // make the call
+        const lm: TestLinterManager = new TestLinterManager(serviceContainerMock.object);
+        await lm.getActiveLinters(silentFlag);
+
+        // test expectations
+        expect(lm.enableUnconfiguredLintersCallCount).to.equal(expectedCallCount);
+    });
+
+    test('Linter manager getActiveLinters checks availability when silent = true.', async () => {
+        // set expectations
+        const expectedCallCount = 0;
+        const silentFlag = true;
+
+        // get setup
+        const serviceContainerMock = getServiceContainerMockForLinterManagerTests();
+
+        // make the call
+        const lm: TestLinterManager = new TestLinterManager(serviceContainerMock.object);
+        await lm.getActiveLinters(silentFlag);
+
+        // test expectations
+        expect(lm.enableUnconfiguredLintersCallCount).to.equal(expectedCallCount);
+    });
+
+});

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -163,7 +163,7 @@ suite('Linting - General Tests', () => {
 
         await linterManager.setActiveLintersAsync([product]);
         await linterManager.enableLintingAsync(enabled);
-        const linter = linterManager.createLinter(product, output, ioc.serviceContainer);
+        const linter = await linterManager.createLinter(product, output, ioc.serviceContainer);
 
         const messages = await linter.lint(document, cancelToken.token);
         if (enabled) {
@@ -211,7 +211,7 @@ suite('Linting - General Tests', () => {
         const document = await workspace.openTextDocument(pythonFile);
 
         await linterManager.setActiveLintersAsync([product], document.uri);
-        const linter = linterManager.createLinter(product, outputChannel, ioc.serviceContainer);
+        const linter = await linterManager.createLinter(product, outputChannel, ioc.serviceContainer);
 
         const messages = await linter.lint(document, cancelToken.token);
         if (messagesToBeReceived.length === 0) {
@@ -260,11 +260,11 @@ suite('Linting - General Tests', () => {
     });
     // tslint:disable-next-line:no-function-expression
     test('Multiple linters', async function () {
-//      Unreliable test being skipped until we can sort it out.  See gh-2609.
-//          - Fails about 1/3 of runs on Windows
-//          - Symptom: lintingEngine::lintOpenPythonFiles returns values *after* command await resolves in lint.tests
-//          - lintOpenPythonFiles returns 3 sets of values, not what I expect (1).
-//          - Haven't yet found a way to await on this properly.
+        //      Unreliable test being skipped until we can sort it out.  See gh-2609.
+        //          - Fails about 1/3 of runs on Windows
+        //          - Symptom: lintingEngine::lintOpenPythonFiles returns values *after* command await resolves in lint.tests
+        //          - lintOpenPythonFiles returns 3 sets of values, not what I expect (1).
+        //          - Haven't yet found a way to await on this properly.
         const skipped = true;
         if (skipped) {
             // tslint:disable-next-line:no-invalid-this
@@ -295,7 +295,7 @@ suite('Linting - General Tests', () => {
         const document = await workspace.openTextDocument(pythonFile);
 
         await linterManager.setActiveLintersAsync([product], document.uri);
-        const linter = linterManager.createLinter(product, outputChannel, ioc.serviceContainer);
+        const linter = await linterManager.createLinter(product, outputChannel, ioc.serviceContainer);
 
         const messages = await linter.lint(document, cancelToken.token);
         assert.equal(messages.length, messageCountToBeReceived, 'Expected number of lint errors does not match lint error count');

--- a/src/test/linters/lintengine.test.ts
+++ b/src/test/linters/lintengine.test.ts
@@ -47,7 +47,7 @@ suite('Linting - LintingEngine', () => {
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IOutputChannel), TypeMoq.It.isValue(STANDARD_OUTPUT_CHANNEL))).returns(() => outputChannel.object);
 
         lintManager = TypeMoq.Mock.ofType<ILinterManager>();
-        lintManager.setup(x => x.isLintingEnabled(TypeMoq.It.isAny())).returns(() => true);
+        lintManager.setup(x => x.isLintingEnabled(TypeMoq.It.isAny())).returns(async () => true);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ILinterManager), TypeMoq.It.isAny())).returns(() => lintManager.object);
 
         lintingEngine = new LintingEngine(serviceContainer.object);
@@ -59,7 +59,7 @@ suite('Linting - LintingEngine', () => {
         try {
             lintingEngine.lintDocument(doc, 'auto').ignoreErrors();
         } catch {
-            lintManager.verify(l => l.isLintingEnabled(TypeMoq.It.isValue(doc.uri)), TypeMoq.Times.once());
+            lintManager.verify(l => l.isLintingEnabled(TypeMoq.It.isAny(), TypeMoq.It.isValue(doc.uri)), TypeMoq.Times.once());
         }
     });
     test('Ensure document.uri is passed into createLinter', () => {

--- a/src/test/linters/linter.availability.unit.test.ts
+++ b/src/test/linters/linter.availability.unit.test.ts
@@ -21,16 +21,14 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = false;
 
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        const [appShellMock, installerMock, wkspcConfigSrvcMock] = getDependenciesForAvailabilityTests();
+        setupWorkspaceServiceForJediSettingTest(jediEnabledValue, wkspcConfigSrvcMock);
 
         // call
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = availabilityProvider.isFeatureEnabled();
 
         // check expectaions
-        expect(result).is.equal(expectedResult);
+        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be disabled when python.jediEnabled defaults to true');
         wkspcConfigSrvcMock.verifyAll();
     });
 
@@ -40,15 +38,12 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = true;
 
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        const [appShellMock, installerMock, wkspcConfigSrvcMock] = getDependenciesForAvailabilityTests();
+        setupWorkspaceServiceForJediSettingTest(jediEnabledValue, wkspcConfigSrvcMock);
 
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
 
-        const result = availabilityProvider.isFeatureEnabled();
-
-        expect(result).is.equal(expectedResult);
+        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be enabled when python.jediEnabled defaults to false');
         wkspcConfigSrvcMock.verifyAll();
     });
 
@@ -59,18 +54,14 @@ suite('Linter Availability Provider tests', () => {
         const pylintWorkspaceFolderValue = undefined;
         const expectedResult = true;
 
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
+        const [appShellMock, installerMock, wkspcConfigSrvcMock, linterInfo] = getDependenciesForAvailabilityTests();
+        setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, wkspcConfigSrvcMock);
 
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
 
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
 
-        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
-
-        expect(result).to.equal(expectedResult);
+        expect(result).to.equal(expectedResult, 'Linter is unconfigured but prompt did not get raised');
         wkspcConfigSrvcMock.verifyAll();
     });
 
@@ -81,16 +72,13 @@ suite('Linter Availability Provider tests', () => {
         const pylintWorkspaceFolderValue = undefined;
         const expectedResult = false;
 
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
+        const [appShellMock, installerMock, wkspcConfigSrvcMock, linterInfo] = getDependenciesForAvailabilityTests();
+        setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, wkspcConfigSrvcMock);
 
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
 
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
-        expect(result).to.equal(expectedResult);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
+        expect(result).to.equal(expectedResult, 'Available linter prompt should not be shown when linter is configured for workspace.');
         wkspcConfigSrvcMock.verifyAll();
     });
 
@@ -101,16 +89,13 @@ suite('Linter Availability Provider tests', () => {
         const pylintWorkspaceFolderValue = undefined;
         const expectedResult = false;
 
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
-
+        // arrange
+        const [appShellMock, installerMock, wkspcConfigSrvcMock, linterInfo] = getDependenciesForAvailabilityTests();
+        setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, wkspcConfigSrvcMock);
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
 
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
-        expect(result).to.equal(expectedResult);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
+        expect(result).to.equal(expectedResult, 'Available linter prompt should not be shown when linter is configured for user.');
         wkspcConfigSrvcMock.verifyAll();
     });
 
@@ -121,34 +106,23 @@ suite('Linter Availability Provider tests', () => {
         const pylintWorkspaceFolderValue = true;
         const expectedResult = false;
 
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-
-        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
-
+        // arrange
+        const [appShellMock, installerMock, wkspcConfigSrvcMock, linterInfo] = getDependenciesForAvailabilityTests();
+        setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, wkspcConfigSrvcMock);
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
 
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
-        expect(result).to.equal(expectedResult);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
+        expect(result).to.equal(expectedResult, 'Available linter prompt should not be shown when linter is configured for workspace-folder.');
         wkspcConfigSrvcMock.verifyAll();
     });
 
-    test('Linter is enabled after being prompted and "Enable <linter>" is selected', async () => {
-        // set expectation
-        const promptReply = { title: 'Enable pylint', enabled: true };
-        const expectedResult = true;
-
+    async function testForLinterPromptResponse(promptReply: { title: string; enabled: boolean } | undefined): Promise<boolean> {
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
-
+        const [appShellMock, installerMock, wkspcConfigSrvcMock] = getDependenciesForAvailabilityTests();
         const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
 
         const linterInfo = new class extends LinterInfo {
-            public testIsEnabled: boolean = !promptReply.enabled;
+            public testIsEnabled: boolean = promptReply ? promptReply.enabled : false;
 
             public async enableAsync(enabled: boolean, resource?: Uri): Promise<void> {
                 this.testIsEnabled = enabled;
@@ -168,12 +142,26 @@ suite('Linter Availability Provider tests', () => {
             })
             .verifiable(TypeMoq.Times.once());
 
-        // call
+        // perform test
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
         const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
+        if (promptReply) {
+            expect(linterInfo.testIsEnabled).to.equal(promptReply.enabled, 'LinterInfo test class was not updated as a result of the test.');
+        }
 
+        return result;
+    }
+
+    test('Linter is enabled after being prompted and "Enable <linter>" is selected', async () => {
+        // set expectations
+        const expectedResult = true;
+        const promptReply = { title: 'Enable pylint', enabled: true };
+
+        // run scenario
+        const result = await testForLinterPromptResponse(promptReply);
+
+        // test results
         expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
-        expect(linterInfo.testIsEnabled).to.equal(promptReply.enabled, 'LinterInfo test class was not updated as a result of the test.');
     });
 
     test('Linter is disabled after being prompted and "Disable <linter>" is selected', async () => {
@@ -181,40 +169,11 @@ suite('Linter Availability Provider tests', () => {
         const promptReply = { title: 'Disable pylint', enabled: false };
         const expectedResult = true;
 
-        // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+        // run scenario
+        const result = await testForLinterPromptResponse(promptReply);
 
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-
-        const linterInfo = new class extends LinterInfo {
-            public testIsEnabled: boolean = !promptReply.enabled;
-
-            public async enableAsync(enabled: boolean, resource?: Uri): Promise<void> {
-                this.testIsEnabled = enabled;
-                return Promise.resolve();
-            }
-
-        }(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-
-        appShellMock.setup(ap => ap.showInformationMessage(
-            TypeMoq.It.isValue(`Linter ${linterInfo.id} is available but not enabled.`),
-            TypeMoq.It.isAny(),
-            TypeMoq.It.isAny())
-        )
-            .returns(() => {
-                // tslint:disable-next-line:no-any
-                return promptReply as any;
-            })
-            .verifiable(TypeMoq.Times.once());
-
-        // call
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
-
+        // test results
         expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
-        expect(linterInfo.testIsEnabled).to.equal(promptReply.enabled, 'LinterInfo test class was not updated as a result of the test.');
     });
 
     test('Linter is left unconfigured after being prompted and the prompt is disabled without any selection made', async () => {
@@ -222,258 +181,137 @@ suite('Linter Availability Provider tests', () => {
         const promptReply = undefined;
         const expectedResult = false;
 
+        // run scenario
+        const result = await testForLinterPromptResponse(promptReply);
+
+        // test results
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+    });
+
+    // Options to test the implementation of the IAvailableLinterActivator.
+    // All options default to values that would otherwise allow the prompt to appear.
+    class AvailablityTestOverallOptions {
+        public jediEnabledValue: boolean = false;
+        public pylintUserEnabled?: boolean;
+        public pylintWorkspaceEnabled?: boolean;
+        public pylintWorkspaceFolderEnabled?: boolean;
+        public linterIsInstalled: boolean = true;
+        public promptReply?: { title: string; enabled: boolean };
+    }
+
+    async function performTestOfOverallImplementation(options: AvailablityTestOverallOptions): Promise<boolean> {
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
-
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-
-        const linterInfo = new class extends LinterInfo {
-            public testIsEnabled: boolean = false;
-
-            public async enableAsync(enabled: boolean, resource?: Uri): Promise<void> {
-                this.testIsEnabled = enabled;
-                return Promise.resolve();
-            }
-
-        }(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-
+        const [appShellMock, installerMock, wkspcConfigSrvcMock, linterInfo] = getDependenciesForAvailabilityTests();
         appShellMock.setup(ap => ap.showInformationMessage(
             TypeMoq.It.isValue(`Linter ${linterInfo.id} is available but not enabled.`),
             TypeMoq.It.isAny(),
             TypeMoq.It.isAny())
         )
-            .returns(() => {
-                // tslint:disable-next-line:no-any
-                return promptReply as any;
-            })
+            // tslint:disable-next-line:no-any
+            .returns(() => options.promptReply as any)
             .verifiable(TypeMoq.Times.once());
 
-        // call
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
+        installerMock.setup(im => im.isInstalled(linterInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => options.linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
 
-        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
-    });
-
-    test('Overall implementation does not change configuration when feature disabled', async () => {
-        // set expectations
-        const jediEnabledValue = true;
-        const expectedResult = false;
-
-        // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        setupWorkspaceServiceForJediSettingTest(options.jediEnabledValue, wkspcConfigSrvcMock);
+        setupWorkspaceMockForLinterConfiguredTests(
+            options.pylintUserEnabled,
+            options.pylintWorkspaceEnabled,
+            options.pylintWorkspaceFolderEnabled,
+            wkspcConfigSrvcMock
+        );
 
         // perform test
         const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+        return availabilityProvider.promptIfLinterAvailable(linterInfo);
+    }
 
+    test('Overall implementation does not change configuration when feature disabled', async () => {
+        // set expectations
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.jediEnabledValue = true;
+        const expectedResult = false;
+
+        // arrange
+        const result = await performTestOfOverallImplementation(testOpts);
+
+        // perform test
         expect(expectedResult).to.equal(result, 'promptIfLinterAvailable should not change any configuration when python.jediEnabled is true.');
-        wkspcConfigSrvcMock.verifyAll();
     });
 
     test('Overall implementation does not change configuration when linter is configured (enabled)', async () => {
         // set expectations
-        const jediEnabledValue = false;
-        const pylintUserEnabled = undefined;
-        const pylintWorkspaceEnabled = true;
-        const pylintWorkspaceFolderEnabled = undefined;
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.pylintWorkspaceEnabled = true;
         const expectedResult = false;
 
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-
-        // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+        const result = await performTestOfOverallImplementation(testOpts);
 
         // perform test
         expect(expectedResult).to.equal(result, 'Configuration should not change if the linter is configured in any way.');
-        wkspcConfigSrvcMock.verifyAll();
     });
 
     test('Overall implementation does not change configuration when linter is configured (disabled)', async () => {
         // set expectations
-        const jediEnabledValue = false;
-        const pylintUserEnabled = undefined;
-        const pylintWorkspaceEnabled = true;
-        const pylintWorkspaceFolderEnabled = undefined;
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.pylintWorkspaceEnabled = false;
         const expectedResult = false;
 
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const result = await performTestOfOverallImplementation(testOpts);
 
-        // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
-
-        // perform test
         expect(expectedResult).to.equal(result, 'Configuration should not change if the linter is disabled in any way.');
-        wkspcConfigSrvcMock.verifyAll();
     });
 
     test('Overall implementation does not change configuration when linter is unavailable in current workspace environment', async () => {
         // set expectations
-        const jediEnabledValue = false;
-        const pylintUserEnabled = undefined;
-        const pylintWorkspaceEnabled = true;
-        const pylintWorkspaceFolderEnabled = undefined;
-        const linterIsInstalled = false;
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.pylintWorkspaceEnabled = true;
         const expectedResult = false;
 
         // arrange
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
-            .returns(async () => linterIsInstalled)
-            .verifiable(TypeMoq.Times.once());
-        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
-
-        // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+        const result = await performTestOfOverallImplementation(testOpts);
 
         expect(expectedResult).to.equal(result, 'Configuration should not change if the linter is unavailable in the current workspace environment.');
-        wkspcConfigSrvcMock.verifyAll();
     });
 
     test('Overall implementation does not change configuration when user is prompted and prompt is dismissed', async () => {
         // set expectations
-        const jediEnabledValue = false;
-        const pylintUserEnabled = undefined;
-        const pylintWorkspaceEnabled = undefined;
-        const pylintWorkspaceFolderEnabled = undefined;
-        const linterIsInstalled = true;
-        const promptReply = undefined;
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.promptReply = undefined; // just being explicit for test readability - this is the default
         const expectedResult = false;
 
         // arrange
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        appShellMock.setup(ap => ap.showInformationMessage(
-            TypeMoq.It.isValue(`Linter ${pylintInfo.id} is available but not enabled.`),
-            TypeMoq.It.isAny(),
-            TypeMoq.It.isAny())
-        )
-            // tslint:disable-next-line:no-any
-            .returns(() => promptReply as any)
-            .verifiable(TypeMoq.Times.once());
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
-            .returns(async () => linterIsInstalled)
-            .verifiable(TypeMoq.Times.once());
-        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
-
-        // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+        const result = await performTestOfOverallImplementation(testOpts);
 
         expect(expectedResult).to.equal(result, 'Configuration should not change if the user is prompted and they dismiss the prompt.');
-        wkspcConfigSrvcMock.verifyAll();
-        appShellMock.verifyAll();
-        installerMock.verifyAll();
     });
 
     test('Overall implementation changes configuration when user is prompted and "Disable <linter>" is selected', async () => {
         // set expectations
-        const jediEnabledValue = false;
-        const pylintUserEnabled = undefined;
-        const pylintWorkspaceEnabled = undefined;
-        const pylintWorkspaceFolderEnabled = undefined;
-        const linterIsInstalled = true;
-        const promptReply = { title: 'Disable pylint', enabled: false };
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.promptReply = { title: 'Disable pylint', enabled: false };
         const expectedResult = true;
 
         // arrange
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        appShellMock.setup(ap => ap.showInformationMessage(
-            TypeMoq.It.isValue(`Linter ${pylintInfo.id} is available but not enabled.`),
-            TypeMoq.It.isAny(),
-            TypeMoq.It.isAny())
-        )
-            .returns(() => {
-                // tslint:disable-next-line:no-any
-                return promptReply as any;
-            })
-            .verifiable(TypeMoq.Times.once());
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
-            .returns(async () => linterIsInstalled)
-            .verifiable(TypeMoq.Times.once());
-        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+        const result = await performTestOfOverallImplementation(testOpts);
 
-        // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
-
-        expect(expectedResult).to.equal(result, 'Configuration should not change if the user is prompted and they dismiss the prompt.');
-        wkspcConfigSrvcMock.verifyAll();
-        appShellMock.verifyAll();
-        installerMock.verifyAll();
+        expect(expectedResult).to.equal(result, 'Configuration should change if the user is prompted and they choose to update the linter config.');
     });
 
     test('Overall implementation changes configuration when user is prompted and "Enable <linter>" is selected', async () => {
         // set expectations
-        const jediEnabledValue = false;
-        const pylintUserEnabled = undefined;
-        const pylintWorkspaceEnabled = undefined;
-        const pylintWorkspaceFolderEnabled = undefined;
-        const linterIsInstalled = true;
-        const promptReply = { title: 'Enable pylint', enabled: true };
+        const testOpts = new AvailablityTestOverallOptions();
+        testOpts.promptReply = { title: 'Enable pylint', enabled: true };
         const expectedResult = true;
 
         // arrange
-        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
-        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
-        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
-        appShellMock.setup(ap => ap.showInformationMessage(
-            TypeMoq.It.isValue(`Linter ${pylintInfo.id} is available but not enabled.`),
-            TypeMoq.It.isAny(),
-            TypeMoq.It.isAny())
-        )
-            .returns(() => {
-                // tslint:disable-next-line:no-any
-                return promptReply as any;
-            })
-            .verifiable(TypeMoq.Times.once());
-        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
-        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
-            .returns(async () => linterIsInstalled)
-            .verifiable(TypeMoq.Times.once());
-        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
-        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+        const result = await performTestOfOverallImplementation(testOpts);
 
-        // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
-        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
-
-        expect(expectedResult).to.equal(result, 'Configuration should not change if the user is prompted and they dismiss the prompt.');
-        wkspcConfigSrvcMock.verifyAll();
-        appShellMock.verifyAll();
-        installerMock.verifyAll();
+        expect(expectedResult).to.equal(result, 'Configuration should change if the user is prompted and they choose to update the linter config.');
     });
 
     test('Discovery of linter is available in the environment returns true when it succeeds and is present', async () => {
@@ -601,4 +439,19 @@ function setupWorkspaceServiceForJediSettingTest(jediEnabledValue: boolean, wksp
         .returns(() => workspaceConfiguration.object)
         .verifiable(TypeMoq.Times.once());
     return wkspcConfigSrvcMock;
+}
+
+function getDependenciesForAvailabilityTests(): [
+    TypeMoq.IMock<IApplicationShell>,
+    TypeMoq.IMock<IInstaller>,
+    TypeMoq.IMock<IWorkspaceService>,
+    LinterInfo
+] {
+    const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+    return [
+        TypeMoq.Mock.ofType<IApplicationShell>(),
+        TypeMoq.Mock.ofType<IInstaller>(),
+        TypeMoq.Mock.ofType<IWorkspaceService>(),
+        new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc'])
+    ];
 }

--- a/src/test/linters/linter.availability.unit.test.ts
+++ b/src/test/linters/linter.availability.unit.test.ts
@@ -1,0 +1,604 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { Uri, WorkspaceConfiguration } from 'vscode';
+import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
+import { IConfigurationService, IInstaller, Product } from '../../client/common/types';
+import { AvailableLinterActivator } from '../../client/linters/linterAvailability';
+import { LinterInfo } from '../../client/linters/linterInfo';
+import { IAvailableLinterActivator } from '../../client/linters/types';
+
+// tslint:disable-next-line:max-func-body-length
+suite('Linter Availability Provider tests', () => {
+
+    test('Availability feature is disabled when global default for jediEnabled=true.', async () => {
+        // set expectations
+        const jediEnabledValue = true;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+
+        // call
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = availabilityProvider.isFeatureEnabled();
+
+        // check expectaions
+        expect(result).is.equal(expectedResult);
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Availability feature is enabled when global default for jediEnabled=false.', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const expectedResult = true;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+
+        const result = availabilityProvider.isFeatureEnabled();
+
+        expect(result).is.equal(expectedResult);
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Prompt will be performed when linter is not configured at all for the workspace, workspace-folder, or the user', async () => {
+        // setup expectations
+        const pylintUserValue = undefined;
+        const pylintWorkspaceValue = undefined;
+        const pylintWorkspaceFolderValue = undefined;
+        const expectedResult = true;
+
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
+
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
+
+        expect(result).to.equal(expectedResult);
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('No prompt performed when linter is configured as enabled for the workspace', async () => {
+        // setup expectations
+        const pylintUserValue = undefined;
+        const pylintWorkspaceValue = true;
+        const pylintWorkspaceFolderValue = undefined;
+        const expectedResult = false;
+
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
+
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
+        expect(result).to.equal(expectedResult);
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('No prompt performed when linter is configured as enabled for the entire user', async () => {
+        // setup expectations
+        const pylintUserValue = true;
+        const pylintWorkspaceValue = undefined;
+        const pylintWorkspaceFolderValue = undefined;
+        const expectedResult = false;
+
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
+
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
+        expect(result).to.equal(expectedResult);
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('No prompt performed when linter is configured as enabled for the workspace-folder', async () => {
+        // setup expectations
+        const pylintUserValue = undefined;
+        const pylintWorkspaceValue = undefined;
+        const pylintWorkspaceFolderValue = true;
+        const expectedResult = false;
+
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        const wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue);
+
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const result = availabilityProvider.isLinterUsingDefaultConfiguration(pylintInfo);
+        expect(result).to.equal(expectedResult);
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Linter is enabled after being prompted and "Enable <linter>" is selected', async () => {
+        // set expectation
+        const promptReply = { title: 'Enable pylint', enabled: true };
+        const expectedResult = true;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        const linterInfo = new class extends LinterInfo {
+            public testIsEnabled: boolean = !promptReply.enabled;
+
+            public async enableAsync(enabled: boolean, resource?: Uri): Promise<void> {
+                this.testIsEnabled = enabled;
+                return Promise.resolve();
+            }
+
+        }(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        appShellMock.setup(ap => ap.showInformationMessage(
+            TypeMoq.It.isValue(`Linter ${linterInfo.id} is available but not enabled.`),
+            TypeMoq.It.isAny(),
+            TypeMoq.It.isAny())
+        )
+            .returns(() => {
+                // tslint:disable-next-line:no-any
+                return promptReply as any;
+            })
+            .verifiable(TypeMoq.Times.once());
+
+        // call
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
+
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+        expect(linterInfo.testIsEnabled).to.equal(promptReply.enabled, 'LinterInfo test class was not updated as a result of the test.');
+    });
+
+    test('Linter is disabled after being prompted and "Disable <linter>" is selected', async () => {
+        // set expectation
+        const promptReply = { title: 'Disable pylint', enabled: false };
+        const expectedResult = true;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        const linterInfo = new class extends LinterInfo {
+            public testIsEnabled: boolean = !promptReply.enabled;
+
+            public async enableAsync(enabled: boolean, resource?: Uri): Promise<void> {
+                this.testIsEnabled = enabled;
+                return Promise.resolve();
+            }
+
+        }(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        appShellMock.setup(ap => ap.showInformationMessage(
+            TypeMoq.It.isValue(`Linter ${linterInfo.id} is available but not enabled.`),
+            TypeMoq.It.isAny(),
+            TypeMoq.It.isAny())
+        )
+            .returns(() => {
+                // tslint:disable-next-line:no-any
+                return promptReply as any;
+            })
+            .verifiable(TypeMoq.Times.once());
+
+        // call
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
+
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+        expect(linterInfo.testIsEnabled).to.equal(promptReply.enabled, 'LinterInfo test class was not updated as a result of the test.');
+    });
+
+    test('Linter is left unconfigured after being prompted and the prompt is disabled without any selection made', async () => {
+        // set expectation
+        const promptReply = undefined;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        const linterInfo = new class extends LinterInfo {
+            public testIsEnabled: boolean = false;
+
+            public async enableAsync(enabled: boolean, resource?: Uri): Promise<void> {
+                this.testIsEnabled = enabled;
+                return Promise.resolve();
+            }
+
+        }(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        appShellMock.setup(ap => ap.showInformationMessage(
+            TypeMoq.It.isValue(`Linter ${linterInfo.id} is available but not enabled.`),
+            TypeMoq.It.isAny(),
+            TypeMoq.It.isAny())
+        )
+            .returns(() => {
+                // tslint:disable-next-line:no-any
+                return promptReply as any;
+            })
+            .verifiable(TypeMoq.Times.once());
+
+        // call
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
+
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+    });
+
+    test('Overall implementation does not change configuration when feature disabled', async () => {
+        // set expectations
+        const jediEnabledValue = true;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        expect(expectedResult).to.equal(result, 'promptIfLinterAvailable should not change any configuration when python.jediEnabled is true.');
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Overall implementation does not change configuration when linter is configured (enabled)', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const pylintUserEnabled = undefined;
+        const pylintWorkspaceEnabled = true;
+        const pylintWorkspaceFolderEnabled = undefined;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        // perform test
+        expect(expectedResult).to.equal(result, 'Configuration should not change if the linter is configured in any way.');
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Overall implementation does not change configuration when linter is configured (disabled)', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const pylintUserEnabled = undefined;
+        const pylintWorkspaceEnabled = true;
+        const pylintWorkspaceFolderEnabled = undefined;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        // perform test
+        expect(expectedResult).to.equal(result, 'Configuration should not change if the linter is disabled in any way.');
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Overall implementation does not change configuration when linter is unavailable in current workspace environment', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const pylintUserEnabled = undefined;
+        const pylintWorkspaceEnabled = true;
+        const pylintWorkspaceFolderEnabled = undefined;
+        const linterIsInstalled = false;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
+        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        expect(expectedResult).to.equal(result, 'Configuration should not change if the linter is unavailable in the current workspace environment.');
+        wkspcConfigSrvcMock.verifyAll();
+    });
+
+    test('Overall implementation does not change configuration when user is prompted and prompt is dismissed', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const pylintUserEnabled = undefined;
+        const pylintWorkspaceEnabled = undefined;
+        const pylintWorkspaceFolderEnabled = undefined;
+        const linterIsInstalled = true;
+        const promptReply = undefined;
+        const expectedResult = false;
+
+        // arrange
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        appShellMock.setup(ap => ap.showInformationMessage(
+            TypeMoq.It.isValue(`Linter ${pylintInfo.id} is available but not enabled.`),
+            TypeMoq.It.isAny(),
+            TypeMoq.It.isAny())
+        )
+            // tslint:disable-next-line:no-any
+            .returns(() => promptReply as any)
+            .verifiable(TypeMoq.Times.once());
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
+        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        expect(expectedResult).to.equal(result, 'Configuration should not change if the user is prompted and they dismiss the prompt.');
+        wkspcConfigSrvcMock.verifyAll();
+        appShellMock.verifyAll();
+        installerMock.verifyAll();
+    });
+
+    test('Overall implementation changes configuration when user is prompted and "Disable <linter>" is selected', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const pylintUserEnabled = undefined;
+        const pylintWorkspaceEnabled = undefined;
+        const pylintWorkspaceFolderEnabled = undefined;
+        const linterIsInstalled = true;
+        const promptReply = { title: 'Disable pylint', enabled: false };
+        const expectedResult = true;
+
+        // arrange
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        appShellMock.setup(ap => ap.showInformationMessage(
+            TypeMoq.It.isValue(`Linter ${pylintInfo.id} is available but not enabled.`),
+            TypeMoq.It.isAny(),
+            TypeMoq.It.isAny())
+        )
+            .returns(() => {
+                // tslint:disable-next-line:no-any
+                return promptReply as any;
+            })
+            .verifiable(TypeMoq.Times.once());
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
+        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        expect(expectedResult).to.equal(result, 'Configuration should not change if the user is prompted and they dismiss the prompt.');
+        wkspcConfigSrvcMock.verifyAll();
+        appShellMock.verifyAll();
+        installerMock.verifyAll();
+    });
+
+    test('Overall implementation changes configuration when user is prompted and "Enable <linter>" is selected', async () => {
+        // set expectations
+        const jediEnabledValue = false;
+        const pylintUserEnabled = undefined;
+        const pylintWorkspaceEnabled = undefined;
+        const pylintWorkspaceFolderEnabled = undefined;
+        const linterIsInstalled = true;
+        const promptReply = { title: 'Enable pylint', enabled: true };
+        const expectedResult = true;
+
+        // arrange
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        appShellMock.setup(ap => ap.showInformationMessage(
+            TypeMoq.It.isValue(`Linter ${pylintInfo.id} is available but not enabled.`),
+            TypeMoq.It.isAny(),
+            TypeMoq.It.isAny())
+        )
+            .returns(() => {
+                // tslint:disable-next-line:no-any
+                return promptReply as any;
+            })
+            .verifiable(TypeMoq.Times.once());
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
+        let wkspcConfigSrvcMock = setupWorkspaceServiceForJediSettingTest(jediEnabledValue);
+        wkspcConfigSrvcMock = setupWorkspaceMockForLinterConfiguredTests(pylintUserEnabled, pylintWorkspaceEnabled, pylintWorkspaceFolderEnabled, wkspcConfigSrvcMock);
+
+        // perform test
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.promptIfLinterAvailable(pylintInfo);
+
+        expect(expectedResult).to.equal(result, 'Configuration should not change if the user is prompted and they dismiss the prompt.');
+        wkspcConfigSrvcMock.verifyAll();
+        appShellMock.verifyAll();
+        installerMock.verifyAll();
+    });
+
+    test('Discovery of linter is available in the environment returns true when it succeeds and is present', async () => {
+        // set expectations
+        const linterIsInstalled = true;
+        const expectedResult = true;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
+
+        // perform test
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.isLinterAvailable(pylintInfo.product);
+
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+        installerMock.verifyAll();
+    });
+
+    test('Discovery of linter is available in the environment returns false when it succeeds and is not present', async () => {
+        // set expectations
+        const linterIsInstalled = false;
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(async () => linterIsInstalled)
+            .verifiable(TypeMoq.Times.once());
+
+        // perform test
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.isLinterAvailable(pylintInfo.product);
+
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+        installerMock.verifyAll();
+    });
+
+    test('Discovery of linter is available in the environment returns false when it fails', async () => {
+        // set expectations
+        const expectedResult = false;
+
+        // arrange
+        const appShellMock = TypeMoq.Mock.ofType<IApplicationShell>();
+        const installerMock = TypeMoq.Mock.ofType<IInstaller>();
+        const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
+        const wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+
+        const pylintInfo = new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc']);
+
+        installerMock.setup(im => im.isInstalled(pylintInfo.product, TypeMoq.It.isAny()))
+            .returns(() => Promise.reject('error testfail'))
+            .verifiable(TypeMoq.Times.once());
+
+        // perform test
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, wkspcConfigSrvcMock.object);
+        const result = await availabilityProvider.isLinterAvailable(pylintInfo.product);
+
+        expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
+        installerMock.verifyAll();
+    });
+});
+
+function setupWorkspaceMockForLinterConfiguredTests(
+    enabledForUser: boolean | undefined,
+    enabeldForWorkspace: boolean | undefined,
+    enabledForWorkspaceFolder: boolean | undefined,
+    wkspcConfigSrvcMock?: TypeMoq.IMock<IWorkspaceService>): TypeMoq.IMock<IWorkspaceService> {
+
+    if (!wkspcConfigSrvcMock) {
+        wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+    }
+    const workspaceConfiguration = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+    workspaceConfiguration.setup(wc => wc.inspect(TypeMoq.It.isValue('pylintEnabled')))
+        .returns(() => {
+            return {
+                key: '',
+                globalValue: enabledForUser,
+                defaultValue: false,
+                workspaceFolderValue: enabeldForWorkspace,
+                workspaceValue: enabledForWorkspaceFolder
+            };
+        })
+        .verifiable(TypeMoq.Times.once());
+
+    wkspcConfigSrvcMock.setup(ws => ws.getConfiguration(TypeMoq.It.isValue('python.linting'), TypeMoq.It.isAny()))
+        .returns(() => workspaceConfiguration.object)
+        .verifiable(TypeMoq.Times.once());
+
+    return wkspcConfigSrvcMock;
+}
+
+function setupWorkspaceServiceForJediSettingTest(jediEnabledValue: boolean, wkspcConfigSrvcMock?: TypeMoq.IMock<IWorkspaceService>): TypeMoq.IMock<IWorkspaceService> {
+
+    if (!wkspcConfigSrvcMock) {
+        wkspcConfigSrvcMock = TypeMoq.Mock.ofType<IWorkspaceService>();
+    }
+    const workspaceConfiguration = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+    workspaceConfiguration.setup(wc => wc.inspect(TypeMoq.It.isValue('jediEnabled')))
+        .returns(() => {
+            return {
+                key: '',
+                globalValue: undefined,
+                defaultValue: jediEnabledValue,
+                workspaceFolderValue: undefined,
+                workspaceValue: undefined
+            };
+        })
+        .verifiable(TypeMoq.Times.once());
+    wkspcConfigSrvcMock.setup(ws => ws.getConfiguration(TypeMoq.It.isValue('python')))
+        .returns(() => workspaceConfiguration.object)
+        .verifiable(TypeMoq.Times.once());
+    return wkspcConfigSrvcMock;
+}


### PR DESCRIPTION
Fix for #974

`pylint` is easily enabled for workspaces that have it available, but it is no longer set at the global default for the vscode-python extension.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
