### PR TITLE
Fix env variable token in ADO yaml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,29 +1,4 @@
-codecov:
-  notify:
-    require_ci_to_pass: yes
-
 coverage:
   precision: 0
   round: up
   range: "70...90"
-
-  status:
-    project: yes
-    patch: yes
-    changes: no
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
-
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
-  branches: null

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
 coverage:
   precision: 0
   round: up
   range: "70...90"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null

--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -141,7 +141,7 @@ jobs:
         customCommand: 'run test:unittests'
 
 
-    - bash: 'bash <(curl -s https://codecov.io/bash) -t $COV_UUID'
+    - bash: 'bash <(curl -s https://codecov.io/bash) -t $(COV_UUID)'
       displayName: 'publish codecov'
       continueOnError: true
       condition: always()

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -214,7 +214,7 @@ steps:
 
       condition: always()
 
-  - bash: 'bash <(curl -s https://codecov.io/bash) -t $COV_UUID -F $(Platform)'
+  - bash: 'bash <(curl -s https://codecov.io/bash) -t $(COV_UUID) -F $(Platform)'
     displayName: 'publish codecov'
     continueOnError: true
     condition: always()

--- a/news/2 Fixes/3630.md
+++ b/news/2 Fixes/3630.md
@@ -1,0 +1,1 @@
+Fix env variable token in ADO yaml.


### PR DESCRIPTION
For #3631

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
