### PR TITLE
Make sure *no* settings are updated under cancellation.

### DIFF
--- a/src/client/unittests/common/managers/testConfigurationManager.ts
+++ b/src/client/unittests/common/managers/testConfigurationManager.ts
@@ -9,6 +9,8 @@ import { ITestConfigSettingsService, ITestConfigurationManager } from '../../typ
 import { TEST_OUTPUT_CHANNEL, UNIT_TEST_PRODUCTS } from '../constants';
 import { UnitTestProduct } from '../types';
 
+export const CANCELLED_ERR = Error('cancelled');
+
 export abstract class TestConfigurationManager implements ITestConfigurationManager {
     protected readonly outputChannel: OutputChannel;
     protected readonly installer: IInstaller;
@@ -62,7 +64,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         appShell.showQuickPick(items, options).then(item => {
             if (!item) {
-                return def.resolve();
+                throw CANCELLED_ERR;
             }
 
             def.resolve(item.label);
@@ -90,7 +92,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         appShell.showQuickPick(items, options).then(item => {
             if (!item) {
-                return def.resolve();
+                throw CANCELLED_ERR;
             }
 
             def.resolve(item.label);

--- a/src/client/unittests/common/managers/testConfigurationManager.ts
+++ b/src/client/unittests/common/managers/testConfigurationManager.ts
@@ -9,8 +9,6 @@ import { ITestConfigSettingsService, ITestConfigurationManager } from '../../typ
 import { TEST_OUTPUT_CHANNEL, UNIT_TEST_PRODUCTS } from '../constants';
 import { UnitTestProduct } from '../types';
 
-export const CANCELLED_ERR = Error('cancelled');
-
 export abstract class TestConfigurationManager implements ITestConfigurationManager {
     protected readonly outputChannel: OutputChannel;
     protected readonly installer: IInstaller;
@@ -64,7 +62,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         appShell.showQuickPick(items, options).then(item => {
             if (!item) {
-                throw CANCELLED_ERR;
+                throw Error('cancelled');
             }
 
             def.resolve(item.label);
@@ -92,7 +90,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         appShell.showQuickPick(items, options).then(item => {
             if (!item) {
-                throw CANCELLED_ERR;
+                throw Error('cancelled');
             }
 
             def.resolve(item.label);

--- a/src/client/unittests/common/managers/testConfigurationManager.ts
+++ b/src/client/unittests/common/managers/testConfigurationManager.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { OutputChannel, QuickPickItem, Uri } from 'vscode';
 import { IApplicationShell } from '../../../common/application/types';
-import { IInstaller, IOutputChannel } from '../../../common/types';
+import { IInstaller, ILogger, IOutputChannel } from '../../../common/types';
 import { createDeferred } from '../../../common/utils/async';
 import { getSubDirectories } from '../../../common/utils/fs';
 import { IServiceContainer } from '../../../ioc/types';
@@ -62,7 +62,8 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         appShell.showQuickPick(items, options).then(item => {
             if (!item) {
-                throw Error('cancelled');
+                this.handleCancelled();  // This will throw an exception.
+                return;
             }
 
             def.resolve(item.label);
@@ -90,7 +91,8 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
         const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
         appShell.showQuickPick(items, options).then(item => {
             if (!item) {
-                throw Error('cancelled');
+                this.handleCancelled();  // This will throw an exception.
+                return;
             }
 
             def.resolve(item.label);
@@ -110,5 +112,11 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
             // The test dirs are now on top.
             return possibleTestDirs;
         });
+    }
+
+    private handleCancelled() {
+        const logger = this.serviceContainer.get<ILogger>(ILogger);
+        logger.logInformation('testing configuration (in UI) cancelled');
+        throw Error('cancelled');
     }
 }


### PR DESCRIPTION
(for #4287)

This is a follow-up to #4313.

There were two things I missed in that earlier PR:
* hitting `<esc>` on the config quickpick wasn't treated as a cancellation so config continued with defaults
* there was a code path that was updating the settings directly

I've fixed both in this PR.

Note that the `python.unitTest.promptToConfigure` setting may still get cleared prematurely (in the cancellation case).  However, that does not seem to be a big deal.