### PR TITLE
Move language server downloads to the CDN

### DIFF
--- a/news/3 Code Health/3000.md
+++ b/news/3 Code Health/3000.md
@@ -1,0 +1,1 @@
+Move language server downloads to the CDN.

--- a/src/client/activation/languageServer/languageServerPackageRepository.ts
+++ b/src/client/activation/languageServer/languageServerPackageRepository.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import { AzureBlobStoreNugetRepository } from '../../common/nuget/azureBlobStoreNugetRepository';
 import { IServiceContainer } from '../../ioc/types';
 
-const azureBlobStorageAccount = 'https://pvsc.blob.core.windows.net';
+const azureBlobStorageAccount = 'https://pvsc.azureedge.net';
 
 export enum LanguageServerDownloadChannel {
     stable = 'stable',

--- a/src/test/activation/languageServer/languageServerPackageRepository.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageRepository.unit.test.ts
@@ -42,12 +42,12 @@ suite('Language Server Download Channels', () => {
         return [instance.storageAccount, instance.storageContainer];
     }
     test('Stable', () => {
-        expect(getPackageInfo(LanguageServerDownloadChannel.stable)).to.be.deep.equal(['https://pvsc.blob.core.windows.net', 'python-language-server-stable']);
+        expect(getPackageInfo(LanguageServerDownloadChannel.stable)).to.be.deep.equal(['https://pvsc.azureedge.net', 'python-language-server-stable']);
     });
     test('Beta', () => {
-        expect(getPackageInfo(LanguageServerDownloadChannel.beta)).to.be.deep.equal(['https://pvsc.blob.core.windows.net', 'python-language-server-beta']);
+        expect(getPackageInfo(LanguageServerDownloadChannel.beta)).to.be.deep.equal(['https://pvsc.azureedge.net', 'python-language-server-beta']);
     });
     test('Daily', () => {
-        expect(getPackageInfo(LanguageServerDownloadChannel.daily)).to.be.deep.equal(['https://pvsc.blob.core.windows.net', 'python-language-server-daily']);
+        expect(getPackageInfo(LanguageServerDownloadChannel.daily)).to.be.deep.equal(['https://pvsc.azureedge.net', 'python-language-server-daily']);
     });
 });

--- a/src/test/activation/languageServer/languageServerPackageService.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.test.ts
@@ -76,7 +76,7 @@ suite('Language Server Package Service', () => {
         const platformService = new PlatformService();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IPlatformService))).returns(() => platformService);
         const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
-        const nugetRepo = new AzureBlobStoreNugetRepository(serviceContainer.object, 'https://pvsc.blob.core.windows.net', defaultStorageChannel);
+        const nugetRepo = new AzureBlobStoreNugetRepository(serviceContainer.object, 'https://pvsc.azureedge.net', defaultStorageChannel);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetRepository))).returns(() => nugetRepo);
         const lsPackageService = new LanguageServerPackageService(serviceContainer.object);
         const packageName = lsPackageService.getNugetPackageName();

--- a/src/test/common/nuget/azureBobStoreRepository.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.test.ts
@@ -29,7 +29,7 @@ suite('Nuget Azure Storage Repository', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nugetService.object);
         const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
 
-        repo = new AzureBlobStoreNugetRepository(serviceContainer.object, 'https://pvsc.blob.core.windows.net', defaultStorageChannel);
+        repo = new AzureBlobStoreNugetRepository(serviceContainer.object, 'https://pvsc.azureedge.net', defaultStorageChannel);
     });
 
     test('Get all packages', async function () {


### PR DESCRIPTION
For #3000

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
