### PR TITLE
Change firing condition for execSelectionInteractive

### DIFF
--- a/news/2 Fixes/4604.md
+++ b/news/2 Fixes/4604.md
@@ -1,0 +1,2 @@
+Fix shift-enter to send the current line to the interactive window when there
+is no selection (thanks to Kevin Kainan Li).

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
             {
                 "command": "python.datascience.execSelectionInteractive",
                 "key": "shift+enter",
-                "when": "editorFocus && editorHasSelection && editorLangId == python && !findInputFocussed && !replaceInputFocussed && python.datascience.ownsSelection && python.datascience.featureenabled"
+                "when": "editorFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && python.datascience.ownsSelection && python.datascience.featureenabled"
             },
             {
                 "command": "python.datascience.runcurrentcelladvance",


### PR DESCRIPTION
If nothing is selected, just run the current line.

For #4604 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] ~Has sufficient logging.~
- [X] ~Has telemetry for enhancements.~
- [X] ~Unit tests & system/integration tests are added/updated~
- [X] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [X] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [X] ~The wiki is updated with any design decisions/details.~
