### PR TITLE
Fix history of length one to behave differently

### DIFF
--- a/news/2 Fixes/4145.md
+++ b/news/2 Fixes/4145.md
@@ -1,0 +1,1 @@
+Fix hitting the up arrow on the input prompt for the Python Interactive window to behave like the terminal window when only 1 item in the history.

--- a/src/datascience-ui/history-react/inputHistory.ts
+++ b/src/datascience-ui/history-react/inputHistory.ts
@@ -51,19 +51,22 @@ export class InputHistory {
     }
 
     private adjustCursors(currentPos: number) {
-        if (currentPos < this.historyStack.length) {
-            this.up = currentPos + 1;
-        } else {
-            this.up = this.historyStack.length;
+        // For a single item, ony up works. But never modify it.
+        if (this.historyStack.length > 1) {
+            if (currentPos < this.historyStack.length) {
+                this.up = currentPos + 1;
+            } else {
+                this.up = this.historyStack.length;
 
-            // If we go off the end, don't make the down go up to the last.
-            // CMD prompt behaves this way. Down is always one off.
-            currentPos = this.historyStack.length - 1;
-        }
-        if (currentPos > 0) {
-            this.down = currentPos - 1;
-        } else {
-            this.down = undefined;
+                // If we go off the end, don't make the down go up to the last.
+                // CMD prompt behaves this way. Down is always one off.
+                currentPos = this.historyStack.length - 1;
+            }
+            if (currentPos > 0) {
+                this.down = currentPos - 1;
+            } else {
+                this.down = undefined;
+            }
         }
     }
 }


### PR DESCRIPTION
For #4145 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
