### PR TITLE
Ensure startup time telemetry still accounts for LS startup time

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -133,7 +133,7 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     sortImports.registerCommands();
 
     serviceManager.get<ICodeExecutionManager>(ICodeExecutionManager).registerCommands();
-    sendStartupTelemetry(activationDeferred.promise, serviceContainer).ignoreErrors();
+    sendStartupTelemetry(Promise.all([activationDeferred.promise, lsActivationPromise]), serviceContainer).ignoreErrors();
 
     const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
     interpreterManager.refresh(workspaceService.hasWorkspaceFolders ? workspaceService.workspaceFolders![0].uri : undefined)
@@ -279,7 +279,9 @@ function initializeServices(context: ExtensionContext, serviceManager: ServiceMa
     const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     interpreterService.getInterpreters(mainWorkspaceUri).ignoreErrors();
 }
-async function sendStartupTelemetry(activatedPromise: Promise<void>, serviceContainer: IServiceContainer) {
+
+// tslint:disable-next-line:no-any
+async function sendStartupTelemetry(activatedPromise: Promise<any>, serviceContainer: IServiceContainer) {
     const logger = serviceContainer.get<ILogger>(ILogger);
     try {
         await activatedPromise;


### PR DESCRIPTION
Telemetry update for LS loading in the background.

Addendum for #3020 

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
