### PR TITLE
In vscode default dark theme default the matplot lib style to dark_background

### DIFF
--- a/src/client/datascience/jupyterServer.ts
+++ b/src/client/datascience/jupyterServer.ts
@@ -12,6 +12,7 @@ import { Observable } from 'rxjs/Observable';
 import * as uuid from 'uuid/v4';
 import * as vscode from 'vscode';
 
+import { IWorkspaceService } from '../common/application/types';
 import { IFileSystem } from '../common/platform/types';
 import { IDisposableRegistry, ILogger } from '../common/types';
 import { createDeferred } from '../common/utils/async';
@@ -36,7 +37,8 @@ export class JupyterServer implements INotebookServer {
         @inject(INotebookProcess) private process: INotebookProcess,
         @inject(IFileSystem) private fileSystem: IFileSystem,
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
-        @inject(IJupyterExecution) private jupyterExecution : IJupyterExecution) {
+        @inject(IJupyterExecution) private jupyterExecution : IJupyterExecution,
+        @inject(IWorkspaceService) private workspaceService: IWorkspaceService) {
     }
 
     public start = async () : Promise<boolean> => {
@@ -84,9 +86,15 @@ export class JupyterServer implements INotebookServer {
             // Wait for it to be ready
             await this.session.kernel.ready;
 
-            // Setup the default imports (this should be configurable in the future)
+            // Check for default dark theme, if so set matplot lib to use dark_background settings
+            let theme: string = '';
+            const workbench = this.workspaceService.getConfiguration('workbench');
+            if (workbench) {
+                theme = workbench.get<string>('colorTheme');
+            }
+
             this.executeSilently(
-                'import pandas as pd\r\nimport numpy\r\n%matplotlib inline\r\nimport matplotlib.pyplot as plt'
+                `import pandas as pd\r\nimport numpy\r\n%matplotlib inline\r\nimport matplotlib.pyplot as plt${theme === 'Default Dark+' ? '\r\nfrom matplotlib import style\r\nstyle.use(\'dark_background\')' : ''}`
             ).ignoreErrors();
 
             return true;

--- a/src/client/datascience/jupyterServer.ts
+++ b/src/client/datascience/jupyterServer.ts
@@ -93,6 +93,7 @@ export class JupyterServer implements INotebookServer {
                 theme = workbench.get<string>('colorTheme');
             }
 
+            // Setup the default imports (this should be configurable in the future)
             this.executeSilently(
                 `import pandas as pd\r\nimport numpy\r\n%matplotlib inline\r\nimport matplotlib.pyplot as plt${theme === 'Default Dark+' ? '\r\nfrom matplotlib import style\r\nstyle.use(\'dark_background\')' : ''}`
             ).ignoreErrors();

--- a/src/client/datascience/jupyterServer.ts
+++ b/src/client/datascience/jupyterServer.ts
@@ -86,16 +86,18 @@ export class JupyterServer implements INotebookServer {
             // Wait for it to be ready
             await this.session.kernel.ready;
 
-            // Check for default dark theme, if so set matplot lib to use dark_background settings
-            let theme: string = '';
+            // Check for dark theme, if so set matplot lib to use dark_background settings
+            let darkTheme: boolean = false;
             const workbench = this.workspaceService.getConfiguration('workbench');
             if (workbench) {
-                theme = workbench.get<string>('colorTheme');
+                const theme = workbench.get<string>('colorTheme');
+                if (theme) {
+                    darkTheme = /dark/i.test(theme);
+                }
             }
 
-            // Setup the default imports (this should be configurable in the future)
             this.executeSilently(
-                `import pandas as pd\r\nimport numpy\r\n%matplotlib inline\r\nimport matplotlib.pyplot as plt${theme === 'Default Dark+' ? '\r\nfrom matplotlib import style\r\nstyle.use(\'dark_background\')' : ''}`
+                `import pandas as pd\r\nimport numpy\r\n%matplotlib inline\r\nimport matplotlib.pyplot as plt${darkTheme ? '\r\nfrom matplotlib import style\r\nstyle.use(\'dark_background\')' : ''}`
             ).ignoreErrors();
 
             return true;


### PR DESCRIPTION
For #3221 

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
