### PR TITLE
Fix debugger tests to remove --file from the PTVSD CLI

### DIFF
--- a/src/test/debugger/attach.ptvsd.test.ts
+++ b/src/test/debugger/attach.ptvsd.test.ts
@@ -61,7 +61,7 @@ suite('Debugging - Attach Debugger', () => {
         // Set the path for PTVSD to be picked up.
         // tslint:disable-next-line:no-string-literal
         env['PYTHONPATH'] = PTVSD_PATH;
-        const pythonArgs = ['-m', 'ptvsd', '--host', 'localhost', '--wait', '--port', `${port}`, '--file', fileToDebug.fileToCommandArgument()];
+        const pythonArgs = ['-m', 'ptvsd', '--host', 'localhost', '--wait', '--port', `${port}`, fileToDebug.fileToCommandArgument()];
         proc = spawn(PYTHON_PATH, pythonArgs, { env: env, cwd: path.dirname(fileToDebug) });
         const exited = new Promise(resolve => proc.once('close', resolve));
         await sleep(3000);

--- a/src/test/debugger/capabilities.test.ts
+++ b/src/test/debugger/capabilities.test.ts
@@ -89,7 +89,7 @@ suite('Debugging - Capabilities', function () {
         const port = await getFreePort({ host, port: 3000 });
         const env = { ...process.env };
         env.PYTHONPATH = PTVSD_PATH;
-        proc = spawn(PYTHON_PATH, ['-m', 'ptvsd', '--host', 'localhost', '--port', `${port}`, '--wait', fileToDebug], { cwd: path.dirname(fileToDebug), env });
+        proc = spawn(PYTHON_PATH, ['-m', 'ptvsd', '--host', 'localhost', '--wait', '--port', `${port}`, fileToDebug], { cwd: path.dirname(fileToDebug), env });
         await sleep(3000);
 
         const connected = createDeferred();

--- a/src/test/debugger/capabilities.test.ts
+++ b/src/test/debugger/capabilities.test.ts
@@ -89,7 +89,7 @@ suite('Debugging - Capabilities', function () {
         const port = await getFreePort({ host, port: 3000 });
         const env = { ...process.env };
         env.PYTHONPATH = PTVSD_PATH;
-        proc = spawn(PYTHON_PATH, ['-m', 'ptvsd', '--host', 'localhost', '--wait', '--port', `${port}`, '--file', fileToDebug], { cwd: path.dirname(fileToDebug), env });
+        proc = spawn(PYTHON_PATH, ['-m', 'ptvsd', '--host', 'localhost', '--port', `${port}`, '--wait', fileToDebug], { cwd: path.dirname(fileToDebug), env });
         await sleep(3000);
 
         const connected = createDeferred();


### PR DESCRIPTION
For #4157

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
