### PR TITLE
Change names of telemetry properties captured during load of ext

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -312,6 +312,7 @@ function initializeServices(context: ExtensionContext, serviceManager: ServiceMa
 async function sendStartupTelemetry(activatedPromise: Promise<any>, serviceContainer: IServiceContainer) {
     try {
         await activatedPromise;
+        durations.totalActivateTime = stopWatch.elapsedTime;
         const props = await getActivationTelemetryProps(serviceContainer);
         sendTelemetryEvent(EventName.EDITOR_LOAD, durations, props);
     } catch (ex) {

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -12,9 +12,14 @@ import { PlatformErrors } from './constants';
 
 export type EditorLoadTelemetry = {
     condaVersion: string | undefined;
+    pythonVersion: string | undefined;
+    interpreterType: InterpreterType | undefined;
     terminal: TerminalShellType;
-    hasUserDefinedInterpreter: boolean;
-    isAutoSelectedWorkspaceInterpreterUsed: boolean;
+    workspaceFolderCount: number;
+    hasPython3: boolean;
+    usingUserDefinedInterpreter: boolean;
+    usingAutoSelectedWorkspaceInterpreter: boolean;
+    usingGlobalInterpreter: boolean;
 };
 export type FormatTelemetry = {
     tool: 'autopep8' | 'black' | 'yapf';


### PR DESCRIPTION
For #3901
Change names of telemetry properties, original properties seem to be have suppressed.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
