### PR TITLE
Ensure type definition files in node_modules/@jupyterlab compile in strict mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
         "obj": true,
         "bin": true,
         "**/__pycache__": true,
-        "node_modules": true,
+        "node_modules": false,
         ".vscode-test": true,
         "**/.mypy_cache/**": true,
         "**/.ropeproject/**": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
         "obj": true,
         "bin": true,
         "**/__pycache__": true,
-        "node_modules": false,
+        "node_modules": true,
         ".vscode-test": true,
         "**/.mypy_cache/**": true,
         "**/.ropeproject/**": true

--- a/build/ci/postInstall.js
+++ b/build/ci/postInstall.js
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const path = require("path");
+const constants_1 = require("../constants");
+/**
+ * In order to compile the extension in strict mode, one of the dependencies (@jupyterlab) has some files that
+ * just won't compile in strict mode.
+ * Unfortunately we cannot fix it by overriding their type definitions
+ * Note: that has been done for a few of the JupyterLabl files (see typings/index.d.ts).
+ * The solution is to modify the type definition file after `npm install`.
+ */
+function fixJupyterLabDTSFiles() {
+    const filePath = path.join(constants_1.ExtensionRootDir, 'node_modules', '@jupyterlab', 'coreutils', 'lib', 'settingregistry.d.ts');
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Type Definition file from JupyterLab not found '${filePath}' (pvsc post install script)`);
+    }
+    const fileContents = fs.readFileSync(filePath, { encoding: 'utf8' });
+    const replacedText = fileContents.replace('[key: string]: ISchema;', '[key: string]: ISchema | undefined;');
+    if (fileContents === replacedText) {
+        throw new Error('Fix for JupyterLabl file \'settingregistry.d.ts\' failed (pvsc post install script)');
+    }
+    fs.writeFileSync(filePath, replacedText);
+}
+fixJupyterLabDTSFiles();

--- a/build/ci/postInstall.ts
+++ b/build/ci/postInstall.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ExtensionRootDir } from '../constants';
+
+/**
+ * In order to compile the extension in strict mode, one of the dependencies (@jupyterlab) has some files that
+ * just won't compile in strict mode.
+ * Unfortunately we cannot fix it by overriding their type definitions
+ * Note: that has been done for a few of the JupyterLabl files (see typings/index.d.ts).
+ * The solution is to modify the type definition file after `npm install`.
+ */
+function fixJupyterLabDTSFiles() {
+    const filePath = path.join(
+        ExtensionRootDir,
+        'node_modules',
+        '@jupyterlab',
+        'coreutils',
+        'lib',
+        'settingregistry.d.ts'
+    );
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Type Definition file from JupyterLab not found '${filePath}' (pvsc post install script)`);
+    }
+
+    const fileContents = fs.readFileSync(filePath, { encoding: 'utf8' });
+    const replacedText = fileContents.replace('[key: string]: ISchema;', '[key: string]: ISchema | undefined;');
+    if (fileContents === replacedText) {
+        throw new Error('Fix for JupyterLabl file \'settingregistry.d.ts\' failed (pvsc post install script)');
+    }
+    fs.writeFileSync(filePath, replacedText);
+}
+
+fixJupyterLabDTSFiles();

--- a/build/webpack/webpack.debugadapter.config.js
+++ b/build/webpack/webpack.debugadapter.config.js
@@ -4,7 +4,6 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const path = require("path");
 const tsconfig_paths_webpack_plugin_1 = require("tsconfig-paths-webpack-plugin");
-const webpack_1 = require("webpack");
 const constants_1 = require("../constants");
 const common_1 = require("./common");
 // tslint:disable-next-line:no-var-requires no-require-imports

--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -4,7 +4,6 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const path = require("path");
 const tsconfig_paths_webpack_plugin_1 = require("tsconfig-paths-webpack-plugin");
-const webpack_1 = require("webpack");
 const constants_1 = require("../constants");
 const common_1 = require("./common");
 // tslint:disable-next-line:no-var-requires no-require-imports

--- a/package.json
+++ b/package.json
@@ -1826,7 +1826,7 @@
         "dump-datascience-webpack-stats": "webpack --config webpack.datascience-ui.config.js --profile --json > tmp/ds-stats.json",
         "compile-webviews": "gulp compile-webviews",
         "compile-webviews-verbose": "npx webpack --config webpack.datascience-ui.config.js",
-        "postinstall": "node ./node_modules/vscode/bin/install",
+        "postinstall": "node ./node_modules/vscode/bin/install && node ./build/ci/postInstall.js",
         "test": "node ./out/test/standardTest.js && node ./out/test/multiRootTest.js",
         "test:unittests": "mocha --require source-map-support/register --opts ./build/.mocha.unittests.opts",
         "test:unittests:cover": "nyc --nycrc-path ./build/.nycrc npm run test:unittests",


### PR DESCRIPTION
For #611
Part of a fix for #611

Fix:
* Change the a block of code in a type definition file from `[key: string]: ISchema;` to `[key: string]: ISchema | undefined;`.
* I.e. just add `| undefined`

@rchiodo 	@IanMatthewHuff 	
As you can see below, I have overridden a few of the type definition files to resolve this sctrict stuff without modifying any npm packages.
However one of the files cannot be overridden in this manner due to the way the files have been import in the jupyter code (i.e. as far as i know it cannot be done).
Hence the solution to modify one line of code to make something optional.

 a look at https://github.com/Microsoft/vscode-python/blob/ae1848a82f5af8983f663d5d4db2c4f77ad62c57/typings/index.d.ts#L4

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [c] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
