### PR TITLE
Correct test failures related to the Black formatter.

### DIFF
--- a/news/3 Code Health/2999.md
+++ b/news/3 Code Health/2999.md
@@ -1,0 +1,1 @@
+Only perform Black-related formatting tests when the current Python-version supports it.

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -242,8 +242,8 @@ export function isVersionInList(version: SemVer, ...searchVersions: string[]): b
  * If you don't need to specify the environment (ie. the workspace) that the Python
  * interpreter is running under, use the simpler `isPythonVersion` instead.
  *
- * @param {skipForVersions} string[] List of versions of python that are to be skipped.
- * @param {resource} vscode.Uri Current workspace resource Uri or undefined.
+ * @param {procService} IProcessService Optionally, use this process service to call out to python with.
+ * @param {versions} string[] Python versions to test for, specified as described above.
  * @return true if the current Python version matches a version in the skip list, false otherwise.
  */
 export async function isPythonVersionInProcess(procService?: IProcessService, ...versions: string[]): Promise<boolean> {
@@ -274,7 +274,7 @@ export async function isPythonVersionInProcess(procService?: IProcessService, ..
  * If you need to specify the environment (ie. the workspace) that the Python
  * interpreter is running under, use `isPythonVersionInProcess` instead.
  *
- * @param {skipForVersions} string[] List of versions of python that are to be skipped.
+ * @param {versions} string[] List of versions of python that are to be skipped.
  * @param {resource} vscode.Uri Current workspace resource Uri or undefined.
  * @return true if the current Python version matches a version in the skip list, false otherwise.
  */


### PR DESCRIPTION
Fixes #2999

- Check for all unsupported versions of Python during formatter tests
- Skip unsupported versions
- Rename test suite to make it more grep-able

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
