### PR TITLE
Disable unreliable linting tests

### DIFF
--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -108,7 +108,14 @@ suite('Linting - General Tests', () => {
     let linterManager: ILinterManager;
     let configService: IConfigurationService;
 
-    suiteSetup(initialize);
+    suiteSetup(async function () {
+        // these tests are currently flakey, and need some refactoring to become reliable
+        // See #3914
+        // tslint:disable-next-line:no-invalid-this
+        return this.skip();
+
+        initialize();
+    });
     setup(async () => {
         initializeDI();
         await initializeTest();

--- a/src/test/linters/lint.test.ts
+++ b/src/test/linters/lint.test.ts
@@ -114,7 +114,7 @@ suite('Linting - General Tests', () => {
         // tslint:disable-next-line:no-invalid-this
         return this.skip();
 
-        initialize();
+        await initialize();
     });
     setup(async () => {
         initializeDI();


### PR DESCRIPTION
For #3914 (initial PR)

Disable these tests until we make time to refactor them. Slated for Jan 2019 sprint 2.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
