### PR TITLE
Give users the capability to define their own regex's for cell/markdown matching

### DIFF
--- a/news/1 Enhancements/4065.md
+++ b/news/1 Enhancements/4065.md
@@ -1,0 +1,1 @@
+Add the capability to have custom regex's for cell/markdown matching

--- a/package.json
+++ b/package.json
@@ -1044,6 +1044,18 @@
                     "description": "Determines if selected code in a python file will go to the terminal or the Python Interactive window when hitting shift+enter",
                     "scope": "resource"
                 },
+                "python.dataScience.codeRegularExpression": {
+                    "type": "string",
+                    "default": "^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
+                    "description": "Regular expression used to identify code cells. All code until the next match is considered part of this cell. \nDefaults to '^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])' if left blank",
+                    "scope": "resource"
+                },
+                "python.dataScience.markdownRegularExpression": {
+                    "type": "string",
+                    "default": "^(#\\s*%%\\s*\\[markdown\\]|#\\s*\\<markdowncell\\>)",
+                    "description": "Regular expression used to identify markdown cells. All comments after this expression are considered part of the markdown. \nDefaults to '^(#\\s*%%\\s*\\[markdown\\]|#\\s*\\<markdowncell\\>)' if left blank",
+                    "scope": "resource"
+                },
                 "python.disableInstallationCheck": {
                     "type": "boolean",
                     "default": false,

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -294,6 +294,8 @@ export interface IDataScienceSettings {
     collapseCellInputCodeByDefault: boolean;
     maxOutputSize? : number;
     sendSelectionToInteractiveWindow? : boolean;
+    markdownRegularExpression? : string;
+    codeRegularExpression? : string;
 }
 
 export const IConfigurationService = Symbol('IConfigurationService');

--- a/src/client/datascience/cellMatcher.ts
+++ b/src/client/datascience/cellMatcher.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import '../common/extensions';
+
+import { IDataScienceSettings } from '../common/types';
+import { noop } from '../common/utils/misc';
+import { RegExpValues } from './constants';
+
+export class CellMatcher {
+    private codeMatchRegEx : RegExp;
+    private markdownMatchRegEx : RegExp;
+    private codeExecRegEx: RegExp;
+    private markdownExecRegEx : RegExp;
+
+    constructor(settings?: IDataScienceSettings) {
+        this.codeMatchRegEx = this.createRegExp(settings ? settings.codeRegularExpression : undefined, RegExpValues.PythonCellMarker);
+        this.markdownMatchRegEx = this.createRegExp(settings ? settings.markdownRegularExpression : undefined, RegExpValues.PythonMarkdownCellMarker);
+        this.codeExecRegEx = new RegExp(`${this.codeMatchRegEx.source}(.*)`);
+        this.markdownExecRegEx = new RegExp(`${this.markdownMatchRegEx.source}(.*)`);
+    }
+
+    public isCell(code: string) : boolean {
+        return this.codeMatchRegEx.test(code) || this.markdownMatchRegEx.test(code);
+    }
+
+    public isMarkdown(code: string) : boolean {
+        return this.markdownMatchRegEx.test(code);
+    }
+
+    public isCode(code: string) : boolean {
+        return this.codeMatchRegEx.test(code);
+    }
+
+    public exec(code: string) : string | undefined {
+        let result: RegExpExecArray;
+        if (this.codeMatchRegEx.test(code)) {
+            this.codeExecRegEx.lastIndex = -1;
+            result = this.codeExecRegEx.exec(code);
+        } else if (this.markdownMatchRegEx.test(code)) {
+            this.markdownExecRegEx.lastIndex = -1;
+            result = this.markdownExecRegEx.exec(code);
+        }
+        if (result) {
+            return result.length > 1 ? result[result.length - 1].trim() : '';
+        }
+        return undefined;
+    }
+
+    private createRegExp(potential: string | undefined, backup: RegExp) : RegExp {
+        try {
+            if (potential) {
+                return new RegExp(potential);
+            }
+        } catch {
+            noop();
+        }
+
+        return backup;
+    }
+}

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -34,8 +34,8 @@ export namespace EditorContexts {
 }
 
 export namespace RegExpValues {
-    export const PythonCellMarker = new RegExp('^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])(.*)');
-    export const PythonMarkdownCellMarker = /^#\s*%%\s*\[markdown\]/;
+    export const PythonCellMarker = /^(#\s*%%|#\s*\<codecell\>|#\s*In\[\d*?\]|#\s*In\[ \])/;
+    export const PythonMarkdownCellMarker = /^(#\s*%%\s*\[markdown\]|#\s*\<markdowncell\>)/;
 }
 
 export namespace HistoryMessages {

--- a/src/client/datascience/datascience.ts
+++ b/src/client/datascience/datascience.ts
@@ -216,10 +216,11 @@ export class DataScience implements IDataScience {
         // Setup the editor context for the cells
         const editorContext = new ContextKey(EditorContexts.HasCodeCells, this.commandManager);
         const activeEditor = this.documentManager.activeTextEditor;
+
         if (activeEditor && activeEditor.document.languageId === PYTHON_LANGUAGE) {
             // Inform the editor context that we have cells, fire and forget is ok on the promise here
             // as we don't care to wait for this context to be set and we can't do anything if it fails
-            editorContext.set(hasCells(activeEditor.document)).catch();
+            editorContext.set(hasCells(activeEditor.document, this.configuration.getSettings().datascience)).catch();
         } else {
             editorContext.set(false).catch();
         }

--- a/src/client/datascience/historycommandlistener.ts
+++ b/src/client/datascience/historycommandlistener.ts
@@ -120,7 +120,7 @@ export class HistoryCommandListener implements IDataScienceCommandListener {
             // If the current file is the active editor, then generate cells from the document.
             const activeEditor = this.documentManager.activeTextEditor;
             if (activeEditor && this.fileSystem.arePathsSame(activeEditor.document.fileName, file)) {
-                const cells = generateCellsFromDocument(activeEditor.document);
+                const cells = generateCellsFromDocument(activeEditor.document, this.configuration.getSettings().datascience);
                 if (cells) {
                     const filtersKey = localize.DataScience.exportDialogFilter();
                     const filtersObject: { [name: string]: string[] } = {};

--- a/src/client/datascience/jupyter/jupyterServer.ts
+++ b/src/client/datascience/jupyter/jupyterServer.ts
@@ -15,7 +15,13 @@ import { CancellationToken } from 'vscode-jsonrpc';
 
 import { IWorkspaceService } from '../../common/application/types';
 import { CancellationError } from '../../common/cancellation';
-import { IAsyncDisposable, IAsyncDisposableRegistry, IDisposableRegistry, ILogger } from '../../common/types';
+import {
+    IAsyncDisposable,
+    IAsyncDisposableRegistry,
+    IConfigurationService,
+    IDisposableRegistry,
+    ILogger
+} from '../../common/types';
 import { createDeferred, Deferred, sleep } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
@@ -122,6 +128,7 @@ export class JupyterServer implements INotebookServer, IAsyncDisposable {
         @inject(IWorkspaceService) private workspaceService: IWorkspaceService,
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
         @inject(IAsyncDisposableRegistry) private asyncRegistry: IAsyncDisposableRegistry,
+        @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IJupyterSessionManager) private sessionManager: IJupyterSessionManager) {
         this.asyncRegistry.push(this);
     }
@@ -203,7 +210,7 @@ export class JupyterServer implements INotebookServer, IAsyncDisposable {
         // If we have a session, execute the code now.
         if (this.session) {
             // Generate our cells ahead of time
-            const cells = generateCells(code, file, line, true, id);
+            const cells = generateCells(this.configService.getSettings().datascience, code, file, line, true, id);
 
             // Might have more than one (markdown might be split)
             if (cells.length > 1) {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -134,10 +134,11 @@ export interface IDataScienceCodeLensProvider extends CodeLensProvider {
 // Wraps the Code Watcher API
 export const ICodeWatcher = Symbol('ICodeWatcher');
 export interface ICodeWatcher {
-    addFile(document: TextDocument): void;
+    setDocument(document: TextDocument): void;
     getFileName() : string;
     getVersion() : number;
     getCodeLenses() : CodeLens[];
+    getCachedSettings() : IDataScienceSettings | undefined;
     runAllCells(): void;
     runCell(range: Range): void;
     runCurrentCell(): void;

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -250,7 +250,8 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             jupyterInterruptTimeout: 10000,
             searchForJupyter: true,
             showCellInputCode: true,
-            collapseCellInputCodeByDefault: true
+            collapseCellInputCodeByDefault: true,
+            markdownRegularExpression : undefined
         };
 
         const workspaceConfig: TypeMoq.IMock<WorkspaceConfiguration> = TypeMoq.Mock.ofType<WorkspaceConfiguration>();

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -1,18 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-// tslint:disable:max-func-body-length no-trailing-whitespace no-multiline-string
+// tslint:disable:max-func-body-length no-trailing-whitespace no-multiline-string chai-vague-errors no-unused-expression
 // Disable whitespace / multiline as we use that to pass in our fake file strings
 import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
-import { Range, Selection, TextEditor } from 'vscode';
+import { CancellationTokenSource, CodeLens, Range, Selection, TextEditor } from 'vscode';
 
 import { IApplicationShell, IDocumentManager } from '../../../client/common/application/types';
+import { PythonSettings } from '../../../client/common/configSettings';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { ILogger } from '../../../client/common/types';
+import { IConfigurationService, ILogger } from '../../../client/common/types';
 import { Commands } from '../../../client/datascience/constants';
+import { DataScienceCodeLensProvider } from '../../../client/datascience/editor-integration/codelensprovider';
 import { CodeWatcher } from '../../../client/datascience/editor-integration/codewatcher';
-import { IHistory, IHistoryProvider } from '../../../client/datascience/types';
+import { ICodeWatcher, IHistory, IHistoryProvider } from '../../../client/datascience/types';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { MockAutoSelectionService } from '../../mocks/autoSelector';
 import { createDocument } from './helpers';
 
 suite('DataScience Code Watcher Unit Tests', () => {
@@ -24,7 +28,17 @@ suite('DataScience Code Watcher Unit Tests', () => {
     let documentManager: TypeMoq.IMock<IDocumentManager>;
     let textEditor: TypeMoq.IMock<TextEditor>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
+    let configService: TypeMoq.IMock<IConfigurationService>;
+    let serviceContainer : TypeMoq.IMock<IServiceContainer>;
+    let tokenSource : CancellationTokenSource;
+    const pythonSettings = new class extends PythonSettings {
+        public fireChangeEvent() {
+            this.changed.fire();
+        }
+    }(undefined, new MockAutoSelectionService());
+
     setup(() => {
+        tokenSource = new CancellationTokenSource();
         appShell = TypeMoq.Mock.ofType<IApplicationShell>();
         logger = TypeMoq.Mock.ofType<ILogger>();
         historyProvider = TypeMoq.Mock.ofType<IHistoryProvider>();
@@ -32,6 +46,27 @@ suite('DataScience Code Watcher Unit Tests', () => {
         documentManager = TypeMoq.Mock.ofType<IDocumentManager>();
         textEditor = TypeMoq.Mock.ofType<TextEditor>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
+        configService = TypeMoq.Mock.ofType<IConfigurationService>();
+
+        // Setup default settings
+        pythonSettings.datascience = {
+            allowImportFromNotebook: true,
+            jupyterLaunchTimeout: 20000,
+            enabled: true,
+            jupyterServerURI: 'local',
+            notebookFileRoot: 'WORKSPACE',
+            changeDirOnImportExport: true,
+            useDefaultConfigForJupyter: true,
+            jupyterInterruptTimeout: 10000,
+            searchForJupyter: true,
+            showCellInputCode: true,
+            collapseCellInputCodeByDefault: true,
+            markdownRegularExpression : undefined
+        };
+
+        // Setup the service container to return code watchers
+        serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        serviceContainer.setup(c => c.get(TypeMoq.It.isValue(ICodeWatcher))).returns(() => new CodeWatcher(appShell.object, logger.object, historyProvider.object, fileSystem.object, configService.object, documentManager.object));
 
         // Setup our active history instance
         historyProvider.setup(h => h.getOrCreateActive()).returns(() => activeHistory.object);
@@ -42,7 +77,10 @@ suite('DataScience Code Watcher Unit Tests', () => {
         // Setup the file system
         fileSystem.setup(f => f.arePathsSame(TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => true);
 
-        codeWatcher = new CodeWatcher(appShell.object, logger.object, historyProvider.object, fileSystem.object, documentManager.object);
+        // Setup config service
+        configService.setup(c => c.getSettings()).returns(() => pythonSettings);
+
+        codeWatcher = new CodeWatcher(appShell.object, logger.object, historyProvider.object, fileSystem.object, configService.object, documentManager.object);
     });
 
     test('Add a file with just a #%% mark to a code watcher', () => {
@@ -51,7 +89,7 @@ suite('DataScience Code Watcher Unit Tests', () => {
         const inputText = `#%%`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Verify meta data
         expect(codeWatcher.getFileName()).to.be.equal(fileName, 'File name of CodeWatcher does not match');
@@ -79,7 +117,7 @@ suite('DataScience Code Watcher Unit Tests', () => {
         const inputText = `dummy`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Verify meta data
         expect(codeWatcher.getFileName()).to.be.equal(fileName, 'File name of CodeWatcher does not match');
@@ -107,7 +145,7 @@ third line
 fourth line`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Verify meta data
         expect(codeWatcher.getFileName()).to.be.equal(fileName, 'File name of CodeWatcher does not match');
@@ -137,6 +175,116 @@ fourth line`;
         document.verifyAll();
     });
 
+    test('Add a file with custom marks to a code watcher', () => {
+        const fileName = 'test.py';
+        const version = 1;
+        const inputText =
+`first line
+second line
+
+# <foobar>
+third line
+
+# <baz>
+fourth line
+
+# <mymarkdown>
+# fifth line`;
+        pythonSettings.datascience.codeRegularExpression = '(#\\s*\\<foobar\\>|#\\s*\\<baz\\>)';
+        pythonSettings.datascience.markdownRegularExpression = '(#\\s*\\<markdowncell\\>|#\\s*\\<mymarkdown\\>)';
+
+        const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+
+        codeWatcher.setDocument(document.object);
+
+        // Verify meta data
+        expect(codeWatcher.getFileName()).to.be.equal(fileName, 'File name of CodeWatcher does not match');
+        expect(codeWatcher.getVersion()).to.be.equal(version, 'File version of CodeWatcher does not match');
+
+        // Verify code lenses
+        const codeLenses = codeWatcher.getCodeLenses();
+        expect(codeLenses.length).to.be.equal(6, 'Incorrect count of code lenses');
+        if (codeLenses[0].command) {
+            expect(codeLenses[0].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
+        }
+        expect(codeLenses[0].range).to.be.deep.equal(new Range(3, 0, 5, 0), 'Run Cell code lens range incorrect');
+        if (codeLenses[1].command) {
+            expect(codeLenses[1].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        }
+        expect(codeLenses[1].range).to.be.deep.equal(new Range(3, 0, 5, 0), 'Run All Cells code lens range incorrect');
+        if (codeLenses[2].command) {
+            expect(codeLenses[2].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
+        }
+        expect(codeLenses[2].range).to.be.deep.equal(new Range(6, 0, 8, 0), 'Run Cell code lens range incorrect');
+        if (codeLenses[3].command) {
+            expect(codeLenses[3].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        }
+        expect(codeLenses[3].range).to.be.deep.equal(new Range(6, 0, 8, 0), 'Run All Cells code lens range incorrect');
+        expect(codeLenses[4].range).to.be.deep.equal(new Range(9, 0, 10, 12), 'Run Cell code lens range incorrect');
+        if (codeLenses[5].command) {
+            expect(codeLenses[5].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        }
+        expect(codeLenses[5].range).to.be.deep.equal(new Range(9, 0, 10, 12), 'Run All Cells code lens range incorrect');
+
+        // Verify function calls
+        document.verifyAll();
+    });
+
+    test('Make sure invalid regex from a user still work', () => {
+        const fileName = 'test.py';
+        const version = 1;
+        const inputText =
+`first line
+second line
+
+# <codecell>
+third line
+
+# <codecell>
+fourth line
+
+# <mymarkdown>
+# fifth line`;
+        pythonSettings.datascience.codeRegularExpression = '# * code cell)';
+        pythonSettings.datascience.markdownRegularExpression = '(#\\s*\\<markdowncell\\>|#\\s*\\<mymarkdown\\>)';
+
+        const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+
+        codeWatcher.setDocument(document.object);
+
+        // Verify meta data
+        expect(codeWatcher.getFileName()).to.be.equal(fileName, 'File name of CodeWatcher does not match');
+        expect(codeWatcher.getVersion()).to.be.equal(version, 'File version of CodeWatcher does not match');
+
+        // Verify code lenses
+        const codeLenses = codeWatcher.getCodeLenses();
+        expect(codeLenses.length).to.be.equal(6, 'Incorrect count of code lenses');
+        if (codeLenses[0].command) {
+            expect(codeLenses[0].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
+        }
+        expect(codeLenses[0].range).to.be.deep.equal(new Range(3, 0, 5, 0), 'Run Cell code lens range incorrect');
+        if (codeLenses[1].command) {
+            expect(codeLenses[1].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        }
+        expect(codeLenses[1].range).to.be.deep.equal(new Range(3, 0, 5, 0), 'Run All Cells code lens range incorrect');
+        if (codeLenses[2].command) {
+            expect(codeLenses[2].command.command).to.be.equal(Commands.RunCell, 'Run Cell code lens command incorrect');
+        }
+        expect(codeLenses[2].range).to.be.deep.equal(new Range(6, 0, 8, 0), 'Run Cell code lens range incorrect');
+        if (codeLenses[3].command) {
+            expect(codeLenses[3].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        }
+        expect(codeLenses[3].range).to.be.deep.equal(new Range(6, 0, 8, 0), 'Run All Cells code lens range incorrect');
+        expect(codeLenses[4].range).to.be.deep.equal(new Range(9, 0, 10, 12), 'Run Cell code lens range incorrect');
+        if (codeLenses[5].command) {
+            expect(codeLenses[5].command.command).to.be.equal(Commands.RunAllCells, 'Run All Cells code lens command incorrect');
+        }
+        expect(codeLenses[5].range).to.be.deep.equal(new Range(9, 0, 10, 12), 'Run All Cells code lens range incorrect');
+
+        // Verify function calls
+        document.verifyAll();
+    });
+
     test('Test the RunCell command', async () => {
         const fileName = 'test.py';
         const version = 1;
@@ -148,7 +296,7 @@ fourth line`;
         const testString = 'testing';
         document.setup(doc => doc.getText(testRange)).returns(() => testString).verifiable(TypeMoq.Times.once());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Set up our expected call to add code
         activeHistory.setup(h => h.addCode(TypeMoq.It.isValue(testString),
@@ -184,7 +332,7 @@ testing2`; // Command tests override getText, so just need the ranges here
         const testString2 = 'testing2';
         document.setup(doc => doc.getText(testRange2)).returns(() => testString2).verifiable(TypeMoq.Times.once());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Set up our expected calls to add code
         activeHistory.setup(h => h.addCode(TypeMoq.It.isValue(testString1),
@@ -216,7 +364,7 @@ testing2`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
         document.setup(d => d.getText(new Range(2, 0, 3, 8))).returns(() => 'testing2').verifiable(TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Set up our expected calls to add code
         activeHistory.setup(h => h.addCode(TypeMoq.It.isValue('testing2'),
@@ -247,7 +395,7 @@ testing1
 testing2`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Set up our expected calls to add code
         activeHistory.setup(h => h.addCode(TypeMoq.It.isValue('testing2'),
@@ -278,7 +426,7 @@ testing2`;
 testing2`;
         const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // We don't want to ever call add code here
         activeHistory.setup(h => h.addCode(TypeMoq.It.isAny(),
@@ -310,7 +458,7 @@ testing2`; // Command tests override getText, so just need the ranges here
         const testString = 'testing1';
         document.setup(d => d.getText(testRange)).returns(() => testString).verifiable(TypeMoq.Times.atLeastOnce());
 
-        codeWatcher.addFile(document.object);
+        codeWatcher.setDocument(document.object);
 
         // Set up our expected calls to add code
         activeHistory.setup(h => h.addCode(TypeMoq.It.isValue(testString),
@@ -347,5 +495,33 @@ testing2`; // Command tests override getText, so just need the ranges here
         textEditor.verifyAll();
         activeHistory.verifyAll();
         document.verifyAll();
+    });
+
+    test('CodeLens returned after settings changed is different', () => {
+        // Create our document
+        const fileName = 'test.py';
+        const version = 1;
+        const inputText = '#%% foobar';
+        const document = createDocument(inputText, fileName, version, TypeMoq.Times.atLeastOnce());
+        const codeLensProvider = new DataScienceCodeLensProvider(serviceContainer.object, configService.object);
+
+        let result = codeLensProvider.provideCodeLenses(document.object, tokenSource.token);
+        expect(result, 'result not okay').to.be.ok;
+        let codeLens = result as CodeLens[];
+        expect(codeLens.length).to.equal(2, 'Code lens wrong length');
+
+        // Change settings
+        pythonSettings.datascience.codeRegularExpression = '#%%%.*dude';
+        result = codeLensProvider.provideCodeLenses(document.object, tokenSource.token);
+        expect(result, 'result not okay').to.be.ok;
+        codeLens = result as CodeLens[];
+        expect(codeLens.length).to.equal(0, 'Code lens wrong length');
+
+        // Change settings to empty
+        pythonSettings.datascience.codeRegularExpression = '';
+        result = codeLensProvider.provideCodeLenses(document.object, tokenSource.token);
+        expect(result, 'result not okay').to.be.ok;
+        codeLens = result as CodeLens[];
+        expect(codeLens.length).to.equal(2, 'Code lens wrong length');
     });
 });

--- a/src/test/datascience/historyCommandListener.unit.test.ts
+++ b/src/test/datascience/historyCommandListener.unit.test.ts
@@ -301,7 +301,7 @@ suite('History command listener', async () => {
         await documentManager.showTextDocument(doc);
         when(jupyterExecution.connectToNotebookServer(anything(), anything())).thenResolve(server.object);
         server.setup(s => s.execute(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAnyNumber(), TypeMoq.It.isAny())).returns(() => {
-            return Promise.resolve(generateCells('a=1', 'bar.py', 0, false));
+            return Promise.resolve(generateCells(undefined, 'a=1', 'bar.py', 0, false));
         });
 
         when(applicationShell.showSaveDialog(argThat(o => o.saveLabel && o.saveLabel.includes('Export')))).thenReturn(Promise.resolve(Uri.file('foo')));

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -150,7 +150,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
     }
 
     public addContinuousOutputCell(code: string, resultGenerator: (cancelToken: CancellationToken) => Promise<{result: string; haveMore: boolean}>) {
-        const cells = generateCells(code, 'foo.py', 1, true);
+        const cells = generateCells(undefined, code, 'foo.py', 1, true);
         cells.forEach(c => {
             const key = concatMultilineString(c.data.source).replace(LineFeedRegEx, '');
             if (c.data.cell_type === 'code') {
@@ -181,7 +181,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
     }
 
     public addCell(code: string, result?: undefined | string | number | nbformat.IUnrecognizedOutput | nbformat.IExecuteResult | nbformat.IDisplayData | nbformat.IStream | nbformat.IError, mimeType?: string) {
-        const cells = generateCells(code, 'foo.py', 1, true);
+        const cells = generateCells(undefined, code, 'foo.py', 1, true);
         cells.forEach(c => {
             const key = concatMultilineString(stripComments(c.data.source)).replace(LineFeedRegEx, '');
             if (c.data.cell_type === 'code') {


### PR DESCRIPTION
Add a bunch of tests to verify it works.

For #4065

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
