### PR TITLE
Ensure configuration changes are debounced correctly

### DIFF
--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -24,11 +24,11 @@ import {
     IUnitTestSettings,
     IWorkspaceSymbolSettings
 } from './types';
+import { debounce } from './utils/decorators';
 import { SystemVariables } from './variables/systemVariables';
 
 // tslint:disable:no-require-imports no-var-requires
 const untildify = require('untildify');
-const _debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
 export class PythonSettings extends EventEmitter implements IPythonSettings {
     private static pythonSettings: Map<string, PythonSettings> = new Map<string, PythonSettings>();
@@ -377,7 +377,7 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
 
             // If workspace config changes, then we could have a cascading effect of on change events.
             // Let's defer the change notification.
-            _debounce(() => this.emit('change'), 1);
+            this.debounceChangeNotification();
         };
         this.disposables.push(this.InterpreterAutoSelectionService.onDidChangeAutoSelectedInterpreter(onDidChange.bind(this)));
         this.disposables.push(this.workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
@@ -390,6 +390,10 @@ export class PythonSettings extends EventEmitter implements IPythonSettings {
         if (initialConfig) {
             this.update(initialConfig);
         }
+    }
+    @debounce(1)
+    protected debounceChangeNotification() {
+        this.emit('change');
     }
 }
 


### PR DESCRIPTION
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
