### PR TITLE
Run failed tests icon should only appear if and when a test has failed

### DIFF
--- a/news/1 Enhancements/4371.md
+++ b/news/1 Enhancements/4371.md
@@ -1,0 +1,1 @@
+Run failed tests icon should only appear if and when a test has failed

--- a/package.json
+++ b/package.json
@@ -215,19 +215,19 @@
                 "command": "python.viewTestOutput",
                 "title": "%python.command.python.viewTestOutput.title%",
                 "category": "Python",
-				"icon": {
-					"light": "resources/light/repl.svg",
-					"dark": "resources/dark/repl.svg"
-				}
+                "icon": {
+                    "light": "resources/light/repl.svg",
+                    "dark": "resources/dark/repl.svg"
+                }
             },
             {
                 "command": "python.viewOutput",
                 "title": "%python.command.python.viewOutput.title%",
                 "category": "Python",
-				"icon": {
-					"light": "resources/light/repl.svg",
-					"dark": "resources/dark/repl.svg"
-				}
+                "icon": {
+                    "light": "resources/light/repl.svg",
+                    "dark": "resources/dark/repl.svg"
+                }
             },
             {
                 "command": "python.selectAndRunTestMethod",
@@ -627,7 +627,8 @@
                 },
                 {
                     "command": "python.runFailedTests",
-                    "group": "navigation@4"
+                    "group": "navigation@4",
+                    "when": "hasFailedTests"
                 },
                 {
                     "command": "python.viewTestOutput",

--- a/src/client/unittests/common/managers/baseTestManager.ts
+++ b/src/client/unittests/common/managers/baseTestManager.ts
@@ -240,9 +240,7 @@ export abstract class BaseTestManager implements ITestManager {
                 this.createCancellationToken(CancellationTokenType.testRunner);
                 return this.runTestImpl(tests, testsToRun, runFailedTests, debug);
             }).then((testResults) => {
-                if (testResults.summary.failures !== 0) {
-                    this.commandManager.executeCommand('setContext', 'hasFailedTests', true);
-                }
+                this.commandManager.executeCommand('setContext', 'hasFailedTests', testResults.summary.failures > 0);
                 this.updateStatus(TestStatus.Idle);
                 this.disposeCancellationToken(CancellationTokenType.testRunner);
                 sendTelemetryEvent(EventName.UNITTEST_RUN, undefined, telementryProperties);

--- a/src/client/unittests/common/managers/baseTestManager.ts
+++ b/src/client/unittests/common/managers/baseTestManager.ts
@@ -1,5 +1,5 @@
 import { CancellationToken, CancellationTokenSource, Diagnostic, DiagnosticCollection, DiagnosticRelatedInformation, Disposable, Event, EventEmitter, languages, OutputChannel, Uri } from 'vscode';
-import { IWorkspaceService } from '../../../common/application/types';
+import { ICommandManager, IWorkspaceService } from '../../../common/application/types';
 import { isNotInstalledError } from '../../../common/helpers';
 import { IFileSystem } from '../../../common/platform/types';
 import { IConfigurationService, IDisposableRegistry, IInstaller, IOutputChannel, IPythonSettings, Product } from '../../../common/types';
@@ -38,6 +38,7 @@ export abstract class BaseTestManager implements ITestManager {
     private testRunnerCancellationTokenSource?: CancellationTokenSource;
     private _installer!: IInstaller;
     private discoverTestsPromise?: Promise<Tests>;
+    private commandManager: ICommandManager;
     private _onDidStatusChange = new EventEmitter<TestStatus>();
     private get installer(): IInstaller {
         if (!this._installer) {
@@ -57,6 +58,7 @@ export abstract class BaseTestManager implements ITestManager {
         this.workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.diagnosticCollection = languages.createDiagnosticCollection(this.testProvider);
         this.unitTestDiagnosticService = serviceContainer.get<IUnitTestDiagnosticService>(IUnitTestDiagnosticService);
+        this.commandManager = serviceContainer.get<ICommandManager>(ICommandManager);
         disposables.push(this);
     }
     protected get testDiscoveryCancellationToken(): CancellationToken | undefined {
@@ -237,7 +239,10 @@ export abstract class BaseTestManager implements ITestManager {
             .then(tests => {
                 this.createCancellationToken(CancellationTokenType.testRunner);
                 return this.runTestImpl(tests, testsToRun, runFailedTests, debug);
-            }).then(() => {
+            }).then((testResults) => {
+                if (testResults.summary.failures !== 0) {
+                    this.commandManager.executeCommand('setContext', 'hasFailedTests', true);
+                }
                 this.updateStatus(TestStatus.Idle);
                 this.disposeCancellationToken(CancellationTokenType.testRunner);
                 sendTelemetryEvent(EventName.UNITTEST_RUN, undefined, telementryProperties);


### PR DESCRIPTION
For #4371 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
