### PR TITLE
Keep testing configuration alive after losing focus

### DIFF
--- a/.github/test_plan.md
+++ b/.github/test_plan.md
@@ -273,11 +273,6 @@ class FailingTests(unittest.TestCase):
     - [ ] `Run Test` works
     - [ ] `Debug Test` works
     - [ ] Module/suite setup methods are also run (run the `test_setup` method to verify)
-- [ ] `Configure Unit Tests` works
-  - [ ] quick pick for framework (and its settings)
-  - [ ] selected framework enabled in workspace settings
-  - [ ] framework's config added (and old config removed)
-  - [ ] other frameworks disabled in workspace settings
 
 #### [`pytest`](https://code.visualstudio.com/docs/python/unit-testing#_pytest-configuration-settings)
 ```python
@@ -326,5 +321,11 @@ def test_failure():
   - [ ] `Run Unit Test Method ...` works
   - [ ] `View Unit Test Output` works
   - [ ] After having at least one failure, `Run Failed Tests` works
+- [ ] `Configure Unit Tests` works
+  - [ ] quick pick for framework (and its settings)
+  - [ ] selected framework enabled in workspace settings
+  - [ ] framework's config added (and old config removed)
+  - [ ] other frameworks disabled in workspace settings
+- [ ] `Configure Unit Tests` does not close if it loses focus
 
 </details>

--- a/news/1 Enhancements/4288.md
+++ b/news/1 Enhancements/4288.md
@@ -1,0 +1,1 @@
+Keep testing configuration alive when losing UI focus.

--- a/src/client/unittests/common/managers/testConfigurationManager.ts
+++ b/src/client/unittests/common/managers/testConfigurationManager.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
-import { OutputChannel, QuickPickItem, Uri, window } from 'vscode';
+import { OutputChannel, QuickPickItem, Uri } from 'vscode';
+import { IApplicationShell } from '../../../common/application/types';
 import { IInstaller, IOutputChannel, Product } from '../../../common/types';
 import { createDeferred } from '../../../common/utils/async';
 import { getSubDirectories } from '../../../common/utils/fs';
@@ -59,7 +60,8 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         items = [{ label: '.', description: 'Root directory' }, ...items];
         items = customOptions.concat(items);
         const def = createDeferred<string>();
-        window.showQuickPick(items, options).then(item => {
+        const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+        appShell.showQuickPick(items, options).then(item => {
             if (!item) {
                 return def.resolve();
             }
@@ -85,7 +87,8 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         ];
 
         const def = createDeferred<string>();
-        window.showQuickPick(items, options).then(item => {
+        const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+        appShell.showQuickPick(items, options).then(item => {
             if (!item) {
                 return def.resolve();
             }

--- a/src/client/unittests/common/managers/testConfigurationManager.ts
+++ b/src/client/unittests/common/managers/testConfigurationManager.ts
@@ -39,6 +39,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
     }
     protected selectTestDir(rootDir: string, subDirs: string[], customOptions: QuickPickItem[] = []): Promise<string> {
         const options = {
+            ignoreFocusOut: true,
             matchOnDescription: true,
             matchOnDetail: true,
             placeHolder: 'Select the directory containing the unit tests'
@@ -74,6 +75,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
 
     protected selectTestFilePattern(): Promise<string> {
         const options = {
+            ignoreFocusOut: true,
             matchOnDescription: true,
             matchOnDetail: true,
             placeHolder: 'Select the pattern to identify test files'

--- a/src/client/unittests/common/testUtils.ts
+++ b/src/client/unittests/common/testUtils.ts
@@ -1,6 +1,6 @@
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
-import { Uri, window, workspace } from 'vscode';
+import { Uri, workspace } from 'vscode';
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import * as constants from '../../common/constants';
 import { IUnitTestSettings, Product } from '../../common/types';
@@ -9,14 +9,13 @@ import { CommandSource } from './constants';
 import { TestFlatteningVisitor } from './testVisitors/flatteningVisitor';
 import { ITestsHelper, ITestVisitor, TestFile, TestFolder, TestProvider, Tests, TestSettingsPropertyNames, TestsToRun, UnitTestProduct } from './types';
 
-export async function selectTestWorkspace(): Promise<Uri | undefined> {
+export async function selectTestWorkspace(appShell: IApplicationShell): Promise<Uri | undefined> {
     if (!Array.isArray(workspace.workspaceFolders) || workspace.workspaceFolders.length === 0) {
         return undefined;
     } else if (workspace.workspaceFolders.length === 1) {
         return workspace.workspaceFolders[0].uri;
     } else {
-        // tslint:disable-next-line:no-any prefer-type-cast
-        const workspaceFolder = await (window as any).showWorkspaceFolderPick({ placeHolder: 'Select a workspace' });
+        const workspaceFolder = await appShell.showWorkspaceFolderPick({ placeHolder: 'Select a workspace' });
         return workspaceFolder ? workspaceFolder.uri : undefined;
     }
 }

--- a/src/client/unittests/configuration.ts
+++ b/src/client/unittests/configuration.ts
@@ -60,6 +60,7 @@ export class UnitTestConfigurationService implements IUnitTestConfigurationServi
             detail: 'https://nose.readthedocs.io/'
         }];
         const options = {
+            ignoreFocusOut: true,
             matchOnDescription: true,
             matchOnDetail: true,
             placeHolder: placeHolderMessage

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -9,7 +9,7 @@ import {
     OutputChannel, TextDocument, Uri, window
 } from 'vscode';
 import {
-    ICommandManager, IDocumentManager, IWorkspaceService
+    IApplicationShell, ICommandManager, IDocumentManager, IWorkspaceService
 } from '../common/application/types';
 import * as constants from '../common/constants';
 import '../common/extensions';
@@ -89,7 +89,8 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
             const wkspaceFolder = this.workspaceService.getWorkspaceFolder(resource);
             wkspace = wkspaceFolder ? wkspaceFolder.uri : undefined;
         } else {
-            wkspace = await selectTestWorkspace();
+            const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+            wkspace = await selectTestWorkspace(appShell);
         }
         if (!wkspace) {
             return;
@@ -322,7 +323,8 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
             const wkspaceFolder = this.workspaceService.getWorkspaceFolder(resource);
             wkspace = wkspaceFolder ? wkspaceFolder.uri : undefined;
         } else {
-            wkspace = await selectTestWorkspace();
+            const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
+            wkspace = await selectTestWorkspace(appShell);
         }
         if (!wkspace) {
             return;


### PR DESCRIPTION
(for #4288)

Note that I changed a few places to use `IApplicationShell` instead of `vscode.window`.  This isn't strictly related to the PR (I thought it was at first), but it's not a big addition so I'd rather just leave it.  If there are any objections then I don't mind dropping that part (i.e. the "Use IApplicationShell instead of vscode.window." commit below).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- ~[ ] Has telemetry for enhancements.~
- ~[ ] Unit tests & system/integration tests are added/updated~
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
