### PR TITLE
Match dots in ignorePatterns globs; fixes .venv not being ignored

### DIFF
--- a/news/2 Fixes/3947.md
+++ b/news/2 Fixes/3947.md
@@ -1,0 +1,2 @@
+Match dots in ignorePatterns globs; fixes .venv not being ignored
+(thanks to [Russell Davis](https://github.com/russelldavis))

--- a/src/client/linters/lintingEngine.ts
+++ b/src/client/linters/lintingEngine.ts
@@ -197,7 +197,8 @@ export class LintingEngine implements ILintingEngine {
         const relativeFileName = typeof workspaceRootPath === 'string' ? path.relative(workspaceRootPath, document.fileName) : document.fileName;
 
         const settings = this.configurationService.getSettings(document.uri);
-        const ignoreMinmatches = settings.linting.ignorePatterns.map(pattern => new Minimatch(pattern));
+        // { dot: true } is important so dirs like `.venv` will be matched by globs
+        const ignoreMinmatches = settings.linting.ignorePatterns.map(pattern => new Minimatch(pattern, { dot: true }));
         if (ignoreMinmatches.some(matcher => matcher.match(document.fileName) || matcher.match(relativeFileName))) {
             return false;
         }


### PR DESCRIPTION
For #3947. Verified the plugin now ignores .venv.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
