### PR TITLE
remove IsTestExecution guard from around data science banner calls

### DIFF
--- a/src/client/datascience/datascience.ts
+++ b/src/client/datascience/datascience.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 import { ICommandManager } from '../common/application/types';
 import { PythonSettings } from '../common/configSettings';
-import { isTestExecution, PYTHON } from '../common/constants';
+import { PYTHON } from '../common/constants';
 import { ContextKey } from '../common/contextKey';
 import { BANNER_NAME_DS_SURVEY, IConfigurationService, IDisposableRegistry, IExtensionContext, IPythonExtensionBanner } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
@@ -57,9 +57,8 @@ export class DataScience implements IDataScience {
     }
 
     public async runAllCells(codeWatcher: ICodeWatcher): Promise<void> {
-        if (!isTestExecution()) {
-            this.dataScienceSurveyBanner.showBanner().ignoreErrors();
-        }
+        this.dataScienceSurveyBanner.showBanner().ignoreErrors();
+        
         let activeCodeWatcher: ICodeWatcher | undefined = codeWatcher;
         if (!activeCodeWatcher) {
             activeCodeWatcher = this.getCurrentCodeWatcher();
@@ -72,9 +71,8 @@ export class DataScience implements IDataScience {
     }
 
     public async runCell(codeWatcher: ICodeWatcher, range: vscode.Range): Promise<void> {
-        if (!isTestExecution()) {
-            this.dataScienceSurveyBanner.showBanner().ignoreErrors();
-        }
+        this.dataScienceSurveyBanner.showBanner().ignoreErrors();
+
         if (codeWatcher) {
             return codeWatcher.runCell(range);
         } else {
@@ -83,9 +81,8 @@ export class DataScience implements IDataScience {
     }
 
     public async runCurrentCell(): Promise<void> {
-        if (!isTestExecution()) {
-            this.dataScienceSurveyBanner.showBanner().ignoreErrors();
-        }
+        this.dataScienceSurveyBanner.showBanner().ignoreErrors();
+
         const activeCodeWatcher = this.getCurrentCodeWatcher();
         if (activeCodeWatcher) {
             return activeCodeWatcher.runCurrentCell();
@@ -95,9 +92,8 @@ export class DataScience implements IDataScience {
     }
 
     public async runCurrentCellAndAdvance(): Promise<void> {
-        if (!isTestExecution()) {
-            this.dataScienceSurveyBanner.showBanner().ignoreErrors();
-        }
+        this.dataScienceSurveyBanner.showBanner().ignoreErrors();
+
         const activeCodeWatcher = this.getCurrentCodeWatcher();
         if (activeCodeWatcher) {
             return activeCodeWatcher.runCurrentCellAndAdvance();

--- a/src/client/datascience/datascience.ts
+++ b/src/client/datascience/datascience.ts
@@ -9,6 +9,7 @@ import { ICommandManager } from '../common/application/types';
 import { PythonSettings } from '../common/configSettings';
 import { PYTHON } from '../common/constants';
 import { ContextKey } from '../common/contextKey';
+import '../common/extensions';
 import { BANNER_NAME_DS_SURVEY, IConfigurationService, IDisposableRegistry, IExtensionContext, IPythonExtensionBanner } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { Commands, EditorContexts } from './constants';

--- a/src/client/datascience/datascience.ts
+++ b/src/client/datascience/datascience.ts
@@ -58,7 +58,7 @@ export class DataScience implements IDataScience {
 
     public async runAllCells(codeWatcher: ICodeWatcher): Promise<void> {
         this.dataScienceSurveyBanner.showBanner().ignoreErrors();
-        
+
         let activeCodeWatcher: ICodeWatcher | undefined = codeWatcher;
         if (!activeCodeWatcher) {
             activeCodeWatcher = this.getCurrentCodeWatcher();


### PR DESCRIPTION
For #3246 

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
