### PR TITLE
Corrected unwanted change from PR #3933

### DIFF
--- a/src/client/activation/languageServer/languageServer.ts
+++ b/src/client/activation/languageServer/languageServer.ts
@@ -182,7 +182,7 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
             }
         }
 
-        const serverModule = path.join(this.languageServerFolder, this.platformData.getEngineExecutableName());
+        const serverModule = path.join(this.context.extensionPath, this.languageServerFolder, this.platformData.getEngineExecutableName());
         this.languageClient = await this.createSelfContainedLanguageClient(serverModule, clientOptions);
         try {
             await this.startLanguageClient();


### PR DESCRIPTION
[Reverting this line from PR #3933 ](https://github.com/Microsoft/vscode-python/commit/ceb2401abcdb81361c107fa2cdd8c3a1faa8d03b#r31924352)



<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
