### PR TITLE
Ensure decorators cannot be applied to async functions

### DIFF
--- a/news/3 Code Health/4055.md
+++ b/news/3 Code Health/4055.md
@@ -1,0 +1,1 @@
+Ensure `debounce` decorator cannot be applied to async functions.

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -171,11 +171,14 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
         if (e && !e.affectsConfiguration('python', this.resource)) {
             return;
         }
-        this.onSettingsChanged().catch(ex => traceError('Failed to detect changes', ex));
+        this.onSettingsChanged();
+    }
+    @debounce(1000)
+    protected onSettingsChanged(): void {
+        this.notifyIfSettingsChanged().ignoreErrors();
     }
     @traceDecorators.verbose('Changes in python settings detected in analysis options')
-    @debounce(1000)
-    protected async onSettingsChanged(): Promise<void> {
+    protected async notifyIfSettingsChanged(): Promise<void> {
         const idata = await this.interpreterDataService.getInterpreterData(this.resource);
         if (!idata || idata.hash !== this.interpreterHash) {
             this.interpreterHash = idata ? idata.hash : '';

--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -58,13 +58,19 @@ function argsToLogString(args: any[]): string {
     try {
         return (args || [])
             .map((item, index) => {
+                if (item === undefined) {
+                    return `Arg ${index + 1}: undefined`;
+                }
+                if (item === null) {
+                    return `Arg ${index + 1}: null`;
+                }
                 try {
-                    if (item.fsPath) {
+                    if (item && item.fsPath) {
                         return `Arg ${index + 1}: <Uri:${item.fsPath}>`;
                     }
                     return `Arg ${index + 1}: ${JSON.stringify(item)}`;
                 } catch {
-                    return `Arg ${index + 1}: UNABLE TO DETERMINE VALUE`;
+                    return `Arg ${index + 1}: <argument cannot be serialized for logging>`;
                 }
             })
             .join(', ');

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -10,6 +10,7 @@ import { InMemoryInterpreterSpecificCache } from './cacheUtils';
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
+type VoidFunction = (...any: any[]) => void;
 /**
  * Debounces a function execution. Function must return either a void or a promise that resolves to a void.
  * @export
@@ -18,12 +19,12 @@ const _debounce = require('lodash/debounce') as typeof import('lodash/debounce')
  */
 export function debounce(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<any>) {
+    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction>) {
         const originalMethod = descriptor.value!;
         // If running tests, lets not debounce (so tests run fast).
         wait = wait && isTestExecution() ? undefined : wait;
         // tslint:disable-next-line:no-invalid-this no-any
-        (descriptor as any).value = _debounce(function () { return originalMethod.apply(this, arguments); }, wait);
+        (descriptor as any).value = _debounce(function () { return originalMethod.apply(this, arguments as any); }, wait);
     };
 }
 

--- a/src/client/sourceMapSupport.ts
+++ b/src/client/sourceMapSupport.ts
@@ -27,10 +27,11 @@ export class SourceMapSupport {
         await this.enableSourceMaps(true);
         const localize = require('./common/utils/localize') as typeof import('./common/utils/localize');
         const disable = localize.Diagnostics.disableSourceMaps();
-        const selection = await this.vscode.window.showWarningMessage(localize.Diagnostics.warnSourceMaps(), disable);
-        if (selection === disable) {
-            await this.disable();
-        }
+        this.vscode.window.showWarningMessage(localize.Diagnostics.warnSourceMaps(), disable).then(selection => {
+            if (selection === disable) {
+                this.disable().ignoreErrors();
+            }
+        });
     }
     public get enabled(): boolean {
         return this.config.get<boolean>(setting, false);

--- a/src/test/activation/languageServer/analysisOptions.unit.test.ts
+++ b/src/test/activation/languageServer/analysisOptions.unit.test.ts
@@ -39,7 +39,7 @@ suite('Language Server - Analysis Options', () => {
         public getTypeshedPaths(): string[] {
             return super.getTypeshedPaths();
         }
-        public async onSettingsChanged(): Promise<void> {
+        public onSettingsChanged(): void {
             return super.onSettingsChanged();
         }
         public async notifyIfValuesHaveChanged(oldArray: string[], newArray: string[]): Promise<void> {
@@ -128,7 +128,7 @@ suite('Language Server - Analysis Options', () => {
         let eventFired = false;
         analysisOptions.onDidChange(() => eventFired = true);
 
-        await analysisOptions.onSettingsChanged();
+        analysisOptions.onSettingsChanged();
         await sleep(1);
 
         expect(eventFired).to.be.equal(false);
@@ -142,7 +142,7 @@ suite('Language Server - Analysis Options', () => {
         let eventFired = false;
         analysisOptions.onDidChange(() => eventFired = true);
 
-        await analysisOptions.onSettingsChanged();
+        analysisOptions.onSettingsChanged();
         await sleep(1);
 
         expect(eventFired).to.be.equal(true);
@@ -156,7 +156,7 @@ suite('Language Server - Analysis Options', () => {
         let eventFired = false;
         analysisOptions.onDidChange(() => eventFired = true);
 
-        await analysisOptions.onSettingsChanged();
+        analysisOptions.onSettingsChanged();
         await sleep(1);
 
         expect(eventFired).to.be.equal(true);
@@ -168,7 +168,7 @@ suite('Language Server - Analysis Options', () => {
         let eventFired = false;
         analysisOptions.onDidChange(() => eventFired = true);
 
-        await analysisOptions.onSettingsChanged();
+        analysisOptions.onSettingsChanged();
         await sleep(1);
 
         expect(eventFired).to.be.equal(true);


### PR DESCRIPTION
For #4055

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
