### PR TITLE
Skip venv discovery tests for Linux in VSTS

### DIFF
--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -9,11 +9,16 @@ import { exec } from 'child_process';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import '../../../client/common/extensions';
-import { IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE } from '../../../client/interpreter/contracts';
+import {
+    IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE
+} from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { deleteFiles, isOs, isPythonVersionInProcess, OSType, PYTHON_PATH, rootWorkspaceUri, waitForCondition } from '../../common';
+import {
+    deleteFiles, isOs, isPythonVersionInProcess, OSType,
+    PYTHON_PATH, rootWorkspaceUri, waitForCondition
+} from '../../common';
 import { IS_MULTI_ROOT_TEST } from '../../constants';
-import { initialize, multirootPath } from '../../initialize';
+import { initialize, IS_VSTS, multirootPath } from '../../initialize';
 
 const timeoutMs = 60_000;
 suite('Interpreters - Workspace VirtualEnv Service', function () {
@@ -52,7 +57,12 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
 
     suiteSetup(async function () {
         // skip for Linux CI, see #3848
-        if (isOs(OSType.Linux) || await isPythonVersionInProcess(undefined, '2')) {
+        if (isOs(OSType.Linux) && IS_VSTS) {
+            return this.skip();
+        }
+
+        // skip for Python < 3, no venv support
+        if (await isPythonVersionInProcess(undefined, '2')) {
             return this.skip();
         }
 


### PR DESCRIPTION
For #3848

- Tests only work about 30-40% of the time
- Suspect `fs.watch` [failing on virtualized Linux](https://nodejs.org/docs/latest/api/fs.html#fs_availability).
- Still works on Travis (!? *isnt Travis virtualized Linux also*? )

---

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
