### PR TITLE
Increase timeouts for loading of extension when preparing to run tests

### DIFF
--- a/news/3 Code Health/4540.md
+++ b/news/3 Code Health/4540.md
@@ -1,0 +1,1 @@
+Increase timeouts for loading of extension when preparing to run tests.

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -103,7 +103,7 @@ export function run(testsRoot: string, callback: TestCallback): void {
      * @returns
      */
     function initializationScript() {
-        const ex = new Error('Failed to initialize extension for tests');
+        const ex = new Error('Failed to initialize Python extension for tests after 2 minutes');
         const failed = new Promise((_, reject) => setTimeout(() => reject(ex), 120_000));
         return Promise.race([initialize(), failed]);
     }

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -104,7 +104,7 @@ export function run(testsRoot: string, callback: TestCallback): void {
      */
     function initializationScript() {
         const ex = new Error('Failed to initialize extension for tests');
-        const failed = new Promise((_, reject) => setTimeout(() => reject(ex), 60_000));
+        const failed = new Promise((_, reject) => setTimeout(() => reject(ex), 120_000));
         return Promise.race([initialize(), failed]);
     }
     // Run the tests.


### PR DESCRIPTION
For #4540

## Loading extension in debug mode can be very slow due to time taken to load packages (disk IO, thats why we bundle the extension for production use).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
