### PR TITLE
Automatically activate syntax highlighting using firstLine in package.json to resolve issue 3892

### DIFF
--- a/news/1 Enhancements/3892.md
+++ b/news/1 Enhancements/3892.md
@@ -1,0 +1,2 @@
+Use firstLine to activate syntax highlinging for files without extensions
+(thanks to [Christopher Gahlon](https://github.com/cgahlon/))

--- a/package.json
+++ b/package.json
@@ -1699,6 +1699,7 @@
         },
         "languages": [
             {
+                "firstLine": "^#!/.*\\bpython[0-9.-]*\\b|",
                 "id": "pip-requirements",
                 "aliases": [
                     "pip requirements",

--- a/package.json
+++ b/package.json
@@ -1699,7 +1699,7 @@
         },
         "languages": [
             {
-                "firstLine": "^#!/.*\\bpython[0-9.-]*\\b|",
+                "firstLine": "^#!/.*\\bpython[0-9.-]*\\b",
                 "id": "pip-requirements",
                 "aliases": [
                     "pip requirements",


### PR DESCRIPTION
For #


- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
