### PR TITLE
Add TreeView data model and hook up existing test data

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -93,8 +93,9 @@ import { ReplProvider } from './providers/replProvider';
 import { registerTypes as providersRegisterTypes } from './providers/serviceRegistry';
 import { activateSimplePythonRefactorProvider } from './providers/simpleRefactorProvider';
 import { TerminalProvider } from './providers/terminalProvider';
-import { PythonTestTreeViewProvider } from './providers/testTreeViewProvider';
-import { ISortImportsEditingProvider } from './providers/types';
+import {
+    IPythonTestTreeViewProvider, ISortImportsEditingProvider
+} from './providers/types';
 import { activateUpdateSparkLibraryProvider } from './providers/updateSparkLibraryProvider';
 import { sendTelemetryEvent } from './telemetry';
 import { EventName } from './telemetry/constants';
@@ -208,7 +209,8 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
 
     context.subscriptions.push(languages.registerCodeActionsProvider(PYTHON, new PythonCodeActionProvider(), { providedCodeActionKinds: [CodeActionKind.SourceOrganizeImports] }));
 
-    context.subscriptions.push(window.registerTreeDataProvider('python_tests', new PythonTestTreeViewProvider()));
+    const testViewProvider = serviceContainer.get<IPythonTestTreeViewProvider>(IPythonTestTreeViewProvider);
+    context.subscriptions.push(window.registerTreeDataProvider('python_tests', testViewProvider));
 
     serviceContainer.getAll<DebugConfigurationProvider>(IDebugConfigurationService).forEach(debugConfigProvider => {
         context.subscriptions.push(debug.registerDebugConfigurationProvider(DebuggerTypeName, debugConfigProvider));

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -93,9 +93,7 @@ import { ReplProvider } from './providers/replProvider';
 import { registerTypes as providersRegisterTypes } from './providers/serviceRegistry';
 import { activateSimplePythonRefactorProvider } from './providers/simpleRefactorProvider';
 import { TerminalProvider } from './providers/terminalProvider';
-import {
-    IPythonTestTreeViewProvider, ISortImportsEditingProvider
-} from './providers/types';
+import { ISortImportsEditingProvider } from './providers/types';
 import { activateUpdateSparkLibraryProvider } from './providers/updateSparkLibraryProvider';
 import { sendTelemetryEvent } from './telemetry';
 import { EventName } from './telemetry/constants';
@@ -208,9 +206,6 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
     context.subscriptions.push(new TerminalProvider(serviceContainer));
 
     context.subscriptions.push(languages.registerCodeActionsProvider(PYTHON, new PythonCodeActionProvider(), { providedCodeActionKinds: [CodeActionKind.SourceOrganizeImports] }));
-
-    const testViewProvider = serviceContainer.get<IPythonTestTreeViewProvider>(IPythonTestTreeViewProvider);
-    context.subscriptions.push(window.registerTreeDataProvider('python_tests', testViewProvider));
 
     serviceContainer.getAll<DebugConfigurationProvider>(IDebugConfigurationService).forEach(debugConfigProvider => {
         context.subscriptions.push(debug.registerDebugConfigurationProvider(DebuggerTypeName, debugConfigProvider));

--- a/src/client/providers/serviceRegistry.ts
+++ b/src/client/providers/serviceRegistry.ts
@@ -5,12 +5,8 @@
 
 import { IServiceManager } from '../ioc/types';
 import { SortImportsEditingProvider } from './importSortProvider';
-import { TestTreeViewProvider } from './testTreeViewProvider';
-import {
-    ISortImportsEditingProvider, ITestTreeViewProvider
-} from './types';
+import { ISortImportsEditingProvider } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ISortImportsEditingProvider>(ISortImportsEditingProvider, SortImportsEditingProvider);
-    serviceManager.addSingleton<ITestTreeViewProvider>(ITestTreeViewProvider, TestTreeViewProvider);
 }

--- a/src/client/providers/serviceRegistry.ts
+++ b/src/client/providers/serviceRegistry.ts
@@ -5,12 +5,12 @@
 
 import { IServiceManager } from '../ioc/types';
 import { SortImportsEditingProvider } from './importSortProvider';
-import { PythonTestTreeViewProvider } from './testTreeViewProvider';
+import { TestTreeViewProvider } from './testTreeViewProvider';
 import {
-    IPythonTestTreeViewProvider, ISortImportsEditingProvider
+    ISortImportsEditingProvider, ITestTreeViewProvider
 } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ISortImportsEditingProvider>(ISortImportsEditingProvider, SortImportsEditingProvider);
-    serviceManager.addSingleton<IPythonTestTreeViewProvider>(IPythonTestTreeViewProvider, PythonTestTreeViewProvider);
+    serviceManager.addSingleton<ITestTreeViewProvider>(ITestTreeViewProvider, TestTreeViewProvider);
 }

--- a/src/client/providers/serviceRegistry.ts
+++ b/src/client/providers/serviceRegistry.ts
@@ -5,8 +5,12 @@
 
 import { IServiceManager } from '../ioc/types';
 import { SortImportsEditingProvider } from './importSortProvider';
-import { ISortImportsEditingProvider } from './types';
+import { PythonTestTreeViewProvider } from './testTreeViewProvider';
+import {
+    IPythonTestTreeViewProvider, ISortImportsEditingProvider
+} from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ISortImportsEditingProvider>(ISortImportsEditingProvider, SortImportsEditingProvider);
+    serviceManager.addSingleton<IPythonTestTreeViewProvider>(IPythonTestTreeViewProvider, PythonTestTreeViewProvider);
 }

--- a/src/client/providers/testTreeViewItem.ts
+++ b/src/client/providers/testTreeViewItem.ts
@@ -11,7 +11,7 @@ import {
     TestStatus, TestSuite
 } from '../unittests/common/types';
 
-export enum PythonTestTreeItemType {
+export enum TestTreeItemType {
     Root = 'Root',
     Package = 'Package',
     File = 'File',
@@ -19,22 +19,22 @@ export enum PythonTestTreeItemType {
     Function = 'Function'
 }
 
-export class PythonTestTreeItem extends TreeItem {
+export class TestTreeItem extends TreeItem {
 
     constructor(
-        kind: PythonTestTreeItemType,
-        private myParent: PythonTestTreeItem,
-        private myChildren: PythonTestTreeItem[],
+        kind: TestTreeItemType,
+        private readonly myParent: TestTreeItem,
+        private readonly myChildren: TestTreeItem[],
         runId: string,
         name: string,
         testStatus: TestStatus = TestStatus.Unknown,
         // tslint:disable-next-line:no-unused-variable
-        private data: TestFolder | TestFile | TestSuite | TestFunction
+        private readonly data: TestFolder | TestFile | TestSuite | TestFunction
     ) {
 
         super(
             `[${kind}] ${name}`,
-            kind === PythonTestTreeItemType.Function ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed
+            kind === TestTreeItemType.Function ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed
         );
 
         this.contextValue = kind;
@@ -44,11 +44,11 @@ export class PythonTestTreeItem extends TreeItem {
 
     public static createFromFolder(
         folder: TestFolder,
-        parent?: PythonTestTreeItem
-    ): PythonTestTreeItem {
+        parent?: TestTreeItem
+    ): TestTreeItem {
 
-        const folderItem = new PythonTestTreeItem(
-            PythonTestTreeItemType.Package,
+        const folderItem = new TestTreeItem(
+            TestTreeItemType.Package,
             parent,
             [],
             folder.nameToRun,
@@ -58,7 +58,7 @@ export class PythonTestTreeItem extends TreeItem {
         );
 
         folder.testFiles.forEach((testFile: TestFile) => {
-            folderItem.children.push(PythonTestTreeItem.createFromFile(testFile, folderItem));
+            folderItem.children.push(TestTreeItem.createFromFile(testFile, folderItem));
         });
 
         return folderItem;
@@ -66,11 +66,11 @@ export class PythonTestTreeItem extends TreeItem {
 
     public static createFromFile(
         testFile: TestFile,
-        parent?: PythonTestTreeItem
-    ): PythonTestTreeItem {
+        parent?: TestTreeItem
+    ): TestTreeItem {
 
-        const fileItem = new PythonTestTreeItem(
-            PythonTestTreeItemType.File,
+        const fileItem = new TestTreeItem(
+            TestTreeItemType.File,
             parent,
             [],
             testFile.nameToRun,
@@ -80,10 +80,10 @@ export class PythonTestTreeItem extends TreeItem {
         );
 
         testFile.functions.forEach((fn: TestFunction) => {
-            fileItem.children.push(PythonTestTreeItem.createFromFunction(fn, fileItem));
+            fileItem.children.push(TestTreeItem.createFromFunction(fn, fileItem));
         });
         testFile.suites.forEach((suite: TestSuite) => {
-            fileItem.children.push(PythonTestTreeItem.createFromSuite(suite, fileItem));
+            fileItem.children.push(TestTreeItem.createFromSuite(suite, fileItem));
         });
 
         return fileItem;
@@ -91,11 +91,11 @@ export class PythonTestTreeItem extends TreeItem {
 
     public static createFromSuite(
         suite: TestSuite,
-        parent: PythonTestTreeItem
-    ): PythonTestTreeItem {
+        parent: TestTreeItem
+    ): TestTreeItem {
 
-        const suiteItem = new PythonTestTreeItem(
-            PythonTestTreeItemType.Suite,
+        const suiteItem = new TestTreeItem(
+            TestTreeItemType.Suite,
             parent,
             [],
             suite.nameToRun,
@@ -105,10 +105,10 @@ export class PythonTestTreeItem extends TreeItem {
         );
 
         suite.suites.forEach((subSuite: TestSuite) => {
-            suiteItem.children.push(PythonTestTreeItem.createFromSuite(subSuite, suiteItem));
+            suiteItem.children.push(TestTreeItem.createFromSuite(subSuite, suiteItem));
         });
         suite.functions.forEach((fn: TestFunction) => {
-            suiteItem.children.push(PythonTestTreeItem.createFromFunction(fn, suiteItem));
+            suiteItem.children.push(TestTreeItem.createFromFunction(fn, suiteItem));
         });
 
         return suiteItem;
@@ -116,12 +116,12 @@ export class PythonTestTreeItem extends TreeItem {
 
     public static createFromFunction(
         fn: TestFunction,
-        parent: PythonTestTreeItem
-    ): PythonTestTreeItem {
+        parent: TestTreeItem
+    ): TestTreeItem {
 
         // tslint:disable-next-line:no-unnecessary-local-variable
-        const funcItem = new PythonTestTreeItem(
-            PythonTestTreeItemType.Function,
+        const funcItem = new TestTreeItem(
+            TestTreeItemType.Function,
             parent,
             undefined,
             fn.nameToRun,
@@ -133,11 +133,11 @@ export class PythonTestTreeItem extends TreeItem {
         return funcItem;
     }
 
-    public get children(): PythonTestTreeItem[] {
+    public get children(): TestTreeItem[] {
         return this.myChildren;
     }
 
-    public get parent(): PythonTestTreeItem {
+    public get parent(): TestTreeItem {
         return this.myParent;
     }
 }

--- a/src/client/providers/testTreeViewItem.ts
+++ b/src/client/providers/testTreeViewItem.ts
@@ -28,7 +28,7 @@ export class PythonTestTreeItem extends TreeItem {
         runId: string,
         name: string,
         testStatus: TestStatus = TestStatus.Unknown,
-        // tslint:disable-next-line:
+        // tslint:disable-next-line:no-unused-variable
         private data: TestFolder | TestFile | TestSuite | TestFunction
     ) {
 

--- a/src/client/providers/testTreeViewItem.ts
+++ b/src/client/providers/testTreeViewItem.ts
@@ -28,6 +28,7 @@ export class PythonTestTreeItem extends TreeItem {
         runId: string,
         name: string,
         testStatus: TestStatus = TestStatus.Unknown,
+        // tslint:disable-next-line:
         private data: TestFolder | TestFile | TestSuite | TestFunction
     ) {
 

--- a/src/client/providers/testTreeViewProvider.ts
+++ b/src/client/providers/testTreeViewProvider.ts
@@ -39,7 +39,7 @@ export class TestTreeViewProvider implements ITestTreeViewProvider, IDisposable 
         this.root = [new TestTreeItem(TestTreeItemType.Root, undefined, undefined, '*', 'no tests discovered yet', TestStatus.Unknown, undefined)];
         this.refresh(this.workspace.workspaceFolders[0].uri);
         disposableRegistry.push(this);
-        this.disposables.push(this.testStore.onTestStoreUpdated(this.onTestStoreUpdated, this));
+        this.disposables.push(this.testStore.onUpdated(this.onTestStoreUpdated, this));
     }
 
     // tslint:disable-next-line:no-empty

--- a/src/client/providers/testTreeViewProvider.ts
+++ b/src/client/providers/testTreeViewProvider.ts
@@ -14,20 +14,20 @@ import {
     ITestCollectionStorageService, TestFolder, Tests, TestStatus
 } from '../unittests/common/types';
 import {
-    PythonTestTreeItem, PythonTestTreeItemType
+    TestTreeItem, TestTreeItemType
 } from './testTreeViewItem';
-import { IPythonTestTreeViewProvider } from './types';
+import { ITestTreeViewProvider as ITestTreeViewProvider } from './types';
 
 @injectable()
-export class PythonTestTreeViewProvider implements IPythonTestTreeViewProvider, IDisposable {
+export class TestTreeViewProvider implements ITestTreeViewProvider, IDisposable {
     /**
      * This will trigger the view to update the changed element/root and its children recursively (if shown).
      * To signal that root has changed, do not pass any argument or pass `undefined` or `null`.
      */
-    public readonly onDidChangeTreeData: Event<PythonTestTreeItem | undefined>;
+    public readonly onDidChangeTreeData: Event<TestTreeItem | undefined>;
 
-    private _onDidChangeTreeData: EventEmitter<PythonTestTreeItem | undefined> = new EventEmitter<PythonTestTreeItem | undefined>();
-    private root: PythonTestTreeItem[];
+    private _onDidChangeTreeData: EventEmitter<TestTreeItem | undefined> = new EventEmitter<TestTreeItem | undefined>();
+    private root: TestTreeItem[];
     private disposables: IDisposable[] = [];
 
     constructor(
@@ -36,7 +36,7 @@ export class PythonTestTreeViewProvider implements IPythonTestTreeViewProvider, 
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry
     ) {
         this.onDidChangeTreeData = this._onDidChangeTreeData.event;
-        this.root = [new PythonTestTreeItem(PythonTestTreeItemType.Root, undefined, undefined, '*', 'no tests discovered yet', TestStatus.Unknown, undefined)];
+        this.root = [new TestTreeItem(TestTreeItemType.Root, undefined, undefined, '*', 'no tests discovered yet', TestStatus.Unknown, undefined)];
         this.refresh(this.workspace.workspaceFolders[0].uri);
         disposableRegistry.push(this);
         this.disposables.push(this.testStore.onTestStoreUpdated(this.onTestStoreUpdated, this));
@@ -54,7 +54,7 @@ export class PythonTestTreeViewProvider implements IPythonTestTreeViewProvider, 
      * @param element The element for which [TreeItem](#TreeItem) representation is asked for.
      * @return [TreeItem](#TreeItem) representation of the element
      */
-    public async getTreeItem(element: PythonTestTreeItem): Promise<PythonTestTreeItem> {
+    public async getTreeItem(element: TestTreeItem): Promise<TestTreeItem> {
         return element;
     }
 
@@ -64,7 +64,7 @@ export class PythonTestTreeViewProvider implements IPythonTestTreeViewProvider, 
      * @param element The element from which the provider gets children. Can be `undefined`.
      * @return Children of `element` or root if no element is passed.
      */
-    public getChildren(element?: PythonTestTreeItem): ProviderResult<PythonTestTreeItem[]> {
+    public getChildren(element?: TestTreeItem): ProviderResult<TestTreeItem[]> {
         if (element === undefined) {
             return this.root;
         }
@@ -80,7 +80,7 @@ export class PythonTestTreeViewProvider implements IPythonTestTreeViewProvider, 
      * @param element The element for which the parent has to be returned.
      * @return Parent of `element`.
      */
-    public getParent?(element: PythonTestTreeItem): ProviderResult<PythonTestTreeItem> {
+    public getParent?(element: TestTreeItem): ProviderResult<TestTreeItem> {
         return element.parent;
     }
 
@@ -94,9 +94,9 @@ export class PythonTestTreeViewProvider implements IPythonTestTreeViewProvider, 
             tests = this.testStore.getTests(resource);
         }
         if (tests && tests.testFolders) {
-            const newRoot: PythonTestTreeItem[] = [];
+            const newRoot: TestTreeItem[] = [];
             tests.testFolders.forEach((tf: TestFolder) => {
-                newRoot.push(PythonTestTreeItem.createFromFolder(tf));
+                newRoot.push(TestTreeItem.createFromFolder(tf));
             });
             this.root = newRoot;
             this._onDidChangeTreeData.fire();

--- a/src/client/providers/types.ts
+++ b/src/client/providers/types.ts
@@ -3,11 +3,22 @@
 
 'use strict';
 
-import { CancellationToken, Uri, WorkspaceEdit } from 'vscode';
+import {
+    CancellationToken, Event, ProviderResult,
+    TreeDataProvider, Uri, WorkspaceEdit
+} from 'vscode';
+import { PythonTestTreeItem } from './testTreeViewItem';
 
 export const ISortImportsEditingProvider = Symbol('ISortImportsEditingProvider');
 export interface ISortImportsEditingProvider {
     provideDocumentSortImportsEdits(uri: Uri, token?: CancellationToken): Promise<WorkspaceEdit | undefined>;
     sortImports(uri?: Uri): Promise<void>;
     registerCommands(): void;
+}
+
+export const IPythonTestTreeViewProvider = Symbol('IPythonTestTreeViewProvider');
+export interface IPythonTestTreeViewProvider extends TreeDataProvider<PythonTestTreeItem> {
+    onDidChangeTreeData: Event<PythonTestTreeItem | undefined>;
+    getTreeItem(element: PythonTestTreeItem): Promise<PythonTestTreeItem>;
+    getChildren(element?: PythonTestTreeItem): ProviderResult<PythonTestTreeItem[]>;
 }

--- a/src/client/providers/types.ts
+++ b/src/client/providers/types.ts
@@ -7,7 +7,7 @@ import {
     CancellationToken, Event, ProviderResult,
     TreeDataProvider, Uri, WorkspaceEdit
 } from 'vscode';
-import { TestTreeItem } from './testTreeViewItem';
+import { TestTreeItem } from '../unittests/providers/testTreeViewItem';
 
 export const ISortImportsEditingProvider = Symbol('ISortImportsEditingProvider');
 export interface ISortImportsEditingProvider {

--- a/src/client/providers/types.ts
+++ b/src/client/providers/types.ts
@@ -7,7 +7,7 @@ import {
     CancellationToken, Event, ProviderResult,
     TreeDataProvider, Uri, WorkspaceEdit
 } from 'vscode';
-import { PythonTestTreeItem } from './testTreeViewItem';
+import { TestTreeItem } from './testTreeViewItem';
 
 export const ISortImportsEditingProvider = Symbol('ISortImportsEditingProvider');
 export interface ISortImportsEditingProvider {
@@ -16,9 +16,9 @@ export interface ISortImportsEditingProvider {
     registerCommands(): void;
 }
 
-export const IPythonTestTreeViewProvider = Symbol('IPythonTestTreeViewProvider');
-export interface IPythonTestTreeViewProvider extends TreeDataProvider<PythonTestTreeItem> {
-    onDidChangeTreeData: Event<PythonTestTreeItem | undefined>;
-    getTreeItem(element: PythonTestTreeItem): Promise<PythonTestTreeItem>;
-    getChildren(element?: PythonTestTreeItem): ProviderResult<PythonTestTreeItem[]>;
+export const ITestTreeViewProvider = Symbol('ITestTreeViewProvider');
+export interface ITestTreeViewProvider extends TreeDataProvider<TestTreeItem> {
+    onDidChangeTreeData: Event<TestTreeItem | undefined>;
+    getTreeItem(element: TestTreeItem): Promise<TestTreeItem>;
+    getChildren(element?: TestTreeItem): ProviderResult<TestTreeItem[]>;
 }

--- a/src/client/unittests/common/services/storageService.ts
+++ b/src/client/unittests/common/services/storageService.ts
@@ -8,14 +8,14 @@ import { FlattenedTestFunction, FlattenedTestSuite, ITestCollectionStorageServic
 
 @injectable()
 export class TestCollectionStorageService implements ITestCollectionStorageService {
-    public readonly onTestStoreUpdated: Event<Uri>;
+    public readonly onUpdated: Event<Uri>;
 
     private testsIndexedByWorkspaceUri = new Map<string, Tests | undefined>();
     private _onTestStoreUpdated: EventEmitter<Uri> = new EventEmitter<Uri>();
 
     constructor(@inject(IDisposableRegistry) disposables: Disposable[]) {
         disposables.push(this);
-        this.onTestStoreUpdated = this._onTestStoreUpdated.event;
+        this.onUpdated = this._onTestStoreUpdated.event;
     }
     public getTests(wkspace: Uri): Tests | undefined {
         const workspaceFolder = this.getWorkspaceFolderPath(wkspace) || '';

--- a/src/client/unittests/common/services/storageService.ts
+++ b/src/client/unittests/common/services/storageService.ts
@@ -1,13 +1,21 @@
 import { inject, injectable } from 'inversify';
-import { Disposable, Uri, workspace } from 'vscode';
+import {
+    Disposable, Event, EventEmitter,
+    Uri, workspace
+} from 'vscode';
 import { IDisposableRegistry } from '../../../common/types';
 import { FlattenedTestFunction, FlattenedTestSuite, ITestCollectionStorageService, TestFunction, Tests, TestSuite } from './../types';
 
 @injectable()
 export class TestCollectionStorageService implements ITestCollectionStorageService {
+    public readonly onTestStoreUpdated: Event<Uri>;
+
     private testsIndexedByWorkspaceUri = new Map<string, Tests | undefined>();
+    private _onTestStoreUpdated: EventEmitter<Uri> = new EventEmitter<Uri>();
+
     constructor(@inject(IDisposableRegistry) disposables: Disposable[]) {
         disposables.push(this);
+        this.onTestStoreUpdated = this._onTestStoreUpdated.event;
     }
     public getTests(wkspace: Uri): Tests | undefined {
         const workspaceFolder = this.getWorkspaceFolderPath(wkspace) || '';
@@ -16,6 +24,7 @@ export class TestCollectionStorageService implements ITestCollectionStorageServi
     public storeTests(wkspace: Uri, tests: Tests | undefined): void {
         const workspaceFolder = this.getWorkspaceFolderPath(wkspace) || '';
         this.testsIndexedByWorkspaceUri.set(workspaceFolder, tests);
+        this._onTestStoreUpdated.fire(wkspace);
     }
     public findFlattendTestFunction(resource: Uri, func: TestFunction): FlattenedTestFunction | undefined {
         const tests = this.getTests(resource);
@@ -33,6 +42,7 @@ export class TestCollectionStorageService implements ITestCollectionStorageServi
     }
     public dispose() {
         this.testsIndexedByWorkspaceUri.clear();
+        this._onTestStoreUpdated.dispose();
     }
     private getWorkspaceFolderPath(resource: Uri): string | undefined {
         const folder = workspace.getWorkspaceFolder(resource);

--- a/src/client/unittests/common/types.ts
+++ b/src/client/unittests/common/types.ts
@@ -1,4 +1,7 @@
-import { CancellationToken, DiagnosticCollection, Disposable, OutputChannel, Uri } from 'vscode';
+import {
+    CancellationToken, DiagnosticCollection, Disposable,
+    Event, OutputChannel, Uri
+} from 'vscode';
 import { IUnitTestSettings, Product } from '../../common/types';
 import { IPythonUnitTestMessage } from '../types';
 import { CommandSource } from './constants';
@@ -181,6 +184,7 @@ export interface ITestVisitor {
 export const ITestCollectionStorageService = Symbol('ITestCollectionStorageService');
 
 export interface ITestCollectionStorageService extends Disposable {
+    onTestStoreUpdated: Event<Uri>;
     getTests(wkspace: Uri): Tests | undefined;
     storeTests(wkspace: Uri, tests: Tests | null | undefined): void;
     findFlattendTestFunction(resource: Uri, func: TestFunction): FlattenedTestFunction | undefined;

--- a/src/client/unittests/common/types.ts
+++ b/src/client/unittests/common/types.ts
@@ -184,7 +184,7 @@ export interface ITestVisitor {
 export const ITestCollectionStorageService = Symbol('ITestCollectionStorageService');
 
 export interface ITestCollectionStorageService extends Disposable {
-    onTestStoreUpdated: Event<Uri>;
+    onUpdated: Event<Uri>;
     getTests(wkspace: Uri): Tests | undefined;
     storeTests(wkspace: Uri, tests: Tests | null | undefined): void;
     findFlattendTestFunction(resource: Uri, func: TestFunction): FlattenedTestFunction | undefined;

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -3,24 +3,42 @@
 // tslint:disable:no-duplicate-imports no-unnecessary-callback-wrapper
 
 import { inject, injectable } from 'inversify';
-import { ConfigurationChangeEvent, Disposable, OutputChannel, TextDocument, Uri } from 'vscode';
-import * as vscode from 'vscode';
-import { ICommandManager, IDocumentManager, IWorkspaceService } from '../common/application/types';
+import {
+    ConfigurationChangeEvent, Disposable,
+    DocumentSymbolProvider, EventEmitter,
+    OutputChannel, TextDocument, Uri, window
+} from 'vscode';
+import {
+    ICommandManager, IDocumentManager, IWorkspaceService
+} from '../common/application/types';
 import * as constants from '../common/constants';
 import '../common/extensions';
-import { IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../common/types';
+import {
+    IConfigurationService, IDisposableRegistry,
+    ILogger, IOutputChannel
+} from '../common/types';
 import { IServiceContainer } from '../ioc/types';
+import { ITestTreeViewProvider } from '../providers/types';
 import { EventName } from '../telemetry/constants';
 import { sendTelemetryEvent } from '../telemetry/index';
 import { activateCodeLenses } from './codeLenses/main';
-import { CANCELLATION_REASON, CommandSource, TEST_OUTPUT_CHANNEL } from './common/constants';
+import {
+    CANCELLATION_REASON, CommandSource, TEST_OUTPUT_CHANNEL
+} from './common/constants';
 import { selectTestWorkspace } from './common/testUtils';
-import { ITestCollectionStorageService, ITestManager, IWorkspaceTestManagerService, TestFile, TestFunction, TestStatus, TestsToRun } from './common/types';
-import { ITestDisplay, ITestResultDisplay, IUnitTestConfigurationService, IUnitTestManagementService } from './types';
+import {
+    ITestCollectionStorageService, ITestManager,
+    IWorkspaceTestManagerService, TestFile,
+    TestFunction, TestStatus, TestsToRun
+} from './common/types';
+import {
+    ITestDisplay, ITestResultDisplay,
+    IUnitTestConfigurationService, IUnitTestManagementService
+} from './types';
 
 @injectable()
 export class UnitTestManagementService implements IUnitTestManagementService, Disposable {
-    private readonly outputChannel: vscode.OutputChannel;
+    private readonly outputChannel: OutputChannel;
     private readonly disposableRegistry: Disposable[];
     private workspaceTestManagerService?: IWorkspaceTestManagerService;
     private documentManager: IDocumentManager;
@@ -28,7 +46,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
     private testResultDisplay?: ITestResultDisplay;
     private autoDiscoverTimer?: NodeJS.Timer;
     private configChangedTimer?: NodeJS.Timer;
-    private readonly onDidChange: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+    private readonly onDidChange: EventEmitter<void> = new EventEmitter<void>();
 
     constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
         this.disposableRegistry = serviceContainer.get<Disposable[]>(IDisposableRegistry);
@@ -45,12 +63,20 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
     }
     public async activate(symboldProvider: vscode.DocumentSymbolProvider): Promise<void> {
         this.workspaceTestManagerService = this.serviceContainer.get<IWorkspaceTestManagerService>(IWorkspaceTestManagerService);
+        const disposablesRegistry = this.serviceContainer.get<Disposable[]>(IDisposableRegistry);
 
         this.registerHandlers();
         this.registerCommands();
+
+        // register provider...
+        const testViewProvider = this.serviceContainer.get<ITestTreeViewProvider>(ITestTreeViewProvider);
+        const disposable = window.registerTreeDataProvider('python_tests', testViewProvider);
+        disposablesRegistry.push(disposable);
+
         this.autoDiscoverTests()
             .catch(ex => this.serviceContainer.get<ILogger>(ILogger).logError('Failed to auto discover tests upon activation', ex));
         await this.registerSymbolProvider(symboldProvider);
+    public async activateCodeLenses(symboldProvider: DocumentSymbolProvider): Promise<void> {
     }
     public async getTestManager(displayTestNotConfiguredMessage: boolean, resource?: Uri): Promise<ITestManager | undefined | void> {
         let wkspace: Uri | undefined;

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -61,7 +61,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
             this.workspaceTestManagerService.dispose();
         }
     }
-    public async activate(symboldProvider: vscode.DocumentSymbolProvider): Promise<void> {
+    public async activate(symbolProvider: DocumentSymbolProvider): Promise<void> {
         this.workspaceTestManagerService = this.serviceContainer.get<IWorkspaceTestManagerService>(IWorkspaceTestManagerService);
         const disposablesRegistry = this.serviceContainer.get<Disposable[]>(IDisposableRegistry);
 
@@ -75,9 +75,14 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
 
         this.autoDiscoverTests()
             .catch(ex => this.serviceContainer.get<ILogger>(ILogger).logError('Failed to auto discover tests upon activation', ex));
-        await this.registerSymbolProvider(symboldProvider);
-    public async activateCodeLenses(symboldProvider: DocumentSymbolProvider): Promise<void> {
+        await this.registerSymbolProvider(symbolProvider);
     }
+
+    public async activateCodeLenses(symbolProvider: DocumentSymbolProvider): Promise<void> {
+        const testCollectionStorage = this.serviceContainer.get<ITestCollectionStorageService>(ITestCollectionStorageService);
+        this.disposableRegistry.push(activateCodeLenses(this.onDidChange, symbolProvider, testCollectionStorage));
+    }
+
     public async getTestManager(displayTestNotConfiguredMessage: boolean, resource?: Uri): Promise<ITestManager | undefined | void> {
         let wkspace: Uri | undefined;
         if (resource) {
@@ -304,9 +309,9 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         this.testResultDisplay.displayProgressStatus(promise, debug);
         await promise;
     }
-    private async registerSymbolProvider(symboldProvider: vscode.DocumentSymbolProvider): Promise<void> {
+    private async registerSymbolProvider(symbolProvider: DocumentSymbolProvider): Promise<void> {
         const testCollectionStorage = this.serviceContainer.get<ITestCollectionStorageService>(ITestCollectionStorageService);
-        this.disposableRegistry.push(activateCodeLenses(this.onDidChange, symboldProvider, testCollectionStorage));
+        this.disposableRegistry.push(activateCodeLenses(this.onDidChange, symbolProvider, testCollectionStorage));
     }
     private registerCommands(): void {
         const disposablesRegistry = this.serviceContainer.get<Disposable[]>(IDisposableRegistry);

--- a/src/client/unittests/providers/testTreeViewItem.ts
+++ b/src/client/unittests/providers/testTreeViewItem.ts
@@ -9,7 +9,7 @@ import {
 import {
     TestFile, TestFolder, TestFunction,
     TestStatus, TestSuite
-} from '../unittests/common/types';
+} from '../common/types';
 
 export enum TestTreeItemType {
     Root = 'Root',

--- a/src/client/unittests/providers/testTreeViewProvider.ts
+++ b/src/client/unittests/providers/testTreeViewProvider.ts
@@ -7,16 +7,18 @@ import { inject, injectable } from 'inversify';
 import {
     Event, EventEmitter, ProviderResult, Uri
 } from 'vscode';
-import { IWorkspaceService } from '../common/application/types';
-import { traceDecorators } from '../common/logger';
-import { IDisposable, IDisposableRegistry, Resource } from '../common/types';
+import { IWorkspaceService } from '../../common/application/types';
+import { traceDecorators } from '../../common/logger';
+import {
+    IDisposable, IDisposableRegistry, Resource
+} from '../../common/types';
+import { ITestTreeViewProvider } from '../../providers/types';
 import {
     ITestCollectionStorageService, TestFolder, Tests, TestStatus
-} from '../unittests/common/types';
+} from '../common/types';
 import {
     TestTreeItem, TestTreeItemType
 } from './testTreeViewItem';
-import { ITestTreeViewProvider as ITestTreeViewProvider } from './types';
 
 @injectable()
 export class TestTreeViewProvider implements ITestTreeViewProvider, IDisposable {

--- a/src/client/unittests/serviceRegistry.ts
+++ b/src/client/unittests/serviceRegistry.ts
@@ -3,6 +3,7 @@
 
 import { Uri } from 'vscode';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
+import { ITestTreeViewProvider } from '../providers/types';
 import { ArgumentsHelper } from './common/argumentsHelper';
 import { NOSETEST_PROVIDER, PYTEST_PROVIDER, UNITTEST_PROVIDER } from './common/constants';
 import { DebugLauncher } from './common/debugLauncher';
@@ -18,8 +19,11 @@ import { TestFlatteningVisitor } from './common/testVisitors/flatteningVisitor';
 import { TestFolderGenerationVisitor } from './common/testVisitors/folderGenerationVisitor';
 import { TestResultResetVisitor } from './common/testVisitors/resultResetVisitor';
 import {
-    ITestCollectionStorageService, ITestConfigSettingsService, ITestDebugLauncher, ITestDiscoveryService, ITestManager, ITestManagerFactory, ITestManagerService, ITestManagerServiceFactory,
-    ITestMessageService, ITestResultsService, ITestRunner, ITestsHelper, ITestsParser, ITestVisitor, IUnitTestSocketServer, IWorkspaceTestManagerService, IXUnitParser, TestProvider
+    ITestCollectionStorageService, ITestConfigSettingsService, ITestDebugLauncher,
+    ITestDiscoveryService, ITestManager, ITestManagerFactory, ITestManagerService,
+    ITestManagerServiceFactory, ITestMessageService, ITestResultsService, ITestRunner,
+    ITestsHelper, ITestsParser, ITestVisitor, IUnitTestSocketServer, IWorkspaceTestManagerService,
+    IXUnitParser, TestProvider
 } from './common/types';
 import { XUnitParser } from './common/xUnitParser';
 import { UnitTestConfigurationService } from './configuration';
@@ -33,13 +37,19 @@ import { TestManagerRunner as NoseTestManagerRunner } from './nosetest/runner';
 import { ArgumentsService as NoseTestArgumentsService } from './nosetest/services/argsService';
 import { TestDiscoveryService as NoseTestDiscoveryService } from './nosetest/services/discoveryService';
 import { TestsParser as NoseTestTestsParser } from './nosetest/services/parserService';
+import { TestTreeViewProvider } from './providers/testTreeViewProvider';
 import { TestManager as PyTestTestManager } from './pytest/main';
 import { TestManagerRunner as PytestManagerRunner } from './pytest/runner';
 import { ArgumentsService as PyTestArgumentsService } from './pytest/services/argsService';
 import { TestDiscoveryService as PytestTestDiscoveryService } from './pytest/services/discoveryService';
 import { TestsParser as PytestTestsParser } from './pytest/services/parserService';
 import { TestMessageService } from './pytest/services/testMessageService';
-import { IArgumentsHelper, IArgumentsService, ITestConfigurationManagerFactory, ITestDisplay, ITestManagerRunner, ITestResultDisplay, IUnitTestConfigurationService, IUnitTestDiagnosticService, IUnitTestHelper, IUnitTestManagementService } from './types';
+import {
+    IArgumentsHelper, IArgumentsService, ITestConfigurationManagerFactory,
+    ITestDisplay, ITestManagerRunner, ITestResultDisplay,
+    IUnitTestConfigurationService, IUnitTestDiagnosticService,
+    IUnitTestHelper, IUnitTestManagementService
+} from './types';
 import { UnitTestHelper } from './unittest/helper';
 import { TestManager as UnitTestTestManager } from './unittest/main';
 import { TestManagerRunner as UnitTestTestManagerRunner } from './unittest/runner';
@@ -92,6 +102,7 @@ export function registerTypes(serviceManager: IServiceManager) {
 
     serviceManager.addSingleton<IUnitTestDiagnosticService>(IUnitTestDiagnosticService, UnitTestDiagnosticService);
     serviceManager.addSingleton<ITestMessageService>(ITestMessageService, TestMessageService, PYTEST_PROVIDER);
+    serviceManager.addSingleton<ITestTreeViewProvider>(ITestTreeViewProvider, TestTreeViewProvider);
 
     serviceManager.addFactory<ITestManager>(ITestManagerFactory, (context) => {
         return (testProvider: TestProvider, workspaceFolder: Uri, rootDirectory: string) => {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -33,7 +33,7 @@ export function initialize() {
     generateMock('scm');
 
     // When upgrading to npm 9-10, this might have to change, as we could have explicit imports (named imports).
-    Module._load = function(request: any, _parent: any) {
+    Module._load = function (request: any, _parent: any) {
         if (request === 'vscode') {
             return mockedVSCode;
         }
@@ -71,6 +71,7 @@ mockedVSCode.RelativePattern = vscodeMocks.vscMockExtHostedTypes.RelativePattern
 mockedVSCode.ProgressLocation = vscodeMocks.vscMockExtHostedTypes.ProgressLocation;
 mockedVSCode.ViewColumn = vscodeMocks.vscMockExtHostedTypes.ViewColumn;
 mockedVSCode.TextEditorRevealType = vscodeMocks.vscMockExtHostedTypes.TextEditorRevealType;
+mockedVSCode.TreeItem = vscodeMocks.vscMockExtHostedTypes.TreeItem;
 
 // This API is used in src/client/telemetry/telemetry.ts
 const extensions = TypeMoq.Mock.ofType<typeof vscode.extensions>();


### PR DESCRIPTION
For #4273 & #4274

- Make Python Test View Provider injectable (testable)
- Maps `Tests` object to `TreeViewItem` hierarchy
- Adds a Event (subscription) model to the `TestStorageService`


**Note**: This is the first in a line of PRs that I will submit on this issue, the primary purpose for this to be merged at this early time is to unblock others from submitting work against the Test Explorer feature as well.

---

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- ~Has sufficient logging.~
- ~Has telemetry for enhancements.~
- ~Unit tests & system/integration tests are added/updated~
- ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
