### PR TITLE
Improvements to message displayed when python path is invalid (in launch.json)

### DIFF
--- a/news/1 Enhancements/3661.md
+++ b/news/1 Enhancements/3661.md
@@ -1,0 +1,1 @@
+Improvements to message displayed when python path is invalid (in launch.json)

--- a/package.nls.json
+++ b/package.nls.json
@@ -135,6 +135,8 @@
     "diagnostics.warnBeforeEnablingSourceMaps": "Enabling source map support in the Python Extension will adversely impact performance of the extension.",
     "diagnostics.enableSourceMapsAndReloadVSC": "Enable and reload Window",
     "diagnostics.lsNotSupported": "Your operating system does not meet the minimum requirements of the Language Server. Reverting to the alternative, Jedi.",
+    "diagnostics.invalidPythonPathInDebuggerSettings": "You need to select a Python interpreter before you start debugging.\n\nTip: click on \"Select Python Interpreter\" in the status bar.",
+    "diagnostics.invalidPythonPathInDebuggerLaunch": "The Python path in your debug configuration is invalid.",
     "DataScience.interruptKernel": "Interrupt iPython Kernel",
     "DataScience.exportingFormat": "Exporting {0}",
     "DataScience.exportCancel": "Cancel",

--- a/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
@@ -4,11 +4,14 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { DiagnosticSeverity, Uri } from 'vscode';
+import * as path from 'path';
+import { DiagnosticSeverity, Uri, workspace as workspc, WorkspaceFolder } from 'vscode';
+import { openFile } from '../../../../test/common';
 import { IWorkspaceService } from '../../../common/application/types';
 import '../../../common/extensions';
 import { Logger, traceError } from '../../../common/logger';
 import { IConfigurationService } from '../../../common/types';
+import { Diagnostics } from '../../../common/utils/localize';
 import { SystemVariables } from '../../../common/variables/systemVariables';
 import { IInterpreterHelper } from '../../../interpreter/contracts';
 import { IServiceContainer } from '../../../ioc/types';
@@ -16,20 +19,23 @@ import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
 import { IDiagnosticsCommandFactory } from '../commands/types';
 import { DiagnosticCodes } from '../constants';
 import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../promptHandler';
-import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService, IInvalidPythonPathInDebuggerService } from '../types';
+import { DiagnosticScope, IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService, IInvalidPythonPathInDebuggerService } from '../types';
 
-const InvalidPythonPathInDebuggerMessage = 'You need to select a Python interpreter before you start debugging.\n\nTip: click on "Select Python Interpreter" in the status bar.';
-
-export class InvalidPythonPathInDebuggerDiagnostic extends BaseDiagnostic {
+export class InvalidPythonPathInDebuggerSettingsDiagnostic extends BaseDiagnostic {
     constructor() {
-        super(DiagnosticCodes.InvalidDebuggerTypeDiagnostic,
-            InvalidPythonPathInDebuggerMessage, DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder);
+        super(DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic,
+            Diagnostics.invalidPythonPathInDebuggerSettings(), DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder);
+    }
+}
+
+export class InvalidPythonPathInDebuggerLaunchDiagnostic extends BaseDiagnostic {
+    constructor() {
+        super(DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic,
+            Diagnostics.invalidPythonPathInDebuggerLaunch(), DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder);
     }
 }
 
 export const InvalidPythonPathInDebuggerServiceId = 'InvalidPythonPathInDebuggerServiceId';
-
-const CommandName = 'python.setInterpreter';
 
 @injectable()
 export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService implements IInvalidPythonPathInDebuggerService {
@@ -39,7 +45,7 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService i
         @inject(IDiagnosticsCommandFactory) private readonly commandFactory: IDiagnosticsCommandFactory,
         @inject(IInterpreterHelper) private readonly interpreterHelper: IInterpreterHelper,
         @inject(IConfigurationService) private readonly configService: IConfigurationService) {
-        super([DiagnosticCodes.InvalidPythonPathInDebuggerDiagnostic], serviceContainer);
+        super([DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic, DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic], serviceContainer);
         this.messageService = serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(IDiagnosticHandlerService, DiagnosticCommandPromptHandlerServiceId);
     }
     public async diagnose(): Promise<IDiagnostic[]> {
@@ -51,33 +57,64 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService i
             return;
         }
         const diagnostic = diagnostics[0];
-        const options = [
-            {
-                prompt: 'Select Python Interpreter',
-                command: this.commandFactory.createCommand(diagnostic, { type: 'executeVSCCommand', options: CommandName })
-            }
-        ];
+        const commandPrompts = this.getCommandPrompts(diagnostic);
 
-        await this.messageService.handle(diagnostic, { commandPrompts: options });
+        await this.messageService.handle(diagnostic, { commandPrompts });
     }
     public async validatePythonPath(pythonPath?: string, resource?: Uri) {
         pythonPath = pythonPath ? this.resolveVariables(pythonPath, resource) : undefined;
+        let pathInLaunchJson = true;
         // tslint:disable-next-line:no-invalid-template-strings
         if (pythonPath === '${config:python.pythonPath}' || !pythonPath) {
+            pathInLaunchJson = false;
             pythonPath = this.configService.getSettings(resource).pythonPath;
         }
         if (await this.interpreterHelper.getInterpreterInformation(pythonPath).catch(() => undefined)) {
             return true;
         }
         traceError(`Invalid Python Path '${pythonPath}'`);
-        this.handle([new InvalidPythonPathInDebuggerDiagnostic()])
-            .catch(ex => Logger.error('Failed to handle invalid python path in debugger', ex))
-            .ignoreErrors();
+        if (pathInLaunchJson) {
+            this.handle([new InvalidPythonPathInDebuggerLaunchDiagnostic()])
+                .catch(ex => Logger.error('Failed to handle invalid python path in launch.json debugger', ex))
+                .ignoreErrors();
+        } else {
+            this.handle([new InvalidPythonPathInDebuggerSettingsDiagnostic()])
+                .catch(ex => Logger.error('Failed to handle invalid python path in settings.json debugger', ex))
+                .ignoreErrors();
+        }
         return false;
     }
     protected resolveVariables(pythonPath: string, resource: Uri | undefined): string {
         const workspaceFolder = resource ? this.workspace.getWorkspaceFolder(resource) : undefined;
         const systemVariables = new SystemVariables(workspaceFolder ? workspaceFolder.uri.fsPath : undefined);
         return systemVariables.resolveAny(pythonPath);
+    }
+    private getCommandPrompts(diagnostic: IDiagnostic): { prompt: string; command?: IDiagnosticCommand }[] {
+        switch (diagnostic.code) {
+            case DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic: {
+                return [{
+                    prompt: 'Select Python Interpreter',
+                    command: this.commandFactory.createCommand(diagnostic, { type: 'executeVSCCommand', options: 'python.setInterpreter' })
+                }];
+            }
+            case DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic: {
+                return [{
+                    prompt: 'Open launch.json',
+                    // tslint:disable-next-line:no-object-literal-type-assertion
+                    command: {
+                        diagnostic, invoke: async (): Promise<void> => {
+                            const launchJson = this.getLaunchJsonFile(workspc.workspaceFolders[0]);
+                            await openFile(launchJson);
+                        }
+                    }
+                }];
+            }
+            default: {
+                throw new Error('Invalid diagnostic for \'InvalidPythonPathInDebuggerService\'');
+            }
+        }
+    }
+    private getLaunchJsonFile(workspaceFolder: WorkspaceFolder) {
+        return path.join(workspaceFolder.uri.fsPath, '.vscode', 'launch.json');
     }
 }

--- a/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
@@ -9,7 +9,7 @@ import { DiagnosticSeverity, Uri, workspace as workspc, WorkspaceFolder } from '
 import { openFile } from '../../../../test/common';
 import { IWorkspaceService } from '../../../common/application/types';
 import '../../../common/extensions';
-import { Logger, traceError } from '../../../common/logger';
+import { traceError } from '../../../common/logger';
 import { IConfigurationService } from '../../../common/types';
 import { Diagnostics } from '../../../common/utils/localize';
 import { SystemVariables } from '../../../common/variables/systemVariables';
@@ -45,7 +45,7 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService i
         @inject(IInterpreterHelper) private readonly interpreterHelper: IInterpreterHelper,
         @inject(IConfigurationService) private readonly configService: IConfigurationService,
         @inject(IDiagnosticHandlerService) @named(DiagnosticCommandPromptHandlerServiceId) protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>) {
-            super([DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic, DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic], serviceContainer);
+        super([DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic, DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic], serviceContainer);
     }
     public async diagnose(): Promise<IDiagnostic[]> {
         return [];
@@ -74,11 +74,11 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService i
         traceError(`Invalid Python Path '${pythonPath}'`);
         if (pathInLaunchJson) {
             this.handle([new InvalidPythonPathInDebuggerLaunchDiagnostic()])
-                .catch(ex => Logger.error('Failed to handle invalid python path in launch.json debugger', ex))
+                .catch(ex => traceError('Failed to handle invalid python path in launch.json debugger', ex))
                 .ignoreErrors();
         } else {
             this.handle([new InvalidPythonPathInDebuggerSettingsDiagnostic()])
-                .catch(ex => Logger.error('Failed to handle invalid python path in settings.json debugger', ex))
+                .catch(ex => traceError('Failed to handle invalid python path in settings.json debugger', ex))
                 .ignoreErrors();
         }
         return false;

--- a/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
 import { DiagnosticSeverity, Uri, workspace as workspc, WorkspaceFolder } from 'vscode';
 import { openFile } from '../../../../test/common';
@@ -39,14 +39,13 @@ export const InvalidPythonPathInDebuggerServiceId = 'InvalidPythonPathInDebugger
 
 @injectable()
 export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService implements IInvalidPythonPathInDebuggerService {
-    protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>;
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(IDiagnosticsCommandFactory) private readonly commandFactory: IDiagnosticsCommandFactory,
         @inject(IInterpreterHelper) private readonly interpreterHelper: IInterpreterHelper,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService) {
-        super([DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic, DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic], serviceContainer);
-        this.messageService = serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(IDiagnosticHandlerService, DiagnosticCommandPromptHandlerServiceId);
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(IDiagnosticHandlerService) @named(DiagnosticCommandPromptHandlerServiceId) protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>) {
+            super([DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic, DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic], serviceContainer);
     }
     public async diagnose(): Promise<IDiagnostic[]> {
         return [];

--- a/src/client/application/diagnostics/constants.ts
+++ b/src/client/application/diagnostics/constants.ts
@@ -9,7 +9,8 @@ export enum DiagnosticCodes {
     NoPythonInterpretersDiagnostic = 'NoPythonInterpretersDiagnostic',
     MacInterpreterSelectedAndNoOtherInterpretersDiagnostic = 'MacInterpreterSelectedAndNoOtherInterpretersDiagnostic',
     MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic = 'MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic',
-    InvalidPythonPathInDebuggerDiagnostic = 'InvalidPythonPathInDebuggerDiagnostic',
+    InvalidPythonPathInDebuggerSettingsDiagnostic = 'InvalidPythonPathInDebuggerSettingsDiagnostic',
+    InvalidPythonPathInDebuggerLaunchDiagnostic = 'InvalidPythonPathInDebuggerLaunchDiagnostic',
     EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic = 'EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic',
     NoCurrentlySelectedPythonInterpreterDiagnostic = 'InvalidPythonInterpreterDiagnostic',
     LSNotSupportedDiagnostic = 'LSNotSupportedDiagnostic'

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -14,6 +14,8 @@ export namespace Diagnostics {
     export const warnBeforeEnablingSourceMaps = localize('diagnostics.warnBeforeEnablingSourceMaps', 'Enabling source map support in the Python Extension will adversely impact performance of the extension.');
     export const enableSourceMapsAndReloadVSC = localize('diagnostics.enableSourceMapsAndReloadVSC', 'Enable and reload Window.');
     export const lsNotSupported = localize('diagnostics.lsNotSupported', 'Your operating system does not meet the minimum requirements of the Language Server. Reverting to the alternative, Jedi.');
+    export const invalidPythonPathInDebuggerSettings = localize('diagnostics.invalidPythonPathInDebuggerSettings', 'You need to select a Python interpreter before you start debugging.\n\nTip: click on "Select Python Interpreter" in the status bar.');
+    export const invalidPythonPathInDebuggerLaunch = localize('diagnostics.invalidPythonPathInDebuggerLaunch', 'The Python path in your debug configuration is invalid.');
 }
 
 export namespace Common {

--- a/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
@@ -44,18 +44,23 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         serviceContainer.setup(s => s.get(typemoq.It.isValue(IWorkspaceService)))
             .returns(() => workspaceService.object);
 
-        diagnosticService = new InvalidPythonPathInDebuggerService(serviceContainer.object, workspaceService.object, commandFactory.object, helper.object, configService.object);
+        diagnosticService = new InvalidPythonPathInDebuggerService(serviceContainer.object, workspaceService.object, commandFactory.object, helper.object, configService.object, messageHandler.object);
     });
 
     test('Can handle InvalidPythonPathInDebugger diagnostics', async () => {
-        const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
-        diagnostic.setup(d => d.code)
-            .returns(() => DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic)
-            .verifiable(typemoq.Times.atLeastOnce());
+        for (const code of [
+            DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic,
+            DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic
+        ]) {
+            const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
+            diagnostic.setup(d => d.code)
+                .returns(() => code)
+                .verifiable(typemoq.Times.atLeastOnce());
 
-        const canHandle = await diagnosticService.canHandle(diagnostic.object);
-        expect(canHandle).to.be.equal(true, 'Invalid value');
-        diagnostic.verifyAll();
+            const canHandle = await diagnosticService.canHandle(diagnostic.object);
+            expect(canHandle).to.be.equal(true, `Should be able to handle ${code}`);
+            diagnostic.verifyAll();
+        }
     });
     test('Can not handle non-InvalidPythonPathInDebugger diagnostics', async () => {
         const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
@@ -71,10 +76,10 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         const diagnostics = await diagnosticService.diagnose();
         expect(diagnostics).to.be.deep.equal([]);
     });
-    test('Should display one option to with a command', async () => {
+    test('InvalidPythonPathInDebuggerSettings diagnostic should display one option to with a command', async () => {
         const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
         diagnostic.setup(d => d.code)
-            .returns(() => DiagnosticCodes.InvalidEnvironmentPathVariableDiagnostic)
+            .returns(() => DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic)
             .verifiable(typemoq.Times.atLeastOnce());
         const interpreterSelectionCommand = typemoq.Mock.ofType<IDiagnosticCommand>();
         commandFactory.setup(f => f.createCommand(typemoq.It.isAny(),
@@ -89,6 +94,24 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         diagnostic.verifyAll();
         commandFactory.verifyAll();
         messageHandler.verifyAll();
+    });
+    test('InvalidPythonPathInDebuggerLaunch diagnostic should display one option to with a command', async () => {
+        const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
+        let options: MessageCommandPrompt | undefined;
+        diagnostic.setup(d => d.code)
+            .returns(() => DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic)
+            .verifiable(typemoq.Times.atLeastOnce());
+        messageHandler.setup(m => m.handle(typemoq.It.isAny(), typemoq.It.isAny()))
+            .callback((_, opts: MessageCommandPrompt) => options = opts)
+            .verifiable(typemoq.Times.once());
+
+        await diagnosticService.handle([diagnostic.object]);
+
+        diagnostic.verifyAll();
+        commandFactory.verifyAll();
+        messageHandler.verifyAll();
+        expect(options!.commandPrompts).to.be.lengthOf(1);
+        expect(options!.commandPrompts[0].prompt).to.be.equal('Open launch.json');
     });
     test('Ensure we get python path from config when path = ${config:python.pythonPath}', async () => {
         const pythonPath = '${config:python.pythonPath}';
@@ -196,7 +219,7 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         helper.verifyAll();
         expect(valid).to.be.equal(true, 'not valid');
     });
-    test('Ensure we do get python path from config when path is provided', async () => {
+    test('Ensure we do not get python path from config when path is provided', async () => {
         const pythonPath = path.join('a', 'b');
 
         const settings = typemoq.Mock.ofType<IPythonSettings>();
@@ -215,12 +238,51 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         helper.verifyAll();
         expect(valid).to.be.equal(true, 'not valid');
     });
-    test('Ensure diagnosics are handled when path is invalid', async () => {
+    test('Ensure InvalidPythonPathInDebuggerLaunch diagnostic is handled when path is invalid in launch.json', async () => {
         const pythonPath = path.join('a', 'b');
+        const settings = typemoq.Mock.ofType<IPythonSettings>();
+        configService
+            .setup(c => c.getSettings(typemoq.It.isAny()))
+            .returns(() => settings.object)
+            .verifiable(typemoq.Times.never());
         let handleInvoked = false;
-        diagnosticService.handle = () => { handleInvoked = true; return Promise.resolve(); };
+        diagnosticService.handle = (diagnostics) => {
+            if (diagnostics.length !== 0 && diagnostics[0].code === DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic){
+                handleInvoked = true;
+            }
+            return Promise.resolve();
+        };
         helper
             .setup(h => h.getInterpreterInformation(typemoq.It.isValue(pythonPath)))
+            .returns(() => Promise.resolve(undefined))
+            .verifiable(typemoq.Times.once());
+
+        const valid = await diagnosticService.validatePythonPath(pythonPath);
+
+        helper.verifyAll();
+        expect(valid).to.be.equal(false, 'should be invalid');
+        expect(handleInvoked).to.be.equal(true, 'should be invoked');
+    });
+    test('Ensure InvalidPythonPathInDebuggerSettings diagnostic is handled when path is invalid in settings.json', async () => {
+        const pythonPath = undefined;
+        const settings = typemoq.Mock.ofType<IPythonSettings>();
+        settings
+            .setup(s => s.pythonPath)
+            .returns(() => 'p')
+            .verifiable(typemoq.Times.once());
+        configService
+            .setup(c => c.getSettings(typemoq.It.isAny()))
+            .returns(() => settings.object)
+            .verifiable(typemoq.Times.once());
+        let handleInvoked = false;
+        diagnosticService.handle = (diagnostics) => {
+            if (diagnostics.length !== 0 && diagnostics[0].code === DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic){
+                handleInvoked = true;
+            }
+            return Promise.resolve();
+        };
+        helper
+            .setup(h => h.getInterpreterInformation(typemoq.It.isValue('p')))
             .returns(() => Promise.resolve(undefined))
             .verifiable(typemoq.Times.once());
 

--- a/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
@@ -50,7 +50,7 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
     test('Can handle InvalidPythonPathInDebugger diagnostics', async () => {
         const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
         diagnostic.setup(d => d.code)
-            .returns(() => DiagnosticCodes.InvalidPythonPathInDebuggerDiagnostic)
+            .returns(() => DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic)
             .verifiable(typemoq.Times.atLeastOnce());
 
         const canHandle = await diagnosticService.canHandle(diagnostic.object);


### PR DESCRIPTION
For #3661

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
