### PR TITLE
Ensure subsequent npm installs do not fail

### DIFF
--- a/build/ci/postInstall.js
+++ b/build/ci/postInstall.js
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
+const colors = require("colors/safe");
 const fs = require("fs");
 const path = require("path");
 const constants_1 = require("../constants");
@@ -13,15 +14,23 @@ const constants_1 = require("../constants");
  * The solution is to modify the type definition file after `npm install`.
  */
 function fixJupyterLabDTSFiles() {
-    const filePath = path.join(constants_1.ExtensionRootDir, 'node_modules', '@jupyterlab', 'coreutils', 'lib', 'settingregistry.d.ts');
+    const relativePath = path.join('node_modules', '@jupyterlab', 'coreutils', 'lib', 'settingregistry.d.ts');
+    const filePath = path.join(constants_1.ExtensionRootDir, relativePath);
     if (!fs.existsSync(filePath)) {
         throw new Error(`Type Definition file from JupyterLab not found '${filePath}' (pvsc post install script)`);
     }
     const fileContents = fs.readFileSync(filePath, { encoding: 'utf8' });
+    if (fileContents.indexOf('[key: string]: ISchema | undefined;') > 0) {
+        // tslint:disable-next-line:no-console
+        console.log(colors.blue(`${relativePath} file already updated (by Python VSC)`));
+        return;
+    }
     const replacedText = fileContents.replace('[key: string]: ISchema;', '[key: string]: ISchema | undefined;');
     if (fileContents === replacedText) {
         throw new Error('Fix for JupyterLabl file \'settingregistry.d.ts\' failed (pvsc post install script)');
     }
     fs.writeFileSync(filePath, replacedText);
+    // tslint:disable-next-line:no-console
+    console.log(colors.green(`${relativePath} file updated (by Python VSC)`));
 }
 fixJupyterLabDTSFiles();

--- a/build/ci/postInstall.ts
+++ b/build/ci/postInstall.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import * as colors from 'colors/safe';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ExtensionRootDir } from '../constants';
@@ -15,24 +16,33 @@ import { ExtensionRootDir } from '../constants';
  * The solution is to modify the type definition file after `npm install`.
  */
 function fixJupyterLabDTSFiles() {
-    const filePath = path.join(
-        ExtensionRootDir,
+    const relativePath = path.join(
         'node_modules',
         '@jupyterlab',
         'coreutils',
         'lib',
         'settingregistry.d.ts'
     );
+    const filePath = path.join(
+        ExtensionRootDir, relativePath
+    );
     if (!fs.existsSync(filePath)) {
         throw new Error(`Type Definition file from JupyterLab not found '${filePath}' (pvsc post install script)`);
     }
 
     const fileContents = fs.readFileSync(filePath, { encoding: 'utf8' });
+    if (fileContents.indexOf('[key: string]: ISchema | undefined;') > 0) {
+        // tslint:disable-next-line:no-console
+        console.log(colors.blue(`${relativePath} file already updated (by Python VSC)`));
+        return;
+    }
     const replacedText = fileContents.replace('[key: string]: ISchema;', '[key: string]: ISchema | undefined;');
     if (fileContents === replacedText) {
         throw new Error('Fix for JupyterLabl file \'settingregistry.d.ts\' failed (pvsc post install script)');
     }
     fs.writeFileSync(filePath, replacedText);
+    // tslint:disable-next-line:no-console
+    console.log(colors.green(`${relativePath} file updated (by Python VSC)`));
 }
 
 fixJupyterLabDTSFiles();

--- a/news/3 Code Health/4109.md
+++ b/news/3 Code Health/4109.md
@@ -1,0 +1,1 @@
+Ensure post npm install scripts do not fail when run more than once.


### PR DESCRIPTION
For #4109

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
