### PR TITLE
Don't register language server onTelemetry when downloadLanguageServer is false

### DIFF
--- a/news/3 Code Health/4199.md
+++ b/news/3 Code Health/4199.md
@@ -1,0 +1,1 @@
+Don't register language server onTelemetry when downloadLanguageServer is false.

--- a/src/test/activation/languageServer/languageServer.unit.test.ts
+++ b/src/test/activation/languageServer/languageServer.unit.test.ts
@@ -12,7 +12,7 @@ import { BaseLanguageClientFactory } from '../../../client/activation/languageSe
 import { LanguageServer } from '../../../client/activation/languageServer/languageServer';
 import { ILanguageClientFactory } from '../../../client/activation/types';
 import '../../../client/common/extensions';
-import { IDisposable } from '../../../client/common/types';
+import { IConfigurationService, IDisposable, IPythonSettings } from '../../../client/common/types';
 import { sleep } from '../../../client/common/utils/async';
 import { UnitTestManagementService } from '../../../client/unittests/main';
 import { IUnitTestManagementService } from '../../../client/unittests/types';
@@ -30,11 +30,13 @@ suite('Language Server - LanguageServer', () => {
     let server: LanguageServerTest;
     let client: typemoq.IMock<LanguageClient>;
     let testManager: IUnitTestManagementService;
+    let configService: typemoq.IMock<IConfigurationService>;
     setup(() => {
         client = typemoq.Mock.ofType<LanguageClient>();
         clientFactory = mock(BaseLanguageClientFactory);
         testManager = mock(UnitTestManagementService);
-        server = new LanguageServerTest(instance(clientFactory), instance(testManager));
+        configService = typemoq.Mock.ofType<IConfigurationService>();
+        server = new LanguageServerTest(instance(clientFactory), instance(testManager), configService.object);
     });
     teardown(() => {
         client.setup(c => c.stop()).returns(() => Promise.resolve());
@@ -52,6 +54,20 @@ suite('Language Server - LanguageServer', () => {
 
         const uri = Uri.file(__filename);
         const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
+
+        const pythonSettings = typemoq.Mock.ofType<IPythonSettings>();
+        pythonSettings
+            .setup(p => p.downloadLanguageServer)
+            .returns(() => true);
+        configService
+            .setup(c => c.getSettings(uri))
+            .returns(() => pythonSettings.object)
+
+        const onTelemetryDisposable = typemoq.Mock.ofType<IDisposable>();
+        client
+            .setup(c => c.onTelemetry(typemoq.It.isAny()))
+            .returns(() => onTelemetryDisposable.object);
+
         client.setup(c => (c as any).then).returns(() => undefined);
         when(clientFactory.createLanguageClient(uri, options)).thenResolve(client.object);
         const startDisposable = typemoq.Mock.ofType<IDisposable>();
@@ -94,6 +110,20 @@ suite('Language Server - LanguageServer', () => {
         const loadExtensionArgs = { x: 1 };
         const uri = Uri.file(__filename);
         const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
+
+        const pythonSettings = typemoq.Mock.ofType<IPythonSettings>();
+        pythonSettings
+            .setup(p => p.downloadLanguageServer)
+            .returns(() => true);
+        configService
+            .setup(c => c.getSettings(uri))
+            .returns(() => pythonSettings.object)
+
+        const onTelemetryDisposable = typemoq.Mock.ofType<IDisposable>();
+        client
+            .setup(c => c.onTelemetry(typemoq.It.isAny()))
+            .returns(() => onTelemetryDisposable.object);
+
         client.setup(c => (c as any).then).returns(() => undefined);
         when(clientFactory.createLanguageClient(uri, options)).thenResolve(client.object);
         const startDisposable = typemoq.Mock.ofType<IDisposable>();
@@ -142,5 +172,97 @@ suite('Language Server - LanguageServer', () => {
     });
     test('Ensure Errors raised when starting test manager are not bubbled up', async () => {
         await server.registerTestServices();
+    });
+    test('Register telemetry handler if LS was downloadeded', async () => {
+        client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
+
+        const uri = Uri.file(__filename);
+        const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
+
+        const pythonSettings = typemoq.Mock.ofType<IPythonSettings>();
+        pythonSettings
+            .setup(p => p.downloadLanguageServer)
+            .returns(() => true)
+            .verifiable(typemoq.Times.once());
+        configService
+            .setup(c => c.getSettings(uri))
+            .returns(() => pythonSettings.object)
+            .verifiable(typemoq.Times.once());
+
+        const onTelemetryDisposable = typemoq.Mock.ofType<IDisposable>();
+        client
+            .setup(c => c.onTelemetry(typemoq.It.isAny()))
+            .returns(() => onTelemetryDisposable.object)
+            .verifiable(typemoq.Times.once());
+
+        client.setup(c => (c as any).then).returns(() => undefined);
+        when(clientFactory.createLanguageClient(uri, options)).thenResolve(client.object);
+        const startDisposable = typemoq.Mock.ofType<IDisposable>();
+        client.setup(c => c.stop()).returns(() => Promise.resolve());
+        client
+            .setup(c => c.start())
+            .returns(() => startDisposable.object)
+            .verifiable(typemoq.Times.once());
+
+        server.start(uri, options).ignoreErrors();
+
+        // Initialize language client and verify that the request was sent out.
+        client
+            .setup(c => c.initializeResult)
+            .returns(() => true as any)
+            .verifiable(typemoq.Times.once());
+        await sleep(120);
+
+        verify(testManager.activate(anything())).once();
+
+        client.verify(c => c.onTelemetry(typemoq.It.isAny()), typemoq.Times.once());
+        pythonSettings.verifyAll();
+        configService.verifyAll();
+    });
+    test('Do not register telemetry handler if LS was not downloadeded', async () => {
+        client.verify(c => c.sendRequest(typemoq.It.isAny(), typemoq.It.isAny()), typemoq.Times.never());
+
+        const uri = Uri.file(__filename);
+        const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
+
+        const pythonSettings = typemoq.Mock.ofType<IPythonSettings>();
+        pythonSettings
+            .setup(p => p.downloadLanguageServer)
+            .returns(() => false)
+            .verifiable(typemoq.Times.once());
+        configService
+            .setup(c => c.getSettings(uri))
+            .returns(() => pythonSettings.object)
+            .verifiable(typemoq.Times.once());
+
+        const onTelemetryDisposable = typemoq.Mock.ofType<IDisposable>();
+        client
+            .setup(c => c.onTelemetry(typemoq.It.isAny()))
+            .returns(() => onTelemetryDisposable.object)
+            .verifiable(typemoq.Times.once());
+
+        client.setup(c => (c as any).then).returns(() => undefined);
+        when(clientFactory.createLanguageClient(uri, options)).thenResolve(client.object);
+        const startDisposable = typemoq.Mock.ofType<IDisposable>();
+        client.setup(c => c.stop()).returns(() => Promise.resolve());
+        client
+            .setup(c => c.start())
+            .returns(() => startDisposable.object)
+            .verifiable(typemoq.Times.once());
+
+        server.start(uri, options).ignoreErrors();
+
+        // Initialize language client and verify that the request was sent out.
+        client
+            .setup(c => c.initializeResult)
+            .returns(() => true as any)
+            .verifiable(typemoq.Times.once());
+        await sleep(120);
+
+        verify(testManager.activate(anything())).once();
+
+        client.verify(c => c.onTelemetry(typemoq.It.isAny()), typemoq.Times.never());
+        pythonSettings.verifyAll();
+        configService.verifyAll();
     });
 });

--- a/src/test/activation/languageServer/languageServer.unit.test.ts
+++ b/src/test/activation/languageServer/languageServer.unit.test.ts
@@ -61,7 +61,7 @@ suite('Language Server - LanguageServer', () => {
             .returns(() => true);
         configService
             .setup(c => c.getSettings(uri))
-            .returns(() => pythonSettings.object)
+            .returns(() => pythonSettings.object);
 
         const onTelemetryDisposable = typemoq.Mock.ofType<IDisposable>();
         client
@@ -117,7 +117,7 @@ suite('Language Server - LanguageServer', () => {
             .returns(() => true);
         configService
             .setup(c => c.getSettings(uri))
-            .returns(() => pythonSettings.object)
+            .returns(() => pythonSettings.object);
 
         const onTelemetryDisposable = typemoq.Mock.ofType<IDisposable>();
         client


### PR DESCRIPTION
For #4199.

Doesn't handle #4425, which should be done later (since I think the tests needs some amount of rewriting anyway in this area).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
