### PR TITLE
Make configuration follow conventions and be understandable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1633,7 +1633,7 @@
                 "python.unitTest.nosetestsEnabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to enable or disable unit testing using nosetests.",
+                    "description": "Enable unit testing using nosetests.",
                     "scope": "resource"
                 },
                 "python.unitTest.nosetestPath": {
@@ -1645,7 +1645,7 @@
                 "python.unitTest.promptToConfigure": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Where to prompt to configure a test framework if potential tests directories are discovered.",
+                    "description": "Prompt to configure a test framework if potential tests directories are discovered.",
                     "scope": "resource"
                 },
                 "python.unitTest.pyTestArgs": {
@@ -1660,7 +1660,7 @@
                 "python.unitTest.pyTestEnabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to enable or disable unit testing using pytest.",
+                    "description": "Enable unit testing using pytest.",
                     "scope": "resource"
                 },
                 "python.unitTest.pyTestPath": {
@@ -1687,13 +1687,13 @@
                 "python.unitTest.unittestEnabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to enable or disable unit testing using unittest.",
+                    "description": "Enable unit testing using unittest.",
                     "scope": "resource"
                 },
                 "python.unitTest.autoTestDiscoverOnSaveEnabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Whether to enable or disable auto run test discovery when saving a unit test file.",
+                    "description": "Enable auto run test discovery when saving a unit test file.",
                     "scope": "resource"
                 },
                 "python.venvFolders": {

--- a/package.json
+++ b/package.json
@@ -950,7 +950,7 @@
         ],
         "configuration": {
             "type": "object",
-            "title": "Python Configuration",
+            "title": "Python",
             "properties": {
                 "python.diagnostics.sourceMapsEnabled": {
                     "type": "boolean",


### PR DESCRIPTION
The title of the settings uses a "Configuration" suffix in the title which is unconventional and looks bad, so I removed it.

<img width="203" alt="screenshot 2018-12-15 at 23 52 50" src="https://user-images.githubusercontent.com/2293981/50048129-8f57d980-00c4-11e9-8490-a533605e46a0.png">

Some of the settings' descriptions are understandable from the json settings but not the descriptions shown in the settings ui, so I updated them.

<img width="542" alt="screenshot 2018-12-15 at 23 42 36" src="https://user-images.githubusercontent.com/2293981/50048137-c7f7b300-00c4-11e9-9ff0-b45ed7293bad.png">

Sort of like answering "Would you like to enable or disable?" with "Yes".

<img width="606" alt="screenshot 2018-12-15 at 23 42 47" src="https://user-images.githubusercontent.com/2293981/50048147-02615000-00c5-11e9-9f43-77d54e4eda29.png">

A "Where..." question cannot really be answered with a boolean.