### PR TITLE
Clear cached display name of python if interpreter changes

### DIFF
--- a/news/2 Fixes/3406.md
+++ b/news/2 Fixes/3406.md
@@ -1,0 +1,1 @@
+Clear cached display name of python if interpreter changes.

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -9,6 +9,7 @@ import * as glob from 'glob';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import * as tmp from 'tmp';
+import { traceDecorators } from '../logger';
 import { createDeferred } from '../utils/async';
 import { IFileSystem, IPlatformService, TemporaryFile } from './types';
 
@@ -142,6 +143,8 @@ export class FileSystem implements IFileSystem {
         fs.unlink(filename, err => err ? deferred.reject(err) : deferred.resolve());
         return deferred.promise;
     }
+
+    @traceDecorators.error('Failed to get FileHash')
     public getFileHash(filePath: string): Promise<string | undefined> {
         return new Promise<string | undefined>(resolve => {
             fs.lstat(filePath, (err, stats) => {


### PR DESCRIPTION
For #3406

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
