### PR TITLE
Make a 2018.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2018.9.1 (18 Oct 2018)
+
+### Fixes
+
+1. Disable activation of conda environments in PowerShell.
+   ([#2732](https://github.com/Microsoft/vscode-python/issues/2732))
+1. Add logging along with some some improvements to the load times of the extension.
+   ([#2827](https://github.com/Microsoft/vscode-python/issues/2827))
+1. Stop `normalizationForInterpreter.py` script from returning CRCRLF line-endings.
+   ([#2857](https://github.com/Microsoft/vscode-python/issues/2857))
+
+### Code Health
+
+1. Add ability to publish extension builds from `release` branches into the blob store.
+   ([#2874](https://github.com/Microsoft/vscode-python/issues/2874))
+
+
 ## 2018.9.0 (9 Oct 2018)
 
 ### Thanks

--- a/news/2 Fixes/2732.md
+++ b/news/2 Fixes/2732.md
@@ -1,1 +1,0 @@
-Disable activation of conda environments in PowerShell.

--- a/news/2 Fixes/2827.md
+++ b/news/2 Fixes/2827.md
@@ -1,1 +1,0 @@
-Add logging along with some some improvements to the load times of the extension.

--- a/news/2 Fixes/2857.md
+++ b/news/2 Fixes/2857.md
@@ -1,1 +1,0 @@
-Stop `normalizationForInterpreter.py` script from returning CRCRLF line-endings.

--- a/news/3 Code Health/2874.md
+++ b/news/3 Code Health/2874.md
@@ -1,1 +1,0 @@
-Add ability to publish extension builds from `release` branches into the blob store.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "python",
-    "version": "2018.9.0",
+    "version": "2018.9.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
-    "version": "2018.9.0",
+    "version": "2018.9.1",
     "publisher": "ms-python",
     "author": {
         "name": "Microsoft Corporation"


### PR DESCRIPTION
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
