### PR TITLE
Do not throw error in launch.json does not exist

### DIFF
--- a/src/client/unittests/common/debugLauncher.ts
+++ b/src/client/unittests/common/debugLauncher.ts
@@ -93,6 +93,9 @@ export class DebugLauncher implements ITestDebugLauncher {
         const workspaceFolder = this.workspaceService.workspaceFolders![0];
         const filename = path.join(workspaceFolder.uri.fsPath, '.vscode', 'launch.json');
         let configs: DebugConfiguration[] = [];
+        if (!(await this.fs.fileExists(filename))) {
+            return [];
+        }
         try {
             let text = await this.fs.readFile(filename);
             text = stripJsonComments(text);
@@ -105,7 +108,7 @@ export class DebugLauncher implements ITestDebugLauncher {
         } catch (exc) {
             traceError('could not get debug config', exc);
             const appShell = this.serviceContainer.get<IApplicationShell>(IApplicationShell);
-            await appShell.showErrorMessage('could not load unit test config from launch.json');
+            await appShell.showErrorMessage('Could not load unit test config from launch.json');
         }
         return configs;
     }

--- a/src/test/unittests/common/debugLauncher.unit.test.ts
+++ b/src/test/unittests/common/debugLauncher.unit.test.ts
@@ -175,9 +175,11 @@ suite('Unit Tests - Debug Launcher', () => {
             .returns(() => workspaceFolders[0]);
 
         if (!debugConfigs) {
-            filesystem.setup(fs => fs.readFile(TypeMoq.It.isAny()))
-                .throws(new Error('file not found'));
+            filesystem.setup(fs => fs.fileExists(TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(false));
         } else {
+            filesystem.setup(fs => fs.fileExists(TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(true));
             if (typeof debugConfigs !== 'string') {
                 debugConfigs = JSON.stringify({
                     version: '0.1.0',


### PR DESCRIPTION
For #332

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
