### PR TITLE
Indent on enter after line continuations

### DIFF
--- a/news/1 Enhancements/3284.md
+++ b/news/1 Enhancements/3284.md
@@ -1,0 +1,1 @@
+Indent on enter after line continuations.

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -163,6 +163,10 @@ export async function activate(context: ExtensionContext): Promise<IExtensionApi
                 action: { indentAction: IndentAction.Indent }
             },
             {
+                beforeText: /^(?!\s+\\)[^#\n]+\\\s*/,
+                action: { indentAction: IndentAction.Indent }
+            },
+            {
                 beforeText: /^\s*#.*/,
                 afterText: /.+$/,
                 action: { indentAction: IndentAction.None, appendText: '# ' }


### PR DESCRIPTION
For #3284.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~ (see #1314)
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
