### PR TITLE
Ensure file names are not captured when sending telemetry for unit tests

### DIFF
--- a/news/2 Fixes/3767.md
+++ b/news/2 Fixes/3767.md
@@ -1,0 +1,1 @@
+Ensure file names are not captured when sending telemetry for unit tests.

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -72,7 +72,7 @@ export type TestRunTelemetry = {
     tool: 'nosetest' | 'pytest' | 'unittest';
     scope: 'currentFile' | 'all' | 'file' | 'class' | 'function' | 'failed';
     debugging: boolean;
-    triggeredBy: 'ui' | 'codelens' | 'commandpalette' | 'auto';
+    triggerSource: 'ui' | 'codelens' | 'commandpalette' | 'auto';
     failed: boolean;
 };
 export type TestDiscoverytTelemetry = {

--- a/src/client/unittests/common/managers/baseTestManager.ts
+++ b/src/client/unittests/common/managers/baseTestManager.ts
@@ -2,6 +2,7 @@ import { CancellationToken, CancellationTokenSource, Disposable, OutputChannel, 
 import { IWorkspaceService } from '../../../common/application/types';
 import { isNotInstalledError } from '../../../common/helpers';
 import { IConfigurationService, IDisposableRegistry, IInstaller, IOutputChannel, IPythonSettings, Product } from '../../../common/types';
+import { getNamesAndValues } from '../../../common/utils/enum';
 import { IServiceContainer } from '../../../ioc/types';
 import { UNITTEST_DISCOVER, UNITTEST_RUN } from '../../../telemetry/constants';
 import { sendTelemetryEvent } from '../../../telemetry/index';
@@ -171,11 +172,13 @@ export abstract class BaseTestManager implements ITestManager {
             Run_Specific_Class: 'false',
             Run_Specific_Function: 'false'
         };
+        //Ensure valid values are sent.
+        const validCmdSourceValues = getNamesAndValues<CommandSource>(CommandSource).map(item => item.value);
         const telementryProperties: TestRunTelemetry = {
             tool: this.testProvider,
             scope: 'all',
             debugging: debug === true,
-            triggeredBy: cmdSource,
+            triggerSource: validCmdSourceValues.indexOf(cmdSource) === -1 ? 'commandpalette' : cmdSource,
             failed: false
         };
         if (runFailedTests === true) {


### PR DESCRIPTION
For #3767

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [no] Unit tests & system/integration tests are added/updated
- [no] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [no] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
