### PR TITLE
Fix onInterpreterChange event to only fire on interpreter change

### DIFF
--- a/news/2 Fixes/3749.md
+++ b/news/2 Fixes/3749.md
@@ -1,0 +1,1 @@
+Don't restart the Jupyter server on any settings change. Also don't throw interpreter changed events on unrelated settings changes.

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -4,7 +4,7 @@ import * as child_process from 'child_process';
 import { EventEmitter } from 'events';
 import * as path from 'path';
 import {
-    ConfigurationTarget, DiagnosticSeverity, Disposable, Uri,
+    ConfigurationChangeEvent, ConfigurationTarget, DiagnosticSeverity, Disposable, Uri,
     workspace, WorkspaceConfiguration
 } from 'vscode';
 import { sendTelemetryEvent } from '../telemetry';
@@ -348,13 +348,16 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         }
     }
     protected initialize(): void {
-        this.disposables.push(workspace.onDidChangeConfiguration(() => {
-            const currentConfig = workspace.getConfiguration('python', this.workspaceRoot);
-            this.update(currentConfig);
+        this.disposables.push(workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
+            if (event.affectsConfiguration('python'))
+            {
+                const currentConfig = workspace.getConfiguration('python', this.workspaceRoot);
+                this.update(currentConfig);
 
-            // If workspace config changes, then we could have a cascading effect of on change events.
-            // Let's defer the change notification.
-            setTimeout(() => this.emit('change'), 1);
+                // If workspace config changes, then we could have a cascading effect of on change events.
+                // Let's defer the change notification.
+                setTimeout(() => this.emit('change'), 1);
+            }
         }));
 
         const initialConfig = workspace.getConfiguration('python', this.workspaceRoot);

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -7,7 +7,6 @@
 
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { EventEmitter } from 'events';
 import { Container } from 'inversify';
 import * as path from 'path';
 import * as TypeMoq from 'typemoq';
@@ -16,7 +15,7 @@ import { IDocumentManager, IWorkspaceService } from '../../client/common/applica
 import { getArchitectureDisplayName } from '../../client/common/platform/registry';
 import { IFileSystem } from '../../client/common/platform/types';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../client/common/process/types';
-import { IConfigurationService, IDisposableRegistry, IPersistentStateFactory } from '../../client/common/types';
+import { IConfigurationService, IDisposableRegistry, IPersistentStateFactory, IPythonSettings } from '../../client/common/types';
 import * as EnumEx from '../../client/common/utils/enum';
 import { noop } from '../../client/common/utils/misc';
 import { Architecture } from '../../client/common/utils/platform';
@@ -36,6 +35,7 @@ import { InterpreterService } from '../../client/interpreter/interpreterService'
 import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
+import { PYTHON_PATH } from '../common';
 
 use(chaiAsPromised);
 
@@ -69,6 +69,8 @@ suite('Interpreters service', () => {
     let persistentStateFactory: TypeMoq.IMock<IPersistentStateFactory>;
     let pythonExecutionFactory: TypeMoq.IMock<IPythonExecutionFactory>;
     let pythonExecutionService: TypeMoq.IMock<IPythonExecutionService>;
+    let configService: TypeMoq.IMock<IConfigurationService>;
+    let pythonSettings: TypeMoq.IMock<IPythonSettings>;
     type ConfigValue<T> = { key: string; defaultValue?: T; globalValue?: T; workspaceValue?: T; workspaceFolderValue?: T };
 
     function setupSuite() {
@@ -88,6 +90,11 @@ suite('Interpreters service', () => {
         persistentStateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
         pythonExecutionFactory = TypeMoq.Mock.ofType<IPythonExecutionFactory>();
         pythonExecutionService = TypeMoq.Mock.ofType<IPythonExecutionService>();
+        configService = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
+        pythonSettings.setup(s => s.pythonPath).returns(() => PYTHON_PATH);
+        configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
 
         pythonExecutionService.setup((p: any) => p.then).returns(() => undefined);
         workspace.setup(x => x.getConfiguration('python', TypeMoq.It.isAny())).returns(() => config.object);
@@ -113,6 +120,7 @@ suite('Interpreters service', () => {
         serviceManager.addSingletonInstance<IPersistentStateFactory>(IPersistentStateFactory, persistentStateFactory.object);
         serviceManager.addSingletonInstance<IPythonExecutionFactory>(IPythonExecutionFactory, pythonExecutionFactory.object);
         serviceManager.addSingletonInstance<IPythonExecutionService>(IPythonExecutionService, pythonExecutionService.object);
+        serviceManager.addSingletonInstance<IConfigurationService>(IConfigurationService, configService.object);
 
         pipenvLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
         wksLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
@@ -149,9 +157,8 @@ suite('Interpreters service', () => {
                 });
             });
 
-        test('Changes to active document should invoke intrepreter.refresh method', async () => {
+        test('Changes to active document should invoke interpreter.refresh method', async () => {
             const service = new InterpreterService(serviceContainer);
-            const configService = TypeMoq.Mock.ofType<IConfigurationService>();
             const documentManager = TypeMoq.Mock.ofType<IDocumentManager>();
 
             let activeTextEditorChangeHandler: Function | undefined;
@@ -159,11 +166,9 @@ suite('Interpreters service', () => {
                 activeTextEditorChangeHandler = handler;
                 return { dispose: noop };
             });
-            serviceManager.addSingletonInstance(IConfigurationService, configService.object);
             serviceManager.addSingletonInstance(IDocumentManager, documentManager.object);
 
             // tslint:disable-next-line:no-any
-            configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => new EventEmitter() as any);
             service.initialize();
             const textEditor = TypeMoq.Mock.ofType<TextEditor>();
             const uri = Uri.file(path.join('usr', 'file.py'));
@@ -175,9 +180,8 @@ suite('Interpreters service', () => {
             interpreterDisplay.verify(i => i.refresh(TypeMoq.It.isValue(uri)), TypeMoq.Times.once());
         });
 
-        test('If there is no active document then intrepreter.refresh should not be invoked', async () => {
+        test('If there is no active document then interpreter.refresh should not be invoked', async () => {
             const service = new InterpreterService(serviceContainer);
-            const configService = TypeMoq.Mock.ofType<IConfigurationService>();
             const documentManager = TypeMoq.Mock.ofType<IDocumentManager>();
 
             let activeTextEditorChangeHandler: Function | undefined;
@@ -185,11 +189,9 @@ suite('Interpreters service', () => {
                 activeTextEditorChangeHandler = handler;
                 return { dispose: noop };
             });
-            serviceManager.addSingletonInstance(IConfigurationService, configService.object);
             serviceManager.addSingletonInstance(IDocumentManager, documentManager.object);
 
             // tslint:disable-next-line:no-any
-            configService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => new EventEmitter() as any);
             service.initialize();
             activeTextEditorChangeHandler!();
 


### PR DESCRIPTION
For #3749 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
