### PR TITLE
Remove extraneous CR characters from normalized code snippets.

### DIFF
--- a/news/2 Fixes/2857.md
+++ b/news/2 Fixes/2857.md
@@ -1,0 +1,1 @@
+Stop `normalizationForInterpreter.py` script from returning CRCRLF line-endings.

--- a/pythonFiles/normalizeForInterpreter.py
+++ b/pythonFiles/normalizeForInterpreter.py
@@ -81,10 +81,10 @@ def normalize_lines(source):
     # we have indented code.
     if (len(lines) > 1 and len(''.join(lines[-2:])) == 0) \
         or source.endswith(('\n\n', '\r\n\r\n')):
-        trailing_newline = os.linesep * 2
+        trailing_newline = '\n' * 2
     # Find out if we have any trailing blank lines
     elif len(lines[-1].strip()) == 0 or source.endswith(('\n', '\r\n')):
-        trailing_newline = os.linesep
+        trailing_newline = '\n'
     else:
         trailing_newline = ''
 
@@ -101,7 +101,7 @@ def normalize_lines(source):
     # Step 2: Add blank lines between each global statement block.
     # A consequtive single lines blocks of code will be treated as a single statement,
     # just to ensure we do not unnecessarily add too many blank lines.
-    source = os.linesep.join(lines)
+    source = '\n'.join(lines)
     tokens = _tokenize(source)
     dedent_indexes = (spos[0] for (toknum, tokval, spos, epos, line) in tokens
                                 if toknum == token.DEDENT and _indent_size(line) == 0)
@@ -111,7 +111,7 @@ def normalize_lines(source):
     for line_number in filter(lambda x: x > 1, start_positions):
         lines.insert(line_number-1, '')
 
-    sys.stdout.write(os.linesep.join(lines) + trailing_newline)
+    sys.stdout.write('\n'.join(lines) + trailing_newline)
     sys.stdout.flush()
 
 

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -33,7 +33,11 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const args = [path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'normalizeForInterpreter.py'), code];
             const processService = await this.processServiceFactory.create(resource);
             const proc = await processService.exec(pythonPath, args, { throwOnStdErr: true });
-            return proc.stdout;
+
+            // tslint:disable-next-line:no-suspicious-comment
+            // HACK FIX: Until we correct the normalize script we can simply remove
+            // extraneous CR characters.
+            return proc.stdout.replace(/\r\r/g, '\r');
         } catch (ex) {
             console.error(ex, 'Python: Failed to normalize code for execution in terminal');
             return code;

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -34,10 +34,7 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             const processService = await this.processServiceFactory.create(resource);
             const proc = await processService.exec(pythonPath, args, { throwOnStdErr: true });
 
-            // tslint:disable-next-line:no-suspicious-comment
-            // HACK FIX: Until we correct the normalize script we can simply remove
-            // extraneous CR characters.
-            return proc.stdout.replace(/\r\r/g, '\r');
+            return proc.stdout;
         } catch (ex) {
             console.error(ex, 'Python: Failed to normalize code for execution in terminal');
             return code;


### PR DESCRIPTION
Fix the `normalizeForInterpreter.py` script.

The script would split lines using `os.linesep` which on Windows is `CRLF`. On Windows, when Python detects any `LF` being written to stdout, it replaces it with `CRLF`. Therefore, our script was unintentionally causing `CRCRLF` to be written to stdout.

For #2857

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are ~added~/**updated**
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
