### PR TITLE
Disable output pane on isort failures

### DIFF
--- a/news/1 Enhancements/2522.md
+++ b/news/1 Enhancements/2522.md
@@ -1,0 +1,2 @@
+Disabled opening the output pane when sorting imports via isort fails.
+(thanks [chrised](https://github.com/chrised/))

--- a/src/client/providers/importSortProvider.ts
+++ b/src/client/providers/importSortProvider.ts
@@ -114,7 +114,6 @@ export class SortImportsEditingProvider implements ISortImportsEditingProvider {
             const message = typeof error === 'string' ? error : (error.message ? error.message : error);
             const outputChannel = this.serviceContainer.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
             outputChannel.appendLine(error);
-            outputChannel.show();
             const logger = this.serviceContainer.get<ILogger>(ILogger);
             logger.logError(`Failed to format imports for '${uri.fsPath}'.`, error);
             this.shell.showErrorMessage(message).then(noop, noop);


### PR DESCRIPTION
As per @DonJayamanne's suggestion in the conversation for issue #2522.

I've been patching this locally for the past few months, so thought I should probably feed it back up.

Fixes #2522

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
