### PR TITLE
Revert "Have ctags use `--extras` instead of `--extra` (#2758)"

### DIFF
--- a/news/2 Fixes/3517.md
+++ b/news/2 Fixes/3517.md
@@ -1,0 +1,1 @@
+Revert ctags argument from `--extras` to `--extra`.

--- a/resources/ctagOptions
+++ b/resources/ctagOptions
@@ -19,5 +19,5 @@
 --exclude=Builds
 --exclude=doc
 --fields=Knz
---extras=+f
+--extra=+f
 --append=no


### PR DESCRIPTION
This reverts commit 3fc7af87f80620dead3cf74d54fd9260f1dbcf4f.

For #3517

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
