### PR TITLE
Revert version of Jedi to 0.12.0

### DIFF
--- a/news/2 Fixes/3514.md
+++ b/news/2 Fixes/3514.md
@@ -1,0 +1,1 @@
+Revert version of Jedi to 0.12.0.

--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -34,7 +34,7 @@ class JediCompletion(object):
 
     def __init__(self):
         self.default_sys_path = sys.path
-        self.environment = jedi.api.environment.Environment(sys.executable)
+        self.environment = jedi.api.environment.Environment(sys.prefix, sys.executable)
         self._input = io.open(sys.stdin.fileno(), encoding='utf-8')
         if (os.path.sep == '/') and (platform.uname()[2].find('Microsoft') > -1):
             # WSL; does not support UNC paths

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jedi==0.12.0
-parso==0.3.1
+parso==0.2.1
 isort==4.3.4
 ptvsd==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jedi==0.13.1
+jedi==0.12.0
 parso==0.3.1
 isort==4.3.4
 ptvsd==4.2.0


### PR DESCRIPTION
For #3514

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
