### PR TITLE
Revert pipenv activation to not use `pipenv shell`

### DIFF
--- a/news/2 Fixes/4394.md
+++ b/news/2 Fixes/4394.md
@@ -1,0 +1,1 @@
+Revert pipenv activation to not use `pipenv shell`

--- a/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
@@ -20,7 +20,7 @@ export class PipEnvActivationCommandProvider implements ITerminalActivationComma
     ) { }
 
     public isShellSupported(_targetShell: TerminalShellType): boolean {
-        return true;
+        return false;
     }
 
     public async getActivationCommands(resource: Uri | undefined, _: TerminalShellType): Promise<string[] | undefined> {

--- a/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
@@ -5,6 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
+import '../../../common/extensions';
 import { IInterpreterService, InterpreterType, IPipEnvService } from '../../../interpreter/contracts';
 import { IWorkspaceService } from '../../application/types';
 import { IFileSystem } from '../../platform/types';


### PR DESCRIPTION
For #4394 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
