### PR TITLE
Bump language server to 0.1.72

### DIFF
--- a/news/2 Fixes/3657.md
+++ b/news/2 Fixes/3657.md
@@ -1,0 +1,6 @@
+Update the Microsoft Python language server to 0.1.72/[2018.12.1](https://github.com/Microsoft/python-language-server/releases/tag/2018.12.1):
+* Properly resolve namespace packages and relative imports.
+* `Go to Definition` now supports namespace packages.
+* Fixed `null` reference exceptions.
+* Fixed erroneously reporting `None`, `True`, and `False` as undefined.
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, code formatting, refactoring, unit tests, snippets, and more.",
     "version": "2018.12.0-beta",
-    "languageServerVersion": "0.1.65",
+    "languageServerVersion": "0.1.72",
     "publisher": "ms-python",
     "author": {
         "name": "Microsoft Corporation"


### PR DESCRIPTION
For #3657

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
