### PR TITLE
Code Lens Provider and Code Watcher unit tests

### DIFF
--- a/src/client/datascience/editor-integration/codelensprovider.ts
+++ b/src/client/datascience/editor-integration/codelensprovider.ts
@@ -8,7 +8,6 @@ import * as vscode from 'vscode';
 import { IConfigurationService } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { ICodeWatcher, IDataScienceCodeLensProvider } from '../types';
-import { CodeWatcher } from './codewatcher';
 
 @injectable()
 export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider {
@@ -22,27 +21,28 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     // Some implementation based on DonJayamanne's jupyter extension work
     public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken):
         vscode.CodeLens[] {
-            // Don't provide any code lenses if we have not enabled data science
-            const settings = this.configuration.getSettings();
-            if (!settings.datascience.enabled) {
-                // Clear out any existing code watchers, providecodelenses is called on settings change
-                // so we don't need to watch the settings change specifically here
-                if (this.activeCodeWatchers.length > 0) {
-                    this.activeCodeWatchers = [];
-                }
-                return [];
+        // Don't provide any code lenses if we have not enabled data science
+        const settings = this.configuration.getSettings();
+        if (!settings.datascience.enabled) {
+            // Clear out any existing code watchers, providecodelenses is called on settings change
+            // so we don't need to watch the settings change specifically here
+            if (this.activeCodeWatchers.length > 0) {
+                this.activeCodeWatchers = [];
             }
+            return [];
+        }
 
-            // See if we already have a watcher for this file and version
-            const codeWatcher: ICodeWatcher | undefined = this.matchWatcher(document.fileName, document.version);
-            if (codeWatcher) {
-                return codeWatcher.getCodeLenses();
-            }
+        // See if we already have a watcher for this file and version
+        const codeWatcher: ICodeWatcher | undefined = this.matchWatcher(document.fileName, document.version);
+        if (codeWatcher) {
+            return codeWatcher.getCodeLenses();
+        }
 
-            // Create a new watcher for this file
-            const newCodeWatcher = new CodeWatcher(this.serviceContainer, document);
-            this.activeCodeWatchers.push(newCodeWatcher);
-            return newCodeWatcher.getCodeLenses();
+        // Create a new watcher for this file
+        const newCodeWatcher = this.serviceContainer.get<ICodeWatcher>(ICodeWatcher);
+        newCodeWatcher.addFile(document);
+        this.activeCodeWatchers.push(newCodeWatcher);
+        return newCodeWatcher.getCodeLenses();
     }
 
     // IDataScienceCodeLensProvider interface

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
+
+import { inject, injectable } from 'inversify';
 import { CodeLens, Command, Position, Range, Selection, TextDocument, TextEditorRevealType, window } from 'vscode';
 
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
 import { ILogger } from '../../common/types';
 import * as localize from '../../common/utils/localize';
-import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry } from '../../telemetry';
 import { Commands, EditorContexts, RegExpValues, Telemetry } from '../constants';
 import { JupyterInstallError } from '../jupyterInstallError';
@@ -18,22 +19,19 @@ export interface ICell {
     title: string;
 }
 
+@injectable()
 export class CodeWatcher implements ICodeWatcher {
     private document?: TextDocument;
     private version: number = -1;
     private fileName: string = '';
     private codeLenses: CodeLens[] = [];
-    private historyProvider: IHistoryProvider;
-    private commandManager: ICommandManager;
-    private applicationShell: IApplicationShell;
-    private logger: ILogger;
 
-    constructor(serviceContainer: IServiceContainer, document: TextDocument) {
-        this.historyProvider = serviceContainer.get<IHistoryProvider>(IHistoryProvider);
-        this.commandManager = serviceContainer.get<ICommandManager>(ICommandManager);
-        this.applicationShell = serviceContainer.get<IApplicationShell>(IApplicationShell);
-        this.logger = serviceContainer.get<ILogger>(ILogger);
+    constructor(@inject(ICommandManager) private commandManager: ICommandManager,
+                @inject(IApplicationShell) private applicationShell: IApplicationShell,
+                @inject(ILogger) private logger: ILogger,
+                @inject(IHistoryProvider) private historyProvider) {}
 
+    public addFile(document: TextDocument) { 
         this.document = document;
 
         // Cache these, we don't want to pull an old version if the document is updated

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -3,9 +3,9 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { CodeLens, Command, Position, Range, Selection, TextDocument, TextEditorRevealType, window } from 'vscode';
+import { CodeLens, Command, Position, Range, Selection, TextDocument, TextEditorRevealType } from 'vscode';
 
-import { IApplicationShell, ICommandManager } from '../../common/application/types';
+import { IApplicationShell, ICommandManager, IDocumentManager } from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
 import { ILogger } from '../../common/types';
 import * as localize from '../../common/utils/localize';
@@ -29,7 +29,8 @@ export class CodeWatcher implements ICodeWatcher {
     constructor(@inject(ICommandManager) private commandManager: ICommandManager,
                 @inject(IApplicationShell) private applicationShell: IApplicationShell,
                 @inject(ILogger) private logger: ILogger,
-                @inject(IHistoryProvider) private historyProvider) {}
+                @inject(IHistoryProvider) private historyProvider,
+                @inject(IDocumentManager) private documentManager) {}
 
     public addFile(document: TextDocument) { 
         this.document = document;
@@ -95,7 +96,7 @@ export class CodeWatcher implements ICodeWatcher {
             const code = this.document.getText(range);
 
             try {
-                await activeHistory.addCode(code, this.getFileName(), range.start.line, window.activeTextEditor);
+                await activeHistory.addCode(code, this.getFileName(), range.start.line, this.documentManager.activeTextEditor);
             } catch (err) {
                 this.handleError(err);
             }
@@ -105,13 +106,13 @@ export class CodeWatcher implements ICodeWatcher {
 
     @captureTelemetry(Telemetry.RunCurrentCell)
     public async runCurrentCell() {
-        if (!window.activeTextEditor || !window.activeTextEditor.document) {
+        if (!this.documentManager.activeTextEditor || !this.documentManager.activeTextEditor.document) {
             return;
         }
 
         for (const lens of this.codeLenses) {
             // Check to see which RunCell lens range overlaps the current selection start
-            if (lens.range.contains(window.activeTextEditor.selection.start) && lens.command && lens.command.command === Commands.RunCell) {
+            if (lens.range.contains(this.documentManager.activeTextEditor.selection.start) && lens.command && lens.command.command === Commands.RunCell) {
                 await this.runCell(lens.range);
                 break;
             }
@@ -120,7 +121,7 @@ export class CodeWatcher implements ICodeWatcher {
 
     @captureTelemetry(Telemetry.RunCurrentCellAndAdvance)
     public async runCurrentCellAndAdvance() {
-        if (!window.activeTextEditor || !window.activeTextEditor.document) {
+        if (!this.documentManager.activeTextEditor || !this.documentManager.activeTextEditor.document) {
             return;
         }
 
@@ -135,7 +136,7 @@ export class CodeWatcher implements ICodeWatcher {
             }
 
             // Check to see which RunCell lens range overlaps the current selection start
-            if (lens.range.contains(window.activeTextEditor.selection.start) && lens.command && lens.command.command === Commands.RunCell) {
+            if (lens.range.contains(this.documentManager.activeTextEditor.selection.start) && lens.command && lens.command.command === Commands.RunCell) {
                 currentRunCellLens = lens;
             }
         }
@@ -181,7 +182,7 @@ export class CodeWatcher implements ICodeWatcher {
     // User has picked run and advance on the last cell of a document
     // Create a new cell at the bottom and put their selection there, ready to type
     private createNewCell(currentRange: Range): Range {
-        const editor = window.activeTextEditor;
+        const editor = this.documentManager.activeTextEditor;
         const newPosition = new Position(currentRange.end.line + 3, 0); // +3 to account for the added spaces and to position after the new mark
 
         if (editor) {
@@ -195,7 +196,7 @@ export class CodeWatcher implements ICodeWatcher {
 
     // Advance the cursor to the selected range
     private advanceToRange(targetRange: Range) {
-        const editor = window.activeTextEditor;
+        const editor = this.documentManager.activeTextEditor;
         const newSelection = new Selection(targetRange.start, targetRange.start);
         if (editor) {
             editor.selection = newSelection;

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -32,7 +32,7 @@ export class CodeWatcher implements ICodeWatcher {
                 @inject(IHistoryProvider) private historyProvider,
                 @inject(IDocumentManager) private documentManager) {}
 
-    public addFile(document: TextDocument) { 
+    public addFile(document: TextDocument) {
         this.document = document;
 
         // Cache these, we don't want to pull an old version if the document is updated

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -5,6 +5,7 @@ import { IServiceManager } from '../ioc/types';
 import { CodeCssGenerator } from './codeCssGenerator';
 import { DataScience } from './datascience';
 import { DataScienceCodeLensProvider } from './editor-integration/codelensprovider';
+import { CodeWatcher } from './editor-integration/codewatcher';
 import { History } from './history';
 import { HistoryCommandListener } from './historycommandlistener';
 import { HistoryProvider } from './historyProvider';
@@ -15,6 +16,7 @@ import { JupyterServer } from './jupyterServer';
 import { StatusProvider } from './statusProvider';
 import {
     ICodeCssGenerator,
+    ICodeWatcher,
     IDataScience,
     IDataScienceCodeLensProvider,
     IDataScienceCommandListener,
@@ -39,4 +41,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.add<INotebookProcess>(INotebookProcess, JupyterProcess);
     serviceManager.addSingleton<ICodeCssGenerator>(ICodeCssGenerator, CodeCssGenerator);
     serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);
+    serviceManager.add<ICodeWatcher>(ICodeWatcher, CodeWatcher);
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -92,6 +92,7 @@ export interface IDataScienceCodeLensProvider extends CodeLensProvider {
 // Wraps the Code Watcher API
 export const ICodeWatcher = Symbol('ICodeWatcher');
 export interface ICodeWatcher {
+    addFile(document: TextDocument);
     getFileName() : string;
     getVersion() : number;
     getCodeLenses() : CodeLens[];

--- a/src/test/datascience/datascience.unit.test.ts
+++ b/src/test/datascience/datascience.unit.test.ts
@@ -7,7 +7,6 @@ import * as TypeMoq from 'typemoq';
 import { IApplicationShell, ICommandManager } from '../../client/common/application/types';
 import { IDisposableRegistry } from '../../client/common/types';
 import { DataScience } from '../../client/datascience/datascience';
-import { DataScienceCodeLensProvider } from '../../client/datascience/editor-integration/codelensprovider';
 import { IDataScience } from '../../client/datascience/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
@@ -17,7 +16,6 @@ suite('Data Science Tests', () => {
     let commandManager: TypeMoq.IMock<ICommandManager>;
     let disposableRegistry: TypeMoq.IMock<IDisposableRegistry>;
     let dataScience: IDataScience;
-    let codeLensProvider: DataScienceCodeLensProvider;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();

--- a/src/test/datascience/datascience.unit.test.ts
+++ b/src/test/datascience/datascience.unit.test.ts
@@ -7,6 +7,7 @@ import * as TypeMoq from 'typemoq';
 import { IApplicationShell, ICommandManager } from '../../client/common/application/types';
 import { IDisposableRegistry } from '../../client/common/types';
 import { DataScience } from '../../client/datascience/datascience';
+import { DataScienceCodeLensProvider } from '../../client/datascience/editor-integration/codelensprovider';
 import { IDataScience } from '../../client/datascience/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
@@ -16,6 +17,7 @@ suite('Data Science Tests', () => {
     let commandManager: TypeMoq.IMock<ICommandManager>;
     let disposableRegistry: TypeMoq.IMock<IDisposableRegistry>;
     let dataScience: IDataScience;
+    let codeLensProvider: DataScienceCodeLensProvider;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();

--- a/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
+++ b/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
@@ -5,10 +5,10 @@
 
 import * as TypeMoq from 'typemoq';
 import { TextDocument } from 'vscode';
-import { IConfigurationService, IPythonSettings, IDataScienceSettings } from '../../../client/common/types';
-import { IDataScienceCodeLensProvider } from '../../../client/datascience/types';
-import { IServiceContainer } from '../../../client/ioc/types';
+import { IConfigurationService, IDataScienceSettings, IPythonSettings } from '../../../client/common/types';
 import { DataScienceCodeLensProvider } from '../../../client/datascience/editor-integration/codelensprovider';
+import { ICodeWatcher, IDataScienceCodeLensProvider } from '../../../client/datascience/types';
+import { IServiceContainer } from '../../../client/ioc/types';
 
 suite('DataScienceCodeLensProvider Unit Tests', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
@@ -29,10 +29,68 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
         codeLensProvider = new DataScienceCodeLensProvider(serviceContainer.object, configurationService.object);
     });
 
-    test('Initialize Code Lenses', () => {
+    test('Initialize Code Lenses one document', () => {
+        // Create our document
         const document = TypeMoq.Mock.ofType<TextDocument>();
         document.setup(d => d.fileName).returns(() => 'test.py');
         document.setup(d => d.version).returns(() => 1);
+
+        const targetCodeWatcher = TypeMoq.Mock.ofType<ICodeWatcher>();
+        targetCodeWatcher.setup(tc => tc.getCodeLenses()).returns(() => []).verifiable(TypeMoq.Times.once());
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICodeWatcher))).returns(() => targetCodeWatcher.object).verifiable(TypeMoq.Times.once());
+
         codeLensProvider.provideCodeLenses(document.object, undefined);
+
+        targetCodeWatcher.verifyAll();
+        serviceContainer.verifyAll();
+    });
+
+    test('Initialize Code Lenses same doc called', () => {
+        // Create our document
+        const document = TypeMoq.Mock.ofType<TextDocument>();
+        document.setup(d => d.fileName).returns(() => 'test.py');
+        document.setup(d => d.version).returns(() => 1);
+
+        const targetCodeWatcher = TypeMoq.Mock.ofType<ICodeWatcher>();
+        targetCodeWatcher.setup(tc => tc.getCodeLenses()).returns(() => []).verifiable(TypeMoq.Times.exactly(2));
+        targetCodeWatcher.setup(tc => tc.getFileName()).returns(() => 'test.py');
+        targetCodeWatcher.setup(tc => tc.getVersion()).returns(() => 1);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICodeWatcher))).returns(() => targetCodeWatcher.object).verifiable(TypeMoq.Times.once());
+
+        codeLensProvider.provideCodeLenses(document.object, undefined);
+        codeLensProvider.provideCodeLenses(document.object, undefined);
+
+        // getCodeLenses should be called twice, but getting the code watcher only once due to same doc
+        targetCodeWatcher.verifyAll();
+        serviceContainer.verifyAll();
+    });
+
+    test('Initialize Code Lenses new name / version', () => {
+        // Create our document
+        const document = TypeMoq.Mock.ofType<TextDocument>();
+        document.setup(d => d.fileName).returns(() => 'test.py');
+        document.setup(d => d.version).returns(() => 1);
+
+        const document2 = TypeMoq.Mock.ofType<TextDocument>();
+        document2.setup(d => d.fileName).returns(() => 'test2.py');
+        document2.setup(d => d.version).returns(() => 1);
+
+        const document3 = TypeMoq.Mock.ofType<TextDocument>();
+        document3.setup(d => d.fileName).returns(() => 'test.py');
+        document3.setup(d => d.version).returns(() => 2);
+
+        const targetCodeWatcher = TypeMoq.Mock.ofType<ICodeWatcher>();
+        targetCodeWatcher.setup(tc => tc.getCodeLenses()).returns(() => []).verifiable(TypeMoq.Times.exactly(3));
+        targetCodeWatcher.setup(tc => tc.getFileName()).returns(() => 'test.py');
+        targetCodeWatcher.setup(tc => tc.getVersion()).returns(() => 1);
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICodeWatcher))).returns(() => targetCodeWatcher.object).verifiable(TypeMoq.Times.exactly(3));
+
+        codeLensProvider.provideCodeLenses(document.object, undefined);
+        codeLensProvider.provideCodeLenses(document2.object, undefined);
+        codeLensProvider.provideCodeLenses(document3.object, undefined);
+
+        // service container get should be called three times as the names and versions don't match
+        targetCodeWatcher.verifyAll();
+        serviceContainer.verifyAll();
     });
 });

--- a/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
+++ b/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as TypeMoq from 'typemoq';
+import { TextDocument } from 'vscode';
+import { IConfigurationService, IPythonSettings, IDataScienceSettings } from '../../../client/common/types';
+import { IDataScienceCodeLensProvider } from '../../../client/datascience/types';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { DataScienceCodeLensProvider } from '../../../client/datascience/editor-integration/codelensprovider';
+
+suite('DataScienceCodeLensProvider Unit Tests', () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let configurationService: TypeMoq.IMock<IConfigurationService>;
+    let codeLensProvider: IDataScienceCodeLensProvider;
+    let dataScienceSettings: TypeMoq.IMock<IDataScienceSettings>;
+    let pythonSettings: TypeMoq.IMock<IPythonSettings>;
+    setup(() => {
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        configurationService = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+        dataScienceSettings = TypeMoq.Mock.ofType<IDataScienceSettings>();
+        dataScienceSettings.setup(d => d.enabled).returns(() => true);
+        pythonSettings.setup(p => p.datascience).returns(() => dataScienceSettings.object);
+        configurationService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+
+        codeLensProvider = new DataScienceCodeLensProvider(serviceContainer.object, configurationService.object);
+    });
+
+    test('Initialize Code Lenses', () => {
+        const document = TypeMoq.Mock.ofType<TextDocument>();
+        document.setup(d => d.fileName).returns(() => 'test.py');
+        document.setup(d => d.version).returns(() => 1);
+        codeLensProvider.provideCodeLenses(document.object, undefined);
+    });
+});

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -2,15 +2,16 @@
 // Licensed under the MIT License.
 
 'use strict';
-
+// tslint:disable:max-func-body-length no-trailing-whitespace no-multiline-string
+// Disable whitespace / multiline as we use that to pass in our fake file strings
 import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
-import { TextDocument, TextEditor, TextLine, Range, Selection } from 'vscode';
-import { CodeWatcher } from '../../../client/datascience/editor-integration/codewatcher';
-import { ICommandManager, IApplicationShell, IDocumentManager } from '../../../client/common/application/types';
+import { Range, Selection, TextDocument, TextEditor, TextLine } from 'vscode';
+import { IApplicationShell, ICommandManager, IDocumentManager } from '../../../client/common/application/types';
 import { ILogger } from '../../../client/common/types';
-import { IHistory, IHistoryProvider } from '../../../client/datascience/types';
 import { Commands } from '../../../client/datascience/constants';
+import { CodeWatcher } from '../../../client/datascience/editor-integration/codewatcher';
+import { IHistory, IHistoryProvider } from '../../../client/datascience/types';
 
 suite('DataScience Code Watcher Unit Tests', () => {
     let codeWatcher: CodeWatcher;
@@ -55,9 +56,9 @@ suite('DataScience Code Watcher Unit Tests', () => {
         const codeLenses = codeWatcher.getCodeLenses();
         expect(codeLenses.length).to.be.equal(2, 'Incorrect count of code lenses');
         expect(codeLenses[0].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
-        expect(codeLenses[0].range).to.be.deep.equal(new Range(0,0,0,3), 'Run Cell code lens range incorrect');
+        expect(codeLenses[0].range).to.be.deep.equal(new Range(0, 0, 0, 3), 'Run Cell code lens range incorrect');
         expect(codeLenses[1].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
-        expect(codeLenses[1].range).to.be.deep.equal(new Range(0,0,0,3), 'Run All Cells code lens range incorrect');
+        expect(codeLenses[1].range).to.be.deep.equal(new Range(0, 0, 0, 3), 'Run All Cells code lens range incorrect');
 
         // Verify function calls
         document.verifyAll();
@@ -86,7 +87,7 @@ suite('DataScience Code Watcher Unit Tests', () => {
     test('Add a file with multiple marks to a code watcher', () => {
         const fileName = 'test.py';
         const version = 1;
-        const inputText = 
+        const inputText =
 `first line
 second line
         
@@ -107,13 +108,13 @@ fourth line`;
         const codeLenses = codeWatcher.getCodeLenses();
         expect(codeLenses.length).to.be.equal(4, 'Incorrect count of code lenses');
         expect(codeLenses[0].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
-        expect(codeLenses[0].range).to.be.deep.equal(new Range(3,0,5,8), 'Run Cell code lens range incorrect');
+        expect(codeLenses[0].range).to.be.deep.equal(new Range(3, 0, 5, 8), 'Run Cell code lens range incorrect');
         expect(codeLenses[1].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
-        expect(codeLenses[1].range).to.be.deep.equal(new Range(3,0,5,8), 'Run All Cells code lens range incorrect');
+        expect(codeLenses[1].range).to.be.deep.equal(new Range(3, 0, 5, 8), 'Run All Cells code lens range incorrect');
         expect(codeLenses[2].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
-        expect(codeLenses[2].range).to.be.deep.equal(new Range(6,0,7,11), 'Run Cell code lens range incorrect');
+        expect(codeLenses[2].range).to.be.deep.equal(new Range(6, 0, 7, 11), 'Run Cell code lens range incorrect');
         expect(codeLenses[3].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
-        expect(codeLenses[3].range).to.be.deep.equal(new Range(6,0,7,11), 'Run All Cells code lens range incorrect');
+        expect(codeLenses[3].range).to.be.deep.equal(new Range(6, 0, 7, 11), 'Run All Cells code lens range incorrect');
 
         // Verify function calls
         document.verifyAll();
@@ -126,7 +127,7 @@ fourth line`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
         // Specify our range and text here
-        const testRange = new Range(0,0,10,10);
+        const testRange = new Range(0, 0, 10, 10);
         const testString = 'testing';
         document.setup(doc => doc.getText(testRange)).returns(() => testString).verifiable(TypeMoq.Times.once());
 
@@ -159,10 +160,10 @@ testing2`; // Command tests override getText, so just need the ranges here
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
         // Specify our range and text here
-        const testRange1 = new Range(0,0,1,8);
+        const testRange1 = new Range(0, 0, 1, 8);
         const testString1 = 'testing1';
         document.setup(doc => doc.getText(testRange1)).returns(() => testString1).verifiable(TypeMoq.Times.once());
-        const testRange2 = new Range(2,0,3,8);
+        const testRange2 = new Range(2, 0, 3, 8);
         const testString2 = 'testing2';
         document.setup(doc => doc.getText(testRange2)).returns(() => testString2).verifiable(TypeMoq.Times.once());
 
@@ -196,29 +197,111 @@ testing1
 #%%
 testing2`; 
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+        document.setup(d => d.getText(new Range(2, 0, 3, 8))).returns(() => 'testing2').verifiable(TypeMoq.Times.atLeastOnce());
 
         codeWatcher.addFile(document.object);
 
-        // Set up our expected call to add code
+        // Set up our expected calls to add code
         activeHistory.setup(h => h.addCode(TypeMoq.It.isValue('testing2'),
                                 TypeMoq.It.isValue(fileName),
-                                TypeMoq.It.isValue(0),
+                                TypeMoq.It.isValue(2),
                                 TypeMoq.It.is((ed: TextEditor) => {
                                     return textEditor.object === ed;
                                 }))).verifiable(TypeMoq.Times.once());
         
         // For this test we need to set up a document selection point
-        textEditor.setup(te => te.selection).returns(() => new Selection(2,0,2,0));
+        textEditor.setup(te => te.selection).returns(() => new Selection(2, 0, 2, 0));
         
-        // Try our RunCell command
+        // Try our RunCell command with the first selection point
         await codeWatcher.runCurrentCell();
 
         // Verify function calls
         activeHistory.verifyAll();
         document.verifyAll();
     });
+
+    test('Test the RunCurrentCell command outside of a cell', async () => {
+        const fileName = 'test.py';
+        const version = 1;
+        const inputText = 
+`testing1
+#%%
+testing2`; 
+        const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+
+        codeWatcher.addFile(document.object);
+
+        // We don't want to ever call add code here
+        activeHistory.setup(h => h.addCode(TypeMoq.It.isAny(),
+                                TypeMoq.It.isAny(),
+                                TypeMoq.It.isAny(),
+                                TypeMoq.It.isAny())).verifiable(TypeMoq.Times.never());
+        
+        // For this test we need to set up a document selection point
+        textEditor.setup(te => te.selection).returns(() => new Selection(0, 0, 0, 0));
+        
+        // Try our RunCell command with the first selection point
+        await codeWatcher.runCurrentCell();
+
+        // Verify function calls
+        activeHistory.verifyAll();
+        document.verifyAll();
+    });
+
+    test('Test the RunCellAndAdvance command with next cell', async () => {
+        const fileName = 'test.py';
+        const version = 1;
+        const inputText = 
+`#%%
+testing1
+#%%
+testing2`; // Command tests override getText, so just need the ranges here
+        const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+        const testRange = new Range(0, 0, 1, 8);
+        const testString = 'testing1';
+        document.setup(d => d.getText(testRange)).returns(() => testString).verifiable(TypeMoq.Times.atLeastOnce());
+
+        codeWatcher.addFile(document.object);
+
+        // Set up our expected calls to add code
+        activeHistory.setup(h => h.addCode(TypeMoq.It.isValue(testString),
+                                TypeMoq.It.isValue('test.py'),
+                                TypeMoq.It.isValue(0),
+                                TypeMoq.It.is((ed: TextEditor) => {
+                                    return textEditor.object === ed;
+                                }))).verifiable(TypeMoq.Times.once());
+
+        // For this test we need to set up a document selection point
+        const selection = new Selection(0, 0, 0, 0);
+        textEditor.setup(te => te.selection).returns(() => selection);
+        
+        //textEditor.setup(te => te.selection = TypeMoq.It.isAny()).verifiable(TypeMoq.Times.once());
+        //textEditor.setup(te => te.selection = TypeMoq.It.isAnyObject<Selection>(Selection));
+        // IANHU: Would be good to check that selection was set, but TypeMoq doesn't seem to like
+        // both getting and setting an object property. isAnyObject is not valid for this class
+        // and is or isAny overwrite the previous property getter if used. Will verify selection set
+        // in functional test
+        // https://github.com/florinn/typemoq/issues/107
+
+        // To get around this, override the advanceToRange function called from within runCurrentCellAndAdvance
+        // this will tell us if we are calling the correct range
+        codeWatcher['advanceToRange'] = (targetRange: Range) => {
+            expect(targetRange.start.line).is.equal(2, 'Incorrect range in run cell and advance');
+            expect(targetRange.start.character).is.equal(0, 'Incorrect range in run cell and advance');
+            expect(targetRange.end.line).is.equal(3, 'Incorrect range in run cell and advance');
+            expect(targetRange.end.character).is.equal(8, 'Incorrect range in run cell and advance');
+        };
+
+        await codeWatcher.runCurrentCellAndAdvance();
+
+        // Verify function calls
+        textEditor.verifyAll();
+        activeHistory.verifyAll();
+        document.verifyAll();
+    });
 });
 
+// Helper function to create a document and get line count and lines
 function createDocument(inputText: string, fileName: string, fileVersion: number,
         times: TypeMoq.Times): TypeMoq.IMock<TextDocument> {
     const document = TypeMoq.Mock.ofType<TextDocument>();
@@ -235,7 +318,7 @@ function createDocument(inputText: string, fileName: string, fileVersion: number
 
     inputLines.forEach((line, index) => {
         const textLine = TypeMoq.Mock.ofType<TextLine>();
-        const testRange = new Range(index,0,index,line.length);
+        const testRange = new Range(index, 0, index, line.length);
         textLine.setup(l => l.text).returns(() => line);
         textLine.setup(l => l.range).returns(() => testRange);
         document.setup(d => d.lineAt(TypeMoq.It.isValue(index))).returns(() => textLine.object).verifiable(TypeMoq.Times.atLeastOnce());

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { TextDocument, TextLine, Range } from 'vscode';
+import { CodeWatcher } from '../../../client/datascience/editor-integration/codewatcher';
+import { ICommandManager, IApplicationShell } from '../../../client/common/application/types';
+import { ILogger } from '../../../client/common/types';
+import { IHistoryProvider } from '../../../client/datascience/types';
+import { Commands } from '../../../client/datascience/constants';
+
+suite('DataScience Code Watcher Unit Tests', () => {
+    let codeWatcher: CodeWatcher;
+    let commandManager: TypeMoq.IMock<ICommandManager>;
+    let appShell: TypeMoq.IMock<IApplicationShell>;
+    let logger: TypeMoq.IMock<ILogger>;
+    let historyProvider: TypeMoq.IMock<IHistoryProvider>;
+    setup(() => {
+        commandManager = TypeMoq.Mock.ofType<ICommandManager>();
+        appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+        logger = TypeMoq.Mock.ofType<ILogger>();
+        historyProvider = TypeMoq.Mock.ofType<IHistoryProvider>();
+
+
+        codeWatcher = new CodeWatcher(commandManager.object, appShell.object, logger.object, historyProvider.object);
+    });
+
+    test('Add a file with just a #%% mark to a code watcher', () => {
+        const fileName = 'test.py';
+        const version = 1;
+        const inputText = `#%%`;
+        const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+
+
+        codeWatcher.addFile(document.object);
+
+        // Verify meta data
+        expect(codeWatcher.getFileName()).to.be.equal(fileName, 'File name of CodeWatcher does not match');
+        expect(codeWatcher.getVersion()).to.be.equal(version, 'File version of CodeWatcher does not match');
+
+        // Verify code lenses
+        const codeLenses = codeWatcher.getCodeLenses();
+        expect(codeLenses.length).to.be.equal(2, 'Incorrect count of code lenses');
+        expect(codeLenses[0].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
+        expect(codeLenses[0].range).to.be.deep.equal(new Range(0,0,0,3), 'Run Cell code lens range incorrect');
+        expect(codeLenses[1].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        expect(codeLenses[1].range).to.be.deep.equal(new Range(0,0,0,3), 'Run All Cells code lens range incorrect');
+
+        // Verify function calls
+        document.verifyAll();
+    });
+});
+
+function createDocument(inputText: string, fileName: string, fileVersion: number,
+        times: TypeMoq.Times): TypeMoq.IMock<TextDocument> {
+    const document = TypeMoq.Mock.ofType<TextDocument>();
+
+    // Split our string on newline chars
+    const inputLines = inputText.split(/\r?\n/);
+
+    // First set the metadata
+    document.setup(d => d.fileName).returns(() => fileName).verifiable(times);
+    document.setup(d => d.version).returns(() => fileVersion).verifiable(times);
+
+    // Next add the lines in
+    document.setup(d => d.lineCount).returns(() => inputLines.length).verifiable(times);
+
+    inputLines.forEach((line, index) => {
+        const lastLine = TypeMoq.Mock.ofType<TextLine>();
+        const testRange = new Range(index,0,index,line.length);
+        lastLine.setup(l => l.text).returns(() => '#%%').verifiable(times);
+        lastLine.setup(l => l.range).returns(() => testRange).verifiable(times);
+        document.setup(d => d.lineAt(TypeMoq.It.isValue(index))).returns(() => lastLine.object).verifiable(TypeMoq.Times.atLeastOnce());
+    });
+
+    return document;
+}


### PR DESCRIPTION
For #3264 

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
