### PR TITLE
Display test activity only when tests have been discovered

### DIFF
--- a/news/1 Enhancements/4317.md
+++ b/news/1 Enhancements/4317.md
@@ -1,0 +1,1 @@
+Display test activity only when tests have been discovered

--- a/package.json
+++ b/package.json
@@ -171,19 +171,19 @@
                 "command": "python.runtests",
                 "title": "%python.command.python.runtests.title%",
                 "category": "Python",
-				"icon": {
-					"light": "resources/light/start.svg",
-					"dark": "resources/dark/start.svg"
-				}
+                "icon": {
+                    "light": "resources/light/start.svg",
+                    "dark": "resources/dark/start.svg"
+                }
             },
             {
                 "command": "python.debugtests",
                 "title": "%python.command.python.debugtests.title%",
                 "category": "Python",
-				"icon": {
-					"light": "resources/light/debug.svg",
-					"dark": "resources/dark/debug.svg"
-				}
+                "icon": {
+                    "light": "resources/light/debug.svg",
+                    "dark": "resources/dark/debug.svg"
+                }
             },
             {
                 "command": "python.execInTerminal",
@@ -239,19 +239,19 @@
                 "command": "python.runFailedTests",
                 "title": "%python.command.python.runFailedTests.title%",
                 "category": "Python",
-				"icon": {
-					"light": "resources/light/start-failed.svg",
-					"dark": "resources/dark/start-failed.svg"
-				}
+                "icon": {
+                    "light": "resources/light/start-failed.svg",
+                    "dark": "resources/dark/start-failed.svg"
+                }
             },
             {
                 "command": "python.discoverTests",
                 "title": "%python.command.python.discoverTests.title%",
                 "category": "Python",
-				"icon": {
-					"light": "resources/light/refresh.svg",
-					"dark": "resources/dark/refresh.svg"
-				}
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
             },
             {
                 "command": "python.configureTests",
@@ -2007,7 +2007,8 @@
             "test": [
                 {
                     "id": "python_tests",
-                    "name": "PYTHON"
+                    "name": "PYTHON",
+                    "when": "testsDiscovered"
                 }
             ]
         }

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -35,6 +35,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
     private readonly disposableRegistry: Disposable[];
     private workspaceTestManagerService?: IWorkspaceTestManagerService;
     private documentManager: IDocumentManager;
+    private commandManager: ICommandManager;
     private workspaceService: IWorkspaceService;
     private testResultDisplay?: ITestResultDisplay;
     private autoDiscoverTimer?: NodeJS.Timer;
@@ -47,6 +48,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         this.outputChannel = serviceContainer.get<OutputChannel>(IOutputChannel, TEST_OUTPUT_CHANNEL);
         this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.documentManager = serviceContainer.get<IDocumentManager>(IDocumentManager);
+        this.commandManager = serviceContainer.get<ICommandManager>(ICommandManager);
 
         this.disposableRegistry.push(this);
     }
@@ -163,7 +165,9 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
 
         // No need to display errors.
         // tslint:disable-next-line:no-empty
-        this.discoverTests(CommandSource.auto, this.workspaceService.workspaceFolders![0].uri, true).catch(() => { });
+        this.discoverTests(CommandSource.auto, this.workspaceService.workspaceFolders![0].uri, true).then(
+            _tests => this.commandManager.executeCommand('setContext', 'testsDiscovered', true)
+        );
     }
     public async discoverTests(cmdSource: CommandSource, resource?: Uri, ignoreCache?: boolean, userInitiated?: boolean, quietMode?: boolean) {
         const testManager = await this.getTestManager(true, resource);

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -167,7 +167,7 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         // tslint:disable-next-line:no-empty
         this.discoverTests(CommandSource.auto, this.workspaceService.workspaceFolders![0].uri, true).then(
             _tests => this.commandManager.executeCommand('setContext', 'testsDiscovered', true)
-        );
+        ).ignoreErrors();
     }
     public async discoverTests(cmdSource: CommandSource, resource?: Uri, ignoreCache?: boolean, userInitiated?: boolean, quietMode?: boolean) {
         const testManager = await this.getTestManager(true, resource);


### PR DESCRIPTION
For #4317 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
