### PR TITLE
Fix discovery of PyTests with packages inbetween folders

### DIFF
--- a/news/2 Fixes/3936.md
+++ b/news/2 Fixes/3936.md
@@ -1,0 +1,1 @@
+Fix discovery of PyTest tests when package folders are inbetween regular test folders (thanks [Alexander Grund](https://github.com/Flamefire))

--- a/src/test/unittests/pytest/pytest_unittest_parser_data.ts
+++ b/src/test/unittests/pytest/pytest_unittest_parser_data.ts
@@ -1383,5 +1383,32 @@ export const pytestScenarioData: PytestDiscoveryScenario[] =
                 "",
                 "======================== no tests ran in 0.36 seconds ========================="
             ]
+        },
+        {
+            pytest_version_spec: ">= 3.7",
+            platform: PytestDataPlatformType.NonWindows,
+            description: "With package inbetween.",
+            rootdir: "/home/user/test/pytest_scenario",
+            test_functions: [
+                "aTest/test_upper.py::test_upper_cmd",
+                "bPackage/testPackage.py::test_package",
+                "zTest/test_lower.py::test_lower_cmd"
+            ],
+            functionCount: 3,
+            stdout: [
+                "============================= test session starts =============================",
+                "platform win32 -- Python 3.7.0, pytest-3.7.4, py-1.6.0, pluggy-0.7.1",
+                "rootdir: /home/user/test/pytest_scenario, inifile:",
+                "collected 3 items",
+                "<Module 'aTest/test_upper.py'>",
+                "  <Function 'test_upper_cmd'>",
+                "<Package '/home/user/test/pytest_scenario/bPackage'>",
+                "  <Module 'testPackage.py'>",
+                "    <Function 'test_package'>",
+                "<Module 'zTest/test_lower.py'>",
+                "  <Function 'test_lower_cmd'>",
+                "",
+                "======================== no tests ran in 0.36 seconds ========================="
+            ]
         }
     ];


### PR DESCRIPTION
For #3936

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x]~ [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
