### PR TITLE
Refresh list of interpreters if python env is created in workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ npm-debug.log
 !yarn.lock
 coverage/
 .vscode-test/**
-.venv*/
+**/.venv*/
 precommit.hook
 pythonFiles/experimental/ptvsd/**
 debug_coverage*/**

--- a/news/1 Enhancements/656.md
+++ b/news/1 Enhancements/656.md
@@ -1,1 +1,1 @@
-Clear cached list of interpreters when an interpeter is created in the workspace folder.
+Clear cached list of interpreters when an interpeter is created in the workspace folder (this allows for virtual environments created in one's workspace folder to be detectable immediately).

--- a/news/1 Enhancements/656.md
+++ b/news/1 Enhancements/656.md
@@ -1,0 +1,1 @@
+Clear cached list of interpreters when an interpeter is created in the workspace folder.

--- a/src/client/common/application/debugService.ts
+++ b/src/client/common/application/debugService.ts
@@ -38,7 +38,7 @@ export class DebugService implements IDebugService {
     public registerDebugConfigurationProvider(debugType: string, provider: any): Disposable {
         return debug.registerDebugConfigurationProvider(debugType, provider);
     }
-    public startDebugging(folder: WorkspaceFolder, nameOrConfiguration: string | DebugConfiguration): Thenable<boolean> {
+    public startDebugging(folder: WorkspaceFolder | undefined, nameOrConfiguration: string | DebugConfiguration): Thenable<boolean> {
         return debug.startDebugging(folder, nameOrConfiguration);
     }
     public addBreakpoints(breakpoints: Breakpoint[]): void {

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -75,6 +75,16 @@ export const STANDARD_OUTPUT_CHANNEL = 'STANDARD_OUTPUT_CHANNEL';
 export function isTestExecution(): boolean {
     return process.env.VSC_PYTHON_CI_TEST === '1';
 }
+
+/**
+ * Whether we're running unit tests (*.unit.test.ts).
+ * These tests have a speacial meaning, they run fast.
+ * @export
+ * @returns {boolean}
+ */
+export function isUnitTestExecution(): boolean {
+    return process.env.VSC_PYTHON_UNIT_TEST === '1';
+}
 export function isLanguageServerTest(): boolean {
     return process.env.VSC_PYTHON_LANGUAGE_SERVER === '1';
 }

--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -16,6 +16,10 @@ export class Logger implements ILogger {
     public static warn(title: string = '', message: any = '') {
         new Logger().logWarning(`${title}, ${message}`);
     }
+    // tslint:disable-next-line:no-any
+    public static verbose(title: string = '') {
+        new Logger().logInformation(title);
+    }
     @skipIfTest(false)
     public logError(message: string, ex?: Error) {
         if (ex) {

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { isTestExecution } from '../constants';
+import { isTestExecution, isUnitTestExecution } from '../constants';
 
 /**
  * Debounces a function execution. Function must return either a void or a promise that resolves to a void.
@@ -11,6 +11,8 @@ export function debounce(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
     return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<any>) {
         const originalMethod = descriptor.value!;
+        // If running tests, lets not debounce (so tests run fast).
+        wait = wait && isUnitTestExecution() ? undefined : wait;
         // tslint:disable-next-line:no-invalid-this no-any
         (descriptor as any).value = _.debounce(function () { return originalMethod.apply(this, arguments); }, wait);
     };

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -1,9 +1,6 @@
 import * as _ from 'lodash';
 import { isTestExecution } from '../constants';
 
-type AsyncVoidAction = (...params: {}[]) => Promise<void>;
-type VoidAction = (...params: {}[]) => void;
-
 /**
  * Debounces a function execution. Function must return either a void or a promise that resolves to a void.
  * @export
@@ -12,7 +9,7 @@ type VoidAction = (...params: {}[]) => void;
  */
 export function debounce(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidAction> | TypedPropertyDescriptor<AsyncVoidAction>) {
+    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<any>) {
         const originalMethod = descriptor.value!;
         // tslint:disable-next-line:no-invalid-this no-any
         (descriptor as any).value = _.debounce(function () { return originalMethod.apply(this, arguments); }, wait);

--- a/src/client/debugger/extension/hooks/constants.ts
+++ b/src/client/debugger/extension/hooks/constants.ts
@@ -5,8 +5,5 @@
 
 export enum PTVSDEvents {
     // Event sent by PTVSD when a child process is launched and ready to be attached to for multi-proc debugging.
-    ChildProcessLaunched = 'ptvsd_subprocess',
-
-    // Event sent by PTVSD when a process is started (identital to the `process` event in debugger protocol).
-    ProcessLaunched = 'ptvsd_process'
+    ChildProcessLaunched = 'ptvsd_subprocess'
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -41,6 +41,7 @@ import { registerTypes as formattersRegisterTypes } from './formatters/serviceRe
 import { IInterpreterSelector } from './interpreter/configuration/types';
 import { ICondaService, IInterpreterService, PythonInterpreter } from './interpreter/contracts';
 import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
+import { setServiceContainer } from './ioc';
 import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
@@ -72,6 +73,7 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     const cont = new Container();
     const serviceManager = new ServiceManager(cont);
     const serviceContainer = new ServiceContainer(cont);
+    setServiceContainer(serviceContainer);
     registerServices(context, serviceManager, serviceContainer);
     initializeServices(context, serviceManager, serviceContainer);
 

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -41,7 +41,6 @@ import { registerTypes as formattersRegisterTypes } from './formatters/serviceRe
 import { IInterpreterSelector } from './interpreter/configuration/types';
 import { ICondaService, IInterpreterService, PythonInterpreter } from './interpreter/contracts';
 import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
-import { setServiceContainer } from './ioc';
 import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
@@ -73,7 +72,7 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     const cont = new Container();
     const serviceManager = new ServiceManager(cont);
     const serviceContainer = new ServiceContainer(cont);
-    setServiceContainer(serviceContainer);
+
     registerServices(context, serviceManager, serviceContainer);
     initializeServices(context, serviceManager, serviceContainer);
 
@@ -159,7 +158,10 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     durations.endActivateTime = stopWatch.elapsedTime;
     activationDeferred.resolve();
 
-    return { ready: activationDeferred.promise };
+    // In test environment return the DI Container.
+    const diContainer = isTestExecution() ? serviceContainer : undefined;
+    // tslint:disable-next-line:no-any
+    return { ready: activationDeferred.promise, diContainer } as any as IExtensionApi;
 }
 
 function registerServices(context: ExtensionContext, serviceManager: ServiceManager, serviceContainer: ServiceContainer) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -158,10 +158,13 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     durations.endActivateTime = stopWatch.elapsedTime;
     activationDeferred.resolve();
 
+    const api = { ready: activationDeferred.promise };
     // In test environment return the DI Container.
-    const diContainer = isTestExecution() ? serviceContainer : undefined;
-    // tslint:disable-next-line:no-any
-    return { ready: activationDeferred.promise, diContainer } as any as IExtensionApi;
+    if (isTestExecution()) {
+        // tslint:disable-next-line:no-any
+        (api as any).serviceContainer = serviceContainer;
+    }
+    return api;
 }
 
 function registerServices(context: ExtensionContext, serviceManager: ServiceManager, serviceContainer: ServiceContainer) {

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -116,3 +116,13 @@ export const IInterpreterLocatorHelper = Symbol('IInterpreterLocatorHelper');
 export interface IInterpreterLocatorHelper {
     mergeInterpreters(interpreters: PythonInterpreter[]): PythonInterpreter[];
 }
+
+export const IInterpreterWatcher = Symbol('IInterpreterWatcher');
+export interface IInterpreterWatcher {
+    onDidCreate: Event<void>;
+}
+
+export const IInterpreterWatcherBuilder = Symbol('IInterpreterWatcherBuilder');
+export interface IInterpreterWatcherBuilder {
+    getWorkspaceVirtualEnvInterpreterWatcher(resource: Uri | undefined): Promise<IInterpreterWatcher>;
+}

--- a/src/client/interpreter/locators/services/cacheableLocatorService.ts
+++ b/src/client/interpreter/locators/services/cacheableLocatorService.ts
@@ -59,9 +59,7 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
         watchers.forEach(watcher => {
             watcher.onDidCreate(() => {
                 Logger.verbose(`Interpreter Watcher change handler for ${this.cacheKeyPrefix}`);
-                // Clear and load the items in the background.
                 this.promisesPerResource.delete(cacheKey);
-                // setTimeout(() => this.getInterpreters(resource).ignoreErrors(), 100);
             }, this, disposableRegisry);
         });
     }
@@ -70,7 +68,7 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
     }
 
     protected abstract getInterpretersImplementation(resource?: Uri): Promise<PythonInterpreter[]>;
-    private createPersistenceStore(resource?: Uri) {
+    protected createPersistenceStore(resource?: Uri) {
         const cacheKey = this.getCacheKey(resource);
         const persistentFactory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         if (this.cachePerWorkspace) {
@@ -80,7 +78,7 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
         }
 
     }
-    private getCachedInterpreters(resource?: Uri) {
+    protected getCachedInterpreters(resource?: Uri): PythonInterpreter[] | undefined {
         const persistence = this.createPersistenceStore(resource);
         if (!Array.isArray(persistence.value)) {
             return;
@@ -92,11 +90,11 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
             };
         });
     }
-    private async cacheInterpreters(interpreters: PythonInterpreter[], resource?: Uri) {
+    protected async cacheInterpreters(interpreters: PythonInterpreter[], resource?: Uri) {
         const persistence = this.createPersistenceStore(resource);
         await persistence.updateValue(interpreters);
     }
-    private getCacheKey(resource?: Uri) {
+    protected getCacheKey(resource?: Uri) {
         if (!resource || !this.cachePerWorkspace) {
             return this.cacheKeyPrefix;
         }

--- a/src/client/interpreter/locators/services/interpreterWatcherBuilder.ts
+++ b/src/client/interpreter/locators/services/interpreterWatcherBuilder.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { IWorkspaceService } from '../../../common/application/types';
+import { traceVerbose } from '../../../common/logger';
+import { createDeferred } from '../../../common/utils/async';
+import { IServiceContainer } from '../../../ioc/types';
+import { IInterpreterWatcher, IInterpreterWatcherBuilder, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../contracts';
+import { WorkspaceVirtualEnvWatcherService } from './workspaceVirtualEnvWatcherService';
+
+@injectable()
+export class InterpreterWatcherBuilder implements IInterpreterWatcherBuilder {
+    private readonly watchersByResource = new Map<string, Promise<IInterpreterWatcher>>();
+    constructor(@inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer
+    ) { }
+
+    @traceVerbose('Build the workspace interpreter watcher')
+    public async getWorkspaceVirtualEnvInterpreterWatcher(resource: Uri | undefined): Promise<IInterpreterWatcher> {
+        const key = this.getResourceKey(resource);
+        if (!this.watchersByResource.has(key)) {
+            const deferred = createDeferred<IInterpreterWatcher>();
+            this.watchersByResource.set(key, deferred.promise);
+            const watcher = this.serviceContainer.get<WorkspaceVirtualEnvWatcherService>(IInterpreterWatcher, WORKSPACE_VIRTUAL_ENV_SERVICE);
+            await watcher.register(resource);
+            deferred.resolve(watcher);
+        }
+        return this.watchersByResource.get(key)!;
+    }
+    protected getResourceKey(resource: Uri | undefined): string {
+        const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
+        return workspaceFolder ? workspaceFolder.uri.fsPath : '';
+    }
+}

--- a/src/client/interpreter/locators/services/interpreterWatcherBuilder.ts
+++ b/src/client/interpreter/locators/services/interpreterWatcherBuilder.ts
@@ -15,6 +15,13 @@ import { WorkspaceVirtualEnvWatcherService } from './workspaceVirtualEnvWatcherS
 @injectable()
 export class InterpreterWatcherBuilder implements IInterpreterWatcherBuilder {
     private readonly watchersByResource = new Map<string, Promise<IInterpreterWatcher>>();
+    /**
+     * Creates an instance of InterpreterWatcherBuilder.
+     * Inject the DI container, as we need to get a new instance of IInterpreterWatcher to build it.
+     * @param {IWorkspaceService} workspaceService
+     * @param {IServiceContainer} serviceContainer
+     * @memberof InterpreterWatcherBuilder
+     */
     constructor(@inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer
     ) { }
@@ -26,7 +33,7 @@ export class InterpreterWatcherBuilder implements IInterpreterWatcherBuilder {
             const deferred = createDeferred<IInterpreterWatcher>();
             this.watchersByResource.set(key, deferred.promise);
             const watcher = this.serviceContainer.get<WorkspaceVirtualEnvWatcherService>(IInterpreterWatcher, WORKSPACE_VIRTUAL_ENV_SERVICE);
-            await watcher.register(resource);
+            await watcher.register();
             deferred.resolve(watcher);
         }
         return this.watchersByResource.get(key)!;

--- a/src/client/interpreter/locators/services/interpreterWatcherBuilder.ts
+++ b/src/client/interpreter/locators/services/interpreterWatcherBuilder.ts
@@ -33,7 +33,7 @@ export class InterpreterWatcherBuilder implements IInterpreterWatcherBuilder {
             const deferred = createDeferred<IInterpreterWatcher>();
             this.watchersByResource.set(key, deferred.promise);
             const watcher = this.serviceContainer.get<WorkspaceVirtualEnvWatcherService>(IInterpreterWatcher, WORKSPACE_VIRTUAL_ENV_SERVICE);
-            await watcher.register();
+            await watcher.register(resource);
             deferred.resolve(watcher);
         }
         return this.watchersByResource.get(key)!;

--- a/src/client/interpreter/locators/services/workspaceVirtualEnvService.ts
+++ b/src/client/interpreter/locators/services/workspaceVirtualEnvService.ts
@@ -19,11 +19,11 @@ export class WorkspaceVirtualEnvService extends BaseVirtualEnvService {
     public constructor(
         @inject(IVirtualEnvironmentsSearchPathProvider) @named('workspace') workspaceVirtualEnvPathProvider: IVirtualEnvironmentsSearchPathProvider,
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
-        @inject(IInterpreterWatcherBuilder) private readonly watcherFactory: IInterpreterWatcherBuilder) {
+        @inject(IInterpreterWatcherBuilder) private readonly builder: IInterpreterWatcherBuilder) {
         super(workspaceVirtualEnvPathProvider, serviceContainer, 'WorkspaceVirtualEnvService', true);
     }
     protected async getInterpreterWatchers(resource: Uri | undefined): Promise<IInterpreterWatcher[]> {
-        return [await this.watcherFactory.getWorkspaceVirtualEnvInterpreterWatcher(resource)];
+        return [await this.builder.getWorkspaceVirtualEnvInterpreterWatcher(resource)];
     }
 }
 

--- a/src/client/interpreter/locators/services/workspaceVirtualEnvService.ts
+++ b/src/client/interpreter/locators/services/workspaceVirtualEnvService.ts
@@ -11,15 +11,19 @@ import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../../common/application/types';
 import { IConfigurationService } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
-import { IVirtualEnvironmentsSearchPathProvider } from '../../contracts';
+import { IInterpreterWatcher, IInterpreterWatcherBuilder, IVirtualEnvironmentsSearchPathProvider } from '../../contracts';
 import { BaseVirtualEnvService } from './baseVirtualEnvService';
 
 @injectable()
 export class WorkspaceVirtualEnvService extends BaseVirtualEnvService {
     public constructor(
-        @inject(IVirtualEnvironmentsSearchPathProvider) @named('workspace') globalVirtualEnvPathProvider: IVirtualEnvironmentsSearchPathProvider,
-        @inject(IServiceContainer) serviceContainer: IServiceContainer) {
-        super(globalVirtualEnvPathProvider, serviceContainer, 'WorkspaceVirtualEnvService', true);
+        @inject(IVirtualEnvironmentsSearchPathProvider) @named('workspace') workspaceVirtualEnvPathProvider: IVirtualEnvironmentsSearchPathProvider,
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(IInterpreterWatcherBuilder) private readonly watcherFactory: IInterpreterWatcherBuilder) {
+        super(workspaceVirtualEnvPathProvider, serviceContainer, 'WorkspaceVirtualEnvService', true);
+    }
+    protected async getInterpreterWatchers(resource: Uri | undefined): Promise<IInterpreterWatcher[]> {
+        return [await this.watcherFactory.getWorkspaceVirtualEnvInterpreterWatcher(resource)];
     }
 }
 

--- a/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
+++ b/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
@@ -37,7 +37,7 @@ export class WorkspaceVirtualEnvWatcherService implements IInterpreterWatcher, D
         }
 
         const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
-        const executable = this.platformService.isWindows ? 'python.exe' : 'python';
+        const executable = this.platformService.isWindows ? 'python*.exe' : 'python*';
         const pattern = path.join('**', executable);
         const globPatern = workspaceFolder ? new RelativePattern(workspaceFolder.uri.fsPath, pattern) : pattern;
         Logger.verbose(`Create file systemwatcher with pattern ${pattern}`);

--- a/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
+++ b/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
@@ -51,7 +51,7 @@ export class WorkspaceVirtualEnvWatcherService implements IInterpreterWatcher {
                 Logger.verbose(`Create file systemwatcher with pattern ${pattern}, for ${rootDir}`);
 
                 const fsWatcher = this.workspaceService.createFileSystemWatcher(pattern);
-                fsWatcher.onDidCreate(e => this.createHandler(e, pathsToWatch), this, this.disposableRegistry);
+                fsWatcher.onDidCreate(e => this.createHandler(e), this, this.disposableRegistry);
 
                 this.disposableRegistry.push(fsWatcher);
                 this.fsWatchers.push(fsWatcher);
@@ -60,13 +60,7 @@ export class WorkspaceVirtualEnvWatcherService implements IInterpreterWatcher {
     }
     @debounce(2000)
     @traceVerbose('Intepreter Watcher change handler')
-    protected createHandler(e: Uri, pathsToCheck: string[]) {
-        const hasMatch = pathsToCheck.some(pathToCheck => e.fsPath.startsWith(pathToCheck));
-        if (!hasMatch) {
-            return;
-        }
-        Logger.verbose(`Invoked ${e.fsPath}`);
-        // Notifiy within a second
+    protected createHandler(e: Uri) {
         this.didCreate.fire();
         // On Windows, creation of environments are slow, hence lets notify again after 10 seconds.
         setTimeout(() => this.didCreate.fire(), 10000);

--- a/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
+++ b/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable, named } from 'inversify';
+import * as path from 'path';
+import { Disposable, Event, EventEmitter, FileSystemWatcher, Uri } from 'vscode';
+import { IWorkspaceService } from '../../../common/application/types';
+import { Logger, traceVerbose } from '../../../common/logger';
+import { IPlatformService } from '../../../common/platform/types';
+import { IDisposableRegistry } from '../../../common/types';
+import { debounce } from '../../../common/utils/decorators';
+import { IInterpreterWatcher, IVirtualEnvironmentsSearchPathProvider } from '../../contracts';
+
+@injectable()
+export class WorkspaceVirtualEnvWatcherService implements IInterpreterWatcher {
+    private readonly didCreate = new EventEmitter<void>();
+    private fsWatchers: FileSystemWatcher[] = [];
+    constructor(@inject(IDisposableRegistry) private readonly disposableRegistry: Disposable[],
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IVirtualEnvironmentsSearchPathProvider) @named('workspace') private readonly workspaceVirtualEnvPathProvider: IVirtualEnvironmentsSearchPathProvider,
+        @inject(IPlatformService) private readonly platformService: IPlatformService) {
+    }
+    public get onDidCreate(): Event<void> {
+        return this.didCreate.event;
+    }
+    @traceVerbose('Register Intepreter Watcher')
+    public async register(resource: Uri | undefined): Promise<void> {
+        if (this.fsWatchers.length > 0) {
+            return;
+        }
+        const pathsToWatch = await this.workspaceVirtualEnvPathProvider.getSearchPaths(resource);
+        const patterns: string[] = [];
+        if (this.platformService.isWindows) {
+            patterns.push(...[
+                path.join('**', '*python*.exe'),
+                path.join('**', '*Python*.exe'),
+                path.join('**', 'Scripts', 'activate.*'),
+                path.join('**', 'Scripts', 'Activate.*')
+            ]);
+        } else {
+            patterns.push(...[
+                path.join('**', '*python*'),
+                path.join('*', 'bin', 'activate*')
+            ]);
+        }
+
+        for (const rootDir of pathsToWatch) {
+            for (const pattern of patterns) {
+                Logger.verbose(`Create file systemwatcher with pattern ${pattern}, for ${rootDir}`);
+
+                const fsWatcher = this.workspaceService.createFileSystemWatcher(pattern);
+                fsWatcher.onDidCreate(e => this.createHandler(e, pathsToWatch), this, this.disposableRegistry);
+
+                this.disposableRegistry.push(fsWatcher);
+                this.fsWatchers.push(fsWatcher);
+            }
+        }
+    }
+    @debounce(2000)
+    @traceVerbose('Intepreter Watcher change handler')
+    protected createHandler(e: Uri, pathsToCheck: string[]) {
+        const hasMatch = pathsToCheck.some(pathToCheck => e.fsPath.startsWith(pathToCheck));
+        if (!hasMatch) {
+            return;
+        }
+        Logger.verbose(`Invoked ${e.fsPath}`);
+        // Notifiy within a second
+        this.didCreate.fire();
+        // On Windows, creation of environments are slow, hence lets notify again after 10 seconds.
+        setTimeout(() => this.didCreate.fire(), 10000);
+    }
+}

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -61,7 +61,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
     serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
 
-    serviceManager.addSingleton<IInterpreterWatcher>(IInterpreterWatcher, WorkspaceVirtualEnvWatcherService, WORKSPACE_VIRTUAL_ENV_SERVICE);
+    serviceManager.add<IInterpreterWatcher>(IInterpreterWatcher, WorkspaceVirtualEnvWatcherService, WORKSPACE_VIRTUAL_ENV_SERVICE);
     serviceManager.addSingleton<IInterpreterWatcherBuilder>(IInterpreterWatcherBuilder, InterpreterWatcherBuilder);
 
     serviceManager.addSingleton<IInterpreterVersionService>(IInterpreterVersionService, InterpreterVersionService);

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -20,6 +20,8 @@ import {
     IInterpreterLocatorService,
     IInterpreterService,
     IInterpreterVersionService,
+    IInterpreterWatcher,
+    IInterpreterWatcherBuilder,
     IKnownSearchPathsForInterpreters,
     INTERPRETER_LOCATOR_SERVICE,
     IPipEnvService,
@@ -42,10 +44,12 @@ import { CondaEnvService } from './locators/services/condaEnvService';
 import { CondaService } from './locators/services/condaService';
 import { CurrentPathService } from './locators/services/currentPathService';
 import { GlobalVirtualEnvironmentsSearchPathProvider, GlobalVirtualEnvService } from './locators/services/globalVirtualEnvService';
+import { InterpreterWatcherBuilder } from './locators/services/interpreterWatcherBuilder';
 import { KnownPathsService, KnownSearchPathsForInterpreters } from './locators/services/KnownPathsService';
 import { PipEnvService } from './locators/services/pipEnvService';
 import { WindowsRegistryService } from './locators/services/windowsRegistryService';
 import { WorkspaceVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvService } from './locators/services/workspaceVirtualEnvService';
+import { WorkspaceVirtualEnvWatcherService } from './locators/services/workspaceVirtualEnvWatcherService';
 import { VirtualEnvironmentManager } from './virtualEnvs/index';
 import { IVirtualEnvironmentManager } from './virtualEnvs/types';
 
@@ -56,6 +60,9 @@ export function registerTypes(serviceManager: IServiceManager) {
 
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
     serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
+
+    serviceManager.addSingleton<IInterpreterWatcher>(IInterpreterWatcher, WorkspaceVirtualEnvWatcherService, WORKSPACE_VIRTUAL_ENV_SERVICE);
+    serviceManager.addSingleton<IInterpreterWatcherBuilder>(IInterpreterWatcherBuilder, InterpreterWatcherBuilder);
 
     serviceManager.addSingleton<IInterpreterVersionService>(IInterpreterVersionService, InterpreterVersionService);
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PythonInterpreterLocatorService, INTERPRETER_LOCATOR_SERVICE);

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { coerce, SemVer } from 'semver';
 import { ConfigurationTarget, Uri, workspace } from 'vscode';
+import { IExtensionApi } from '../client/api';
 import { PythonSettings } from '../client/common/configSettings';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 import { traceError } from '../client/common/logger';
@@ -11,6 +12,7 @@ import { BufferDecoder } from '../client/common/process/decoder';
 import { ProcessService } from '../client/common/process/proc';
 import { IProcessService } from '../client/common/process/types';
 import { getOSType, OSType } from '../client/common/utils/platform';
+import { IServiceContainer } from '../client/ioc/types';
 import { IS_MULTI_ROOT_TEST } from './initialize';
 
 export { sleep } from './core';
@@ -287,4 +289,8 @@ export async function isPythonVersion(...versions: string[]): Promise<boolean> {
         traceError(`Failed to determine the current Python version when comparing against list [${versions.join(', ')}].`);
         return false;
     }
+}
+
+export interface IExtensionTestApi extends IExtensionApi {
+    serviceContainer: IServiceContainer;
 }

--- a/src/test/debugger/extension/configProvider/provider.unit.test.ts
+++ b/src/test/debugger/extension/configProvider/provider.unit.test.ts
@@ -24,7 +24,7 @@ import { DebugOptions, LaunchRequestArguments } from '../../../../client/debugge
 import { IInterpreterHelper } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
 
-suite('Debuggingx - Config Provider', () => {
+suite('Debugging - Config Provider', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let debugProvider: DebugConfigurationProvider;
     let platformService: TypeMoq.IMock<IPlatformService>;
@@ -60,7 +60,6 @@ suite('Debuggingx - Config Provider', () => {
         diagnosticsService
             .setup(h => h.validatePythonPath(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(true));
-        const pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
 
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPythonExecutionFactory))).returns(() => factory.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IConfigurationService))).returns(() => confgService.object);
@@ -455,7 +454,6 @@ suite('Debuggingx - Config Provider', () => {
         const debugConfiguration: DebugConfiguration = { request: requestType, type: 'python', name: '', ...settings };
         const workspaceFolder = createMoqWorkspaceFolder(__dirname);
 
-
         const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, debugConfiguration);
         if (mustHaveDebugOption) {
             expect((debugConfig as any).debugOptions).contains(debugOptionName);
@@ -463,7 +461,9 @@ suite('Debuggingx - Config Provider', () => {
             expect((debugConfig as any).debugOptions).not.contains(debugOptionName);
         }
     }
-    ['launch', 'attach'].forEach((requestType: 'launch' | 'attach') => {
+    type LaunchOrAttach = 'launch' | 'attach';
+    const items: LaunchOrAttach[] = ['launch', 'attach'];
+    items.forEach(requestType => {
         test(`Must not contain Sub Process when not specified (${requestType})`, async () => {
             await testSetting(requestType, {}, DebugOptions.SubProcess, false);
         });

--- a/src/test/debugger/extension/hooks/childProcessAttachHandler.unit.test.ts
+++ b/src/test/debugger/extension/hooks/childProcessAttachHandler.unit.test.ts
@@ -10,7 +10,7 @@ import { ChildProcessAttachEventHandler } from '../../../../client/debugger/exte
 import { ChildProcessAttachService } from '../../../../client/debugger/extension/hooks/childProcessAttachService';
 import { PTVSDEvents } from '../../../../client/debugger/extension/hooks/constants';
 
-suite('Debugy - Child Process', () => {
+suite('Debug - Child Process', () => {
     test('Do not attach to child process if event is invalid', async () => {
         const attachService = mock(ChildProcessAttachService);
         const handler = new ChildProcessAttachEventHandler(instance(attachService));

--- a/src/test/debugger/extension/hooks/childProcessAttachHandler.unit.test.ts
+++ b/src/test/debugger/extension/hooks/childProcessAttachHandler.unit.test.ts
@@ -15,7 +15,7 @@ suite('Debugy - Child Process', () => {
         const attachService = mock(ChildProcessAttachService);
         const handler = new ChildProcessAttachEventHandler(instance(attachService));
         const body: any = {};
-        await handler.handleCustomEvent({ event: PTVSDEvents.ProcessLaunched, body, session: {} as any });
+        await handler.handleCustomEvent({ event: 'abc', body, session: {} as any });
         verify(attachService.attach(body)).never();
     });
     test('Do not attach to child process if event is invalid', async () => {

--- a/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
+++ b/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
@@ -15,7 +15,7 @@ import { ChildProcessAttachService } from '../../../../client/debugger/extension
 import { ChildProcessLaunchData } from '../../../../client/debugger/extension/hooks/types';
 import { AttachRequestArguments, LaunchRequestArguments } from '../../../../client/debugger/types';
 
-suite('Debugy - Attach to Child Process', () => {
+suite('Debug - Attach to Child Process', () => {
     test('Message is not displayed if debugger is launched', async () => {
         const shell = mock(ApplicationShell);
         const debugService = mock(DebugService);
@@ -192,7 +192,7 @@ suite('Debugy - Attach to Child Process', () => {
 
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(debugService.startDebugging(undefined, anything())).once();
-        const [_, secondArg] = capture(debugService.startDebugging).last();
+        const [, secondArg] = capture(debugService.startDebugging).last();
         expect(secondArg).to.deep.equal(debugConfig);
         verify(shell.showErrorMessage(anything())).never();
     });
@@ -235,7 +235,7 @@ suite('Debugy - Attach to Child Process', () => {
 
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(debugService.startDebugging(undefined, anything())).once();
-        const [_, secondArg] = capture(debugService.startDebugging).last();
+        const [, secondArg] = capture(debugService.startDebugging).last();
         expect(secondArg).to.deep.equal(debugConfig);
         verify(shell.showErrorMessage(anything())).never();
     });

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import { IExtensionApi } from '../client/api';
 import { PythonSettings } from '../client/common/configSettings';
 import { PVSC_EXTENSION_ID } from '../client/common/constants';
-import { clearPythonPathInWorkspaceFolder, PYTHON_PATH, resetGlobalPythonPathSetting, setPythonPathInWorkspaceRoot } from './common';
+import { clearPythonPathInWorkspaceFolder, IExtensionTestApi, PYTHON_PATH, resetGlobalPythonPathSetting, setPythonPathInWorkspaceRoot } from './common';
 
 export * from './constants';
 export * from './ciConstants';
@@ -26,11 +26,13 @@ export async function initializePython() {
 }
 
 // tslint:disable-next-line:no-any
-export async function initialize(): Promise<any> {
+export async function initialize(): Promise<IExtensionTestApi> {
     await initializePython();
-    await activateExtension();
+    const api = await activateExtension();
     // Dispose any cached python settings (used only in test env).
     PythonSettings.dispose();
+    // tslint:disable-next-line:no-any
+    return api as any as IExtensionTestApi;
 }
 export async function activateExtension() {
     const extension = vscode.extensions.getExtension<IExtensionApi>(PVSC_EXTENSION_ID)!;
@@ -40,6 +42,7 @@ export async function activateExtension() {
     const api = await extension.activate();
     // Wait untill its ready to use.
     await api.ready;
+    return api;
 }
 // tslint:disable-next-line:no-any
 export async function initializeTest(): Promise<any> {

--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -36,9 +36,6 @@ export async function initialize(): Promise<IExtensionTestApi> {
 }
 export async function activateExtension() {
     const extension = vscode.extensions.getExtension<IExtensionApi>(PVSC_EXTENSION_ID)!;
-    if (extension.isActive) {
-        return;
-    }
     const api = await extension.activate();
     // Wait untill its ready to use.
     await api.ready;

--- a/src/test/interpreters/locators/cacheableLocatorService.unit.test.ts
+++ b/src/test/interpreters/locators/cacheableLocatorService.unit.test.ts
@@ -57,7 +57,7 @@ suite('Interpreters - Cacheable Locator Service', () => {
             serviceContainer = mock(ServiceContainer);
         });
 
-        test('Interpreters mus be retrieved once, then cached', async () => {
+        test('Interpreters must be retrieved once, then cached', async () => {
             const expectedInterpreters = [1, 2] as any;
             const mockedLocatorForVerification = mock(MockLocator);
             const locator = new class extends Locator {

--- a/src/test/interpreters/locators/cacheableLocatorService.unit.test.ts
+++ b/src/test/interpreters/locators/cacheableLocatorService.unit.test.ts
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect } from 'chai';
+import * as md5 from 'md5';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Disposable, Uri, WorkspaceFolder } from 'vscode';
+import { IWorkspaceService } from '../../../client/common/application/types';
+import { WorkspaceService } from '../../../client/common/application/workspace';
+import { noop } from '../../../client/common/utils/misc';
+import { IInterpreterWatcher, PythonInterpreter } from '../../../client/interpreter/contracts';
+import { CacheableLocatorService } from '../../../client/interpreter/locators/services/cacheableLocatorService';
+import { ServiceContainer } from '../../../client/ioc/container';
+
+suite('Interpreters - Cacheable Locator Service', () => {
+    suite('Caching', () => {
+        class Locator extends CacheableLocatorService {
+            constructor(name, serviceCcontainer, private readonly mockLocator: MockLocator) {
+                super(name, serviceCcontainer);
+            }
+            public dispose() {
+                noop();
+            }
+            protected async getInterpretersImplementation(resource?: Uri): Promise<PythonInterpreter[]> {
+                return this.mockLocator.getInterpretersImplementation();
+            }
+            protected getCachedInterpreters(resource?: Uri): PythonInterpreter[] | undefined {
+                return this.mockLocator.getCachedInterpreters();
+            }
+            protected async cacheInterpreters(interpreters: PythonInterpreter[], resource?: Uri) {
+                return this.mockLocator.cacheInterpreters();
+            }
+            protected getCacheKey(resource?: Uri) {
+                return this.mockLocator.getCacheKey();
+            }
+        }
+        class MockLocator {
+            public async getInterpretersImplementation(): Promise<PythonInterpreter[]> {
+                return [];
+            }
+            public getCachedInterpreters(): PythonInterpreter[] | undefined {
+                return;
+            }
+            public async cacheInterpreters() {
+                return;
+            }
+            public getCacheKey(): string {
+                return '';
+            }
+        }
+        let serviceContainer: ServiceContainer;
+        setup(() => {
+            serviceContainer = mock(ServiceContainer);
+        });
+
+        test('Interpreters mus be retrieved once, then cached', async () => {
+            const expectedInterpreters = [1, 2] as any;
+            const mockedLocatorForVerification = mock(MockLocator);
+            const locator = new class extends Locator {
+                protected async addHandlersForInterpreterWatchers(cacheKey: string, resource: Uri | undefined): Promise<void> {
+                    noop();
+                }
+            }('dummy', instance(serviceContainer), instance(mockedLocatorForVerification));
+
+            when(mockedLocatorForVerification.getInterpretersImplementation()).thenResolve(expectedInterpreters);
+            when(mockedLocatorForVerification.getCacheKey()).thenReturn('xyz');
+            when(mockedLocatorForVerification.getCachedInterpreters()).thenResolve();
+
+            const [items1, items2, items3] = await Promise.all([locator.getInterpreters(), locator.getInterpreters(), locator.getInterpreters()]);
+            expect(items1).to.be.deep.equal(expectedInterpreters);
+            expect(items2).to.be.deep.equal(expectedInterpreters);
+            expect(items3).to.be.deep.equal(expectedInterpreters);
+
+            verify(mockedLocatorForVerification.getInterpretersImplementation()).once();
+            verify(mockedLocatorForVerification.getCachedInterpreters()).atLeast(1);
+            verify(mockedLocatorForVerification.cacheInterpreters()).atLeast(1);
+        });
+
+        test('Ensure onDidCreate event handler is attached', async () => {
+            const mockedLocatorForVerification = mock(MockLocator);
+            class Watcher implements IInterpreterWatcher {
+                public onDidCreate(listener: (e: void) => any, thisArgs?: any, disposables?: Disposable[]): Disposable {
+                    return { dispose: noop };
+                }
+            }
+            const watcher: IInterpreterWatcher = mock(Watcher);
+
+            const locator = new class extends Locator {
+                protected async getInterpreterWatchers(_resource: Uri | undefined): Promise<IInterpreterWatcher[]> {
+                    return [instance(watcher)];
+                }
+            }('dummy', instance(serviceContainer), instance(mockedLocatorForVerification));
+
+            await locator.getInterpreters();
+
+            verify(watcher.onDidCreate(anything(), anything(), anything())).once();
+        });
+
+        test('Ensure cache is cleared when watcher event fires', async () => {
+            const expectedInterpreters = [1, 2] as any;
+            const mockedLocatorForVerification = mock(MockLocator);
+            class Watcher implements IInterpreterWatcher {
+                private listner?: (e: void) => any;
+                public onDidCreate(listener: (e: void) => any, thisArgs?: any, disposables?: Disposable[]): Disposable {
+                    this.listner = listener;
+                    return { dispose: noop };
+                }
+                public invokeListeners() {
+                    this.listner!(undefined);
+                }
+            }
+            const watcher = new Watcher();
+
+            const locator = new class extends Locator {
+                protected async getInterpreterWatchers(_resource: Uri | undefined): Promise<IInterpreterWatcher[]> {
+                    return [watcher];
+                }
+            }('dummy', instance(serviceContainer), instance(mockedLocatorForVerification));
+
+            when(mockedLocatorForVerification.getInterpretersImplementation()).thenResolve(expectedInterpreters);
+            when(mockedLocatorForVerification.getCacheKey()).thenReturn('xyz');
+            when(mockedLocatorForVerification.getCachedInterpreters()).thenResolve();
+
+            const [items1, items2, items3] = await Promise.all([locator.getInterpreters(), locator.getInterpreters(), locator.getInterpreters()]);
+            expect(items1).to.be.deep.equal(expectedInterpreters);
+            expect(items2).to.be.deep.equal(expectedInterpreters);
+            expect(items3).to.be.deep.equal(expectedInterpreters);
+
+            verify(mockedLocatorForVerification.getInterpretersImplementation()).once();
+            verify(mockedLocatorForVerification.getCachedInterpreters()).atLeast(1);
+            verify(mockedLocatorForVerification.cacheInterpreters()).once();
+
+            watcher.invokeListeners();
+
+            const [items4, items5, items6] = await Promise.all([locator.getInterpreters(), locator.getInterpreters(), locator.getInterpreters()]);
+            expect(items4).to.be.deep.equal(expectedInterpreters);
+            expect(items5).to.be.deep.equal(expectedInterpreters);
+            expect(items6).to.be.deep.equal(expectedInterpreters);
+
+            // We must get the list of interperters again and cache the new result again.
+            verify(mockedLocatorForVerification.getInterpretersImplementation()).twice();
+            verify(mockedLocatorForVerification.cacheInterpreters()).twice();
+        });
+    });
+    suite('Cache Key', () => {
+        class Locator extends CacheableLocatorService {
+            public dispose() {
+                noop();
+            }
+            // tslint:disable-next-line:no-unnecessary-override
+            public getCacheKey(resource?: Uri) {
+                return super.getCacheKey(resource);
+            }
+            protected async getInterpretersImplementation(resource?: Uri): Promise<PythonInterpreter[]> {
+                return [];
+            }
+            protected getCachedInterpreters(resource?: Uri): PythonInterpreter[] | undefined {
+                return [];
+            }
+            protected async cacheInterpreters(interpreters: PythonInterpreter[], resource?: Uri) {
+                noop();
+            }
+        }
+        let serviceContainer: ServiceContainer;
+        setup(() => {
+            serviceContainer = mock(ServiceContainer);
+        });
+
+        test('Cache Key must contain name of locator', async () => {
+            const locator = new Locator('hello-World', instance(serviceContainer));
+
+            const key = locator.getCacheKey();
+
+            expect(key).contains('hello-World');
+        });
+
+        test('Cache Key must not contain path to workspace', async () => {
+            const workspace = mock(WorkspaceService);
+            const workspaceFolder: WorkspaceFolder = { name: '1', index: 1, uri: Uri.file(__dirname) };
+
+            when(workspace.hasWorkspaceFolders).thenReturn(true);
+            when(workspace.workspaceFolders).thenReturn([workspaceFolder]);
+            when(workspace.getWorkspaceFolder(anything())).thenReturn(workspaceFolder);
+            when(serviceContainer.get<IWorkspaceService>(IWorkspaceService)).thenReturn(instance(workspace));
+            when(serviceContainer.get<IWorkspaceService>(IWorkspaceService, anything())).thenReturn(instance(workspace));
+
+            const locator = new Locator('hello-World', instance(serviceContainer), false);
+
+            const key = locator.getCacheKey(Uri.file('something'));
+
+            expect(key).contains('hello-World');
+            expect(key).not.contains(md5(workspaceFolder.uri.fsPath));
+        });
+
+        test('Cache Key must contain path to workspace', async () => {
+            const workspace = mock(WorkspaceService);
+            const workspaceFolder: WorkspaceFolder = { name: '1', index: 1, uri: Uri.file(__dirname) };
+            const resource = Uri.file('a');
+
+            when(workspace.hasWorkspaceFolders).thenReturn(true);
+            when(workspace.workspaceFolders).thenReturn([workspaceFolder]);
+            when(workspace.getWorkspaceFolder(resource)).thenReturn(workspaceFolder);
+            when(serviceContainer.get<IWorkspaceService>(IWorkspaceService)).thenReturn(instance(workspace));
+            when(serviceContainer.get<IWorkspaceService>(IWorkspaceService, anything())).thenReturn(instance(workspace));
+
+            const locator = new Locator('hello-World', instance(serviceContainer), true);
+
+            const key = locator.getCacheKey(resource);
+
+            expect(key).contains('hello-World');
+            expect(key).contains(md5(workspaceFolder.uri.fsPath));
+        });
+    });
+});

--- a/src/test/interpreters/locators/interpreterWatcherBuilder.unit.test.ts
+++ b/src/test/interpreters/locators/interpreterWatcherBuilder.unit.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect } from 'chai';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { WorkspaceService } from '../../../client/common/application/workspace';
+import { IInterpreterWatcher, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
+import { InterpreterWatcherBuilder } from '../../../client/interpreter/locators/services/interpreterWatcherBuilder';
+import { ServiceContainer } from '../../../client/ioc/container';
+
+suite('Interpreters - Watcher Builder', () => {
+    test('Build Workspace Virtual Env Watcher', async () => {
+        const workspaceService = mock(WorkspaceService);
+        const serviceContainer = mock(ServiceContainer);
+        const builder = new InterpreterWatcherBuilder(instance(workspaceService), instance(serviceContainer));
+        const watcher = { register: () => Promise.resolve() };
+
+        when(workspaceService.getWorkspaceFolder(anything())).thenReturn();
+        when(serviceContainer.get<IInterpreterWatcher>(IInterpreterWatcher, WORKSPACE_VIRTUAL_ENV_SERVICE)).thenReturn(watcher as any as IInterpreterWatcher);
+
+        const item = await builder.getWorkspaceVirtualEnvInterpreterWatcher(undefined);
+
+        expect(item).to.be.equal(watcher, 'invalid');
+    });
+    test('Ensure we cache Workspace Virtual Env Watcher', async () => {
+        const workspaceService = mock(WorkspaceService);
+        const serviceContainer = mock(ServiceContainer);
+        const builder = new InterpreterWatcherBuilder(instance(workspaceService), instance(serviceContainer));
+        const watcher = { register: () => Promise.resolve() };
+
+        when(workspaceService.getWorkspaceFolder(anything())).thenReturn();
+        when(serviceContainer.get<IInterpreterWatcher>(IInterpreterWatcher, WORKSPACE_VIRTUAL_ENV_SERVICE)).thenReturn(watcher as any as IInterpreterWatcher);
+
+        const [item1, item2, item3] = await Promise.all([
+            builder.getWorkspaceVirtualEnvInterpreterWatcher(undefined),
+            builder.getWorkspaceVirtualEnvInterpreterWatcher(undefined),
+            builder.getWorkspaceVirtualEnvInterpreterWatcher(undefined)
+        ]);
+
+        expect(item1).to.be.equal(watcher, 'invalid');
+        expect(item2).to.be.equal(watcher, 'invalid');
+        expect(item3).to.be.equal(watcher, 'invalid');
+    });
+});

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -59,7 +59,7 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
         await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === firstEnvName, 'Standard', 1);
     }).timeout(120_000);
 
-    test('Dynamic Environments Detection', async () => {
+    test('Dynamic Environment Detection', async () => {
         const locator = serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
         // Ensure environment in our workspace folder is detected.
         const firstEnvName = path.basename(firstEnvDir);

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -4,9 +4,10 @@
 'use strict';
 
 // tslint:disable:no-any max-classes-per-file max-func-body-length no-invalid-this
-import { spawnSync } from 'child_process';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { getVirtualEnvBinName } from '../../../client/common/platform/osinfo';
+import { PlatformService } from '../../../client/common/platform/platformService';
 import { sleep } from '../../../client/common/utils/async';
 import { noop } from '../../../client/common/utils/misc';
 import { IInterpreterLocatorService, PythonInterpreter, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
@@ -16,15 +17,16 @@ import { IS_MULTI_ROOT_TEST } from '../../constants';
 import { initialize } from '../../initialize';
 
 suite('Interpreters - Workspace VirtualEnv Service', () => {
+
     let serviceContainer: IServiceContainer;
     const envSuffix = + new Date().getTime().toString();
     const firstEnvDir = path.join(rootWorkspaceUri.fsPath, `.venv1${envSuffix}`);
     const secondEnvDir = path.join(rootWorkspaceUri.fsPath, `.venv2${envSuffix}`);
 
     suiteSetup(async function () {
-        this.timeout(120_000);
+        this.timeout(60_000);
         serviceContainer = (await initialize()).serviceContainer;
-        if (!await isPythonVersionInProcess(undefined, '3') || IS_MULTI_ROOT_TEST) {
+        if (IS_MULTI_ROOT_TEST || !await isPythonVersionInProcess(undefined, '3')) {
             return this.skip();
         }
         await deletePythonEnvironments();
@@ -33,20 +35,23 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
     teardown(deletePythonEnvironments);
 
     async function createPythonEnvironment(envDir: string) {
-        const envName = path.basename(envDir);
-        spawnSync(PYTHON_PATH, ['-m', 'venv', envName], { cwd: rootWorkspaceUri.fsPath });
+        const executable = path.basename(PYTHON_PATH);
+        const scriptsBinDir = getVirtualEnvBinName(new PlatformService().info);
+        await fs.ensureDir(path.join(envDir, scriptsBinDir));
+        await new Promise((resolve, reject) => fs.copyFile(PYTHON_PATH, path.join(envDir, scriptsBinDir, executable),
+            (ex) => ex ? reject(ex) : resolve()));
     }
     async function deletePythonEnvironments() {
         await sleep(1000);
         await fs.remove(firstEnvDir).catch(noop);
         await fs.remove(secondEnvDir).catch(noop);
     }
-    async function waitForLocaInterpreterToBeDetected(locator: IInterpreterLocatorService, predicate: (item: PythonInterpreter) => boolean, predicateTitle: string, expectedCount: number) {
+    async function waitForLocaInterpreterToBeDetected(locator: IInterpreterLocatorService, predicate: (item: PythonInterpreter) => boolean, predicateTitle: string) {
         // tslint:disable-next-line:prefer-array-literal
-        for (const _ of new Array(120)) {
+        for (const _ of new Array(60)) {
             const items = await locator.getInterpreters(rootWorkspaceUri);
             const identified = items.filter(predicate).length;
-            if (identified >= expectedCount) {
+            if (identified > 0) {
                 return;
             }
             await sleep(500);
@@ -57,19 +62,19 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
         const locator = serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
         // Ensure environment in our workspace folder is detected.
         const firstEnvName = path.basename(firstEnvDir);
-        await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === firstEnvName, 'Standard', 1);
-    }).timeout(120_000);
+        await waitForLocaInterpreterToBeDetected(locator, item => item.envName === firstEnvName, 'Standard');
+    });
 
     test('Dynamic Environment Detection', async () => {
         const locator = serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
         // Ensure environment in our workspace folder is detected.
         const firstEnvName = path.basename(firstEnvDir);
-        await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === firstEnvName, 'Standard', 1);
+        await waitForLocaInterpreterToBeDetected(locator, item => item.envName === firstEnvName, 'Standard');
 
         await createPythonEnvironment(secondEnvDir);
 
         // Ensure the new virtual env is also detected.
         const secondEnvName = path.basename(secondEnvDir);
-        await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === secondEnvName, 'Second Environment', 1);
-    }).timeout(180_000);
+        await waitForLocaInterpreterToBeDetected(locator, item => item.envName === secondEnvName, 'Second Environment');
+    });
 });

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -17,8 +17,9 @@ import { initialize } from '../../initialize';
 
 suite('Interpreters - Workspace VirtualEnv Service', () => {
     let serviceContainer: IServiceContainer;
-    const firstEnvDir = path.join(rootWorkspaceUri.fsPath, '.venv1');
-    const secondEnvDir = path.join(rootWorkspaceUri.fsPath, '.venv2');
+    const envSuffix = + new Date().getTime().toString();
+    const firstEnvDir = path.join(rootWorkspaceUri.fsPath, `.venv1${envSuffix}`);
+    const secondEnvDir = path.join(rootWorkspaceUri.fsPath, `.venv2${envSuffix}`);
 
     suiteSetup(async function () {
         this.timeout(120_000);
@@ -45,7 +46,7 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
         for (const _ of new Array(120)) {
             const items = await locator.getInterpreters(rootWorkspaceUri);
             const identified = items.filter(predicate).length;
-            if (identified === expectedCount) {
+            if (identified >= expectedCount) {
                 return;
             }
             await sleep(500);
@@ -69,7 +70,6 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
 
         // Ensure the new virtual env is also detected.
         const secondEnvName = path.basename(secondEnvDir);
-        await waitForLocaInterpreterToBeDetected(locator, () => true, 'New Environment', 2);
         await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === secondEnvName, 'Second Environment', 1);
     }).timeout(180_000);
 });

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -12,7 +12,7 @@ import { sleep } from '../../../client/common/utils/async';
 import { noop } from '../../../client/common/utils/misc';
 import { IInterpreterLocatorService, PythonInterpreter, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { isPythonVersionInProcess, PYTHON_PATH, rootWorkspaceUri } from '../../common';
+import { PYTHON_PATH, rootWorkspaceUri } from '../../common';
 import { IS_MULTI_ROOT_TEST } from '../../constants';
 import { initialize } from '../../initialize';
 
@@ -24,11 +24,11 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
     const secondEnvDir = path.join(rootWorkspaceUri.fsPath, `.venv2${envSuffix}`);
 
     suiteSetup(async function () {
-        this.timeout(60_000);
-        serviceContainer = (await initialize()).serviceContainer;
-        if (IS_MULTI_ROOT_TEST || !await isPythonVersionInProcess(undefined, '3')) {
+        if (IS_MULTI_ROOT_TEST) {
             return this.skip();
         }
+        this.timeout(60_000);
+        serviceContainer = (await initialize()).serviceContainer;
         await deletePythonEnvironments();
     });
     setup(() => createPythonEnvironment(firstEnvDir));

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length no-invalid-this
+import { spawnSync } from 'child_process';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { sleep } from '../../../client/common/utils/async';
+import { noop } from '../../../client/common/utils/misc';
+import { IInterpreterLocatorService, PythonInterpreter, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
+import { getServiceContainer } from '../../../client/ioc';
+import { isPythonVersionInProcess, PYTHON_PATH, rootWorkspaceUri } from '../../common';
+import { IS_MULTI_ROOT_TEST } from '../../constants';
+
+suite('Interpreters - Workspace VirtualEnv Service', () => {
+    const ioc = getServiceContainer();
+    const firstEnvDir = path.join(rootWorkspaceUri.fsPath, '.venv1');
+    const secondEnvDir = path.join(rootWorkspaceUri.fsPath, '.venv2');
+
+    setup(async function () {
+        if (!await isPythonVersionInProcess(undefined, '3') || IS_MULTI_ROOT_TEST) {
+            return this.skip();
+        }
+        await createPythonEnvironment(firstEnvDir);
+    });
+    teardown(deletePythonEnvironments);
+
+    async function createPythonEnvironment(envDir: string) {
+        const envName = path.basename(envDir);
+        spawnSync(PYTHON_PATH, ['-m', 'venv', envName], { cwd: rootWorkspaceUri.fsPath });
+    }
+    async function deletePythonEnvironments() {
+        await sleep(1000);
+        await fs.remove(firstEnvDir).catch(noop);
+        await fs.remove(secondEnvDir).catch(noop);
+    }
+    async function waitForLocaInterpreterToBeDetected(locator: IInterpreterLocatorService, predicate: (item: PythonInterpreter) => boolean, predicateTitle: string) {
+        // tslint:disable-next-line:prefer-array-literal
+        for (const _ of new Array(30)) {
+            const items = await locator.getInterpreters(rootWorkspaceUri);
+            const identified = items.filter(predicate).length;
+            if (identified > 0) {
+                return;
+            }
+            await sleep(500);
+        }
+        throw new Error(`${predicateTitle}, Environments not detected in the workspacce ${rootWorkspaceUri.fsPath}`);
+    }
+    test('Environment Detection', async () => {
+        const locator = ioc.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
+        // Ensure environment in our workspace folder is detected.
+        const firstEnvName = path.basename(firstEnvDir);
+        await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === firstEnvName, 'Standard');
+
+        // Create a new workspace virtual env, and ensure we return a cached list of environments.
+        await createPythonEnvironment(secondEnvDir);
+        await waitForLocaInterpreterToBeDetected(locator, item => item.cachedEntry === true, 'Cached');
+
+        // Ensure the new virtual env is also detected.
+        const secondEnvName = path.basename(secondEnvDir);
+        await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === secondEnvName, 'New Environment');
+    }).timeout(60000);
+});

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -42,7 +42,7 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
     }
     async function waitForLocaInterpreterToBeDetected(locator: IInterpreterLocatorService, predicate: (item: PythonInterpreter) => boolean, predicateTitle: string, expectedCount: number) {
         // tslint:disable-next-line:prefer-array-literal
-        for (const _ of new Array(60)) {
+        for (const _ of new Array(120)) {
             const items = await locator.getInterpreters(rootWorkspaceUri);
             const identified = items.filter(predicate).length;
             if (identified === expectedCount) {

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -10,16 +10,18 @@ import * as path from 'path';
 import { sleep } from '../../../client/common/utils/async';
 import { noop } from '../../../client/common/utils/misc';
 import { IInterpreterLocatorService, PythonInterpreter, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
-import { getServiceContainer } from '../../../client/ioc';
+import { IServiceContainer } from '../../../client/ioc/types';
 import { isPythonVersionInProcess, PYTHON_PATH, rootWorkspaceUri } from '../../common';
 import { IS_MULTI_ROOT_TEST } from '../../constants';
+import { initialize } from '../../initialize';
 
 suite('Interpreters - Workspace VirtualEnv Service', () => {
-    const ioc = getServiceContainer();
+    let serviceContainer: IServiceContainer;
     const firstEnvDir = path.join(rootWorkspaceUri.fsPath, '.venv1');
     const secondEnvDir = path.join(rootWorkspaceUri.fsPath, '.venv2');
 
     setup(async function () {
+        serviceContainer = (await initialize()).serviceContainer;
         if (!await isPythonVersionInProcess(undefined, '3') || IS_MULTI_ROOT_TEST) {
             return this.skip();
         }
@@ -49,7 +51,7 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
         throw new Error(`${predicateTitle}, Environments not detected in the workspacce ${rootWorkspaceUri.fsPath}`);
     }
     test('Environment Detection', async () => {
-        const locator = ioc.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
+        const locator = serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
         // Ensure environment in our workspace folder is detected.
         const firstEnvName = path.basename(firstEnvDir);
         await waitForLocaInterpreterToBeDetected(locator, item => !item.cachedEntry && item.envName === firstEnvName, 'Standard');

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -42,7 +42,6 @@ suite('Interpreters - Workspace VirtualEnv Service', () => {
             (ex) => ex ? reject(ex) : resolve()));
     }
     async function deletePythonEnvironments() {
-        await sleep(1000);
         await fs.remove(firstEnvDir).catch(noop);
         await fs.remove(secondEnvDir).catch(noop);
     }

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.unit.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.unit.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect } from 'chai';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Uri } from 'vscode';
+import { IInterpreterWatcher } from '../../../client/interpreter/contracts';
+import { InterpreterWatcherBuilder } from '../../../client/interpreter/locators/services/interpreterWatcherBuilder';
+import { WorkspaceVirtualEnvService } from '../../../client/interpreter/locators/services/workspaceVirtualEnvService';
+import { ServiceContainer } from '../../../client/ioc/container';
+
+suite('Interpreters - Workspace VirtualEnv Service', () => {
+
+    test('Get list of watchers', async () => {
+        const serviceContainer = mock(ServiceContainer);
+        const builder = mock(InterpreterWatcherBuilder);
+        const locator = new class extends WorkspaceVirtualEnvService {
+            // tslint:disable-next-line:no-unnecessary-override
+            public async getInterpreterWatchers(resource: Uri | undefined): Promise<IInterpreterWatcher[]> {
+                return super.getInterpreterWatchers(resource);
+            }
+        }(undefined as any, instance(serviceContainer), instance(builder));
+
+        const watchers = 1 as any;
+        when(builder.getWorkspaceVirtualEnvInterpreterWatcher(anything())).thenResolve(watchers);
+
+        const items = await locator.getInterpreterWatchers(undefined);
+
+        expect(items).to.deep.equal([watchers]);
+        verify(builder.getWorkspaceVirtualEnvInterpreterWatcher(anything())).once();
+    });
+});

--- a/src/test/interpreters/locators/workspaceVirtualEnvWatcherService.unit.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvWatcherService.unit.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect } from 'chai';
+import * as path from 'path';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Disposable, FileSystemWatcher, Uri } from 'vscode';
+import { WorkspaceService } from '../../../client/common/application/workspace';
+import { PlatformService } from '../../../client/common/platform/platformService';
+import { sleep } from '../../../client/common/utils/async';
+import { noop } from '../../../client/common/utils/misc';
+import { OSType } from '../../../client/common/utils/platform';
+import { WorkspaceVirtualEnvWatcherService } from '../../../client/interpreter/locators/services/workspaceVirtualEnvWatcherService';
+
+suite('Interpreters - Workspace VirtualEnv Watcher Service', () => {
+    let disposables: Disposable[] = [];
+    teardown(() => {
+        disposables.forEach(d => {
+            try {
+                d.dispose();
+            } catch { noop(); }
+        });
+        disposables = [];
+    });
+
+    async function checkForFileChanges(os: OSType, expectedGlobs: string[]) {
+        const workspaceService = mock(WorkspaceService);
+        const platformService = mock(PlatformService);
+        const watcher = new WorkspaceVirtualEnvWatcherService([], instance(workspaceService), instance(platformService));
+
+        when(platformService.isWindows).thenReturn(os === OSType.Windows);
+        when(platformService.isLinux).thenReturn(os === OSType.Linux);
+        when(platformService.isMac).thenReturn(os === OSType.OSX);
+
+        class FSWatcher {
+            public onDidCreate(_listener: (e: Uri) => any, _thisArgs?: any, _disposables?: Disposable[]): Disposable {
+                return { dispose: noop };
+            }
+        }
+        const fsWatchers: FSWatcher[] = [];
+        for (const glob of expectedGlobs) {
+            const fsWatcher = mock(FSWatcher);
+            fsWatchers.push(fsWatcher);
+            when(workspaceService.createFileSystemWatcher(glob)).thenReturn(instance(fsWatcher as any as FileSystemWatcher));
+        }
+        await watcher.register();
+
+        for (const glob of expectedGlobs) {
+            verify(workspaceService.createFileSystemWatcher(glob)).once();
+        }
+        for (const fsWatcher of fsWatchers) {
+            verify(fsWatcher.onDidCreate(anything(), anything(), anything())).once();
+        }
+    }
+    test('Register for file changes on windows', async () => {
+        await checkForFileChanges(OSType.Windows, [
+            path.join('**', '*python*.exe'),
+            path.join('**', '*Python*.exe'),
+            path.join('**', 'Scripts', 'activate.*'),
+            path.join('**', 'Scripts', 'Activate.*')
+        ]);
+    });
+    test('Register for file changes on Mac', async () => {
+        await checkForFileChanges(OSType.OSX, [
+            path.join('**', '*python*'),
+            path.join('*', 'bin', 'activate*')
+        ]);
+    });
+    test('Register for file changes on Linux', async () => {
+        await checkForFileChanges(OSType.Linux, [
+            path.join('**', '*python*'),
+            path.join('*', 'bin', 'activate*')
+        ]);
+    });
+
+    async function ensureFileChanesAreHandled(os: OSType) {
+        const workspaceService = mock(WorkspaceService);
+        const platformService = mock(PlatformService);
+        const watcher = new WorkspaceVirtualEnvWatcherService(disposables, instance(workspaceService), instance(platformService));
+
+        when(platformService.isWindows).thenReturn(os === OSType.Windows);
+        when(platformService.isLinux).thenReturn(os === OSType.Linux);
+        when(platformService.isMac).thenReturn(os === OSType.OSX);
+
+        class FSWatcher {
+            private listener?: (e: Uri) => any;
+            public onDidCreate(listener: (e: Uri) => any, _thisArgs?: any, _disposables?: Disposable[]): Disposable {
+                this.listener = listener;
+                return { dispose: noop };
+            }
+            public invokeListener(e: Uri) {
+                this.listener!(e);
+            }
+        }
+        const fsWatcher = new FSWatcher();
+        when(workspaceService.createFileSystemWatcher(anything())).thenReturn(fsWatcher as any as FileSystemWatcher);
+        await watcher.register();
+        let invoked = false;
+        watcher.onDidCreate(() => invoked = true, watcher);
+
+        fsWatcher.invokeListener(Uri.file(''));
+        // We need this sleep, as we have a debounce (so lets wait).
+        await sleep(10);
+
+        expect(invoked).to.be.equal(true, 'invalid');
+    }
+    test('Check file change handler on Windows', async () => {
+        await ensureFileChanesAreHandled(OSType.Windows);
+    });
+    test('Check file change handler on Mac', async () => {
+        await ensureFileChanesAreHandled(OSType.OSX);
+    });
+    test('Check file change handler on Linux', async () => {
+        await ensureFileChanesAreHandled(OSType.Linux);
+    });
+});

--- a/src/test/interpreters/locators/workspaceVirtualEnvWatcherService.unit.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvWatcherService.unit.test.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Disposable, FileSystemWatcher, Uri } from 'vscode';
 import { WorkspaceService } from '../../../client/common/application/workspace';
+import { isUnitTestExecution } from '../../../client/common/constants';
 import { PlatformService } from '../../../client/common/platform/platformService';
 import { sleep } from '../../../client/common/utils/async';
 import { noop } from '../../../client/common/utils/misc';
@@ -18,6 +19,12 @@ import { WorkspaceVirtualEnvWatcherService } from '../../../client/interpreter/l
 
 suite('Interpreters - Workspace VirtualEnv Watcher Service', () => {
     let disposables: Disposable[] = [];
+    setup(function () {
+        if (!isUnitTestExecution()) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
+        }
+    });
     teardown(() => {
         disposables.forEach(d => {
             try {

--- a/src/test/interpreters/locators/workspaceVirtualEnvWatcherService.unit.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvWatcherService.unit.test.ts
@@ -76,13 +76,13 @@ suite('Interpreters - Workspace VirtualEnv Watcher Service', () => {
         for (const hasWorkspaceFolder of [true, false]) {
             const uriSuffix = uri ? ` (with resource & ${hasWorkspaceFolder ? 'with' : 'without'} workspace folder)` : '';
             test(`Register for file changes on windows ${uriSuffix}`, async () => {
-                await checkForFileChanges(OSType.Windows, path.join('**', 'python.exe'), uri, hasWorkspaceFolder);
+                await checkForFileChanges(OSType.Windows, path.join('**', 'python*.exe'), uri, hasWorkspaceFolder);
             });
             test(`Register for file changes on Mac ${uriSuffix}`, async () => {
-                await checkForFileChanges(OSType.OSX, path.join('**', 'python'), uri, hasWorkspaceFolder);
+                await checkForFileChanges(OSType.OSX, path.join('**', 'python*'), uri, hasWorkspaceFolder);
             });
             test(`Register for file changes on Linux ${uriSuffix}`, async () => {
-                await checkForFileChanges(OSType.Linux, path.join('**', 'python'), uri, hasWorkspaceFolder);
+                await checkForFileChanges(OSType.Linux, path.join('**', 'python*'), uri, hasWorkspaceFolder);
             });
         }
     }

--- a/src/test/mocks/vsc/index.ts
+++ b/src/test/mocks/vsc/index.ts
@@ -54,7 +54,7 @@ export namespace vscMock {
         public event: vscode.Event<T>;
         public emitter: NodeEventEmitter;
         constructor() {
-            this.event = this.add;
+            this.event = this.add.bind(this);
             this.emitter = new NodeEventEmitter();
         }
         public fire(data?: T): void {
@@ -75,11 +75,11 @@ export namespace vscMock {
     }
 
     export class CancellationToken extends EventEmitter<any> implements vscode.CancellationToken {
-        public isCancellationRequested: boolean;
+        public isCancellationRequested!: boolean;
         public onCancellationRequested: vscode.Event<any>;
         constructor() {
             super();
-            this.onCancellationRequested = this.add;
+            this.onCancellationRequested = this.add.bind(this);
         }
         public cancel() {
             this.isCancellationRequested = true;

--- a/src/test/unittests.ts
+++ b/src/test/unittests.ts
@@ -17,6 +17,7 @@ import { MOCHA_CI_REPORTER_ID, MOCHA_CI_REPORTFILE,
 import * as vscodeMoscks from './vscode-mock';
 
 process.env.VSC_PYTHON_CI_TEST = '1';
+process.env.VSC_PYTHON_UNIT_TEST = '1';
 
 export function runTests(testOptions?: { grep?: string; timeout?: number }) {
     vscodeMoscks.initialize();

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -67,6 +67,7 @@ mockedVSCode.SignatureHelp = vscodeMocks.vscMockExtHostedTypes.SignatureHelp;
 mockedVSCode.DocumentLink = vscodeMocks.vscMockExtHostedTypes.DocumentLink;
 mockedVSCode.TextEdit = vscodeMocks.vscMockExtHostedTypes.TextEdit;
 mockedVSCode.WorkspaceEdit = vscodeMocks.vscMockExtHostedTypes.WorkspaceEdit;
+mockedVSCode.RelativePattern = vscodeMocks.vscMockExtHostedTypes.RelativePattern;
 
 // This API is used in src/client/telemetry/telemetry.ts
 const extensions = TypeMoq.Mock.ofType<typeof vscode.extensions>();


### PR DESCRIPTION
For #656

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
