### PR TITLE
Add missing commands in russian translation

### DIFF
--- a/package.nls.ru.json
+++ b/package.nls.ru.json
@@ -15,6 +15,7 @@
     "python.command.python.selectAndRunTestFile.title": "Запустить тестовый файл...",
     "python.command.python.runCurrentTestFile.title": "Запустить текущий тестовый файл",
     "python.command.python.runFailedTests.title": "Запустить непрошедшие тесты",
+    "python.command.python.discoverTests.title": "Обнаружить тесты",
     "python.command.python.execSelectionInTerminal.title": "Выполнить выбранный текст или текущую строку в консоли",
     "python.command.python.execSelectionInDjangoShell.title": "Выполнить выбранный текст или текущую строку в оболочке Django",
     "python.command.python.goToPythonObject.title": "Перейти к объекту Python",
@@ -37,6 +38,8 @@
     "python.snippet.launch.flask.description": "Отладка приложения Flask",
     "python.snippet.launch.flaskOld.label": "Python: Flask (0.10.x или старее)",
     "python.snippet.launch.flaskOld.description": "Отладка приложения Flask (старый стиль)",
+    "python.snippet.launch.gevent.label": "Python: Gevent",
+    "python.snippet.launch.gevent.description": "Отладка приложения Gevent",
     "python.snippet.launch.pyramid.label": "Python: Приложение Pyramid",
     "python.snippet.launch.pyramid.description": "Отладка приложения Pyramid",
     "python.snippet.launch.watson.label": "Python: Приложение Watson",
@@ -44,5 +47,8 @@
     "python.snippet.launch.attach.label": "Python: Подключить отладчик",
     "python.snippet.launch.attach.description": "Подключить отладчик для удаленной отладки",
     "python.snippet.launch.scrapy.label": "Python: Scrapy",
-    "python.snippet.launch.scrapy.description": "Scrapy в интегрированной консоли"
+    "python.snippet.launch.scrapy.description": "Scrapy в интегрированной консоли",
+    "LanguageServiceSurveyBanner.bannerMessage": "Не могли бы вы уделить 2 минуты, чтобы рассказать нам насколько хорошо у вас работает Python Language Server?",
+    "LanguageServiceSurveyBanner.bannerLabelYes": "Да, пройти опрос сейчас",
+    "LanguageServiceSurveyBanner.bannerLabelNo": "Нет, спасибо"
 }


### PR DESCRIPTION
Added several commands not previously translated

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
