### PR TITLE
add missing RU translation entry

### DIFF
--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -21,7 +21,7 @@
     "python.command.python.setLinter.title": "Выбрать анализатор кода",
     "python.command.python.enableLinting.title": "Включить анализатор кода",
     "python.command.python.runLinting.title": "Выполнить анализ кода",
-    "python.snippet.launch.standard.label": "Python: Current File",
+    "python.snippet.launch.standard.label": "Python: Текущий файл",
     "python.snippet.launch.standard.description": "Отладить программу Python со стандартным выводом",
     "python.snippet.launch.pyspark.label": "Python: PySpark",
     "python.snippet.launch.pyspark.description": "Отладка PySpark",


### PR DESCRIPTION
Looks like translation for `python.snippet.launch.standard.label` was missing

For #

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
