### PR TITLE
WIP: DISCUSS - Start LS in background

### DIFF
--- a/PERF_RECORDINGS.md
+++ b/PERF_RECORDINGS.md
@@ -1,0 +1,32 @@
+!!DO NOT MERGE TO MASTER!!
+
+# With my change
+----------------
+
+## Jedi
+Extension startup duration [start = 2984, end = 3858] = 874
+**ms-python.python** false 2971 524 351
+
+## LS, needs downloading
+Extension startup duration [start = 2314, end = 3084] = 770
+**ms - python.python** false 2334 387 389
+
+## LS, already downloaded
+
+Extension startup duration [start = 2111, end = 2803] = 692
+**ms-python.python** false 2078 368 325
+
+# Without my change
+-------------------
+
+## Jedi
+Extension startup duration [start = 4854, end = 6597] = 1743
+**ms-python.python** false 4889 1099 644
+
+## LS, needs downloading
+Extension startup duration [start = 2342, end = 64562] = 62220
+**ms-python.python** false 2335 486 61734
+
+## LS, already downloaded
+Extension startup duration [start = 2348, end = 7551] = 5203
+**ms-python.pythonfalse** 2343 449 4754

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -5,9 +5,10 @@ if ((Reflect as any).metadata === undefined) {
     // tslint:disable-next-line:no-require-imports no-var-requires
     require('reflect-metadata');
 }
+const showStatsInStdOut = true; // REMOVE THIS PRIOR TO MERGE
 const durations: { [key: string]: number } = {};
 import { StopWatch } from './common/utils/stopWatch';
-// Do not move this linne of code (used to measure extension load times).
+// Do not move this line of code (used to measure extension load times).
 const stopWatch = new StopWatch();
 import { Container } from 'inversify';
 import {
@@ -121,7 +122,15 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     activateSimplePythonRefactorProvider(context, standardOutputChannel, serviceContainer);
 
     const activationService = serviceContainer.get<IExtensionActivationService>(IExtensionActivationService);
-    await activationService.activate();
+    // language server activation does not need to be awaited, allow it to initialize in the
+    activationService.activate()
+        .then(
+            () => standardOutputChannel.appendLine('Language server started successfully.'),
+            (rejectedReason) => standardOutputChannel.appendLine(`Language Server startup failed. Reason: ${rejectedReason}`)
+        )
+        .catch(
+            (exceptionReason) => standardOutputChannel.appendLine(`Language Server startup exception raised: ${exceptionReason}`)
+        ).ignoreErrors();
 
     const sortImports = serviceContainer.get<ISortImportsEditingProvider>(ISortImportsEditingProvider);
     sortImports.registerCommands();
@@ -290,6 +299,10 @@ async function sendStartupTelemetry(activatedPromise: Promise<void>, serviceCont
 
         const props = { condaVersion, terminal: terminalShellType, pythonVersion, interpreterType, workspaceFolderCount, hasPython3 };
         sendTelemetryEvent(EDITOR_LOAD, durations, props);
+        if (showStatsInStdOut === true) {
+            const stdOut = serviceContainer.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+            stdOut.appendLine(`Extension startup duration [start = ${durations.startActivateTime}, end = ${durations.endActivateTime}] = ${durations.endActivateTime - durations.startActivateTime}`);
+        }
     } catch (ex) {
         logger.logError('sendStartupTelemetry failed.', ex);
     }


### PR DESCRIPTION
For #3020

- Just stopping the await in extension might be enough
- We may need some further hook up to defer LS activities cleanly
- Note that there are some extra items that shouldn't merge to master

- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
