### PR TITLE
Always use bundled version of PTVSD in the debugger

### DIFF
--- a/news/2 Fixes/3283.md
+++ b/news/2 Fixes/3283.md
@@ -1,5 +1,5 @@
-Always use bundled version of `PTVSD`, unless specified.
-To use a custom version of `PTVSD` in the debugger add `customDebugger` into your `launch.json` configuration as follows:
+Always use bundled version of [`ptvsd`](https://github.com/microsoft/ptvsd), unless specified.
+To use a custom version of `ptvsd` in the debugger, add `customDebugger` into your `launch.json` configuration as follows:
 ```js
     "type": "python",
     "request": "launch",

--- a/news/2 Fixes/3283.md
+++ b/news/2 Fixes/3283.md
@@ -1,0 +1,7 @@
+Always use bundled version of `PTVSD`, unless specified.
+To use a custom version of `PTVSD` in the debugger add `customDebugger` into your `launch.json` configuration as follows:
+```js
+    "type": "python",
+    "request": "launch",
+    "customDebugger": true
+```

--- a/news/2 Fixes/3283.md
+++ b/news/2 Fixes/3283.md
@@ -1,6 +1,6 @@
 Always use bundled version of [`ptvsd`](https://github.com/microsoft/ptvsd), unless specified.
 To use a custom version of `ptvsd` in the debugger, add `customDebugger` into your `launch.json` configuration as follows:
-```js
+```json
     "type": "python",
     "request": "launch",
     "customDebugger": true

--- a/pythonFiles/experimental/ptvsd_launcher.py
+++ b/pythonFiles/experimental/ptvsd_launcher.py
@@ -6,10 +6,17 @@ import os.path
 import sys
 import traceback
 
+useCustomPtvsd = sys.argv[1] == '--custom'
+ptvsdArgs = sys.argv[:]
+ptvsdArgs.pop(1)
+
 # Load the debugger package
 try:
     ptvs_lib_path = os.path.join(os.path.dirname(__file__), 'ptvsd')
-    sys.path.append(ptvs_lib_path)
+    if useCustomPtvsd:
+        sys.path.append(ptvs_lib_path)
+    else:
+        sys.path.insert(0, ptvs_lib_path)
     try:
         import ptvsd
         import ptvsd.debugger as vspd
@@ -35,4 +42,4 @@ finally:
     if ptvs_lib_path:
         sys.path.remove(ptvs_lib_path)
 
-main(sys.argv)
+main(ptvsdArgs)

--- a/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
@@ -12,13 +12,15 @@ import { IDebugLauncherScriptProvider, IRemoteDebugLauncherScriptProvider, Local
 const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'experimental', 'ptvsd_launcher.py');
 export class NoDebugLauncherScriptProvider implements IDebugLauncherScriptProvider<LocalDebugOptions> {
     public getLauncherArgs(options: LocalDebugOptions): string[] {
-        return [script, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
+        const customDebugger = options.customDebugger ? '--custom' : '--default';
+        return [script, customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
 export class DebuggerLauncherScriptProvider implements IDebugLauncherScriptProvider<LocalDebugOptions>  {
     public getLauncherArgs(options: LocalDebugOptions): string[] {
-        return [script, '--client', '--host', options.host, '--port', options.port.toString()];
+        const customDebugger = options.customDebugger ? '--custom' : '--default';
+        return [script, customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 

--- a/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
@@ -27,6 +27,6 @@ export class DebuggerLauncherScriptProvider implements IDebugLauncherScriptProvi
 export class RemoteDebuggerLauncherScriptProvider implements IRemoteDebugLauncherScriptProvider {
     public getLauncherArgs(options: RemoteDebugOptions): string[] {
         const waitArgs = options.waitUntilDebuggerAttaches ? ['--wait'] : [];
-        return [script, '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
+        return [script, '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
     }
 }

--- a/src/client/debugger/debugAdapter/DebugClients/localDebugClientV2.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/localDebugClientV2.ts
@@ -13,7 +13,7 @@ export class LocalDebugClientV2 extends LocalDebugClient {
         super(args, debugSession, canLaunchTerminal, launcherScriptProvider);
     }
     protected buildDebugArguments(cwd: string, debugPort: number): string[] {
-        return this.launcherScriptProvider.getLauncherArgs({ host: 'localhost', port: debugPort });
+        return this.launcherScriptProvider.getLauncherArgs({ host: 'localhost', port: debugPort, customDebugger: this.args.customDebugger });
     }
     protected buildStandardArguments() {
         const programArgs = Array.isArray(this.args.args) && this.args.args.length > 0 ? this.args.args : [];

--- a/src/client/debugger/debugAdapter/types.ts
+++ b/src/client/debugger/debugAdapter/types.ts
@@ -9,7 +9,7 @@ import { Disposable } from 'vscode';
 import { Logger } from 'vscode-debugadapter';
 import { Message } from 'vscode-debugadapter/lib/messages';
 
-export type LocalDebugOptions = { port: number; host: string };
+export type LocalDebugOptions = { port: number; host: string; customDebugger?: boolean };
 export type RemoteDebugOptions = LocalDebugOptions & { waitUntilDebuggerAttaches: boolean };
 
 export interface IDebugLauncherScriptProvider<T> {

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -42,6 +42,7 @@ export interface IKnownAttachDebugArguments extends ICommonDebugArguments {
     localRoot?: string;
     remoteRoot?: string;
     pathMappings?: { localRoot: string; remoteRoot: string }[];
+    customDebugger?: boolean;
 }
 
 export interface IKnownLaunchRequestArguments extends ICommonDebugArguments {

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -17,22 +17,32 @@ suite('Debugger - Launcher Script Provider', () => {
     });
     test('Test debug launcher args', async () => {
         const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 });
-        const expectedArgs = [expectedPath, '--client', '--host', 'something', '--port', '1234'];
+        const expectedArgs = [expectedPath, '--default', '--client', '--host', 'something', '--port', '1234'];
         expect(args).to.be.deep.equal(expectedArgs);
     });
     test('Test non-debug launcher args', async () => {
         const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 });
-        const expectedArgs = [expectedPath, '--nodebug', '--client', '--host', 'something', '--port', '1234'];
+        const expectedArgs = [expectedPath, '--default', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
+        expect(args).to.be.deep.equal(expectedArgs);
+    });
+    test('Test debug launcher args and custom ptvsd', async () => {
+        const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
+        const expectedArgs = [expectedPath, '--custom', '--client', '--host', 'something', '--port', '1234'];
+        expect(args).to.be.deep.equal(expectedArgs);
+    });
+    test('Test non-debug launcher args and custom ptvsd', async () => {
+        const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
+        const expectedArgs = [expectedPath, '--custom', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
         expect(args).to.be.deep.equal(expectedArgs);
     });
     test('Test remote debug launcher args (and do not wait for debugger to attach)', async () => {
         const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false });
-        const expectedArgs = [expectedPath, '--host', 'something', '--port', '1234'];
+        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234'];
         expect(args).to.be.deep.equal(expectedArgs);
     });
     test('Test remote debug launcher args (and wait for debugger to attach)', async () => {
         const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true });
-        const expectedArgs = [expectedPath, '--host', 'something', '--port', '1234', '--wait'];
+        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
         expect(args).to.be.deep.equal(expectedArgs);
     });
 });

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -15,12 +15,12 @@ const expectedPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'experimental'
 suite('Extension API Debugger', () => {
     test('Test debug launcher args (no-wait)', async () => {
         const args = await buildApi(Promise.resolve()).debug.getRemoteLauncherCommand('something', 1234, false);
-        const expectedArgs = [expectedPath, '--host', 'something', '--port', '1234'];
+        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234'];
         expect(args).to.be.deep.equal(expectedArgs);
     });
     test('Test debug launcher args (wait)', async () => {
         const args = await buildApi(Promise.resolve()).debug.getRemoteLauncherCommand('something', 1234, true);
-        const expectedArgs = [expectedPath, '--host', 'something', '--port', '1234', '--wait'];
+        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
         expect(args).to.be.deep.equal(expectedArgs);
     });
 });


### PR DESCRIPTION
For #3283

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
