### PR TITLE
Allow codes like ABC123 for flake8 v3 plugins

### DIFF
--- a/news/2 Fixes/4443.md
+++ b/news/2 Fixes/4443.md
@@ -1,0 +1,1 @@
+Supports error codes like ABC123 as used in plugins for flake8 v3 onwards.

--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -19,7 +19,8 @@ import {
 // tslint:disable-next-line:no-require-imports no-var-requires no-any
 const namedRegexp = require('named-js-regexp');
 // Allow negative column numbers (https://github.com/PyCQA/pylint/issues/1822)
-const REGEX = '(?<line>\\d+),(?<column>-?\\d+),(?<type>\\w+),(?<code>\\w\\d+):(?<message>.*)\\r?(\\n|$)';
+// Allow codes with more than one letter (e.g. plugins for flake8 v3 onwards)
+const REGEX = '(?<line>\\d+),(?<column>-?\\d+),(?<type>\\w+),(?<code>\\w+\\d+):(?<message>.*)\\r?(\\n|$)';
 
 export interface IRegexGroup {
     line: number;


### PR DESCRIPTION
Quoting the flake8 plugin author instructions:

"Please Note: Your entry point does not need to be exactly 4 characters as of Flake8 3.0. Consider using an entry point with 3 letters followed by 3 numbers (i.e. ABC123 )."

http://flake8.pycqa.org/en/latest/plugin-development/registering-plugins.html

This change was in last part motivated by the increasing number of error code collisions with flake8 plugins using the original one letter and three numbers pattern.

This regular expression fix was suggested by @jraygauthier on issue #4074.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
