### PR TITLE
Added command to view python output

### DIFF
--- a/news/1 Enhancements/4362.md
+++ b/news/1 Enhancements/4362.md
@@ -1,0 +1,1 @@
+Added command `Show Output` to display the `Python` output panel.

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "onCommand:python.setShebangInterpreter",
         "onCommand:python.viewTestUI",
         "onCommand:python.viewTestOutput",
+        "onCommand:python.viewOutput",
         "onCommand:python.selectAndRunTestMethod",
         "onCommand:python.selectAndDebugTestMethod",
         "onCommand:python.selectAndRunTestFile",
@@ -213,6 +214,15 @@
             {
                 "command": "python.viewTestOutput",
                 "title": "%python.command.python.viewTestOutput.title%",
+                "category": "Python",
+				"icon": {
+					"light": "resources/light/repl.svg",
+					"dark": "resources/dark/repl.svg"
+				}
+            },
+            {
+                "command": "python.viewOutput",
+                "title": "%python.command.python.viewOutput.title%",
                 "category": "Python",
 				"icon": {
 					"light": "resources/light/repl.svg",
@@ -483,6 +493,12 @@
                 }
             ],
             "commandPalette": [
+                {
+                    "command": "python.viewOutput",
+                    "title": "%python.command.python.viewOutput.title%",
+                    "category": "Python",
+                    "when": "config.noExists"
+                },
                 {
                     "command": "python.runTestNode",
                     "title": "Run",

--- a/package.json
+++ b/package.json
@@ -496,8 +496,7 @@
                 {
                     "command": "python.viewOutput",
                     "title": "%python.command.python.viewOutput.title%",
-                    "category": "Python",
-                    "when": "config.noExists"
+                    "category": "Python"
                 },
                 {
                     "command": "python.runTestNode",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,6 +10,7 @@
     "python.command.python.updateSparkLibrary.title": "Update Workspace PySpark Libraries",
     "python.command.python.refactorExtractVariable.title": "Extract Variable",
     "python.command.python.refactorExtractMethod.title": "Extract Method",
+    "python.command.python.viewOutput.title": "Show Output",
     "python.command.python.viewTestOutput.title": "Show Unit Test Output",
     "python.command.python.selectAndRunTestMethod.title": "Run Unit Test Method ...",
     "python.command.python.selectAndDebugTestMethod.title": "Debug Unit Test Method ...",

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -27,6 +27,7 @@ export namespace Commands {
     export const Tests_Ask_To_Stop_Test = 'python.askToStopUnitTests';
     export const Tests_Ask_To_Stop_Discovery = 'python.askToStopUnitTestDiscovery';
     export const Tests_Stop = 'python.stopUnitTests';
+    export const ViewOutput = 'python.viewOutput';
     export const Tests_ViewOutput = 'python.viewTestOutput';
     export const Tests_Select_And_Run_Method = 'python.selectAndRunTestMethod';
     export const Tests_Select_And_Debug_Method = 'python.selectAndDebugTestMethod';

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -38,8 +38,8 @@ import { buildApi, IExtensionApi } from './api';
 import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { IApplicationDiagnostics } from './application/types';
 import { DebugService } from './common/application/debugService';
-import { IApplicationShell, IWorkspaceService } from './common/application/types';
-import { isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
+import { IApplicationShell, ICommandManager, IWorkspaceService } from './common/application/types';
+import { Commands, isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as registerDotNetTypes } from './common/dotnet/serviceRegistry';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
 import { traceError } from './common/logger';
@@ -287,6 +287,10 @@ function initializeServices(context: ExtensionContext, serviceManager: ServiceMa
     const disposables = serviceManager.get<IDisposableRegistry>(IDisposableRegistry);
     const dispatcher = new DebugSessionEventDispatcher(handlers, DebugService.instance, disposables);
     dispatcher.registerEventHandlers();
+
+    const cmdManager = serviceContainer.get<ICommandManager>(ICommandManager);
+    const outputChannel = serviceManager.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
+    disposables.push(cmdManager.registerCommand(Commands.ViewOutput, () => outputChannel.show()));
 
     // Display progress of interpreter refreshes only after extension has activated.
     serviceContainer.get<InterpreterLocatorProgressHandler>(InterpreterLocatorProgressHandler).register();


### PR DESCRIPTION
For #4362

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
