### PR TITLE
Move 'Multiple linters' system test into its own file

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -203,8 +203,10 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
     const api = buildApi(Promise.all([activationDeferred.promise, lsActivationPromise]));
     // In test environment return the DI Container.
     if (isTestExecution()) {
-        // tslint:disable-next-line:no-any
+        // tslint:disable:no-any
         (api as any).serviceContainer = serviceContainer;
+        (api as any).serviceManager = serviceManager;
+        // tslint:enable:no-any
     }
     return api;
 }

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -15,8 +15,10 @@ import { IExtensionApi } from '../client/api';
 import { IProcessService } from '../client/common/process/types';
 import { IPythonSettings, Resource } from '../client/common/types';
 import { PythonInterpreter } from '../client/interpreter/contracts';
-import { IServiceContainer } from '../client/ioc/types';
-import { EXTENSION_ROOT_DIR_FOR_TESTS, IS_MULTI_ROOT_TEST, IS_PERF_TEST, IS_SMOKE_TEST } from './constants';
+import { IServiceContainer, IServiceManager } from '../client/ioc/types';
+import {
+    EXTENSION_ROOT_DIR_FOR_TESTS, IS_MULTI_ROOT_TEST, IS_PERF_TEST, IS_SMOKE_TEST
+} from './constants';
 import { noop, sleep } from './core';
 
 const StreamZip = require('node-stream-zip');
@@ -368,6 +370,7 @@ export async function isPythonVersion(...versions: string[]): Promise<boolean> {
 
 export interface IExtensionTestApi extends IExtensionApi {
     serviceContainer: IServiceContainer;
+    serviceManager: IServiceManager;
 }
 
 export async function unzip(zipFile: string, targetFolder: string): Promise<void> {

--- a/src/test/linters/lint.multilinter.test.ts
+++ b/src/test/linters/lint.multilinter.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { ConfigurationTarget, DiagnosticCollection, Uri, window, workspace } from 'vscode';
+import { ICommandManager } from '../../client/common/application/types';
+import { Product } from '../../client/common/installer/productInstaller';
+import { PythonToolExecutionService } from '../../client/common/process/pythonToolService';
+import {
+    ExecutionResult, IPythonToolExecutionService, SpawnOptions
+} from '../../client/common/process/types';
+import { ExecutionInfo, IConfigurationService } from '../../client/common/types';
+import { ILinterManager } from '../../client/linters/types';
+import { deleteFile, IExtensionTestApi, PythonSettingKeys, rootWorkspaceUri } from '../common';
+import { closeActiveWindows, initialize, initializeTest, IS_MULTI_ROOT_TEST } from '../initialize';
+
+const workspaceUri = Uri.file(path.join(__dirname, '..', '..', '..', 'src', 'test'));
+const pythoFilesPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonFiles', 'linting');
+
+// Mocked out python tool execution - all we need is mocked linter return values.
+class MockPythonToolExecService extends PythonToolExecutionService {
+
+    // mocked samples of linter messages from flake8 and pylint:
+    public flake8Msg: string = '1,1,W,W391:blank line at end of file\ns:142:13), <anonymous>:1\n1,7,E,E999:SyntaxError: invalid syntax\n';
+    public pylintMsg: string = '************* Module print\ns:142:13), <anonymous>:1\n1,0,error,syntax-error:Missing parentheses in call to \'print\'. Did you mean print(x)? (<unknown>, line 1)\n';
+
+    // depending on the moduleName being exec'd, return the appropriate sample.
+    public async exec(executionInfo: ExecutionInfo, options: SpawnOptions, resource: Uri): Promise<ExecutionResult<string>> {
+        let msg = this.flake8Msg;
+        if (executionInfo.moduleName === 'pylint') {
+            msg = this.pylintMsg;
+        }
+        return { stdout: msg };
+    }
+}
+
+// tslint:disable-next-line:max-func-body-length
+suite('Linting - Multiple Linters Enabled Test', () => {
+    let api: IExtensionTestApi;
+    let configService: IConfigurationService;
+    let linterManager: ILinterManager;
+
+    suiteSetup(async () => {
+        api = await initialize();
+        configService = api.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        linterManager = api.serviceContainer.get<ILinterManager>(ILinterManager);
+    });
+    setup(async () => {
+        await initializeTest();
+        await resetSettings();
+
+        // We only want to return some valid strings from linters, we don't care if they
+        // are being returned by actual linters (we aren't testing linters here, only how
+        // our code responds to those linters)
+        api.serviceManager.rebind<IPythonToolExecutionService>(IPythonToolExecutionService, MockPythonToolExecService);
+    });
+    suiteTeardown(closeActiveWindows);
+    teardown(async () => {
+        await closeActiveWindows();
+        await resetSettings();
+        await deleteFile(path.join(workspaceUri.fsPath, '.pylintrc'));
+        await deleteFile(path.join(workspaceUri.fsPath, '.pydocstyle'));
+
+        // restore the execution service as it was...
+        api.serviceManager.rebind<IPythonToolExecutionService>(IPythonToolExecutionService, PythonToolExecutionService);
+    });
+
+    async function resetSettings() {
+        // Don't run these updates in parallel, as they are updating the same file.
+        const target = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
+
+        await configService.updateSetting('linting.enabled', true, rootWorkspaceUri, target);
+        await configService.updateSetting('linting.lintOnSave', false, rootWorkspaceUri, target);
+        await configService.updateSetting('linting.pylintUseMinimalCheckers', false, workspaceUri);
+
+        linterManager.getAllLinterInfos().forEach(async (x) => {
+            await configService.updateSetting(makeSettingKey(x.product), false, rootWorkspaceUri, target);
+        });
+    }
+
+    function makeSettingKey(product: Product): PythonSettingKeys {
+        return `linting.${linterManager.getLinterInfo(product).enabledSettingName}` as PythonSettingKeys;
+    }
+
+    test('Multiple linters', async () => {
+        await closeActiveWindows();
+        const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
+        await window.showTextDocument(document);
+        await configService.updateSetting('linting.enabled', true, workspaceUri);
+        await configService.updateSetting('linting.pylintUseMinimalCheckers', false, workspaceUri);
+        await configService.updateSetting('linting.pylintEnabled', true, workspaceUri);
+        await configService.updateSetting('linting.flake8Enabled', true, workspaceUri);
+
+        const commands = api.serviceContainer.get<ICommandManager>(ICommandManager);
+
+        const collection = await commands.executeCommand('python.runLinting') as DiagnosticCollection;
+        assert.notEqual(collection, undefined, 'python.runLinting did not return valid diagnostics collection.');
+
+        const messages = collection!.get(document.uri);
+        assert.notEqual(messages!.length, 0, 'No diagnostic messages.');
+        assert.notEqual(messages!.filter(x => x.source === 'pylint').length, 0, 'No pylint messages.');
+        assert.notEqual(messages!.filter(x => x.source === 'flake8').length, 0, 'No flake8 messages.');
+    });
+});

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -5,12 +5,14 @@
 import * as assert from 'assert';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { CancellationTokenSource, ConfigurationTarget, DiagnosticCollection, Uri, window, workspace } from 'vscode';
-import { ICommandManager } from '../../client/common/application/types';
+import { CancellationTokenSource, ConfigurationTarget, Uri, workspace } from 'vscode';
 import { WorkspaceService } from '../../client/common/application/workspace';
 import { STANDARD_OUTPUT_CHANNEL } from '../../client/common/constants';
 import { Product } from '../../client/common/installer/productInstaller';
-import { CTagsProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from '../../client/common/installer/productPath';
+import {
+    CTagsProductPathService, FormatterProductPathService, LinterProductPathService,
+    RefactoringLibraryProductPathService, TestFrameworkProductPathService
+} from '../../client/common/installer/productPath';
 import { ProductService } from '../../client/common/installer/productService';
 import { IProductPathService, IProductService } from '../../client/common/installer/types';
 import { IConfigurationService, IOutputChannel, ProductType } from '../../client/common/types';
@@ -269,32 +271,6 @@ suite('Linting - General Tests', () => {
         await configService.updateSetting('linting.pylintUseMinimalCheckers', false, workspaceUri);
         await testEnablingDisablingOfLinter(Product.pylint, true, file);
     });
-    test('Multiple linters', async function () {
-
-        // This test notoriously times out. Change to mocked-up results (we don't need actual system results here).
-        // Tracked by #2571
-
-        // tslint:disable-next-line:no-invalid-this
-        return this.skip();
-        // tslint:enable:no-invalid-this
-        await closeActiveWindows();
-        const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
-        await window.showTextDocument(document);
-        await configService.updateSetting('linting.enabled', true, workspaceUri);
-        await configService.updateSetting('linting.pylintUseMinimalCheckers', false, workspaceUri);
-        await configService.updateSetting('linting.pylintEnabled', true, workspaceUri);
-        await configService.updateSetting('linting.flake8Enabled', true, workspaceUri);
-
-        const commands = ioc.serviceContainer.get<ICommandManager>(ICommandManager);
-        const collection = await commands.executeCommand('python.runLinting') as DiagnosticCollection;
-        assert.notEqual(collection, undefined, 'python.runLinting did not return valid diagnostics collection.');
-
-        const messages = collection!.get(document.uri);
-        assert.notEqual(messages!.length, 0, 'No diagnostic messages.');
-        assert.notEqual(messages!.filter(x => x.source === 'pylint').length, 0, 'No pylint messages.');
-        assert.notEqual(messages!.filter(x => x.source === 'flake8').length, 0, 'No flake8 messages.');
-    });
-
     // tslint:disable-next-line:no-any
     async function testLinterMessageCount(product: Product, pythonFile: string, messageCountToBeReceived: number): Promise<any> {
         const outputChannel = ioc.serviceContainer.get<MockOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);


### PR DESCRIPTION
Fix for #2571

- Multiple linters test just uses the app, no ioc-mocking necessary.
  - (Thus it did not truly belong in `linter.test.ts`)
- Only needed mocked linter output stub to be a good system test

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~

