### PR TITLE
Ensure LS receives intellicode messages after it starts

### DIFF
--- a/src/test/activation/languageServer/languageServer.unit.test.ts
+++ b/src/test/activation/languageServer/languageServer.unit.test.ts
@@ -11,6 +11,7 @@ import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
 import { BaseLanguageClientFactory } from '../../../client/activation/languageServer/languageClientFactory';
 import { LanguageServer } from '../../../client/activation/languageServer/languageServer';
 import { ILanaguageServer, ILanguageClientFactory } from '../../../client/activation/types';
+import '../../../client/common/extensions';
 import { IDisposable } from '../../../client/common/types';
 import { sleep } from '../../../client/common/utils/async';
 
@@ -29,8 +30,54 @@ suite('Language Server - LanguageServer', () => {
         client.setup(c => c.stop()).returns(() => Promise.resolve());
         server.dispose();
     });
-    test('Loading extension will throw an error if not activated', () => {
-        expect(() => server.loadExtension()).throws();
+    test('Loading extension will not throw an error if not activated', () => {
+        expect(() => server.loadExtension()).not.throw();
+    });
+    test('Loading extension will not throw an error if not activated but after it loads message will be sent', async () => {
+        const loadExtensionArgs = { x: 1 };
+
+        expect(() => server.loadExtension({ a: '2' })).not.throw();
+
+        client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
+
+        const uri = Uri.file(__filename);
+        const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
+        client.setup(c => (c as any).then).returns(() => undefined);
+        when(clientFactory.createLanguageClient(uri, options)).thenResolve(client.object);
+        const startDisposable = typemoq.Mock.ofType<IDisposable>();
+        client.setup(c => c.stop()).returns(() => Promise.resolve());
+        client
+            .setup(c => c.start())
+            .returns(() => startDisposable.object)
+            .verifiable(typemoq.Times.once());
+        client
+            .setup(c =>
+                c.sendRequest(typemoq.It.isValue('python/loadExtension'), typemoq.It.isValue(loadExtensionArgs))
+            )
+            .returns(() => Promise.resolve(undefined) as any);
+
+        expect(() => server.loadExtension(loadExtensionArgs)).not.throw();
+        client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
+        client
+            .setup(c => c.initializeResult)
+            .returns(() => false as any)
+            .verifiable(typemoq.Times.once());
+
+        server.start(uri, options).ignoreErrors();
+
+        // Even though server has started request should not yet be sent out.
+        // Not untill language client has initialized.
+        expect(() => server.loadExtension(loadExtensionArgs)).not.throw();
+        client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
+
+        // // Initialize language client and verify that the request was sent out.
+        client
+            .setup(c => c.initializeResult)
+            .returns(() => true as any)
+            .verifiable(typemoq.Times.once());
+        await sleep(120);
+
+        client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.atLeast(2));
     });
     test('Send telemetry when LS has started and disposes appropriately', async () => {
         const loadExtensionArgs = { x: 1 };
@@ -41,28 +88,33 @@ suite('Language Server - LanguageServer', () => {
         const startDisposable = typemoq.Mock.ofType<IDisposable>();
         client.setup(c => c.stop()).returns(() => Promise.resolve());
         client
-            .setup(c => c.start()).returns(() => startDisposable.object)
+            .setup(c => c.start())
+            .returns(() => startDisposable.object)
             .verifiable(typemoq.Times.once());
         client
-            .setup(c => c.sendRequest(typemoq.It.isValue('python/loadExtension'), typemoq.It.isValue(loadExtensionArgs)))
+            .setup(c =>
+                c.sendRequest(typemoq.It.isValue('python/loadExtension'), typemoq.It.isValue(loadExtensionArgs))
+            )
             .returns(() => Promise.resolve(undefined) as any);
 
-        expect(() => server.loadExtension(loadExtensionArgs)).throws('Activation not completed or not invoked');
+        expect(() => server.loadExtension(loadExtensionArgs)).not.throw();
         client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
         client
-            .setup(c => c.initializeResult).returns(() => false as any)
+            .setup(c => c.initializeResult)
+            .returns(() => false as any)
             .verifiable(typemoq.Times.once());
 
         const promise = server.start(uri, options);
 
         // Even though server has started request should not yet be sent out.
         // Not untill language client has initialized.
-        expect(() => server.loadExtension(loadExtensionArgs)).throws('Activation not completed');
+        expect(() => server.loadExtension(loadExtensionArgs)).not.throw();
         client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
 
         // // Initialize language client and verify that the request was sent out.
         client
-            .setup(c => c.initializeResult).returns(() => true as any)
+            .setup(c => c.initializeResult)
+            .returns(() => true as any)
             .verifiable(typemoq.Times.once());
         await sleep(120);
         expect(() => server.loadExtension(loadExtensionArgs)).to.not.throw();


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
