### PR TITLE
Ensure interpreter is auto selected before updating status bar

### DIFF
--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -43,7 +43,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         await this.activateWorkspace(this.getActiveResource());
         await this.autoSelection.autoSelectInterpreter(undefined);
     }
-    @traceDecorators.error('Failed to activate a worksapce')
+    @traceDecorators.error('Failed to activate a workspace')
     public async activateWorkspace(resource: Resource) {
         const key = this.getWorkspaceKey(resource);
         if (this.activatedWorkspaces.has(key)) {

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -7,7 +7,7 @@ import { inject, injectable, multiInject } from 'inversify';
 import { TextDocument, workspace } from 'vscode';
 import { IApplicationDiagnostics } from '../application/types';
 import { IDocumentManager, IWorkspaceService } from '../common/application/types';
-import { isTestExecution, PYTHON_LANGUAGE } from '../common/constants';
+import { PYTHON_LANGUAGE } from '../common/constants';
 import { traceDecorators } from '../common/logger';
 import { IDisposable, Resource } from '../common/types';
 import { IInterpreterAutoSelectionService } from '../interpreter/autoSelection/types';
@@ -26,14 +26,14 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         @inject(IInterpreterAutoSelectionService) private readonly autoSelection: IInterpreterAutoSelectionService,
         @inject(IApplicationDiagnostics) private readonly appDiagnostics: IApplicationDiagnostics,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
-    ) { }
+    ) {}
 
     public dispose() {
         while (this.disposables.length > 0) {
             const disposable = this.disposables.shift()!;
             disposable.dispose();
         }
-        if (this. docOpenedHandler){
+        if (this.docOpenedHandler) {
             this.docOpenedHandler.dispose();
             this.docOpenedHandler = undefined;
         }
@@ -52,14 +52,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         this.activatedWorkspaces.add(key);
         // Get latest interpreter list in the background.
         this.interpreterService.getInterpreters(resource).ignoreErrors();
+
         await this.autoSelection.autoSelectInterpreter(resource);
-
         await Promise.all(this.activationServices.map(item => item.activate(resource)));
-
-        // When testing, do not perform health checks, as modal dialogs can be displayed.
-        if (!isTestExecution()) {
-            await this.appDiagnostics.performPreStartupHealthCheck(resource);
-        }
+        await this.appDiagnostics.performPreStartupHealthCheck(resource);
     }
     protected async initialize() {
         this.addHandlers();

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -102,14 +102,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         this.activateWorkspace(folder ? folder.uri : undefined).ignoreErrors();
     }
     protected getWorkspaceKey(resource: Resource) {
-        if (!resource) {
-            return '';
-        }
-        const workspaceFolder = this.workspaceService.getWorkspaceFolder(resource);
-        if (!workspaceFolder) {
-            return '';
-        }
-        return workspaceFolder.uri.fsPath;
+        return this.workspaceService.getWorkspaceFolderIdentifier(resource, '');
     }
     private getActiveResource(): Resource {
         if (this.documentManager.activeTextEditor && !this.documentManager.activeTextEditor.document.isUntitled) {

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -22,11 +22,12 @@ type ActivatorInfo = { jedi: boolean; activator: ILanguageServerActivator };
 @injectable()
 export class LanguageServerExtensionActivationService implements IExtensionActivationService, Disposable {
     private currentActivator?: ActivatorInfo;
-    private activatedOnce: boolean;
+    private activatedOnce: boolean = false;
     private readonly workspaceService: IWorkspaceService;
     private readonly output: OutputChannel;
     private readonly appShell: IApplicationShell;
     private readonly lsNotSupportedDiagnosticService: IDiagnosticsService;
+    private resource!: Resource;
 
     constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
         this.workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
@@ -41,10 +42,11 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         disposables.push(this.workspaceService.onDidChangeConfiguration(this.onDidChangeConfiguration.bind(this)));
     }
 
-    public async activate(_resource: Resource): Promise<void> {
+    public async activate(resource: Resource): Promise<void> {
         if (this.currentActivator || this.activatedOnce) {
             return;
         }
+        this.resource = resource;
         this.activatedOnce = true;
 
         let jedi = this.useJedi();
@@ -114,10 +116,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         }
     }
     private useJedi(): boolean {
-        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders
-            ? this.workspaceService.workspaceFolders!.map(item => item.uri)
-            : [undefined];
         const configuraionService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
-        return workspacesUris.filter(uri => configuraionService.getSettings(uri).jediEnabled).length > 0;
+        return configuraionService.getSettings(this.resource).jediEnabled;
     }
 }

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -116,7 +116,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         }
     }
     private useJedi(): boolean {
-        const configuraionService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
-        return configuraionService.getSettings(this.resource).jediEnabled;
+        const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        return configurationService.getSettings(this.resource).jediEnabled;
     }
 }

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -13,6 +13,7 @@ import { IDisposable, LanguageServerDownloadChannels, Resource } from '../common
 export const IExtensionActivationManager = Symbol('IExtensionActivationManager');
 export interface IExtensionActivationManager extends IDisposable {
     activate(): Promise<void>;
+    activateWorkspace(resource: Resource): Promise<void>;
 }
 
 export const IExtensionActivationService = Symbol('IExtensionActivationService');

--- a/src/client/application/diagnostics/applicationDiagnostics.ts
+++ b/src/client/application/diagnostics/applicationDiagnostics.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import { DiagnosticSeverity } from 'vscode';
-import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
+import { isTestExecution, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import { ILogger, IOutputChannel, Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { IApplicationDiagnostics } from '../types';
@@ -21,6 +21,10 @@ export class ApplicationDiagnostics implements IApplicationDiagnostics {
         this.serviceContainer.get<ISourceMapSupportService>(ISourceMapSupportService).register();
     }
     public async performPreStartupHealthCheck(resource: Resource): Promise<void> {
+        // When testing, do not perform health checks, as modal dialogs can be displayed.
+        if (!isTestExecution()) {
+            return;
+        }
         const services = this.serviceContainer.getAll<IDiagnosticsService>(IDiagnosticsService);
         // Perform these validation checks in the foreground.
         await this.runDiagnostics(services.filter(item => !item.runInBackground), resource);

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -586,7 +586,7 @@ export interface IWorkspaceService {
      * @returns {string}
      * @memberof IWorkspaceService
      */
-    getWorkspaceFolderIdentifier(resource: Uri | undefined): string;
+    getWorkspaceFolderIdentifier(resource: Uri | undefined, defaultValue?: string): string;
     /**
      * Returns a path that is relative to the workspace folder or folders.
      *

--- a/src/client/common/application/workspace.ts
+++ b/src/client/common/application/workspace.ts
@@ -3,6 +3,7 @@
 
 import { injectable } from 'inversify';
 import { CancellationToken, ConfigurationChangeEvent, Event, FileSystemWatcher, GlobPattern, Uri, workspace, WorkspaceConfiguration, WorkspaceFolder, WorkspaceFoldersChangeEvent } from 'vscode';
+import { Resource } from '../types';
 import { IWorkspaceService } from './types';
 
 @injectable()
@@ -37,8 +38,8 @@ export class WorkspaceService implements IWorkspaceService {
     public findFiles(include: GlobPattern, exclude?: GlobPattern, maxResults?: number, token?: CancellationToken): Thenable<Uri[]> {
         return workspace.findFiles(include, exclude, maxResults, token);
     }
-    public getWorkspaceFolderIdentifier(resource: Uri): string {
+    public getWorkspaceFolderIdentifier(resource: Resource, defaultValue: string = ''): string {
         const workspaceFolder = resource ? workspace.getWorkspaceFolder(resource) : undefined;
-        return workspaceFolder ? workspaceFolder.uri.fsPath : '';
+        return workspaceFolder ? workspaceFolder.uri.fsPath : defaultValue;
     }
 }

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -65,7 +65,7 @@ export class PythonSettings implements IPythonSettings {
         return this.changed.event;
     }
 
-    constructor(workspaceFolder: Uri | undefined, private readonly InterpreterAutoSelectionService: IInterpreterAutoSeletionProxyService,
+    constructor(workspaceFolder: Uri | undefined, private readonly interpreterAutoSelectionService: IInterpreterAutoSeletionProxyService,
         workspace?: IWorkspaceService) {
         this.workspace = workspace || new WorkspaceService();
         this.workspaceRoot = workspaceFolder ? workspaceFolder : Uri.file(__dirname);
@@ -129,9 +129,9 @@ export class PythonSettings implements IPythonSettings {
         this.pythonPath = systemVariables.resolveAny(pythonSettings.get<string>('pythonPath'))!;
         // If user has defined a custom value, use it else try to get the best interpreter ourselves.
         if (this.pythonPath.length === 0 || this.pythonPath === 'python') {
-            const autoSelectedPythonInterpreter = this.InterpreterAutoSelectionService.getAutoSelectedInterpreter(this.workspaceRoot);
+            const autoSelectedPythonInterpreter = this.interpreterAutoSelectionService.getAutoSelectedInterpreter(this.workspaceRoot);
             if (autoSelectedPythonInterpreter) {
-                this.InterpreterAutoSelectionService.setWorkspaceInterpreter(this.workspaceRoot, autoSelectedPythonInterpreter).ignoreErrors();
+                this.interpreterAutoSelectionService.setWorkspaceInterpreter(this.workspaceRoot, autoSelectedPythonInterpreter).ignoreErrors();
             }
             this.pythonPath = autoSelectedPythonInterpreter ? autoSelectedPythonInterpreter.path : this.pythonPath;
         }
@@ -382,7 +382,7 @@ export class PythonSettings implements IPythonSettings {
             // Let's defer the change notification.
             this.debounceChangeNotification();
         };
-        this.disposables.push(this.InterpreterAutoSelectionService.onDidChangeAutoSelectedInterpreter(onDidChange.bind(this)));
+        this.disposables.push(this.interpreterAutoSelectionService.onDidChangeAutoSelectedInterpreter(onDidChange.bind(this)));
         this.disposables.push(this.workspace.onDidChangeConfiguration((event: ConfigurationChangeEvent) => {
             if (event.affectsConfiguration('python')) {
                 onDidChange();

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -73,6 +73,7 @@ export type InterpreterInfomation = {
     sysVersion: string;
     architecture: Architecture;
     sysPrefix: string;
+    pipEnvWorkspaceFolder?: string;
 };
 export const IPythonExecutionService = Symbol('IPythonExecutionService');
 

--- a/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
@@ -6,13 +6,17 @@
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { IInterpreterService, InterpreterType, IPipEnvService } from '../../../interpreter/contracts';
+import { IWorkspaceService } from '../../application/types';
+import { IFileSystem } from '../../platform/types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
 
 @injectable()
 export class PipEnvActivationCommandProvider implements ITerminalActivationCommandProvider {
     constructor(
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IPipEnvService) private readonly pipenvService: IPipEnvService
+        @inject(IPipEnvService) private readonly pipenvService: IPipEnvService,
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IFileSystem) private readonly fs: IFileSystem
     ) { }
 
     public isShellSupported(_targetShell: TerminalShellType): boolean {
@@ -24,7 +28,12 @@ export class PipEnvActivationCommandProvider implements ITerminalActivationComma
         if (!interpreter || interpreter.type !== InterpreterType.Pipenv) {
             return;
         }
-
+        // Activate using `pipenv shell` only if the current folder relates pipenv environment.
+        const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
+        if (workspaceFolder && interpreter.pipEnvWorkspaceFolder &&
+            !this.fs.arePathsSame(workspaceFolder.uri.fsPath, interpreter.pipEnvWorkspaceFolder)) {
+            return;
+        }
         const execName = this.pipenvService.executable;
         return [`${execName.fileToCommandArgument()} shell`];
     }

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -120,7 +120,7 @@ export interface IPipEnvService {
 
 export const IInterpreterLocatorHelper = Symbol('IInterpreterLocatorHelper');
 export interface IInterpreterLocatorHelper {
-    mergeInterpreters(interpreters: PythonInterpreter[]): PythonInterpreter[];
+    mergeInterpreters(interpreters: PythonInterpreter[]): Promise<PythonInterpreter[]>;
 }
 
 export const IInterpreterWatcher = Symbol('IInterpreterWatcher');

--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -34,7 +34,6 @@ export class InterpreterDisplay implements IInterpreterDisplay {
         disposableRegistry.push(this.statusBar);
 
         this.interpreterService.onDidChangeInterpreterInformation(this.onDidChangeInterpreterInformation, this, disposableRegistry);
-        this.autoSelection.onDidChangeAutoSelectedInterpreter(() => this.updateDisplay(this.currentlySelectedWorkspaceFolder), this, disposableRegistry);
     }
     public async refresh(resource?: Uri) {
         // Use the workspace Uri if available

--- a/src/client/interpreter/locators/services/baseVirtualEnvService.ts
+++ b/src/client/interpreter/locators/services/baseVirtualEnvService.ts
@@ -3,6 +3,7 @@
 import { injectable, unmanaged } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import { traceError } from '../../../common/logger';
 import { IFileSystem, IPlatformService } from '../../../common/platform/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { IInterpreterHelper, IVirtualEnvironmentsSearchPathProvider, PythonInterpreter } from '../../contracts';
@@ -44,7 +45,7 @@ export class BaseVirtualEnvService extends CacheableLocatorService {
             .then(interpreters => Promise.all(interpreters.map(interpreter => this.getVirtualEnvDetails(interpreter, resource))))
             .then(interpreters => interpreters.filter(interpreter => !!interpreter).map(interpreter => interpreter!))
             .catch((err) => {
-                console.error('Python Extension (lookForInterpretersInVenvs):', err);
+                traceError('Python Extension (lookForInterpretersInVenvs):', err);
                 // Ignore exceptions.
                 return [] as PythonInterpreter[];
             });

--- a/src/client/interpreter/locators/services/cacheableLocatorService.ts
+++ b/src/client/interpreter/locators/services/cacheableLocatorService.ts
@@ -66,7 +66,7 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
             return deferred.promise;
         }
 
-        const cachedInterpreters = this.getCachedInterpreters(resource);
+        const cachedInterpreters = ignoreCache ? undefined : this.getCachedInterpreters(resource);
         return Array.isArray(cachedInterpreters) ? cachedInterpreters : deferred.promise;
     }
     protected async addHandlersForInterpreterWatchers(cacheKey: string, resource: Uri | undefined): Promise<void> {

--- a/src/client/interpreter/locators/services/pipEnvService.ts
+++ b/src/client/interpreter/locators/services/pipEnvService.ts
@@ -25,7 +25,7 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
     private readonly configService: IConfigurationService;
 
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
-        super('PipEnvService', serviceContainer);
+        super('PipEnvService', serviceContainer, true);
         this.helper = this.serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
         this.processServiceFactory = this.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         this.workspace = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);

--- a/src/client/interpreter/locators/services/pipEnvService.ts
+++ b/src/client/interpreter/locators/services/pipEnvService.ts
@@ -11,6 +11,7 @@ import { IProcessServiceFactory } from '../../../common/process/types';
 import { IConfigurationService, ICurrentProcess, ILogger } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { IInterpreterHelper, InterpreterType, IPipEnvService, PythonInterpreter } from '../../contracts';
+import { IPipEnvServiceHelper } from '../types';
 import { CacheableLocatorService } from './cacheableLocatorService';
 
 const pipEnvFileNameVariable = 'PIPENV_PIPFILE';
@@ -23,6 +24,7 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
     private readonly fs: IFileSystem;
     private readonly logger: ILogger;
     private readonly configService: IConfigurationService;
+    private readonly pipEnvServiceHelper: IPipEnvServiceHelper;
 
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         super('PipEnvService', serviceContainer, true);
@@ -32,9 +34,10 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
         this.fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
         this.logger = this.serviceContainer.get<ILogger>(ILogger);
         this.configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        this.pipEnvServiceHelper = this.serviceContainer.get<IPipEnvServiceHelper>(IPipEnvServiceHelper);
     }
     // tslint:disable-next-line:no-empty
-    public dispose() { }
+    public dispose() {}
     public async isRelatedPipEnvironment(dir: string, pythonPath: string): Promise<boolean> {
         // In PipEnv, the name of the cwd is used as a prefix in the virtual env.
         if (pythonPath.indexOf(`${path.sep}${path.basename(dir)}-`) === -1) {
@@ -55,7 +58,7 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
         }
 
         return this.getInterpreterFromPipenv(pipenvCwd)
-            .then(item => item ? [item] : [])
+            .then(item => (item ? [item] : []))
             .catch(() => []);
     }
 
@@ -70,10 +73,12 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
             return;
         }
         this._hasInterpreters.resolve(true);
+        await this.pipEnvServiceHelper.trackWorkspaceFolder(interpreterPath, Uri.file(pipenvCwd));
         return {
             ...(details as PythonInterpreter),
             path: interpreterPath,
-            type: InterpreterType.Pipenv
+            type: InterpreterType.Pipenv,
+            pipEnvWorkspaceFolder: pipenvCwd
         };
     }
 
@@ -89,12 +94,12 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
 
     private async getInterpreterPathFromPipenv(cwd: string, ignoreErrors = false): Promise<string | undefined> {
         // Quick check before actually running pipenv
-        if (!await this.checkIfPipFileExists(cwd)) {
+        if (!(await this.checkIfPipFileExists(cwd))) {
             return;
         }
         try {
             const pythonPath = await this.invokePipenv('--py', cwd);
-            return (pythonPath && await this.fs.fileExists(pythonPath)) ? pythonPath : undefined;
+            return pythonPath && (await this.fs.fileExists(pythonPath)) ? pythonPath : undefined;
             // tslint:disable-next-line:no-empty
         } catch (error) {
             traceError('PipEnv identification failed', error);
@@ -103,13 +108,15 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
             }
             const errorMessage = error.message || error;
             const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-            appShell.showWarningMessage(`Workspace contains pipfile but attempt to run 'pipenv --py' failed with ${errorMessage}. Make sure pipenv is on the PATH.`);
+            appShell.showWarningMessage(
+                `Workspace contains pipfile but attempt to run 'pipenv --py' failed with ${errorMessage}. Make sure pipenv is on the PATH.`
+            );
         }
     }
     private async checkIfPipFileExists(cwd: string): Promise<boolean> {
         const currentProcess = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);
         const pipFileName = currentProcess.env[pipEnvFileNameVariable];
-        if (typeof pipFileName === 'string' && await this.fs.fileExists(path.join(cwd, pipFileName))) {
+        if (typeof pipFileName === 'string' && (await this.fs.fileExists(path.join(cwd, pipFileName)))) {
             return true;
         }
         if (await this.fs.fileExists(path.join(cwd, 'Pipfile'))) {
@@ -139,13 +146,18 @@ export class PipEnvService extends CacheableLocatorService implements IPipEnvSer
                 LC_ALL: currentProc.env.LC_ALL,
                 LANG: currentProc.env.LANG
             };
-            enviromentVariableValues[platformService.pathVariableName] = currentProc.env[platformService.pathVariableName];
+            enviromentVariableValues[platformService.pathVariableName] =
+                currentProc.env[platformService.pathVariableName];
 
             this.logger.logWarning('Error in invoking PipEnv', error);
-            this.logger.logWarning(`Relevant Environment Variables ${JSON.stringify(enviromentVariableValues, undefined, 4)}`);
+            this.logger.logWarning(
+                `Relevant Environment Variables ${JSON.stringify(enviromentVariableValues, undefined, 4)}`
+            );
             const errorMessage = error.message || error;
             const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-            appShell.showWarningMessage(`Workspace contains pipfile but attempt to run 'pipenv --venv' failed with '${errorMessage}'. Make sure pipenv is on the PATH.`);
+            appShell.showWarningMessage(
+                `Workspace contains pipfile but attempt to run 'pipenv --venv' failed with '${errorMessage}'. Make sure pipenv is on the PATH.`
+            );
         }
     }
 }

--- a/src/client/interpreter/locators/services/pipEnvServiceHelper.ts
+++ b/src/client/interpreter/locators/services/pipEnvServiceHelper.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { IFileSystem } from '../../../common/platform/types';
+import { IPersistentState, IPersistentStateFactory } from '../../../common/types';
+import { IPipEnvServiceHelper } from '../types';
+
+type PipEnvInformation = { pythonPath: string; workspaceFolder: string; envName: string };
+@injectable()
+export class PipEnvServiceHelper implements IPipEnvServiceHelper {
+    private initialized = false;
+    private readonly state: IPersistentState<ReadonlyArray<PipEnvInformation>>;
+    constructor(
+        @inject(IPersistentStateFactory) private readonly statefactory: IPersistentStateFactory,
+        @inject(IFileSystem) private readonly fs: IFileSystem
+    ) {
+        this.state = this.statefactory.createGlobalPersistentState<ReadonlyArray<PipEnvInformation>>(
+            'PipEnvInformation',
+            []
+        );
+    }
+    public async getPipEnvInfo(pythonPath: string): Promise<{ workspaceFolder: Uri; envName: string} | undefined> {
+        await this.initializeStateStore();
+        const info = this.state.value.find(item => this.fs.arePathsSame(item.pythonPath, pythonPath));
+        return info ? { workspaceFolder: Uri.file(info.workspaceFolder), envName: info.envName } : undefined;
+    }
+    public async trackWorkspaceFolder(pythonPath: string, workspaceFolder: Uri): Promise<void> {
+        await this.initializeStateStore();
+        const values = [...this.state.value].filter(item => !this.fs.arePathsSame(item.pythonPath, pythonPath));
+        const envName = path.basename(workspaceFolder.fsPath);
+        values.push({ pythonPath, workspaceFolder: workspaceFolder.fsPath, envName });
+        await this.state.updateValue(values);
+    }
+    protected async initializeStateStore() {
+        if (this.initialized) {
+            return;
+        }
+        const list = await Promise.all(
+            this.state.value.map(async item => ((await this.fs.fileExists(item.pythonPath)) ? item : undefined))
+        );
+        const filteredList = list.filter(item => !!item) as PipEnvInformation[];
+        await this.state.updateValue(filteredList);
+        this.initialized = true;
+    }
+}

--- a/src/client/interpreter/locators/types.ts
+++ b/src/client/interpreter/locators/types.ts
@@ -3,7 +3,14 @@
 
 'use strict';
 
+import { Uri } from 'vscode';
+
 export const IPythonInPathCommandProvider = Symbol('IPythonInPathCommandProvider');
 export interface IPythonInPathCommandProvider {
     getCommands(): { command: string; args?: string[] }[];
+}
+export const IPipEnvServiceHelper = Symbol('IPipEnvServiceHelper');
+export interface IPipEnvServiceHelper {
+    getPipEnvInfo(pythonPath: string): Promise<{ workspaceFolder: Uri; envName: string} | undefined>;
+    trackWorkspaceFolder(pythonPath: string, workspaceFolder: Uri): Promise<void>;
 }

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -61,10 +61,11 @@ import { GlobalVirtualEnvironmentsSearchPathProvider, GlobalVirtualEnvService } 
 import { InterpreterWatcherBuilder } from './locators/services/interpreterWatcherBuilder';
 import { KnownPathsService, KnownSearchPathsForInterpreters } from './locators/services/KnownPathsService';
 import { PipEnvService } from './locators/services/pipEnvService';
+import { PipEnvServiceHelper } from './locators/services/pipEnvServiceHelper';
 import { WindowsRegistryService } from './locators/services/windowsRegistryService';
 import { WorkspaceVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvService } from './locators/services/workspaceVirtualEnvService';
 import { WorkspaceVirtualEnvWatcherService } from './locators/services/workspaceVirtualEnvWatcherService';
-import { IPythonInPathCommandProvider } from './locators/types';
+import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from './locators/types';
 import { VirtualEnvironmentManager } from './virtualEnvs/index';
 import { IVirtualEnvironmentManager } from './virtualEnvs/types';
 
@@ -74,6 +75,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IVirtualEnvironmentsSearchPathProvider>(IVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvironmentsSearchPathProvider, 'workspace');
 
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
+    serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
     serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
     serviceManager.addSingleton<IPythonInPathCommandProvider>(IPythonInPathCommandProvider, PythonInPathCommandProvider);
 

--- a/src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
+++ b/src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
@@ -7,6 +7,10 @@ import * as assert from 'assert';
 import { instance, mock, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import { Uri } from 'vscode';
+import { IWorkspaceService } from '../../../../client/common/application/types';
+import { WorkspaceService } from '../../../../client/common/application/workspace';
+import { FileSystem } from '../../../../client/common/platform/fileSystem';
+import { IFileSystem } from '../../../../client/common/platform/types';
 import { PipEnvActivationCommandProvider } from '../../../../client/common/terminal/environmentActivationProviders/pipEnvActivationProvider';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../../../../client/common/terminal/types';
 import { getNamesAndValues } from '../../../../client/common/utils/enum';
@@ -22,12 +26,19 @@ suite('Terminals Activation - Pipenv', () => {
             let activationProvider: ITerminalActivationCommandProvider;
             let interpreterService: IInterpreterService;
             let pipenvService: TypeMoq.IMock<IPipEnvService>;
+            let workspaceService: IWorkspaceService;
+            let fs: IFileSystem;
             setup(() => {
+                interpreterService = mock(InterpreterService);
+                fs = mock(FileSystem);
+                workspaceService = mock(WorkspaceService);
                 interpreterService = mock(InterpreterService);
                 pipenvService = TypeMoq.Mock.ofType<IPipEnvService>();
                 activationProvider = new PipEnvActivationCommandProvider(
                     instance(interpreterService),
-                    pipenvService.object
+                    pipenvService.object,
+                    instance(workspaceService),
+                    instance(fs)
                 );
 
                 pipenvService.setup(p => p.executable).returns(() => pipenvExecFile);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -143,6 +143,7 @@ import {
     KnownSearchPathsForInterpreters
 } from '../../client/interpreter/locators/services/KnownPathsService';
 import { PipEnvService } from '../../client/interpreter/locators/services/pipEnvService';
+import { PipEnvServiceHelper } from '../../client/interpreter/locators/services/pipEnvServiceHelper';
 import { WindowsRegistryService } from '../../client/interpreter/locators/services/windowsRegistryService';
 import {
     WorkspaceVirtualEnvironmentsSearchPathProvider,
@@ -151,7 +152,7 @@ import {
 import {
     WorkspaceVirtualEnvWatcherService
 } from '../../client/interpreter/locators/services/workspaceVirtualEnvWatcherService';
-import { IPythonInPathCommandProvider } from '../../client/interpreter/locators/types';
+import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../../client/interpreter/locators/types';
 import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
 import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
 import { MockAutoSelectionService } from '../mocks/autoSelector';
@@ -219,6 +220,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<ITerminalActivationCommandProvider>(
             ITerminalActivationCommandProvider, PipEnvActivationCommandProvider, TerminalActivationProviders.pipenv);
         this.serviceManager.addSingleton<ITerminalManager>(ITerminalManager, TerminalManager);
+        this.serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
 
         // Setup our command list
         this.commandManager.registerCommand('setContext', (name: string, value: boolean) => {

--- a/src/test/interpreters/autoSelection/index.unit.test.ts
+++ b/src/test/interpreters/autoSelection/index.unit.test.ts
@@ -45,8 +45,8 @@ suite('Interpreters - Auto Selection', () => {
     let helper: IInterpreterHelper;
     let proxy: IInterpreterAutoSeletionProxyService;
     class InterpreterAutoSelectionServiceTest extends InterpreterAutoSelectionService {
-        public initializeStore(): Promise<void> {
-            return super.initializeStore();
+        public initializeStore(resource: Resource): Promise<void> {
+            return super.initializeStore(resource);
         }
         public storeAutoSelectedInterpreter(resource: Resource, interpreter: PythonInterpreter | undefined) {
             return super.storeAutoSelectedInterpreter(resource, interpreter);
@@ -127,9 +127,9 @@ suite('Interpreters - Auto Selection', () => {
     test('Initializing the store would be executed once', async () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
 
-        await autoSelectionService.initializeStore();
-        await autoSelectionService.initializeStore();
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
+        await autoSelectionService.initializeStore(undefined);
+        await autoSelectionService.initializeStore(undefined);
 
         verify(stateFactory.createGlobalPersistentState(preferredGlobalInterpreter, undefined)).once();
     });
@@ -140,7 +140,7 @@ suite('Interpreters - Auto Selection', () => {
         when(state.value).thenReturn(interpreterInfo);
         when(fs.fileExists(pythonPath)).thenResolve(false);
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
 
         verify(stateFactory.createGlobalPersistentState(preferredGlobalInterpreter, undefined)).once();
         verify(state.value).atLeast(1);
@@ -154,7 +154,7 @@ suite('Interpreters - Auto Selection', () => {
         when(state.value).thenReturn(interpreterInfo);
         when(fs.fileExists(pythonPath)).thenResolve(true);
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
 
         verify(stateFactory.createGlobalPersistentState(preferredGlobalInterpreter, undefined)).once();
         verify(state.value).atLeast(1);
@@ -168,7 +168,7 @@ suite('Interpreters - Auto Selection', () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
@@ -186,7 +186,7 @@ suite('Interpreters - Auto Selection', () => {
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
         when(state.value).thenReturn(interpreterInfoInState);
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
@@ -204,7 +204,7 @@ suite('Interpreters - Auto Selection', () => {
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
         when(state.value).thenReturn(interpreterInfoInState);
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
@@ -217,7 +217,7 @@ suite('Interpreters - Auto Selection', () => {
         const interpreterInfo = { path: pythonPath } as any;
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.setGlobalInterpreter(interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
@@ -233,7 +233,7 @@ suite('Interpreters - Auto Selection', () => {
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(resource);
 
@@ -248,7 +248,7 @@ suite('Interpreters - Auto Selection', () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.setWorkspaceInterpreter(resource, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(resource);
 
@@ -262,7 +262,7 @@ suite('Interpreters - Auto Selection', () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
 
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(undefined);
 
@@ -277,7 +277,7 @@ suite('Interpreters - Auto Selection', () => {
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
         const globalInterpreterInfo = { path: 'global Value' };
         when(state.value).thenReturn(globalInterpreterInfo as any);
-        await autoSelectionService.initializeStore();
+        await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
         const anotherResourceOfAnotherWorkspace = Uri.parse('Some other workspace');
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(anotherResourceOfAnotherWorkspace);

--- a/src/test/interpreters/autoSelection/index.unit.test.ts
+++ b/src/test/interpreters/autoSelection/index.unit.test.ts
@@ -8,7 +8,6 @@
 import { expect } from 'chai';
 import { SemVer } from 'semver';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
-import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
@@ -16,6 +15,7 @@ import { PersistentState, PersistentStateFactory } from '../../../client/common/
 import { FileSystem } from '../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IPersistentStateFactory, Resource } from '../../../client/common/types';
+import { createDeferred } from '../../../client/common/utils/async';
 import { InterpreterAutoSelectionService } from '../../../client/interpreter/autoSelection';
 import { InterpreterAutoSeletionProxyService } from '../../../client/interpreter/autoSelection/proxy';
 import { CachedInterpretersAutoSelectionRule } from '../../../client/interpreter/autoSelection/rules/cached';
@@ -30,7 +30,7 @@ import { InterpreterHelper } from '../../../client/interpreter/helpers';
 
 const preferredGlobalInterpreter = 'preferredGlobalPyInterpreter';
 
-suite('Interpreters - Auto Selection', () => {
+suite('xInterpreters - Auto Selection', () => {
     let autoSelectionService: InterpreterAutoSelectionServiceTest;
     let workspaceService: IWorkspaceService;
     let stateFactory: IPersistentStateFactory;
@@ -50,6 +50,9 @@ suite('Interpreters - Auto Selection', () => {
         }
         public storeAutoSelectedInterpreter(resource: Resource, interpreter: PythonInterpreter | undefined) {
             return super.storeAutoSelectedInterpreter(resource, interpreter);
+        }
+        public getAutoSelectedWorkspacePromises() {
+            return this.autoSelectedWorkspacePromises;
         }
     }
     setup(() => {
@@ -75,7 +78,7 @@ suite('Interpreters - Auto Selection', () => {
         );
     });
 
-    test('Instance is registere in proxy', () => {
+    test('Instance is registered in proxy', () => {
         verify(proxy.registerInstance!(autoSelectionService)).once();
     });
     test('Rules are chained in order of preference', () => {
@@ -165,6 +168,7 @@ suite('Interpreters - Auto Selection', () => {
         let eventFired = false;
         const pythonPath = 'Hello World';
         const interpreterInfo = { path: pythonPath } as any;
+        when(workspaceService.getWorkspaceFolderIdentifier(undefined, anything())).thenReturn('');
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
 
@@ -185,6 +189,7 @@ suite('Interpreters - Auto Selection', () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
         when(state.value).thenReturn(interpreterInfoInState);
+        when(workspaceService.getWorkspaceFolderIdentifier(undefined, anything())).thenReturn('');
 
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
@@ -203,6 +208,7 @@ suite('Interpreters - Auto Selection', () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
         when(state.value).thenReturn(interpreterInfoInState);
+        when(workspaceService.getWorkspaceFolderIdentifier(undefined, anything())).thenReturn('');
 
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(undefined, interpreterInfo);
@@ -216,6 +222,7 @@ suite('Interpreters - Auto Selection', () => {
         const pythonPath = 'Hello World';
         const interpreterInfo = { path: pythonPath } as any;
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
+        when(workspaceService.getWorkspaceFolderIdentifier(undefined, anything())).thenReturn('');
 
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.setGlobalInterpreter(interpreterInfo);
@@ -232,6 +239,7 @@ suite('Interpreters - Auto Selection', () => {
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
         autoSelectionService.onDidChangeAutoSelectedInterpreter(() => eventFired = true);
+        when(workspaceService.getWorkspaceFolderIdentifier(undefined, anything())).thenReturn('');
 
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
@@ -241,18 +249,37 @@ suite('Interpreters - Auto Selection', () => {
         expect(selectedInterpreter).to.deep.equal(interpreterInfo);
         expect(eventFired).to.deep.equal(false, 'event fired');
     });
-    test('Store workspace interpreter info in state store', async () => {
+    test('Storing workspace interpreter info in state store should fail', async () => {
         const pythonPath = 'Hello World';
         const interpreterInfo = { path: pythonPath } as any;
         const resource = Uri.parse('one');
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
+        when(workspaceService.getWorkspaceFolderIdentifier(anything(), anything())).thenReturn('');
 
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.setWorkspaceInterpreter(resource, interpreterInfo);
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(resource);
 
         verify(state.updateValue(interpreterInfo)).never();
+        expect(selectedInterpreter ? selectedInterpreter : undefined).to.deep.equal(undefined, 'not undefined');
+    });
+    test('Store workspace interpreter info in state store', async () => {
+        const pythonPath = 'Hello World';
+        const interpreterInfo = { path: pythonPath } as any;
+        const resource = Uri.parse('one');
+        when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
+        when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
+        when(workspaceService.getWorkspaceFolderIdentifier(anything(), anything())).thenReturn('');
+        const deferred = createDeferred<void>();
+        deferred.resolve();
+        autoSelectionService.getAutoSelectedWorkspacePromises().set('', deferred);
+
+        await autoSelectionService.initializeStore(undefined);
+        await autoSelectionService.setWorkspaceInterpreter(resource, interpreterInfo);
+        const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(resource);
+
+        verify(state.updateValue(interpreterInfo)).once();
         expect(selectedInterpreter).to.deep.equal(interpreterInfo);
     });
     test('Return undefined when we do not have a global value', async () => {
@@ -261,6 +288,7 @@ suite('Interpreters - Auto Selection', () => {
         const resource = Uri.parse('one');
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
         when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
+        when(workspaceService.getWorkspaceFolderIdentifier(undefined, anything())).thenReturn('');
 
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
@@ -274,44 +302,22 @@ suite('Interpreters - Auto Selection', () => {
         const interpreterInfo = { path: pythonPath } as any;
         const resource = Uri.parse('one');
         when(stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(preferredGlobalInterpreter, undefined)).thenReturn(instance(state));
-        when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
         const globalInterpreterInfo = { path: 'global Value' };
         when(state.value).thenReturn(globalInterpreterInfo as any);
+        when(workspaceService.getWorkspaceFolderIdentifier(resource, anything())).thenReturn('1');
+        const deferred = createDeferred<void>();
+        deferred.resolve();
+        autoSelectionService.getAutoSelectedWorkspacePromises().set('', deferred);
+
         await autoSelectionService.initializeStore(undefined);
         await autoSelectionService.storeAutoSelectedInterpreter(resource, interpreterInfo);
+
         const anotherResourceOfAnotherWorkspace = Uri.parse('Some other workspace');
+        when(workspaceService.getWorkspaceFolderIdentifier(anotherResourceOfAnotherWorkspace, anything())).thenReturn('2');
+
         const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(anotherResourceOfAnotherWorkspace);
 
-        verify(workspaceService.getWorkspaceFolder(resource)).once();
-        verify(workspaceService.getWorkspaceFolder(anotherResourceOfAnotherWorkspace)).once();
         verify(state.updateValue(interpreterInfo)).never();
         expect(selectedInterpreter).to.deep.equal(globalInterpreterInfo);
-    });
-    test('setWorkspaceInterpreter will invoke storeAutoSelectedInterpreter with same args', async () => {
-        const pythonPath = 'Hello World';
-        const interpreterInfo = { path: pythonPath } as any;
-        const resource = Uri.parse('one');
-        const moq = typemoq.Mock.ofInstance(autoSelectionService, typemoq.MockBehavior.Loose, false);
-        moq
-            .setup(m => m.storeAutoSelectedInterpreter(typemoq.It.isValue(resource), typemoq.It.isValue(interpreterInfo)))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        moq.callBase = true;
-        await moq.object.setWorkspaceInterpreter(resource, interpreterInfo);
-
-        moq.verifyAll();
-    });
-    test('setGlobalInterpreter will invoke storeAutoSelectedInterpreter with same args and without a resource', async () => {
-        const pythonPath = 'Hello World';
-        const interpreterInfo = { path: pythonPath } as any;
-        const moq = typemoq.Mock.ofInstance(autoSelectionService, typemoq.MockBehavior.Loose, false);
-        moq
-            .setup(m => m.storeAutoSelectedInterpreter(typemoq.It.isValue(undefined), typemoq.It.isValue(interpreterInfo)))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        moq.callBase = true;
-        await moq.object.setGlobalInterpreter(interpreterInfo);
-
-        moq.verifyAll();
     });
 });

--- a/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
@@ -35,7 +35,7 @@ import {
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 import { KnownPathsService } from '../../../../client/interpreter/locators/services/KnownPathsService';
 
-suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
+suite('xInterpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
     let rule: WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest;
     let stateFactory: IPersistentStateFactory;
     let fs: IFileSystem;
@@ -304,7 +304,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         const nextInvoked = createDeferred();
         rule.next = () => Promise.resolve(nextInvoked.resolve());
         rule.getWorkspaceVirtualEnvInterpreters = () => virtualEnvPromise.promise;
-        when(pipEnvLocator.getInterpreters(folderUri)).thenResolve([interpreterInfo]);
+        when(pipEnvLocator.getInterpreters(folderUri, true)).thenResolve([interpreterInfo]);
         when(helper.getBestInterpreter(deepEqual([interpreterInfo]))).thenReturn(interpreterInfo);
 
         rule.cacheSelectedInterpreter = () => Promise.resolve();
@@ -335,7 +335,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         const nextInvoked = createDeferred();
         rule.next = () => Promise.resolve(nextInvoked.resolve());
         rule.getWorkspaceVirtualEnvInterpreters = () => Promise.resolve([interpreterInfo]);
-        when(pipEnvLocator.getInterpreters(folderUri)).thenResolve([interpreterInfo]);
+        when(pipEnvLocator.getInterpreters(folderUri, true)).thenResolve([interpreterInfo]);
         when(helper.getBestInterpreter(deepEqual([interpreterInfo]))).thenReturn(interpreterInfo);
 
         rule.cacheSelectedInterpreter = () => Promise.resolve();
@@ -366,7 +366,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         const nextInvoked = createDeferred();
         rule.next = () => Promise.resolve(nextInvoked.resolve());
         rule.getWorkspaceVirtualEnvInterpreters = () => virtualEnvPromise.promise;
-        when(pipEnvLocator.getInterpreters(folderUri)).thenResolve([]);
+        when(pipEnvLocator.getInterpreters(folderUri, true)).thenResolve([]);
         when(helper.getBestInterpreter(deepEqual(anything()))).thenReturn(interpreterInfo);
 
         rule.cacheSelectedInterpreter = () => Promise.resolve();
@@ -397,7 +397,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         const nextInvoked = createDeferred();
         rule.next = () => Promise.resolve(nextInvoked.resolve());
         rule.getWorkspaceVirtualEnvInterpreters = () => Promise.resolve([]);
-        when(pipEnvLocator.getInterpreters(folderUri)).thenResolve([]);
+        when(pipEnvLocator.getInterpreters(folderUri, true)).thenResolve([]);
         when(helper.getBestInterpreter(deepEqual(anything()))).thenReturn(interpreterInfo);
 
         rule.cacheSelectedInterpreter = () => Promise.resolve();

--- a/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
@@ -33,14 +33,12 @@ import {
     WorkspacePythonPath
 } from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
-import { InterpreterService } from '../../../../client/interpreter/interpreterService';
 import { KnownPathsService } from '../../../../client/interpreter/locators/services/KnownPathsService';
 
 suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
     let rule: WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest;
     let stateFactory: IPersistentStateFactory;
     let fs: IFileSystem;
-    let interpreterService: InterpreterService;
     let state: PersistentState<PythonInterpreter | undefined>;
     let helper: IInterpreterHelper;
     let platform: IPlatformService;
@@ -69,7 +67,6 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         stateFactory = mock(PersistentStateFactory);
         state = mock(PersistentState);
         fs = mock(FileSystem);
-        interpreterService = mock(InterpreterService);
         helper = mock(InterpreterHelper);
         platform = mock(PlatformService);
         pipEnvLocator = mock(KnownPathsService);
@@ -83,7 +80,6 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         rule = new WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest(
             instance(fs),
             instance(helper),
-            instance(interpreterService),
             instance(stateFactory),
             instance(platform),
             instance(workspaceService),

--- a/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
@@ -33,12 +33,14 @@ import {
     WorkspacePythonPath
 } from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
+import { InterpreterService } from '../../../../client/interpreter/interpreterService';
 import { KnownPathsService } from '../../../../client/interpreter/locators/services/KnownPathsService';
 
 suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
     let rule: WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest;
     let stateFactory: IPersistentStateFactory;
     let fs: IFileSystem;
+    let interpreterService: InterpreterService;
     let state: PersistentState<PythonInterpreter | undefined>;
     let helper: IInterpreterHelper;
     let platform: IPlatformService;
@@ -67,6 +69,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         stateFactory = mock(PersistentStateFactory);
         state = mock(PersistentState);
         fs = mock(FileSystem);
+        interpreterService = mock(InterpreterService);
         helper = mock(InterpreterHelper);
         platform = mock(PlatformService);
         pipEnvLocator = mock(KnownPathsService);
@@ -80,6 +83,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         rule = new WorkspaceVirtualEnvInterpretersAutoSelectionRuleTest(
             instance(fs),
             instance(helper),
+            instance(interpreterService),
             instance(stateFactory),
             instance(platform),
             instance(workspaceService),

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -229,7 +229,7 @@ suite('Interpreters service', () => {
             const pythonPath = '1234';
             const interpreterInfo: Partial<PythonInterpreter> = { path: pythonPath };
             const fileHash = 'File_Hash';
-            const hash = `${fileHash}-${md5(JSON.stringify(interpreterInfo))}`;
+            const hash = `${fileHash}-${md5(JSON.stringify({ ...interpreterInfo, displayName: '' }))}`;
             fileSystem
                 .setup(fs => fs.getFileHash(TypeMoq.It.isValue(pythonPath)))
                 .returns(() => Promise.resolve(fileHash))

--- a/src/test/interpreters/interpreterService.unit.test.ts
+++ b/src/test/interpreters/interpreterService.unit.test.ts
@@ -368,14 +368,6 @@ suite('Interpreters service', () => {
     });
 
     suite('Interprter Cache', () => {
-        class InterpreterServiceTest extends InterpreterService {
-            public async getInterpreterCache(pythonPath: string): Promise<IPersistentState<{ fileHash: string; info?: PythonInterpreter }>> {
-                return super.getInterpreterCache(pythonPath);
-            }
-            public async updateCachedInterpreterInformation(info: PythonInterpreter): Promise<void> {
-                return super.updateCachedInterpreterInformation(info);
-            }
-        }
         setup(() => {
             setupSuite();
             fileSystem.reset();
@@ -412,7 +404,7 @@ suite('Interpreters service', () => {
                 .returns(() => state.object)
                 .verifiable(TypeMoq.Times.once());
 
-            const service = new InterpreterServiceTest(serviceContainer);
+            const service = new InterpreterService(serviceContainer);
 
             const store = await service.getInterpreterCache(pythonPath);
 
@@ -452,7 +444,7 @@ suite('Interpreters service', () => {
                 .returns(() => state.object)
                 .verifiable(TypeMoq.Times.once());
 
-            const service = new InterpreterServiceTest(serviceContainer);
+            const service = new InterpreterService(serviceContainer);
 
             const store = await service.getInterpreterCache(pythonPath);
 

--- a/src/test/interpreters/locators/helpers.unit.test.ts
+++ b/src/test/interpreters/locators/helpers.unit.test.ts
@@ -14,6 +14,7 @@ import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture } from '../../../client/common/utils/platform';
 import { IInterpreterHelper, IInterpreterLocatorHelper, InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
 import { InterpreterLocatorHelper } from '../../../client/interpreter/locators/helpers';
+import { IPipEnvServiceHelper } from '../../../client/interpreter/locators/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 
 enum OS {
@@ -27,17 +28,19 @@ suite('Interpreters - Locators Helper', () => {
     let platform: TypeMoq.IMock<IPlatformService>;
     let helper: IInterpreterLocatorHelper;
     let fs: TypeMoq.IMock<IFileSystem>;
+    let pipEnvHelper: TypeMoq.IMock<IPipEnvServiceHelper>;
     let interpreterServiceHelper: TypeMoq.IMock<IInterpreterHelper>;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         platform = TypeMoq.Mock.ofType<IPlatformService>();
         fs = TypeMoq.Mock.ofType<IFileSystem>();
+        pipEnvHelper = TypeMoq.Mock.ofType<IPipEnvServiceHelper>();
         interpreterServiceHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platform.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterHelper))).returns(() => interpreterServiceHelper.object);
 
-        helper = new InterpreterLocatorHelper(serviceContainer.object);
+        helper = new InterpreterLocatorHelper(fs.object, pipEnvHelper.object);
     });
     test('Ensure default Mac interpreter is not excluded from the list of interpreters', async () => {
         platform.setup(p => p.isWindows).returns(() => false);

--- a/src/test/interpreters/locators/index.unit.test.ts
+++ b/src/test/interpreters/locators/index.unit.test.ts
@@ -90,7 +90,7 @@ suite('Interpreters - Locators Index', () => {
 
                 helper
                     .setup(h => h.mergeInterpreters(TypeMoq.It.isAny()))
-                    .returns(() => locatorsWithInterpreters.map(item => item.interpreters[0]))
+                    .returns(() => Promise.resolve(locatorsWithInterpreters.map(item => item.interpreters[0])))
                     .verifiable(TypeMoq.Times.once());
 
                 await locator.getInterpreters(resource);
@@ -151,7 +151,7 @@ suite('Interpreters - Locators Index', () => {
                 const expectedInterpreters = locatorsWithInterpreters.map(item => item.interpreters[0]);
                 helper
                     .setup(h => h.mergeInterpreters(TypeMoq.It.isAny()))
-                    .returns(() => expectedInterpreters)
+                    .returns(() => Promise.resolve(expectedInterpreters))
                     .verifiable(TypeMoq.Times.once());
 
                 const interpreters = await locator.getInterpreters(resource);

--- a/src/test/telemetry/index.unit.test.ts
+++ b/src/test/telemetry/index.unit.test.ts
@@ -11,7 +11,7 @@ import { EXTENSION_ROOT_DIR } from '../../client/constants';
 import { sendTelemetryEvent } from '../../client/telemetry';
 import { correctPathForOsType } from '../common';
 
-suite('Telemetry', () => {
+suite('xTelemetry', () => {
     const oldValueOfVSC_PYTHON_UNIT_TEST = process.env.VSC_PYTHON_UNIT_TEST;
     const oldValueOfVSC_PYTHON_CI_TEST = process.env.VSC_PYTHON_CI_TEST;
     setup(() => {


### PR DESCRIPTION
For #3501 	

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
