### PR TITLE
Add option to disable automatic isort

### DIFF
--- a/news/1 Enhancements/4216.md
+++ b/news/1 Enhancements/4216.md
@@ -1,0 +1,1 @@
+Add an option to disable automated isort.

--- a/package.json
+++ b/package.json
@@ -1594,6 +1594,12 @@
                     "description": "Path to the pipenv executable to use for activation.",
                     "scope": "resource"
                 },
+                "python.sortImports.enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable sorting Python imports automatically",
+                    "default": true,
+                    "scope": "resource"
+                },
                 "python.sortImports.args": {
                     "type": "array",
                     "description": "Arguments passed in. Each argument is a separate item in the array.",

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -192,7 +192,7 @@ export class PythonSettings implements IPythonSettings {
             this.sortImports = sortImportSettings;
         }
         // Support for travis.
-        this.sortImports = this.sortImports ? this.sortImports : { path: '', args: [] };
+        this.sortImports = this.sortImports ? this.sortImports : { enabled: true, path: '', args: [] };
         // Support for travis.
         this.linting = this.linting ? this.linting : {
             enabled: false,

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -163,6 +163,7 @@ export interface IPythonSettings {
     readonly onDidChange: Event<void>;
 }
 export interface ISortImportSettings {
+    readonly enabled: boolean;
     readonly path: string;
     readonly args: string[];
 }

--- a/src/client/providers/importSortProvider.ts
+++ b/src/client/providers/importSortProvider.ts
@@ -32,6 +32,10 @@ export class SortImportsEditingProvider implements ISortImportsEditingProvider {
     @captureTelemetry(EventName.FORMAT_SORT_IMPORTS)
     public async provideDocumentSortImportsEdits(uri: Uri, token?: CancellationToken): Promise<WorkspaceEdit | undefined> {
         const document = await this.documentManager.openTextDocument(uri);
+        const settings = this.configurationService.getSettings(uri);
+        if (!settings.sortImports.enabled) {
+            return;
+        }
         if (!document) {
             return;
         }
@@ -48,7 +52,6 @@ export class SortImportsEditingProvider implements ISortImportsEditingProvider {
         if (tmpFile) {
             await fsService.writeFile(tmpFile.filePath, document.getText());
         }
-        const settings = this.configurationService.getSettings(uri);
         const isort = settings.sortImports.path;
         const filePath = tmpFile ? tmpFile.filePath : document.uri.fsPath;
         const args = [filePath, '--diff'].concat(settings.sortImports.args);


### PR DESCRIPTION
For #4216

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~