### PR TITLE
Manually trigger creation of venvs to resolve flaky venv creation tests

### DIFF
--- a/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
+++ b/src/client/interpreter/locators/services/workspaceVirtualEnvWatcherService.ts
@@ -57,7 +57,7 @@ export class WorkspaceVirtualEnvWatcherService implements IInterpreterWatcher, D
         }
     }
     @traceDecorators.verbose('Intepreter Watcher change handler')
-    protected async createHandler(e: Uri) {
+    public async createHandler(e: Uri) {
         this.didCreate.fire();
         // On Windows, creation of environments are very slow, hence lets notify again after
         // the python executable is accessible (i.e. when we can launch the process).

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -36,19 +36,14 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
     const venvPrefix = '.venv';
     let serviceContainer: IServiceContainer;
 
-    async function manuallyTriggerFSWatcherInWorkspace(resource: Resource) {
-        // Monitoring files on virtualized environments can be finicky...
-        // Lets trigger the fs watcher manually for the tests.
-        const builder = serviceContainer.get<IInterpreterWatcherBuilder>(IInterpreterWatcherBuilder);
-        const watcher = await builder.getWorkspaceVirtualEnvInterpreterWatcher(resource) as WorkspaceVirtualEnvWatcherService;
-        watcher.createHandler(resource).ignoreErrors();
-    }
     async function manuallyTriggerFSWatcher(deferred: Deferred<void>) {
         // Monitoring files on virtualized environments can be finicky...
         // Lets trigger the fs watcher manually for the tests.
         const stopWatch = new StopWatch();
+        const builder = serviceContainer.get<IInterpreterWatcherBuilder>(IInterpreterWatcherBuilder);
+        const watcher = await builder.getWorkspaceVirtualEnvInterpreterWatcher(workspaceUri) as WorkspaceVirtualEnvWatcherService;
         while (!deferred.completed && stopWatch.elapsedTime < (timeoutMs - 10_000)) {
-            manuallyTriggerFSWatcherInWorkspace(workspaceUri).ignoreErrors();
+            watcher.createHandler(workspaceUri).ignoreErrors();
             await sleep(1000);
         }
     }

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -12,20 +12,19 @@ import '../../../client/common/extensions';
 import { createDeferredFromPromise, Deferred } from '../../../client/common/utils/async';
 import { StopWatch } from '../../../client/common/utils/stopWatch';
 import {
-    IInterpreterLocatorService, IInterpreterWatcherBuilder, WORKSPACE_VIRTUAL_ENV_SERVICE
+    IInterpreterLocatorService,
+    IInterpreterWatcherBuilder,
+    WORKSPACE_VIRTUAL_ENV_SERVICE
 } from '../../../client/interpreter/contracts';
 import { WorkspaceVirtualEnvWatcherService } from '../../../client/interpreter/locators/services/workspaceVirtualEnvWatcherService';
 import { IServiceContainer } from '../../../client/ioc/types';
-import {
-    deleteFiles, isOs, isPythonVersionInProcess, OSType,
-    PYTHON_PATH, rootWorkspaceUri, waitForCondition
-} from '../../common';
+import { deleteFiles, isPythonVersionInProcess, PYTHON_PATH, rootWorkspaceUri, waitForCondition } from '../../common';
 import { IS_MULTI_ROOT_TEST } from '../../constants';
 import { sleep } from '../../core';
-import { initialize, IS_VSTS, multirootPath } from '../../initialize';
+import { initialize, multirootPath } from '../../initialize';
 
 const timeoutMs = 60_000;
-suite('Interpreters - Workspace VirtualEnv Service', function () {
+suite('Interpreters - Workspace VirtualEnv Service', function() {
     this.timeout(timeoutMs);
     this.retries(0);
 
@@ -40,8 +39,10 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
         // Lets trigger the fs watcher manually for the tests.
         const stopWatch = new StopWatch();
         const builder = serviceContainer.get<IInterpreterWatcherBuilder>(IInterpreterWatcherBuilder);
-        const watcher = await builder.getWorkspaceVirtualEnvInterpreterWatcher(workspaceUri) as WorkspaceVirtualEnvWatcherService;
-        while (!deferred.completed && stopWatch.elapsedTime < (timeoutMs - 10_000)) {
+        const watcher = (await builder.getWorkspaceVirtualEnvInterpreterWatcher(
+            workspaceUri
+        )) as WorkspaceVirtualEnvWatcherService;
+        while (!deferred.completed && stopWatch.elapsedTime < timeoutMs - 10_000) {
             watcher.createHandler(workspaceUri).ignoreErrors();
             await sleep(1000);
         }
@@ -51,7 +52,11 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
             const items = await locator.getInterpreters(workspaceUri);
             return items.some(item => item.envName === envNameToLookFor);
         };
-        const promise = waitForCondition(predicate, timeoutMs, `${envNameToLookFor}, Environment not detected in the workspace ${workspaceUri.fsPath}`);
+        const promise = waitForCondition(
+            predicate,
+            timeoutMs,
+            `${envNameToLookFor}, Environment not detected in the workspace ${workspaceUri.fsPath}`
+        );
         const deferred = createDeferredFromPromise(promise);
         manuallyTriggerFSWatcher(deferred).ignoreErrors();
         await deferred.promise;
@@ -60,32 +65,34 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
         // Ensure env is random to avoid conflicts in tests (currupting test data).
         const envName = `${venvPrefix}${envSuffix}${new Date().getTime().toString()}`;
         return new Promise<string>((resolve, reject) => {
-            exec(`${PYTHON_PATH.fileToCommandArgument()} -m venv ${envName}`, { cwd: workspaceUri.fsPath }, (ex, _, stderr) => {
-                if (ex) {
-                    return reject(ex);
+            exec(
+                `${PYTHON_PATH.fileToCommandArgument()} -m venv ${envName}`,
+                { cwd: workspaceUri.fsPath },
+                (ex, _, stderr) => {
+                    if (ex) {
+                        return reject(ex);
+                    }
+                    if (stderr && stderr.length > 0) {
+                        reject(new Error(`Failed to create Env ${envName}, ${PYTHON_PATH}, Error: ${stderr}`));
+                    } else {
+                        resolve(envName);
+                    }
                 }
-                if (stderr && stderr.length > 0) {
-                    reject(new Error(`Failed to create Env ${envName}, ${PYTHON_PATH}, Error: ${stderr}`));
-                } else {
-                    resolve(envName);
-                }
-            });
+            );
         });
     }
 
-    suiteSetup(async function () {
-        // skip for Linux CI, see #3848
-        if (isOs(OSType.Linux) && IS_VSTS) {
-            return this.skip();
-        }
-
+    suiteSetup(async function() {
         // skip for Python < 3, no venv support
         if (await isPythonVersionInProcess(undefined, '2')) {
             return this.skip();
         }
 
         serviceContainer = (await initialize()).serviceContainer;
-        locator = serviceContainer.get<IInterpreterLocatorService>(IInterpreterLocatorService, WORKSPACE_VIRTUAL_ENV_SERVICE);
+        locator = serviceContainer.get<IInterpreterLocatorService>(
+            IInterpreterLocatorService,
+            WORKSPACE_VIRTUAL_ENV_SERVICE
+        );
         // This test is required, we need to wait for interpreter listing completes,
         // before proceeding with other tests.
         await deleteFiles(path.join(workspaceUri.fsPath, `${venvPrefix}*`));
@@ -109,7 +116,7 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
         await waitForInterpreterToBeDetected(env2);
     });
 
-    test('Detect a new Virtual Environment, and other workspace folder must not be affected (multiroot)', async function () {
+    test('Detect a new Virtual Environment, and other workspace folder must not be affected (multiroot)', async function() {
         if (!IS_MULTI_ROOT_TEST) {
             return this.skip();
         }
@@ -117,7 +124,10 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
         let items4 = await locator.getInterpreters(workspace4);
         expect(items4).to.be.lengthOf(0);
 
-        const [env1, env2] = await Promise.all([createVirtualEnvironment('first3'), createVirtualEnvironment('second3')]);
+        const [env1, env2] = await Promise.all([
+            createVirtualEnvironment('first3'),
+            createVirtualEnvironment('second3')
+        ]);
         await Promise.all([waitForInterpreterToBeDetected(env1), waitForInterpreterToBeDetected(env2)]);
 
         // Workspace4 should still not have any interpreters.

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -48,7 +48,6 @@ suite('Interpreters - Workspace VirtualEnv Service', function () {
         // Lets trigger the fs watcher manually for the tests.
         const stopWatch = new StopWatch();
         while (!deferred.completed && stopWatch.elapsedTime < (timeoutMs - 10_000)) {
-            manuallyTriggerFSWatcherInWorkspace(workspace4).ignoreErrors();
             manuallyTriggerFSWatcherInWorkspace(workspaceUri).ignoreErrors();
             await sleep(1000);
         }

--- a/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
+++ b/src/test/interpreters/locators/workspaceVirtualEnvService.test.ts
@@ -9,7 +9,6 @@ import { exec } from 'child_process';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import '../../../client/common/extensions';
-import { Resource } from '../../../client/common/types';
 import { createDeferredFromPromise, Deferred } from '../../../client/common/utils/async';
 import { StopWatch } from '../../../client/common/utils/stopWatch';
 import {


### PR DESCRIPTION
For #3848

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
