### PR TITLE
Expand variables in `pythonPath` before validating it

### DIFF
--- a/news/2 Fixes/3392.md
+++ b/news/2 Fixes/3392.md
@@ -1,0 +1,1 @@
+Expand variables in `pythonPath` before validating it.

--- a/src/client/debugger/extension/configProviders/baseProvider.ts
+++ b/src/client/debugger/extension/configProviders/baseProvider.ts
@@ -40,7 +40,7 @@ export abstract class BaseConfigurationProvider implements DebugConfigurationPro
             }
 
             await this.provideLaunchDefaults(workspaceFolder, config);
-            const isValid = await this.validateLaunchConfiguration(config);
+            const isValid = await this.validateLaunchConfiguration(folder, config);
             if (!isValid) {
                 return;
             }
@@ -90,9 +90,9 @@ export abstract class BaseConfigurationProvider implements DebugConfigurationPro
         // Pass workspace folder so we can get this when we get debug events firing.
         debugConfiguration.workspaceFolder = workspaceFolder ? workspaceFolder.fsPath : undefined;
     }
-    protected async validateLaunchConfiguration(debugConfiguration: LaunchRequestArguments): Promise<boolean> {
+    protected async validateLaunchConfiguration(folder: WorkspaceFolder | undefined, debugConfiguration: LaunchRequestArguments): Promise<boolean> {
         const diagnosticService = this.serviceContainer.get<IInvalidPythonPathInDebuggerService>(IDiagnosticsService, InvalidPythonPathInDebuggerServiceId);
-        return diagnosticService.validatePythonPath(debugConfiguration.pythonPath);
+        return diagnosticService.validatePythonPath(debugConfiguration.pythonPath, folder ? folder.uri : undefined);
     }
     private getWorkspaceFolder(folder: WorkspaceFolder | undefined): Uri | undefined {
         if (folder) {


### PR DESCRIPTION
For #3392

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
