### PR TITLE
Disable consistently failing tests for specific OS and Python versions to get CI running clean.

### DIFF
--- a/news/3 Code Health/2795.md
+++ b/news/3 Code Health/2795.md
@@ -1,0 +1,1 @@
+Skip known failing tests for specific OS and Python version combinations to get CI running cleanly.

--- a/src/test/autocomplete/pep526.test.ts
+++ b/src/test/autocomplete/pep526.test.ts
@@ -4,8 +4,11 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { OSType } from '../../client/common/utils/platform';
-import { rootWorkspaceUri, shouldSkipForOs, shouldSkipForPythonVersion } from '../common';
-import { closeActiveWindows, initialize, initializeTest, IsLanguageServerTest } from '../initialize';
+import { isOs, isPythonVersion, rootWorkspaceUri } from '../common';
+import {
+    closeActiveWindows, initialize,
+    initializeTest, IsLanguageServerTest
+} from '../initialize';
 import { UnitTestIocContainer } from '../unittests/serviceRegistry';
 
 const autoCompPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonFiles', 'autocomp');
@@ -46,8 +49,8 @@ suite('Autocomplete PEP 526', () => {
     test('variable (abc:str)', async function () {
         // This test has not been working for many months in Python 3.4 and 3.5 under
         // Windows and macOS.Tracked by #2545.
-        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
-            if (await shouldSkipForPythonVersion(['3.4', '3.5'])) {
+        if (isOs(OSType.Windows, OSType.OSX)) {
+            if (await isPythonVersion('3.4', '3.5')) {
                 // tslint:disable-next-line:no-invalid-this
                 return this.skip();
             }
@@ -66,8 +69,8 @@ suite('Autocomplete PEP 526', () => {
     test('variable (abc: str = "")', async function () {
         // This test has not been working for many months in Python 3.4 and 3.5 under
         // Windows and macOS.Tracked by #2545.
-        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
-            if (await shouldSkipForPythonVersion(['3.4', '3.5'])) {
+        if (isOs(OSType.Windows, OSType.OSX)) {
+            if (await isPythonVersion('3.4', '3.5')) {
                 // tslint:disable-next-line:no-invalid-this
                 return this.skip();
             }
@@ -86,8 +89,8 @@ suite('Autocomplete PEP 526', () => {
     test('variable (abc = UNKNOWN # type: str)', async function () {
         // This test has not been working for many months in Python 3.4 and 3.5 under
         // Windows and macOS.Tracked by #2545.
-        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
-            if (await shouldSkipForPythonVersion(['3.4', '3.5'])) {
+        if (isOs(OSType.Windows, OSType.OSX)) {
+            if (await isPythonVersion('3.4', '3.5')) {
                 // tslint:disable-next-line:no-invalid-this
                 return this.skip();
             }
@@ -103,7 +106,16 @@ suite('Autocomplete PEP 526', () => {
         assert.notEqual(list!.items.filter(item => item.label === 'lower').length, 0, 'lower not found');
     });
 
-    test('class methods', async () => {
+    test('class methods', async function () {
+        // This test has not been working for many months in Python 3.4 and 3.5 under
+        // Windows and macOS.Tracked by #2545.
+        if (isOs(OSType.Windows, OSType.OSX)) {
+            if (await isPythonVersion('3.4', '3.5')) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');

--- a/src/test/autocomplete/pep526.test.ts
+++ b/src/test/autocomplete/pep526.test.ts
@@ -1,7 +1,10 @@
+'use strict';
+
 import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { rootWorkspaceUri } from '../common';
+import { OSType } from '../../client/common/utils/platform';
+import { rootWorkspaceUri, shouldSkipForOs, shouldSkipForPythonVersion } from '../common';
 import { closeActiveWindows, initialize, initializeTest, IsLanguageServerTest } from '../initialize';
 import { UnitTestIocContainer } from '../unittests/serviceRegistry';
 
@@ -40,7 +43,16 @@ suite('Autocomplete PEP 526', () => {
         ioc.registerProcessTypes();
     }
 
-    test('variable (abc:str)', async () => {
+    test('variable (abc:str)', async function () {
+        // This test has not been working for many months in Python 3.4 and 3.5 under
+        // Windows and macOS.Tracked by #2545.
+        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
+            if (await shouldSkipForPythonVersion(['3.4', '3.5'])) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');
@@ -51,7 +63,16 @@ suite('Autocomplete PEP 526', () => {
         assert.notEqual(list!.items.filter(item => item.label === 'lower').length, 0, 'lower not found');
     });
 
-    test('variable (abc: str = "")', async () => {
+    test('variable (abc: str = "")', async function () {
+        // This test has not been working for many months in Python 3.4 and 3.5 under
+        // Windows and macOS.Tracked by #2545.
+        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
+            if (await shouldSkipForPythonVersion(['3.4', '3.5'])) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');
@@ -62,7 +83,16 @@ suite('Autocomplete PEP 526', () => {
         assert.notEqual(list!.items.filter(item => item.label === 'lower').length, 0, 'lower not found');
     });
 
-    test('variable (abc = UNKNOWN # type: str)', async () => {
+    test('variable (abc = UNKNOWN # type: str)', async function () {
+        // This test has not been working for many months in Python 3.4 and 3.5 under
+        // Windows and macOS.Tracked by #2545.
+        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
+            if (await shouldSkipForPythonVersion(['3.4', '3.5'])) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -6,7 +6,7 @@ import { coerce, SemVer } from 'semver';
 import { ConfigurationTarget, Uri, workspace } from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
-import { error } from '../client/common/logger';
+import { traceError } from '../client/common/logger';
 import { BufferDecoder } from '../client/common/process/decoder';
 import { ProcessService } from '../client/common/process/proc';
 import { IProcessService } from '../client/common/process/types';
@@ -168,7 +168,7 @@ export async function getPythonSemVer(procService?: IProcessService): Promise<Se
         .then(strVersion => new SemVer(strVersion.stdout.trim()))
         .catch((err) => {
             // if the call fails this should make it loudly apparent.
-            error('getPythonSemVer', `[ERROR] shouldSkipForPythonVersion: ${err}`);
+            traceError('getPythonSemVer', err);
             return undefined;
         });
 }
@@ -252,7 +252,7 @@ export async function isPythonVersionInProcess(procService?: IProcessService, ..
     if (currentPyVersion) {
         return isVersionInList(currentPyVersion, ...versions);
     } else {
-        error('ERROR: isPythonVersionInProcess', `Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
+        traceError(`Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
         return false;
     }
 }
@@ -283,7 +283,7 @@ export async function isPythonVersion(...versions: string[]): Promise<boolean> {
     if (currentPyVersion) {
         return isVersionInList(currentPyVersion, ...versions);
     } else {
-        error('ERROR: isPythonVersion', `Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
+        traceError(`Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
         return false;
     }
 }

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -185,7 +185,7 @@ export async function shouldSkipForPythonVersion(skipForVersions: string[], proc
     // see if the major/minor version matches any member of the skip-list.
     const isPresent = skipForVersions.findIndex((ver: string) => ver === currentPyVersion);
 
-    if (isPresent) {
+    if (isPresent >= 0) {
         return true;
     }
     return false;

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -2,14 +2,17 @@
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { coerce, SemVer } from 'semver';
 import { ConfigurationTarget, Uri, workspace } from 'vscode';
 import { PythonSettings } from '../client/common/configSettings';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
+import { error } from '../client/common/logger';
 import { BufferDecoder } from '../client/common/process/decoder';
 import { ProcessService } from '../client/common/process/proc';
 import { IProcessService } from '../client/common/process/types';
 import { getOSType, OSType } from '../client/common/utils/platform';
 import { IS_MULTI_ROOT_TEST } from './initialize';
+
 export { sleep } from './core';
 
 // tslint:disable:no-invalid-this no-any
@@ -136,16 +139,16 @@ function getPythonPath(): string {
 }
 
 /**
- * Determine if a test should be skipped based on the current OS.
+ * Determine if the current platform is included in a list of platforms.
  *
- * @param {skipForOses} OSType List of operating system Ids that should be skipped.
- * @return true if the current OS matches one from the skip list, false otherwise.
+ * @param {OSes} OSType[] List of operating system Ids to check within.
+ * @return true if the current OS matches one from the list, false otherwise.
  */
-export function shouldSkipForOs(skipForOses: OSType[]): boolean {
+export function isOs(...OSes: OSType[]): boolean {
     // get current OS
     const currentOS: OSType = getOSType();
     // compare and return
-    if (skipForOses.indexOf(currentOS) === -1) {
+    if (OSes.indexOf(currentOS) === -1) {
         return false;
     }
     return true;
@@ -155,38 +158,132 @@ export function shouldSkipForOs(skipForOses: OSType[]): boolean {
  * Get the current Python interpreter version.
  *
  * @param {procService} IProcessService Optionally specify the IProcessService implementation to use to execute with.
- * @return `"MAJOR.MINOR"` version of the Python interpreter, "0" if an error occurs.
+ * @return `SemVer` version of the Python interpreter, or `undefined` if an error occurs.
  */
-export async function getPythonVersionString(procService?: IProcessService): Promise<string> {
+export async function getPythonSemVer(procService?: IProcessService): Promise<SemVer | undefined> {
     const pythonProcRunner = procService ? procService : new ProcessService(new BufferDecoder());
-    const pyVerArgs = ['-c', 'import sys;print("{0}.{1}".format(*sys.version_info[:2]))'];
+    const pyVerArgs = ['-c', 'import sys;print("{0}.{1}.{2}".format(*sys.version_info[:3]))'];
 
     return pythonProcRunner.exec(PYTHON_PATH, pyVerArgs)
-        .then((result) => result.stdout.trim())
+        .then(strVersion => new SemVer(strVersion.stdout.trim()))
         .catch((err) => {
             // if the call fails this should make it loudly apparent.
-            // tslint:disable-next-line:no-console
-            console.log(`[ERROR] shouldSkipForPythonVersion: ${err}`);
-            return '0';
+            error('getPythonSemVer', `[ERROR] shouldSkipForPythonVersion: ${err}`);
+            return undefined;
         });
 }
 
 /**
- * Determine if a test should be skipped based on the Python version.
+ * Match a given semver version specification with a list of loosely defined
+ * version strings.
  *
- * @param {skipForVersions} string[] List of major.minor version of python that are to be skipped.
- * @param {resource} vscode.Uri Current workspace resource Uri or undefined.
- * @return true if the current Python version matches a version in the skip list, false otherwise.
+ * Specify versions by their major version at minimum - the minor and patch
+ * version numbers are optional.
+ *
+ * '3', '3.6', '3.6.6', are all vald and only the portions specified will be matched
+ * against the current running Python interpreter version.
+ *
+ * Example scenarios:
+ * '3' will match version 3.5.6, 3.6.4, 3.6.6, and 3.7.0.
+ * '3.6' will match version 3.6.4 and 3.6.6.
+ * '3.6.4' will match version 3.6.4 only.
+ *
+ * @param {version} SemVer the version to look for.
+ * @param {searchVersions} string[] List of loosely-specified versions to match against.
  */
-export async function shouldSkipForPythonVersion(skipForVersions: string[], procService?: IProcessService): Promise<boolean> {
-    // get the current python version major/minor
-    const currentPyVersion = await getPythonVersionString(procService);
-
+export function isVersionInList(version: SemVer, ...searchVersions: string[]): boolean {
     // see if the major/minor version matches any member of the skip-list.
-    const isPresent = skipForVersions.findIndex((ver: string) => ver === currentPyVersion);
+    const isPresent = searchVersions.findIndex(ver => {
+        const semverChecker = coerce(ver);
+        if (semverChecker) {
+            if (semverChecker.compare(version) === 0) {
+                return true;
+            } else {
+                // compare all the parts of the version that we have, we know we have
+                // at minimum the major version or semverChecker would be 'null'...
+                const versionParts = ver.split('.');
+                let matches = parseInt(versionParts[0], 10) === version.major;
+
+                if (matches && versionParts.length >= 2) {
+                    matches = parseInt(versionParts[1], 10) === version.minor;
+                }
+
+                if (matches && versionParts.length >= 3) {
+                    matches = parseInt(versionParts[2], 10) === version.patch;
+                }
+
+                return matches;
+            }
+        }
+        return false;
+    });
 
     if (isPresent >= 0) {
         return true;
     }
     return false;
+}
+
+/**
+ * Determine if the Python interpreter version running in a given `IProcessService`
+ * is in a selection of versions.
+ *
+ * You can specify versions by specifying the major version at minimum - the minor and
+ * patch version numbers are optional.
+ *
+ * '3', '3.6', '3.6.6', are all vald and only the portions specified will be matched
+ * against the current running Python interpreter version.
+ *
+ * Example scenarios:
+ * '3' will match version 3.5.6, 3.6.4, 3.6.6, and 3.7.0.
+ * '3.6' will match version 3.6.4 and 3.6.6.
+ * '3.6.4' will match version 3.6.4 only.
+ *
+ * If you don't need to specify the environment (ie. the workspace) that the Python
+ * interpreter is running under, use the simpler `isPythonVersion` instead.
+ *
+ * @param {skipForVersions} string[] List of versions of python that are to be skipped.
+ * @param {resource} vscode.Uri Current workspace resource Uri or undefined.
+ * @return true if the current Python version matches a version in the skip list, false otherwise.
+ */
+export async function isPythonVersionInProcess(procService?: IProcessService, ...versions: string[]): Promise<boolean> {
+    // get the current python version major/minor
+    const currentPyVersion = await getPythonSemVer(procService);
+    if (currentPyVersion) {
+        return isVersionInList(currentPyVersion, ...versions);
+    } else {
+        error('ERROR: isPythonVersionInProcess', `Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
+        return false;
+    }
+}
+
+/**
+ * Determine if the current interpreter version is in a given selection of versions.
+ *
+ * You can specify versions by using up to the first three semver parts of a python
+ * version.
+ *
+ * '3', '3.6', '3.6.6', are all vald and only the portions specified will be matched
+ * against the current running Python interpreter version.
+ *
+ * Example scenarios:
+ * '3' will match version 3.5.6, 3.6.4, 3.6.6, and 3.7.0.
+ * '3.6' will match version 3.6.4 and 3.6.6.
+ * '3.6.4' will match version 3.6.4 only.
+ *
+ * If you need to specify the environment (ie. the workspace) that the Python
+ * interpreter is running under, use `isPythonVersionInProcess` instead.
+ *
+ * @param {skipForVersions} string[] List of versions of python that are to be skipped.
+ * @param {resource} vscode.Uri Current workspace resource Uri or undefined.
+ * @return true if the current Python version matches a version in the skip list, false otherwise.
+ */
+export async function isPythonVersion(...versions: string[]): Promise<boolean> {
+    const currentPyVersion = await getPythonSemVer();
+    if (currentPyVersion) {
+        return isVersionInList(currentPyVersion, ...versions);
+    } else {
+        error('ERROR: isPythonVersion', `Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
+        return false;
+    }
 }

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+'use strict';
+
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { CancellationTokenSource } from 'vscode';
@@ -8,12 +10,14 @@ import { PythonSettings } from '../../../client/common/configSettings';
 import { BufferDecoder } from '../../../client/common/process/decoder';
 import { ProcessService } from '../../../client/common/process/proc';
 import { StdErrError } from '../../../client/common/process/types';
+import { OSType } from '../../../client/common/utils/platform';
+import { shouldSkipForOs, shouldSkipForPythonVersion } from '../../common';
 import { initialize } from './../../initialize';
 
 use(chaiAsPromised);
 
 // tslint:disable-next-line:max-func-body-length
-suite('ProcessService', () => {
+suite('ProcessService Observable', () => {
     let pythonPath: string;
     suiteSetup(() => {
         pythonPath = PythonSettings.getInstance().pythonPath;
@@ -33,6 +37,13 @@ suite('ProcessService', () => {
     });
 
     test('exec should output print unicode characters', async () => {
+        // This test has not been working for many months in Python 2.7 under
+        // Windows. Tracked by #2546.
+        if (shouldSkipForOs([OSType.Windows]) && await shouldSkipForPythonVersion(['2.7'])) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
+        }
+
         const procService = new ProcessService(new BufferDecoder());
         const printOutput = 'öä';
         const result = await procService.exec(pythonPath, ['-c', `print("${printOutput}")`]);

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -36,7 +36,7 @@ suite('ProcessService Observable', () => {
         expect(result.stderr).to.equal(undefined, 'stderr not undefined');
     });
 
-    test('exec should output print unicode characters', async () => {
+    test('exec should output print unicode characters', async function () {
         // This test has not been working for many months in Python 2.7 under
         // Windows. Tracked by #2546.
         if (shouldSkipForOs([OSType.Windows]) && await shouldSkipForPythonVersion(['2.7'])) {

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -11,7 +11,7 @@ import { BufferDecoder } from '../../../client/common/process/decoder';
 import { ProcessService } from '../../../client/common/process/proc';
 import { StdErrError } from '../../../client/common/process/types';
 import { OSType } from '../../../client/common/utils/platform';
-import { shouldSkipForOs, shouldSkipForPythonVersion } from '../../common';
+import { isOs, isPythonVersion } from '../../common';
 import { initialize } from './../../initialize';
 
 use(chaiAsPromised);
@@ -38,8 +38,8 @@ suite('ProcessService Observable', () => {
 
     test('exec should output print unicode characters', async function () {
         // This test has not been working for many months in Python 2.7 under
-        // Windows. Tracked by #2546.
-        if (shouldSkipForOs([OSType.Windows]) && await shouldSkipForPythonVersion(['2.7'])) {
+        // Windows. Tracked by #2546. (unicode under Py2.7 is tough!)
+        if (isOs(OSType.Windows) && await isPythonVersion('2.7')) {
             // tslint:disable-next-line:no-invalid-this
             return this.skip();
         }

--- a/src/test/common/process/pythonProc.simple.multiroot.test.ts
+++ b/src/test/common/process/pythonProc.simple.multiroot.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+'use strict';
+
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { execFile } from 'child_process';
@@ -18,14 +20,26 @@ import { IFileSystem, IPlatformService } from '../../../client/common/platform/t
 import { CurrentProcess } from '../../../client/common/process/currentProcess';
 import { registerTypes as processRegisterTypes } from '../../../client/common/process/serviceRegistry';
 import { IPythonExecutionFactory, StdErrError } from '../../../client/common/process/types';
-import { IConfigurationService, ICurrentProcess, IDisposableRegistry, IPathUtils, IsWindows } from '../../../client/common/types';
+import {
+    IConfigurationService, ICurrentProcess,
+    IDisposableRegistry, IPathUtils, IsWindows
+} from '../../../client/common/types';
 import { IS_WINDOWS } from '../../../client/common/util';
-import { registerTypes as variablesRegisterTypes } from '../../../client/common/variables/serviceRegistry';
+import { OSType } from '../../../client/common/utils/platform';
+import {
+    registerTypes as variablesRegisterTypes
+} from '../../../client/common/variables/serviceRegistry';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { ServiceManager } from '../../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { clearPythonPathInWorkspaceFolder } from '../../common';
-import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } from './../../initialize';
+import {
+    clearPythonPathInWorkspaceFolder, shouldSkipForOs,
+    shouldSkipForPythonVersion
+} from '../../common';
+import {
+    closeActiveWindows, initialize, initializeTest,
+    IS_MULTI_ROOT_TEST
+} from './../../initialize';
 
 use(chaiAsPromised);
 
@@ -91,6 +105,15 @@ suite('PythonExecutableService', () => {
     });
 
     test('Importing with a valid PYTHONPATH from .env file should succeed', async () => {
+        // This test has not been working for many months in Python 2.7 under
+        // Windows. Tracked by #2547.
+        if (shouldSkipForOs([OSType.Windows])) {
+            if (await shouldSkipForPythonVersion(['2.7'])) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         await configService.updateSetting('envFile', undefined, workspace4PyFile, ConfigurationTarget.WorkspaceFolder);
         const pythonExecService = await pythonExecFactory.create({ resource: workspace4PyFile });
         const promise = pythonExecService.exec([workspace4PyFile.fsPath], { cwd: path.dirname(workspace4PyFile.fsPath), throwOnStdErr: true });

--- a/src/test/common/process/pythonProc.simple.multiroot.test.ts
+++ b/src/test/common/process/pythonProc.simple.multiroot.test.ts
@@ -33,8 +33,8 @@ import { ServiceContainer } from '../../../client/ioc/container';
 import { ServiceManager } from '../../../client/ioc/serviceManager';
 import { IServiceContainer } from '../../../client/ioc/types';
 import {
-    clearPythonPathInWorkspaceFolder, shouldSkipForOs,
-    shouldSkipForPythonVersion
+    clearPythonPathInWorkspaceFolder, isOs,
+    isPythonVersion
 } from '../../common';
 import {
     closeActiveWindows, initialize, initializeTest,
@@ -107,11 +107,9 @@ suite('PythonExecutableService', () => {
     test('Importing with a valid PYTHONPATH from .env file should succeed', async function () {
         // This test has not been working for many months in Python 2.7 under
         // Windows. Tracked by #2547.
-        if (shouldSkipForOs([OSType.Windows])) {
-            if (await shouldSkipForPythonVersion(['2.7'])) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
+        if (isOs(OSType.Windows) && await isPythonVersion('2.7')) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
         }
 
         await configService.updateSetting('envFile', undefined, workspace4PyFile, ConfigurationTarget.WorkspaceFolder);

--- a/src/test/common/process/pythonProc.simple.multiroot.test.ts
+++ b/src/test/common/process/pythonProc.simple.multiroot.test.ts
@@ -104,7 +104,7 @@ suite('PythonExecutableService', () => {
         await expect(promise).to.eventually.be.rejectedWith(StdErrError);
     });
 
-    test('Importing with a valid PYTHONPATH from .env file should succeed', async () => {
+    test('Importing with a valid PYTHONPATH from .env file should succeed', async function () {
         // This test has not been working for many months in Python 2.7 under
         // Windows. Tracked by #2547.
         if (shouldSkipForOs([OSType.Windows])) {

--- a/src/test/format/extension.format.test.ts
+++ b/src/test/format/extension.format.test.ts
@@ -5,7 +5,7 @@ import { IProcessServiceFactory, IPythonExecutionFactory } from '../../client/co
 import { AutoPep8Formatter } from '../../client/formatters/autoPep8Formatter';
 import { BlackFormatter } from '../../client/formatters/blackFormatter';
 import { YapfFormatter } from '../../client/formatters/yapfFormatter';
-import { PythonVersionInformation } from '../../client/unittests/common/types';
+import { isPythonVersionInProcess } from '../common';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 import { MockProcessService } from '../mocks/proc';
 import { compareFiles } from '../textUtils';
@@ -121,9 +121,10 @@ suite('Formatting', () => {
     });
     // tslint:disable-next-line:no-function-expression
     test('Black', async function () {
-        const pyVersion: PythonVersionInformation = await ioc.getPythonMajorMinorVersion(Uri.parse(blackFileToFormat));
-
-        if (pyVersion && (pyVersion.major < 3 || (pyVersion.major === 3 && pyVersion.minor < 6))) {
+        const processService = await ioc.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory)
+            .create(Uri.file(workspaceRootPath));
+        if (await isPythonVersionInProcess(processService, '2.7', '3.4', '3.5')) {
+            // Skip for versions of python below 3.6, as Black doesn't support them at all.
             // tslint:disable-next-line:no-invalid-this
             return this.skip();
         }

--- a/src/test/refactor/extension.refactor.extract.var.test.ts
+++ b/src/test/refactor/extension.refactor.extract.var.test.ts
@@ -8,8 +8,7 @@ import { PythonSettings } from '../../client/common/configSettings';
 import { getTextEditsFromPatch } from '../../client/common/editor';
 import { extractVariable } from '../../client/providers/simpleRefactorProvider';
 import { RefactorProxy } from '../../client/refactor/proxy';
-import { PythonVersionInformation } from '../../client/unittests/common/types';
-import { rootWorkspaceUri } from '../common';
+import { isPythonVersion } from '../common';
 import { UnitTestIocContainer } from '../unittests/serviceRegistry';
 import { closeActiveWindows, initialize, initializeTest, IS_CI_SERVER } from './../initialize';
 import { MockOutputChannel } from './../mockClasses';
@@ -84,9 +83,7 @@ suite('Variable Extraction', () => {
 
     // tslint:disable-next-line:no-function-expression
     test('Extract Variable', async function () {
-        const pyVersion: PythonVersionInformation = await ioc.getPythonMajorMinorVersion(rootWorkspaceUri);
-
-        if (pyVersion.major === 3 && pyVersion.minor === 7) {
+        if (isPythonVersion('3.7')) {
             // tslint:disable-next-line:no-invalid-this
             return this.skip();
         } else {

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// tslint:disable:no-multiline-string no-trailing-whitespace max-func-body-length no-any
+'use strict';
 
 import { expect } from 'chai';
 import * as fs from 'fs-extra';
@@ -16,14 +16,16 @@ import { BufferDecoder } from '../../../client/common/process/decoder';
 import { ProcessService } from '../../../client/common/process/proc';
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { IConfigurationService, IPythonSettings } from '../../../client/common/types';
+import { OSType } from '../../../client/common/utils/platform';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { CodeExecutionHelper } from '../../../client/terminals/codeExecution/helper';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
-import { PYTHON_PATH } from '../../common';
+import { PYTHON_PATH, shouldSkipForOs, shouldSkipForPythonVersion } from '../../common';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 
+// tslint:disable-next-line:max-func-body-length
 suite('Terminal - Code Execution Helper', () => {
     let documentManager: TypeMoq.IMock<IDocumentManager>;
     let applicationShell: TypeMoq.IMock<IApplicationShell>;
@@ -41,6 +43,7 @@ suite('Terminal - Code Execution Helper', () => {
         configService = TypeMoq.Mock.ofType<IConfigurationService>();
         const pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
         pythonSettings.setup(p => p.pythonPath).returns(() => PYTHON_PATH);
+        // tslint:disable-next-line:no-any
         processService.setup((x: any) => x.then).returns(() => undefined);
         configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
         envVariablesProvider.setup(e => e.getEnvironmentVariables(TypeMoq.It.isAny())).returns(() => Promise.resolve({}));
@@ -56,9 +59,6 @@ suite('Terminal - Code Execution Helper', () => {
         document = TypeMoq.Mock.ofType<TextDocument>();
         editor = TypeMoq.Mock.ofType<TextEditor>();
         editor.setup(e => e.document).returns(() => document.object);
-
-        // tslint:disable-next-line:no-invalid-this
-        // this.skip();
     });
 
     async function ensureBlankLinesAreRemoved(source: string, expectedSource: string) {
@@ -72,7 +72,16 @@ suite('Terminal - Code Execution Helper', () => {
         expectedSource = expectedSource.splitLines({ removeEmptyEntries: false, trim: false }).join(EOL);
         expect(normalizedZCode).to.be.equal(expectedSource);
     }
-    test('Ensure blank lines are NOT removed when code is not indented (simple)', async () => {
+    test('Ensure blank lines are NOT removed when code is not indented (simple)', async function () {
+        // This test has not been working for many months in Python 2.7 under
+        // Windows.Tracked by #2544.
+        if (shouldSkipForOs([OSType.Windows])) {
+            if (await shouldSkipForPythonVersion(['2.7'])) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         const code = ['import sys', '', '', '', 'print(sys.executable)', '', 'print("1234")', '', '', 'print(1)', 'print(2)'];
         const expectedCode = code.filter(line => line.trim().length > 0).join(EOL);
         await ensureBlankLinesAreRemoved(code.join(EOL), expectedCode);
@@ -89,17 +98,44 @@ suite('Terminal - Code Execution Helper', () => {
         expect(doubleCrIndex).to.be.equal(-1, 'Double CR (CRCRLF) line endings detected in normalized code snippet.');
     });
     ['', '1', '2', '3', '4', '5', '6', '7'].forEach(fileNameSuffix => {
-        test(`Ensure blank lines are removed (Sample${fileNameSuffix})`, async () => {
+        test(`Ensure blank lines are removed (Sample${fileNameSuffix})`, async function () {
+            // This test has not been working for many months in Python 2.7 under
+            // Windows.Tracked by #2544.
+            if (shouldSkipForOs([OSType.Windows])) {
+                if (await shouldSkipForPythonVersion(['2.7'])) {
+                    // tslint:disable-next-line:no-invalid-this
+                    return this.skip();
+                }
+            }
+
             const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
             const expectedCode = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`), 'utf8');
             await ensureBlankLinesAreRemoved(code, expectedCode);
         });
-        test(`Ensure last two blank lines are preserved (Sample${fileNameSuffix})`, async () => {
+        test(`Ensure last two blank lines are preserved (Sample${fileNameSuffix})`, async function () {
+            // This test has not been working for many months in Python 2.7 under
+            // Windows.Tracked by #2544.
+            if (shouldSkipForOs([OSType.Windows])) {
+                if (await shouldSkipForPythonVersion(['2.7'])) {
+                    // tslint:disable-next-line:no-invalid-this
+                    return this.skip();
+                }
+            }
+
             const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
             const expectedCode = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`), 'utf8');
             await ensureBlankLinesAreRemoved(code + EOL, expectedCode + EOL);
         });
-        test(`Ensure last two blank lines are preserved even if we have more than 2 trailing blank lines (Sample${fileNameSuffix})`, async () => {
+        test(`Ensure last two blank lines are preserved even if we have more than 2 trailing blank lines (Sample${fileNameSuffix})`, async function () {
+            // This test has not been working for many months in Python 2.7 under
+            // Windows.Tracked by #2544.
+            if (shouldSkipForOs([OSType.Windows])) {
+                if (await shouldSkipForPythonVersion(['2.7'])) {
+                    // tslint:disable-next-line:no-invalid-this
+                    return this.skip();
+                }
+            }
+
             const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
             const expectedCode = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`), 'utf8');
             await ensureBlankLinesAreRemoved(code + EOL + EOL + EOL + EOL, expectedCode + EOL);

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -21,7 +21,7 @@ import { IEnvironmentVariablesProvider } from '../../../client/common/variables/
 import { IServiceContainer } from '../../../client/ioc/types';
 import { CodeExecutionHelper } from '../../../client/terminals/codeExecution/helper';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
-import { PYTHON_PATH, shouldSkipForOs, shouldSkipForPythonVersion } from '../../common';
+import { isOs, isPythonVersion, PYTHON_PATH } from '../../common';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 
@@ -75,11 +75,9 @@ suite('Terminal - Code Execution Helper', () => {
     test('Ensure blank lines are NOT removed when code is not indented (simple)', async function () {
         // This test has not been working for many months in Python 2.7 under
         // Windows.Tracked by #2544.
-        if (shouldSkipForOs([OSType.Windows])) {
-            if (await shouldSkipForPythonVersion(['2.7'])) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
+        if (isOs(OSType.Windows) && await isPythonVersion('2.7')) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
         }
 
         const code = ['import sys', '', '', '', 'print(sys.executable)', '', 'print("1234")', '', '', 'print(1)', 'print(2)'];
@@ -101,11 +99,9 @@ suite('Terminal - Code Execution Helper', () => {
         test(`Ensure blank lines are removed (Sample${fileNameSuffix})`, async function () {
             // This test has not been working for many months in Python 2.7 under
             // Windows.Tracked by #2544.
-            if (shouldSkipForOs([OSType.Windows])) {
-                if (await shouldSkipForPythonVersion(['2.7'])) {
-                    // tslint:disable-next-line:no-invalid-this
-                    return this.skip();
-                }
+            if (isOs(OSType.Windows) && await isPythonVersion('2.7')) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
             }
 
             const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
@@ -115,11 +111,9 @@ suite('Terminal - Code Execution Helper', () => {
         test(`Ensure last two blank lines are preserved (Sample${fileNameSuffix})`, async function () {
             // This test has not been working for many months in Python 2.7 under
             // Windows.Tracked by #2544.
-            if (shouldSkipForOs([OSType.Windows])) {
-                if (await shouldSkipForPythonVersion(['2.7'])) {
-                    // tslint:disable-next-line:no-invalid-this
-                    return this.skip();
-                }
+            if (isOs(OSType.Windows) && await isPythonVersion('2.7')) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
             }
 
             const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
@@ -129,11 +123,9 @@ suite('Terminal - Code Execution Helper', () => {
         test(`Ensure last two blank lines are preserved even if we have more than 2 trailing blank lines (Sample${fileNameSuffix})`, async function () {
             // This test has not been working for many months in Python 2.7 under
             // Windows.Tracked by #2544.
-            if (shouldSkipForOs([OSType.Windows])) {
-                if (await shouldSkipForPythonVersion(['2.7'])) {
-                    // tslint:disable-next-line:no-invalid-this
-                    return this.skip();
-                }
+            if (isOs(OSType.Windows) && await isPythonVersion('2.7')) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
             }
 
             const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');

--- a/src/test/unittests/serviceRegistry.ts
+++ b/src/test/unittests/serviceRegistry.ts
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+'use strict';
+
 import { Uri } from 'vscode';
-import { IPythonExecutionFactory } from '../../client/common/process/types';
+import { IProcessServiceFactory } from '../../client/common/process/types';
 import { IServiceContainer } from '../../client/ioc/types';
-import { NOSETEST_PROVIDER, PYTEST_PROVIDER, UNITTEST_PROVIDER } from '../../client/unittests/common/constants';
+import {
+    NOSETEST_PROVIDER, PYTEST_PROVIDER,
+    UNITTEST_PROVIDER
+} from '../../client/unittests/common/constants';
 import { TestCollectionStorageService } from '../../client/unittests/common/services/storageService';
 import { TestManagerService } from '../../client/unittests/common/services/testManagerService';
 import { TestResultsService } from '../../client/unittests/common/services/testResultsService';
@@ -12,11 +17,12 @@ import { TestsHelper } from '../../client/unittests/common/testUtils';
 import { TestFlatteningVisitor } from '../../client/unittests/common/testVisitors/flatteningVisitor';
 import { TestFolderGenerationVisitor } from '../../client/unittests/common/testVisitors/folderGenerationVisitor';
 import { TestResultResetVisitor } from '../../client/unittests/common/testVisitors/resultResetVisitor';
-import { ITestResultsService, ITestsHelper, ITestsParser,
-    ITestVisitor, IUnitTestSocketServer,
-    PythonVersionInformation, TestProvider } from '../../client/unittests/common/types';
-// tslint:disable-next-line:no-duplicate-imports
-import { ITestCollectionStorageService, ITestDiscoveryService, ITestManager, ITestManagerFactory, ITestManagerService, ITestManagerServiceFactory } from '../../client/unittests/common/types';
+import {
+    ITestCollectionStorageService, ITestDiscoveryService, ITestManager,
+    ITestManagerFactory, ITestManagerService, ITestManagerServiceFactory,
+    ITestResultsService, ITestsHelper, ITestsParser, ITestVisitor,
+    IUnitTestSocketServer, PythonVersionInformation, TestProvider
+} from '../../client/unittests/common/types';
 import { TestManager as NoseTestManager } from '../../client/unittests/nosetest/main';
 import { TestDiscoveryService as NoseTestDiscoveryService } from '../../client/unittests/nosetest/services/discoveryService';
 import { TestsParser as NoseTestTestsParser } from '../../client/unittests/nosetest/services/parserService';
@@ -26,6 +32,7 @@ import { TestsParser as PytestTestsParser } from '../../client/unittests/pytest/
 import { TestManager as UnitTestTestManager } from '../../client/unittests/unittest/main';
 import { TestDiscoveryService as UnitTestTestDiscoveryService } from '../../client/unittests/unittest/services/discoveryService';
 import { TestsParser as UnitTestTestsParser } from '../../client/unittests/unittest/services/parserService';
+import { getPythonVersionString } from '../common';
 import { IocContainer } from '../serviceRegistry';
 import { MockUnitTestSocketServer } from './mocks';
 
@@ -33,30 +40,28 @@ export class UnitTestIocContainer extends IocContainer {
     constructor() {
         super();
     }
-    public getPythonMajorVersion(resource: Uri) {
-        return this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource })
-            .then(pythonProcess => pythonProcess.exec(['-c', 'import sys;print(sys.version_info[0])'], {}))
-            .then(output => parseInt(output.stdout.trim(), 10));
+    public getPythonMajorVersion(resource: Uri): Promise<number> {
+        return this.getPythonMajorMinorVersion(resource)
+            .then(versionInfo => versionInfo.major);
     }
 
     public getPythonMajorMinorVersionString(resource: Uri): Promise<string> {
-        return this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource })
-            .then(pythonProcess => pythonProcess.exec(['-c', 'import sys;print("{0}.{1}".format(*sys.version_info[:2]))'], {}))
-            .then(output => output.stdout.trim());
+        return this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory).create(resource)
+            .then(async (procService) => getPythonVersionString(procService));
     }
 
     public getPythonMajorMinorVersion(resource: Uri): Promise<PythonVersionInformation> {
-        return this.serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory).create({ resource })
-            .then(pythonProcess => pythonProcess.exec(['-c', 'import sys;print("{0}|{1}".format(*sys.version_info[:2]))'], {}))
+        return this.getPythonMajorMinorVersionString(resource)
             .then(output => {
-                const versionString: string = output.stdout.trim();
-                const versionInfo: string[] = versionString.split('|');
+                const versionString: string = output.trim();
+                const versionInfo: string[] = versionString.split('.');
                 return {
                     major: parseInt(versionInfo[0].trim(), 10),
                     minor: parseInt(versionInfo[1].trim(), 10)
                 };
             });
     }
+
     public registerTestVisitors() {
         this.serviceManager.add<ITestVisitor>(ITestVisitor, TestFlatteningVisitor, 'TestFlatteningVisitor');
         this.serviceManager.add<ITestVisitor>(ITestVisitor, TestFolderGenerationVisitor, 'TestFolderGenerationVisitor');

--- a/src/test/unittests/unittest/unittest.test.ts
+++ b/src/test/unittests/unittest/unittest.test.ts
@@ -114,7 +114,7 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
         assert.equal(testRunResult.summary.skipped, 0, `Expected to have skipped 0 tests during this test-run. Instead, ${testRunResult.summary.skipped} where skipped.`);
     });
 
-    test('Ensure correct test count for running a set of tests multiple times', async () => {
+    test('Ensure correct test count for running a set of tests multiple times', async function () {
         // This test has not been working for many months in Python 3.4 under
         // Windows and macOS.Tracked by #2548.
         if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
@@ -147,7 +147,16 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
         assert.equal(testRunResult.summary.passed, 2, 'This test was written assuming there was 2 tests run that would succeed. (iteration 2)');
     });
 
-    test('Re-run failed tests results in the correct number of tests counted', async () => {
+    test('Re-run failed tests results in the correct number of tests counted', async function () {
+        // This test has not been working for many months in Python 3.4 under
+        // Windows and macOS.Tracked by #2548.
+        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
+            if (await shouldSkipForPythonVersion(['3.4'])) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+        }
+
         await updateSetting('unitTest.unittestArgs', ['-s=./tests', '-p=test_*.py'], rootWorkspaceUri, configTarget);
         const factory = ioc.serviceContainer.get<ITestManagerFactory>(ITestManagerFactory);
         const testManager = factory('unittest', rootWorkspaceUri, UNITTEST_COUNTS_TEST_FILE_PATH);

--- a/src/test/unittests/unittest/unittest.test.ts
+++ b/src/test/unittests/unittest/unittest.test.ts
@@ -12,8 +12,8 @@ import {
     TestFunction, Tests, TestsToRun
 } from '../../../client/unittests/common/types';
 import {
-    rootWorkspaceUri, shouldSkipForOs,
-    shouldSkipForPythonVersion, updateSetting
+    isOs, isPythonVersion,
+    rootWorkspaceUri, updateSetting
 } from '../../common';
 import { UnitTestIocContainer } from '../serviceRegistry';
 import {
@@ -117,8 +117,8 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
     test('Ensure correct test count for running a set of tests multiple times', async function () {
         // This test has not been working for many months in Python 3.4 under
         // Windows and macOS.Tracked by #2548.
-        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
-            if (await shouldSkipForPythonVersion(['3.4'])) {
+        if (isOs(OSType.Windows, OSType.OSX)) {
+            if (await isPythonVersion('3.4')) {
                 // tslint:disable-next-line:no-invalid-this
                 return this.skip();
             }
@@ -150,8 +150,8 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
     test('Re-run failed tests results in the correct number of tests counted', async function () {
         // This test has not been working for many months in Python 3.4 under
         // Windows and macOS.Tracked by #2548.
-        if (shouldSkipForOs([OSType.Windows, OSType.OSX])) {
-            if (await shouldSkipForPythonVersion(['3.4'])) {
+        if (isOs(OSType.Windows, OSType.OSX)) {
+            if (await isPythonVersion('3.4')) {
                 // tslint:disable-next-line:no-invalid-this
                 return this.skip();
             }


### PR DESCRIPTION
For #2795

Specific known tests are disabled for specific OS and Python version test runs only. Once the rolling-CI build runs 'green' on Azure DevOps, we can turn on warnings as errors so that the build results become meaningful.

- Each disabled test is commented to indicate the issue that tracks it's re-enabling
- Common test utility code moved to `src/test/common.ts`

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
