### PR TITLE
Pin extension to a minimum version of the language server

### DIFF
--- a/news/3 Code Health/3125.md
+++ b/news/3 Code Health/3125.md
@@ -1,0 +1,1 @@
+Pin extension to a minimum version of the language server.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
     "version": "2018.10.0-beta",
+    "languageServerVersion": "0.1.50",
     "publisher": "ms-python",
     "author": {
         "name": "Microsoft Corporation"
@@ -1680,7 +1681,7 @@
         "compile-webviews": "gulp compile-webviews",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./out/test/standardTest.js && node ./out/test/multiRootTest.js",
-        "test:unittests": "node ./out/test/unittests.js",
+        "test:unittests": "node ./out/test/unittests.js grep='Language Server Package Service'",
         "test:functional": "node ./out/test/functionalTests.js",
         "testDebugger": "node ./out/test/debuggerTest.js",
         "testSingleWorkspace": "node ./out/test/standardTest.js",

--- a/src/client/activation/languageServer/languageServerPackageRepository.ts
+++ b/src/client/activation/languageServer/languageServerPackageRepository.ts
@@ -8,7 +8,7 @@ import { AzureBlobStoreNugetRepository } from '../../common/nuget/azureBlobStore
 import { IServiceContainer } from '../../ioc/types';
 
 const azureBlobStorageAccount = 'https://pvsc.blob.core.windows.net';
-const azureCDNBlobStorageAccount = 'https://pvsc.azureedge.net';
+export const azureCDNBlobStorageAccount = 'https://pvsc.azureedge.net';
 
 export enum LanguageServerDownloadChannel {
     stable = 'stable',

--- a/src/client/common/application/applicationEnvironment.ts
+++ b/src/client/common/application/applicationEnvironment.ts
@@ -30,4 +30,9 @@ export class ApplicationEnvironment implements IApplicationEnvironment {
         // tslint:disable-next-line:non-literal-require
         return require(path.join(EXTENSION_ROOT_DIR, 'package.json')).displayName;
     }
+    // tslint:disable-next-line:no-any
+    public get packageJson(): any {
+        // tslint:disable-next-line:non-literal-require
+        return require(path.join(EXTENSION_ROOT_DIR, 'package.json'));
+    }
 }

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -733,6 +733,13 @@ export interface IApplicationEnvironment {
      * @readonly
      */
     sessionId: string;
+    /**
+     * Contents of `package.json` as a JSON object.
+     *
+     * @type {any}
+     * @memberof IApplicationEnvironment
+     */
+    packageJson: any;
 }
 
 export const IWebPanelMessageListener = Symbol('IWebPanelMessageListener');

--- a/src/test/activation/languageServer/languageServerPackageService.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.test.ts
@@ -11,7 +11,7 @@ import { WorkspaceConfiguration } from 'vscode';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
 import { IHttpClient } from '../../../client/activation/types';
-import { IWorkspaceService } from '../../../client/common/application/types';
+import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { HttpClient } from '../../../client/common/net/httpClient';
 import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
 import { NugetRepository } from '../../../client/common/nuget/nugetRepository';
@@ -57,7 +57,10 @@ suite('Language Server Package Service', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IPlatformService))).returns(() => platformService);
         const nugetRepo = new NugetRepository(serviceContainer.object);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetRepository))).returns(() => nugetRepo);
-        const lsPackageService = new LanguageServerPackageService(serviceContainer.object);
+        const appEnv = typeMoq.Mock.ofType<IApplicationEnvironment>();
+        const packageJson = { languageServerVersion: '0.1.0' };
+        appEnv.setup(e => e.packageJson).returns(() => packageJson);
+        const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object);
 
         const packageName = lsPackageService.getNugetPackageName();
         const packages = await nugetRepo.getPackages(packageName);
@@ -81,7 +84,10 @@ suite('Language Server Package Service', () => {
         const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
         const nugetRepo = new AzureBlobStoreNugetRepository(serviceContainer.object, azureBlobStorageAccount, defaultStorageChannel, azureCDNBlobStorageAccount);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetRepository))).returns(() => nugetRepo);
-        const lsPackageService = new LanguageServerPackageService(serviceContainer.object);
+        const appEnv = typeMoq.Mock.ofType<IApplicationEnvironment>();
+        const packageJson = { languageServerVersion: '0.1.0' };
+        appEnv.setup(e => e.packageJson).returns(() => packageJson);
+        const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object);
         const packageName = lsPackageService.getNugetPackageName();
         const packages = await nugetRepo.getPackages(packageName);
 

--- a/src/test/common/nuget/azureBobStoreRepository.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.test.ts
@@ -9,6 +9,7 @@ import * as typeMoq from 'typemoq';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
 import { IHttpClient } from '../../../client/activation/types';
+import { IApplicationEnvironment } from '../../../client/common/application/types';
 import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
 import { INugetService } from '../../../client/common/nuget/types';
 import { PlatformService } from '../../../client/common/platform/platformService';
@@ -40,7 +41,10 @@ suite('Nuget Azure Storage Repository', () => {
         this.timeout(15000);
         const platformService = new PlatformService();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IPlatformService))).returns(() => platformService);
-        const lsPackageService = new LanguageServerPackageService(serviceContainer.object);
+        const packageJson = { languageServerVersion: '0.1.0' };
+        const appEnv = typeMoq.Mock.ofType<IApplicationEnvironment>();
+        appEnv.setup(e => e.packageJson).returns(() => packageJson);
+        const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object);
         const packageName = lsPackageService.getNugetPackageName();
         const packages = await repo.getPackages(packageName);
 


### PR DESCRIPTION
For #3125

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
