### PR TITLE
Activation of multiple parts of the extension for multiple workspaces

### DIFF
--- a/news/2 Fixes/3501.md
+++ b/news/2 Fixes/3501.md
@@ -1,0 +1,1 @@
+Auto-select virtual environment in multi-root workspaces

--- a/news/2 Fixes/3502.md
+++ b/news/2 Fixes/3502.md
@@ -1,0 +1,1 @@
+Validate interpreter in multi-root workspaces

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -35,7 +35,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         }
     }
     public async activate(): Promise<void> {
-        this.initialize();
+        await this.initialize();
         this.activateWorkspace(this.getActiveResource()).ignoreErrors();
     }
     protected async initialize() {
@@ -70,7 +70,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
             return;
         }
         const folder = this.workspaceService.getWorkspaceFolder(doc.uri);
-        this.activateWorkspace(folder ? folder.uri : undefined);
+        this.activateWorkspace(folder ? folder.uri : undefined).ignoreErrors();
     }
     @traceDecorators.error('Failed to activate a worksapce')
     protected async activateWorkspace(resource: Resource) {

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -26,7 +26,9 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         @inject(IInterpreterAutoSelectionService) private readonly autoSelection: IInterpreterAutoSelectionService,
         @inject(IApplicationDiagnostics) private readonly appDiagnostics: IApplicationDiagnostics,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
-    ) {}
+    ) {
+        this.addHandlers();
+    }
 
     public dispose() {
         while (this.disposables.length > 0) {
@@ -36,14 +38,12 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
     }
     public async activate(): Promise<void> {
         await this.initialize();
-        this.activateWorkspace(this.getActiveResource()).ignoreErrors();
+        await this.activateWorkspace(this.getActiveResource());
     }
     protected async initialize() {
         // Get latest interpreter list.
         const mainWorkspaceUri = this.getActiveResource();
         this.interpreterService.getInterpreters(mainWorkspaceUri).ignoreErrors();
-
-        await this.autoSelection.autoSelectInterpreter(undefined);
     }
     protected addHandlers() {
         this.workspaceService.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged, this, this.disposables);

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { inject, multiInject } from 'inversify';
+import { inject, injectable, multiInject } from 'inversify';
 import { TextDocument, workspace } from 'vscode';
 import { IApplicationDiagnostics } from '../application/types';
 import { IDocumentManager, IWorkspaceService } from '../common/application/types';
@@ -14,6 +14,7 @@ import { IInterpreterAutoSelectionService } from '../interpreter/autoSelection/t
 import { IInterpreterService } from '../interpreter/contracts';
 import { IExtensionActivationManager, IExtensionActivationService } from './types';
 
+@injectable()
 export class ExtensionActivationManager implements IExtensionActivationManager {
     private readonly disposables: IDisposable[] = [];
     private docOpenedHandler?: IDisposable;
@@ -80,8 +81,9 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
 
         // When testing, do not perform health checks, as modal dialogs can be displayed.
         if (!isTestExecution()) {
-            await this.appDiagnostics.performPreStartupHealthCheck(undefined);
+            await this.appDiagnostics.performPreStartupHealthCheck(resource);
         }
+        await this.autoSelection.autoSelectInterpreter(resource);
     }
     protected getWorkspaceKey(resource: Resource) {
         if (!resource) {

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -18,7 +18,7 @@ import { IExtensionActivationManager, IExtensionActivationService } from './type
 export class ExtensionActivationManager implements IExtensionActivationManager {
     private readonly disposables: IDisposable[] = [];
     private docOpenedHandler?: IDisposable;
-    private readonly activatedWorksapces = new Set<string>();
+    private readonly activatedWorkspaces = new Set<string>();
     constructor(
         @multiInject(IExtensionActivationService) private readonly activationServices: IExtensionActivationService[],
         @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
@@ -67,7 +67,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
     }
     protected onDocOpened(doc: TextDocument) {
         const key = this.getWorkspaceKey(doc.uri);
-        if (this.activatedWorksapces.has(key)) {
+        if (this.activatedWorkspaces.has(key)) {
             return;
         }
         const folder = this.workspaceService.getWorkspaceFolder(doc.uri);
@@ -76,7 +76,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
     @traceDecorators.error('Failed to activate a worksapce')
     protected async activateWorkspace(resource: Resource) {
         const key = this.getWorkspaceKey(resource);
-        this.activatedWorksapces.add(key);
+        this.activatedWorkspaces.add(key);
 
         await Promise.all(this.activationServices.map(item => item.activate(resource)));
 

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -48,8 +48,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         this.disposables.push(this.workspaceService.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged, this));
     }
     protected addRemoveDocOpenedHandlers() {
-        if (this.hasMultipleWorkspaces() && !this.docOpenedHandler) {
-            this.docOpenedHandler = this.documentManager.onDidOpenTextDocument(this.onDocOpened, this);
+        if (this.hasMultipleWorkspaces()) {
+            if (!this.docOpenedHandler) {
+                this.docOpenedHandler = this.documentManager.onDidOpenTextDocument(this.onDocOpened, this);
+            }
             return;
         }
         if (this.docOpenedHandler) {

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -26,9 +26,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         @inject(IInterpreterAutoSelectionService) private readonly autoSelection: IInterpreterAutoSelectionService,
         @inject(IApplicationDiagnostics) private readonly appDiagnostics: IApplicationDiagnostics,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
-    ) {
-        this.addHandlers();
-    }
+    ) { }
 
     public dispose() {
         while (this.disposables.length > 0) {
@@ -44,9 +42,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         // Get latest interpreter list.
         const mainWorkspaceUri = this.getActiveResource();
         this.interpreterService.getInterpreters(mainWorkspaceUri).ignoreErrors();
+        this.addHandlers();
     }
     protected addHandlers() {
-        this.workspaceService.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged, this, this.disposables);
+        this.disposables.push(this.workspaceService.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged, this));
     }
     protected addRemoveDocOpenedHandlers() {
         if (this.hasMultipleWorkspaces() && !this.docOpenedHandler) {

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -33,6 +33,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
             const disposable = this.disposables.shift();
             disposable.dispose();
         }
+        if (this. docOpenedHandler){
+            this.docOpenedHandler.dispose();
+            this.docOpenedHandler = undefined;
+        }
     }
     public async activate(): Promise<void> {
         await this.initialize();

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, multiInject } from 'inversify';
+import { TextDocument, workspace } from 'vscode';
+import { IApplicationDiagnostics } from '../application/types';
+import { IDocumentManager, IWorkspaceService } from '../common/application/types';
+import { isTestExecution } from '../common/constants';
+import { traceDecorators } from '../common/logger';
+import { IDisposable, Resource } from '../common/types';
+import { IInterpreterAutoSelectionService } from '../interpreter/autoSelection/types';
+import { IInterpreterService } from '../interpreter/contracts';
+import { IExtensionActivationManager, IExtensionActivationService } from './types';
+
+export class ExtensionActivationManager implements IExtensionActivationManager {
+    private readonly disposables: IDisposable[] = [];
+    private docOpenedHandler?: IDisposable;
+    private readonly activatedWorksapces = new Set<string>();
+    constructor(
+        @multiInject(IExtensionActivationService) private readonly activationServices: IExtensionActivationService[],
+        @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
+        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        @inject(IInterpreterAutoSelectionService) private readonly autoSelection: IInterpreterAutoSelectionService,
+        @inject(IApplicationDiagnostics) private readonly appDiagnostics: IApplicationDiagnostics,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
+    ) {}
+
+    public dispose() {
+        while (this.disposables.length > 0) {
+            const disposable = this.disposables.shift();
+            disposable.dispose();
+        }
+    }
+    public async activate(): Promise<void> {
+        this.initialize();
+        this.activateWorkspace(this.getActiveResource()).ignoreErrors();
+    }
+    protected async initialize() {
+        // Get latest interpreter list.
+        const mainWorkspaceUri = this.getActiveResource();
+        this.interpreterService.getInterpreters(mainWorkspaceUri).ignoreErrors();
+
+        await this.autoSelection.autoSelectInterpreter(undefined);
+    }
+    protected addHandlers() {
+        this.workspaceService.onDidChangeWorkspaceFolders(this.onWorkspaceFoldersChanged, this, this.disposables);
+    }
+    protected addRemoveDocOpenedHandlers() {
+        if (this.hasMultipleWorkspaces() && !this.docOpenedHandler) {
+            this.docOpenedHandler = this.documentManager.onDidOpenTextDocument(this.onDocOpened, this);
+            return;
+        }
+        if (this.docOpenedHandler) {
+            this.docOpenedHandler.dispose();
+            this.docOpenedHandler = undefined;
+        }
+    }
+    protected onWorkspaceFoldersChanged() {
+        this.addRemoveDocOpenedHandlers();
+    }
+    protected hasMultipleWorkspaces() {
+        return this.workspaceService.hasWorkspaceFolders && this.workspaceService.workspaceFolders.length > 1;
+    }
+    protected onDocOpened(doc: TextDocument) {
+        const key = this.getWorkspaceKey(doc.uri);
+        if (this.activatedWorksapces.has(key)) {
+            return;
+        }
+        const folder = this.workspaceService.getWorkspaceFolder(doc.uri);
+        this.activateWorkspace(folder ? folder.uri : undefined);
+    }
+    @traceDecorators.error('Failed to activate a worksapce')
+    protected async activateWorkspace(resource: Resource) {
+        const key = this.getWorkspaceKey(resource);
+        this.activatedWorksapces.add(key);
+
+        await Promise.all(this.activationServices.map(item => item.activate(resource)));
+
+        // When testing, do not perform health checks, as modal dialogs can be displayed.
+        if (!isTestExecution()) {
+            await this.appDiagnostics.performPreStartupHealthCheck(undefined);
+        }
+    }
+    protected getWorkspaceKey(resource: Resource) {
+        if (!resource) {
+            return '';
+        }
+        const workspaceFolder = this.workspaceService.getWorkspaceFolder(resource);
+        if (!workspaceFolder) {
+            return '';
+        }
+        return workspaceFolder.uri.fsPath;
+    }
+    private getActiveResource(): Resource {
+        if (this.documentManager.activeTextEditor && !this.documentManager.activeTextEditor.document.isUntitled) {
+            return this.documentManager.activeTextEditor.document.uri;
+        }
+        return Array.isArray(this.workspaceService.workspaceFolders) && workspace.workspaceFolders.length > 0
+            ? workspace.workspaceFolders[0].uri
+            : undefined;
+    }
+}

--- a/src/client/activation/jedi.ts
+++ b/src/client/activation/jedi.ts
@@ -21,10 +21,10 @@ import { OnTypeFormattingDispatcher } from '../typeFormatters/dispatcher';
 import { OnEnterFormatter } from '../typeFormatters/onEnterFormatter';
 import { IUnitTestManagementService } from '../unittests/types';
 import { WorkspaceSymbols } from '../workspaceSymbols/main';
-import { IExtensionActivator } from './types';
+import { ILanguageServerActivator } from './types';
 
 @injectable()
-export class JediExtensionActivator implements IExtensionActivator {
+export class JediExtensionActivator implements ILanguageServerActivator {
     private readonly context: IExtensionContext;
     private jediFactory?: JediFactory;
     private readonly documentSelector: DocumentFilter[];
@@ -36,19 +36,36 @@ export class JediExtensionActivator implements IExtensionActivator {
     public async activate(): Promise<void> {
         const context = this.context;
 
-        const jediFactory = this.jediFactory = new JediFactory(context.asAbsolutePath('.'), this.serviceManager);
+        const jediFactory = (this.jediFactory = new JediFactory(context.asAbsolutePath('.'), this.serviceManager));
         context.subscriptions.push(jediFactory);
         context.subscriptions.push(...activateGoToObjectDefinitionProvider(jediFactory));
 
         context.subscriptions.push(jediFactory);
-        context.subscriptions.push(languages.registerRenameProvider(this.documentSelector, new PythonRenameProvider(this.serviceManager)));
+        context.subscriptions.push(
+            languages.registerRenameProvider(this.documentSelector, new PythonRenameProvider(this.serviceManager))
+        );
         const definitionProvider = new PythonDefinitionProvider(jediFactory);
 
         context.subscriptions.push(languages.registerDefinitionProvider(this.documentSelector, definitionProvider));
-        context.subscriptions.push(languages.registerHoverProvider(this.documentSelector, new PythonHoverProvider(jediFactory)));
-        context.subscriptions.push(languages.registerReferenceProvider(this.documentSelector, new PythonReferenceProvider(jediFactory)));
-        context.subscriptions.push(languages.registerCompletionItemProvider(this.documentSelector, new PythonCompletionItemProvider(jediFactory, this.serviceManager), '.'));
-        context.subscriptions.push(languages.registerCodeLensProvider(this.documentSelector, this.serviceManager.get<IShebangCodeLensProvider>(IShebangCodeLensProvider)));
+        context.subscriptions.push(
+            languages.registerHoverProvider(this.documentSelector, new PythonHoverProvider(jediFactory))
+        );
+        context.subscriptions.push(
+            languages.registerReferenceProvider(this.documentSelector, new PythonReferenceProvider(jediFactory))
+        );
+        context.subscriptions.push(
+            languages.registerCompletionItemProvider(
+                this.documentSelector,
+                new PythonCompletionItemProvider(jediFactory, this.serviceManager),
+                '.'
+            )
+        );
+        context.subscriptions.push(
+            languages.registerCodeLensProvider(
+                this.documentSelector,
+                this.serviceManager.get<IShebangCodeLensProvider>(IShebangCodeLensProvider)
+            )
+        );
 
         const onTypeDispatcher = new OnTypeFormattingDispatcher({
             '\n': new OnEnterFormatter(),
@@ -56,7 +73,14 @@ export class JediExtensionActivator implements IExtensionActivator {
         });
         const onTypeTriggers = onTypeDispatcher.getTriggerCharacters();
         if (onTypeTriggers) {
-            context.subscriptions.push(languages.registerOnTypeFormattingEditProvider(PYTHON, onTypeDispatcher, onTypeTriggers.first, ...onTypeTriggers.more));
+            context.subscriptions.push(
+                languages.registerOnTypeFormattingEditProvider(
+                    PYTHON,
+                    onTypeDispatcher,
+                    onTypeTriggers.first,
+                    ...onTypeTriggers.more
+                )
+            );
         }
 
         const serviceContainer = this.serviceManager.get<IServiceContainer>(IServiceContainer);
@@ -67,13 +91,23 @@ export class JediExtensionActivator implements IExtensionActivator {
 
         const pythonSettings = this.serviceManager.get<IConfigurationService>(IConfigurationService).getSettings();
         if (pythonSettings.devOptions.indexOf('DISABLE_SIGNATURE') === -1) {
-            context.subscriptions.push(languages.registerSignatureHelpProvider(this.documentSelector, new PythonSignatureProvider(jediFactory), '(', ','));
+            context.subscriptions.push(
+                languages.registerSignatureHelpProvider(
+                    this.documentSelector,
+                    new PythonSignatureProvider(jediFactory),
+                    '(',
+                    ','
+                )
+            );
         }
 
-        context.subscriptions.push(languages.registerRenameProvider(PYTHON, new PythonRenameProvider(serviceContainer)));
+        context.subscriptions.push(
+            languages.registerRenameProvider(PYTHON, new PythonRenameProvider(serviceContainer))
+        );
 
         const testManagementService = this.serviceManager.get<IUnitTestManagementService>(IUnitTestManagementService);
-        testManagementService.activate()
+        testManagementService
+            .activate()
             .then(() => testManagementService.activateCodeLenses(symbolProvider))
             .catch(ex => this.serviceManager.get<ILogger>(ILogger).logError('Failed to activate Unit Tests', ex));
     }

--- a/src/client/activation/languageServer/activator.ts
+++ b/src/client/activation/languageServer/activator.ts
@@ -10,26 +10,36 @@ import { traceDecorators } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 import { IConfigurationService, Resource } from '../../common/types';
 import { EXTENSION_ROOT_DIR } from '../../constants';
-import { IExtensionActivator, ILanguageServerDownloader, ILanguageServerFolderService, ILanguageServerManager } from '../types';
+import {
+    ILanguageServerActivator,
+    ILanguageServerDownloader,
+    ILanguageServerFolderService,
+    ILanguageServerManager
+} from '../types';
 
 /**
  * Starts the language server managers per workspaces (currently one for first workspace).
  *
  * @export
  * @class LanguageServerExtensionActivator
- * @implements {IExtensionActivator}
+ * @implements {ILanguageServerActivator}
  */
 @injectable()
-export class LanguageServerExtensionActivator implements IExtensionActivator {
-    constructor(@inject(ILanguageServerManager) private readonly manager: ILanguageServerManager,
+export class LanguageServerExtensionActivator implements ILanguageServerActivator {
+    constructor(
+        @inject(ILanguageServerManager) private readonly manager: ILanguageServerManager,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(ILanguageServerDownloader) private readonly lsDownloader: ILanguageServerDownloader,
-        @inject(ILanguageServerFolderService) private readonly languageServerFolderService: ILanguageServerFolderService,
-        @inject(IConfigurationService) private readonly configurationService: IConfigurationService) { }
+        @inject(ILanguageServerFolderService)
+        private readonly languageServerFolderService: ILanguageServerFolderService,
+        @inject(IConfigurationService) private readonly configurationService: IConfigurationService
+    ) {}
     @traceDecorators.error('Failed to activate language server')
     public async activate(): Promise<void> {
-        const mainWorkspaceUri = this.workspace.hasWorkspaceFolders ? this.workspace.workspaceFolders![0].uri : undefined;
+        const mainWorkspaceUri = this.workspace.hasWorkspaceFolders
+            ? this.workspace.workspaceFolders![0].uri
+            : undefined;
         await this.ensureLanguageServerIsAvailable(mainWorkspaceUri);
         await this.manager.start(mainWorkspaceUri);
     }
@@ -45,7 +55,7 @@ export class LanguageServerExtensionActivator implements IExtensionActivator {
         const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName();
         const languageServerFolderPath = path.join(EXTENSION_ROOT_DIR, languageServerFolder);
         const mscorlib = path.join(languageServerFolderPath, 'mscorlib.dll');
-        if (!await this.fs.fileExists(mscorlib)) {
+        if (!(await this.fs.fileExists(mscorlib))) {
             await this.lsDownloader.downloadLanguageServer(languageServerFolderPath);
         }
     }

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -9,7 +9,8 @@ import { DataScienceSurveyBanner } from '../datascience/dataScienceSurveyBanner'
 import { IServiceManager } from '../ioc/types';
 import { LanguageServerSurveyBanner } from '../languageServices/languageServerSurveyBanner';
 import { ProposeLanguageServerBanner } from '../languageServices/proposeLanguageServerBanner';
-import { ExtensionActivationService } from './activationService';
+import { ExtensionActivationManager } from './activationManager';
+import { LanguageServerExtensionActivationService } from './activationService';
 import { JediExtensionActivator } from './jedi';
 import { LanguageServerExtensionActivator } from './languageServer/activator';
 import { LanguageServerAnalysisOptions } from './languageServer/analysisOptions';
@@ -24,12 +25,13 @@ import { BetaLanguageServerPackageRepository, DailyLanguageServerPackageReposito
 import { LanguageServerPackageService } from './languageServer/languageServerPackageService';
 import { LanguageServerManager } from './languageServer/manager';
 import { PlatformData } from './languageServer/platformData';
-import { ExtensionActivators, IDownloadChannelRule, IExtensionActivationService, IExtensionActivator, IInterpreterDataService, ILanguageClientFactory, ILanguageServer, ILanguageServerAnalysisOptions, ILanguageServerCompatibilityService as ILanagueServerCompatibilityService, ILanguageServerDownloader, ILanguageServerFolderService, ILanguageServerManager, ILanguageServerPackageService, IPlatformData, LanguageClientFactory } from './types';
+import { IDownloadChannelRule, IExtensionActivationManager, IExtensionActivationService, IInterpreterDataService, ILanguageClientFactory, ILanguageServer, ILanguageServerActivator, ILanguageServerAnalysisOptions, ILanguageServerCompatibilityService as ILanagueServerCompatibilityService, ILanguageServerDownloader, ILanguageServerFolderService, ILanguageServerManager, ILanguageServerPackageService, IPlatformData, LanguageClientFactory, LanguageServerActivator } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
-    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, ExtensionActivationService);
-    serviceManager.add<IExtensionActivator>(IExtensionActivator, JediExtensionActivator, ExtensionActivators.Jedi);
-    serviceManager.add<IExtensionActivator>(IExtensionActivator, LanguageServerExtensionActivator, ExtensionActivators.DotNet);
+    serviceManager.addSingleton<IExtensionActivationManager>(IExtensionActivationManager, ExtensionActivationManager);
+    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, LanguageServerExtensionActivationService);
+    serviceManager.add<ILanguageServerActivator>(ILanguageServerActivator, JediExtensionActivator, LanguageServerActivator.Jedi);
+    serviceManager.add<ILanguageServerActivator>(ILanguageServerActivator, LanguageServerExtensionActivator, LanguageServerActivator.DotNet);
     serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, LanguageServerSurveyBanner, BANNER_NAME_LS_SURVEY);
     serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, ProposeLanguageServerBanner, BANNER_NAME_PROPOSE_LS);
     serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, DataScienceSurveyBanner, BANNER_NAME_DS_SURVEY);

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -10,18 +10,23 @@ import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
 import { NugetPackage } from '../common/nuget/types';
 import { IDisposable, LanguageServerDownloadChannels, Resource } from '../common/types';
 
-export const IExtensionActivationService = Symbol('IExtensionActivationService');
-export interface IExtensionActivationService {
+export const IExtensionActivationManager = Symbol('IExtensionActivationManager');
+export interface IExtensionActivationManager extends IDisposable {
     activate(): Promise<void>;
 }
 
-export enum ExtensionActivators {
+export const IExtensionActivationService = Symbol('IExtensionActivationService');
+export interface IExtensionActivationService {
+    activate(resource: Resource): Promise<void>;
+}
+
+export enum LanguageServerActivator {
     Jedi = 'Jedi',
     DotNet = 'DotNet'
 }
 
-export const IExtensionActivator = Symbol('IExtensionActivator');
-export interface IExtensionActivator extends IDisposable {
+export const ILanguageServerActivator = Symbol('ILanguageServerActivator');
+export interface ILanguageServerActivator extends IDisposable {
     activate(): Promise<void>;
 }
 

--- a/src/client/interpreter/autoSelection/index.ts
+++ b/src/client/interpreter/autoSelection/index.ts
@@ -90,12 +90,12 @@ export class InterpreterAutoSelectionService implements IInterpreterAutoSelectio
         return this.globallyPreferredInterpreter.value;
     }
     public async setWorkspaceInterpreter(resource: Uri, interpreter: PythonInterpreter | undefined) {
-        await this.storeAutoSelectedInterperter(resource, interpreter);
+        await this.storeAutoSelectedInterpreter(resource, interpreter);
     }
     public async setGlobalInterpreter(interpreter: PythonInterpreter) {
-        await this.storeAutoSelectedInterperter(undefined, interpreter);
+        await this.storeAutoSelectedInterpreter(undefined, interpreter);
     }
-    protected async storeAutoSelectedInterperter(resource: Resource, interpreter: PythonInterpreter | undefined) {
+    protected async storeAutoSelectedInterpreter(resource: Resource, interpreter: PythonInterpreter | undefined) {
         const workspaceFolderPath = this.getWorkspacePathKey(resource);
         if (workspaceFolderPath === workspacePathNameForGlobalWorkspaces) {
             // Update store only if this version is better.

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -31,7 +31,7 @@ suite('Activation - ActivationManager', () => {
         }
         // tslint:disable-next-line:no-unnecessary-override
         public async activateWorkspace(resource: Resource) {
-            super.activateWorkspace(resource);
+            await super.activateWorkspace(resource);
         }
         // tslint:disable-next-line:no-unnecessary-override
         public addRemoveDocOpenedHandlers() {

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import * as typemoq from 'typemoq';
+import { TextDocument, Uri } from 'vscode';
+import { ExtensionActivationManager } from '../../client/activation/activationManager';
+import { LanguageServerExtensionActivationService } from '../../client/activation/activationService';
+import { IExtensionActivationService } from '../../client/activation/types';
+import { ApplicationDiagnostics } from '../../client/application/diagnostics/applicationDiagnostics';
+import { IApplicationDiagnostics } from '../../client/application/types';
+import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
+import { WorkspaceService } from '../../client/common/application/workspace';
+import { IDisposable } from '../../client/common/types';
+import { InterpreterAutoSelectionService } from '../../client/interpreter/autoSelection';
+import { IInterpreterAutoSelectionService } from '../../client/interpreter/autoSelection/types';
+import { IInterpreterService } from '../../client/interpreter/contracts';
+import { InterpreterService } from '../../client/interpreter/interpreterService';
+
+// tslint:disable-next-line:max-func-body-length
+suite('Activation - ActivationManager', () => {
+    class ExtensionActivationManagerTest extends ExtensionActivationManager {
+        // tslint:disable-next-line:no-unnecessary-override
+        public addHandlers() {
+            return super.addHandlers();
+        }
+        // tslint:disable-next-line:no-unnecessary-override
+        public async initialize() {
+            return super.initialize();
+        }
+    }
+    let managerTest: ExtensionActivationManagerTest;
+    let workspaceService: IWorkspaceService;
+    let appDiagnostics: IApplicationDiagnostics;
+    let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
+    let interpreterService: IInterpreterService;
+    let documentManager: typemoq.IMock<IDocumentManager>;
+    let activationService1: IExtensionActivationService;
+    let activationService2: IExtensionActivationService;
+    setup(() => {
+        workspaceService = mock(WorkspaceService);
+        appDiagnostics = mock(ApplicationDiagnostics);
+        autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
+        interpreterService = mock(InterpreterService);
+        documentManager = typemoq.Mock.ofType<IDocumentManager>();
+        activationService1 = mock(LanguageServerExtensionActivationService);
+        activationService2 = mock(LanguageServerExtensionActivationService);
+        managerTest = new ExtensionActivationManagerTest([instance(activationService1), instance(activationService2)],
+            documentManager.object,
+            instance(interpreterService),
+            autoSelection.object,
+            instance(appDiagnostics),
+            instance(workspaceService));
+    });
+    test('Initialize will add event handlers and will dispose them when running dispose', async () => {
+        const disposable = typemoq.Mock.ofType<IDisposable>();
+        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(() => disposable.object);
+
+        when(workspaceService.workspaceFolders).thenReturn([]);
+        when(interpreterService.getInterpreters(undefined)).thenResolve([]);
+        documentManager.setup(d => d.activeTextEditor).returns(() => undefined).verifiable(typemoq.Times.once());
+        await managerTest.initialize();
+
+        verify(workspaceService.onDidChangeWorkspaceFolders).once();
+        verify(workspaceService.workspaceFolders).once();
+        verify(interpreterService.getInterpreters(undefined)).once();
+
+        documentManager.verifyAll();
+
+        disposable.setup(d => d.dispose()).verifiable(typemoq.Times.once());
+
+        managerTest.dispose();
+
+        disposable.verifyAll();
+    });
+    test('Activate workspace specific to the resource in case of Multiple workspaces when a file is opened', async () => {
+        const disposable1 = typemoq.Mock.ofType<IDisposable>();
+        const disposable2 = typemoq.Mock.ofType<IDisposable>();
+        let fileOpenedHandler!: (e: TextDocument) => Promise<void>;
+        let workspaceFoldersChangedHandler!: Function;
+        const documentUri = Uri.file('a');
+        const document = typemoq.Mock.ofType<TextDocument>();
+        document.setup(d => d.uri).returns(() => documentUri);
+
+        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(cb => { workspaceFoldersChangedHandler = cb; return disposable1.object; });
+        documentManager
+            .setup(w => w.onDidOpenTextDocument(typemoq.It.isAny(), typemoq.It.isAny()))
+            .callback(cb => (fileOpenedHandler = cb))
+            .returns(() => disposable2.object)
+            .verifiable(typemoq.Times.once());
+
+        const resource = Uri.parse('two');
+        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
+        const folder2 = { name: 'two', uri: resource, index: 2 };
+        when(workspaceService.workspaceFolders).thenReturn([folder1, folder2]);
+        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+        when(workspaceService.getWorkspaceFolder(document.object.uri)).thenReturn(folder2);
+
+        when(workspaceService.getWorkspaceFolder(resource)).thenReturn(folder2);
+        when(activationService1.activate(resource)).thenResolve();
+        when(activationService2.activate(resource)).thenResolve();
+        autoSelection
+            .setup(a => a.autoSelectInterpreter(resource))
+            .returns(() => Promise.resolve());
+
+        // Add workspaceFoldersChangedHandler
+        await managerTest.addHandlers();
+        expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+        // Add fileOpenedHandler
+        workspaceFoldersChangedHandler.call(managerTest);
+        expect(fileOpenedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+        // Check if activate workspace is called on opening a file
+        fileOpenedHandler.call(managerTest, document.object);
+
+        documentManager.verifyAll();
+        verify(workspaceService.onDidChangeWorkspaceFolders).once();
+        verify(workspaceService.workspaceFolders).once();
+        verify(workspaceService.getWorkspaceFolder(anything())).thrice();
+        verify(activationService1.activate(folder2.uri)).once();
+        verify(activationService2.activate(folder2.uri)).once();
+    });
+});

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -143,7 +143,7 @@ suite('Activation - ActivationManager', () => {
         verify(activationService1.activate(resource)).once();
         verify(activationService2.activate(resource)).once();
     });
-    test('Function activateWorkspace() works as expected', async () => {
+    test('Function activateWorkspace() will be filtered to current resource', async () => {
         const resource = Uri.parse('two');
         const folder = { name: 'two', uri: resource, index: 2 };
 
@@ -206,7 +206,6 @@ suite('Activation - ActivationManager', () => {
 
         workspaceFoldersChangedHandler.call(managerTest);
 
-        verify(workspaceService.onDidChangeWorkspaceFolders).once();
         verify(workspaceService.workspaceFolders).twice();
         verify(workspaceService.hasWorkspaceFolders).twice();
     });

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -10,12 +10,10 @@ import { TextDocument, Uri } from 'vscode';
 import { ExtensionActivationManager } from '../../client/activation/activationManager';
 import { LanguageServerExtensionActivationService } from '../../client/activation/activationService';
 import { IExtensionActivationService } from '../../client/activation/types';
-import { ApplicationDiagnostics } from '../../client/application/diagnostics/applicationDiagnostics';
 import { IApplicationDiagnostics } from '../../client/application/types';
 import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
 import { WorkspaceService } from '../../client/common/application/workspace';
-import { IDisposable } from '../../client/common/types';
-import { InterpreterAutoSelectionService } from '../../client/interpreter/autoSelection';
+import { IDisposable, Resource } from '../../client/common/types';
 import { IInterpreterAutoSelectionService } from '../../client/interpreter/autoSelection/types';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { InterpreterService } from '../../client/interpreter/interpreterService';
@@ -31,18 +29,30 @@ suite('Activation - ActivationManager', () => {
         public async initialize() {
             return super.initialize();
         }
+        // tslint:disable-next-line:no-unnecessary-override
+        public async activateWorkspace(resource: Resource) {
+            super.activateWorkspace(resource);
+        }
+        // tslint:disable-next-line:no-unnecessary-override
+        public addRemoveDocOpenedHandlers() {
+            super.addRemoveDocOpenedHandlers();
+        }
     }
     let managerTest: ExtensionActivationManagerTest;
     let workspaceService: IWorkspaceService;
-    let appDiagnostics: IApplicationDiagnostics;
+    let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
     let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
     let interpreterService: IInterpreterService;
     let documentManager: typemoq.IMock<IDocumentManager>;
     let activationService1: IExtensionActivationService;
     let activationService2: IExtensionActivationService;
+    const oldValueOfVSC_PYTHON_UNIT_TEST = process.env.VSC_PYTHON_UNIT_TEST;
+    const oldValueOfVSC_PYTHON_CI_TEST = process.env.VSC_PYTHON_CI_TEST;
     setup(() => {
+        process.env.VSC_PYTHON_UNIT_TEST = undefined;
+        process.env.VSC_PYTHON_CI_TEST = undefined;
         workspaceService = mock(WorkspaceService);
-        appDiagnostics = mock(ApplicationDiagnostics);
+        appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
         autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
         interpreterService = mock(InterpreterService);
         documentManager = typemoq.Mock.ofType<IDocumentManager>();
@@ -52,8 +62,12 @@ suite('Activation - ActivationManager', () => {
             documentManager.object,
             instance(interpreterService),
             autoSelection.object,
-            instance(appDiagnostics),
+            appDiagnostics.object,
             instance(workspaceService));
+    });
+    teardown(() => {
+        process.env.VSC_PYTHON_UNIT_TEST = oldValueOfVSC_PYTHON_UNIT_TEST;
+        process.env.VSC_PYTHON_CI_TEST = oldValueOfVSC_PYTHON_CI_TEST;
     });
     test('Initialize will add event handlers and will dispose them when running dispose', async () => {
         const disposable = typemoq.Mock.ofType<IDisposable>();
@@ -104,10 +118,14 @@ suite('Activation - ActivationManager', () => {
         when(activationService2.activate(resource)).thenResolve();
         autoSelection
             .setup(a => a.autoSelectInterpreter(resource))
-            .returns(() => Promise.resolve());
-
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.once());
+        appDiagnostics
+            .setup(a => a.performPreStartupHealthCheck(resource))
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.once());
         // Add workspaceFoldersChangedHandler
-        await managerTest.addHandlers();
+        managerTest.addHandlers();
         expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
 
         // Add fileOpenedHandler
@@ -120,8 +138,76 @@ suite('Activation - ActivationManager', () => {
         documentManager.verifyAll();
         verify(workspaceService.onDidChangeWorkspaceFolders).once();
         verify(workspaceService.workspaceFolders).once();
+        verify(workspaceService.hasWorkspaceFolders).once();
         verify(workspaceService.getWorkspaceFolder(anything())).thrice();
-        verify(activationService1.activate(folder2.uri)).once();
-        verify(activationService2.activate(folder2.uri)).once();
+        verify(activationService1.activate(resource)).once();
+        verify(activationService2.activate(resource)).once();
+    });
+    test('Function activateWorkspace() works as expected', async () => {
+        const resource = Uri.parse('two');
+        const folder = { name: 'two', uri: resource, index: 2 };
+
+        when(workspaceService.getWorkspaceFolder(resource)).thenReturn(folder);
+        when(activationService1.activate(resource)).thenResolve();
+        when(activationService2.activate(resource)).thenResolve();
+        autoSelection
+            .setup(a => a.autoSelectInterpreter(resource))
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.once());
+        appDiagnostics
+            .setup(a => a.performPreStartupHealthCheck(resource))
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.once());
+
+        await managerTest.activateWorkspace(resource);
+
+        verify(workspaceService.getWorkspaceFolder(resource)).once();
+        verify(activationService1.activate(resource)).once();
+        verify(activationService2.activate(resource)).once();
+    });
+    test('Handler docOpenedHandler is disposed in case no. of workspace folders decreases to one', async () => {
+        const disposable1 = typemoq.Mock.ofType<IDisposable>();
+        const disposable2 = typemoq.Mock.ofType<IDisposable>();
+        let docOpenedHandler!: (e: TextDocument) => Promise<void>;
+        let workspaceFoldersChangedHandler!: Function;
+        const documentUri = Uri.file('a');
+        const document = typemoq.Mock.ofType<TextDocument>();
+        document.setup(d => d.uri).returns(() => documentUri);
+
+        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(cb => { workspaceFoldersChangedHandler = cb; return disposable1.object; });
+        documentManager
+            .setup(w => w.onDidOpenTextDocument(typemoq.It.isAny(), typemoq.It.isAny()))
+            .callback(cb => (docOpenedHandler = cb))
+            .returns(() => disposable2.object)
+            .verifiable(typemoq.Times.once());
+
+        const resource = Uri.parse('two');
+        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
+        const folder2 = { name: 'two', uri: resource, index: 2 };
+        when(workspaceService.workspaceFolders).thenReturn([folder1, folder2]);
+        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+        // Add workspaceFoldersChangedHandler
+        managerTest.addHandlers();
+        expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+        // Add docOpenedHandler
+        workspaceFoldersChangedHandler.call(managerTest);
+        expect(docOpenedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+        documentManager.verifyAll();
+        verify(workspaceService.onDidChangeWorkspaceFolders).once();
+        verify(workspaceService.workspaceFolders).once();
+        verify(workspaceService.hasWorkspaceFolders).once();
+
+        //Removed no. of folders to one
+        when(workspaceService.workspaceFolders).thenReturn([folder1]);
+        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+        disposable2.setup(d => d.dispose()).verifiable(typemoq.Times.once());
+
+        workspaceFoldersChangedHandler.call(managerTest);
+
+        verify(workspaceService.onDidChangeWorkspaceFolders).once();
+        verify(workspaceService.workspaceFolders).twice();
+        verify(workspaceService.hasWorkspaceFolders).twice();
     });
 });

--- a/src/test/activation/languageServer/activator.unit.test.ts
+++ b/src/test/activation/languageServer/activator.unit.test.ts
@@ -10,7 +10,12 @@ import { LanguageServerExtensionActivator } from '../../../client/activation/lan
 import { LanguageServerDownloader } from '../../../client/activation/languageServer/downloader';
 import { LanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';
 import { LanguageServerManager } from '../../../client/activation/languageServer/manager';
-import { IExtensionActivator, ILanguageServerDownloader, ILanguageServerFolderService, ILanguageServerManager } from '../../../client/activation/types';
+import {
+    ILanguageServerActivator,
+    ILanguageServerDownloader,
+    ILanguageServerFolderService,
+    ILanguageServerManager
+} from '../../../client/activation/types';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { PythonSettings } from '../../../client/common/configSettings';
@@ -25,7 +30,7 @@ import { sleep } from '../../core';
 // tslint:disable:max-func-body-length
 
 suite('Language Server - Activator', () => {
-    let activator: IExtensionActivator;
+    let activator: ILanguageServerActivator;
     let workspaceService: IWorkspaceService;
     let manager: ILanguageServerManager;
     let fs: IFileSystem;
@@ -42,10 +47,14 @@ suite('Language Server - Activator', () => {
         configuration = mock(ConfigurationService);
         settings = mock(PythonSettings);
         when(configuration.getSettings(anything())).thenReturn(instance(settings));
-        activator = new LanguageServerExtensionActivator(instance(manager),
-            instance(workspaceService), instance(fs),
-            instance(lsDownloader), instance(lsFolderService),
-            instance(configuration));
+        activator = new LanguageServerExtensionActivator(
+            instance(manager),
+            instance(workspaceService),
+            instance(fs),
+            instance(lsDownloader),
+            instance(lsFolderService),
+            instance(configuration)
+        );
     });
     test('Manager must be started without any workspace', async () => {
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -194,7 +194,7 @@ suite('Module Installer', () => {
                             }
 
                             if (installerClass === PipInstaller) {
-                                test(`Ensure getActiveInterperter is used in PipInstaller (${product.name})`, async () => {
+                                test(`Ensure getActiveInterpreter is used in PipInstaller (${product.name})`, async () => {
                                     setActiveInterpreter();
                                     try {
                                         await installer.installModule(product.name, resource);

--- a/src/test/interpreters/autoSelection/index.unit.test.ts
+++ b/src/test/interpreters/autoSelection/index.unit.test.ts
@@ -48,8 +48,8 @@ suite('Interpreters - Auto Selection', () => {
         public initializeStore(): Promise<void> {
             return super.initializeStore();
         }
-        public storeAutoSelectedInterperter(resource: Resource, interpreter: PythonInterpreter | undefined) {
-            return super.storeAutoSelectedInterperter(resource, interpreter);
+        public storeAutoSelectedInterpreter(resource: Resource, interpreter: PythonInterpreter | undefined) {
+            return super.storeAutoSelectedInterpreter(resource, interpreter);
         }
     }
     setup(() => {
@@ -169,7 +169,7 @@ suite('Interpreters - Auto Selection', () => {
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
 
         await autoSelectionService.initializeStore();
-        await autoSelectionService.storeAutoSelectedInterperter(undefined, interpreterInfo);
+        await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
         verify(state.updateValue(interpreterInfo)).once();
@@ -187,7 +187,7 @@ suite('Interpreters - Auto Selection', () => {
         when(state.value).thenReturn(interpreterInfoInState);
 
         await autoSelectionService.initializeStore();
-        await autoSelectionService.storeAutoSelectedInterperter(undefined, interpreterInfo);
+        await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
         verify(state.updateValue(anything())).never();
@@ -205,7 +205,7 @@ suite('Interpreters - Auto Selection', () => {
         when(state.value).thenReturn(interpreterInfoInState);
 
         await autoSelectionService.initializeStore();
-        await autoSelectionService.storeAutoSelectedInterperter(undefined, interpreterInfo);
+        await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
         verify(state.updateValue(anything())).once();
@@ -234,7 +234,7 @@ suite('Interpreters - Auto Selection', () => {
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
 
         await autoSelectionService.initializeStore();
-        await autoSelectionService.storeAutoSelectedInterperter(resource, interpreterInfo);
+        await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(resource);
 
         verify(state.updateValue(interpreterInfo)).never();
@@ -263,7 +263,7 @@ suite('Interpreters - Auto Selection', () => {
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
 
         await autoSelectionService.initializeStore();
-        await autoSelectionService.storeAutoSelectedInterperter(resource, interpreterInfo);
+        await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
         verify(state.updateValue(interpreterInfo)).never();
@@ -278,7 +278,7 @@ suite('Interpreters - Auto Selection', () => {
         const globalInterpreterInfo = { path: 'global Value' };
         when(state.value).thenReturn(globalInterpreterInfo as any);
         await autoSelectionService.initializeStore();
-        await autoSelectionService.storeAutoSelectedInterperter(resource, interpreterInfo);
+        await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
         const anotherResourceOfAnotherWorkspace = Uri.parse('Some other workspace');
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(anotherResourceOfAnotherWorkspace);
 
@@ -287,13 +287,13 @@ suite('Interpreters - Auto Selection', () => {
         verify(state.updateValue(interpreterInfo)).never();
         expect(selectedInterpreter).to.deep.equal(globalInterpreterInfo);
     });
-    test('setWorkspaceInterpreter will invoke storeAutoSelectedInterperter with same args', async () => {
+    test('setWorkspaceInterpreter will invoke storeAutoSelectedInterpreter with same args', async () => {
         const pythonPath = 'Hello World';
         const interpreterInfo = { path: pythonPath } as any;
         const resource = Uri.parse('one');
         const moq = typemoq.Mock.ofInstance(autoSelectionService, typemoq.MockBehavior.Loose, false);
         moq
-            .setup(m => m.storeAutoSelectedInterperter(typemoq.It.isValue(resource), typemoq.It.isValue(interpreterInfo)))
+            .setup(m => m.storeAutoSelectedInterpreter(typemoq.It.isValue(resource), typemoq.It.isValue(interpreterInfo)))
             .returns(() => Promise.resolve())
             .verifiable(typemoq.Times.once());
         moq.callBase = true;
@@ -301,12 +301,12 @@ suite('Interpreters - Auto Selection', () => {
 
         moq.verifyAll();
     });
-    test('setGlobalInterpreter will invoke storeAutoSelectedInterperter with same args and without a resource', async () => {
+    test('setGlobalInterpreter will invoke storeAutoSelectedInterpreter with same args and without a resource', async () => {
         const pythonPath = 'Hello World';
         const interpreterInfo = { path: pythonPath } as any;
         const moq = typemoq.Mock.ofInstance(autoSelectionService, typemoq.MockBehavior.Loose, false);
         moq
-            .setup(m => m.storeAutoSelectedInterperter(typemoq.It.isValue(undefined), typemoq.It.isValue(interpreterInfo)))
+            .setup(m => m.storeAutoSelectedInterpreter(typemoq.It.isValue(undefined), typemoq.It.isValue(interpreterInfo)))
             .returns(() => Promise.resolve())
             .verifiable(typemoq.Times.once());
         moq.callBase = true;


### PR DESCRIPTION
For #3501 #3502
Part 4 of #3502

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
