### PR TITLE
Sort news entries by issue number

### DIFF
--- a/news/announce.py
+++ b/news/announce.py
@@ -31,7 +31,12 @@ class NewsEntry:
 
 
 def news_entries(directory):
-    """Yield news entries in the directory."""
+    """Yield news entries in the directory.
+
+    Entries are sorted by issue number.
+
+    """
+    entries = []
     for path in directory.iterdir():
         if path.name == "README.md":
             continue
@@ -45,7 +50,9 @@ def news_entries(directory):
             raise ValueError(f"'{path}' is not encoded as UTF-8") from exc
         if "\ufeff" in entry:
             raise ValueError(f"'{path}' contains the BOM")
-        yield NewsEntry(issue, entry, path)
+        entries.append(NewsEntry(issue, entry, path))
+    entries.sort(key=operator.attrgetter("issue_number"))
+    yield from entries
 
 
 @dataclasses.dataclass

--- a/news/test_announce.py
+++ b/news/test_announce.py
@@ -30,6 +30,17 @@ def test_news_entry_formatting(directory):
         assert result.description == body
 
 
+def test_news_entry_sorting(directory):
+    oldest_entry = directory / "45.md"
+    newest_entry = directory / "123.md"
+    oldest_entry.write_text("45", encoding="utf-8")
+    newest_entry.write_text("123", encoding="utf-8")
+    results = list(ann.news_entries(directory))
+    assert len(results) == 2
+    assert results[0].issue_number == 45
+    assert results[1].issue_number == 123
+
+
 def test_only_utf8(directory):
     entry = directory / "42.md"
     entry.write_text("Hello, world", encoding="utf-16")


### PR DESCRIPTION
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
