### PR TITLE
Explicitly find the full path to the executable being run

### DIFF
--- a/pvsc-dev-ext.py
+++ b/pvsc-dev-ext.py
@@ -32,6 +32,8 @@ class VSCode(enum.Enum):
 
 def run_command(command, cwd=None):
     """Run the specified command in a subprocess shell."""
+    executable = shutil.which(command[0])
+    command[0] = executable
     cmd = subprocess.run(command, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
     cmd.check_returncode()
 


### PR DESCRIPTION
Otherwise things like npm won't run under Windows 10.

Fixes an issue introduced by #3838. (FYI @tonybaloney)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strike-through the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing