### PR TITLE
Fix precedence in `parsePyTestModuleCollectionResult`

### DIFF
--- a/news/2 Fixes/4360.md
+++ b/news/2 Fixes/4360.md
@@ -1,0 +1,1 @@
+Fix precedence in `parsePyTestModuleCollectionResult`.

--- a/news/2 Fixes/4360.md
+++ b/news/2 Fixes/4360.md
@@ -1,1 +1,2 @@
 Fix precedence in `parsePyTestModuleCollectionResult`.
+(thanks [Tammo Ippen](https://github.com/tammoippen))

--- a/src/client/unittests/pytest/services/parserService.ts
+++ b/src/client/unittests/pytest/services/parserService.ts
@@ -169,7 +169,7 @@ export class TestsParser implements ITestsParser {
 
             const parentNode = this.findParentOfCurrentItem(indent, parentNodes);
 
-            if (parentNode && trimmedLine.startsWith('<Class ') || trimmedLine.startsWith('<UnitTestCase ')) {
+            if (parentNode && (trimmedLine.startsWith('<Class ') || trimmedLine.startsWith('<UnitTestCase '))) {
                 const isUnitTest = trimmedLine.startsWith('<UnitTestCase ');
                 if (isUnitTest) {
                     name = extractBetweenDelimiters(trimmedLine, '<UnitTestCase ', '>');
@@ -194,7 +194,7 @@ export class TestsParser implements ITestsParser {
                 suite.isInstance = true;
                 return;
             }
-            if (parentNode && trimmedLine.startsWith('<TestCaseFunction ') || trimmedLine.startsWith('<Function ')) {
+            if (parentNode && (trimmedLine.startsWith('<TestCaseFunction ') || trimmedLine.startsWith('<Function '))) {
                 if (trimmedLine.startsWith('<Function ')) {
                     name = extractBetweenDelimiters(trimmedLine, '<Function ', '>');
                 } else {


### PR DESCRIPTION
For ...

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] ~Has sufficient logging.~
- [X] ~Has telemetry for enhancements.~
- [X] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [X] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~


When discovering tests with pytest, the `Python Test Log` ended with:
```
Test Discovery failed: 
TypeError: Cannot read property 'item' of undefined
```

The developer console gives me:
```
[Extension Host] Python Extension: displayDiscoverStatus TypeError: Cannot read property 'item' of undefined
	at module.exports.l.parsePyTestModuleCollectionResult.t.forEach.t (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77591:45)
	at Array.forEach (<anonymous>)
	at l.parsePyTestModuleCollectionResult (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77527:11)
	at module.exports.l.getTestFiles.e.split.forEach (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77463:23)
	at Array.forEach (<anonymous>)
	at l.getTestFiles (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77458:29)
	at l.parse (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77445:24)
	at h.<anonymous> (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77387:31)
	at Generator.next (<anonymous>)
	at s (/Users/tammoippen/.vscode/extensions/ms-python.python-2019.1.0/out/client/extension.js:77303:21)
```

Which pointed me to `parsePyTestModuleCollectionResult` and `parentNode` not being correctly guarded (`undefined` in my case).

