### PR TITLE
Use Pylint message names instead of codes

### DIFF
--- a/news/1 Enhancements/2906.md
+++ b/news/1 Enhancements/2906.md
@@ -1,0 +1,2 @@
+Use Pylint message names instead of codes
+(thanks to [Roman Kornev](https://github.com/RomanKornev/))

--- a/src/client/linters/pylint.ts
+++ b/src/client/linters/pylint.ts
@@ -15,6 +15,8 @@ import { ILintMessage } from './types';
 const pylintrc = 'pylintrc';
 const dotPylintrc = '.pylintrc';
 
+const REGEX = '(?<line>\\d+),(?<column>-?\\d+),(?<type>\\w+),(?<code>[\\w-]+):(?<message>.*)\\r?(\\n|$)';
+
 export class Pylint extends BaseLinter {
     private fileSystem: IFileSystem;
     private platformService: IPlatformService;
@@ -67,12 +69,12 @@ export class Pylint extends BaseLinter {
             ];
         }
         const args = [
-            '--msg-template=\'{line},{column},{category},{msg_id}:{msg}\'',
+            '--msg-template=\'{line},{column},{category},{symbol}:{msg}\'',
             '--reports=n',
             '--output-format=text',
             uri.fsPath
         ];
-        const messages = await this.run(minArgs.concat(args), document, cancellation);
+        const messages = await this.run(minArgs.concat(args), document, cancellation, REGEX);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.pylintCategorySeverity);
         });


### PR DESCRIPTION
For #2906 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
