### PR TITLE
Resolve pythonPath before comparing it to shebang

### DIFF
--- a/news/2 Fixes/4601.md
+++ b/news/2 Fixes/4601.md
@@ -1,0 +1,1 @@
+Resolve pythonPath before comparing it to shebang

--- a/src/client/interpreter/display/shebangCodeLensProvider.ts
+++ b/src/client/interpreter/display/shebangCodeLensProvider.ts
@@ -51,7 +51,8 @@ export class ShebangCodeLensProvider implements IShebangCodeLensProvider {
     private async createShebangCodeLens(document: TextDocument) {
         const shebang = await this.detectShebang(document);
         const pythonPath = this.configurationService.getSettings(document.uri).pythonPath;
-        if (!shebang || shebang === pythonPath) {
+        const resolvedPythonPath = await this.getFullyQualifiedPathToInterpreter(pythonPath, document.uri);
+        if (!shebang || shebang === resolvedPythonPath) {
             return [];
         }
         const firstLine = document.lineAt(0);

--- a/src/client/interpreter/display/shebangCodeLensProvider.ts
+++ b/src/client/interpreter/display/shebangCodeLensProvider.ts
@@ -50,9 +50,12 @@ export class ShebangCodeLensProvider implements IShebangCodeLensProvider {
     }
     private async createShebangCodeLens(document: TextDocument) {
         const shebang = await this.detectShebang(document);
+        if (!shebang) {
+            return [];
+        }
         const pythonPath = this.configurationService.getSettings(document.uri).pythonPath;
         const resolvedPythonPath = await this.getFullyQualifiedPathToInterpreter(pythonPath, document.uri);
-        if (!shebang || shebang === resolvedPythonPath) {
+        if (shebang === resolvedPythonPath) {
             return [];
         }
         const firstLine = document.lineAt(0);

--- a/src/test/providers/shebangCodeLenseProvider.unit.test.ts
+++ b/src/test/providers/shebangCodeLenseProvider.unit.test.ts
@@ -129,6 +129,10 @@ suite('Shebang detection', () => {
     test('No code lens when there\'s no shebang', async () => {
         const [document] = createDocument('');
         pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+        processService.setup(p => p.exec(typemoq.It.isValue('python'), typemoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: 'python' }))
+            .verifiable(typemoq.Times.once());
+
         provider.detectShebang = () => Promise.resolve('');
 
         const codeLenses = await provider.provideCodeLenses(document.object);
@@ -138,6 +142,10 @@ suite('Shebang detection', () => {
     test('No code lens when shebang is an empty string', async () => {
         const [document] = createDocument('#!');
         pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+        processService.setup(p => p.exec(typemoq.It.isValue('python'), typemoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: 'python' }))
+            .verifiable(typemoq.Times.once());
+
         provider.detectShebang = () => Promise.resolve('');
 
         const codeLenses = await provider.provideCodeLenses(document.object);
@@ -147,6 +155,10 @@ suite('Shebang detection', () => {
     test('No code lens when python path in settings is the same as that in shebang', async () => {
         const [document] = createDocument('#!python');
         pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+        processService.setup(p => p.exec(typemoq.It.isValue('python'), typemoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: 'python' }))
+            .verifiable(typemoq.Times.once());
+
         provider.detectShebang = () => Promise.resolve('python');
 
         const codeLenses = await provider.provideCodeLenses(document.object);
@@ -156,6 +168,10 @@ suite('Shebang detection', () => {
     test('Code lens returned when python path in settings is different to one in shebang', async () => {
         const [document] = createDocument('#!python');
         pythonSettings.setup(p => p.pythonPath).returns(() => 'different');
+        processService.setup(p => p.exec(typemoq.It.isValue('different'), typemoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: 'different' }))
+            .verifiable(typemoq.Times.once());
+
         provider.detectShebang = () => Promise.resolve('python');
 
         const codeLenses = await provider.provideCodeLenses(document.object);


### PR DESCRIPTION
For #4601

When comparing if the path to the Python interpreter from the shebang in a file and the pythonPath setting point to one and the same interpreter, resolve pythonPath to the path to the actual Python interpreter executable before the comparison.

This solves the problem of having _python.pythonPath_ set to a symlink to the actual Python interpreter and having a _/usr/bin/env_ shebang in a file, where both would actually point to the same interpreter, but the _Set as interpreter_ CodeLens would display anyway, because the CodeLens provider wouldn't recognize that.

For example, on macOS, with Python installed by Homebrew,`#!/usr/bin/env python3` and `python.pythonPath: "/usr/local/bin/python3"` both actually point to the same interpreter and give `sys.executable == '/usr/local/opt/python3/bin/python3.7'`, but they would be treated as different interpreters.

This was originally done with https://github.com/Microsoft/vscode-python/commit/73723670f85477aeefc1fe92167fa0f96e729941 but then undone with https://github.com/Microsoft/vscode-python/commit/edbd57ad3cbdb8685de5eabf7933a9ecd7607ae2.

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
