### PR TITLE
Add localRoot & remoteRoot to the launch.json snippets

### DIFF
--- a/news/1 Enhancements/1385.md
+++ b/news/1 Enhancements/1385.md
@@ -1,0 +1,1 @@
+Add localRoot and remoteRoot defaults for Remote Debugging configuration in `launch.json`.

--- a/package.json
+++ b/package.json
@@ -675,7 +675,7 @@
                         }
                     },
                     {
-                        "label": "Python: (Remote Attach)",
+                        "label": "Python: Remote Attach",
                         "description": "%python.snippet.launch.attach.description%",
                         "body": {
                             "name": "Attach (Remote Debug)",

--- a/package.json
+++ b/package.json
@@ -675,14 +675,20 @@
                         }
                     },
                     {
-                        "label": "Python: Attach",
+                        "label": "Python: (Remote Attach)",
                         "description": "%python.snippet.launch.attach.description%",
                         "body": {
                             "name": "Attach (Remote Debug)",
                             "type": "python",
                             "request": "attach",
                             "port": 5678,
-                            "host": "localhost"
+                            "host": "localhost",
+                            "pathMappings": [
+                                {
+                                    "localRoot": "${workspaceFolder}",
+                                    "remoteRoot": "."
+                                }
+                            ]
                         }
                     }
                 ],

--- a/resources/default.launch.json
+++ b/resources/default.launch.json
@@ -7,7 +7,7 @@
         "console": "integratedTerminal"
     },
     {
-        "name": "Python: Attach (Remote Debug)",
+        "name": "Python: Remote Attach",
         "type": "python",
         "request": "attach",
         "port": 5678,

--- a/resources/default.launch.json
+++ b/resources/default.launch.json
@@ -7,11 +7,17 @@
         "console": "integratedTerminal"
     },
     {
-        "name": "Python: Attach",
+        "name": "Python: Attach (Remote Debug)",
         "type": "python",
         "request": "attach",
         "port": 5678,
-        "host": "localhost"
+        "host": "localhost",
+        "pathMappings": [
+            {
+                "localRoot": "${workspaceFolder}",
+                "remoteRoot": "."
+            }
+        ]
     },
     {
         "name": "Python: Module",

--- a/src/client/debugger/extension/configuration/providers/remoteAttach.ts
+++ b/src/client/debugger/extension/configuration/providers/remoteAttach.ts
@@ -19,11 +19,18 @@ const defaultPort = 5678;
 export class RemoteAttachDebugConfigurationProvider implements IDebugConfigurationProvider {
     public async buildConfiguration(input: MultiStepInput<DebugConfigurationState>, state: DebugConfigurationState): Promise<InputStep<DebugConfigurationState> | void> {
         const config: Partial<AttachRequestArguments> = {
-            name: localize('python.snippet.launch.attach.label', 'Python: Attach')(),
+            name: localize('python.snippet.launch.attach.label', 'Python: Attach (Remote Debug)')(),
             type: DebuggerTypeName,
             request: 'attach',
             port: defaultPort,
-            host: defaultHost
+            host: defaultHost,
+            pathMappings: [
+                {
+                    // tslint:disable-next-line:no-invalid-template-strings
+                    localRoot: '${workspaceFolder}',
+                    remoteRoot: '.'
+                }
+            ]
         };
 
         config.host = await input.showInputBox({

--- a/src/client/debugger/extension/configuration/providers/remoteAttach.ts
+++ b/src/client/debugger/extension/configuration/providers/remoteAttach.ts
@@ -19,7 +19,7 @@ const defaultPort = 5678;
 export class RemoteAttachDebugConfigurationProvider implements IDebugConfigurationProvider {
     public async buildConfiguration(input: MultiStepInput<DebugConfigurationState>, state: DebugConfigurationState): Promise<InputStep<DebugConfigurationState> | void> {
         const config: Partial<AttachRequestArguments> = {
-            name: localize('python.snippet.launch.attach.label', 'Python: Attach (Remote Debug)')(),
+            name: localize('python.snippet.launch.attach.label', 'Python: Remote Attach')(),
             type: DebuggerTypeName,
             request: 'attach',
             port: defaultPort,

--- a/src/test/debugger/extension/configuration/providers/remoteAttach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/remoteAttach.unit.test.ts
@@ -83,7 +83,13 @@ suite('Debugging - Configuration Provider Remote Attach', () => {
             type: DebuggerTypeName,
             request: 'attach',
             port: 5678,
-            host: 'localhost'
+            host: 'localhost',
+            pathMappings: [
+                {
+                    localRoot: '${workspaceFolder}',
+                    remoteRoot: '.'
+                }
+            ]
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -110,7 +116,13 @@ suite('Debugging - Configuration Provider Remote Attach', () => {
             type: DebuggerTypeName,
             request: 'attach',
             port: 9999,
-            host: 'Hello'
+            host: 'Hello',
+            pathMappings: [
+                {
+                    localRoot: '${workspaceFolder}',
+                    remoteRoot: '.'
+                }
+            ]
         };
 
         expect(state.config).to.be.deep.equal(config);


### PR DESCRIPTION
For #1385

- Will set localRoot to "${workspaceFolder}" by default
- Will set remoteRoot to "." by default
- PTVSD will (eventually, see Microsoft/ptvsd#691) pick this up and infer "." to be CWD.

---


- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
