### PR TITLE
Re-enable tests for multiple linters

### DIFF
--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -16,6 +16,7 @@ import { IProductPathService, IProductService } from '../../client/common/instal
 import { IConfigurationService, IOutputChannel, ProductType } from '../../client/common/types';
 import { LinterManager } from '../../client/linters/linterManager';
 import { ILinterManager, ILintMessage, LintMessageSeverity } from '../../client/linters/types';
+import { IS_TRAVIS } from '../ciConstants';
 import { deleteFile, PythonSettingKeys, rootWorkspaceUri } from '../common';
 import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } from '../initialize';
 import { MockOutputChannel } from '../mockClasses';
@@ -269,7 +270,15 @@ suite('Linting - General Tests', () => {
         await configService.updateSetting('linting.pylintUseMinimalCheckers', false, workspaceUri);
         await testEnablingDisablingOfLinter(Product.pylint, true, file);
     });
-    test('Multiple linters', async () => {
+    test('Multiple linters', async function () {
+        // travis times out with the 25sec limit, but is also going to be retired
+        // in the near future in favour of Azure DevOps pipelines. Since Azure DevOps
+        // seem to not timeout (at least as much), skip this test in Travis.
+        if (IS_TRAVIS) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
+        }
+
         await closeActiveWindows();
         const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
         await window.showTextDocument(document);

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -269,11 +269,7 @@ suite('Linting - General Tests', () => {
         await configService.updateSetting('linting.pylintUseMinimalCheckers', false, workspaceUri);
         await testEnablingDisablingOfLinter(Product.pylint, true, file);
     });
-    // tslint:disable-next-line:no-function-expression
-    test('Multiple linters', async function () {
-        // skip this unreliable test: gh 2571 tracking this issue...
-        // tslint:disable-next-line:no-invalid-this
-        return this.skip();
+    test('Multiple linters', async () => {
         await closeActiveWindows();
         const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
         await window.showTextDocument(document);


### PR DESCRIPTION
Failing test is no longer able to repro locally.

For #2571 

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
