### PR TITLE
Update nightly CI to use YAML definition

### DIFF
--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -1,9 +1,10 @@
 parameters:
-  name: 'Unit_Test_Run'
+  name: 'Prebuild'
   PythonVersion: '3.7'
   NodeVersion: '8.11.2'
   NpmVersion: 'latest'
-  PoolName: 'Hosted Ubuntu 1604'
+  pool:
+    name: 'Hosted Ubuntu 1604'
   MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
   MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
   MOCHA_REPORTER_JUNIT: true
@@ -14,11 +15,9 @@ parameters:
 
 jobs:
 - job: ${{ parameters.name }}
-  pool:
-    name: ${{ parameters.PoolName }}
+  pool: ${{ parameters.pool }}
 
   variables:
-    # TODO: use {{ insert }}: {{ parameters.variables }}, it would not work at time I wrote this
     nodeVersion: ${{ parameters.NodeVersion }}
     npmVersion: ${{ parameters.NpmVersion }}
     pythonVersion: ${{ parameters.PythonVersion }}

--- a/build/ci/templates/test-phase-job.yml
+++ b/build/ci/templates/test-phase-job.yml
@@ -1,0 +1,50 @@
+parameters:
+  PythonVersion: '3.7'
+  NodeVersion: '8.11.2'
+  NpmVersion: 'latest'
+  PoolName: 'Hosted Ubuntu 1604'
+  MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
+  MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
+  MOCHA_REPORTER_JUNIT: true
+  UploadBinary: false
+  AzureStorageAccountName: 'vscodepythonci'
+  AzureStorageContainerName: 'vscode-python-ci'
+  BuildNumber: '$(Build.BuildNumber)'
+  Platform: 'Linux'
+  DependsOn: 'Prebuild'
+
+jobs:
+- job:
+  displayName: ${{ format('{SystemTest {1} Py{2}', parameters.Platform, parameters.PythonVersion) }}
+  dependsOn: ${{ parameters.DependsOn }}
+  pool:
+    ${{ parameters.pool }}
+
+  variables:
+    # TODO: use {{ insert }}: {{ parameters.variables }}, it would not work at time I wrote this
+    nodeVersion: ${{ parameters.NodeVersion }}
+    npmVersion: ${{ parameters.NpmVersion }}
+    pythonVersion: ${{ parameters.PythonVersion }}
+    mochaReportFile: ${{ parameters.MOCHA_CI_REPORTFILE }}
+    MOCHA_CI_REPORTER_ID: ${{ parameters.MOCHA_CI_REPORTER_ID }}
+    MOCHA_CI_REPORTFILE: ${{ parameters.MOCHA_CI_REPORTFILE }}
+    MOCHA_REPORTER_JUNIT: ${{ parameters.MOCHA_REPORTER_JUNIT }}
+    uploadBinary: ${{ parameters.UploadBinary }}
+    azureStorageAccountName: ${{ parameters.AzureStorageAccountName }}
+    azureStorageContainerName: ${{ parameters.AzureStorageContainerName }}
+    platform: ${{ parameters.Platform }}
+    buildNumber: ${{ parameters.BuildNumber }}
+
+  strategy:
+    maxParallel: 3
+    matrix:
+      SingleWorkspace:
+        TestSuiteName: 'testSingleWorkspace'
+      MultiWorkspace:
+        TestSuiteName: 'testMultiWorkspace'
+      Debugger:
+        TestSuiteName: 'testDebugger'
+
+
+  steps:
+  - template: test-phase.yml

--- a/build/ci/templates/test-phase.yml
+++ b/build/ci/templates/test-phase.yml
@@ -32,13 +32,28 @@ steps:
 
       echo pre-defined Build Number = $BUILD_BUILDNUMBER
 
+      echo platform given is $(Platform), or $(platform), or $PLATFORM_FROM_PARAMS
+
     displayName: 'Show build vars'
-    name: 'bash_tool_show_bld_vars'
     env:
       TEST_SUITE_NAME: $(testSuiteName)
       NODE_VERSION: $(nodeVersion)
       NPM_VERSION: $(npmVersion)
       PYTHON_VERSION: $(pythonVersion)
+      PLATFORM_FROM_PARAMS: ${{ parameters.Platform }}
+
+
+  - bash: |
+
+      printenv
+
+    displayName: 'Bash printenv'
+    
+
+  - powershell: |
+      Get-Variable
+      
+    displayName: 'PS: Show all variables'
 
 
   - powershell: |
@@ -84,7 +99,6 @@ steps:
       echo Reported Python Path = `python -c "import sys;print(sys.executable)"`
 
     displayName: 'Show Python Version'
-    name: 'show_py_ver'
 
 
   - task: PythonScript@0
@@ -123,7 +137,6 @@ steps:
       echo Reported Python Path = `python -c "import sys;print(sys.executable)"`
 
     displayName: 'Show build dependency versions'
-    name: 'show_bld_deps_vers'
 
 
   - task: Npm@1
@@ -201,6 +214,7 @@ steps:
 
   - task: PublishTestResults@2
     displayName: 'Publish JUnit test results'
+    condition: always()
     inputs:
       testResultsFiles: '**/junit-report.xml'
 
@@ -212,7 +226,6 @@ steps:
 
       buildConfiguration: '$(TestSuiteName)'
 
-      condition: always()
 
   - bash: 'bash <(curl -s https://codecov.io/bash) -t $(COV_UUID) -F $(Platform)'
     displayName: 'publish codecov'

--- a/build/ci/templates/virtual_env_tests.yml
+++ b/build/ci/templates/virtual_env_tests.yml
@@ -1,15 +1,31 @@
-jobs:
-- job: ${{ parameters.name }}
-  dependsOn: 'PR_Validate_Windows_py37'
+parameters:
+  PythonVersion: '3.7'
+  NodeVersion: '8.11.2'
+  NpmVersion: 'latest'
+  AzureStorageAccountName: 'vscodepythonci'
+  AzureStorageContainerName: 'vscode-python-ci'
+  Platform: 'macOS'
   pool:
-    name: ${{ parameters.PoolName }}
+    name: 'Hosted macOS'
+  EnvironmentExecutableFolder: 'bin'
+  PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+  TEST_FILES_SUFFIX: 'testvirtualenvs'
+  TestSuiteName: 'testSingleWorkspace'
+  DependsOn: 'Prebuild'
+
+
+jobs:
+- job:
+  displayName: ${{ format('{VirtualEnvTest {1} Py{2}', parameters.Platform, parameters.PythonVersion) }}
+  dependsOn: ${{ parameters.DependsOn }}
+  pool: ${{ parameters.pool }}
 
   variables:
     nodeVersion: ${{ parameters.NodeVersion }}
     npmVersion: ${{ parameters.NpmVersion }}
     pythonVersion: ${{ parameters.PythonVersion }}
     platform: ${{ parameters.Platform }}
-    azureStorageAcctName: ${{ parameters.AzureStorageAccountName }}
+    azureStorageAccountName: ${{ parameters.AzureStorageAccountName }}
     azureStorageContainerName: ${{ parameters.AzureStorageContainerName }}
     environmentExecutableFolder: ${{ parameters.EnvironmentExecutableFolder }}
     PYTHON_VIRTUAL_ENVS_LOCATION: ${{ parameters.PYTHON_VIRTUAL_ENVS_LOCATION }}
@@ -44,7 +60,7 @@ jobs:
     - powershell: |
         New-Item -ItemType directory -Path "$(System.ArtifactsDirectory)/bin-artifacts"
 
-        $buildArtifactUri = "https://$(azureStorageAcctName).blob.core.windows.net/$(azureStorageContainerName)/$(Build.BuildNumber)/bin-artifacts.zip"
+        $buildArtifactUri = "https://$(azureStorageAccountName).blob.core.windows.net/$(azureStorageContainerName)/$(Build.BuildNumber)/bin-artifacts.zip"
         Write-Verbose "Downloading from $buildArtifactUri"
 
         $destination = "$(System.ArtifactsDirectory)/bin-artifacts/bin-artifacts.zip"

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -1,0 +1,153 @@
+resources:
+- repo: self
+  clean: true
+
+# No trigger specified here. This is a nightly build only and
+# there isn't a way to specify scheduled builds in YAML at time
+# of writing...
+trigger: none
+
+# Only nightly builds.
+pr: none
+
+jobs:
+
+# Build the extension and run unit tests on it, if successful upload
+# the bits to be used in each subsequent job
+- template: templates/compile-and-validate.yml
+  parameters:
+    name: 'Prebuild'
+    pool:
+      name: 'Hosted VS2017'
+    UploadBinary: true
+    Platform: 'Windows'
+    PythonVersion: '3.7'
+
+# Begin test phases:
+
+## Virtual Environment Tests
+- template: templates/virtual_env_tests.yml
+  parameters:
+    Platform: 'Windows'
+    pool:
+      name: 'Hosted VS2017'
+
+- template: templates/virtual_env_tests.yml
+  parameters:
+    Platform: 'Linux'
+    pool:
+      name: 'Hosted Ubuntu 1604'
+
+- template: templates/virtual_env_tests.yml
+  parameters:
+    Platform: 'macOS'
+    pool:
+      name: 'Hosted macOS'
+
+
+## Other Tests
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted VS2017'
+    Platform: 'Windows'
+    PythonVersion: '3.7'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted VS2017'
+    Platform: 'Windows'
+    PythonVersion: '3.6'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted VS2017'
+    Platform: 'Windows'
+    PythonVersion: '3.5'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted VS2017'
+    Platform: 'Windows'
+    PythonVersion: '3.4'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted VS2017'
+    Platform: 'Windows'
+    PythonVersion: '2.7'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted Ubuntu 1604'
+    Platform: 'Linux'
+    PythonVersion: '3.7'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted Ubuntu 1604'
+    Platform: 'Linux'
+    PythonVersion: '3.6'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted Ubuntu 1604'
+    Platform: 'Linux'
+    PythonVersion: '3.5'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted Ubuntu 1604'
+    Platform: 'Linux'
+    PythonVersion: '3.4'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted Ubuntu 1604'
+    Platform: 'Linux'
+    PythonVersion: '2.7'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted macOS'
+    Platform: 'macOS'
+    PythonVersion: '3.7'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted macOS'
+    Platform: 'macOS'
+    PythonVersion: '3.6'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted macOS'
+    Platform: 'macOS'
+    PythonVersion: '3.5'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted macOS'
+    Platform: 'macOS'
+    PythonVersion: '3.4'
+
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted macOS'
+    Platform: 'macOS'
+    PythonVersion: '2.7'
+

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -4,202 +4,52 @@ resources:
 
 jobs:
 
+# Build the bits for testing, and ensure they pass unit testing
 - template: templates/compile-and-validate.yml
   parameters:
-    name: 'PR_Validate_Windows_py37'
-    PythonVersion: '3.7'
-    NodeVersion: '8.11.2'
-    NpmVersion: 'latest'
-    PoolName: 'Hosted VS2017'
+    name: 'Prebuild'
+    pool:
+      name: 'Hosted VS2017'
     UploadBinary: true
     Platform: 'Windows'
     AzureStorageAccountName: 'vscodepythonci'
     AzureStorageContainerName: 'vscode-python-ci'
 
 
+# Perform system tests
+
+## Virtual Environment Tests
 - template: templates/virtual_env_tests.yml
   parameters:
-    name: 'VirtualEnv_Tests_Windows_py37'
-    PythonVersion: '3.7'
-    NodeVersion: '8.11.2'
-    NpmVersion: 'latest'
-    AzureStorageAccountName: 'vscodepythonci'
-    AzureStorageContainerName: 'vscode-python-ci'
     Platform: 'Windows'
     PoolName: 'Hosted VS2017'
-    EnvironmentExecutableFolder: 'Scripts'
-    PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-    TEST_FILES_SUFFIX: 'testvirtualenvs'
-    TestSuiteName: 'testSingleWorkspace'
-
 
 - template: templates/virtual_env_tests.yml
   parameters:
-    name: 'VirtualEnv_Tests_Linux_py37'
-    PythonVersion: '3.7'
-    NodeVersion: '8.11.2'
-    NpmVersion: 'latest'
-    AzureStorageAccountName: 'vscodepythonci'
-    AzureStorageContainerName: 'vscode-python-ci'
     Platform: 'Linux'
     PoolName: 'Hosted Ubuntu 1604'
-    EnvironmentExecutableFolder: 'bin'
-    PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-    TEST_FILES_SUFFIX: 'testvirtualenvs'
-    TestSuiteName: 'testSingleWorkspace'
-
 
 - template: templates/virtual_env_tests.yml
   parameters:
-    name: 'VirtualEnv_Tests_MacOS_py37'
-    PythonVersion: '3.7'
-    NodeVersion: '8.11.2'
-    NpmVersion: 'latest'
-    AzureStorageAccountName: 'vscodepythonci'
-    AzureStorageContainerName: 'vscode-python-ci'
     Platform: 'macOS'
     PoolName: 'Hosted macOS'
-    EnvironmentExecutableFolder: 'bin'
-    PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-    TEST_FILES_SUFFIX: 'testvirtualenvs'
-    TestSuiteName: 'testSingleWorkspace'
 
-- job: 'System_Test_macOS'
-  dependsOn: 'PR_Validate_Windows_py37'
-  pool:
-    name: 'Hosted macOS'
-  steps:
-  - template: templates/test-phase.yml
-  strategy:
-    maxParallel: 3
-    matrix:
-      SingleWorkspace:
-        TestSuiteName: 'testSingleWorkspace'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'macOS'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
-      MultiWorkspace:
-        TestSuiteName: 'testMultiWorkspace'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'macOS'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
-      Debugger:
-        TestSuiteName: 'testDebugger'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'macOS'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
+## Other System Tests
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted VS2017'
+    Platform: 'Windows'
 
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted Ubuntu 1604'
+    Platform: 'Linux'
 
-- job: 'System_Test_Windows'
-  dependsOn: 'PR_Validate_Windows_py37'
-  pool:
-    name: 'Hosted VS2017'
-  steps:
-  - template: templates/test-phase.yml
-  strategy:
-    maxParallel: 3
-    matrix:
-      SingleWorkspace:
-        TestSuiteName: 'testSingleWorkspace'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'Windows'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
-      MultiWorkspace:
-        TestSuiteName: 'testMultiWorkspace'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'Windows'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
-      Debugger:
-        TestSuiteName: 'testDebugger'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'Windows'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
+- template: templates/test-phase-job.yml
+  parameters:
+    pool:
+      name: 'Hosted macOS'
+    Platform: 'macOS'
 
-
-- job: 'System_Test_Run_Linux'
-  dependsOn: 'PR_Validate_Windows_py37'
-  pool:
-    name: 'Hosted Ubuntu 1604'
-  steps:
-  - template: templates/test-phase.yml
-  strategy:
-    maxParallel: 10
-    matrix:
-      SingleWorkspace:
-        TestSuiteName: 'testSingleWorkspace'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'Linux'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
-      MultiWorkspace:
-        TestSuiteName: 'testMultiWorkspace'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'Linux'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'
-      Debugger:
-        TestSuiteName: 'testDebugger'
-        BuildNumber: '$(Build.BuildNumber)'
-        Platform: 'Linux'
-        PythonVersion: '3.7'
-        NodeVersion: '8.11.2'
-        NpmVersion: 'latest'
-        MOCHA_CI_REPORTER_ID: '$(Build.SourcesDirectory)/build/ci/mocha-vsts-reporter.js'
-        MOCHA_CI_REPORTFILE: '$(Build.ArtifactStagingDirectory)/reports/junit-report.xml'
-        MOCHA_REPORTER_JUNIT: true
-        AzureStorageAccountName: 'vscodepythonci'
-        AzureStorageContainerName: 'vscode-python-ci'

--- a/src/test/languageServers/jedi/autocomplete/pep526.test.ts
+++ b/src/test/languageServers/jedi/autocomplete/pep526.test.ts
@@ -20,17 +20,16 @@ const filePep526 = path.join(autoCompPath, 'pep526.py');
 
 // tslint:disable-next-line:max-func-body-length
 suite('Autocomplete PEP 526', () => {
-    let isPython2: boolean;
     let ioc: UnitTestIocContainer;
     suiteSetup(async function () {
+        // Pep526 only valid for 3.6+ (#2545)
+        if (await isPythonVersion('2', '3.4', '3.5')) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
+        }
+
         await initialize();
         initializeDI();
-        isPython2 = await ioc.getPythonMajorVersion(rootWorkspaceUri) === 2;
-        if (isPython2) {
-            // tslint:disable-next-line:no-invalid-this
-            this.skip();
-            return;
-        }
     });
     setup(initializeTest);
     suiteTeardown(closeActiveWindows);
@@ -44,17 +43,7 @@ suite('Autocomplete PEP 526', () => {
         ioc.registerVariableTypes();
         ioc.registerProcessTypes();
     }
-
-    test('variable (abc:str)', async function () {
-        // This test has not been working for many months in Python 3.4 and 3.5 under
-        // Windows and macOS.Tracked by #2545.
-        if (isOs(OSType.Windows, OSType.OSX)) {
-            if (await isPythonVersion('3.4', '3.5')) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-        }
-
+    test('variable (abc:str)', async () => {
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');
@@ -65,16 +54,7 @@ suite('Autocomplete PEP 526', () => {
         assert.notEqual(list!.items.filter(item => item.label === 'lower').length, 0, 'lower not found');
     });
 
-    test('variable (abc: str = "")', async function () {
-        // This test has not been working for many months in Python 3.4 and 3.5 under
-        // Windows and macOS.Tracked by #2545.
-        if (isOs(OSType.Windows, OSType.OSX)) {
-            if (await isPythonVersion('3.4', '3.5')) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-        }
-
+    test('variable (abc: str = "")', async () => {
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');
@@ -85,16 +65,7 @@ suite('Autocomplete PEP 526', () => {
         assert.notEqual(list!.items.filter(item => item.label === 'lower').length, 0, 'lower not found');
     });
 
-    test('variable (abc = UNKNOWN # type: str)', async function () {
-        // This test has not been working for many months in Python 3.4 and 3.5 under
-        // Windows and macOS.Tracked by #2545.
-        if (isOs(OSType.Windows, OSType.OSX)) {
-            if (await isPythonVersion('3.4', '3.5')) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-        }
-
+    test('variable (abc = UNKNOWN # type: str)', async () => {
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');
@@ -105,16 +76,7 @@ suite('Autocomplete PEP 526', () => {
         assert.notEqual(list!.items.filter(item => item.label === 'lower').length, 0, 'lower not found');
     });
 
-    test('class methods', async function () {
-        // This test has not been working for many months in Python 3.4 and 3.5 under
-        // Windows and macOS.Tracked by #2545.
-        if (isOs(OSType.Windows, OSType.OSX)) {
-            if (await isPythonVersion('3.4', '3.5')) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-        }
-
+    test('class methods', async () => {
         const textDocument = await vscode.workspace.openTextDocument(filePep526);
         await vscode.window.showTextDocument(textDocument);
         assert(vscode.window.activeTextEditor, 'No active editor');

--- a/src/test/unittests/unittest/unittest.test.ts
+++ b/src/test/unittests/unittest/unittest.test.ts
@@ -115,13 +115,10 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
     });
 
     test('Ensure correct test count for running a set of tests multiple times', async function () {
-        // This test has not been working for many months in Python 3.4 under
-        // Windows and macOS.Tracked by #2548.
-        if (isOs(OSType.Windows, OSType.OSX)) {
-            if (await isPythonVersion('3.4')) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
+        // This test has not been working for many months in Python 3.4. Tracked by #2548.
+        if (await isPythonVersion('3.4')) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
         }
 
         await updateSetting('unitTest.unittestArgs', ['-s=./tests', '-p=test_*.py'], rootWorkspaceUri, configTarget);
@@ -148,13 +145,10 @@ suite('Unit Tests - unittest - discovery against actual python process', () => {
     });
 
     test('Re-run failed tests results in the correct number of tests counted', async function () {
-        // This test has not been working for many months in Python 3.4 under
-        // Windows and macOS.Tracked by #2548.
-        if (isOs(OSType.Windows, OSType.OSX)) {
-            if (await isPythonVersion('3.4')) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
+        // This test has not been working for many months in Python 3.4. Tracked by #2548.
+        if (await isPythonVersion('3.4')) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
         }
 
         await updateSetting('unitTest.unittestArgs', ['-s=./tests', '-p=test_*.py'], rootWorkspaceUri, configTarget);


### PR DESCRIPTION
For #3555, also handles #2545 and touches #2548

- Simplified definition YAML, push detail out to job/step templates
- Simplified VirtualEnv a bit as well
- Turned off tests for pep526 when Python < 3.6 (#2545)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
