### PR TITLE
Respect value defined for `pylintEnabled` in user `settings.json`

### DIFF
--- a/news/2 Fixes/3388.md
+++ b/news/2 Fixes/3388.md
@@ -1,0 +1,1 @@
+Respect value defined for `pylintEnabled` in user `settings.json`.

--- a/src/client/linters/linterInfo.ts
+++ b/src/client/linters/linterInfo.ts
@@ -80,7 +80,7 @@ export class PylintLinterInfo extends LinterInfo {
         }
         // If we're using new LS, then by default Pylint is disabled (unless the user provides a value).
         const inspection = this.workspaceService.getConfiguration('python', resource).inspect<boolean>('linting.pylintEnabled');
-        if (!inspection || inspection.globalValue === undefined && inspection.workspaceFolderValue === undefined || inspection.workspaceValue === undefined) {
+        if (!inspection || (inspection.globalValue === undefined && (inspection.workspaceFolderValue === undefined || inspection.workspaceValue === undefined))) {
             return false;
         }
         return enabled;

--- a/src/test/linters/linterinfo.unit.test.ts
+++ b/src/test/linters/linterinfo.unit.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:chai-vague-errors no-unused-expression max-func-body-length no-any
+
+import { expect } from 'chai';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { WorkspaceService } from '../../client/common/application/workspace';
+import { ConfigurationService } from '../../client/common/configuration/service';
+import { PylintLinterInfo } from '../../client/linters/linterInfo';
+
+suite('Linter Info - Pylint', () => {
+    test('Test disabled when Pylint is explicitly disabled', async () => {
+        const config = mock(ConfigurationService);
+        const workspaceService = mock(WorkspaceService);
+        const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
+
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: false } } as any);
+
+        expect(linterInfo.isEnabled()).to.be.false;
+    });
+    test('Test disabled when Jedi is enabled and Pylint is explicitly disabled', async () => {
+        const config = mock(ConfigurationService);
+        const workspaceService = mock(WorkspaceService);
+        const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
+
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: false }, jediEnabled: true } as any);
+
+        expect(linterInfo.isEnabled()).to.be.false;
+    });
+    test('Test enabled when Jedi is enabled and Pylint is explicitly enabled', async () => {
+        const config = mock(ConfigurationService);
+        const workspaceService = mock(WorkspaceService);
+        const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
+
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: true } as any);
+
+        expect(linterInfo.isEnabled()).to.be.true;
+    });
+    test('Test disabled when using Language Server and Pylint is not configured', async () => {
+        const config = mock(ConfigurationService);
+        const workspaceService = mock(WorkspaceService);
+        const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
+
+        const inspection = {};
+        const pythonConfig = {
+            inspect: () => inspection
+        };
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
+        when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
+
+        expect(linterInfo.isEnabled()).to.be.false;
+    });
+    test('Test enabled when using Language Server and Pylint is configured', async () => {
+        const config = mock(ConfigurationService);
+        const workspaceService = mock(WorkspaceService);
+        const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
+
+        const inspection = {
+            globalValue: 'something',
+            workspaceFolderValue: 'something',
+            workspaceValue: 'something'
+        };
+        const pythonConfig = {
+            inspect: () => inspection
+        };
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
+        when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
+
+        expect(linterInfo.isEnabled()).to.be.true;
+    });
+});


### PR DESCRIPTION
For #3388

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
