### PR TITLE
Add YAML build scripts that mimic the current PR validation build

### DIFF
--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -148,6 +148,14 @@ jobs:
 
 
     - task: CmdLine@1
+      displayName: 'pip upgrade pip'
+      inputs:
+        filename: python
+
+        arguments: '-m pip install --upgrade pip'
+
+
+    - task: CmdLine@1
       displayName: 'pip install requirements'
       inputs:
         filename: python

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -1,0 +1,205 @@
+parameters:
+  name: 'Unit_Test_Run'
+  PythonVersion: '3.7'
+  NodeVersion: '8.11.2'
+  NpmVersion: 'latest'
+  PoolName: 'Hosted Ubuntu 1604'
+  MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+  MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+  MOCHA_REPORTER_JUNIT: true
+  PublishVsix: false
+  RunHygiene: true
+  UploadBinary: false
+  AzureStorageAccountName: 'vscodepythonartifacts'
+  AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+
+jobs:
+- job: ${{ parameters.name }}
+  pool:
+    name: ${{ parameters.PoolName }}
+
+  variables:
+    # TODO: use {{ insert }}: {{ parameters.variables }}, it would not work at time I wrote this
+    nodeVersion: ${{ parameters.NodeVersion }}
+    npmVersion: ${{ parameters.NpmVersion }}
+    pythonVersion: ${{ parameters.PythonVersion }}
+    publishVsix: ${{ parameters.PublishVsix }}
+    mochaReportFile: ${{ parameters.MOCHA_CI_REPORTFILE }}
+    MOCHA_CI_REPORTER_ID: ${{ parameters.MOCHA_CI_REPORTER_ID }}
+    MOCHA_CI_REPORTFILE: ${{ parameters.MOCHA_CI_REPORTFILE }}
+    MOCHA_REPORTER_JUNIT: ${{ parameters.MOCHA_REPORTER_JUNIT }}
+    runHygiene: ${{ parameters.RunHygiene }}
+    uploadBinary: ${{ parameters.UploadBinary }}
+    azureStorageAcctName: ${{ parameters.AzureStorageAccountName }}
+    azureStorageContainerName: ${{ parameters.AzureStorageContainerName }}
+    plaform: ${{ parameters.Platform }}
+
+  steps:
+    - bash: echo REQUESTED VARIABLE VALUES
+
+        echo Node Version = $(nodeVersion)
+
+        echo Python Version = $(pythonVersion)
+
+        echo NPM Version = $(npmVersion)
+
+        echo Publish VSIX? = $(publishVsix)
+
+        echo Mocha reportfile = '$(mochaReportFile)'
+
+        echo MOCHA_CI_REPORTFILE = $MOCHA_CI_REPORTFILE
+
+        echo MOCHA_CI_REPORTER_ID = $MOCHA_CI_REPORTER_ID
+
+        echo MOCHA_REPORTER_JUNIT = $MOCHA_REPORTER_JUNIT
+
+        echo COV_UUID = $COV_UUID
+
+        echo Run Hygiene = $(runHygiene)
+
+      displayName: 'Ch Ch Checkit Owt'
+      name: 'bash_tool_non_conditional_run'
+
+
+  # - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  #   displayName: 'Component Detection'
+
+  #   continueOnError: true
+  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+
+    - task: NodeTool@0
+      displayName: 'Use Node $(nodeVersion)'
+      inputs:
+        versionSpec: '$(nodeVersion)'
+
+
+    - task: UsePythonVersion@0
+      displayName: 'Use Python $(pythonVersion)'
+      inputs:
+        versionSpec: '$(pythonVersion)'
+
+
+    - task: Npm@1
+      displayName: 'update npm'
+      inputs:
+        command: custom
+
+        verbose: true
+
+        customCommand: 'install -g npm@$(npmVersion)'
+
+
+    - task: Npm@1
+      displayName: 'npm ci'
+      inputs:
+        command: custom
+
+        verbose: true
+
+        customCommand: ci
+
+
+    - task: Npm@1
+      displayName: 'run vscode:prepublish'
+      inputs:
+        command: custom
+
+        verbose: false
+
+        customCommand: 'run vscode:prepublish'
+
+
+    - task: Gulp@0
+      displayName: 'gulp code hygiene'
+      inputs:
+        targets: 'hygiene-modified'
+      condition: and(succeeded(), eq(variables['runHygiene'], 'true'))
+
+
+    - task: Npm@1
+      displayName: 'run cover:enable'
+      inputs:
+        command: custom
+
+        verbose: false
+
+        customCommand: 'run cover:enable'
+
+
+    - task: Npm@1
+      displayName: 'run test:unittests'
+      inputs:
+        command: custom
+
+        verbose: false
+
+        customCommand: 'run test:unittests'
+
+
+    - bash: 'bash <(curl -s https://codecov.io/bash) -t $COV_UUID'
+      displayName: 'publish codecov'
+      continueOnError: true
+      condition: always()
+
+
+    - task: CmdLine@1
+      displayName: 'pip install requirements'
+      inputs:
+        filename: python
+
+        arguments: '-m pip install --upgrade -r ./requirements.txt'
+
+
+    - task: CmdLine@1
+      displayName: 'pip install ptvsd'
+      inputs:
+        filename: python
+
+        arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd ptvsd --no-cache-dir'
+
+      enabled: false
+
+
+    - task: CmdLine@1
+      displayName: 'pip install ptvsd [dev]'
+      inputs:
+        filename: python
+
+        arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/'
+
+
+    - task: ArchiveFiles@2
+      displayName: 'Capture Binaries'
+      inputs:
+        rootFolderOrFile: out
+
+        archiveFile: '$(Build.ArtifactStagingDirectory)/bin-artifacts.zip'
+
+
+    - task: AzureFileCopy@2
+      displayName: 'Upload bin-artifacts to cloud-store'
+      inputs:
+        SourcePath: '$(Build.ArtifactStagingDirectory)/bin-artifacts.zip'
+#       azureSubscription: 'dekeeler-ptvsazure-acct-for-dev'
+        azureSubscription: 'dekeeler-vscodepythonartifacts'
+        Destination: AzureBlob
+#       storage: vscodepythonci
+        storage: $(azureStorageAcctName)
+#       ContainerName: 'vscode-python-ci'
+        ContainerName: $(azureStorageContainerName)
+        BlobPrefix: '$(Build.BuildNumber)'
+      condition: and(succeeded(), eq(variables['uploadBinary'], 'true'))
+
+
+    - bash: echo AVAILABLE DEPENDENCY VERSIONS
+
+        echo Node Version = `node -v`
+
+        echo NPM Version = `npm -v`
+
+        echo Python Version = `python --version`
+
+      displayName: 'See whazzzup'
+      name: 'see_what_is_up_dawg'
+

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -10,8 +10,8 @@ parameters:
   PublishVsix: false
   RunHygiene: true
   UploadBinary: false
-  AzureStorageAccountName: 'vscodepythonartifacts'
-  AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+  AzureStorageAccountName: 'vscodepythonartifacts'  # 'vscodepythonci'
+  AzureStorageContainerName: 'pvsc-ci-yaml-artifacts' # 'vscode-python-ci'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -61,11 +61,11 @@ jobs:
       name: 'bash_tool_non_conditional_run'
 
 
-  # - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  #   displayName: 'Component Detection'
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
 
-  #   continueOnError: true
-  #   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      continueOnError: true
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
 
     - task: NodeTool@0
@@ -181,12 +181,9 @@ jobs:
       displayName: 'Upload bin-artifacts to cloud-store'
       inputs:
         SourcePath: '$(Build.ArtifactStagingDirectory)/bin-artifacts.zip'
-#       azureSubscription: 'dekeeler-ptvsazure-acct-for-dev'
-        azureSubscription: 'dekeeler-vscodepythonartifacts'
+        azureSubscription: 'dekeeler-ptvsazure-acct-for-dev'
         Destination: AzureBlob
-#       storage: vscodepythonci
         storage: $(azureStorageAcctName)
-#       ContainerName: 'vscode-python-ci'
         ContainerName: $(azureStorageContainerName)
         BlobPrefix: '$(Build.BuildNumber)'
       condition: and(succeeded(), eq(variables['uploadBinary'], 'true'))

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -53,8 +53,8 @@ jobs:
 
         echo Run Hygiene = $(runHygiene)
 
-      displayName: 'Ch Ch Checkit Owt'
-      name: 'bash_tool_non_conditional_run'
+      displayName: 'Show build vars'
+      name: 'show_bld_vars'
 
 
     - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
@@ -94,6 +94,18 @@ jobs:
         verbose: true
 
         customCommand: ci
+
+
+    - bash: echo AVAILABLE DEPENDENCY VERSIONS
+
+        echo Node Version = `node -v`
+
+        echo NPM Version = `npm -v`
+
+        echo Python Version = `python --version`
+
+      displayName: 'Show build dependency versions'
+      name: 'show_bld_deps_vers'
 
 
     - task: Npm@1
@@ -183,16 +195,3 @@ jobs:
         ContainerName: $(azureStorageContainerName)
         BlobPrefix: '$(Build.BuildNumber)'
       condition: and(succeeded(), eq(variables['uploadBinary'], 'true'))
-
-
-    - bash: echo AVAILABLE DEPENDENCY VERSIONS
-
-        echo Node Version = `node -v`
-
-        echo NPM Version = `npm -v`
-
-        echo Python Version = `python --version`
-
-      displayName: 'See whazzzup'
-      name: 'see_what_is_up_dawg'
-

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -7,7 +7,6 @@ parameters:
   MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
   MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
   MOCHA_REPORTER_JUNIT: true
-  PublishVsix: false
   RunHygiene: true
   UploadBinary: false
   AzureStorageAccountName: 'vscodepythonci'
@@ -23,7 +22,6 @@ jobs:
     nodeVersion: ${{ parameters.NodeVersion }}
     npmVersion: ${{ parameters.NpmVersion }}
     pythonVersion: ${{ parameters.PythonVersion }}
-    publishVsix: ${{ parameters.PublishVsix }}
     mochaReportFile: ${{ parameters.MOCHA_CI_REPORTFILE }}
     MOCHA_CI_REPORTER_ID: ${{ parameters.MOCHA_CI_REPORTER_ID }}
     MOCHA_CI_REPORTFILE: ${{ parameters.MOCHA_CI_REPORTFILE }}
@@ -42,8 +40,6 @@ jobs:
         echo Python Version = $(pythonVersion)
 
         echo NPM Version = $(npmVersion)
-
-        echo Publish VSIX? = $(publishVsix)
 
         echo Mocha reportfile = '$(mochaReportFile)'
 

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -108,14 +108,10 @@ jobs:
       name: 'show_bld_deps_vers'
 
 
-    - task: Npm@1
-      displayName: 'run vscode:prepublish'
+    - task: Gulp@0
+      displayName: 'gulp prePublishNonBundle'
       inputs:
-        command: custom
-
-        verbose: false
-
-        customCommand: 'run vscode:prepublish'
+        targets: 'prePublishNonBundle'
 
 
     - task: Gulp@0
@@ -164,17 +160,7 @@ jobs:
       inputs:
         filename: python
 
-        arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd ptvsd --no-cache-dir'
-
-      enabled: false
-
-
-    - task: CmdLine@1
-      displayName: 'pip install ptvsd [dev]'
-      inputs:
-        filename: python
-
-        arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/'
+        arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd --no-cache-dir --implementation py --no-deps ptvsd'
 
 
     - task: ArchiveFiles@2

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -10,8 +10,8 @@ parameters:
   PublishVsix: false
   RunHygiene: true
   UploadBinary: false
-  AzureStorageAccountName: 'vscodepythonartifacts'  # 'vscodepythonci'
-  AzureStorageContainerName: 'pvsc-ci-yaml-artifacts' # 'vscode-python-ci'
+  AzureStorageAccountName: 'vscodepythonci'
+  AzureStorageContainerName: 'vscode-python-ci'
 
 jobs:
 - job: ${{ parameters.name }}

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -22,37 +22,20 @@ steps:
 
       echo NPM Version = $NPM_VERSION
 
-      echo Mocha reportfile = $MOCHA_REPORTFILE
-
       echo MOCHA_CI_REPORTFILE = $MOCHA_CI_REPORTFILE
 
       echo MOCHA_CI_REPORTER_ID = $MOCHA_CI_REPORTER_ID
 
       echo MOCHA_REPORTER_JUNIT = $MOCHA_REPORTER_JUNIT
 
-      echo COV_UUID = $COV_UUID
-
-      echo Test Suite Name = $TEST_SUITE_NAME
-
-      echo params Test Suite Name = $OT_TEST_SUITE_NAME
-
-      echo giver Test Suite Name = $(TestSuiteName)
-
-      echo parameter Test Suite Name = ${{ parameters.TestSuiteName }}
+      echo Test Suite Name = $(TestSuiteName)
 
       echo pre-defined Build Number = $BUILD_BUILDNUMBER
 
-      echo My Build Number = $BUILD_NUM
-
-      echo Try just accessing a parameter 'platform' = $PARAMETERS_PLATFORM
-
-    displayName: 'Ch Ch Checkit Owt'
-    name: 'bash_tool_non_conditional_run'
+    displayName: 'Show build vars'
+    name: 'bash_tool_show_bld_vars'
     env:
-      BUILD_NUM: $(Build.BuildNumber)
-      MOCHA_REPORTFILE: $(mochaReportFile)
       TEST_SUITE_NAME: $(testSuiteName)
-      OT_TEST_SUITE_NAME: ${{ format('{0}', parameters.TestSuiteName) }}
       NODE_VERSION: $(nodeVersion)
       NPM_VERSION: $(npmVersion)
       PYTHON_VERSION: $(pythonVersion)
@@ -94,14 +77,14 @@ steps:
       versionSpec: '$(PythonVersion)'
 
 
-  - bash: echo INTERIM WHAZZUP PYTHON VERSION
+  - bash: echo SHOW ACQUIRED PYTHON
 
       echo Python Version = `python --version`
 
       echo Reported Python Path = `python -c "import sys;print(sys.executable)"`
 
-    displayName: 'See Python Version'
-    name: 'see_py_ver'
+    displayName: 'Show Python Version'
+    name: 'show_py_ver'
 
 
   - task: PythonScript@0
@@ -139,8 +122,8 @@ steps:
 
       echo Reported Python Path = `python -c "import sys;print(sys.executable)"`
 
-    displayName: 'See whazzzup'
-    name: 'see_what_is_up_dawg'
+    displayName: 'Show build dependency versions'
+    name: 'show_bld_deps_vers'
 
 
   - task: Npm@1

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -149,17 +149,7 @@ steps:
     inputs:
       filename: python
 
-      arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd ptvsd --no-cache-dir'
-
-    enabled: false
-
-
-  - task: CmdLine@1
-    displayName: 'pip install ptvsd [dev]'
-    inputs:
-      filename: python
-
-      arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/'
+      arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd --no-cache-dir --implementation py --no-deps ptvsd'
 
 
   - task: Npm@1

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -137,6 +137,14 @@ steps:
 
 
   - task: CmdLine@1
+    displayName: 'pip upgrade pip'
+    inputs:
+      filename: python
+
+      arguments: '-m pip install --upgrade pip'
+
+
+  - task: CmdLine@1
     displayName: 'pip install requirements'
     inputs:
       filename: python

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -38,6 +38,8 @@ steps:
 
       echo giver Test Suite Name = $(TestSuiteName)
 
+      echo parameter Test Suite Name = ${{ parameters.TestSuiteName }}
+
       echo pre-defined Build Number = $BUILD_BUILDNUMBER
 
       echo My Build Number = $BUILD_NUM
@@ -59,7 +61,7 @@ steps:
   - powershell: |
       New-Item -ItemType directory -Path "$(System.ArtifactsDirectory)/bin-artifacts"
 
-      $buildArtifactUri = "https://${{ parameters.AzureStorageAccountName }}.blob.core.windows.net/${{ parameters.AzureStorageContainerName }}/$(Build.BuildNumber)/bin-artifacts.zip"
+      $buildArtifactUri = "https://$(AzureStorageAccountName).blob.core.windows.net/$(AzureStorageContainerName)/$(Build.BuildNumber)/bin-artifacts.zip"
       Write-Verbose "Downloading from $buildArtifactUri"
 
       $destination = "$(System.ArtifactsDirectory)/bin-artifacts/bin-artifacts.zip"
@@ -81,15 +83,15 @@ steps:
 
 
   - task: NodeTool@0
-    displayName: 'Use Node ${{ parameters.NodeVersion }}'
+    displayName: 'Use Node $(NodeVersion)'
     inputs:
-      versionSpec: '${{ parameters.NodeVersion }}'
+      versionSpec: '$(NodeVersion)'
 
 
   - task: UsePythonVersion@0
-    displayName: 'Use Python ${{ parameters.PythonVersion }}'
+    displayName: 'Use Python $(PythonVersion)'
     inputs:
-      versionSpec: '${{ parameters.PythonVersion }}'
+      versionSpec: '$(PythonVersion)'
 
 
   - bash: echo INTERIM WHAZZUP PYTHON VERSION
@@ -122,7 +124,7 @@ steps:
 
       verbose: true
 
-      customCommand: ${{ format('install -g npm@{0}', parameters.NpmVersion) }}
+      customCommand: 'install -g npm@$(NpmVersion)'
 
 
   - bash: echo AVAILABLE DEPENDENCY VERSIONS
@@ -213,16 +215,16 @@ steps:
 
       searchFolder: '$(Build.ArtifactStagingDirectory)'
 
-      testRunTitle: ${{ format('{0}_{1}_{2}', parameters.Platform, parameters.BuildNumber, parameters.TestSuiteName) }}
+      testRunTitle: '$(Platform) - $(BuildNumber) $(TestSuiteName)'
 
-      buildPlatform: ${{ parameters.Platform }}
+      buildPlatform: '$(Platform)'
 
-      buildConfiguration: '${{ parameters.TestSuiteName }}'
+      buildConfiguration: '$(TestSuiteName)'
 
     condition: always()
 
 
-  - bash: 'bash <(curl -s https://codecov.io/bash) -t $COV_UUID -F ${{ parameters.Platform }}'
+  - bash: 'bash <(curl -s https://codecov.io/bash) -t $COV_UUID -F $(Platform)'
     displayName: 'publish codecov'
     continueOnError: true
     condition: always()

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -1,31 +1,17 @@
-parameters:
-  PythonVersion: '3.7'
-  NodeVersion: '8.11.2'
-  NpmVersion: 'latest'
-  BuildNumber: ''
-  MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
-  MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-  MOCHA_REPORTER_JUNIT: true
-  CodeCovFlag: ''
-  DependsOn: ''
-  AzureStorageAccountName: 'vscodepythonartifacts'
-  AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
-  Platform: ''
-  TestSuiteName: ''
-
-
-# nodeVersion: ${{ parameters.NodeVersion }}
-# npmVersion: ${{ parameters.NpmVersion }}
-# pythonVersion: ${{ parameters.PythonVersion }}
-# mochaReportFile: ${{ parameters.MOCHA_CI_REPORTFILE }}
-# MOCHA_CI_REPORTER_ID: ${{ parameters.MOCHA_CI_REPORTER_ID }}
-# MOCHA_CI_REPORTFILE: ${{ parameters.MOCHA_CI_REPORTFILE }}
-# MOCHA_REPORTER_JUNIT: ${{ parameters.MOCHA_REPORTER_JUNIT }}
-# testSuiteName: ${{ parameters.TestSuiteName }}
-# codeCovFlag: ${{ parameters.Platform }}
-# azureStorageAcctName: ${{ parameters.AzureStorageAccountName }}
-# azureStorageContainerName: ${{ parameters.AzureStorageContainerName }}
-# platform: ${{ parameters.Platform }}
+# These are the used parameters in this definition:
+# TODO: Find a way to make default values become overridden with values
+#       specified in the master YAML definition...
+#   TestSuiteName: ''
+#   BuildNumber: ''
+#   Platform: ''
+#   PythonVersion: '3.7'
+#   NodeVersion: '8.11.2'
+#   NpmVersion: 'latest'
+#   MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+#   MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+#   MOCHA_REPORTER_JUNIT: true
+#   AzureStorageAccountName: 'vscodepythonartifacts'
+#   AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
 
 steps:
   - bash: echo REQUESTED VARIABLE VALUES

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -1,0 +1,242 @@
+parameters:
+  PythonVersion: '3.7'
+  NodeVersion: '8.11.2'
+  NpmVersion: 'latest'
+  BuildNumber: ''
+  MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+  MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+  MOCHA_REPORTER_JUNIT: true
+  CodeCovFlag: ''
+  DependsOn: ''
+  AzureStorageAccountName: 'vscodepythonartifacts'
+  AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+  Platform: ''
+  TestSuiteName: ''
+
+
+# nodeVersion: ${{ parameters.NodeVersion }}
+# npmVersion: ${{ parameters.NpmVersion }}
+# pythonVersion: ${{ parameters.PythonVersion }}
+# mochaReportFile: ${{ parameters.MOCHA_CI_REPORTFILE }}
+# MOCHA_CI_REPORTER_ID: ${{ parameters.MOCHA_CI_REPORTER_ID }}
+# MOCHA_CI_REPORTFILE: ${{ parameters.MOCHA_CI_REPORTFILE }}
+# MOCHA_REPORTER_JUNIT: ${{ parameters.MOCHA_REPORTER_JUNIT }}
+# testSuiteName: ${{ parameters.TestSuiteName }}
+# codeCovFlag: ${{ parameters.Platform }}
+# azureStorageAcctName: ${{ parameters.AzureStorageAccountName }}
+# azureStorageContainerName: ${{ parameters.AzureStorageContainerName }}
+# platform: ${{ parameters.Platform }}
+
+steps:
+  - bash: echo REQUESTED VARIABLE VALUES
+
+      echo Node Version = $NODE_VERSION
+
+      echo Python Version = $PYTHON_VERSION
+
+      echo NPM Version = $NPM_VERSION
+
+      echo Mocha reportfile = $MOCHA_REPORTFILE
+
+      echo MOCHA_CI_REPORTFILE = $MOCHA_CI_REPORTFILE
+
+      echo MOCHA_CI_REPORTER_ID = $MOCHA_CI_REPORTER_ID
+
+      echo MOCHA_REPORTER_JUNIT = $MOCHA_REPORTER_JUNIT
+
+      echo COV_UUID = $COV_UUID
+
+      echo Test Suite Name = $TEST_SUITE_NAME
+
+      echo params Test Suite Name = $OT_TEST_SUITE_NAME
+
+      echo giver Test Suite Name = $(TestSuiteName)
+
+      echo pre-defined Build Number = $BUILD_BUILDNUMBER
+
+      echo My Build Number = $BUILD_NUM
+
+      echo Try just accessing a parameter 'platform' = $PARAMETERS_PLATFORM
+
+    displayName: 'Ch Ch Checkit Owt'
+    name: 'bash_tool_non_conditional_run'
+    env:
+      BUILD_NUM: $(Build.BuildNumber)
+      MOCHA_REPORTFILE: $(mochaReportFile)
+      TEST_SUITE_NAME: $(testSuiteName)
+      OT_TEST_SUITE_NAME: ${{ format('{0}', parameters.TestSuiteName) }}
+      NODE_VERSION: $(nodeVersion)
+      NPM_VERSION: $(npmVersion)
+      PYTHON_VERSION: $(pythonVersion)
+
+
+  - powershell: |
+      New-Item -ItemType directory -Path "$(System.ArtifactsDirectory)/bin-artifacts"
+
+      $buildArtifactUri = "https://${{ parameters.AzureStorageAccountName }}.blob.core.windows.net/${{ parameters.AzureStorageContainerName }}/$(Build.BuildNumber)/bin-artifacts.zip"
+      Write-Verbose "Downloading from $buildArtifactUri"
+
+      $destination = "$(System.ArtifactsDirectory)/bin-artifacts/bin-artifacts.zip"
+      Write-Verbose "Destination file: $destination"
+
+      Invoke-WebRequest -Uri $buildArtifactUri -OutFile $destination -Verbose
+
+    displayName: 'Download bin-artifacts from cloud-storage'
+
+
+  - task: ExtractFiles@1
+    displayName: 'Splat bin-artifacts'
+    inputs:
+      archiveFilePatterns: '$(System.ArtifactsDirectory)/bin-artifacts/bin-artifacts.zip'
+
+      destinationFolder: '$(Build.SourcesDirectory)'
+
+      cleanDestinationFolder: false
+
+
+  - task: NodeTool@0
+    displayName: 'Use Node ${{ parameters.NodeVersion }}'
+    inputs:
+      versionSpec: '${{ parameters.NodeVersion }}'
+
+
+  - task: UsePythonVersion@0
+    displayName: 'Use Python ${{ parameters.PythonVersion }}'
+    inputs:
+      versionSpec: '${{ parameters.PythonVersion }}'
+
+
+  - bash: echo INTERIM WHAZZUP PYTHON VERSION
+
+      echo Python Version = `python --version`
+
+      echo Reported Python Path = `python -c "import sys;print(sys.executable)"`
+
+    displayName: 'See Python Version'
+    name: 'see_py_ver'
+
+
+  - task: PythonScript@0
+    displayName: 'Set CI_PYTHON_PATH'
+    inputs:
+      scriptSource: inline
+      failOnStderr: true
+      script: |
+        from __future__ import print_function
+
+        import sys
+
+        print('##vso[task.setvariable variable=CI_PYTHON_PATH;]{}'.format(sys.executable))
+
+
+  - task: Npm@1
+    displayName: 'update npm'
+    inputs:
+      command: custom
+
+      verbose: true
+
+      customCommand: ${{ format('install -g npm@{0}', parameters.NpmVersion) }}
+
+
+  - bash: echo AVAILABLE DEPENDENCY VERSIONS
+
+      echo Node Version = `node -v`
+
+      echo NPM Version = `npm -v`
+
+      echo Python Version = `python --version`
+
+      echo CI_PYTHON_PATH = $CI_PYTHON_PATH
+
+      echo Reported Python Path = `python -c "import sys;print(sys.executable)"`
+
+    displayName: 'See whazzzup'
+    name: 'see_what_is_up_dawg'
+
+
+  - task: Npm@1
+    displayName: 'npm ci'
+    inputs:
+      command: custom
+
+      verbose: true
+
+      customCommand: ci
+
+
+  - task: CmdLine@1
+    displayName: 'pip install requirements'
+    inputs:
+      filename: python
+
+      arguments: '-m pip install --upgrade -r ./requirements.txt'
+
+
+  - task: CmdLine@1
+    displayName: 'pip install ptvsd'
+    inputs:
+      filename: python
+
+      arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd ptvsd --no-cache-dir'
+
+    enabled: false
+
+
+  - task: CmdLine@1
+    displayName: 'pip install ptvsd [dev]'
+    inputs:
+      filename: python
+
+      arguments: '-m pip install -t ./pythonFiles/experimental/ptvsd git+https://github.com/Microsoft/ptvsd/'
+
+
+  - task: Npm@1
+    displayName: 'run $(TestSuiteName)'
+    inputs:
+      command: custom
+
+      verbose: true
+
+      customCommand: 'run $(TestSuiteName)'
+
+
+  - task: PythonScript@0
+    displayName: 'Ensure test results'
+    inputs:
+      scriptSource: inline
+      failOnStderr: true
+      script: |
+        from __future__ import print_function
+
+        import os
+        import sys
+
+
+        test_logfile = os.environ.get('MOCHA_CI_REPORTFILE')
+
+        if not os.path.exists(test_logfile):
+            print('##vso[task.logissue type=error]Cannot find mocha test results file {}. Did the test run actually fail?'.format(test_logfile))
+            print('ERROR: Log file could not be found. Ensure test run did not fail.', file=sys.stderr)
+
+
+  - task: PublishTestResults@2
+    displayName: 'Publish JUnit test results'
+    inputs:
+      testResultsFiles: '**/junit-report.xml'
+
+      searchFolder: '$(Build.ArtifactStagingDirectory)'
+
+      testRunTitle: ${{ format('{0}_{1}_{2}', parameters.Platform, parameters.BuildNumber, parameters.TestSuiteName) }}
+
+      buildPlatform: ${{ parameters.Platform }}
+
+      buildConfiguration: '${{ parameters.TestSuiteName }}'
+
+    condition: always()
+
+
+  - bash: 'bash <(curl -s https://codecov.io/bash) -t $COV_UUID -F ${{ parameters.Platform }}'
+    displayName: 'publish codecov'
+    continueOnError: true
+    condition: always()

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -1,0 +1,155 @@
+resources:
+- repo: self
+  clean: true
+
+jobs:
+
+- template: templates/compile-and-validate.yml
+  parameters:
+    name: 'PR_Validate_Windows_py37'
+    PythonVersion: '3.7'
+    NodeVersion: '8.11.2'
+    NpmVersion: 'latest'
+    PoolName: 'Hosted VS2017'
+    UploadBinary: true
+    Platform: 'Windows'
+
+- job: 'System_Test_macOS'
+  dependsOn: 'PR_Validate_Windows_py37'
+  pool:
+    name: 'Hosted macOS'
+  steps:
+  - template: templates/test-phase.yml
+  strategy:
+    maxParallel: 3
+    matrix:
+      SingleWorkspace:
+        TestSuiteName: 'testSingleWorkspace'
+        BuildNumber: '$(Build.BuildNumber)'
+        Platform: 'macOS'
+        PythonVersion: '3.7'
+        NodeVersion: '8.11.2'
+        NpmVersion: 'latest'
+        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+        MOCHA_REPORTER_JUNIT: true
+        AzureStorageAccountName: 'vscodepythonartifacts'
+        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+      MultiWorkspace:
+        TestSuiteName: 'testMultiWorkspace'
+        BuildNumber: '$(Build.BuildNumber)'
+        Platform: 'macOS'
+        PythonVersion: '3.7'
+        NodeVersion: '8.11.2'
+        NpmVersion: 'latest'
+        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+        MOCHA_REPORTER_JUNIT: true
+        AzureStorageAccountName: 'vscodepythonartifacts'
+        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+      Debugger:
+        TestSuiteName: 'testDebugger'
+        BuildNumber: '$(Build.BuildNumber)'
+        Platform: 'macOS'
+        PythonVersion: '3.7'
+        NodeVersion: '8.11.2'
+        NpmVersion: 'latest'
+        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+        MOCHA_REPORTER_JUNIT: true
+        AzureStorageAccountName: 'vscodepythonartifacts'
+        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+
+
+- job: 'System_Test_Windows'
+  dependsOn: 'PR_Validate_Windows_py37'
+  pool:
+    name: 'Hosted VS2017'
+  steps:
+  - template: templates/test-phase.yml
+  strategy:
+    maxParallel: 3
+    matrix:
+      SingleWorkspace:
+        TestSuiteName: 'testSingleWorkspace'
+        BuildNumber: '$(Build.BuildNumber)'
+        Platform: 'Windows'
+        PythonVersion: '3.7'
+        NodeVersion: '8.11.2'
+        NpmVersion: 'latest'
+        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+        MOCHA_REPORTER_JUNIT: true
+        AzureStorageAccountName: 'vscodepythonartifacts'
+        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+      MultiWorkspace:
+        TestSuiteName: 'testMultiWorkspace'
+        BuildNumber: '$(Build.BuildNumber)'
+        Platform: 'Windows'
+        PythonVersion: '3.7'
+        NodeVersion: '8.11.2'
+        NpmVersion: 'latest'
+        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+        MOCHA_REPORTER_JUNIT: true
+        AzureStorageAccountName: 'vscodepythonartifacts'
+        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+      Debugger:
+        TestSuiteName: 'testDebugger'
+        BuildNumber: '$(Build.BuildNumber)'
+        Platform: 'Windows'
+        PythonVersion: '3.7'
+        NodeVersion: '8.11.2'
+        NpmVersion: 'latest'
+        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+        MOCHA_REPORTER_JUNIT: true
+        AzureStorageAccountName: 'vscodepythonartifacts'
+        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+
+
+# - job: 'System_Test_Run_Linux'
+#   dependsOn: 'PR_Validate_Windows_py37'
+#   pool:
+#     name: 'Hosted Ubuntu 1604'
+#   steps:
+#   - template: templates/test-phase.yml
+#   strategy:
+#     maxParallel: 10
+#     matrix:
+#       SingleWorkspace:
+#         TestSuiteName: 'testSingleWorkspace'
+#         BuildNumber: '$(Build.BuildNumber)'
+#         Platform: 'Linux'
+#         PythonVersion: '3.7'
+#         NodeVersion: '8.11.2'
+#         NpmVersion: 'latest'
+#         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+#         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+#         MOCHA_REPORTER_JUNIT: true
+#         AzureStorageAccountName: 'vscodepythonartifacts'
+#         AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+#       MultiWorkspace:
+#         TestSuiteName: 'testMultiWorkspace'
+#         BuildNumber: '$(Build.BuildNumber)'
+#         Platform: 'Linux'
+#         PythonVersion: '3.7'
+#         NodeVersion: '8.11.2'
+#         NpmVersion: 'latest'
+#         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+#         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+#         MOCHA_REPORTER_JUNIT: true
+#         AzureStorageAccountName: 'vscodepythonartifacts'
+#         AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+#       Debugger:
+#         TestSuiteName: 'testDebugger'
+#         BuildNumber: '$(Build.BuildNumber)'
+#         Platform: 'Linux'
+#         PythonVersion: '3.7'
+#         NodeVersion: '8.11.2'
+#         NpmVersion: 'latest'
+#         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
+#         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+#         MOCHA_REPORTER_JUNIT: true
+#         AzureStorageAccountName: 'vscodepythonartifacts'
+#         AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -13,6 +13,8 @@ jobs:
     PoolName: 'Hosted VS2017'
     UploadBinary: true
     Platform: 'Windows'
+    AzureStorageAccountName: 'vscodepythonci'
+    AzureStorageContainerName: 'vscode-python-ci'
 
 - job: 'System_Test_macOS'
   dependsOn: 'PR_Validate_Windows_py37'
@@ -33,8 +35,8 @@ jobs:
         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
         MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonartifacts'
-        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+        AzureStorageAccountName: 'vscodepythonci'
+        AzureStorageContainerName: 'vscode-python-ci'
       MultiWorkspace:
         TestSuiteName: 'testMultiWorkspace'
         BuildNumber: '$(Build.BuildNumber)'
@@ -45,8 +47,8 @@ jobs:
         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
         MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonartifacts'
-        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+        AzureStorageAccountName: 'vscodepythonci'
+        AzureStorageContainerName: 'vscode-python-ci'
       Debugger:
         TestSuiteName: 'testDebugger'
         BuildNumber: '$(Build.BuildNumber)'
@@ -57,8 +59,8 @@ jobs:
         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
         MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonartifacts'
-        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+        AzureStorageAccountName: 'vscodepythonci'
+        AzureStorageContainerName: 'vscode-python-ci'
 
 
 - job: 'System_Test_Windows'
@@ -80,8 +82,8 @@ jobs:
         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
         MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonartifacts'
-        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+        AzureStorageAccountName: 'vscodepythonci'
+        AzureStorageContainerName: 'vscode-python-ci'
       MultiWorkspace:
         TestSuiteName: 'testMultiWorkspace'
         BuildNumber: '$(Build.BuildNumber)'
@@ -92,8 +94,8 @@ jobs:
         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
         MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonartifacts'
-        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+        AzureStorageAccountName: 'vscodepythonci'
+        AzureStorageContainerName: 'vscode-python-ci'
       Debugger:
         TestSuiteName: 'testDebugger'
         BuildNumber: '$(Build.BuildNumber)'
@@ -104,8 +106,8 @@ jobs:
         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
         MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonartifacts'
-        AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+        AzureStorageAccountName: 'vscodepythonci'
+        AzureStorageContainerName: 'vscode-python-ci'
 
 
 # - job: 'System_Test_Run_Linux'
@@ -127,8 +129,8 @@ jobs:
 #         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
 #         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
 #         MOCHA_REPORTER_JUNIT: true
-#         AzureStorageAccountName: 'vscodepythonartifacts'
-#         AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+#         AzureStorageAccountName: 'vscodepythonci'
+#         AzureStorageContainerName: 'vscode-python-ci'
 #       MultiWorkspace:
 #         TestSuiteName: 'testMultiWorkspace'
 #         BuildNumber: '$(Build.BuildNumber)'
@@ -139,8 +141,8 @@ jobs:
 #         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
 #         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
 #         MOCHA_REPORTER_JUNIT: true
-#         AzureStorageAccountName: 'vscodepythonartifacts'
-#         AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+#         AzureStorageAccountName: 'vscodepythonci'
+#         AzureStorageContainerName: 'vscode-python-ci'
 #       Debugger:
 #         TestSuiteName: 'testDebugger'
 #         BuildNumber: '$(Build.BuildNumber)'
@@ -151,5 +153,5 @@ jobs:
 #         MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/.mocha-reporter/mocha-vsts-reporter.js'
 #         MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
 #         MOCHA_REPORTER_JUNIT: true
-#         AzureStorageAccountName: 'vscodepythonartifacts'
-#         AzureStorageContainerName: 'pvsc-ci-yaml-artifacts'
+#         AzureStorageAccountName: 'vscodepythonci'
+#         AzureStorageContainerName: 'vscode-python-ci'

--- a/news/3 Code Health/3350.md
+++ b/news/3 Code Health/3350.md
@@ -1,0 +1,1 @@
+Add YAML file specification for CI builds


### PR DESCRIPTION
Fix for #3350

- Definition mimics the current PR-validation build closely

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
