### PR TITLE
Ensure new warnings are not ignored when bundling with WebPack

### DIFF
--- a/news/3 Code Health/3468.md
+++ b/news/3 Code Health/3468.md
@@ -1,0 +1,1 @@
+Ensure new warnings are not ignored when bundling the extension with WebPack.


### PR DESCRIPTION
For #3468

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[n/a] Unit tests & system/integration tests are added/updated~
- ~[n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
