### PR TITLE
Add support for source maps in the extension

### DIFF
--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
+const glob = require("glob");
+const path = require("path");
 const webpack_bundle_analyzer_1 = require("webpack-bundle-analyzer");
 const constants_1 = require("../constants");
 exports.nodeModulesToExternalize = [
@@ -19,7 +21,7 @@ exports.nodeModulesToExternalize = [
     'azure-storage',
     'request',
     'request-progress',
-    'source-map',
+    'source-map-support',
     'file-matcher',
     'diff-match-patch',
     'sudo-prompt',
@@ -37,3 +39,9 @@ function getDefaultPlugins(name) {
     return plugins;
 }
 exports.getDefaultPlugins = getDefaultPlugins;
+function getListOfExistingModulesInOutDir() {
+    const outDir = path.join(constants_1.ExtensionRootDir, 'out', 'client');
+    const files = glob.sync('**/*.js', { sync: true, cwd: outDir });
+    return files.map(filePath => `./${filePath.slice(0, -3)}`);
+}
+exports.getListOfExistingModulesInOutDir = getListOfExistingModulesInOutDir;

--- a/build/webpack/common.ts
+++ b/build/webpack/common.ts
@@ -3,8 +3,11 @@
 
 'use strict';
 
+import * as glob from 'glob';
+import * as path from 'path';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
-import { isCI } from '../constants';
+import { ExtensionRootDir, isCI } from '../constants';
+
 export const nodeModulesToExternalize = [
     'unicode/category/Lu',
     'unicode/category/Ll',
@@ -20,7 +23,7 @@ export const nodeModulesToExternalize = [
     'azure-storage',
     'request',
     'request-progress',
-    'source-map',
+    'source-map-support',
     'file-matcher',
     'diff-match-patch',
     'sudo-prompt',
@@ -39,4 +42,10 @@ export function getDefaultPlugins(name: 'extension' | 'debugger' | 'dependencies
         );
     }
     return plugins;
+}
+
+export function getListOfExistingModulesInOutDir() {
+    const outDir = path.join(ExtensionRootDir, 'out', 'client');
+    const files = glob.sync('**/*.js', { sync: true, cwd: outDir });
+    return files.map(filePath => `./${filePath.slice(0, -3)}`);
 }

--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -74,7 +74,9 @@ const config = {
         new webpack_1.ContextReplacementPlugin(/getos/, /logic\/.*.js/),
         new WrapperPlugin({
             test: /\extension.js$/,
-            header: 'require(\'./sourceMapSupport\').default(require(\'vscode\'));'
+            // Import source map warning file only if source map is enabled.
+            // Minimize importing external files.
+            header: '(function(){if (require(\'vscode\').workspace.getConfiguration(\'python.diagnostics\', undefined).get(\'sourceMapsEnabled\', false)) {require(\'./sourceMapSupport\').default(require(\'vscode\'));}})();'
         })
     ],
     resolve: {

--- a/build/webpack/webpack.extension.config.ts
+++ b/build/webpack/webpack.extension.config.ts
@@ -79,7 +79,9 @@ const config: Configuration = {
         new ContextReplacementPlugin(/getos/, /logic\/.*.js/),
         new WrapperPlugin({
             test: /\extension.js$/,
-            header: 'require(\'./sourceMapSupport\').default(require(\'vscode\'));'
+            // Import source map warning file only if source map is enabled.
+            // Minimize importing external files.
+            header: '(function(){if (require(\'vscode\').workspace.getConfiguration(\'python.diagnostics\', undefined).get(\'sourceMapsEnabled\', false)) {require(\'./sourceMapSupport\').default(require(\'vscode\'));}})();'
         })
     ],
     resolve: {

--- a/build/webpack/webpack.extension.sourceMaps.config.js
+++ b/build/webpack/webpack.extension.sourceMaps.config.js
@@ -4,11 +4,8 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const path = require("path");
 const tsconfig_paths_webpack_plugin_1 = require("tsconfig-paths-webpack-plugin");
-const webpack_1 = require("webpack");
 const constants_1 = require("../constants");
 const common_1 = require("./common");
-// tslint:disable-next-line:no-var-requires no-require-imports
-const WrapperPlugin = require('wrapper-webpack-plugin');
 // tslint:disable-next-line:no-var-requires no-require-imports
 const configFileName = path.join(constants_1.ExtensionRootDir, 'tsconfig.extension.json');
 // Some modules will be pre-genearted and stored in out/.. dir and they'll be referenced via NormalModuleReplacementPlugin
@@ -18,8 +15,7 @@ const config = {
     mode: 'production',
     target: 'node',
     entry: {
-        extension: './src/client/extension.ts',
-        'debugger/debugAdapter/main': './src/client/debugger/debugAdapter/main.ts'
+        sourceMapSupport: './src/client/sourceMapSupport.ts'
     },
     devtool: 'source-map',
     node: {
@@ -27,32 +23,6 @@ const config = {
     },
     module: {
         rules: [
-            {
-                // JupyterServices imports node-fetch using `eval`.
-                test: /@jupyterlab[\\\/]services[\\\/].*js$/,
-                use: [
-                    {
-                        loader: path.join(__dirname, 'loaders', 'fixEvalRequire.js')
-                    }
-                ]
-            },
-            {
-                // Do not use __dirname in getos when using require.
-                test: /getos[\\\/]index.js$/,
-                use: [
-                    {
-                        loader: path.join(__dirname, 'loaders', 'fixGetosRequire.js')
-                    }
-                ]
-            },
-            {
-                test: /\.ts$/,
-                use: [
-                    {
-                        loader: path.join(__dirname, 'loaders', 'externalizeDependencies.js')
-                    }
-                ]
-            },
             {
                 test: /\.ts$/,
                 exclude: /node_modules/,
@@ -70,12 +40,7 @@ const config = {
         ...existingModulesInOutDir
     ],
     plugins: [
-        ...common_1.getDefaultPlugins('extension'),
-        new webpack_1.ContextReplacementPlugin(/getos/, /logic\/.*.js/),
-        new WrapperPlugin({
-            test: /\extension.js$/,
-            header: 'require(\'./sourceMapSupport\').default(require(\'vscode\'));'
-        })
+        ...common_1.getDefaultPlugins('dependencies')
     ],
     resolve: {
         extensions: ['.ts', '.js'],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -194,6 +194,7 @@ gulp.task('restorePrePublishScript', (done) => {
 
 gulp.task('webpack', async () => {
     await spawnAsync('npx', ['webpack', '--mode', 'production']);
+    await spawnAsync('npx', ['webpack', '--config', './build/webpack/webpack.extension.sourceMaps.config.js', '--mode', 'production']);
     await spawnAsync('npx', ['webpack', '--config', './build/webpack/webpack.extension.config.js', '--mode', 'production']);
 });
 

--- a/package.json
+++ b/package.json
@@ -820,6 +820,12 @@
             "type": "object",
             "title": "Python Configuration",
             "properties": {
+                "python.diagnostics.sourceMapsEnabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable source map support for meaningful strack traces in error logs.",
+                    "scope": "application"
+                },
                 "python.autoComplete.addBrackets": {
                     "type": "boolean",
                     "default": false,
@@ -1867,6 +1873,7 @@
         "webpack-fix-default-import-plugin": "^1.0.3",
         "webpack-merge": "^4.1.4",
         "webpack-node-externals": "^1.7.2",
+        "webpack-stream": "^5.1.1",
         "wrapper-webpack-plugin": "^2.0.0",
         "yargs": "^12.0.2"
     },

--- a/package.json
+++ b/package.json
@@ -1873,7 +1873,6 @@
         "webpack-fix-default-import-plugin": "^1.0.3",
         "webpack-merge": "^4.1.4",
         "webpack-node-externals": "^1.7.2",
-        "webpack-stream": "^5.1.1",
         "wrapper-webpack-plugin": "^2.0.0",
         "yargs": "^12.0.2"
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -79,7 +79,7 @@
     "DataScience.jupyterNbConvertNotSupported": "Importing notebooks requires Jupyter nbconvert to be installed.",
     "DataScience.jupyterLaunchTimedOut": "The Jupyter notebook server failed to launch in time",
     "DataScience.jupyterLaunchNoURL": "Failed to find the URL of the launched Jupyter notebook server",
-    "DataScience.pythonInteractiveHelpLink" : "Get more help",
+    "DataScience.pythonInteractiveHelpLink": "Get more help",
     "DataScience.importingFormat": "Importing {0}",
     "DataScience.startingJupyter": "Starting Jupyter Server",
     "Interpreters.RefreshingInterpreters": "Refreshing Python Interpreters",
@@ -103,8 +103,10 @@
     "DataScience.pythonVersionHeaderNoPyKernel": "Python Version may not match, no ipykernel found:",
     "DataScience.pythonRestartHeader": "Restarted Kernel:",
     "Linter.InstalledButNotEnabled": "Linter {0} is installed but not enabled.",
-    "DataScience.jupyterNotebookFailure" : "Jupyter notebook failed to launch. \r\n{0}",
-    "DataScience.notebookVersionFormat" : "Jupyter Notebook Version: {0}",
-    "DataScience.jupyterKernelNotSupportedOnActive" : "Jupyter kernel cannot be started from '{0}'. Using closest match {1} instead.",
-    "DataScience.jupyterKernelSpecNotFound" : "Cannot create a Jupyter kernel spec and none are available for use"
+    "DataScience.jupyterNotebookFailure": "Jupyter notebook failed to launch. \r\n{0}",
+    "DataScience.notebookVersionFormat": "Jupyter Notebook Version: {0}",
+    "DataScience.jupyterKernelNotSupportedOnActive": "Jupyter kernel cannot be started from '{0}'. Using closest match {1} instead.",
+    "DataScience.jupyterKernelSpecNotFound": "Cannot create a Jupyter kernel spec and none are available for use",
+    "diagnostics.warnSourceMaps": "Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.",
+    "diagnostics.disableSourceMaps": "Disable Source Map Support"
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -5,9 +5,14 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { EXTENSION_ROOT_DIR } from '../constants';
+import { EXTENSION_ROOT_DIR } from '../../constants';
 
 // External callers of localize use these tables to retrieve localized values.
+export namespace Diagnostics {
+    export const warnSourceMaps = localize('diagnostics.warnSourceMaps', 'Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.');
+    export const disableSourceMaps = localize('diagnostics.disableSourceMaps', 'Disable Source Map Support');
+}
+
 export namespace LanguageServiceSurveyBanner {
     export const bannerMessage = localize('LanguageServiceSurveyBanner.bannerMessage', 'Can you please take 2 minutes to tell us how the Python Language Server is working for you?');
     export const bannerLabelYes = localize('LanguageServiceSurveyBanner.bannerLabelYes', 'Yes, take survey now');
@@ -91,21 +96,21 @@ export function localize(key: string, defValue: string) {
     };
 }
 
-export function getCollection () {
+export function getCollection() {
     // Load the current collection
     if (!loadedCollection || parseLocale() !== loadedLocale) {
         load();
     }
 
     // Combine the default and loaded collections
-    return {...defaultCollection, ...loadedCollection};
+    return { ...defaultCollection, ...loadedCollection };
 }
 
 export function getAskedForCollection() {
     return askedForCollection;
 }
 
-function parseLocale() : string {
+function parseLocale(): string {
     // Attempt to load from the vscode locale. If not there, use english
     const vscodeConfigString = process.env.VSCODE_NLS_CONFIG;
     return vscodeConfigString ? JSON.parse(vscodeConfigString).locale : 'en-us';

--- a/src/client/sourceMapSupport.ts
+++ b/src/client/sourceMapSupport.ts
@@ -18,13 +18,13 @@ export class SourceMapSupport {
         if (!this.enabled) {
             return;
         }
+        require('./node_modules/source-map-support').install();
         const localize = require('./common/utils/localize') as typeof import('./common/utils/localize');
         const disable = localize.Diagnostics.disableSourceMaps();
         const selection = await this.vscode.window.showWarningMessage(localize.Diagnostics.warnSourceMaps(), disable);
         if (selection === disable) {
             await this.disable();
         }
-        require('source-map-support').install();
     }
     public get enabled(): boolean {
         return this.config.get<boolean>(setting, false);

--- a/src/client/sourceMapSupport.ts
+++ b/src/client/sourceMapSupport.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { WorkspaceConfiguration } from 'vscode';
+type VSCode = typeof import('vscode');
+
+// tslint:disable:no-require-imports
+const setting = 'sourceMapsEnabled';
+
+export class SourceMapSupport {
+    private readonly config: WorkspaceConfiguration;
+    constructor(private readonly vscode: VSCode) {
+        this.config = this.vscode.workspace.getConfiguration('python.diagnostics', undefined);
+    }
+    public async initialize(): Promise<void> {
+        if (!this.enabled) {
+            return;
+        }
+        const localize = require('./common/utils/localize') as typeof import('./common/utils/localize');
+        const disable = localize.Diagnostics.disableSourceMaps();
+        const selection = await this.vscode.window.showWarningMessage(localize.Diagnostics.warnSourceMaps(), disable);
+        if (selection === disable) {
+            await this.disable();
+        }
+        require('source-map-support').install();
+    }
+    public get enabled(): boolean {
+        return this.config.get<boolean>(setting, false);
+    }
+    public async disable(): Promise<void> {
+        await this.config.update(setting, false, this.vscode.ConfigurationTarget.Global);
+    }
+}
+// tslint:disable-next-line:no-default-export
+export default function initialize(vscode: VSCode) {
+    new SourceMapSupport(vscode).initialize().catch(ex => {
+        console.error('Failed to initialize source map support in extension');
+    });
+}

--- a/src/client/sourceMapSupport.ts
+++ b/src/client/sourceMapSupport.ts
@@ -18,7 +18,7 @@ export class SourceMapSupport {
         if (!this.enabled) {
             return;
         }
-        require('./node_modules/source-map-support').install();
+        this.initializeSourceMaps();
         const localize = require('./common/utils/localize') as typeof import('./common/utils/localize');
         const disable = localize.Diagnostics.disableSourceMaps();
         const selection = await this.vscode.window.showWarningMessage(localize.Diagnostics.warnSourceMaps(), disable);
@@ -31,6 +31,9 @@ export class SourceMapSupport {
     }
     public async disable(): Promise<void> {
         await this.config.update(setting, false, this.vscode.ConfigurationTarget.Global);
+    }
+    protected initializeSourceMaps() {
+        require('./node_modules/source-map-support').install();
     }
 }
 // tslint:disable-next-line:no-default-export

--- a/src/test/sourceMapSupport.unit.test.ts
+++ b/src/test/sourceMapSupport.unit.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any
+
+import { expect } from 'chai';
+import { ConfigurationTarget } from 'vscode';
+import { Diagnostics } from '../client/common/utils/localize';
+import * as sourceMaps from '../client/sourceMapSupport';
+import { noop, sleep } from './core';
+
+suite('Source Map Support', () => {
+    function createVSCStub(isEnabled: boolean = false, selectDisableButton: boolean = false) {
+        const stubInfo = {
+            configValueRetrieved: false,
+            configValueUpdated: false,
+            messageDisplayed: false
+        };
+        const vscode = {
+            workspace: {
+                getConfiguration: (setting: string, _defaultValue: any) => {
+                    if (setting !== 'python.diagnostics') {
+                        return;
+                    }
+                    return {
+                        get: (prop: string) => {
+                            stubInfo.configValueRetrieved = prop === 'sourceMapsEnabled';
+                            return isEnabled;
+                        },
+                        update: (prop: string, value: boolean, scope: ConfigurationTarget) => {
+                            if (prop === 'sourceMapsEnabled' && value === false && scope === ConfigurationTarget.Global) {
+                                stubInfo.configValueUpdated = true;
+                            }
+                        }
+                    };
+                }
+            },
+            window: {
+                showWarningMessage: () => {
+                    stubInfo.messageDisplayed = true;
+                    return Promise.resolve(selectDisableButton ? Diagnostics.disableSourceMaps() : undefined);
+                }
+            },
+            ConfigurationTarget: ConfigurationTarget
+        };
+        return { stubInfo, vscode };
+    }
+    test('Test message is not displayed when source maps are not enabled', async () => {
+        const stub = createVSCStub(false);
+        sourceMaps.default(stub.vscode as any);
+        await sleep(100);
+        expect(stub.stubInfo.configValueRetrieved).to.be.equal(true, 'Config Value not retrieved');
+        expect(stub.stubInfo.messageDisplayed).to.be.equal(false, 'Message displayed');
+    });
+    test('Test message is not displayed when source maps are not enabled', async () => {
+        const stub = createVSCStub(true);
+        const instance = new class extends sourceMaps.SourceMapSupport {
+            protected initializeSourceMaps() {
+                noop();
+            }
+        }(stub.vscode as any);
+        await instance.initialize();
+        expect(stub.stubInfo.configValueRetrieved).to.be.equal(true, 'Config Value not retrieved');
+        expect(stub.stubInfo.messageDisplayed).to.be.equal(true, 'Message displayed');
+        expect(stub.stubInfo.configValueUpdated).to.be.equal(false, 'Config Value updated');
+    });
+    test('Test message is not displayed when source maps are not enabled', async () => {
+        const stub = createVSCStub(true, true);
+        const instance = new class extends sourceMaps.SourceMapSupport {
+            protected initializeSourceMaps() {
+                noop();
+            }
+        }(stub.vscode as any);
+        await instance.initialize();
+        expect(stub.stubInfo.configValueRetrieved).to.be.equal(true, 'Config Value not retrieved');
+        expect(stub.stubInfo.messageDisplayed).to.be.equal(true, 'Message displayed');
+        expect(stub.stubInfo.configValueUpdated).to.be.equal(true, 'Config Value not updated');
+    });
+});


### PR DESCRIPTION
For #3436

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
