### PR TITLE
gh-3740: Handle activation errors.

### DIFF
--- a/news/1 Enhancements/3740.md
+++ b/news/1 Enhancements/3740.md
@@ -1,0 +1,1 @@
+Handle errors happening during extension activation.

--- a/package.json
+++ b/package.json
@@ -1841,6 +1841,7 @@
         "request-progress": "^3.0.0",
         "rxjs": "^5.5.9",
         "semver": "^5.5.0",
+        "stack-trace": "0.0.10",
         "sudo-prompt": "^8.2.0",
         "svg-inline-react": "^3.1.0",
         "tmp": "^0.0.29",

--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -84,11 +84,7 @@ export function traceVerbose(message: string) {
     new Logger().logInformation(message);
 }
 export function traceError(message: string, ex?: Error) {
-    try {
-        new Logger().logError(message, ex);
-    } catch (e) {
-        // ignore
-    }
+    new Logger().logError(message, ex);
 }
 export function traceInfo(message: string) {
     new Logger().logInformation(message);

--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -84,7 +84,11 @@ export function traceVerbose(message: string) {
     new Logger().logInformation(message);
 }
 export function traceError(message: string, ex?: Error) {
-    new Logger().logError(message, ex);
+    try {
+        new Logger().logError(message, ex);
+    } catch (e) {
+        // ignore
+    }
 }
 export function traceInfo(message: string) {
     new Logger().logInformation(message);

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -410,7 +410,7 @@ function sanitizeFilename(filename: string): string {
 function getStackTrace(ex: Error): string {
     // We aren't showing the error message (ex.message) since it might
     // contain PII.
-    let trace = 'Error: <message hidden>';
+    let trace = '';
     for (const frame of stackTrace.parse(ex)) {
         let filename = frame.getFileName();
         if (filename) {
@@ -422,7 +422,7 @@ function getStackTrace(ex: Error): string {
             trace += '\n\tat <anonymous>';
         }
     }
-    return trace;
+    return trace.trim();
 }
 
 async function sendErrorTelemetry(ex: Error) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -388,7 +388,6 @@ interface IAppShell {
 
 function notifyUser(msg: string) {
     try {
-        msg = `Python Extension: ${msg}`;
         let appShell = (window as IAppShell);
         if (activatedServiceContainer) {
             appShell = activatedServiceContainer.get<IApplicationShell>(IApplicationShell);

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -408,7 +408,9 @@ function sanitizeFilename(filename: string): string {
 }
 
 function getStackTrace(ex: Error): string {
-    let trace = `Error: ${ex.message}`;
+    // We aren't showing the error message (ex.message) since it might
+    // contain PII.
+    let trace = 'Error: <message hidden>';
     for (const frame of stackTrace.parse(ex)) {
         let filename = frame.getFileName();
         if (filename) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -330,11 +330,7 @@ function getPreferredWorkspaceInterpreter(resource: Resource, serviceContainer: 
 // telemetry
 
 // tslint:disable-next-line:no-any
-async function getActivationTelemetryProps(serviceContainer?: IServiceContainer): Promise<any> {
-    if (!serviceContainer) {
-        return {};
-    }
-
+async function getActivationTelemetryProps(serviceContainer: IServiceContainer): Promise<any> {
     // tslint:disable-next-line:no-suspicious-comment
     // TODO: Not all of this data is showing up in the database...
     // tslint:disable-next-line:no-suspicious-comment
@@ -458,11 +454,13 @@ function getStackTrace(ex: Error): string {
 async function sendErrorTelemetry(ex: Error) {
     try {
         // tslint:disable-next-line:no-any
-        let props: any;
-        try {
-            props = await getActivationTelemetryProps(activatedServiceContainer);
-        } catch (ex) {
-            props = {};
+        let props: any = {};
+        if (activatedServiceContainer) {
+            try {
+                props = await getActivationTelemetryProps(activatedServiceContainer);
+            } catch (ex) {
+                // ignore
+            }
         }
         props.stackTrace = getStackTrace(ex);
         sendTelemetryEvent(EDITOR_LOAD, durations, props);

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -32,7 +32,7 @@ import { buildApi, IExtensionApi } from './api';
 import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { IApplicationDiagnostics } from './application/types';
 import { DebugService } from './common/application/debugService';
-import { IWorkspaceService } from './common/application/types';
+import { IApplicationShell, IWorkspaceService } from './common/application/types';
 import { isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as registerDotNetTypes } from './common/dotnet/serviceRegistry';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
@@ -354,9 +354,21 @@ function handleError(ex: Error) {
         .ignoreErrors();
 }
 
+interface IAppShell {
+    showErrorMessage(string);
+}
+
 function notifyUser(msg: string) {
-    // tslint:disable-next-line:no-suspicious-comment
-    // TODO: finish
+    try {
+        msg = `Python Extension: ${msg}`;
+        let appShell = (window as IAppShell);
+        if (activatedServiceContainer) {
+            appShell = activatedServiceContainer.get<IApplicationShell>(IApplicationShell);
+        }
+        appShell.showErrorMessage(msg);
+    } catch (ex) {
+        // ignore
+    }
 }
 
 function logError(ex: Error, msg: string) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -36,6 +36,7 @@ import { IApplicationShell, IWorkspaceService } from './common/application/types
 import { isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as registerDotNetTypes } from './common/dotnet/serviceRegistry';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
+import { Logger } from './common/logger';
 import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
 import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
@@ -372,8 +373,17 @@ function notifyUser(msg: string) {
 }
 
 function logError(ex: Error, msg: string) {
-    // tslint:disable-next-line:no-suspicious-comment
-    // TODO: finish
+    try {
+        let logger: ILogger;
+        if (activatedServiceContainer) {
+            logger = activatedServiceContainer.get<ILogger>(ILogger);
+        } else {
+            logger = new Logger();
+        }
+        logger.logError(msg, ex);
+    } catch (ex) {
+        // ignore
+    }
 }
 
 async function sendErrorTelemetry(ex: Error) {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -391,7 +391,8 @@ function notifyUser(msg: string) {
         if (activatedServiceContainer) {
             appShell = activatedServiceContainer.get<IApplicationShell>(IApplicationShell);
         }
-        appShell.showErrorMessage(msg);
+        appShell.showErrorMessage(msg)
+            .ignoreErrors();
     } catch (ex) {
         // ignore
     }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -417,7 +417,18 @@ function logError(ex: Error, msg: string) {
     }
 }
 
-async function sendErrorTelemetry(ex: Error) {
+function getStackTrace(ex: Error): string {
     // tslint:disable-next-line:no-suspicious-comment
-    // TODO: finish
+    // TODO: Sanitize filenames.
+    return ex.stack || '';
+}
+
+async function sendErrorTelemetry(ex: Error) {
+    try {
+        const props = await getActivationTelemetryProps(activatedServiceContainer);
+        props.stackTrace = getStackTrace(ex);
+        sendTelemetryEvent(EDITOR_LOAD, durations, props);
+    } catch (ex) {
+        logError(ex, 'sendErrorTelemetry() failed.');
+    }
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -100,8 +100,17 @@ durations.codeLoadingTime = stopWatch.elapsedTime;
 const activationDeferred = createDeferred<void>();
 let activatedServiceContainer: ServiceContainer | undefined;
 
-// tslint:disable-next-line:max-func-body-length
 export async function activate(context: ExtensionContext): Promise<IExtensionApi> {
+    try {
+        return await activateUnsafe(context);
+    } catch (ex) {
+        handleError(ex);
+        throw ex;  // re-raise
+    }
+}
+
+// tslint:disable-next-line:max-func-body-length
+async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi> {
     displayProgress(activationDeferred.promise);
     durations.startActivateTime = stopWatch.elapsedTime;
     const cont = new Container();
@@ -333,4 +342,29 @@ function getPreferredWorkspaceInterpreter(resource: Resource, serviceContainer: 
     const workspaceInterpreterSelector = serviceContainer.get<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, AutoSelectionRule.workspaceVirtualEnvs);
     const interpreter = workspaceInterpreterSelector.getPreviouslyAutoSelectedInterpreter(resource);
     return interpreter ? interpreter.path : undefined;
+}
+
+/////////////////////////////
+// error handling
+
+function handleError(ex: Error) {
+    notifyUser('extension activation failed (see console log).');
+    logError(ex, 'extension activation failed');
+    sendErrorTelemetry(ex)
+        .ignoreErrors();
+}
+
+function notifyUser(msg: string) {
+    // tslint:disable-next-line:no-suspicious-comment
+    // TODO: finish
+}
+
+function logError(ex: Error, msg: string) {
+    // tslint:disable-next-line:no-suspicious-comment
+    // TODO: finish
+}
+
+async function sendErrorTelemetry(ex: Error) {
+    // tslint:disable-next-line:no-suspicious-comment
+    // TODO: finish
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -38,7 +38,7 @@ import { IApplicationShell, IWorkspaceService } from './common/application/types
 import { isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as registerDotNetTypes } from './common/dotnet/serviceRegistry';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
-import { Logger } from './common/logger';
+import { traceError } from './common/logger';
 import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
 import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
@@ -50,7 +50,6 @@ import {
     IDisposableRegistry,
     IExtensionContext,
     IFeatureDeprecationManager,
-    ILogger,
     IMemento,
     IOutputChannel,
     Resource,
@@ -308,7 +307,7 @@ async function sendStartupTelemetry(activatedPromise: Promise<any>, serviceConta
         const props = await getActivationTelemetryProps(serviceContainer);
         sendTelemetryEvent(EDITOR_LOAD, durations, props);
     } catch (ex) {
-        logError(ex, 'sendStartupTelemetry() failed.');
+        traceError('sendStartupTelemetry() failed.', ex);
     }
 }
 
@@ -377,7 +376,7 @@ async function getActivationTelemetryProps(serviceContainer: IServiceContainer):
 
 function handleError(ex: Error) {
     notifyUser('extension activation failed (see console log).');
-    logError(ex, 'extension activation failed');
+    traceError('extension activation failed', ex);
     sendErrorTelemetry(ex)
         .ignoreErrors();
 }
@@ -393,20 +392,6 @@ function notifyUser(msg: string) {
             appShell = activatedServiceContainer.get<IApplicationShell>(IApplicationShell);
         }
         appShell.showErrorMessage(msg);
-    } catch (ex) {
-        // ignore
-    }
-}
-
-function logError(ex: Error, msg: string) {
-    try {
-        let logger: ILogger;
-        if (activatedServiceContainer) {
-            logger = activatedServiceContainer.get<ILogger>(ILogger);
-        } else {
-            logger = new Logger();
-        }
-        logger.logError(msg, ex);
     } catch (ex) {
         // ignore
     }
@@ -463,7 +448,7 @@ async function sendErrorTelemetry(ex: Error) {
         }
         props.stackTrace = getStackTrace(ex);
         sendTelemetryEvent(EDITOR_LOAD, durations, props);
-    } catch (ex) {
-        logError(ex, 'sendErrorTelemetry() failed.');
+    } catch (exc2) {
+        traceError('sendErrorTelemetry() failed.', exc2);
     }
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -10,7 +10,7 @@ import { StopWatch } from './common/utils/stopWatch';
 // Do not move this line of code (used to measure extension load times).
 const stopWatch = new StopWatch();
 import { Container } from 'inversify';
-import { sep as pathSep } from 'path';
+import { basename as pathBasename, sep as pathSep } from 'path';
 import * as stackTrace from 'stack-trace';
 import {
     CodeActionKind,
@@ -397,24 +397,12 @@ function notifyUser(msg: string) {
     }
 }
 
-let ExtRootDir = '';
-const VSCodeRootFile = `${pathSep}extensionHostProcess.js`;
-let VSCodeRootDir = '';
-
 function sanitizeFilename(filename: string): string {
-    if (ExtRootDir === '') {
-        ExtRootDir = EXTENSION_ROOT_DIR + pathSep;
-    }
-
-    if (filename.startsWith(ExtRootDir)) {
-        filename = `<pvsc>${pathSep}${filename.substring(ExtRootDir.length)}`;
-    } else if (VSCodeRootDir !== '' && filename.startsWith(VSCodeRootDir)) {
-        filename = `<vscode>${pathSep}${filename.substring(VSCodeRootDir.length)}`;
-    } else if (filename.endsWith(VSCodeRootFile)) {
-        if (VSCodeRootDir === '') {
-            VSCodeRootDir = filename.substring(0, filename.length - VSCodeRootFile.length) + pathSep;
-            filename = `<vscode>${VSCodeRootFile}`;
-        }
+    if (filename.startsWith(EXTENSION_ROOT_DIR + pathSep)) {
+        filename = `<pvsc>${filename.substring(EXTENSION_ROOT_DIR.length)}`;
+    } else {
+        // We don't really care about files outside our extension.
+        filename = `<hidden>${pathSep}${pathBasename(filename)}`;
     }
     return filename;
 }


### PR DESCRIPTION
(for #3740)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
