### PR TITLE
Ensure all diagnostic checks accept resource args

### DIFF
--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -56,7 +56,7 @@ export class ExtensionActivationService implements IExtensionActivationService, 
 
         let jedi = this.useJedi();
         if (!jedi) {
-            const diagnostic = await this.lsNotSupportedDiagnosticService.diagnose();
+            const diagnostic = await this.lsNotSupportedDiagnosticService.diagnose(undefined);
             this.lsNotSupportedDiagnosticService.handle(diagnostic).ignoreErrors();
             if (diagnostic.length){
                 sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_PLATFORM_NOT_SUPPORTED);

--- a/src/client/application/diagnostics/applicationDiagnostics.ts
+++ b/src/client/application/diagnostics/applicationDiagnostics.ts
@@ -6,7 +6,7 @@
 import { inject, injectable, named } from 'inversify';
 import { DiagnosticSeverity } from 'vscode';
 import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
-import { ILogger, IOutputChannel } from '../../common/types';
+import { ILogger, IOutputChannel, Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { IApplicationDiagnostics } from '../types';
 import { InvalidMacPythonInterpreterServiceId } from './checks/macPythonInterpreter';
@@ -19,10 +19,10 @@ export class ApplicationDiagnostics implements IApplicationDiagnostics {
     public register() {
         this.serviceContainer.get<ISourceMapSupportService>(ISourceMapSupportService).register();
     }
-    public async performPreStartupHealthCheck(): Promise<void> {
+    public async performPreStartupHealthCheck(resource: Resource): Promise<void> {
         const diagnosticsServices = this.serviceContainer.getAll<IDiagnosticsService>(IDiagnosticsService);
         await Promise.all(diagnosticsServices.map(async diagnosticsService => {
-            const diagnostics = await diagnosticsService.diagnose();
+            const diagnostics = await diagnosticsService.diagnose(resource);
             this.log(diagnostics);
             if (diagnostics.length > 0) {
                 await diagnosticsService.handle(diagnostics);

--- a/src/client/application/diagnostics/base.ts
+++ b/src/client/application/diagnostics/base.ts
@@ -5,6 +5,7 @@
 
 import { injectable, unmanaged } from 'inversify';
 import { DiagnosticSeverity } from 'vscode';
+import { Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -14,7 +15,8 @@ import { DiagnosticScope, IDiagnostic, IDiagnosticFilterService, IDiagnosticsSer
 @injectable()
 export abstract class BaseDiagnostic implements IDiagnostic {
     constructor(public readonly code: DiagnosticCodes, public readonly message: string,
-        public readonly severity: DiagnosticSeverity, public readonly scope: DiagnosticScope) { }
+        public readonly severity: DiagnosticSeverity, public readonly scope: DiagnosticScope,
+        public readonly resource: Resource) { }
 }
 
 @injectable()
@@ -24,7 +26,7 @@ export abstract class BaseDiagnosticsService implements IDiagnosticsService {
         @unmanaged() protected serviceContainer: IServiceContainer) {
         this.filterService = serviceContainer.get<IDiagnosticFilterService>(IDiagnosticFilterService);
     }
-    public abstract diagnose(): Promise<IDiagnostic[]>;
+    public abstract diagnose(resource: Resource): Promise<IDiagnostic[]>;
     public abstract handle(diagnostics: IDiagnostic[]): Promise<void>;
     public async canHandle(diagnostic: IDiagnostic): Promise<boolean> {
         sendTelemetryEvent(EventName.DIAGNOSTICS_MESSAGE, undefined, { code: diagnostic.code });

--- a/src/client/application/diagnostics/checks/envPathVariable.ts
+++ b/src/client/application/diagnostics/checks/envPathVariable.ts
@@ -8,7 +8,7 @@ import { DiagnosticSeverity } from 'vscode';
 import { IApplicationEnvironment } from '../../../common/application/types';
 import '../../../common/extensions';
 import { IPlatformService } from '../../../common/platform/types';
-import { ICurrentProcess, IPathUtils } from '../../../common/types';
+import { ICurrentProcess, IPathUtils, Resource } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
 import { IDiagnosticsCommandFactory } from '../commands/types';
@@ -20,9 +20,9 @@ const InvalidEnvPathVariableMessage = 'The environment variable \'{0}\' seems to
     ' The existence of such a character is known to have caused the {1} extension to not load. If the extension fails to load please modify your paths to remove this \'"\' character.';
 
 export class InvalidEnvironmentPathVariableDiagnostic extends BaseDiagnostic {
-    constructor(message: string) {
+    constructor(message: string, resource: Resource) {
         super(DiagnosticCodes.InvalidEnvironmentPathVariableDiagnostic,
-            message, DiagnosticSeverity.Warning, DiagnosticScope.Global);
+            message, DiagnosticSeverity.Warning, DiagnosticScope.Global, resource);
     }
 }
 
@@ -37,13 +37,13 @@ export class EnvironmentPathVariableDiagnosticsService extends BaseDiagnosticsSe
         this.platform = this.serviceContainer.get<IPlatformService>(IPlatformService);
         this.messageService = serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(IDiagnosticHandlerService, DiagnosticCommandPromptHandlerServiceId);
     }
-    public async diagnose(): Promise<IDiagnostic[]> {
+    public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
         if (this.platform.isWindows &&
             this.doesPathVariableHaveInvalidEntries()) {
             const env = this.serviceContainer.get<IApplicationEnvironment>(IApplicationEnvironment);
             const message = InvalidEnvPathVariableMessage
                 .format(this.platform.pathVariableName, env.extensionName);
-            return [new InvalidEnvironmentPathVariableDiagnostic(message)];
+            return [new InvalidEnvironmentPathVariableDiagnostic(message, resource)];
         } else {
             return [];
         }

--- a/src/client/application/diagnostics/checks/invalidDebuggerType.ts
+++ b/src/client/application/diagnostics/checks/invalidDebuggerType.ts
@@ -9,6 +9,7 @@ import { DiagnosticSeverity, WorkspaceFolder } from 'vscode';
 import { ICommandManager, IWorkspaceService } from '../../../common/application/types';
 import '../../../common/extensions';
 import { IFileSystem } from '../../../common/platform/types';
+import { Resource } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
 import { IDiagnosticsCommandFactory } from '../commands/types';
@@ -21,9 +22,10 @@ const InvalidDebuggerTypeMessage = 'Your launch.json file needs to be updated to
     'not work. Would you like to automatically update your launch.json file now?';
 
 export class InvalidDebuggerTypeDiagnostic extends BaseDiagnostic {
-    constructor(message: string) {
+    constructor(message: string, resource: Resource) {
         super(DiagnosticCodes.InvalidDebuggerTypeDiagnostic,
-            message, DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder);
+            message, DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder,
+            resource);
     }
 }
 
@@ -42,9 +44,9 @@ export class InvalidDebuggerTypeDiagnosticsService extends BaseDiagnosticsServic
         this.fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
         cmdManager.registerCommand(CommandName, this.fixLaunchJson, this);
     }
-    public async diagnose(): Promise<IDiagnostic[]> {
+    public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
         if (await this.isExperimentalDebuggerUsed()) {
-            return [new InvalidDebuggerTypeDiagnostic(InvalidDebuggerTypeMessage)];
+            return [new InvalidDebuggerTypeDiagnostic(InvalidDebuggerTypeMessage, resource)];
         } else {
             return [];
         }

--- a/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
@@ -10,7 +10,7 @@ import { openFile } from '../../../../test/common';
 import { IWorkspaceService } from '../../../common/application/types';
 import '../../../common/extensions';
 import { traceError } from '../../../common/logger';
-import { IConfigurationService } from '../../../common/types';
+import { IConfigurationService, Resource } from '../../../common/types';
 import { Diagnostics } from '../../../common/utils/localize';
 import { SystemVariables } from '../../../common/variables/systemVariables';
 import { IInterpreterHelper } from '../../../interpreter/contracts';
@@ -22,16 +22,18 @@ import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '.
 import { DiagnosticScope, IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService, IInvalidPythonPathInDebuggerService } from '../types';
 
 export class InvalidPythonPathInDebuggerSettingsDiagnostic extends BaseDiagnostic {
-    constructor() {
+    constructor(resource: Resource) {
         super(DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic,
-            Diagnostics.invalidPythonPathInDebuggerSettings(), DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder);
+            Diagnostics.invalidPythonPathInDebuggerSettings(), DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder,
+            resource);
     }
 }
 
 export class InvalidPythonPathInDebuggerLaunchDiagnostic extends BaseDiagnostic {
-    constructor() {
+    constructor(resource: Resource) {
         super(DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic,
-            Diagnostics.invalidPythonPathInDebuggerLaunch(), DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder);
+            Diagnostics.invalidPythonPathInDebuggerLaunch(), DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder,
+            resource);
     }
 }
 
@@ -47,7 +49,7 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService i
         @inject(IDiagnosticHandlerService) @named(DiagnosticCommandPromptHandlerServiceId) protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>) {
         super([DiagnosticCodes.InvalidPythonPathInDebuggerSettingsDiagnostic, DiagnosticCodes.InvalidPythonPathInDebuggerLaunchDiagnostic], serviceContainer);
     }
-    public async diagnose(): Promise<IDiagnostic[]> {
+    public async diagnose(_resource: Resource): Promise<IDiagnostic[]> {
         return [];
     }
     public async handle(diagnostics: IDiagnostic[]): Promise<void> {
@@ -73,11 +75,11 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService i
         }
         traceError(`Invalid Python Path '${pythonPath}'`);
         if (pathInLaunchJson) {
-            this.handle([new InvalidPythonPathInDebuggerLaunchDiagnostic()])
+            this.handle([new InvalidPythonPathInDebuggerLaunchDiagnostic(resource)])
                 .catch(ex => traceError('Failed to handle invalid python path in launch.json debugger', ex))
                 .ignoreErrors();
         } else {
-            this.handle([new InvalidPythonPathInDebuggerSettingsDiagnostic()])
+            this.handle([new InvalidPythonPathInDebuggerSettingsDiagnostic(resource)])
                 .catch(ex => traceError('Failed to handle invalid python path in settings.json debugger', ex))
                 .ignoreErrors();
         }

--- a/src/client/application/diagnostics/checks/lsNotSupported.ts
+++ b/src/client/application/diagnostics/checks/lsNotSupported.ts
@@ -6,6 +6,7 @@
 import { inject, named } from 'inversify';
 import { DiagnosticSeverity } from 'vscode';
 import { ILanguageServerCompatibilityService } from '../../../activation/types';
+import { Resource } from '../../../common/types';
 import { Diagnostics } from '../../../common/utils/localize';
 import { IServiceContainer } from '../../../ioc/types';
 import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
@@ -15,9 +16,9 @@ import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '.
 import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../types';
 
 export class LSNotSupportedDiagnostic extends BaseDiagnostic {
-    constructor(message: string) {
+    constructor(message: string, resource: Resource) {
         super(DiagnosticCodes.LSNotSupportedDiagnostic,
-            message, DiagnosticSeverity.Warning, DiagnosticScope.Global);
+            message, DiagnosticSeverity.Warning, DiagnosticScope.Global, resource);
     }
 }
 
@@ -29,11 +30,11 @@ export class LSNotSupportedDiagnosticService extends BaseDiagnosticsService {
     @inject(IDiagnosticHandlerService) @named(DiagnosticCommandPromptHandlerServiceId) protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>) {
         super([DiagnosticCodes.LSNotSupportedDiagnostic], serviceContainer);
     }
-    public async diagnose(): Promise<IDiagnostic[]>{
+    public async diagnose(resource: Resource): Promise<IDiagnostic[]>{
         if (await this.lsCompatibility.isSupported()) {
             return [];
         } else{
-            return [new LSNotSupportedDiagnostic(Diagnostics.lsNotSupported())];
+            return [new LSNotSupportedDiagnostic(Diagnostics.lsNotSupported(), resource)];
         }
     }
     public async handle(diagnostics: IDiagnostic[]): Promise<void>{

--- a/src/client/application/diagnostics/checks/macPythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/macPythonInterpreter.ts
@@ -18,8 +18,10 @@ import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '.
 import { DiagnosticScope, IDiagnostic, IDiagnosticCommand, IDiagnosticHandlerService } from '../types';
 
 const messages = {
-    [DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic]: 'You have selected the macOS system install of Python, which is not recommended for use with the Python extension. Some functionality will be limited, please select a different interpreter.',
-    [DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic]: 'The macOS system install of Python is not recommended, some functionality in the extension will be limited. Install another version of Python for the best experience.'
+    [DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic]:
+        'You have selected the macOS system install of Python, which is not recommended for use with the Python extension. Some functionality will be limited, please select a different interpreter.',
+    [DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic]:
+        'The macOS system install of Python is not recommended, some functionality in the extension will be limited. Install another version of Python for the best experience.'
 };
 
 export class InvalidMacPythonInterpreterDiagnostic extends BaseDiagnostic {
@@ -34,15 +36,19 @@ export const InvalidMacPythonInterpreterServiceId = 'InvalidMacPythonInterpreter
 export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
     protected changeThrottleTimeout = 1000;
     private timeOut?: NodeJS.Timer;
-    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer,
+    constructor(
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IPlatformService) private readonly platform: IPlatformService,
-        @inject(IInterpreterHelper) private readonly helper: IInterpreterHelper) {
+        @inject(IInterpreterHelper) private readonly helper: IInterpreterHelper
+    ) {
         super(
             [
                 DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic,
                 DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic
-            ], serviceContainer);
+            ],
+            serviceContainer
+        );
         this.addPythonPathChangedHandler();
     }
     public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
@@ -50,7 +56,7 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
             return [];
         }
         const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
-        const settings = configurationService.getSettings();
+        const settings = configurationService.getSettings(resource);
         if (settings.disableInstallationChecks === true) {
             return [];
         }
@@ -60,7 +66,7 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
             return [];
         }
 
-        const currentInterpreter = await this.interpreterService.getActiveInterpreter();
+        const currentInterpreter = await this.interpreterService.getActiveInterpreter(resource);
         if (!currentInterpreter) {
             return [];
         }
@@ -72,25 +78,40 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
             return [];
         }
 
-        const interpreters = await this.interpreterService.getInterpreters();
+        const interpreters = await this.interpreterService.getInterpreters(resource);
         if (interpreters.filter(i => !this.helper.isMacDefaultPythonPath(i.path)).length === 0) {
-            return [new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic, resource)];
+            return [
+                new InvalidMacPythonInterpreterDiagnostic(
+                    DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic,
+                    resource
+                )
+            ];
         }
 
-        return [new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic, resource)];
+        return [
+            new InvalidMacPythonInterpreterDiagnostic(
+                DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic,
+                resource
+            )
+        ];
     }
     public async handle(diagnostics: IDiagnostic[]): Promise<void> {
         if (diagnostics.length === 0) {
             return;
         }
-        const messageService = this.serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(IDiagnosticHandlerService, DiagnosticCommandPromptHandlerServiceId);
-        await Promise.all(diagnostics.map(async diagnostic => {
-            if (!this.canHandle(diagnostic)) {
-                return;
-            }
-            const commandPrompts = this.getCommandPrompts(diagnostic);
-            return messageService.handle(diagnostic, { commandPrompts, message: diagnostic.message });
-        }));
+        const messageService = this.serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(
+            IDiagnosticHandlerService,
+            DiagnosticCommandPromptHandlerServiceId
+        );
+        await Promise.all(
+            diagnostics.map(async diagnostic => {
+                if (!this.canHandle(diagnostic)) {
+                    return;
+                }
+                const commandPrompts = this.getCommandPrompts(diagnostic);
+                return messageService.handle(diagnostic, { commandPrompts, message: diagnostic.message });
+            })
+        );
     }
     protected addPythonPathChangedHandler() {
         const workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
@@ -99,7 +120,9 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
     }
     protected async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
         const workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
-        const workspacesUris: (Uri | undefined)[] = workspaceService.hasWorkspaceFolders ? workspaceService.workspaceFolders!.map(workspace => workspace.uri) : [undefined];
+        const workspacesUris: (Uri | undefined)[] = workspaceService.hasWorkspaceFolders
+            ? workspaceService.workspaceFolders!.map(workspace => workspace.uri)
+            : [undefined];
         const workspaceUriIndex = workspacesUris.findIndex(uri => event.affectsConfiguration('python.pythonPath', uri));
         if (workspaceUriIndex === -1) {
             return;
@@ -111,27 +134,42 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
         }
         this.timeOut = setTimeout(() => {
             this.timeOut = undefined;
-            this.diagnose(workspacesUris[workspaceUriIndex]).then(dianostics => this.handle(dianostics)).ignoreErrors();
+            this.diagnose(workspacesUris[workspaceUriIndex])
+                .then(diagnostics => this.handle(diagnostics))
+                .ignoreErrors();
         }, this.changeThrottleTimeout);
     }
     private getCommandPrompts(diagnostic: IDiagnostic): { prompt: string; command?: IDiagnosticCommand }[] {
         const commandFactory = this.serviceContainer.get<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory);
         switch (diagnostic.code) {
             case DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic: {
-                return [{
-                    prompt: 'Select Python Interpreter',
-                    command: commandFactory.createCommand(diagnostic, { type: 'executeVSCCommand', options: 'python.setInterpreter' })
-                }];
+                return [
+                    {
+                        prompt: 'Select Python Interpreter',
+                        command: commandFactory.createCommand(diagnostic, {
+                            type: 'executeVSCCommand',
+                            options: 'python.setInterpreter'
+                        })
+                    }
+                ];
             }
             case DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic: {
-                return [{
-                    prompt: 'Learn more',
-                    command: commandFactory.createCommand(diagnostic, { type: 'launch', options: 'https://code.visualstudio.com/docs/python/python-tutorial#_prerequisites' })
-                },
-                {
-                    prompt: 'Download',
-                    command: commandFactory.createCommand(diagnostic, { type: 'launch', options: 'https://www.python.org/downloads' })
-                }];
+                return [
+                    {
+                        prompt: 'Learn more',
+                        command: commandFactory.createCommand(diagnostic, {
+                            type: 'launch',
+                            options: 'https://code.visualstudio.com/docs/python/python-tutorial#_prerequisites'
+                        })
+                    },
+                    {
+                        prompt: 'Download',
+                        command: commandFactory.createCommand(diagnostic, {
+                            type: 'launch',
+                            options: 'https://www.python.org/downloads'
+                        })
+                    }
+                ];
             }
             default: {
                 throw new Error('Invalid diagnostic for \'InvalidMacPythonInterpreterService\'');

--- a/src/client/application/diagnostics/checks/powerShellActivation.ts
+++ b/src/client/application/diagnostics/checks/powerShellActivation.ts
@@ -8,7 +8,7 @@ import { DiagnosticSeverity } from 'vscode';
 import '../../../common/extensions';
 import { Logger } from '../../../common/logger';
 import { useCommandPromptAsDefaultShell } from '../../../common/terminal/commandPrompt';
-import { IConfigurationService, ICurrentProcess } from '../../../common/types';
+import { IConfigurationService, ICurrentProcess, Resource } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
@@ -21,10 +21,10 @@ import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../type
 const PowershellActivationNotSupportedWithBatchFilesMessage = 'Activation of the selected Python environment is not supported in PowerShell. Consider changing your shell to Command Prompt.';
 
 export class PowershellActivationNotAvailableDiagnostic extends BaseDiagnostic {
-    constructor() {
+    constructor(resource: Resource) {
         super(DiagnosticCodes.EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic,
             PowershellActivationNotSupportedWithBatchFilesMessage,
-            DiagnosticSeverity.Warning, DiagnosticScope.Global);
+            DiagnosticSeverity.Warning, DiagnosticScope.Global, resource);
     }
 }
 
@@ -37,7 +37,7 @@ export class PowerShellActivationHackDiagnosticsService extends BaseDiagnosticsS
         super([DiagnosticCodes.EnvironmentActivationInPowerShellWithBatchFilesNotSupportedDiagnostic], serviceContainer);
         this.messageService = serviceContainer.get<IDiagnosticHandlerService<MessageCommandPrompt>>(IDiagnosticHandlerService, DiagnosticCommandPromptHandlerServiceId);
     }
-    public async diagnose(): Promise<IDiagnostic[]> {
+    public async diagnose(_resource: Resource): Promise<IDiagnostic[]> {
         return [];
     }
     public async handle(diagnostics: IDiagnostic[]): Promise<void> {

--- a/src/client/application/diagnostics/types.ts
+++ b/src/client/application/diagnostics/types.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { DiagnosticSeverity, Uri } from 'vscode';
+import { Resource } from '../../common/types';
 import { DiagnosticCodes } from './constants';
 
 export enum DiagnosticScope {
@@ -16,12 +17,13 @@ export interface IDiagnostic {
     readonly message: string;
     readonly severity: DiagnosticSeverity;
     readonly scope: DiagnosticScope;
+    readonly resource: Resource;
 }
 
 export const IDiagnosticsService = Symbol('IDiagnosticsService');
 
 export interface IDiagnosticsService {
-    diagnose(): Promise<IDiagnostic[]>;
+    diagnose(resource: Resource): Promise<IDiagnostic[]>;
     canHandle(diagnostic: IDiagnostic): Promise<boolean>;
     handle(diagnostics: IDiagnostic[]): Promise<void>;
 }

--- a/src/client/application/types.ts
+++ b/src/client/application/types.ts
@@ -3,6 +3,8 @@
 
 'use strict';
 
+import { Resource } from '../common/types';
+
 export const IApplicationDiagnostics = Symbol('IApplicationDiagnostics');
 
 export interface IApplicationDiagnostics {
@@ -12,6 +14,6 @@ export interface IApplicationDiagnostics {
      * @returns {Promise<void>}
      * @memberof IApplicationDiagnostics
      */
-    performPreStartupHealthCheck(): Promise<void>;
+    performPreStartupHealthCheck(resource: Resource): Promise<void>;
     register(): void;
 }

--- a/src/client/common/terminal/activator/powershellFailedHandler.ts
+++ b/src/client/common/terminal/activator/powershellFailedHandler.ts
@@ -4,10 +4,11 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
-import { Terminal, Uri } from 'vscode';
+import { Terminal } from 'vscode';
 import { PowerShellActivationHackDiagnosticsServiceId, PowershellActivationNotAvailableDiagnostic } from '../../../application/diagnostics/checks/powerShellActivation';
 import { IDiagnosticsService } from '../../../application/diagnostics/types';
 import { IPlatformService } from '../../platform/types';
+import { Resource } from '../../types';
 import { ITerminalActivationHandler, ITerminalHelper, TerminalShellType } from '../types';
 
 @injectable()
@@ -16,7 +17,7 @@ export class PowershellTerminalActivationFailedHandler implements ITerminalActiv
         @inject(IPlatformService) private readonly platformService: IPlatformService,
         @inject(IDiagnosticsService) @named(PowerShellActivationHackDiagnosticsServiceId) private readonly diagnosticService: IDiagnosticsService) {
     }
-    public async handleActivation(_terminal: Terminal, resource: Uri | undefined, _preserveFocus: boolean, activated: boolean) {
+    public async handleActivation(_terminal: Terminal, resource: Resource, _preserveFocus: boolean, activated: boolean) {
         if (activated || !this.platformService.isWindows) {
             return;
         }
@@ -29,7 +30,7 @@ export class PowershellTerminalActivationFailedHandler implements ITerminalActiv
         if (!activationCommands || !Array.isArray(activationCommands) || activationCommands.length === 0) {
             return;
         }
-        this.diagnosticService.handle([new PowershellActivationNotAvailableDiagnostic()]).ignoreErrors();
+        this.diagnosticService.handle([new PowershellActivationNotAvailableDiagnostic(resource)]).ignoreErrors();
     }
 
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -132,7 +132,7 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
     // When testing, do not perform health checks, as modal dialogs can be displayed.
     if (!isTestExecution()) {
         const appDiagnostics = serviceContainer.get<IApplicationDiagnostics>(IApplicationDiagnostics);
-        await appDiagnostics.performPreStartupHealthCheck();
+        await appDiagnostics.performPreStartupHealthCheck(undefined);
     }
 
     serviceManager.get<ITerminalAutoActivation>(ITerminalAutoActivation).register();

--- a/src/test/activation/activationService.unit.test.ts
+++ b/src/test/activation/activationService.unit.test.ts
@@ -85,7 +85,7 @@ suite('Activation - ActivationService', () => {
                 } else {
                     diagnostics = [];
                 }
-                lsNotSupportedDiagnosticService.setup(l => l.diagnose()).returns(() => Promise.resolve(diagnostics));
+                lsNotSupportedDiagnosticService.setup(l => l.diagnose(undefined)).returns(() => Promise.resolve(diagnostics));
                 lsNotSupportedDiagnosticService.setup(l => l.handle(TypeMoq.It.isValue(diagnostics))).returns(() => Promise.resolve());
                 serviceContainer
                     .setup(c => c.get(TypeMoq.It.isValue(IExtensionActivator), TypeMoq.It.isValue(activatorName)))
@@ -282,7 +282,7 @@ suite('Activation - ActivationService', () => {
                     const activatorJedi = TypeMoq.Mock.ofType<IExtensionActivator>();
                     const activationService = new ExtensionActivationService(serviceContainer.object);
                     const diagnostics = [];
-                    lsNotSupportedDiagnosticService.setup(l => l.diagnose()).returns(() => Promise.resolve(diagnostics));
+                    lsNotSupportedDiagnosticService.setup(l => l.diagnose(undefined)).returns(() => Promise.resolve(diagnostics));
                     lsNotSupportedDiagnosticService.setup(l => l.handle(TypeMoq.It.isValue(diagnostics))).returns(() => Promise.resolve());
                     serviceContainer
                         .setup(c => c.get(TypeMoq.It.isValue(IExtensionActivator), TypeMoq.It.isValue(ExtensionActivators.DotNet)))

--- a/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
+++ b/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
@@ -59,20 +59,20 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
     });
 
     test('Performing Pre Startup Health Check must check Path environment variable and Debugger Type along with Mac Interpreter', async () => {
-        envHealthCheck.setup(e => e.diagnose())
+        envHealthCheck.setup(e => e.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve([]))
             .verifiable(typemoq.Times.once());
-        debuggerTypeCheck.setup(e => e.diagnose())
+        debuggerTypeCheck.setup(e => e.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve([]))
             .verifiable(typemoq.Times.once());
-        macInterperterCheck.setup(p => p.diagnose())
+        macInterperterCheck.setup(p => p.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve([]))
             .verifiable(typemoq.Times.once());
         macInterperterCheck.setup(p => p.handle(typemoq.It.isValue([])))
             .returns(() => Promise.resolve())
             .verifiable(typemoq.Times.once());
 
-        await appDiagnostics.performPreStartupHealthCheck();
+        await appDiagnostics.performPreStartupHealthCheck(undefined);
 
         envHealthCheck.verifyAll();
         debuggerTypeCheck.verifyAll();
@@ -80,7 +80,7 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
     });
 
     test('Diagnostics Returned by Per Startup Health Checks must be logged', async () => {
-        macInterperterCheck.setup(p => p.diagnose())
+        macInterperterCheck.setup(p => p.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve([]))
             .verifiable(typemoq.Times.once());
 
@@ -90,7 +90,8 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
                 code: `Error${i}` as any,
                 message: `Error${i}`,
                 scope: i % 2 === 0 ? DiagnosticScope.Global : DiagnosticScope.WorkspaceFolder,
-                severity: DiagnosticSeverity.Error
+                severity: DiagnosticSeverity.Error,
+                resource: undefined
             };
             diagnostics.push(diagnostic);
         }
@@ -99,7 +100,8 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
                 code: `Warning${i}` as any,
                 message: `Warning${i}`,
                 scope: i % 2 === 0 ? DiagnosticScope.Global : DiagnosticScope.WorkspaceFolder,
-                severity: DiagnosticSeverity.Warning
+                severity: DiagnosticSeverity.Warning,
+                resource: undefined
             };
             diagnostics.push(diagnostic);
         }
@@ -108,7 +110,8 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
                 code: `Info${i}` as any,
                 message: `Info${i}`,
                 scope: i % 2 === 0 ? DiagnosticScope.Global : DiagnosticScope.WorkspaceFolder,
-                severity: DiagnosticSeverity.Information
+                severity: DiagnosticSeverity.Information,
+                resource: undefined
             };
             diagnostics.push(diagnostic);
         }
@@ -138,14 +141,14 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
             }
         }
 
-        envHealthCheck.setup(e => e.diagnose())
+        envHealthCheck.setup(e => e.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve(diagnostics))
             .verifiable(typemoq.Times.once());
-        debuggerTypeCheck.setup(e => e.diagnose())
+        debuggerTypeCheck.setup(e => e.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve([]))
             .verifiable(typemoq.Times.once());
 
-        await appDiagnostics.performPreStartupHealthCheck();
+        await appDiagnostics.performPreStartupHealthCheck(undefined);
 
         envHealthCheck.verifyAll();
         debuggerTypeCheck.verifyAll();

--- a/src/test/application/diagnostics/checks/envPathVariable.unit.test.ts
+++ b/src/test/application/diagnostics/checks/envPathVariable.unit.test.ts
@@ -92,14 +92,14 @@ suite('Application Diagnostics - Checks Env Path Variable', () => {
         platformService.setup(p => p.isMac).returns(() => true);
         platformService.setup(p => p.isLinux).returns(() => false);
         platformService.setup(p => p.isWindows).returns(() => false);
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal([]);
     });
     test('Should return empty diagnostics for Linux', async () => {
         platformService.setup(p => p.isMac).returns(() => false);
         platformService.setup(p => p.isLinux).returns(() => true);
         platformService.setup(p => p.isWindows).returns(() => false);
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal([]);
     });
     test('Should return empty diagnostics for Windows if path variable is valid', async () => {
@@ -110,7 +110,7 @@ suite('Application Diagnostics - Checks Env Path Variable', () => {
         ].join(pathDelimiter);
         procEnv.setup(env => env[pathVariableName]).returns(() => paths);
 
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
 
         expect(diagnostics).to.be.deep.equal([]);
     });
@@ -123,7 +123,7 @@ suite('Application Diagnostics - Checks Env Path Variable', () => {
         ].join(pathDelimiter);
         procEnv.setup(env => env[pathVariableName]).returns(() => paths);
 
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
 
         expect(diagnostics).to.be.lengthOf(1);
         expect(diagnostics[0].code).to.be.equal(DiagnosticCodes.InvalidEnvironmentPathVariableDiagnostic);
@@ -140,7 +140,7 @@ suite('Application Diagnostics - Checks Env Path Variable', () => {
         platformService.setup(p => p.isWindows).returns(() => true);
         procEnv.setup(env => env[pathVariableName]).returns(() => paths);
 
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
 
         expect(diagnostics).to.be.lengthOf(0);
     });

--- a/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
@@ -73,7 +73,7 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         diagnostic.verifyAll();
     });
     test('Should return empty diagnostics', async () => {
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal([]);
     });
     test('InvalidPythonPathInDebuggerSettings diagnostic should display one option to with a command', async () => {

--- a/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
@@ -102,7 +102,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => true)
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
+            const diagnostics = await diagnosticService.diagnose(undefined);
             expect(diagnostics).to.be.deep.equal([]);
             platformService.verifyAll();
         });
@@ -112,7 +112,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => true)
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
+            const diagnostics = await diagnosticService.diagnose(undefined);
             expect(diagnostics).to.be.deep.equal([]);
             settings.verifyAll();
             platformService.verifyAll();
@@ -139,7 +139,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => false)
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
+            const diagnostics = await diagnosticService.diagnose(undefined);
             expect(diagnostics).to.be.deep.equal([]);
             settings.verifyAll();
             interpreterService.verifyAll();
@@ -171,7 +171,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => false)
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
+            const diagnostics = await diagnosticService.diagnose(undefined);
             expect(diagnostics).to.be.deep.equal([]);
             settings.verifyAll();
             interpreterService.verifyAll();
@@ -203,8 +203,8 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => true)
                 .verifiable(typemoq.Times.atLeastOnce());
 
-            const diagnostics = await diagnosticService.diagnose();
-            expect(diagnostics).to.be.deep.equal([new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic)]);
+            const diagnostics = await diagnosticService.diagnose(undefined);
+            expect(diagnostics).to.be.deep.equal([new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic, undefined)], 'not the same');
             settings.verifyAll();
             interpreterService.verifyAll();
             platformService.verifyAll();
@@ -241,15 +241,15 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => { return Promise.resolve({ type: InterpreterType.Unknown } as any); })
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
-            expect(diagnostics).to.be.deep.equal([new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic)]);
+            const diagnostics = await diagnosticService.diagnose(undefined);
+            expect(diagnostics).to.be.deep.equal([new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic, undefined)], 'not the same');
             settings.verifyAll();
             interpreterService.verifyAll();
             platformService.verifyAll();
             helper.verifyAll();
         });
         test('Handling no interpreters diagnostic should return select interpreter cmd', async () => {
-            const diagnostic = new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic);
+            const diagnostic = new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic, undefined);
             const cmd = {} as any as IDiagnosticCommand;
             let messagePrompt: MessageCommandPrompt | undefined;
             messageHandler
@@ -270,7 +270,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Select Python Interpreter', command: cmd }]);
         });
         test('Handling no interpreters diagnostisc should return download and learn links', async () => {
-            const diagnostic = new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic);
+            const diagnostic = new InvalidMacPythonInterpreterDiagnostic(DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic, undefined);
             const cmdDownload = {} as any as IDiagnosticCommand;
             const cmdLearn = {} as any as IDiagnosticCommand;
             let messagePrompt: MessageCommandPrompt | undefined;

--- a/src/test/application/diagnostics/checks/powerShellActivation.unit.test.ts
+++ b/src/test/application/diagnostics/checks/powerShellActivation.unit.test.ts
@@ -87,7 +87,7 @@ suite('Application Diagnostics - PowerShell Activation', () => {
         diagnostic.verifyAll();
     });
     test('Must return empty diagnostics', async () => {
-        const diagnostics = await diagnosticService.diagnose();
+        const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal([]);
     });
     test('Should display three options in message displayed with 4 commands', async () => {

--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -93,7 +93,7 @@ suite('xApplication Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => true)
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
+            const diagnostics = await diagnosticService.diagnose(undefined);
             expect(diagnostics).to.be.deep.equal([]);
             settings.verifyAll();
         });
@@ -107,13 +107,13 @@ suite('xApplication Diagnostics - Checks Python Interpreter', () => {
                 .returns(() => Promise.resolve(false))
                 .verifiable(typemoq.Times.once());
 
-            const diagnostics = await diagnosticService.diagnose();
-            expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic)]);
+            const diagnostics = await diagnosticService.diagnose(undefined);
+            expect(diagnostics).to.be.deep.equal([new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic, undefined)], 'not the same');
             settings.verifyAll();
             interpreterService.verifyAll();
         });
         test('Handling no interpreters diagnostic should return download link', async () => {
-            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic);
+            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic, undefined);
             const cmd = {} as any as IDiagnosticCommand;
             let messagePrompt: MessageCommandPrompt | undefined;
             messageHandler
@@ -135,7 +135,7 @@ suite('xApplication Diagnostics - Checks Python Interpreter', () => {
         });
         test('Handling no currently selected interpreter diagnostic should show select interpreter message', async () => {
             const diagnostic = new InvalidPythonInterpreterDiagnostic(
-                DiagnosticCodes.NoCurrentlySelectedPythonInterpreterDiagnostic
+                DiagnosticCodes.NoCurrentlySelectedPythonInterpreterDiagnostic, undefined
             );
             const cmd = {} as any as IDiagnosticCommand;
             let messagePrompt: MessageCommandPrompt | undefined;
@@ -157,7 +157,7 @@ suite('xApplication Diagnostics - Checks Python Interpreter', () => {
             expect(messagePrompt!.commandPrompts).to.be.deep.equal([{ prompt: 'Select Python Interpreter', command: cmd }]);
         });
         test('Handling no interpreters diagnostic should return select interpreter cmd', async () => {
-            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoCurrentlySelectedPythonInterpreterDiagnostic);
+            const diagnostic = new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoCurrentlySelectedPythonInterpreterDiagnostic, undefined);
             const cmd = {} as any as IDiagnosticCommand;
             let messagePrompt: MessageCommandPrompt | undefined;
             messageHandler

--- a/src/test/application/diagnostics/promptHandler.unit.test.ts
+++ b/src/test/application/diagnostics/promptHandler.unit.test.ts
@@ -30,7 +30,7 @@ suite('Application Diagnostics - PromptHandler', () => {
 
     getNamesAndValues<DiagnosticSeverity>(DiagnosticSeverity).forEach(severity => {
         test(`Handling a diagnositic of severity '${severity.name}' should display a message without any buttons`, async () => {
-            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value };
+            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value, resource: undefined };
             switch (severity.value) {
                 case DiagnosticSeverity.Error: {
                     appShell.setup(a => a.showErrorMessage(typemoq.It.isValue(diagnostic.message)))
@@ -53,7 +53,7 @@ suite('Application Diagnostics - PromptHandler', () => {
             appShell.verifyAll();
         });
         test(`Handling a diagnositic of severity '${severity.name}' should display a custom message with buttons`, async () => {
-            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value };
+            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value, resource: undefined };
             const options: MessageCommandPrompt = {
                 commandPrompts: [
                     { prompt: 'Yes' },
@@ -87,7 +87,7 @@ suite('Application Diagnostics - PromptHandler', () => {
             appShell.verifyAll();
         });
         test(`Handling a diagnositic of severity '${severity.name}' should display a custom message with buttons and invoke selected command`, async () => {
-            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value };
+            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value, resource: undefined };
             const command = typemoq.Mock.ofType<IDiagnosticCommand>();
             const options: MessageCommandPrompt = {
                 commandPrompts: [

--- a/src/test/interpreters/autoSelection/rules/cached.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/cached.unit.test.ts
@@ -18,7 +18,10 @@ import { InterpreterAutoSelectionService } from '../../../../client/interpreter/
 import { NextAction } from '../../../../client/interpreter/autoSelection/rules/baseRule';
 import { CachedInterpretersAutoSelectionRule } from '../../../../client/interpreter/autoSelection/rules/cached';
 import { SystemWideInterpretersAutoSelectionRule } from '../../../../client/interpreter/autoSelection/rules/system';
-import { IInterpreterAutoSelectionRule, IInterpreterAutoSelectionService } from '../../../../client/interpreter/autoSelection/types';
+import {
+    IInterpreterAutoSelectionRule,
+    IInterpreterAutoSelectionService
+} from '../../../../client/interpreter/autoSelection/types';
 import { IInterpreterHelper, PythonInterpreter } from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 
@@ -33,10 +36,16 @@ suite('Interpreters - Auto Selection - Cached Rule', () => {
     let helper: IInterpreterHelper;
     class CachedInterpretersAutoSelectionRuleTest extends CachedInterpretersAutoSelectionRule {
         public readonly rules!: IInterpreterAutoSelectionRule[];
-        public async setGlobalInterpreter(interpreter?: PythonInterpreter, manager?: IInterpreterAutoSelectionService): Promise<boolean> {
+        public async setGlobalInterpreter(
+            interpreter?: PythonInterpreter,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<boolean> {
             return super.setGlobalInterpreter(interpreter, manager);
         }
-        public async onAutoSelectInterpreter(resource: Resource, manager?: IInterpreterAutoSelectionService): Promise<NextAction> {
+        public async onAutoSelectInterpreter(
+            resource: Resource,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<NextAction> {
             return super.onAutoSelectInterpreter(resource, manager);
         }
     }
@@ -49,13 +58,20 @@ suite('Interpreters - Auto Selection - Cached Rule', () => {
         currentPathInterpreter = mock(SystemWideInterpretersAutoSelectionRule);
         winRegInterpreter = mock(SystemWideInterpretersAutoSelectionRule);
 
-        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(instance(state));
-        rule = new CachedInterpretersAutoSelectionRuleTest(instance(fs), instance(helper),
-            instance(stateFactory), instance(systemInterpreter),
-            instance(currentPathInterpreter), instance(winRegInterpreter));
+        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(
+            instance(state)
+        );
+        rule = new CachedInterpretersAutoSelectionRuleTest(
+            instance(fs),
+            instance(helper),
+            instance(stateFactory),
+            instance(systemInterpreter),
+            instance(currentPathInterpreter),
+            instance(winRegInterpreter)
+        );
     });
 
-    test('Invoke next rule if there are no cached intepreters', async () => {
+    test('Invoke next rule if there are no cached interpreters', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
 

--- a/src/test/interpreters/autoSelection/rules/currentPath.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/currentPath.unit.test.ts
@@ -18,7 +18,11 @@ import { InterpreterAutoSelectionService } from '../../../../client/interpreter/
 import { NextAction } from '../../../../client/interpreter/autoSelection/rules/baseRule';
 import { CurrentPathInterpretersAutoSelectionRule } from '../../../../client/interpreter/autoSelection/rules/currentPath';
 import { IInterpreterAutoSelectionService } from '../../../../client/interpreter/autoSelection/types';
-import { IInterpreterHelper, IInterpreterLocatorService, PythonInterpreter } from '../../../../client/interpreter/contracts';
+import {
+    IInterpreterHelper,
+    IInterpreterLocatorService,
+    PythonInterpreter
+} from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 import { KnownPathsService } from '../../../../client/interpreter/locators/services/KnownPathsService';
 
@@ -30,10 +34,16 @@ suite('Interpreters - Auto Selection - Current Path Rule', () => {
     let locator: IInterpreterLocatorService;
     let helper: IInterpreterHelper;
     class CurrentPathInterpretersAutoSelectionRuleTest extends CurrentPathInterpretersAutoSelectionRule {
-        public async setGlobalInterpreter(interpreter?: PythonInterpreter, manager?: IInterpreterAutoSelectionService): Promise<boolean> {
+        public async setGlobalInterpreter(
+            interpreter?: PythonInterpreter,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<boolean> {
             return super.setGlobalInterpreter(interpreter, manager);
         }
-        public async onAutoSelectInterpreter(resource: Resource, manager?: IInterpreterAutoSelectionService): Promise<NextAction> {
+        public async onAutoSelectInterpreter(
+            resource: Resource,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<NextAction> {
             return super.onAutoSelectInterpreter(resource, manager);
         }
     }
@@ -44,12 +54,18 @@ suite('Interpreters - Auto Selection - Current Path Rule', () => {
         helper = mock(InterpreterHelper);
         locator = mock(KnownPathsService);
 
-        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(instance(state));
-        rule = new CurrentPathInterpretersAutoSelectionRuleTest(instance(fs), instance(helper),
-            instance(stateFactory), instance(locator));
+        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(
+            instance(state)
+        );
+        rule = new CurrentPathInterpretersAutoSelectionRuleTest(
+            instance(fs),
+            instance(helper),
+            instance(stateFactory),
+            instance(locator)
+        );
     });
 
-    test('Invoke next rule if there are no intepreters in the current path', async () => {
+    test('Invoke next rule if there are no interpreters in the current path', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
 

--- a/src/test/interpreters/autoSelection/rules/system.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/system.unit.test.ts
@@ -30,10 +30,16 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
     let interpreterService: IInterpreterService;
     let helper: IInterpreterHelper;
     class SystemWideInterpretersAutoSelectionRuleTest extends SystemWideInterpretersAutoSelectionRule {
-        public async setGlobalInterpreter(interpreter?: PythonInterpreter, manager?: IInterpreterAutoSelectionService): Promise<boolean> {
+        public async setGlobalInterpreter(
+            interpreter?: PythonInterpreter,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<boolean> {
             return super.setGlobalInterpreter(interpreter, manager);
         }
-        public async onAutoSelectInterpreter(resource: Resource, manager?: IInterpreterAutoSelectionService): Promise<NextAction> {
+        public async onAutoSelectInterpreter(
+            resource: Resource,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<NextAction> {
             return super.onAutoSelectInterpreter(resource, manager);
         }
     }
@@ -44,12 +50,18 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
         helper = mock(InterpreterHelper);
         interpreterService = mock(InterpreterService);
 
-        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(instance(state));
-        rule = new SystemWideInterpretersAutoSelectionRuleTest(instance(fs), instance(helper),
-            instance(stateFactory), instance(interpreterService));
+        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(
+            instance(state)
+        );
+        rule = new SystemWideInterpretersAutoSelectionRuleTest(
+            instance(fs),
+            instance(helper),
+            instance(stateFactory),
+            instance(interpreterService)
+        );
     });
 
-    test('Invoke next rule if there are no intepreters in the current path', async () => {
+    test('Invoke next rule if there are no interpreters in the current path', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
         let setGlobalInterpreterInvoked = false;
@@ -67,7 +79,7 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
         expect(nextAction).to.be.equal(NextAction.runNextRule);
         expect(setGlobalInterpreterInvoked).to.be.equal(true, 'setGlobalInterpreter not invoked');
     });
-    test('Invoke next rule if there intepreters in the current path but update fails', async () => {
+    test('Invoke next rule if there interpreters in the current path but update fails', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
         let setGlobalInterpreterInvoked = false;
@@ -86,7 +98,7 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
         expect(nextAction).to.be.equal(NextAction.runNextRule);
         expect(setGlobalInterpreterInvoked).to.be.equal(true, 'setGlobalInterpreter not invoked');
     });
-    test('Do not Invoke next rule if there intepreters in the current path and update does not fail', async () => {
+    test('Do not Invoke next rule if there interpreters in the current path and update does not fail', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
         let setGlobalInterpreterInvoked = false;

--- a/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
@@ -26,7 +26,12 @@ import { WorkspaceVirtualEnvInterpretersAutoSelectionRule } from '../../../../cl
 import { IInterpreterAutoSelectionService } from '../../../../client/interpreter/autoSelection/types';
 import { PythonPathUpdaterService } from '../../../../client/interpreter/configuration/pythonPathUpdaterService';
 import { IPythonPathUpdaterServiceManager } from '../../../../client/interpreter/configuration/types';
-import { IInterpreterHelper, IInterpreterLocatorService, PythonInterpreter, WorkspacePythonPath } from '../../../../client/interpreter/contracts';
+import {
+    IInterpreterHelper,
+    IInterpreterLocatorService,
+    PythonInterpreter,
+    WorkspacePythonPath
+} from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 import { KnownPathsService } from '../../../../client/interpreter/locators/services/KnownPathsService';
 
@@ -42,7 +47,10 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
     let pythonPathUpdaterService: IPythonPathUpdaterServiceManager;
     let workspaceService: IWorkspaceService;
     class WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest extends WorkspaceVirtualEnvInterpretersAutoSelectionRule {
-        public async setGlobalInterpreter(interpreter?: PythonInterpreter, manager?: IInterpreterAutoSelectionService): Promise<boolean> {
+        public async setGlobalInterpreter(
+            interpreter?: PythonInterpreter,
+            manager?: IInterpreterAutoSelectionService
+        ): Promise<boolean> {
             return super.setGlobalInterpreter(interpreter, manager);
         }
         public async next(resource: Resource, manager?: IInterpreterAutoSelectionService): Promise<void> {
@@ -66,11 +74,19 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         virtualEnvLocator = mock(KnownPathsService);
         pythonPathUpdaterService = mock(PythonPathUpdaterService);
 
-        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(instance(state));
-        rule = new WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest(instance(fs), instance(helper),
-            instance(stateFactory), instance(platform),
-            instance(workspaceService), instance(pythonPathUpdaterService),
-            instance(pipEnvLocator), instance(virtualEnvLocator));
+        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(anything(), undefined)).thenReturn(
+            instance(state)
+        );
+        rule = new WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest(
+            instance(fs),
+            instance(helper),
+            instance(stateFactory),
+            instance(platform),
+            instance(workspaceService),
+            instance(pythonPathUpdaterService),
+            instance(pipEnvLocator),
+            instance(virtualEnvLocator)
+        );
     });
     test('Invoke next rule if there is no workspace', async () => {
         const nextRule = mock(BaseRuleService);
@@ -153,11 +169,17 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
 
         await rule.cacheSelectedInterpreter(resource, { path: pythonPath } as any);
 
-        verify(pythonPathUpdaterService.updatePythonPath(pythonPath, workspacePythonPath.configTarget, 'load', workspacePythonPath.folderUri)).once();
+        verify(
+            pythonPathUpdaterService.updatePythonPath(
+                pythonPath,
+                workspacePythonPath.configTarget,
+                'load',
+                workspacePythonPath.folderUri
+            )
+        ).once();
         verify(helper.getActiveWorkspaceUri(resource)).once();
     });
     test('getWorkspaceVirtualEnvInterpreters will not return any interpreters if there is no workspace ', async () => {
-
         let envs = await rule.getWorkspaceVirtualEnvInterpreters(undefined);
         expect(envs || []).to.be.lengthOf(0);
 
@@ -189,7 +211,11 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         const workspaceFolder: WorkspaceFolder = { name: '', index: 0, uri: folderUri };
         const resource = Uri.file('x');
 
-        when(virtualEnvLocator.getInterpreters(resource, true)).thenResolve([interpreter1, interpreter2, interpreter3] as any);
+        when(virtualEnvLocator.getInterpreters(resource, true)).thenResolve([
+            interpreter1,
+            interpreter2,
+            interpreter3
+        ] as any);
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn(workspaceFolder);
         when(platform.osType).thenReturn(OSType.Windows);
 
@@ -220,7 +246,11 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
             const workspaceFolder: WorkspaceFolder = { name: '', index: 0, uri: folderUri };
             const resource = Uri.file('x');
 
-            when(virtualEnvLocator.getInterpreters(resource, true)).thenResolve([interpreter1, interpreter2, interpreter3] as any);
+            when(virtualEnvLocator.getInterpreters(resource, true)).thenResolve([
+                interpreter1,
+                interpreter2,
+                interpreter3
+            ] as any);
             when(workspaceService.getWorkspaceFolder(resource)).thenReturn(workspaceFolder);
             when(platform.osType).thenReturn(osType);
 
@@ -317,7 +347,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         verify(helper.getActiveWorkspaceUri(resource)).atLeast(1);
         verify(manager.setWorkspaceInterpreter(folderUri, interpreterInfo)).once();
     });
-    test('Wait for virtualEnv if pipEnv completes without any intepreters', async () => {
+    test('Wait for virtualEnv if pipEnv completes without any interpreters', async () => {
         const folderUri = Uri.parse('Folder');
         type PythonPathInConfig = { workspaceFolderValue: string };
         const pythonPathInConfig = typemoq.Mock.ofType<PythonPathInConfig>();
@@ -348,7 +378,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         verify(helper.getActiveWorkspaceUri(resource)).atLeast(1);
         verify(manager.setWorkspaceInterpreter(folderUri, interpreterInfo)).once();
     });
-    test('Wait for pipEnv if VirtualEnv completes without any intepreters', async () => {
+    test('Wait for pipEnv if VirtualEnv completes without any interpreters', async () => {
         const folderUri = Uri.parse('Folder');
         type PythonPathInConfig = { workspaceFolderValue: string };
         const pythonPathInConfig = typemoq.Mock.ofType<PythonPathInConfig>();


### PR DESCRIPTION
For #3502 
First part of #3502

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [no] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
