### PR TITLE
Change status to not say "Starting Jupyter Server" when server is already up

### DIFF
--- a/src/client/datascience/history.ts
+++ b/src/client/datascience/history.ts
@@ -398,17 +398,14 @@ export class History implements IHistory {
         try {
 
             // Make sure we're loaded first.
-            const statusLoad = this.setStatus(localize.DataScience.startingJupyter());
             try {
                 await this.loadPromise;
             } catch (exc) {
-                // We should dispose ourselvs if the load fails. Othewise the user
+                // We should dispose ourselves if the load fails. Othewise the user
                 // updates their install and we just fail again because the load promise is the same.
                 await this.dispose();
 
                 throw exc;
-            } finally {
-                statusLoad.dispose();
             }
 
             // Then show our webpanel
@@ -725,7 +722,9 @@ export class History implements IHistory {
     }
 
     private load = async (): Promise<void> => {
-        const status = this.setStatus(localize.DataScience.startingJupyter());
+        // Status depends upon if we're about to connect to existing server or not.
+        const status = (await this.jupyterServerManager.getServer()) ?
+            this.setStatus(localize.DataScience.connectingToJupyter()) : this.setStatus(localize.DataScience.startingJupyter());
 
         // Check to see if we support ipykernel or not
         try {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -52,6 +52,7 @@ export interface INotebookServerLaunchInfo
 export const INotebookServerManager = Symbol('INotebookServerManager');
 export interface INotebookServerManager {
     getOrCreateServer(): Promise<INotebookServer | undefined>;
+    getServer() : Promise<INotebookServer | undefined>;
 }
 
 // Talks to a jupyter ipython kernel to retrieve data for cells


### PR DESCRIPTION
No bug. We haven't shipped this problem yet, so not bothering to create an issue

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
