### PR TITLE
Attempt to address missing kernelspec issue

### DIFF
--- a/news/2 Fixes/3699.md
+++ b/news/2 Fixes/3699.md
@@ -1,0 +1,1 @@
+Survive missing kernelspecs as a default will be created.

--- a/src/client/common/asyncDisposableRegistry.ts
+++ b/src/client/common/asyncDisposableRegistry.ts
@@ -15,7 +15,9 @@ export class AsyncDisposableRegistry implements IAsyncDisposableRegistry {
         await Promise.all(promises);
     }
 
-    public push(disposable: IDisposable) {
-        this.list.push(disposable);
+    public push(disposable: IDisposable | undefined) {
+        if (disposable) {
+            this.list.push(disposable);
+        }
     }
 }

--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -48,6 +48,9 @@ export class JupyterSessionManager implements IJupyterSessionManager {
                 const spec = kernelspecs[k];
                 return new JupyterKernelSpec(spec);
             });
+        } catch {
+            // For some reason this is failing. Just return nothing
+            return [];
         } finally {
             // Cleanup the session manager as we don't need it anymore
             if (sessionManager) {

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -196,7 +196,9 @@ export class MockJupyterManager implements IJupyterSessionManager {
 
     public startNew(connInfo: IConnection, kernelSpec: IJupyterKernelSpec, cancelToken?: CancellationToken) : Promise<IJupyterSession> {
         this.asyncRegistry.push(connInfo);
-        this.asyncRegistry.push(kernelSpec);
+        if (kernelSpec) {
+            this.asyncRegistry.push(kernelSpec);
+        }
         if (this.sessionTimeout && cancelToken) {
             const localTimeout = this.sessionTimeout;
             return Cancellation.race(async () => {

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -23,13 +23,13 @@ import { JupyterExecution } from '../../client/datascience/jupyter/jupyterExecut
 import {
     CellState,
     ICell,
+    IConnection,
     IJupyterExecution,
+    IJupyterKernelSpec,
     INotebookExporter,
     INotebookImporter,
     INotebookServer,
     InterruptResult,
-    IConnection,
-    IJupyterKernelSpec,
 } from '../../client/datascience/types';
 import {
     IInterpreterService,

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -28,6 +28,8 @@ import {
     INotebookImporter,
     INotebookServer,
     InterruptResult,
+    IConnection,
+    IJupyterKernelSpec,
 } from '../../client/datascience/types';
 import {
     IInterpreterService,
@@ -716,6 +718,25 @@ plt.show()`,
             await generateNonDefaultConfig();
             const server = await createNotebookServer(true);
             assert.ok(server, 'Never connected to a default server with a bad default config');
+
+            await verifySimple(server, `a=1${os.EOL}a`, 1);
+        }
+    });
+
+    runTest('Invalid kernel spec works', async () => {
+        if (ioc.mockJupyter) {
+            // Make a dummy class that will fail during launch
+            class FailedKernelSpec extends JupyterExecution {
+                protected async getMatchingKernelSpec(connection?: IConnection, cancelToken?: CancellationToken): Promise<IJupyterKernelSpec | undefined> {
+                    return Promise.resolve(undefined);
+                }
+            }
+            ioc.serviceManager.rebind<IJupyterExecution>(IJupyterExecution, FailedKernelSpec);
+            jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
+            addMockData(`a=1${os.EOL}a`, 1);
+
+            const server = await createNotebookServer(true);
+            assert.ok(server, 'Empty kernel spec messes up creating a server');
 
             await verifySimple(server, `a=1${os.EOL}a`, 1);
         }


### PR DESCRIPTION
For #3669

Functional tests verifies we work without a kernelspec and I hand forced this to make sure Jupyter does too.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
