### PR TITLE
Fix context menus to not run cell commands twice

### DIFF
--- a/news/2 Fixes/4532.md
+++ b/news/2 Fixes/4532.md
@@ -1,0 +1,1 @@
+Fix double running of cells with the context menu

--- a/src/client/datascience/editor-integration/codewatcher.ts
+++ b/src/client/datascience/editor-integration/codewatcher.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable } from 'inversify';
+import * as uuid from 'uuid/v4';
 import { CodeLens, Command, Position, Range, Selection, TextDocument, TextEditor, TextEditorRevealType } from 'vscode';
 
 import { IApplicationShell, IDocumentManager } from '../../common/application/types';
@@ -87,7 +88,7 @@ export class CodeWatcher implements ICodeWatcher {
                 const range: Range = new Range(lens.command.arguments[1], lens.command.arguments[2], lens.command.arguments[3], lens.command.arguments[4]);
                 if (this.document && range) {
                     const code = this.document.getText(range);
-                    await activeHistory.addCode(code, this.getFileName(), range.start.line, id);
+                    await activeHistory.addCode(code, this.getFileName(), range.start.line, uuid());
                 }
             }
         }
@@ -96,7 +97,7 @@ export class CodeWatcher implements ICodeWatcher {
         if (this.codeLenses.length === 0) {
             if (this.document) {
                 const code = this.document.getText();
-                await activeHistory.addCode(code, this.getFileName(), 0, id);
+                await activeHistory.addCode(code, this.getFileName(), 0, uuid());
             }
         }
     }
@@ -119,7 +120,7 @@ export class CodeWatcher implements ICodeWatcher {
             }
 
             if (code && code.trim().length) {
-                await activeHistory.addCode(code, this.getFileName(), activeEditor.selection.start.line, id, activeEditor);
+                await activeHistory.addCode(code, this.getFileName(), activeEditor.selection.start.line, uuid(), activeEditor);
             }
         }
     }
@@ -132,7 +133,7 @@ export class CodeWatcher implements ICodeWatcher {
             const code = this.document.getText(range);
 
             try {
-                await activeHistory.addCode(code, this.getFileName(), range.start.line, id, this.documentManager.activeTextEditor);
+                await activeHistory.addCode(code, this.getFileName(), range.start.line, uuid(), this.documentManager.activeTextEditor);
             } catch (err) {
                 this.handleError(err);
             }


### PR DESCRIPTION
For #4532

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
