### PR TITLE
Activate the conda environment before running jupyter

### DIFF
--- a/news/2 Fixes/3341.md
+++ b/news/2 Fixes/3341.md
@@ -1,0 +1,1 @@
+Activate conda prior to running jupyter for the python interactive window.

--- a/src/client/common/process/proc.ts
+++ b/src/client/common/process/proc.ts
@@ -159,6 +159,8 @@ export class ProcessService implements IProcessService {
                 } else if (shellOptions.throwOnStdErr && stderr && stderr.length) {
                     reject(new Error(stderr));
                 } else {
+                    // Make sure stderr is undefined if we actually had none. This is checked
+                    // elsewhere because that's how exec behaves.
                     resolve({ stderr: stderr && stderr.length > 0 ? stderr : undefined, stdout: stdout });
                 }
             });

--- a/src/client/common/process/proc.ts
+++ b/src/client/common/process/proc.ts
@@ -159,7 +159,7 @@ export class ProcessService implements IProcessService {
                 } else if (shellOptions.throwOnStdErr && stderr && stderr.length) {
                     reject(new Error(stderr));
                 } else {
-                    resolve({ stderr: stderr, stdout: stdout });
+                    resolve({ stderr: stderr && stderr.length > 0 ? stderr : undefined, stdout: stdout });
                 }
             });
         });

--- a/src/client/common/process/proc.ts
+++ b/src/client/common/process/proc.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { spawn } from 'child_process';
+import { exec, spawn } from 'child_process';
 import { Observable } from 'rxjs/Observable';
 import * as tk from 'tree-kill';
 import { Disposable } from 'vscode';
@@ -14,6 +14,7 @@ import {
     IProcessService,
     ObservableExecutionResult,
     Output,
+    ShellOptions,
     SpawnOptions,
     StdErrError
 } from './types';
@@ -37,23 +38,11 @@ export class ProcessService implements IProcessService {
         } catch {
             // Ignore.
         }
-
     }
+
     public execObservable(file: string, args: string[], options: SpawnOptions = {}): ObservableExecutionResult<string> {
-        const encoding = options.encoding = typeof options.encoding === 'string' && options.encoding.length > 0 ? options.encoding : DEFAULT_ENCODING;
-        delete options.encoding;
-        const spawnOptions = { ...options };
-        if (!spawnOptions.env || Object.keys(spawnOptions).length === 0) {
-            const env = this.env ? this.env : process.env;
-            spawnOptions.env = { ...env };
-        }
-
-        // Always ensure we have unbuffered output.
-        spawnOptions.env.PYTHONUNBUFFERED = '1';
-        if (!spawnOptions.env.PYTHONIOENCODING) {
-            spawnOptions.env.PYTHONIOENCODING = 'utf-8';
-        }
-
+        const spawnOptions = this.getDefaultOptions(options);
+        const encoding = spawnOptions.encoding ? spawnOptions.encoding : 'utf8';
         const proc = spawn(file, args, spawnOptions);
         let procExited = false;
 
@@ -109,19 +98,8 @@ export class ProcessService implements IProcessService {
         };
     }
     public exec(file: string, args: string[], options: SpawnOptions = {}): Promise<ExecutionResult<string>> {
-        const encoding = options.encoding = typeof options.encoding === 'string' && options.encoding.length > 0 ? options.encoding : DEFAULT_ENCODING;
-        delete options.encoding;
-        const spawnOptions = { ...options };
-        if (!spawnOptions.env || Object.keys(spawnOptions).length === 0) {
-            const env = this.env ? this.env : process.env;
-            spawnOptions.env = { ...env };
-        }
-
-        // Always ensure we have unbuffered output.
-        spawnOptions.env.PYTHONUNBUFFERED = '1';
-        if (!spawnOptions.env.PYTHONIOENCODING) {
-            spawnOptions.env.PYTHONIOENCODING = 'utf-8';
-        }
+        const spawnOptions = this.getDefaultOptions(options);
+        const encoding = spawnOptions.encoding ? spawnOptions.encoding : 'utf8';
         const proc = spawn(file, args, spawnOptions);
         const deferred = createDeferred<ExecutionResult<string>>();
         const disposables: Disposable[] = [];
@@ -171,4 +149,43 @@ export class ProcessService implements IProcessService {
 
         return deferred.promise;
     }
+
+    public shellExec(command: string, options: ShellOptions = {}): Promise<ExecutionResult<string>> {
+        const shellOptions = this.getDefaultOptions(options);
+        return new Promise((resolve, reject) => {
+            exec(command, shellOptions, (e, stdout, stderr) => {
+                if (e && e !== null) {
+                    reject(e);
+                } else if (shellOptions.throwOnStdErr && stderr && stderr.length) {
+                    reject(new Error(stderr));
+                } else {
+                    resolve({ stderr: stderr, stdout: stdout });
+                }
+            });
+        });
+    }
+
+    private getDefaultOptions<T extends (ShellOptions | SpawnOptions)>(options: T) : T {
+        const execOptions = options as SpawnOptions;
+        const defaultOptions = JSON.parse(JSON.stringify(options));
+        if (execOptions)
+        {
+            const encoding = execOptions.encoding = typeof execOptions.encoding === 'string' && execOptions.encoding.length > 0 ? execOptions.encoding : DEFAULT_ENCODING;
+            delete execOptions.encoding;
+            defaultOptions.encoding = encoding;
+        }
+        if (!defaultOptions.env || Object.keys(defaultOptions).length === 0) {
+            const env = this.env ? this.env : process.env;
+            defaultOptions.env = { ...env };
+        }
+
+        // Always ensure we have unbuffered output.
+        defaultOptions.env.PYTHONUNBUFFERED = '1';
+        if (!defaultOptions.env.PYTHONIOENCODING) {
+            defaultOptions.env.PYTHONIOENCODING = 'utf-8';
+        }
+
+        return defaultOptions;
+    }
+
 }

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-import { ChildProcess, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
+import { ChildProcess, ExecOptions, SpawnOptions as ChildProcessSpawnOptions } from 'child_process';
 import { Observable } from 'rxjs/Observable';
 import { CancellationToken, Uri } from 'vscode';
+
 import { ExecutionInfo } from '../types';
 import { Architecture } from '../utils/platform';
 import { EnvironmentVariables } from '../variables/types';
@@ -31,6 +31,9 @@ export type SpawnOptions = ChildProcessSpawnOptions & {
     throwOnStdErr?: boolean;
 };
 
+// tslint:disable-next-line:interface-name
+export type ShellOptions = ExecOptions & { throwOnStdErr? : boolean };
+
 export type ExecutionResult<T extends string | Buffer> = {
     stdout: T;
     stderr?: T;
@@ -39,6 +42,7 @@ export type ExecutionResult<T extends string | Buffer> = {
 export interface IProcessService {
     execObservable(file: string, args: string[], options?: SpawnOptions): ObservableExecutionResult<string>;
     exec(file: string, args: string[], options?: SpawnOptions): Promise<ExecutionResult<string>>;
+    shellExec(command: string, options?: ShellOptions): Promise<ExecutionResult<string>>;
 }
 
 export const IProcessServiceFactory = Symbol('IProcessServiceFactory');

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -53,9 +53,7 @@ export interface ICondaService {
     getInterpreterPath(condaEnvironmentPath: string): string;
     isCondaEnvironment(interpreterPath: string): Promise<boolean>;
     getCondaEnvironment(interpreterPath: string): Promise<{ name: string; path: string } | undefined>;
-    // Base Node.js SpawnOptions uses any for environment, so use that here as well
-    // tslint:disable-next-line:no-any
-    getActivatedCondaEnvironment(interpreter: PythonInterpreter, inputEnvironment: any): Promise<any>;
+    getActivatedCondaEnvironment(interpreter: PythonInterpreter, inputEnvironment?: NodeJS.ProcessEnv): Promise<NodeJS.ProcessEnv>;
 }
 
 export enum InterpreterType {

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -271,7 +271,7 @@ export class CondaService implements ICondaService {
         // From that path we need to start an activate script
         const activateCommand = this.platform.isWindows ?
             `"${path.join(path.dirname(condaPath), 'activate')}"` :
-            `source #${path.join(path.dirname(condaPath), 'activate')}#`;
+            `source "${path.join(path.dirname(condaPath), 'activate')}"`;
         const result = {...input};
         const processService = await this.processServiceFactory.create();
 

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -380,6 +380,7 @@ export class CondaService implements ICondaService {
         const condaExe = this.platform.isWindows ? 'conda.exe' : 'conda';
         const scriptsDir = this.platform.isWindows ? 'Scripts' : 'bin';
         const interpreterDir = interpreter ? path.dirname(interpreter.path) : '';
+        const envName = interpreter && interpreter.envName ? interpreter.envName : 'xxx'; // Prevents non named from being found
         let condaPath = path.join(interpreterDir, condaExe);
         if (await this.fileSystem.fileExists(condaPath)) {
             return condaPath;
@@ -393,7 +394,7 @@ export class CondaService implements ICondaService {
 
         // Might be in a situation where this is not the default python env, but rather one running
         // from a virtualenv
-        const envsPos = interpreterDir.indexOf(path.join('envs', interpreter.envName));
+        const envsPos = interpreterDir.indexOf(path.join('envs', envName));
         if (envsPos > 0) {
             // This should be where the original python was run from when the environment was created.
             const originalPath = interpreterDir.slice(0, envsPos);

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -271,7 +271,7 @@ export class CondaService implements ICondaService {
         // From that path we need to start an activate script
         const activateCommand = this.platform.isWindows ?
             `"${path.join(path.dirname(condaPath), 'activate')}"` :
-            `source "${path.join(path.dirname(condaPath), 'activate')}"`;
+            `. "${path.join(path.dirname(condaPath), 'activate')}"`;
         const result = {...input};
         const processService = await this.processServiceFactory.create();
 

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -68,7 +68,7 @@ export class CondaService implements ICondaService {
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IInterpreterLocatorService) @named(WINDOWS_REGISTRY_SERVICE) @optional() private registryLookupForConda?: IInterpreterLocatorService
     ) {
-        this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(this.onInterpreterChanged));
+        this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(this.onInterpreterChanged.bind(this)));
         this.activationProvider = serviceContainer.get<ITerminalActivationCommandProvider>(ITerminalActivationCommandProvider,
             this.platform.isWindows ? 'commandPromptAndPowerShell' : 'bashCShellFish');
         this.shellType = this.platform.isWindows ? TerminalShellType.commandPrompt : TerminalShellType.bash; // Defaults for Child_Process.exec
@@ -479,7 +479,7 @@ export class CondaService implements ICondaService {
     /**
      * Called when the user changes the current interpreter.
      */
-    private onInterpreterChanged = () : void => {
+    private onInterpreterChanged() : void {
         // Clear our activated environment cache as it can't match the current one anymore
         this.activatedEnvironmentCache = {};
     }

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -290,8 +290,8 @@ export class CondaService implements ICondaService {
         }
 
         // Special case. The 'environment' we have is the base environment. Previous call would have
-        // thrown an error with 'conda info --envs' in the help.
-        if (!shellExecResult && error && error.hasOwnProperty('stack') && error.stack.includes('conda info --envs')) {
+        // thrown an error.
+        if (!shellExecResult && error) {
             try {
                 const command = `"${activateCommand}" && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
                 shellExecResult = await processService.shellExec(command, { env: inputEnvironment });

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -270,8 +270,8 @@ export class CondaService implements ICondaService {
 
         // From that path we need to start an activate script
         const activateCommand = this.platform.isWindows ?
-            path.join(path.dirname(condaPath), 'activate') :
-            `source ${path.join(path.dirname(condaPath), 'activate')}`;
+            `"${path.join(path.dirname(condaPath), 'activate')}"` :
+            `source #${path.join(path.dirname(condaPath), 'activate')}#`;
         const result = {...input};
         const processService = await this.processServiceFactory.create();
 
@@ -281,7 +281,7 @@ export class CondaService implements ICondaService {
         // tslint:disable-next-line:no-any
         let error : any;
         try {
-            const command = `"${activateCommand}" && conda activate ${condaEnvironmentName} && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
+            const command = `${activateCommand} && conda activate ${condaEnvironmentName} && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
             shellExecResult = await processService.shellExec(command, { env: inputEnvironment });
         } catch (err) {
             // If that crashes for whatever reason, then just return empty data.

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -269,7 +269,9 @@ export class CondaService implements ICondaService {
         }
 
         // From that path we need to start an activate script
-        const activatePath = path.join(path.dirname(condaPath), 'activate');
+        const activateCommand = this.platform.isWindows ?
+            path.join(path.dirname(condaPath), 'activate') :
+            `source ${path.join(path.dirname(condaPath), 'activate')}`;
         const result = {...input};
         const processService = await this.processServiceFactory.create();
 
@@ -279,7 +281,7 @@ export class CondaService implements ICondaService {
         // tslint:disable-next-line:no-any
         let error : any;
         try {
-            const command = `"${activatePath}" && conda activate ${condaEnvironmentName} && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
+            const command = `"${activateCommand}" && conda activate ${condaEnvironmentName} && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
             shellExecResult = await processService.shellExec(command, { env: inputEnvironment });
         } catch (err) {
             // If that crashes for whatever reason, then just return empty data.
@@ -291,7 +293,7 @@ export class CondaService implements ICondaService {
         // thrown an error with 'conda info --envs' in the help.
         if (!shellExecResult && error && error.hasOwnProperty('stack') && error.stack.includes('conda info --envs')) {
             try {
-                const command = `"${activatePath}" && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
+                const command = `"${activateCommand}" && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
                 shellExecResult = await processService.shellExec(command, { env: inputEnvironment });
             } catch (err) {
                 // If that crashes for whatever reason, then just return empty data.

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -275,12 +275,14 @@ export class CondaService implements ICondaService {
         const result = {...input};
         const processService = await this.processServiceFactory.create();
 
-        // In order to make sure we know where the environment output is, put in a dummy echo we can look for
+        // Run the activate command collect the environment from it.
         const listEnv = this.platform.isWindows ? 'set' : 'printenv';
         let shellExecResult: ExecutionResult<string> | undefined;
         // tslint:disable-next-line:no-any
         let error : any;
         try {
+            // In order to make sure we know where the environment output is,
+            // put in a dummy echo we can look for
             const command = `${activateCommand} && conda activate ${condaEnvironmentName} && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
             shellExecResult = await processService.shellExec(command, { env: inputEnvironment });
         } catch (err) {

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -1,23 +1,19 @@
-import {
-    inject, injectable,
-    named, optional
-} from 'inversify';
+import { inject, injectable, named, optional } from 'inversify';
 import * as path from 'path';
 import { parse, SemVer } from 'semver';
+
 import { Logger } from '../../../common/logger';
-import {
-    IFileSystem, IPlatformService
-} from '../../../common/platform/types';
-import { IProcessServiceFactory } from '../../../common/process/types';
-import {
-    IConfigurationService, ILogger,
-    IPersistentStateFactory
-} from '../../../common/types';
+import { IFileSystem, IPlatformService } from '../../../common/platform/types';
+import { ExecutionResult, IProcessServiceFactory } from '../../../common/process/types';
+import { IConfigurationService, IDisposableRegistry, ILogger, IPersistentStateFactory } from '../../../common/types';
 import { compareVersion } from '../../../common/utils/version';
-import { IServiceContainer } from '../../../ioc/types';
 import {
-    CondaInfo, ICondaService, IInterpreterLocatorService,
-    InterpreterType, PythonInterpreter,
+    CondaInfo,
+    ICondaService,
+    IInterpreterLocatorService,
+    IInterpreterService,
+    InterpreterType,
+    PythonInterpreter,
     WINDOWS_REGISTRY_SERVICE
 } from '../../contracts';
 import { CondaHelper } from './condaHelper';
@@ -41,6 +37,11 @@ const condaGlobPathsForWindows = [
 // format for glob processing:
 export const CondaLocationsGlobWin = `{${condaGlobPathsForWindows.join(',')}}`;
 
+// Regex for splitting environment strings
+const EnvironmentSplitRegex = /^\s*([^=]+)\s*=\s*(.+)\s*$/;
+
+export const CondaGetEnvironmentPrefix = 'Outputting Environment Now...';
+
 /**
  * A wrapper around a conda installation.
  */
@@ -48,18 +49,21 @@ export const CondaLocationsGlobWin = `{${condaGlobPathsForWindows.join(',')}}`;
 export class CondaService implements ICondaService {
     private condaFile!: Promise<string | undefined>;
     private isAvailable: boolean | undefined;
-    private readonly processServiceFactory: IProcessServiceFactory;
-    private readonly platform: IPlatformService;
-    private readonly logger: ILogger;
     private readonly condaHelper = new CondaHelper();
+    private activatedEnvironmentCache : { [key: string] : NodeJS.ProcessEnv } = {};
 
     constructor(
-        @inject(IServiceContainer) private serviceContainer: IServiceContainer,
+        @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
+        @inject(IPlatformService) private platform: IPlatformService,
+        @inject(IFileSystem) private fileSystem: IFileSystem,
+        @inject(IPersistentStateFactory) private persistentStateFactory: IPersistentStateFactory,
+        @inject(IConfigurationService) private configService: IConfigurationService,
+        @inject(ILogger) private logger: ILogger,
+        @inject(IInterpreterService) private interpreterService: IInterpreterService,
+        @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
         @inject(IInterpreterLocatorService) @named(WINDOWS_REGISTRY_SERVICE) @optional() private registryLookupForConda?: IInterpreterLocatorService
     ) {
-        this.processServiceFactory = this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
-        this.platform = this.serviceContainer.get<IPlatformService>(IPlatformService);
-        this.logger = this.serviceContainer.get<ILogger>(ILogger);
+        this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(this.onInterpreterChanged));
     }
 
     public get condaEnvironmentsFile(): string | undefined {
@@ -163,11 +167,10 @@ export class CondaService implements ICondaService {
      * @memberof CondaService
      */
     public async isCondaEnvironment(interpreterPath: string): Promise<boolean> {
-        const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
         const dir = path.dirname(interpreterPath);
-        const isWindows = this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows;
+        const isWindows = this.platform.isWindows;
         const condaMetaDirectory = isWindows ? path.join(dir, 'conda-meta') : path.join(dir, '..', 'conda-meta');
-        return fs.directoryExists(condaMetaDirectory);
+        return this.fileSystem.directoryExists(condaMetaDirectory);
     }
 
     /**
@@ -185,13 +188,12 @@ export class CondaService implements ICondaService {
         const subDirName = path.basename(dir);
         const goUpOnLevel = ['BIN', 'SCRIPTS'].indexOf(subDirName.toUpperCase()) !== -1;
         const interpreterPathToMatch = goUpOnLevel ? path.join(dir, '..') : dir;
-        const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
 
         // From the list of conda environments find this dir.
-        let matchingEnvs = Array.isArray(environments) ? environments.filter(item => fs.arePathsSame(item.path, interpreterPathToMatch)) : [];
+        let matchingEnvs = Array.isArray(environments) ? environments.filter(item => this.fileSystem.arePathsSame(item.path, interpreterPathToMatch)) : [];
         if (matchingEnvs.length === 0) {
             environments = await this.getCondaEnvironments(true);
-            matchingEnvs = Array.isArray(environments) ? environments.filter(item => fs.arePathsSame(item.path, interpreterPathToMatch)) : [];
+            matchingEnvs = Array.isArray(environments) ? environments.filter(item => this.fileSystem.arePathsSame(item.path, interpreterPathToMatch)) : [];
         }
 
         if (matchingEnvs.length > 0) {
@@ -207,9 +209,8 @@ export class CondaService implements ICondaService {
      */
     public async getCondaEnvironments(ignoreCache: boolean): Promise<({ name: string; path: string }[]) | undefined> {
         // Global cache.
-        const persistentFactory = this.serviceContainer.get<IPersistentStateFactory>(IPersistentStateFactory);
         // tslint:disable-next-line:no-any
-        const globalPersistence = persistentFactory.createGlobalPersistentState<{ data: { name: string; path: string }[] | undefined }>('CONDA_ENVIRONMENTS', undefined as any);
+        const globalPersistence = this.persistentStateFactory.createGlobalPersistentState<{ data: { name: string; path: string }[] | undefined }>('CONDA_ENVIRONMENTS', undefined as any);
         if (!ignoreCache && globalPersistence.value) {
             return globalPersistence.value.data;
         }
@@ -243,36 +244,112 @@ export class CondaService implements ICondaService {
      * For the given interpreter return an activated Conda environment object
      * with the correct addition to the path and environmental variables
      */
-    // Base Node.js SpawnOptions uses any for environment, so use that here as well
-    // tslint:disable-next-line:no-any
-    public getActivatedCondaEnvironment(interpreter: PythonInterpreter, inputEnvironment: any): any {
+    public getActivatedCondaEnvironment = async (interpreter: PythonInterpreter, inputEnvironment?: NodeJS.ProcessEnv): Promise<NodeJS.ProcessEnv> => {
+        const input = inputEnvironment ? inputEnvironment : process.env;
         if (interpreter.type !== InterpreterType.Conda) {
-            return;
+            return input;
         }
 
-        const activatedEnvironment = {...inputEnvironment};
-        const isWindows = this.platform.isWindows;
+        // Shell execute conda activate and scrape the environment from it. This should be the necessary environment to
+        // run anything that depends upon conda
+        const condaEnvironmentName = interpreter.envName ? interpreter.envName : interpreter.path;
 
+        // We may have already computed this cache on a previous request
+        if (this.activatedEnvironmentCache &&
+            this.activatedEnvironmentCache.hasOwnProperty(condaEnvironmentName)) {
+            return this.activatedEnvironmentCache[condaEnvironmentName];
+        }
+
+        // New environment
+
+        // Attempt to find where conda is installed.
+        const condaPath = await this.getCondaFileFromInterpreter(interpreter);
+        if (!condaPath) {
+            return input;
+        }
+
+        // From that path we need to start an activate script
+        const activatePath = path.join(path.dirname(condaPath), 'activate');
+        const result = {...input};
+        const processService = await this.processServiceFactory.create();
+
+        // In order to make sure we know where the environment output is, put in a dummy echo we can look for
+        const listEnv = this.platform.isWindows ? 'set' : 'printenv';
+        let shellExecResult: ExecutionResult<string> | undefined;
+        // tslint:disable-next-line:no-any
+        let error : any;
+        try {
+            const command = `"${activatePath}" && conda activate ${condaEnvironmentName} && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
+            shellExecResult = await processService.shellExec(command, { env: inputEnvironment });
+        } catch (err) {
+            // If that crashes for whatever reason, then just return empty data.
+            this.logger.logWarning(err);
+            error = err;
+        }
+
+        // Special case. The 'environment' we have is the base environment. Previous call would have
+        // thrown an error with 'conda info --envs' in the help.
+        if (!shellExecResult && error && error.hasOwnProperty('stack') && error.stack.includes('conda info --envs')) {
+            try {
+                const command = `"${activatePath}" && echo '${CondaGetEnvironmentPrefix}' && ${listEnv}`;
+                shellExecResult = await processService.shellExec(command, { env: inputEnvironment });
+            } catch (err) {
+                // If that crashes for whatever reason, then just return empty data.
+                this.logger.logWarning(err);
+            }
+        }
+
+        // Parse the lines of the output until we find the dummy command
+        if (shellExecResult && shellExecResult.stdout.length > 0) {
+            this.parseEnvironmentOutput(shellExecResult.stdout, result);
+        } else {
+            // Still not found. Try just adding some things by hand.
+            this.addDefaultCondaEnvironment(interpreter, result);
+        }
+
+        this.activatedEnvironmentCache[condaEnvironmentName] = result;
+        return this.activatedEnvironmentCache[condaEnvironmentName];
+    }
+
+    private parseEnvironmentOutput(output: string, result: NodeJS.ProcessEnv) {
+        const lines = output.splitLines({trim: true, removeEmptyEntries: true});
+        let foundDummyOutput = false;
+        for (let i = 0; i < lines.length; i += 1) {
+            if (foundDummyOutput) {
+                // Split on equal
+                const match = EnvironmentSplitRegex.exec(lines[i]);
+                if (match && match !== null && match.length > 2) {
+                    result[match[1]] = match[2];
+                }
+            } else {
+                // See if we found the dummy output or not yet
+                foundDummyOutput = lines[i].includes(CondaGetEnvironmentPrefix);
+            }
+        }
+    }
+
+    /**
+     * Adds the default paths and env vars for conda to the current result
+     */
+    private addDefaultCondaEnvironment(interpreter: PythonInterpreter, result: NodeJS.ProcessEnv) {
         if (interpreter.envPath) {
-            if (isWindows) {
+            if (this.platform.isWindows) {
                 // Windows: Path, ; as separator, 'Scripts' as directory
                 const condaPath = path.join(interpreter.envPath, 'Scripts');
-                activatedEnvironment.Path = condaPath.concat(';', `${inputEnvironment.Path ? inputEnvironment.Path : ''}`);
+                result.Path = condaPath.concat(';', `${result.Path ? result.Path : ''}`);
             } else {
                 // Mac: PATH, : as separator, 'bin' as directory
                 const condaPath = path.join(interpreter.envPath, 'bin');
-                activatedEnvironment.PATH = condaPath.concat(':', `${inputEnvironment.PATH ? inputEnvironment.PATH : ''}`);
+                result.PATH = condaPath.concat(':', `${result.PATH ? result.PATH : ''}`);
             }
 
             // Conda also wants a couple of environmental variables set
-            activatedEnvironment.CONDA_PREFIX = interpreter.envPath;
+            result.CONDA_PREFIX = interpreter.envPath;
         }
 
         if (interpreter.envName) {
-            activatedEnvironment.CONDA_DEFAULT_ENV = interpreter.envName;
+            result.CONDA_DEFAULT_ENV = interpreter.envName;
         }
-
-        return activatedEnvironment;
     }
 
     /**
@@ -297,12 +374,48 @@ export class CondaService implements ICondaService {
         }
     }
 
+    private async getCondaFileFromInterpreter(interpreter: PythonInterpreter | undefined) : Promise<string | undefined> {
+        const condaExe = this.platform.isWindows ? 'conda.exe' : 'conda';
+        const scriptsDir = this.platform.isWindows ? 'Scripts' : 'bin';
+        let condaPath = interpreter ? path.join(path.dirname(interpreter.path), condaExe) : '';
+        if (await this.fileSystem.fileExists(condaPath)) {
+            return condaPath;
+        }
+        // Conda path has changed locations, check the new location in the scripts directory after checking
+        // the old location
+        condaPath = interpreter ? path.join(path.dirname(interpreter.path), scriptsDir, condaExe) : '';
+        if (await this.fileSystem.fileExists(condaPath)) {
+            return condaPath;
+        }
+
+        // Might be in a situation where this is not the default python env, but rather one running
+        // from a virtualenv
+        const split = interpreter ? path.dirname(interpreter.path).split(path.sep) : [];
+        if (interpreter && split && split.length > 0 && split[split.length - 1] === interpreter.envName) {
+            // Then we need to go up one more to check for 'envs'
+            if (split.length > 1 && split[split.length - 2] === 'envs') {
+                // This should be where the original python was run from.
+                const originalPath = split.slice(0, split.length - 2).join(path.sep);
+                condaPath = path.join(originalPath, condaExe);
+
+                if (await this.fileSystem.fileExists(condaPath)) {
+                    return condaPath;
+                }
+
+                // Also look in the scripts directory here too.
+                condaPath = path.join(originalPath, scriptsDir, condaExe);
+                if (await this.fileSystem.fileExists(condaPath)) {
+                    return condaPath;
+                }
+            }
+        }
+    }
+
     /**
      * Return the path to the "conda file", if there is one (in known locations).
      */
     private async getCondaFileImpl() {
-        const settings = this.serviceContainer.get<IConfigurationService>(IConfigurationService).getSettings();
-        const fileSystem = this.serviceContainer.get<IFileSystem>(IFileSystem);
+        const settings = this.configService.getSettings();
 
         const setting = settings.condaPath;
         if (setting && setting !== '') {
@@ -317,15 +430,9 @@ export class CondaService implements ICondaService {
             const interpreters = await this.registryLookupForConda.getInterpreters();
             const condaInterpreters = interpreters.filter(this.detectCondaEnvironment);
             const condaInterpreter = this.getLatestVersion(condaInterpreters);
-            let condaPath = condaInterpreter ? path.join(path.dirname(condaInterpreter.path), 'conda.exe') : '';
-            if (await fileSystem.fileExists(condaPath)) {
-                return condaPath;
-            }
-            // Conda path has changed locations, check the new location in the scripts directory after checking
-            // the old location
-            condaPath = condaInterpreter ? path.join(path.dirname(condaInterpreter.path), 'Scripts', 'conda.exe') : '';
-            if (await fileSystem.fileExists(condaPath)) {
-                return condaPath;
+            const interpreterPath = await this.getCondaFileFromInterpreter(condaInterpreter);
+            if (interpreterPath) {
+                return interpreterPath;
             }
         }
         return this.getCondaFileFromKnownLocations();
@@ -336,9 +443,8 @@ export class CondaService implements ICondaService {
      * Note: For now we simply return the first one found.
      */
     private async getCondaFileFromKnownLocations(): Promise<string> {
-        const fileSystem = this.serviceContainer.get<IFileSystem>(IFileSystem);
         const globPattern = this.platform.isWindows ? CondaLocationsGlobWin : CondaLocationsGlob;
-        const condaFiles = await fileSystem.search(globPattern)
+        const condaFiles = await this.fileSystem.search(globPattern)
             .catch<string[]>((failReason) => {
                 Logger.warn(
                     'Default conda location search failed.',
@@ -348,5 +454,14 @@ export class CondaService implements ICondaService {
             });
         const validCondaFiles = condaFiles.filter(condaPath => condaPath.length > 0);
         return validCondaFiles.length === 0 ? 'conda' : validCondaFiles[0];
+    }
+
+    /**
+     * Called when the user changes the current interpreter.
+     */
+    private onInterpreterChanged = () : Promise<void> => {
+        // Clear our activated environment cache as it can't match the current one anymore
+        this.activatedEnvironmentCache = {};
+        return Promise.resolve();
     }
 }

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -171,7 +171,7 @@ suite('ProcessService Observable', () => {
     test('shellExec should be able to run python too', async () => {
         const procService = new ProcessService(new BufferDecoder());
         const printOutput = '1234';
-        const result = await procService.shellExec(`"${pythonPath}" -c print("${printOutput}")`);
+        const result = await procService.shellExec(`"${pythonPath}" -c "print('${printOutput}')"`);
 
         expect(result).not.to.be.an('undefined', 'result is undefined');
         expect(result.stderr).to.equal(undefined, 'stderr not empty');

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -168,4 +168,21 @@ suite('ProcessService Observable', () => {
         expect(result.stdout).equals('', 'stdout is invalid');
         expect(result.stderr).equals(undefined, 'stderr is invalid');
     });
+    test('shellExec should be able to run python too', async () => {
+        const procService = new ProcessService(new BufferDecoder());
+        const printOutput = '1234';
+        const result = await procService.shellExec(`"${pythonPath}" -c 'import sys' 'sys.exit()'`);
+
+        expect(result).not.to.be.an('undefined', 'result is undefined');
+        expect(result.stdout.trim()).to.be.equal(printOutput, 'Invalid output');
+        expect(result.stderr).to.equal(undefined, 'stderr not undefined');
+
+        expect(result.stdout).equals('', 'stdout is invalid');
+        expect(result.stderr).equals(undefined, 'stderr is invalid');
+    });
+    test('shellExec should fail on invalid command', async () => {
+        const procService = new ProcessService(new BufferDecoder());
+        const result = procService.shellExec('invalid command');
+        await expect(result).to.eventually.be.rejectedWith(Error, 'a', 'Expected error to be thrown');
+    });
 });

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -171,10 +171,10 @@ suite('ProcessService Observable', () => {
     test('shellExec should be able to run python too', async () => {
         const procService = new ProcessService(new BufferDecoder());
         const printOutput = '1234';
-        const result = await procService.shellExec(`"${pythonPath}" -c 'print("${printOutput}")'`);
+        const result = await procService.shellExec(`"${pythonPath}" -c print("${printOutput}")`);
 
         expect(result).not.to.be.an('undefined', 'result is undefined');
-        expect(result.stderr).to.equal('', 'stderr not empty');
+        expect(result.stderr).to.equal(undefined, 'stderr not empty');
         expect(result.stdout.trim()).to.be.equal(printOutput, 'Invalid output');
     });
     test('shellExec should fail on invalid command', async () => {

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -174,7 +174,7 @@ suite('ProcessService Observable', () => {
         const result = await procService.shellExec(`"${pythonPath}" -c 'print("${printOutput}")'`);
 
         expect(result).not.to.be.an('undefined', 'result is undefined');
-        expect(result.stderr).to.equal(undefined, 'stderr not undefined');
+        expect(result.stderr).to.equal('', 'stderr not empty');
         expect(result.stdout.trim()).to.be.equal(printOutput, 'Invalid output');
     });
     test('shellExec should fail on invalid command', async () => {

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -174,11 +174,8 @@ suite('ProcessService Observable', () => {
         const result = await procService.shellExec(`"${pythonPath}" -c 'import sys' 'sys.exit()'`);
 
         expect(result).not.to.be.an('undefined', 'result is undefined');
-        expect(result.stdout.trim()).to.be.equal(printOutput, 'Invalid output');
         expect(result.stderr).to.equal(undefined, 'stderr not undefined');
-
-        expect(result.stdout).equals('', 'stdout is invalid');
-        expect(result.stderr).equals(undefined, 'stderr is invalid');
+        expect(result.stdout.trim()).to.be.equal(printOutput, 'Invalid output');
     });
     test('shellExec should fail on invalid command', async () => {
         const procService = new ProcessService(new BufferDecoder());

--- a/src/test/common/process/proc.exec.test.ts
+++ b/src/test/common/process/proc.exec.test.ts
@@ -171,7 +171,7 @@ suite('ProcessService Observable', () => {
     test('shellExec should be able to run python too', async () => {
         const procService = new ProcessService(new BufferDecoder());
         const printOutput = '1234';
-        const result = await procService.shellExec(`"${pythonPath}" -c 'import sys' 'sys.exit()'`);
+        const result = await procService.shellExec(`"${pythonPath}" -c 'print("${printOutput}")'`);
 
         expect(result).not.to.be.an('undefined', 'result is undefined');
         expect(result.stderr).to.equal(undefined, 'stderr not undefined');

--- a/src/test/interpreters/condaService.unit.test.ts
+++ b/src/test/interpreters/condaService.unit.test.ts
@@ -95,6 +95,7 @@ suite('Interpreters Conda Service', () => {
             logger.object,
             interpreterService.object,
             disposableRegistry,
+            serviceContainer.object,
             registryInterpreterLocatorService.object);
 
     });
@@ -384,7 +385,8 @@ suite('Interpreters Conda Service', () => {
             config.object,
             logger.object,
             interpreterService.object,
-            disposableRegistry);
+            disposableRegistry,
+            serviceContainer.object);
 
         const result = await condaSrv.getCondaFile();
         expect(result).is.equal(expected);
@@ -402,7 +404,6 @@ suite('Interpreters Conda Service', () => {
 
         // We should not try to call other unwanted methods.
         processService.verifyAll();
-        platformService.verify(p => p.isWindows, TypeMoq.Times.never());
         registryInterpreterLocatorService.verify(r => r.getInterpreters(TypeMoq.It.isAny()), TypeMoq.Times.never());
     });
 
@@ -413,7 +414,6 @@ suite('Interpreters Conda Service', () => {
         assert.equal(condaExe, 'conda', 'Failed to identify conda.exe');
 
         // We should not try to call other unwanted methods.
-        platformService.verify(p => p.isWindows, TypeMoq.Times.never());
         registryInterpreterLocatorService.verify(r => r.getInterpreters(TypeMoq.It.isAny()), TypeMoq.Times.never());
     });
 
@@ -425,7 +425,6 @@ suite('Interpreters Conda Service', () => {
         processService.verify(p => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()), TypeMoq.Times.once());
 
         // We should not try to call other unwanted methods.
-        platformService.verify(p => p.isWindows, TypeMoq.Times.never());
         registryInterpreterLocatorService.verify(r => r.getInterpreters(TypeMoq.It.isAny()), TypeMoq.Times.never());
 
         await condaService.getCondaFile();

--- a/src/test/mocks/proc.ts
+++ b/src/test/mocks/proc.ts
@@ -1,7 +1,16 @@
-import { EventEmitter } from 'events';
 import 'rxjs/add/observable/of';
+
+import { EventEmitter } from 'events';
 import { Observable } from 'rxjs/Observable';
-import { ExecutionResult, IProcessService, ObservableExecutionResult, Output, SpawnOptions } from '../../client/common/process/types';
+
+import {
+    ExecutionResult,
+    IProcessService,
+    ObservableExecutionResult,
+    Output,
+    ShellOptions,
+    SpawnOptions
+} from '../../client/common/process/types';
 import { noop } from '../core';
 
 type ExecObservableCallback = (result: Observable<Output<string>> | Output<string>) => void;
@@ -52,4 +61,13 @@ export class MockProcessService extends EventEmitter implements IProcessService 
 
         return valueReturned ? value! : this.procService.exec(file, args, options);
     }
+
+    public async shellExec(command: string, options?: ShellOptions): Promise<ExecutionResult<string>> {
+        let value: ExecutionResult<string> | undefined;
+        let valueReturned = false;
+        this.emit('shellExec', command, options, (result: ExecutionResult<string>) => { value = result; valueReturned = true; });
+
+        return valueReturned ? value! : this.procService.shellExec(command, options);
+    }
+
 }


### PR DESCRIPTION
Run the conda activate script and scrape all of the environment from it prior to launching jupyter (or any other command with the same interpreter)

I'm hoping this will finally fix #3341. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
