### PR TITLE
#3597: Modified mypy linter plugin to support column numbers for repo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1326,7 +1326,8 @@
                     "description": "Arguments passed in. Each argument is a separate item in the array.",
                     "default": [
                         "--ignore-missing-imports",
-                        "--follow-imports=silent"
+                        "--follow-imports=silent",
+                        "--show-column-numbers"
                     ],
                     "items": {
                         "type": "string"

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -5,7 +5,7 @@ import { IServiceContainer } from '../ioc/types';
 import { BaseLinter } from './baseLinter';
 import { ILintMessage } from './types';
 
-export const REGEX = '(?<file>.+):(?<line>\\d+): (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
+export const REGEX = '(?<file>[^:]+):(?<line>\\d+)(:(?<column>\\d+))?: (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
 
 export class MyPy extends BaseLinter {
     constructor(outputChannel: OutputChannel, serviceContainer: IServiceContainer) {

--- a/src/test/linters/mypy.unit.test.ts
+++ b/src/test/linters/mypy.unit.test.ts
@@ -15,6 +15,7 @@ import { ILintMessage } from '../../client/linters/types';
 const output = `
 provider.pyi:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 provider.pyi:11: error: Name 'not_declared_var' is not defined
+provider.pyi:12:21: error: Expression has type "Any"
 `;
 
 suite('Linting - MyPy', () => {
@@ -34,6 +35,14 @@ suite('Linting - MyPy', () => {
                 message: 'Name \'not_declared_var\' is not defined',
                 column: 0,
                 line: 11,
+                type: 'error',
+                provider: 'mypy'
+             } as ILintMessage],
+            [lines[3], {
+                code: undefined,
+                message: 'Expression has type "Any"',
+                column: 21,
+                line: 12,
                 type: 'error',
                 provider: 'mypy'
              } as ILintMessage]


### PR DESCRIPTION
…rted errors.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
