### PR TITLE
Ensure we handle errors when checking support for LS

### DIFF
--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -29,6 +29,7 @@ export type LanguageServerErrorTelemetry = {
 
 export type LanguageServePlatformSupported = {
     supported: boolean;
+    failureType?: 'UnknownError';
 };
 
 export type LinterTrigger = 'auto' | 'save';

--- a/src/test/activation/languageServer/languageServerCompatibilityService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerCompatibilityService.unit.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import * as typeMoq from 'typemoq';
+import { LanguageServerCompatibilityService } from '../../../client/activation/languageServer/languageServerCompatibilityService';
+import { ILanguageServerCompatibilityService } from '../../../client/activation/types';
+import { IDotNetCompatibilityService } from '../../../client/common/dotnet/types';
+
+suite('Language Server Support', () => {
+    let compatService: typeMoq.IMock<IDotNetCompatibilityService>;
+    let service: ILanguageServerCompatibilityService;
+    setup(() => {
+        compatService = typeMoq.Mock.ofType<IDotNetCompatibilityService>();
+        service = new LanguageServerCompatibilityService(compatService.object);
+    });
+    test('Not supported if there are errors ', async () => {
+        compatService.setup(c => c.isSupported()).returns(() => Promise.reject(new Error('kaboom')));
+        const supported = await service.isSupported();
+        expect(supported).to.equal(false, 'incorrect');
+    });
+    test('Not supported if there are not errors ', async () => {
+        compatService.setup(c => c.isSupported()).returns(() => Promise.resolve(false));
+        const supported = await service.isSupported();
+        expect(supported).to.equal(false, 'incorrect');
+    });
+    test('Support if there are not errors ', async () => {
+        compatService.setup(c => c.isSupported()).returns(() => Promise.resolve(true));
+        const supported = await service.isSupported();
+        expect(supported).to.equal(true, 'incorrect');
+    });
+});


### PR DESCRIPTION
For #2729

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
