### PR TITLE
Fixes #3530: codelens test run works without exception.

### DIFF
--- a/news/2 Fixes/3530.md
+++ b/news/2 Fixes/3530.md
@@ -1,0 +1,1 @@
+Tests debugged via CodeLens no longer break for a `SystemExit` exception after successful test completion.

--- a/pythonFiles/testlauncher.py
+++ b/pythonFiles/testlauncher.py
@@ -33,7 +33,7 @@ Press Enter to close. . .''')
             raw_input()
         except NameError:
             input()
-        sys.exit(1)
+        os._exit(1)
 
 
 def run(cwd, testRunner, args):
@@ -53,7 +53,7 @@ def run(cwd, testRunner, args):
         else:
             import nose
             nose.run(argv=args)
-        sys.exit(0)
+        os._exit(0)
     finally:
         pass
 


### PR DESCRIPTION
Fixes #3530

Updates `sys.exit(...)` to `os._exit(...)`, which is similar but does not raise a SystemExit exception, thus allowing CodeLens to finish without the debugger breaking on exit.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
