### PR TITLE
Corrected keys in localize.ts

### DIFF
--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -26,8 +26,8 @@ export namespace LanguageService {
     export const bannerLabelYes = localize('LanguageService.bannerLabelYes', 'Yes, take survey now');
     export const bannerLabelNo = localize('LanguageService.bannerLabelNo', 'No, thanks');
     export const lsFailedToStart = localize('LanguageService.lsFailedToStart', 'We encountered an issue starting the Language Server. Reverting to the alternative, Jedi. Check the Output panel for details.');
-    export const lsFailedToDownload = localize('LanguageService.lsFailedToStart', 'We encountered an issue downloading the Language Server. Reverting to the alternative, Jedi. Check the Output panel for details..');
-    export const lsFailedToExtract = localize('LanguageService.lsFailedToStart', 'We encountered an issue extracting the Language Server. Reverting to the alternative, Jedi. Check the Output panel for details.');
+    export const lsFailedToDownload = localize('LanguageService.lsFailedToDownload', 'We encountered an issue downloading the Language Server. Reverting to the alternative, Jedi. Check the Output panel for details..');
+    export const lsFailedToExtract = localize('LanguageService.lsFailedToExtract', 'We encountered an issue extracting the Language Server. Reverting to the alternative, Jedi. Check the Output panel for details.');
 }
 
 export namespace Interpreters {


### PR DESCRIPTION
[Incorporated comment from PR #3933 ](https://github.com/Microsoft/vscode-python/pull/3933/files#r248083686)

For #3268 , #3267

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
