### PR TITLE
Fix logic for skipped test

### DIFF
--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -52,7 +52,7 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
 
     suiteSetup(async function () {
         // skip for Linux CI, see #3848
-        if (isOs(OSType.Linux) || await isPythonVersionInProcess(undefined, '3')) {
+        if (isOs(OSType.Linux) || await isPythonVersionInProcess(undefined, '2')) {
             return this.skip();
         }
 


### PR DESCRIPTION
Addendum to #3848

- Test for venv must be skipped for Linux or Python 2.x, not Python 3.x

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
