### PR TITLE
Add a build number to the rolling and release build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ script:
     fi
   - if [[ $BUNDLE == "true" && $AZURE_STORAGE_ACCOUNT && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         npm run clean;
-        npm run updateBuildNumber
+        npm run updateBuildNumber -- --buildNumber $TRAVIS_BUILD_NUMBER
         npm run package;
         npx gulp clean:cleanExceptTests;
         npm run testSmoke;
@@ -112,7 +112,7 @@ script:
     fi
   - if [[ $BUNDLE == "true" && $AZURE_STORAGE_ACCOUNT && "$TRAVIS_BRANCH" == release* && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         npm run clean;
-        npm run updateBuildNumber
+        npm run updateBuildNumber -- --buildNumber $TRAVIS_BUILD_NUMBER
         npm run package;
         npx gulp clean:cleanExceptTests;
         npm run testSmoke;

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ script:
     fi
   - if [[ $BUNDLE == "true" && $AZURE_STORAGE_ACCOUNT && "$TRAVIS_BRANCH" == release* && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         npm run clean;
-        npm run updateBuildNumber -- --buildNumber $TRAVIS_BUILD_NUMBER
+        npm run updateBuildNumber -- --buildNumber $TRAVIS_BUILD_NUMBER --updateChangelog
         npm run package;
         npx gulp clean:cleanExceptTests;
         npm run testSmoke;

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ script:
     fi
   - if [[ $BUNDLE == "true" && $AZURE_STORAGE_ACCOUNT && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         npm run clean;
+        npm run updateBuildNumber
         npm run package;
         npx gulp clean:cleanExceptTests;
         npm run testSmoke;
@@ -111,6 +112,7 @@ script:
     fi
   - if [[ $BUNDLE == "true" && $AZURE_STORAGE_ACCOUNT && "$TRAVIS_BRANCH" == release* && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
         npm run clean;
+        npm run updateBuildNumber
         npm run package;
         npx gulp clean:cleanExceptTests;
         npm run testSmoke;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 2019.1.<build_version> (29 Jan 2019)
-
-todo: put next version here. <build_version> will be replaced
-
 ## 2018.12.1 (14 Dec 2018)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2019.1.0.<build_version> (29 Jan 2019)
+## 2019.1.<build_version> (29 Jan 2019)
 
 todo: put next version here. <build_version> will be replaced
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.1.0.<build_version> (29 Jan 2019)
+
+todo: put next version here. <build_version> will be replaced
+
 ## 2018.12.1 (14 Dec 2018)
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,11 +238,12 @@ Starting in 2018, the extension switched to
 auto-updates and thus there is no need to track its version
 number for backwards-compatibility. As such, the major version
 is the current year, the minor version is the month when feature
-freeze was reached, and the micro version is how many releases there
-have been in that month (starting at 0). For example
-the release made when we reach feature freeze in July 2018
-would be `2018.7.0`, and if there is a second release in that month
-it would be `2018.7.1`.
+freeze was reached, the micro version is how many releases there
+have been in that month (starting at 0), and the build number is the
+epoch time on the build machine when a build was generated.
+For example the release made when we reach feature freeze in July 2018
+would be `2018.7.0.<some number>`, and if there is a second release in that month
+it would be `2018.7.1.<some number>`.
 
 ## Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,12 +238,10 @@ Starting in 2018, the extension switched to
 auto-updates and thus there is no need to track its version
 number for backwards-compatibility. As such, the major version
 is the current year, the minor version is the month when feature
-freeze was reached, the micro version is how many releases there
-have been in that month (starting at 0), and the build number is the
-epoch time on the build machine when a build was generated.
+freeze was reached, and the build number is a number that increments for every build.
 For example the release made when we reach feature freeze in July 2018
-would be `2018.7.0.<some number>`, and if there is a second release in that month
-it would be `2018.7.1.<some number>`.
+would be `2018.7.<some number>`, and if there is a second release in that month
+it would be `2018.7.<some larger number>`.
 
 ## Releasing
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,12 +183,14 @@ async function updateBuildNumber(args) {
         // Write back to the package json
         await fsExtra.writeFile('package.json', JSON.stringify(packageJson, null, 4), 'utf-8');
 
-        // Update the changelog.md if we can find a <version_number> entry
-        const changeLogContents = await fsExtra.readFile('CHANGELOG.md', 'utf-8');
-        const fixedContents = changeLogContents.replace(/\<build_version\>/, buildNumberPortion);
+        // Update the changelog.md if we are told to (this should happen on the release branch)
+        if (args.updateChangelog) {
+            const changeLogContents = await fsExtra.readFile('CHANGELOG.md', 'utf-8');
+            const fixedContents = changeLogContents.replace(/##\s*(\d+)\.(\d+)\.(\d+)\s*\(/, `## $1.$2.${buildNumberPortion} (`);
 
-        // Write back to changelog.md
-        await fsExtra.writeFile('CHANGELOG.md', fixedContents, 'utf-8');
+            // Write back to changelog.md
+            await fsExtra.writeFile('CHANGELOG.md', fixedContents, 'utf-8');
+        }
     } else {
         throw Error('buildNumber argument required for updateBuildNumber task')
     }

--- a/news/1 Enhancements/4183.md
+++ b/news/1 Enhancements/4183.md
@@ -1,0 +1,1 @@
+Add a build number to our released builds

--- a/package.json
+++ b/package.json
@@ -1892,7 +1892,8 @@
         "clean": "gulp clean",
         "cover:enable": "gulp cover:enable",
         "debugger-coverage": "gulp debugger-coverage",
-        "cover:inlinesource": "gulp inlinesource"
+        "cover:inlinesource": "gulp inlinesource",
+        "updateBuildNumber": "gulp updateBuildNumber"
     },
     "dependencies": {
         "@jupyterlab/services": "^3.1.4",


### PR DESCRIPTION
For #4183 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
