### PR TITLE
PEP8ify

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -1,10 +1,12 @@
-import os
 import io
+import json
+import os
+import platform
 import re
 import sys
-import json
 import traceback
-import platform
+
+import jedi
 
 jediPreview = False
 
@@ -23,6 +25,7 @@ class RedirectStdout(object):
         os.dup2(self.oldstdout_fno, 1)
         os.close(self.oldstdout_fno)
 
+        
 class JediCompletion(object):
     basic_types = {
         'module': 'import',
@@ -624,6 +627,7 @@ class JediCompletion(object):
                 sys.stderr.write(traceback.format_exc() + '\n')
                 sys.stderr.flush()
 
+
 if __name__ == '__main__':
     cachePrefix = 'v'
     modulesToLoad = ''
@@ -640,7 +644,7 @@ if __name__ == '__main__':
             modulesToLoad = sys.argv[1]
 
     sys.path.insert(0, jediPath)
-    import jedi
+
     if jediPreview:
         jedi.settings.cache_directory = os.path.join(
             jedi.settings.cache_directory, cachePrefix + jedi.__version__.replace('.', ''))


### PR DESCRIPTION
reordered imports and two newlines after class, #pep3

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
