### PR TITLE
Added support for multi root workspaces with the new language server server

### DIFF
--- a/news/2 Fixes/3008.md
+++ b/news/2 Fixes/3008.md
@@ -1,0 +1,1 @@
+Add support for multi root workspaces with the new language server server

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -77,9 +77,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         }
     }
     protected onWorkspaceFoldersChanged() {
+        //If an activated workspace folder was removed, delete its key
         const workspaceKeys = this.workspaceService.workspaceFolders!.map(workspaceFolder => this.getWorkspaceKey(workspaceFolder.uri));
         const activatedWkspcKeys = Array.from(this.activatedWorkspaces.keys());
-        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
+        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(item => workspaceKeys.indexOf(item) < 0);
         if (activatedWkspcFoldersRemoved.length > 0) {
             for (const folder of activatedWkspcFoldersRemoved) {
                 this.activatedWorkspaces.delete(folder);

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -77,6 +77,12 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         }
     }
     protected onWorkspaceFoldersChanged() {
+        const workspaceKeys = this.workspaceService.workspaceFolders!.map(workspaceFolder => this.getWorkspaceKey(workspaceFolder.uri));
+        const activatedWkspcKeys = Array.from(this.activatedWorkspaces.keys());
+        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
+        if (activatedWkspcFoldersRemoved.length > 0){
+            this.activatedWorkspaces.delete(activatedWkspcFoldersRemoved[0]);
+        }
         this.addRemoveDocOpenedHandlers();
     }
     protected hasMultipleWorkspaces() {

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -80,8 +80,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         const workspaceKeys = this.workspaceService.workspaceFolders!.map(workspaceFolder => this.getWorkspaceKey(workspaceFolder.uri));
         const activatedWkspcKeys = Array.from(this.activatedWorkspaces.keys());
         const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
-        if (activatedWkspcFoldersRemoved.length > 0){
-            this.activatedWorkspaces.delete(activatedWkspcFoldersRemoved[0]);
+        if (activatedWkspcFoldersRemoved.length > 0) {
+            for (const folder of activatedWkspcFoldersRemoved) {
+                this.activatedWorkspaces.delete(folder);
+            }
         }
         this.addRemoveDocOpenedHandlers();
     }

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -103,7 +103,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         //If an activated workspace folder was removed, dispose its activator
         const workspaceKeys = this.workspaceService.workspaceFolders!.map(workspaceFolder => this.getWorkspacePathKey(workspaceFolder.uri));
         const activatedWkspcKeys = Array.from(this.lsActivatedWorkspaces.keys());
-        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
+        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(item => workspaceKeys.indexOf(item) < 0);
         if (activatedWkspcFoldersRemoved.length > 0) {
             for (const folder of activatedWkspcFoldersRemoved) {
                 this.lsActivatedWorkspaces.get(folder).dispose();

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -105,8 +105,10 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         const activatedWkspcKeys = Array.from(this.lsActivatedWorkspaces.keys());
         const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
         if (activatedWkspcFoldersRemoved.length > 0) {
-            this.lsActivatedWorkspaces.get(activatedWkspcFoldersRemoved[0]).dispose();
-            this.lsActivatedWorkspaces.delete(activatedWkspcFoldersRemoved[0]);
+            for (const folder of activatedWkspcFoldersRemoved) {
+                this.lsActivatedWorkspaces.get(folder).dispose();
+                this.lsActivatedWorkspaces.delete(folder);
+            }
         }
     }
 

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -23,7 +23,6 @@ type ActivatorInfo = { jedi: boolean; activator: ILanguageServerActivator };
 @injectable()
 export class LanguageServerExtensionActivationService implements IExtensionActivationService, Disposable {
     private lsActivatedWorkspaces = new Map<string, ILanguageServerActivator>();
-    private workspaceFoldersCount = 1;
     private currentActivator?: ActivatorInfo;
     private jediActivatedOnce: boolean = false;
     private readonly workspaceService: IWorkspaceService;
@@ -101,18 +100,13 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
     }
 
     protected onWorkspaceFoldersChanged() {
-        if (this.workspaceService.workspaceFolders!.length < this.workspaceFoldersCount) {
-            //If the removed workspace folder was activated, dispose its activator
-            this.workspaceFoldersCount += -1;
-            const workspaceKeys = this.workspaceService.workspaceFolders!.map(workspaceFolder => this.getWorkspacePathKey(workspaceFolder.uri));
-            const activatedWkspcKeys = Array.from(this.lsActivatedWorkspaces.keys());
-            const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
-            if (activatedWkspcFoldersRemoved.length > 0) {
-                this.lsActivatedWorkspaces.get(activatedWkspcFoldersRemoved[0]).dispose();
-                this.lsActivatedWorkspaces.delete(activatedWkspcFoldersRemoved[0]);
-            }
-        } else {
-            this.workspaceFoldersCount += 1;
+        //If an activated workspace folder was removed, dispose its activator
+        const workspaceKeys = this.workspaceService.workspaceFolders!.map(workspaceFolder => this.getWorkspacePathKey(workspaceFolder.uri));
+        const activatedWkspcKeys = Array.from(this.lsActivatedWorkspaces.keys());
+        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
+        if (activatedWkspcFoldersRemoved.length > 0) {
+            this.lsActivatedWorkspaces.get(activatedWkspcFoldersRemoved[0]).dispose();
+            this.lsActivatedWorkspaces.delete(activatedWkspcFoldersRemoved[0]);
         }
     }
 

--- a/src/client/activation/jedi.ts
+++ b/src/client/activation/jedi.ts
@@ -33,7 +33,7 @@ export class JediExtensionActivator implements ILanguageServerActivator {
         this.documentSelector = PYTHON;
     }
 
-    public async activate(_resource: Resource): Promise<void> {
+    public async activate(resource: Resource): Promise<void> {
         const context = this.context;
 
         const jediFactory = (this.jediFactory = new JediFactory(context.asAbsolutePath('.'), this.serviceManager));
@@ -89,7 +89,7 @@ export class JediExtensionActivator implements ILanguageServerActivator {
         const symbolProvider = new JediSymbolProvider(serviceContainer, jediFactory);
         context.subscriptions.push(languages.registerDocumentSymbolProvider(this.documentSelector, symbolProvider));
 
-        const pythonSettings = this.serviceManager.get<IConfigurationService>(IConfigurationService).getSettings();
+        const pythonSettings = this.serviceManager.get<IConfigurationService>(IConfigurationService).getSettings(resource);
         if (pythonSettings.devOptions.indexOf('DISABLE_SIGNATURE') === -1) {
             context.subscriptions.push(
                 languages.registerSignatureHelpProvider(

--- a/src/client/activation/jedi.ts
+++ b/src/client/activation/jedi.ts
@@ -4,7 +4,7 @@
 import { inject, injectable } from 'inversify';
 import { DocumentFilter, languages } from 'vscode';
 import { PYTHON } from '../common/constants';
-import { IConfigurationService, IExtensionContext, ILogger } from '../common/types';
+import { IConfigurationService, IExtensionContext, ILogger, Resource } from '../common/types';
 import { IShebangCodeLensProvider } from '../interpreter/contracts';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { JediFactory } from '../languageServices/jediProxyFactory';
@@ -33,7 +33,7 @@ export class JediExtensionActivator implements ILanguageServerActivator {
         this.documentSelector = PYTHON;
     }
 
-    public async activate(): Promise<void> {
+    public async activate(_resource: Resource): Promise<void> {
         const context = this.context;
 
         const jediFactory = (this.jediFactory = new JediFactory(context.asAbsolutePath('.'), this.serviceManager));

--- a/src/client/activation/jedi.ts
+++ b/src/client/activation/jedi.ts
@@ -34,6 +34,9 @@ export class JediExtensionActivator implements ILanguageServerActivator {
     }
 
     public async activate(resource: Resource): Promise<void> {
+        if (this.jediFactory) {
+            throw new Error('Jedi already started');
+        }
         const context = this.context;
 
         const jediFactory = (this.jediFactory = new JediFactory(context.asAbsolutePath('.'), this.serviceManager));
@@ -89,7 +92,7 @@ export class JediExtensionActivator implements ILanguageServerActivator {
         const symbolProvider = new JediSymbolProvider(serviceContainer, jediFactory);
         context.subscriptions.push(languages.registerDocumentSymbolProvider(this.documentSelector, symbolProvider));
 
-        const pythonSettings = this.serviceManager.get<IConfigurationService>(IConfigurationService).getSettings(resource);
+        const pythonSettings = this.serviceManager.get<IConfigurationService>(IConfigurationService).getSettings();
         if (pythonSettings.devOptions.indexOf('DISABLE_SIGNATURE') === -1) {
             context.subscriptions.push(
                 languages.registerSignatureHelpProvider(

--- a/src/client/activation/languageServer/activator.ts
+++ b/src/client/activation/languageServer/activator.ts
@@ -34,14 +34,16 @@ export class LanguageServerExtensionActivator implements ILanguageServerActivato
         @inject(ILanguageServerFolderService)
         private readonly languageServerFolderService: ILanguageServerFolderService,
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService
-    ) {}
+    ) { }
     @traceDecorators.error('Failed to activate language server')
-    public async activate(): Promise<void> {
-        const mainWorkspaceUri = this.workspace.hasWorkspaceFolders
-            ? this.workspace.workspaceFolders![0].uri
-            : undefined;
-        await this.ensureLanguageServerIsAvailable(mainWorkspaceUri);
-        await this.manager.start(mainWorkspaceUri);
+    public async activate(resource: Resource): Promise<void> {
+        if (!resource) {
+            resource = this.workspace.hasWorkspaceFolders
+                ? this.workspace.workspaceFolders![0].uri
+                : undefined;
+        }
+        await this.ensureLanguageServerIsAvailable(resource);
+        await this.manager.start(resource);
     }
     public dispose(): void {
         this.manager.dispose();

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -79,7 +79,7 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
         properties['DatabasePath'] = path.join(this.context.extensionPath, this.languageServerFolder);
 
         let searchPaths = interpreterData ? interpreterData.searchPaths.split(path.delimiter) : [];
-        const settings = this.configuration.getSettings();
+        const settings = this.configuration.getSettings(this.resource);
         if (settings.autoComplete) {
             const extraPaths = settings.autoComplete.extraPaths;
             if (extraPaths && extraPaths.length > 0) {

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -5,10 +5,10 @@
 
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
-import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, Event, EventEmitter, OutputChannel, Position, TextDocument } from 'vscode';
+import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, DocumentFilter, Event, EventEmitter, OutputChannel, Position, TextDocument } from 'vscode';
 import { LanguageClientOptions, ProvideCompletionItemsSignature } from 'vscode-languageclient';
 import { IWorkspaceService } from '../../common/application/types';
-import { isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
+import { isTestExecution, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import { traceDecorators, traceError } from '../../common/logger';
 import { BANNER_NAME_PROPOSE_LS, IConfigurationService, IExtensionContext, IOutputChannel, IPathUtils, IPythonExtensionBanner, Resource } from '../../common/types';
 import { debounce } from '../../common/utils/decorators';
@@ -99,11 +99,20 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
 
         this.excludedFiles = this.getExcludedFiles();
         this.typeshedPaths = this.getTypeshedPaths();
-
+        const workspaceFolder = this.workspace.getWorkspaceFolder(this.resource);
+        const documentSelector = [
+            { scheme: 'file', language: PYTHON_LANGUAGE },
+            { scheme: 'untitled', language: PYTHON_LANGUAGE }
+        ];
+        if (workspaceFolder){
+            // tslint:disable-next-line:no-any
+            (documentSelector[0] as any).pattern = `${workspaceFolder.uri.fsPath}/**/*`;
+        }
         // Options to control the language client
         return {
             // Register the server for Python documents
-            documentSelector: PYTHON,
+            documentSelector,
+            workspaceFolder,
             synchronize: {
                 configurationSection: PYTHON_LANGUAGE
             },

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
-import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, DocumentFilter, Event, EventEmitter, OutputChannel, Position, TextDocument } from 'vscode';
+import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, Event, EventEmitter, OutputChannel, Position, TextDocument } from 'vscode';
 import { LanguageClientOptions, ProvideCompletionItemsSignature } from 'vscode-languageclient';
 import { IWorkspaceService } from '../../common/application/types';
 import { isTestExecution, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';

--- a/src/client/activation/languageServer/languageServerExtension.ts
+++ b/src/client/activation/languageServer/languageServerExtension.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { Event, EventEmitter } from 'vscode';
+import { ICommandManager } from '../../common/application/types';
+import '../../common/extensions';
+import { IDisposable } from '../../common/types';
+import { ILanguageServerExtension } from '../types';
+
+const loadExtensionCommand = 'python._loadLanguageServerExtension';
+
+@injectable()
+export class LanguageServerExtension implements ILanguageServerExtension {
+    public loadExtensionArgs?: {};
+    protected readonly _invoked = new EventEmitter<void>();
+    private disposable?: IDisposable;
+    constructor(@inject(ICommandManager) private readonly commandManager: ICommandManager) { }
+    public dispose() {
+        if (this.disposable) {
+            this.disposable.dispose();
+        }
+    }
+    public register(): Promise<void> {
+        if (this.disposable) {
+            return;
+        }
+        this.disposable = this.commandManager.registerCommand(loadExtensionCommand, args => {
+            this.loadExtensionArgs = args;
+            this._invoked.fire();
+        });
+    }
+    public get invoked(): Event<void> {
+        return this._invoked.event;
+    }
+}

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -86,7 +86,7 @@ export class LanguageServerExtension implements ILanguageServerExtension {
             this.disposable.dispose();
         }
     }
-    public async register(): Promise<void> {
+    public register(): Promise<void> {
         if (this.disposable) {
             return;
         }

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -19,7 +19,6 @@ const loadExtensionCommand = 'python._loadLanguageServerExtension';
 
 @injectable()
 export class LanguageServerManager implements ILanguageServerManager {
-    protected static loadExtensionArgs?: {};
     private languageServer?: ILanguageServer;
     private resource!: Resource;
     private disposables: IDisposable[] = [];
@@ -76,6 +75,7 @@ export class LanguageServerManager implements ILanguageServerManager {
     }
 }
 
+@injectable()
 export class LanguageServerExtension implements ILanguageServerExtension {
     public loadExtensionArgs?: {};
     protected readonly changed = new EventEmitter<void>();

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -4,8 +4,6 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { Event, EventEmitter } from 'vscode';
-import { ICommandManager } from '../../common/application/types';
 import '../../common/extensions';
 import { traceDecorators } from '../../common/logger';
 import { IDisposable, Resource } from '../../common/types';
@@ -14,8 +12,6 @@ import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { ILanguageServer, ILanguageServerAnalysisOptions, ILanguageServerExtension, ILanguageServerManager } from '../types';
-
-const loadExtensionCommand = 'python._loadLanguageServerExtension';
 
 @injectable()
 export class LanguageServerManager implements ILanguageServerManager {
@@ -72,30 +68,5 @@ export class LanguageServerManager implements ILanguageServerManager {
         const options = await this.analysisOptions!.getAnalysisOptions();
         await this.languageServer.start(this.resource, options);
         this.loadExtensionIfNecessary();
-    }
-}
-
-@injectable()
-export class LanguageServerExtension implements ILanguageServerExtension {
-    public loadExtensionArgs?: {};
-    protected readonly changed = new EventEmitter<void>();
-    private disposable?: IDisposable;
-    constructor(@inject(ICommandManager) private readonly commandManager: ICommandManager) { }
-    public dispose() {
-        if (this.disposable) {
-            this.disposable.dispose();
-        }
-    }
-    public register(): Promise<void> {
-        if (this.disposable) {
-            return;
-        }
-        this.disposable = this.commandManager.registerCommand(loadExtensionCommand, args => {
-            this.loadExtensionArgs = args;
-            this.changed.fire();
-        });
-    }
-    public get invoked(): Event<void> {
-        return this.changed.event;
     }
 }

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -21,10 +21,11 @@ import { InterpreterDataService } from './languageServer/interpreterDataService'
 import { BaseLanguageClientFactory, DownloadedLanguageClientFactory, SimpleLanguageClientFactory } from './languageServer/languageClientFactory';
 import { LanguageServer } from './languageServer/languageServer';
 import { LanguageServerCompatibilityService } from './languageServer/languageServerCompatibilityService';
+import { LanguageServerExtension } from './languageServer/languageServerExtension';
 import { LanguageServerFolderService } from './languageServer/languageServerFolderService';
 import { BetaLanguageServerPackageRepository, DailyLanguageServerPackageRepository, LanguageServerDownloadChannel, StableLanguageServerPackageRepository } from './languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from './languageServer/languageServerPackageService';
-import { LanguageServerExtension, LanguageServerManager } from './languageServer/manager';
+import { LanguageServerManager } from './languageServer/manager';
 import { PlatformData } from './languageServer/platformData';
 import { IDownloadChannelRule, IExtensionActivationManager, IExtensionActivationService, IInterpreterDataService, ILanguageClientFactory, ILanguageServer, ILanguageServerActivator, ILanguageServerAnalysisOptions, ILanguageServerCompatibilityService as ILanagueServerCompatibilityService, ILanguageServerDownloader, ILanguageServerExtension, ILanguageServerFolderService, ILanguageServerManager, ILanguageServerPackageService, IPlatformData, LanguageClientFactory, LanguageServerActivator } from './types';
 

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -24,13 +24,14 @@ import { LanguageServerCompatibilityService } from './languageServer/languageSer
 import { LanguageServerFolderService } from './languageServer/languageServerFolderService';
 import { BetaLanguageServerPackageRepository, DailyLanguageServerPackageRepository, LanguageServerDownloadChannel, StableLanguageServerPackageRepository } from './languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from './languageServer/languageServerPackageService';
-import { LanguageServerManager } from './languageServer/manager';
+import { LanguageServerExtension, LanguageServerManager } from './languageServer/manager';
 import { PlatformData } from './languageServer/platformData';
-import { IDownloadChannelRule, IExtensionActivationManager, IExtensionActivationService, IInterpreterDataService, ILanguageClientFactory, ILanguageServer, ILanguageServerActivator, ILanguageServerAnalysisOptions, ILanguageServerCompatibilityService as ILanagueServerCompatibilityService, ILanguageServerDownloader, ILanguageServerFolderService, ILanguageServerManager, ILanguageServerPackageService, IPlatformData, LanguageClientFactory, LanguageServerActivator } from './types';
+import { IDownloadChannelRule, IExtensionActivationManager, IExtensionActivationService, IInterpreterDataService, ILanguageClientFactory, ILanguageServer, ILanguageServerActivator, ILanguageServerAnalysisOptions, ILanguageServerCompatibilityService as ILanagueServerCompatibilityService, ILanguageServerDownloader, ILanguageServerExtension, ILanguageServerFolderService, ILanguageServerManager, ILanguageServerPackageService, IPlatformData, LanguageClientFactory, LanguageServerActivator } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
-    serviceManager.addSingleton<IExtensionActivationManager>(IExtensionActivationManager, ExtensionActivationManager);
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, LanguageServerExtensionActivationService);
+    serviceManager.addSingleton<ILanguageServerExtension>(ILanguageServerExtension, LanguageServerExtension);
+    serviceManager.add<IExtensionActivationManager>(IExtensionActivationManager, ExtensionActivationManager);
     serviceManager.add<ILanguageServerActivator>(ILanguageServerActivator, JediExtensionActivator, LanguageServerActivator.Jedi);
     serviceManager.add<ILanguageServerActivator>(ILanguageServerActivator, LanguageServerExtensionActivator, LanguageServerActivator.DotNet);
     serviceManager.addSingleton<IPythonExtensionBanner>(IPythonExtensionBanner, LanguageServerSurveyBanner, BANNER_NAME_LS_SURVEY);

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -92,7 +92,7 @@ export const ILanguageServerExtension = Symbol('ILanguageServerExtension');
 export interface ILanguageServerExtension extends IDisposable {
     readonly invoked: Event<void>;
     loadExtensionArgs?: {};
-    register(): Promise<void>;
+    register(): void;
 }
 export const ILanguageServer = Symbol('ILanguageServer');
 export interface ILanguageServer extends IDisposable {

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -28,7 +28,7 @@ export enum LanguageServerActivator {
 
 export const ILanguageServerActivator = Symbol('ILanguageServerActivator');
 export interface ILanguageServerActivator extends IDisposable {
-    activate(): Promise<void>;
+    activate(resource: Resource): Promise<void>;
 }
 
 export const IHttpClient = Symbol('IHttpClient');

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -88,6 +88,12 @@ export const ILanguageServerManager = Symbol('ILanguageServerManager');
 export interface ILanguageServerManager extends IDisposable {
     start(resource: Resource): Promise<void>;
 }
+export const ILanguageServerExtension = Symbol('ILanguageServerExtension');
+export interface ILanguageServerExtension extends IDisposable {
+    readonly invoked: Event<void>;
+    loadExtensionArgs?: {};
+    register(): Promise<void>;
+}
 export const ILanguageServer = Symbol('ILanguageServer');
 export interface ILanguageServer extends IDisposable {
     start(resource: Resource, options: LanguageClientOptions): Promise<void>;

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -381,6 +381,11 @@ export class PythonSettings implements IPythonSettings {
         if (activatedWkspcFoldersRemoved.length > 0) {
             PythonSettings.pythonSettings.delete(activatedWkspcFoldersRemoved[0]);
         }
+        if (activatedWkspcFoldersRemoved.length > 0) {
+            for (const folder of activatedWkspcFoldersRemoved) {
+                PythonSettings.pythonSettings.delete(folder);
+            }
+        }
     }
     protected initialize(): void {
         const onDidChange = () => {

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -377,10 +377,7 @@ export class PythonSettings implements IPythonSettings {
         //If an activated workspace folder was removed, delete its key
         const workspaceKeys = this.workspace.workspaceFolders!.map(workspaceFolder => workspaceFolder.uri.fsPath);
         const activatedWkspcKeys = Array.from(PythonSettings.pythonSettings.keys());
-        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(x => workspaceKeys.indexOf(x) < 0);
-        if (activatedWkspcFoldersRemoved.length > 0) {
-            PythonSettings.pythonSettings.delete(activatedWkspcFoldersRemoved[0]);
-        }
+        const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter(item => workspaceKeys.indexOf(item) < 0);
         if (activatedWkspcFoldersRemoved.length > 0) {
             for (const folder of activatedWkspcFoldersRemoved) {
                 PythonSettings.pythonSettings.delete(folder);

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -1,5 +1,7 @@
+import { DocumentFilter } from 'vscode';
+
 export const PYTHON_LANGUAGE = 'python';
-export const PYTHON = [
+export const PYTHON: DocumentFilter[] = [
     { scheme: 'file', language: PYTHON_LANGUAGE },
     { scheme: 'untitled', language: PYTHON_LANGUAGE }
 ];

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -33,7 +33,7 @@ import {
 } from 'vscode';
 
 import { registerTypes as activationRegisterTypes } from './activation/serviceRegistry';
-import { IExtensionActivationManager } from './activation/types';
+import { IExtensionActivationManager, ILanguageServerExtension } from './activation/types';
 import { buildApi, IExtensionApi } from './api';
 import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { IApplicationDiagnostics } from './application/types';
@@ -294,6 +294,7 @@ function initializeServices(context: ExtensionContext, serviceManager: ServiceMa
     serviceContainer.get<IApplicationDiagnostics>(IApplicationDiagnostics).register();
     serviceContainer.get<ITestCodeNavigatorCommandHandler>(ITestCodeNavigatorCommandHandler).register();
     serviceContainer.get<ITestExplorerCommandHandler>(ITestExplorerCommandHandler).register();
+    serviceContainer.get<ILanguageServerExtension>(ILanguageServerExtension).register();
 }
 
 // tslint:disable-next-line:no-any

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -32,6 +32,7 @@ import { ITestDisplay, ITestResultDisplay, IUnitTestConfigurationService, IUnitT
 @injectable()
 export class UnitTestManagementService implements IUnitTestManagementService, Disposable {
     private readonly outputChannel: OutputChannel;
+    private activatedOnce: boolean = false;
     private readonly disposableRegistry: Disposable[];
     private workspaceTestManagerService?: IWorkspaceTestManagerService;
     private documentManager: IDocumentManager;
@@ -59,6 +60,10 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         return this._onDidStatusChange.event;
     }
     public async activate(symbolProvider: DocumentSymbolProvider): Promise<void> {
+        if (this.activatedOnce) {
+            return;
+        }
+        this.activatedOnce = true;
         this.workspaceTestManagerService = this.serviceContainer.get<IWorkspaceTestManagerService>(IWorkspaceTestManagerService);
         const disposablesRegistry = this.serviceContainer.get<Disposable[]>(IDisposableRegistry);
 

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -174,7 +174,7 @@ suite('Activation - ActivationManager', () => {
 
         documentManager.verifyAll();
         verify(workspaceService.onDidChangeWorkspaceFolders).once();
-        verify(workspaceService.workspaceFolders).once();
+        verify(workspaceService.workspaceFolders).atLeast(1);
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(workspaceService.getWorkspaceFolder(anything())).atLeast(1);
         verify(activationService1.activate(resource)).once();
@@ -230,7 +230,7 @@ suite('Activation - ActivationManager', () => {
 
         documentManager.verifyAll();
         verify(workspaceService.onDidChangeWorkspaceFolders).once();
-        verify(workspaceService.workspaceFolders).once();
+        verify(workspaceService.workspaceFolders).atLeast(1);
         verify(workspaceService.hasWorkspaceFolders).once();
 
         //Removed no. of folders to one
@@ -240,7 +240,7 @@ suite('Activation - ActivationManager', () => {
 
         workspaceFoldersChangedHandler.call(managerTest);
 
-        verify(workspaceService.workspaceFolders).twice();
+        verify(workspaceService.workspaceFolders).atLeast(1);
         verify(workspaceService.hasWorkspaceFolders).twice();
     });
 });

--- a/src/test/activation/activationService.unit.test.ts
+++ b/src/test/activation/activationService.unit.test.ts
@@ -96,7 +96,7 @@ suite('Activation - ActivationService', () => {
                 lsSupported: boolean = true
             ) {
                 activator
-                    .setup(a => a.activate())
+                    .setup(a => a.activate(undefined))
                     .returns(() => Promise.resolve())
                     .verifiable(TypeMoq.Times.once());
                 let activatorName = LanguageServerActivator.Jedi;
@@ -339,7 +339,7 @@ suite('Activation - ActivationService', () => {
                         .returns(() => activatorDotNet.object)
                         .verifiable(TypeMoq.Times.once());
                     activatorDotNet
-                        .setup(a => a.activate())
+                        .setup(a => a.activate(undefined))
                         .returns(() => Promise.reject(new Error('')))
                         .verifiable(TypeMoq.Times.once());
                     serviceContainer
@@ -352,7 +352,7 @@ suite('Activation - ActivationService', () => {
                         .returns(() => activatorJedi.object)
                         .verifiable(TypeMoq.Times.once());
                     activatorJedi
-                        .setup(a => a.activate())
+                        .setup(a => a.activate(undefined))
                         .returns(() => Promise.resolve())
                         .verifiable(TypeMoq.Times.once());
 

--- a/src/test/activation/activationService.unit.test.ts
+++ b/src/test/activation/activationService.unit.test.ts
@@ -5,15 +5,15 @@
 
 // tslint:disable:max-func-body-length
 
+import { expect } from 'chai';
 import { SemVer } from 'semver';
 import * as TypeMoq from 'typemoq';
-import { ConfigurationChangeEvent, Disposable } from 'vscode';
+import { ConfigurationChangeEvent, Disposable, Uri } from 'vscode';
 import { LanguageServerExtensionActivationService } from '../../client/activation/activationService';
 import {
     FolderVersionPair,
     IExtensionActivationService,
     ILanguageServerActivator,
-    ILanguageServerCompatibilityService,
     ILanguageServerFolderService,
     LanguageServerActivator
 } from '../../client/activation/types';
@@ -21,7 +21,7 @@ import { LSNotSupportedDiagnosticServiceId } from '../../client/application/diag
 import { IDiagnosticsService } from '../../client/application/diagnostics/types';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../client/common/application/types';
 import { IPlatformService } from '../../client/common/platform/types';
-import { IConfigurationService, IDisposableRegistry, IOutputChannel, IPythonSettings } from '../../client/common/types';
+import { IConfigurationService, IDisposable, IDisposableRegistry, IOutputChannel, IPythonSettings, Resource } from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
 suite('Activation - ActivationService', () => {
@@ -33,7 +33,6 @@ suite('Activation - ActivationService', () => {
             let cmdManager: TypeMoq.IMock<ICommandManager>;
             let workspaceService: TypeMoq.IMock<IWorkspaceService>;
             let platformService: TypeMoq.IMock<IPlatformService>;
-            let lanagueServerSupportedService: TypeMoq.IMock<ILanguageServerCompatibilityService>;
             let lsNotSupportedDiagnosticService: TypeMoq.IMock<IDiagnosticsService>;
             setup(() => {
                 serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
@@ -48,7 +47,6 @@ suite('Activation - ActivationService', () => {
                     path: '',
                     version: new SemVer('1.2.3')
                 };
-                lanagueServerSupportedService = TypeMoq.Mock.ofType<ILanguageServerCompatibilityService>();
                 lsNotSupportedDiagnosticService = TypeMoq.Mock.ofType<IDiagnosticsService>();
                 workspaceService.setup(w => w.hasWorkspaceFolders).returns(() => false);
                 workspaceService.setup(w => w.workspaceFolders).returns(() => []);
@@ -127,7 +125,6 @@ suite('Activation - ActivationService', () => {
             }
 
             test('LS is supported', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object);
@@ -135,7 +132,6 @@ suite('Activation - ActivationService', () => {
                 await testActivation(activationService, activator, true);
             });
             test('LS is not supported', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(false));
                 pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object);
@@ -144,7 +140,6 @@ suite('Activation - ActivationService', () => {
             });
 
             test('Activatory must be activated', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object);
@@ -152,7 +147,6 @@ suite('Activation - ActivationService', () => {
                 await testActivation(activationService, activator);
             });
             test('Activatory must be deactivated', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object);
@@ -168,7 +162,6 @@ suite('Activation - ActivationService', () => {
                 activator.verifyAll();
             });
             test('Prompt user to reload VS Code and reload, when setting is toggled', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
                 let jediIsEnabledValueInSetting = jediIsEnabled;
                 workspaceService
@@ -206,7 +199,6 @@ suite('Activation - ActivationService', () => {
                 cmdManager.verifyAll();
             });
             test('Prompt user to reload VS Code and do not reload, when setting is toggled', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
                 let jediIsEnabledValueInSetting = jediIsEnabled;
                 workspaceService
@@ -244,7 +236,6 @@ suite('Activation - ActivationService', () => {
                 cmdManager.verifyAll();
             });
             test('Do not prompt user to reload VS Code when setting is not toggled', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
                 workspaceService
                     .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
@@ -280,7 +271,6 @@ suite('Activation - ActivationService', () => {
                 cmdManager.verifyAll();
             });
             test('Do not prompt user to reload VS Code when setting is not changed', async () => {
-                lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                 let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
                 workspaceService
                     .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
@@ -317,7 +307,6 @@ suite('Activation - ActivationService', () => {
             });
             if (!jediIsEnabled) {
                 test('Revert to jedi when LS activation fails', async () => {
-                    lanagueServerSupportedService.setup(ls => ls.isSupported()).returns(() => Promise.resolve(true));
                     pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
                     const activatorDotNet = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                     const activatorJedi = TypeMoq.Mock.ofType<ILanguageServerActivator>();
@@ -361,6 +350,82 @@ suite('Activation - ActivationService', () => {
                     activatorDotNet.verifyAll();
                     activatorJedi.verifyAll();
                     serviceContainer.verifyAll();
+                });
+                async function testActivationOfResource(
+                    activationService: IExtensionActivationService,
+                    activator: TypeMoq.IMock<ILanguageServerActivator>,
+                    resource: Resource
+                ) {
+                    activator
+                        .setup(a => a.activate(resource))
+                        .returns(() => Promise.resolve())
+                        .verifiable(TypeMoq.Times.once());
+                    lsNotSupportedDiagnosticService
+                        .setup(l => l.diagnose(undefined))
+                        .returns(() => Promise.resolve([]));
+                    lsNotSupportedDiagnosticService
+                        .setup(l => l.handle(TypeMoq.It.isValue([])))
+                        .returns(() => Promise.resolve());
+                    serviceContainer
+                        .setup(c => c.get(TypeMoq.It.isValue(ILanguageServerActivator), TypeMoq.It.isValue(LanguageServerActivator.DotNet)))
+                        .returns(() => activator.object)
+                        .verifiable(TypeMoq.Times.atLeastOnce());
+                    workspaceService
+                        .setup(w => w.getWorkspaceFolderIdentifier(resource, ''))
+                        .returns(() => resource.fsPath)
+                        .verifiable(TypeMoq.Times.atLeastOnce());
+
+                    await activationService.activate(resource);
+
+                    activator.verifyAll();
+                    serviceContainer.verifyAll();
+                    workspaceService.verifyAll();
+                }
+                test('Activator is disposed if activated workspace is removed', async () => {
+                    pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                    let workspaceFoldersChangedHandler!: Function;
+                    workspaceService
+                        .setup(w => w.onDidChangeWorkspaceFolders(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                        .callback(cb => (workspaceFoldersChangedHandler = cb))
+                        .returns(() => TypeMoq.Mock.ofType<IDisposable>().object)
+                        .verifiable(TypeMoq.Times.once());
+                    const activationService = new LanguageServerExtensionActivationService(serviceContainer.object);
+                    workspaceService.verifyAll();
+                    expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
+                    const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
+                    const folder2 = { name: 'two', uri: Uri.parse('two'), index: 2 };
+                    const folder3 = { name: 'three', uri: Uri.parse('three'), index: 3 };
+
+                    const activator1 = TypeMoq.Mock.ofType<ILanguageServerActivator>();
+                    await testActivationOfResource(activationService, activator1, folder1.uri);
+                    const activator2 = TypeMoq.Mock.ofType<ILanguageServerActivator>();
+                    await testActivationOfResource(activationService, activator2, folder2.uri);
+                    const activator3 = TypeMoq.Mock.ofType<ILanguageServerActivator>();
+                    await testActivationOfResource(activationService, activator3, folder3.uri);
+
+                    //Now remove folder3
+                    workspaceService.reset();
+                    workspaceService.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+                    workspaceService
+                        .setup(w => w.getWorkspaceFolderIdentifier(folder1.uri, ''))
+                        .returns(() => folder1.uri.fsPath)
+                        .verifiable(TypeMoq.Times.atLeastOnce());
+                    workspaceService
+                        .setup(w => w.getWorkspaceFolderIdentifier(folder2.uri, ''))
+                        .returns(() => folder2.uri.fsPath)
+                        .verifiable(TypeMoq.Times.atLeastOnce());
+                    activator1
+                        .setup(d => d.dispose())
+                        .verifiable(TypeMoq.Times.never());
+                    activator2
+                        .setup(d => d.dispose())
+                        .verifiable(TypeMoq.Times.never());
+                    activator3
+                        .setup(d => d.dispose())
+                        .verifiable(TypeMoq.Times.once());
+                    workspaceFoldersChangedHandler.call(activationService);
+                    workspaceService.verifyAll();
+                    activator3.verifyAll();
                 });
             }
         });

--- a/src/test/activation/languageServer/activator.unit.test.ts
+++ b/src/test/activation/languageServer/activator.unit.test.ts
@@ -61,7 +61,7 @@ suite('Language Server - Activator', () => {
         when(manager.start(undefined)).thenResolve();
         when(settings.downloadLanguageServer).thenReturn(false);
 
-        await activator.activate();
+        await activator.activate(undefined);
 
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
@@ -76,7 +76,7 @@ suite('Language Server - Activator', () => {
         when(manager.start(undefined)).thenResolve();
         when(settings.downloadLanguageServer).thenReturn(false);
 
-        await activator.activate();
+        await activator.activate(undefined);
 
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
@@ -94,7 +94,7 @@ suite('Language Server - Activator', () => {
         when(lsFolderService.getLanguageServerFolderName()).thenResolve(languageServerFolder);
         when(fs.fileExists(mscorlib)).thenResolve(true);
 
-        await activator.activate();
+        await activator.activate(undefined);
 
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
@@ -114,7 +114,7 @@ suite('Language Server - Activator', () => {
         when(fs.fileExists(mscorlib)).thenResolve(false);
         when(lsDownloader.downloadLanguageServer(languageServerFolderPath)).thenReturn(deferred.promise);
 
-        const promise = activator.activate();
+        const promise = activator.activate(undefined);
         await sleep(1);
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(lsFolderService.getLanguageServerFolderName()).once();
@@ -135,7 +135,7 @@ suite('Language Server - Activator', () => {
         when(manager.start(uri)).thenResolve();
         when(settings.downloadLanguageServer).thenReturn(false);
 
-        await activator.activate();
+        await activator.activate(undefined);
 
         verify(manager.start(uri)).once();
         verify(workspaceService.hasWorkspaceFolders).once();

--- a/src/test/activation/languageServer/languageServerExtension.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerExtension.unit.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import * as typemoq from 'typemoq';
+import { LanguageServerExtension } from '../../../client/activation/languageServer/languageServerExtension';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { ICommandManager } from '../../../client/common/application/types';
+import { IDisposable } from '../../../client/common/types';
+
+use(chaiAsPromised);
+
+// tslint:disable:max-func-body-length no-any chai-vague-errors no-unused-expression
+
+const loadExtensionCommand = 'python._loadLanguageServerExtension';
+
+suite('Language Server - Language Server Extension', () => {
+    class LanguageServerExtensionTest extends LanguageServerExtension {
+        // tslint:disable-next-line:no-unnecessary-override
+        public async register(): Promise<void> {
+            return super.register();
+        }
+        public clearLoadExtensionArgs() {
+            super.loadExtensionArgs = undefined;
+        }
+    }
+    let extension: LanguageServerExtensionTest;
+    let cmdManager: ICommandManager;
+    let commandRegistrationDisposable: typemoq.IMock<IDisposable>;
+    setup(() => {
+        cmdManager = mock(CommandManager);
+        commandRegistrationDisposable = typemoq.Mock.ofType<IDisposable>();
+        extension = new LanguageServerExtensionTest(instance(cmdManager));
+        extension.clearLoadExtensionArgs();
+    });
+    test('Must register command handler', async () => {
+        when(cmdManager.registerCommand(loadExtensionCommand, anything())).thenReturn(
+            commandRegistrationDisposable.object
+        );
+        await extension.register();
+        verify(cmdManager.registerCommand(loadExtensionCommand, anything())).once();
+        extension.dispose();
+        commandRegistrationDisposable.verify(d => d.dispose(), typemoq.Times.once());
+    });
+});

--- a/src/test/activation/languageServer/manager.unit.test.ts
+++ b/src/test/activation/languageServer/manager.unit.test.ts
@@ -5,7 +5,7 @@
 
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
@@ -89,6 +89,7 @@ suite('xLanguage Server - Manager', () => {
             verify(analysisOptions.getAnalysisOptions()).once();
             verify(serviceContainer.get<ILanguageServer>(ILanguageServer)).once();
             verify(languageServer.start(resource, languageClientOptions)).once();
+            expect(invoked).to.be.true;
             expect(analysisHandlerRegistered).to.be.true;
             verify(languageServer.dispose()).never();
         }
@@ -176,21 +177,6 @@ suite('xLanguage Server - Manager', () => {
             verify(serviceContainer.get<ILanguageServer>(ILanguageServer)).thrice();
             verify(languageServer.start(resource, languageClientOptions)).thrice();
         });
-        // Write system test to test this
-        // test('Must load extension when command is sent', async () => {
-        //     const args = { x: 1 };
-        //     when(lsExtension.loadExtensionArgs).thenReturn(undefined);
-        //     await startLanguageServer();
-
-        //     verify(languageServer.loadExtension(args)).never();
-
-        //     await extension.register();
-        //     const cb = capture(commandManager.registerCommand).first()[1] as Function;
-        //     cb.call(manager, args);
-
-        //     verify(languageServer.loadExtension(args)).once();
-        //     commandRegistrationDisposable.verify(d => d.dispose(), typemoq.Times.never());
-        // });
         test('Must load extension when command was been sent before starting LS', async () => {
             const args = { x: 1 };
             when(lsExtension.loadExtensionArgs).thenReturn(args as any);


### PR DESCRIPTION
For #3008 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
