### PR TITLE
fixed some typos in comments

### DIFF
--- a/pythonFiles/completionServer.py
+++ b/pythonFiles/completionServer.py
@@ -20,7 +20,7 @@ from encodings import utf_8, ascii
 try:
     import thread
 except ImportError:
-    # Renamed in Python3k
+    # Renamed in Python 3
     import _thread as thread
 
 # Reference material
@@ -143,8 +143,8 @@ class jediSocketServer(object):
                 if self.check_for_exit_socket_loop():
                     break
 
-                # we receive a series of 4 byte commands.  Each command then
-                # has it's own format which we must parse before continuing to
+                # we receive a series of 4 byte commands. Each command then
+                # has its own format which we must parse before continuing to
                 # the next command.
                 self.flush()
                 self.conn.settimeout(10)


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
