### PR TITLE
Ensure diagnostic handlers are always displayed

### DIFF
--- a/src/client/application/diagnostics/base.ts
+++ b/src/client/application/diagnostics/base.ts
@@ -17,7 +17,8 @@ import { DiagnosticScope, IDiagnostic, IDiagnosticFilterService, IDiagnosticsSer
 export abstract class BaseDiagnostic implements IDiagnostic {
     constructor(public readonly code: DiagnosticCodes, public readonly message: string,
         public readonly severity: DiagnosticSeverity, public readonly scope: DiagnosticScope,
-        public readonly resource: Resource) { }
+        public readonly resource: Resource,
+        public readonly invokeHandler: 'always' | 'default' = 'default') { }
 }
 
 @injectable()
@@ -37,6 +38,9 @@ export abstract class BaseDiagnosticsService implements IDiagnosticsService {
             return;
         }
         const diagnosticsToHandle = diagnostics.filter(item => {
+            if (item.invokeHandler && item.invokeHandler === 'always') {
+                return true;
+            }
             const key = this.getDiagnosticsKey(item);
             if (BaseDiagnosticsService.handledDiagnosticCodeKeys.indexOf(key) !== -1) {
                 return false;

--- a/src/client/application/diagnostics/checks/invalidDebuggerType.ts
+++ b/src/client/application/diagnostics/checks/invalidDebuggerType.ts
@@ -29,7 +29,8 @@ export class InvalidDebuggerTypeDiagnostic extends BaseDiagnostic {
             message,
             DiagnosticSeverity.Error,
             DiagnosticScope.WorkspaceFolder,
-            resource
+            resource,
+            'always'
         );
     }
 }

--- a/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
@@ -41,7 +41,8 @@ export class InvalidPythonPathInDebuggerDiagnostic extends BaseDiagnostic {
             messages[code],
             DiagnosticSeverity.Error,
             DiagnosticScope.WorkspaceFolder,
-            resource
+            resource,
+            'always'
         );
     }
 }

--- a/src/client/application/diagnostics/checks/powerShellActivation.ts
+++ b/src/client/application/diagnostics/checks/powerShellActivation.ts
@@ -28,7 +28,8 @@ export class PowershellActivationNotAvailableDiagnostic extends BaseDiagnostic {
             PowershellActivationNotSupportedWithBatchFilesMessage,
             DiagnosticSeverity.Warning,
             DiagnosticScope.Global,
-            resource
+            resource,
+            'always'
         );
     }
 }

--- a/src/client/application/diagnostics/types.ts
+++ b/src/client/application/diagnostics/types.ts
@@ -23,6 +23,7 @@ export interface IDiagnostic {
     readonly severity: DiagnosticSeverity;
     readonly scope: DiagnosticScope;
     readonly resource: Resource;
+    readonly invokeHandler: 'always' | 'default';
 }
 
 export const IDiagnosticsService = Symbol('IDiagnosticsService');

--- a/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
+++ b/src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
@@ -88,8 +88,9 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
             message: 'Error',
             scope: undefined,
             severity: undefined,
-            resource: undefined
-        };
+            resource: undefined,
+            invokeHandler: 'default'
+        } as any;
         envHealthCheck.setup(e => e.diagnose(typemoq.It.isAny()))
             .returns(() => Promise.resolve([diagnostic]))
             .verifiable(typemoq.Times.once());
@@ -125,7 +126,8 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
                 message: `Error${i}`,
                 scope: i % 2 === 0 ? DiagnosticScope.Global : DiagnosticScope.WorkspaceFolder,
                 severity: DiagnosticSeverity.Error,
-                resource: undefined
+                resource: undefined,
+                invokeHandler: 'default'
             };
             diagnostics.push(diagnostic);
         }
@@ -135,7 +137,8 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
                 message: `Warning${i}`,
                 scope: i % 2 === 0 ? DiagnosticScope.Global : DiagnosticScope.WorkspaceFolder,
                 severity: DiagnosticSeverity.Warning,
-                resource: undefined
+                resource: undefined,
+                invokeHandler: 'default'
             };
             diagnostics.push(diagnostic);
         }
@@ -145,7 +148,8 @@ suite('Application Diagnostics - ApplicationDiagnostics', () => {
                 message: `Info${i}`,
                 scope: i % 2 === 0 ? DiagnosticScope.Global : DiagnosticScope.WorkspaceFolder,
                 severity: DiagnosticSeverity.Information,
-                resource: undefined
+                resource: undefined,
+                invokeHandler: 'default'
             };
             diagnostics.push(diagnostic);
         }

--- a/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
@@ -28,7 +28,7 @@ import { IConfigurationService, IPythonSettings } from '../../../../client/commo
 import { IInterpreterHelper } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
 
-suite('xApplication Diagnostics - Checks Python Path in debugger', () => {
+suite('Application Diagnostics - Checks Python Path in debugger', () => {
     let diagnosticService: IInvalidPythonPathInDebuggerService;
     let messageHandler: typemoq.IMock<IDiagnosticHandlerService<MessageCommandPrompt>>;
     let commandFactory: typemoq.IMock<IDiagnosticsCommandFactory>;
@@ -96,7 +96,8 @@ suite('xApplication Diagnostics - Checks Python Path in debugger', () => {
     });
     test('Can not handle non-InvalidPythonPathInDebugger diagnostics', async () => {
         const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
-        diagnostic.setup(d => d.code)
+        diagnostic
+            .setup(d => d.code)
             .returns(() => 'Something Else' as any)
             .verifiable(typemoq.Times.atLeastOnce());
 
@@ -152,7 +153,9 @@ suite('xApplication Diagnostics - Checks Python Path in debugger', () => {
             )
             .returns(() => interpreterSelectionCommand.object)
             .verifiable(typemoq.Times.exactly(1));
-        messageHandler.setup(m => m.handle(typemoq.It.isAny(), typemoq.It.isAny())).verifiable(typemoq.Times.exactly(1));
+        messageHandler
+            .setup(m => m.handle(typemoq.It.isAny(), typemoq.It.isAny()))
+            .verifiable(typemoq.Times.exactly(1));
 
         await diagnosticService.handle([diagnostic.object]);
         await diagnosticService.handle([diagnostic.object]);
@@ -181,7 +184,9 @@ suite('xApplication Diagnostics - Checks Python Path in debugger', () => {
             )
             .returns(() => interpreterSelectionCommand.object)
             .verifiable(typemoq.Times.exactly(2));
-        messageHandler.setup(m => m.handle(typemoq.It.isAny(), typemoq.It.isAny())).verifiable(typemoq.Times.exactly(2));
+        messageHandler
+            .setup(m => m.handle(typemoq.It.isAny(), typemoq.It.isAny()))
+            .verifiable(typemoq.Times.exactly(2));
 
         await diagnosticService.handle([diagnostic.object]);
         await diagnosticService.handle([diagnostic.object]);

--- a/src/test/application/diagnostics/promptHandler.unit.test.ts
+++ b/src/test/application/diagnostics/promptHandler.unit.test.ts
@@ -30,7 +30,14 @@ suite('Application Diagnostics - PromptHandler', () => {
 
     getNamesAndValues<DiagnosticSeverity>(DiagnosticSeverity).forEach(severity => {
         test(`Handling a diagnositic of severity '${severity.name}' should display a message without any buttons`, async () => {
-            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value, resource: undefined };
+            const diagnostic: IDiagnostic = {
+                code: '1' as any,
+                message: 'one',
+                scope: DiagnosticScope.Global,
+                severity: severity.value,
+                resource: undefined,
+                invokeHandler: 'default'
+            };
             switch (severity.value) {
                 case DiagnosticSeverity.Error: {
                     appShell.setup(a => a.showErrorMessage(typemoq.It.isValue(diagnostic.message)))
@@ -53,7 +60,14 @@ suite('Application Diagnostics - PromptHandler', () => {
             appShell.verifyAll();
         });
         test(`Handling a diagnositic of severity '${severity.name}' should display a custom message with buttons`, async () => {
-            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value, resource: undefined };
+            const diagnostic: IDiagnostic = {
+                code: '1' as any,
+                message: 'one',
+                scope: DiagnosticScope.Global,
+                severity: severity.value,
+                resource: undefined,
+                invokeHandler: 'default'
+            };
             const options: MessageCommandPrompt = {
                 commandPrompts: [
                     { prompt: 'Yes' },
@@ -87,7 +101,14 @@ suite('Application Diagnostics - PromptHandler', () => {
             appShell.verifyAll();
         });
         test(`Handling a diagnositic of severity '${severity.name}' should display a custom message with buttons and invoke selected command`, async () => {
-            const diagnostic: IDiagnostic = { code: '1' as any, message: 'one', scope: DiagnosticScope.Global, severity: severity.value, resource: undefined };
+            const diagnostic: IDiagnostic = {
+                code: '1' as any,
+                message: 'one',
+                scope: DiagnosticScope.Global,
+                severity: severity.value,
+                resource: undefined,
+                invokeHandler: 'default'
+            };
             const command = typemoq.Mock.ofType<IDiagnosticCommand>();
             const options: MessageCommandPrompt = {
                 commandPrompts: [


### PR DESCRIPTION
For #3661

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
