### PR TITLE
Fix .env related updates during multiroot test phase by using unique files for .env updates.

### DIFF
--- a/src/test/common/variables/envVarsProvider.multiroot.test.ts
+++ b/src/test/common/variables/envVarsProvider.multiroot.test.ts
@@ -63,7 +63,9 @@ suite('Multiroot Environment Variables Provider', () => {
     suiteTeardown(async () => {
         await closeActiveWindows();
         testFilesToDelete.forEach(async (fullFilePath: string) => {
-            fs.remove(fullFilePath).ignoreErrors();
+            if (await fs.pathExists(fullFilePath)) {
+                fs.remove(fullFilePath).ignoreErrors();
+            }
         });
     });
 


### PR DESCRIPTION
For #4468 (originally written as a fix within PR #4460).

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
