### PR TITLE
Fix progress reporting for the new LS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "7.0.0"
+                "@babel/highlight": "^7.0.0"
             }
         },
         "@babel/core": {
@@ -19,20 +19,20 @@
             "integrity": "sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0",
-                "@babel/generator": "7.0.0",
-                "@babel/helpers": "7.1.0",
-                "@babel/parser": "7.1.0",
-                "@babel/template": "7.1.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0",
-                "convert-source-map": "1.5.1",
-                "debug": "3.2.5",
-                "json5": "0.5.1",
-                "lodash": "4.17.11",
-                "resolve": "1.7.1",
-                "semver": "5.5.0",
-                "source-map": "0.5.7"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.0.0",
+                "@babel/helpers": "^7.1.0",
+                "@babel/parser": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "convert-source-map": "^1.1.0",
+                "debug": "^3.1.0",
+                "json5": "^0.5.0",
+                "lodash": "^4.17.10",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -41,7 +41,7 @@
                     "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.1.1"
                     }
                 },
                 "lodash": {
@@ -64,11 +64,11 @@
             "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0",
-                "jsesc": "2.5.1",
-                "lodash": "4.17.11",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "@babel/types": "^7.0.0",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "lodash": {
@@ -85,7 +85,7 @@
             "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -94,8 +94,8 @@
             "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/helper-explode-assignable-expression": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-builder-react-jsx": {
@@ -104,8 +104,8 @@
             "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0",
-                "esutils": "2.0.2"
+                "@babel/types": "^7.0.0",
+                "esutils": "^2.0.0"
             }
         },
         "@babel/helper-call-delegate": {
@@ -114,9 +114,9 @@
             "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "7.0.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-define-map": {
@@ -125,9 +125,9 @@
             "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/types": "7.0.0",
-                "lodash": "4.17.11"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
             },
             "dependencies": {
                 "lodash": {
@@ -144,8 +144,8 @@
             "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-function-name": {
@@ -154,9 +154,9 @@
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "7.0.0",
-                "@babel/template": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -165,7 +165,7 @@
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -174,7 +174,7 @@
             "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -183,7 +183,7 @@
             "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-module-imports": {
@@ -192,7 +192,7 @@
             "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-module-transforms": {
@@ -201,12 +201,12 @@
             "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@babel/helper-simple-access": "7.1.0",
-                "@babel/helper-split-export-declaration": "7.0.0",
-                "@babel/template": "7.1.0",
-                "@babel/types": "7.0.0",
-                "lodash": "4.17.11"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
             },
             "dependencies": {
                 "lodash": {
@@ -223,7 +223,7 @@
             "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -238,7 +238,7 @@
             "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.17.10"
             },
             "dependencies": {
                 "lodash": {
@@ -255,11 +255,11 @@
             "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "7.0.0",
-                "@babel/helper-wrap-function": "7.1.0",
-                "@babel/template": "7.1.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-wrap-function": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-replace-supers": {
@@ -268,10 +268,10 @@
             "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "7.0.0",
-                "@babel/helper-optimise-call-expression": "7.0.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-simple-access": {
@@ -280,8 +280,8 @@
             "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
             "dev": true,
             "requires": {
-                "@babel/template": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -290,7 +290,7 @@
             "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.0.0"
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helper-wrap-function": {
@@ -299,10 +299,10 @@
             "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/template": "7.1.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/helpers": {
@@ -311,9 +311,9 @@
             "integrity": "sha512-V1jXUTNdTpBn37wqqN73U+eBpzlLHmxA4aDaghJBggmzly/FpIJMHXse9lgdzQQT4gs5jZ5NmYxOL8G3ROc29g==",
             "dev": true,
             "requires": {
-                "@babel/template": "7.1.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/highlight": {
@@ -322,9 +322,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "4.0.0"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -333,7 +333,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -342,9 +342,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -365,7 +365,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -382,9 +382,9 @@
             "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-remap-async-to-generator": "7.1.0",
-                "@babel/plugin-syntax-async-generators": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0",
+                "@babel/plugin-syntax-async-generators": "^7.0.0"
             }
         },
         "@babel/plugin-proposal-json-strings": {
@@ -393,8 +393,8 @@
             "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-json-strings": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-json-strings": "^7.0.0"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -403,8 +403,8 @@
             "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
@@ -413,8 +413,8 @@
             "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
@@ -423,9 +423,9 @@
             "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0",
-                "regexpu-core": "4.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.2.0"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -434,7 +434,7 @@
             "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -443,7 +443,7 @@
             "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-jsx": {
@@ -452,7 +452,7 @@
             "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -461,7 +461,7 @@
             "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
@@ -470,7 +470,7 @@
             "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -479,7 +479,7 @@
             "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
@@ -488,9 +488,9 @@
             "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-remap-async-to-generator": "7.1.0"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
@@ -499,7 +499,7 @@
             "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-block-scoping": {
@@ -508,8 +508,8 @@
             "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "lodash": "4.17.11"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "lodash": "^4.17.10"
             },
             "dependencies": {
                 "lodash": {
@@ -526,14 +526,14 @@
             "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "7.0.0",
-                "@babel/helper-define-map": "7.1.0",
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-optimise-call-expression": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-replace-supers": "7.1.0",
-                "@babel/helper-split-export-declaration": "7.0.0",
-                "globals": "11.7.0"
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-define-map": "^7.1.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "globals": "^11.1.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
@@ -542,7 +542,7 @@
             "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-destructuring": {
@@ -551,7 +551,7 @@
             "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
@@ -560,9 +560,9 @@
             "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0",
-                "regexpu-core": "4.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -571,7 +571,7 @@
             "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
@@ -580,8 +580,8 @@
             "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -590,7 +590,7 @@
             "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-function-name": {
@@ -599,8 +599,8 @@
             "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-literals": {
@@ -609,7 +609,7 @@
             "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-modules-amd": {
@@ -618,8 +618,8 @@
             "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
@@ -628,9 +628,9 @@
             "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-simple-access": "7.1.0"
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -639,8 +639,8 @@
             "integrity": "sha512-8EDKMAsitLkiF/D4Zhe9CHEE2XLh4bfLbb9/Zf3FgXYQOZyZYyg7EAel/aT2A7bHv62jwHf09q2KU/oEexr83g==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
@@ -649,8 +649,8 @@
             "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-new-target": {
@@ -659,7 +659,7 @@
             "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-object-super": {
@@ -668,8 +668,8 @@
             "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-replace-supers": "7.1.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0"
             }
         },
         "@babel/plugin-transform-parameters": {
@@ -678,9 +678,9 @@
             "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "7.1.0",
-                "@babel/helper-get-function-arity": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-call-delegate": "^7.1.0",
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-react-display-name": {
@@ -689,7 +689,7 @@
             "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx": {
@@ -698,9 +698,9 @@
             "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-jsx": "7.0.0"
+                "@babel/helper-builder-react-jsx": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-jsx": "^7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
@@ -709,8 +709,8 @@
             "integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-jsx": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-jsx": "^7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
@@ -719,8 +719,8 @@
             "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-jsx": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-jsx": "^7.0.0"
             }
         },
         "@babel/plugin-transform-regenerator": {
@@ -729,7 +729,7 @@
             "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
             "dev": true,
             "requires": {
-                "regenerator-transform": "0.13.3"
+                "regenerator-transform": "^0.13.3"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -738,7 +738,7 @@
             "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-spread": {
@@ -747,7 +747,7 @@
             "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
@@ -756,8 +756,8 @@
             "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0"
             }
         },
         "@babel/plugin-transform-template-literals": {
@@ -766,8 +766,8 @@
             "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
@@ -776,7 +776,7 @@
             "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -785,9 +785,9 @@
             "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0",
-                "regexpu-core": "4.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
             }
         },
         "@babel/preset-env": {
@@ -796,47 +796,47 @@
             "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "7.1.0",
-                "@babel/plugin-proposal-json-strings": "7.0.0",
-                "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-                "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
-                "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
-                "@babel/plugin-syntax-async-generators": "7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
-                "@babel/plugin-transform-arrow-functions": "7.0.0",
-                "@babel/plugin-transform-async-to-generator": "7.1.0",
-                "@babel/plugin-transform-block-scoped-functions": "7.0.0",
-                "@babel/plugin-transform-block-scoping": "7.0.0",
-                "@babel/plugin-transform-classes": "7.1.0",
-                "@babel/plugin-transform-computed-properties": "7.0.0",
-                "@babel/plugin-transform-destructuring": "7.0.0",
-                "@babel/plugin-transform-dotall-regex": "7.0.0",
-                "@babel/plugin-transform-duplicate-keys": "7.0.0",
-                "@babel/plugin-transform-exponentiation-operator": "7.1.0",
-                "@babel/plugin-transform-for-of": "7.0.0",
-                "@babel/plugin-transform-function-name": "7.1.0",
-                "@babel/plugin-transform-literals": "7.0.0",
-                "@babel/plugin-transform-modules-amd": "7.1.0",
-                "@babel/plugin-transform-modules-commonjs": "7.1.0",
-                "@babel/plugin-transform-modules-systemjs": "7.0.0",
-                "@babel/plugin-transform-modules-umd": "7.1.0",
-                "@babel/plugin-transform-new-target": "7.0.0",
-                "@babel/plugin-transform-object-super": "7.1.0",
-                "@babel/plugin-transform-parameters": "7.1.0",
-                "@babel/plugin-transform-regenerator": "7.0.0",
-                "@babel/plugin-transform-shorthand-properties": "7.0.0",
-                "@babel/plugin-transform-spread": "7.0.0",
-                "@babel/plugin-transform-sticky-regex": "7.0.0",
-                "@babel/plugin-transform-template-literals": "7.0.0",
-                "@babel/plugin-transform-typeof-symbol": "7.0.0",
-                "@babel/plugin-transform-unicode-regex": "7.0.0",
-                "browserslist": "4.1.1",
-                "invariant": "2.2.4",
-                "js-levenshtein": "1.1.4",
-                "semver": "5.5.0"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+                "@babel/plugin-proposal-json-strings": "^7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+                "@babel/plugin-syntax-async-generators": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+                "@babel/plugin-transform-arrow-functions": "^7.0.0",
+                "@babel/plugin-transform-async-to-generator": "^7.1.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+                "@babel/plugin-transform-block-scoping": "^7.0.0",
+                "@babel/plugin-transform-classes": "^7.1.0",
+                "@babel/plugin-transform-computed-properties": "^7.0.0",
+                "@babel/plugin-transform-destructuring": "^7.0.0",
+                "@babel/plugin-transform-dotall-regex": "^7.0.0",
+                "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+                "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+                "@babel/plugin-transform-for-of": "^7.0.0",
+                "@babel/plugin-transform-function-name": "^7.1.0",
+                "@babel/plugin-transform-literals": "^7.0.0",
+                "@babel/plugin-transform-modules-amd": "^7.1.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+                "@babel/plugin-transform-modules-umd": "^7.1.0",
+                "@babel/plugin-transform-new-target": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.1.0",
+                "@babel/plugin-transform-parameters": "^7.1.0",
+                "@babel/plugin-transform-regenerator": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+                "@babel/plugin-transform-spread": "^7.0.0",
+                "@babel/plugin-transform-sticky-regex": "^7.0.0",
+                "@babel/plugin-transform-template-literals": "^7.0.0",
+                "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+                "@babel/plugin-transform-unicode-regex": "^7.0.0",
+                "browserslist": "^4.1.0",
+                "invariant": "^2.2.2",
+                "js-levenshtein": "^1.1.3",
+                "semver": "^5.3.0"
             }
         },
         "@babel/preset-react": {
@@ -845,11 +845,11 @@
             "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-transform-react-display-name": "7.0.0",
-                "@babel/plugin-transform-react-jsx": "7.0.0",
-                "@babel/plugin-transform-react-jsx-self": "7.0.0",
-                "@babel/plugin-transform-react-jsx-source": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-transform-react-display-name": "^7.0.0",
+                "@babel/plugin-transform-react-jsx": "^7.0.0",
+                "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+                "@babel/plugin-transform-react-jsx-source": "^7.0.0"
             }
         },
         "@babel/runtime": {
@@ -858,7 +858,7 @@
             "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
             "dev": true,
             "requires": {
-                "regenerator-runtime": "0.12.1"
+                "regenerator-runtime": "^0.12.0"
             }
         },
         "@babel/runtime-corejs2": {
@@ -867,8 +867,8 @@
             "integrity": "sha512-drxaPByExlcRDKW4ZLubUO4ZkI8/8ax9k9wve1aEthdLKFzjB7XRkOQ0xoTIWGxqdDnWDElkjYq77bt7yrcYJQ==",
             "dev": true,
             "requires": {
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.12.1"
+                "core-js": "^2.5.7",
+                "regenerator-runtime": "^0.12.0"
             }
         },
         "@babel/template": {
@@ -877,9 +877,9 @@
             "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0",
-                "@babel/parser": "7.1.0",
-                "@babel/types": "7.0.0"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@babel/traverse": {
@@ -888,15 +888,15 @@
             "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0",
-                "@babel/generator": "7.0.0",
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-split-export-declaration": "7.0.0",
-                "@babel/parser": "7.1.0",
-                "@babel/types": "7.0.0",
-                "debug": "3.2.5",
-                "globals": "11.7.0",
-                "lodash": "4.17.11"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.0.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "debug": "^3.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
             },
             "dependencies": {
                 "debug": {
@@ -905,7 +905,7 @@
                     "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.1.1"
                     }
                 },
                 "lodash": {
@@ -928,9 +928,9 @@
             "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2",
-                "lodash": "4.17.11",
-                "to-fast-properties": "2.0.0"
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
             },
             "dependencies": {
                 "lodash": {
@@ -947,12 +947,12 @@
             "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
             "dev": true,
             "requires": {
-                "@emotion/hash": "0.6.6",
-                "@emotion/memoize": "0.6.6",
-                "@emotion/serialize": "0.9.1",
-                "convert-source-map": "1.5.1",
-                "find-root": "1.1.0",
-                "source-map": "0.7.3"
+                "@emotion/hash": "^0.6.6",
+                "@emotion/memoize": "^0.6.6",
+                "@emotion/serialize": "^0.9.1",
+                "convert-source-map": "^1.5.1",
+                "find-root": "^1.1.0",
+                "source-map": "^0.7.2"
             },
             "dependencies": {
                 "source-map": {
@@ -981,10 +981,10 @@
             "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
             "dev": true,
             "requires": {
-                "@emotion/hash": "0.6.6",
-                "@emotion/memoize": "0.6.6",
-                "@emotion/unitless": "0.6.7",
-                "@emotion/utils": "0.8.2"
+                "@emotion/hash": "^0.6.6",
+                "@emotion/memoize": "^0.6.6",
+                "@emotion/unitless": "^0.6.7",
+                "@emotion/utils": "^0.8.2"
             }
         },
         "@emotion/stylis": {
@@ -1011,11 +1011,11 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "css": "2.2.3",
-                "normalize-path": "2.1.1",
-                "source-map": "0.5.7",
-                "through2": "2.0.3"
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.5.6",
+                "through2": "^2.0.3"
             }
         },
         "@gulp-sourcemaps/map-sources": {
@@ -1024,8 +1024,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "2.1.1",
-                "through2": "2.0.3"
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
             }
         },
         "@jupyterlab/coreutils": {
@@ -1033,16 +1033,16 @@
             "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.1.4.tgz",
             "integrity": "sha512-jSjn+xZj+kJrSWJ2Hz3jpxq0EXNpQrsnf+dD+pnDPc8mAeQ2XVu/x63VZyIDx8u2MELrIodFsUmQTxeudXKlOg==",
             "requires": {
-                "@phosphor/algorithm": "1.1.2",
-                "@phosphor/coreutils": "1.3.0",
-                "@phosphor/disposable": "1.1.2",
-                "@phosphor/signaling": "1.2.2",
-                "ajv": "5.1.6",
-                "comment-json": "1.1.3",
-                "minimist": "1.2.0",
-                "moment": "2.21.0",
-                "path-posix": "1.0.0",
-                "url-parse": "1.4.3"
+                "@phosphor/algorithm": "^1.1.2",
+                "@phosphor/coreutils": "^1.3.0",
+                "@phosphor/disposable": "^1.1.2",
+                "@phosphor/signaling": "^1.2.2",
+                "ajv": "~5.1.6",
+                "comment-json": "^1.1.3",
+                "minimist": "~1.2.0",
+                "moment": "~2.21.0",
+                "path-posix": "~1.0.0",
+                "url-parse": "~1.4.3"
             },
             "dependencies": {
                 "ajv": {
@@ -1050,9 +1050,9 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
                     "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
                     "requires": {
-                        "co": "4.6.0",
-                        "json-schema-traverse": "0.3.1",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-schema-traverse": "^0.3.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 }
             }
@@ -1062,11 +1062,11 @@
             "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.7.tgz",
             "integrity": "sha512-EbmQH7+9SOBZXq3wOhBII7DQXeOeu7v5v8qPK7hJrjGUWSZhGYGglzm05ou5bP/Q2h+Y+Ar3tYX/LUupR6JuaA==",
             "requires": {
-                "@phosphor/algorithm": "1.1.2",
-                "@phosphor/coreutils": "1.3.0",
-                "@phosphor/disposable": "1.1.2",
-                "@phosphor/messaging": "1.2.2",
-                "@phosphor/signaling": "1.2.2"
+                "@phosphor/algorithm": "^1.1.2",
+                "@phosphor/coreutils": "^1.3.0",
+                "@phosphor/disposable": "^1.1.2",
+                "@phosphor/messaging": "^1.2.2",
+                "@phosphor/signaling": "^1.2.2"
             }
         },
         "@jupyterlab/services": {
@@ -1074,14 +1074,14 @@
             "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.1.4.tgz",
             "integrity": "sha512-EK8WDbqGWsbsYAtd1AbpelaXOrtuHDgV5fNcdXTnHyhvA/uXn/yYRI+mKO2sTjVjAjVL6n/XNomd0czzp+kiGg==",
             "requires": {
-                "@jupyterlab/coreutils": "2.1.4",
-                "@jupyterlab/observables": "2.0.7",
-                "@phosphor/algorithm": "1.1.2",
-                "@phosphor/coreutils": "1.3.0",
-                "@phosphor/disposable": "1.1.2",
-                "@phosphor/signaling": "1.2.2",
-                "node-fetch": "1.7.3",
-                "ws": "1.1.5"
+                "@jupyterlab/coreutils": "^2.1.4",
+                "@jupyterlab/observables": "^2.0.7",
+                "@phosphor/algorithm": "^1.1.2",
+                "@phosphor/coreutils": "^1.3.0",
+                "@phosphor/disposable": "^1.1.2",
+                "@phosphor/signaling": "^1.2.2",
+                "node-fetch": "~1.7.3",
+                "ws": "~1.1.4"
             }
         },
         "@mapbox/polylabel": {
@@ -1090,7 +1090,7 @@
             "integrity": "sha1-xXFGGbZa3QgmOOoGAn5psUUA76Y=",
             "dev": true,
             "requires": {
-                "tinyqueue": "1.2.3"
+                "tinyqueue": "^1.1.0"
             }
         },
         "@nteract/markdown": {
@@ -1099,11 +1099,11 @@
             "integrity": "sha512-nRJuAfX+3n/geJAQj6IqEsbhpiPOjyFlUTzh1bdT2hyLGbd2VdbANXDliWTDKVHOHYWxh0zOLQhRvQ4B6G5QlQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "@nteract/mathjax": "2.1.4",
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.2",
-                "react-markdown": "3.6.0"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "@nteract/mathjax": "^2.1.4",
+                "babel-runtime": "^6.26.0",
+                "prop-types": "^15.6.1",
+                "react-markdown": "^3.1.4"
             }
         },
         "@nteract/mathjax": {
@@ -1112,9 +1112,9 @@
             "integrity": "sha512-dY+h3iBsfioSg+33uB04LE9tIt79ClbEumXKz7eciS251jXw8VZcmo/YFqldThpgckbCvveNCliM4Y5sTk1gog==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.2"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "babel-runtime": "^6.26.0",
+                "prop-types": "^15.6.1"
             }
         },
         "@nteract/octicons": {
@@ -1123,8 +1123,8 @@
             "integrity": "sha512-spBTHmaD4+W/Ww0UQt1uXmeYGM5GBA5TExdcuDBn3dLWqsfwjf1nTEfygLx4TRtuqImfPAuUHM4iV+2WkXgMBg==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "babel-runtime": "6.26.0"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "babel-runtime": "^6.26.0"
             }
         },
         "@nteract/plotly": {
@@ -1139,20 +1139,20 @@
             "integrity": "sha512-lPLmZJSiTn6x3zo3zQM+xgY6XXAg2ocrqhQb+zczfPPlINs9TeOmT39R2+QKO9VycOhPIGlAh1n/IHRQOAE6eQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "7.1.2",
-                "@babel/runtime-corejs2": "7.1.2",
-                "@nteract/octicons": "0.4.3",
-                "@nteract/transform-plotly": "3.2.3",
-                "d3-time-format": "2.1.3",
-                "lodash": "4.17.11",
-                "moment": "2.21.0",
-                "numeral": "2.0.6",
-                "react-color": "2.14.1",
-                "react-hot-loader": "4.3.11",
-                "react-table": "6.8.6",
+                "@babel/runtime": "^7.0.0",
+                "@babel/runtime-corejs2": "^7.0.0",
+                "@nteract/octicons": "^0.4.3",
+                "@nteract/transform-plotly": "^3.2.3",
+                "d3-time-format": "^2.0.5",
+                "lodash": "^4.17.4",
+                "moment": "^2.18.1",
+                "numeral": "^2.0.6",
+                "react-color": "^2.14.1",
+                "react-hot-loader": "^4.1.2",
+                "react-table": "^6.8.6",
                 "react-table-hoc-fixed-columns": "1.0.1",
-                "semiotic": "1.15.1",
-                "tv4": "1.3.0"
+                "semiotic": "^1.14.4",
+                "tv4": "^1.3.0"
             }
         },
         "@nteract/transform-geojson": {
@@ -1161,9 +1161,9 @@
             "integrity": "sha512-7LDEUik1DNr11ajp66LqfEnP+CYi0XtaUVJMKN4U+YyGCYcLqtHi9OkLF6jjGe/6SSyL+ukzVU/LNSRJRMN+dA==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "babel-runtime": "6.26.0",
-                "leaflet": "1.3.4"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "babel-runtime": "^6.26.0",
+                "leaflet": "^1.0.3"
             }
         },
         "@nteract/transform-model-debug": {
@@ -1172,8 +1172,8 @@
             "integrity": "sha512-TVNUtTbc0W3cgbdUMFpTqiCWziMpI/7zsR44bwoFScNFmf//HjsQtcXPwj418AHLmywblIeMbtiLFDhrpbpfww==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "babel-runtime": "6.26.0"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "babel-runtime": "^6.26.0"
             }
         },
         "@nteract/transform-plotly": {
@@ -1182,10 +1182,10 @@
             "integrity": "sha512-JPBwW39glHcBF6swMIGWERw8+kcVIonoADPhrnseQcyScjx69Kd7tkAy58iCnVrV4fFvOUT1W0lGXSNTkMAh0Q==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "@nteract/plotly": "1.0.0",
-                "babel-runtime": "6.26.0",
-                "lodash": "4.17.11"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "@nteract/plotly": "^1.0.0",
+                "babel-runtime": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "@nteract/transform-vdom": {
@@ -1194,8 +1194,8 @@
             "integrity": "sha512-NIi4hZzmlXeisZoWU77z++hMGYabunNmDj/wNLAmOCAGnGH6rD3ZTszrBOkP2pPlnm0Je3OqJ2Pun3GZKdCOpQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "babel-runtime": "6.26.0"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "babel-runtime": "^6.26.0"
             }
         },
         "@nteract/transforms": {
@@ -1204,14 +1204,14 @@
             "integrity": "sha512-Y18j197/Dgz9KMOT+G3ocWQTRZcVVPQnMs6AbUgOSUTvoSiPMZb8ZQtIURRXS/1E1oAg05Ch6lVXlbnyClj4Ag==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "@nteract/markdown": "2.1.4",
-                "@nteract/mathjax": "2.1.4",
-                "@nteract/transform-vdom": "2.2.3",
-                "ansi-to-react": "3.3.3",
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.2",
-                "react-json-tree": "0.11.0"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "@nteract/markdown": "^2.1.4",
+                "@nteract/mathjax": "^2.1.4",
+                "@nteract/transform-vdom": "^2.2.3",
+                "ansi-to-react": "^3.3.3",
+                "babel-runtime": "^6.26.0",
+                "prop-types": "^15.6.1",
+                "react-json-tree": "^0.11.0"
             }
         },
         "@phosphor/algorithm": {
@@ -1224,7 +1224,7 @@
             "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.2.tgz",
             "integrity": "sha1-xMC4uREpkF+zap8kPy273kYtq40=",
             "requires": {
-                "@phosphor/algorithm": "1.1.2"
+                "@phosphor/algorithm": "^1.1.2"
             }
         },
         "@phosphor/coreutils": {
@@ -1237,7 +1237,7 @@
             "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.1.2.tgz",
             "integrity": "sha1-oZLdai5sadXQnTns8zTauTd4Bg4=",
             "requires": {
-                "@phosphor/algorithm": "1.1.2"
+                "@phosphor/algorithm": "^1.1.2"
             }
         },
         "@phosphor/messaging": {
@@ -1245,8 +1245,8 @@
             "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.2.tgz",
             "integrity": "sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=",
             "requires": {
-                "@phosphor/algorithm": "1.1.2",
-                "@phosphor/collections": "1.1.2"
+                "@phosphor/algorithm": "^1.1.2",
+                "@phosphor/collections": "^1.1.2"
             }
         },
         "@phosphor/signaling": {
@@ -1254,7 +1254,7 @@
             "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.2.tgz",
             "integrity": "sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=",
             "requires": {
-                "@phosphor/algorithm": "1.1.2"
+                "@phosphor/algorithm": "^1.1.2"
             }
         },
         "@sindresorhus/is": {
@@ -1287,7 +1287,7 @@
             "integrity": "sha512-/kgYvj5Pwiv/bOlJ6c5GlRF/W6lUGSLrpQGl/7Gg6w7tvBYcf0iF91+wwyuwDYGO2zM0wNpcoPixZVif8I/r6g==",
             "dev": true,
             "requires": {
-                "@types/chai": "4.1.3"
+                "@types/chai": "*"
             }
         },
         "@types/chai-as-promised": {
@@ -1296,7 +1296,7 @@
             "integrity": "sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==",
             "dev": true,
             "requires": {
-                "@types/chai": "4.1.3"
+                "@types/chai": "*"
             }
         },
         "@types/cheerio": {
@@ -1317,7 +1317,7 @@
             "integrity": "sha512-b2oEEnno1LIGKMR7uBEsr40al1UijF1HEpRn0+Yf1xOLl24iQgB7DBpZVMM7y54G5wCNoclDrRO65E6KHPNO2w==",
             "dev": true,
             "requires": {
-                "@types/tern": "0.22.1"
+                "@types/tern": "*"
             }
         },
         "@types/commander": {
@@ -1326,7 +1326,7 @@
             "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
             "dev": true,
             "requires": {
-                "commander": "2.15.1"
+                "commander": "*"
             }
         },
         "@types/copy-webpack-plugin": {
@@ -1335,8 +1335,8 @@
             "integrity": "sha512-/L0m5kc7pKGpsu97TTgAP6YcVRmau2Wj0HpRPQBGEbZXT1DZkdozZPCZHGDWXpxcvWDFTxob2JmYJj3RC7CwFA==",
             "dev": true,
             "requires": {
-                "@types/minimatch": "3.0.3",
-                "@types/webpack": "4.4.19"
+                "@types/minimatch": "*",
+                "@types/webpack": "*"
             }
         },
         "@types/decompress": {
@@ -1345,7 +1345,7 @@
             "integrity": "sha512-2jlSsNAVhrWJtgOV3V85MJ09yRoeUTUWQeeusNYAcJVkUmoVRVElvmkWN0TK+Lgdlyd9pIRyja/DTBcyqD8xyA==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/del": {
@@ -1354,7 +1354,7 @@
             "integrity": "sha512-y6qRq6raBuu965clKgx6FHuiPu3oHdtmzMPXi8Uahsjdq1L6DL5fS/aY5/s71YwM7k6K1QIWvem5vNwlnNGIkQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "5.0.35"
+                "@types/glob": "*"
             }
         },
         "@types/diff-match-patch": {
@@ -1369,9 +1369,9 @@
             "integrity": "sha512-gwRnrp1yFweJhPGBR01nfesxYcml8SayxHEwA6x+1T+Lqez5iMdCRJgt/I9HqpjMi5Mmtb/7MswY6FN4bMypNg==",
             "dev": true,
             "requires": {
-                "@types/decompress": "4.2.2",
-                "@types/got": "8.3.1",
-                "@types/node": "9.4.7"
+                "@types/decompress": "*",
+                "@types/got": "*",
+                "@types/node": "*"
             }
         },
         "@types/enzyme": {
@@ -1380,8 +1380,8 @@
             "integrity": "sha512-jvAbagrpoSNAXeZw2kRpP10eTsSIH8vW1IBLCXbN0pbZsYZU8FvTPMMd5OzSWUKWTQfrbXFUY8e6un/W4NpqIA==",
             "dev": true,
             "requires": {
-                "@types/cheerio": "0.22.9",
-                "@types/react": "16.4.14"
+                "@types/cheerio": "*",
+                "@types/react": "*"
             }
         },
         "@types/enzyme-adapter-react-16": {
@@ -1390,7 +1390,7 @@
             "integrity": "sha512-9eRLBsC/Djkys05BdTWgav8v6fSCjyzjNuLwG2sfa2b2g/VAN10luP0zB0VwtOWFQ0LGjIboJJvIsVdU5gqRmg==",
             "dev": true,
             "requires": {
-                "@types/enzyme": "3.1.14"
+                "@types/enzyme": "*"
             }
         },
         "@types/estree": {
@@ -1405,7 +1405,7 @@
             "integrity": "sha512-LLiivgWKii4JeMzFy3trrxqkRrVSdue8WmbXyHuSJLwNrhIQU5MTrc65jhxEPwMyh5HR1xevSdD+k2nnSRKw9g==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/events": {
@@ -1420,7 +1420,7 @@
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/fs-extra": {
@@ -1429,7 +1429,7 @@
             "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/get-port": {
@@ -1444,9 +1444,9 @@
             "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
             "dev": true,
             "requires": {
-                "@types/events": "1.2.0",
-                "@types/minimatch": "3.0.3",
-                "@types/node": "9.4.7"
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
             }
         },
         "@types/got": {
@@ -1455,7 +1455,7 @@
             "integrity": "sha512-CGEPw67/Ub6gNMusk062tueurxN+HyjDCvYl4QVBKiSO+fqluXmRX/wSqST/4RtKth4mz8lDZiaZIpXr/uPROg==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/html-minifier": {
@@ -1464,9 +1464,9 @@
             "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
             "dev": true,
             "requires": {
-                "@types/clean-css": "3.4.30",
-                "@types/relateurl": "0.2.28",
-                "@types/uglify-js": "3.0.4"
+                "@types/clean-css": "*",
+                "@types/relateurl": "*",
+                "@types/uglify-js": "*"
             }
         },
         "@types/html-webpack-plugin": {
@@ -1475,9 +1475,9 @@
             "integrity": "sha512-in9rViBsTRB4ZApndZ12It68nGzSMHVK30JD7c49iLIHMFeTPbP7I7wevzMv7re2o0k5TlU6Ry/beyrmgWX7Bg==",
             "dev": true,
             "requires": {
-                "@types/html-minifier": "3.5.2",
-                "@types/tapable": "1.0.4",
-                "@types/webpack": "4.4.19"
+                "@types/html-minifier": "*",
+                "@types/tapable": "*",
+                "@types/webpack": "*"
             }
         },
         "@types/iconv-lite": {
@@ -1486,7 +1486,7 @@
             "integrity": "sha1-qjuL2ivlErGuCgV7lC6GnDcKVWk=",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/istanbul": {
@@ -1501,10 +1501,10 @@
             "integrity": "sha512-XHMNZFQ0Ih3A4/NTWAO15+OsQafPKnQCanN0FYGbsTM/EoI5EoEAvvkF51/DQC2BT5low4tomp7k2RLMlriA5Q==",
             "dev": true,
             "requires": {
-                "@types/events": "1.2.0",
-                "@types/node": "9.4.7",
-                "@types/tough-cookie": "2.3.3",
-                "parse5": "4.0.0"
+                "@types/events": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "parse5": "^4.0.0"
             },
             "dependencies": {
                 "parse5": {
@@ -1527,8 +1527,8 @@
             "integrity": "sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7",
-                "@types/webpack": "4.4.19"
+                "@types/node": "*",
+                "@types/webpack": "*"
             }
         },
         "@types/lodash": {
@@ -1543,7 +1543,7 @@
             "integrity": "sha1-k+I0N/zRenucqY0CqmAC6DWEL+g=",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/minimatch": {
@@ -1582,8 +1582,8 @@
             "integrity": "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
             "dev": true,
             "requires": {
-                "@types/prop-types": "15.5.6",
-                "csstype": "2.5.7"
+                "@types/prop-types": "*",
+                "csstype": "^2.2.0"
             }
         },
         "@types/react-codemirror": {
@@ -1592,8 +1592,8 @@
             "integrity": "sha512-59UY5C5EVaFq/f+p1mkgLpNQELehdCNGTiLuFYacjptTzDDSyMKF4Zrs1z2WJWQSh53vIeuS8i2JrPFyfHjxBw==",
             "dev": true,
             "requires": {
-                "@types/codemirror": "0.0.71",
-                "@types/react": "16.4.14"
+                "@types/codemirror": "*",
+                "@types/react": "*"
             }
         },
         "@types/react-dom": {
@@ -1602,8 +1602,8 @@
             "integrity": "sha512-WF/KAOia7pskV+J8f+UlNuFeCRkJuJAkyyeYPPtNe6suw0y7cWyUP/DPdPXsGUwQEkv2qlLVSrgVaoCm/PmO0Q==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7",
-                "@types/react": "16.4.14"
+                "@types/node": "*",
+                "@types/react": "*"
             }
         },
         "@types/react-json-tree": {
@@ -1612,7 +1612,7 @@
             "integrity": "sha512-OyCFv5pHZXVULzjbNXBz+Il+vcYz8RzHl1BXQ297XMBTu4+oqVdZUVgU/PMmndSO05met1KqtKVJaj2K5K79+g==",
             "dev": true,
             "requires": {
-                "@types/react": "16.4.14"
+                "@types/react": "*"
             }
         },
         "@types/relateurl": {
@@ -1627,10 +1627,10 @@
             "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "dev": true,
             "requires": {
-                "@types/caseless": "0.12.1",
-                "@types/form-data": "2.2.1",
-                "@types/node": "9.4.7",
-                "@types/tough-cookie": "2.3.3"
+                "@types/caseless": "*",
+                "@types/form-data": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*"
             }
         },
         "@types/semver": {
@@ -1675,7 +1675,7 @@
             "integrity": "sha512-gyIhOlWPqI8vtYTlRb61HKV7x+3wjpJIQi8mTaweVtEMvhIV6Xajo8FVcNJWeJOBuedRCzK2Uy+uhj/rJmR9oQ==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/tern": {
@@ -1684,7 +1684,7 @@
             "integrity": "sha512-CRzPRkg8hYLwunsj61r+rqPJQbiCIEQqlMMY/0k7krgIsoSaFgGg1ZH2f9qaR1YpenaMl6PnlTtUkCbNH/uo+A==",
             "dev": true,
             "requires": {
-                "@types/estree": "0.0.39"
+                "@types/estree": "*"
             }
         },
         "@types/tmp": {
@@ -1705,7 +1705,7 @@
             "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1728,7 +1728,7 @@
             "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@types/webpack": {
@@ -1737,11 +1737,11 @@
             "integrity": "sha512-vO/PuQ9iF9Gy8spN8RUUjt5reu9Z+Tb7iWxeAopCmXaIZaIsOgtY5U6UE2ELlcRUBO1HbNWhy+lQE9G92IJcmQ==",
             "dev": true,
             "requires": {
-                "@types/anymatch": "1.3.0",
-                "@types/node": "9.4.7",
-                "@types/tapable": "1.0.4",
-                "@types/uglify-js": "3.0.4",
-                "source-map": "0.6.1"
+                "@types/anymatch": "*",
+                "@types/node": "*",
+                "@types/tapable": "*",
+                "@types/uglify-js": "*",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -1758,7 +1758,7 @@
             "integrity": "sha512-+qy5xatScNZW4NbIVaiV38XOeHbKRa4FIPeMf2VDpZEon9W/cxjaVR080vRrRGvfq4tRvOusTEypSMxTvjcSzw==",
             "dev": true,
             "requires": {
-                "@types/webpack": "4.4.19"
+                "@types/webpack": "*"
             }
         },
         "@types/winreg": {
@@ -1773,7 +1773,7 @@
             "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "@webassemblyjs/ast": {
@@ -1850,7 +1850,7 @@
             "integrity": "sha512-tOarWChdG1a3y1yqCX0JMDKzrat5tQe4pV6K/TX19BcXsBLYxFQOL1DEDa5KG9syeyvCrvZ+i1+Mv1ExngvktQ==",
             "dev": true,
             "requires": {
-                "@xtuc/ieee754": "1.2.0"
+                "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
@@ -1966,8 +1966,8 @@
             "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
             "dev": true,
             "requires": {
-                "jsonparse": "1.2.0",
-                "through": "2.3.8"
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
             }
         },
         "abab": {
@@ -1988,7 +1988,7 @@
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "2.1.18",
+                "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
             }
         },
@@ -2004,7 +2004,7 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3"
+                "acorn": "^5.0.0"
             }
         },
         "acorn-globals": {
@@ -2013,8 +2013,8 @@
             "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
             "dev": true,
             "requires": {
-                "acorn": "6.0.2",
-                "acorn-walk": "6.1.0"
+                "acorn": "^6.0.1",
+                "acorn-walk": "^6.0.1"
             },
             "dependencies": {
                 "acorn": {
@@ -2042,10 +2042,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-errors": {
@@ -2066,9 +2066,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2077,7 +2077,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2100,7 +2100,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -2154,7 +2154,7 @@
             "integrity": "sha512-ma1GhrnEsR70TvGKneM6Fa1UCB76ZTuVjw9KiO/BSBaJfLFjvoiKC+i2BPBqkRoQaLl35I0Vi2g52XmKEKM7VA==",
             "dev": true,
             "requires": {
-                "entities": "1.1.1"
+                "entities": "^1.1.1"
             }
         },
         "ansi-to-react": {
@@ -2163,10 +2163,10 @@
             "integrity": "sha512-Ztq11TxaO157sv5rcVNa+jlPbGZxNtfslxWv5N5mDzyUWDZtwfiQAul/gegIOh5xTjN/FOoc2X6KBBnFsGbZ+g==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "7.1.2",
-                "anser": "1.4.7",
-                "babel-runtime": "6.26.0",
-                "escape-carriage": "1.2.0"
+                "@babel/runtime-corejs2": "^7.0.0",
+                "anser": "^1.4.1",
+                "babel-runtime": "^6.26.0",
+                "escape-carriage": "^1.2.0"
             }
         },
         "ansi-wrap": {
@@ -2181,8 +2181,8 @@
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2191,7 +2191,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -2206,9 +2206,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "expand-brackets": {
@@ -2217,7 +2217,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -2226,7 +2226,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2241,7 +2241,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "kind-of": {
@@ -2250,7 +2250,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "micromatch": {
@@ -2259,19 +2259,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 }
             }
@@ -2282,7 +2282,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "applicationinsights": {
@@ -2318,7 +2318,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "argv": {
@@ -2339,7 +2339,7 @@
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.1"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-flatten": {
@@ -2354,7 +2354,7 @@
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.1"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-union": {
@@ -2399,8 +2399,8 @@
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
             "dev": true,
             "requires": {
-                "array-slice": "1.1.0",
-                "is-number": "4.0.0"
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2417,7 +2417,7 @@
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2452,9 +2452,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "1.0.0",
-                "get-value": "2.0.6",
-                "kind-of": "5.1.0"
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2471,7 +2471,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -2492,9 +2492,9 @@
             "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.10.0",
+                "function-bind": "^1.1.1"
             }
         },
         "arrify": {
@@ -2520,9 +2520,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -2580,10 +2580,10 @@
             "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0",
-                "process-nextick-args": "1.0.7",
-                "stream-exhaust": "1.0.2"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^1.0.7",
+                "stream-exhaust": "^1.0.1"
             }
         },
         "async-each": {
@@ -2604,7 +2604,7 @@
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
             "dev": true,
             "requires": {
-                "async-done": "1.3.1"
+                "async-done": "^1.2.2"
             }
         },
         "asynckit": {
@@ -2624,14 +2624,14 @@
             "integrity": "sha512-slv66OAJB8orL+UUaTI3pKlLorwIvS4ARZzYR9iJJyGsEgOqueMfOMdKySWzZ73vIkEe3fcwFgsKMg4d8zyb1g==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "enhanced-resolve": "4.1.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.11",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.9",
-                "webpack-log": "1.2.0"
+                "chalk": "^2.4.1",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.5",
+                "micromatch": "^3.1.9",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.3",
+                "webpack-log": "^1.2.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2640,7 +2640,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -2649,9 +2649,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -2666,7 +2666,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -2686,15 +2686,15 @@
             "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.1.tgz",
             "integrity": "sha512-rnFo1uMIPtilusRCpK91tfY3P4Q7qRsDNwriXdp+OeTIGkGt0cTxL4mhqYfNPYPK+WBQmBdGWhOk+iROM05dcw==",
             "requires": {
-                "browserify-mime": "1.2.9",
-                "extend": "1.2.1",
+                "browserify-mime": "~1.2.9",
+                "extend": "~1.2.1",
                 "json-edm-parser": "0.1.2",
                 "md5.js": "1.3.4",
-                "readable-stream": "2.0.6",
-                "request": "2.88.0",
-                "underscore": "1.8.3",
-                "uuid": "3.3.2",
-                "validator": "9.4.1",
+                "readable-stream": "~2.0.0",
+                "request": "^2.86.0",
+                "underscore": "~1.8.3",
+                "uuid": "^3.0.0",
+                "validator": "~9.4.1",
                 "xml2js": "0.2.8",
                 "xmlbuilder": "0.4.3"
             },
@@ -2714,8 +2714,8 @@
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
                     "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "mime-db": {
@@ -2728,7 +2728,7 @@
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
                     "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
                     "requires": {
-                        "mime-db": "1.36.0"
+                        "mime-db": "~1.36.0"
                     }
                 },
                 "oauth-sign": {
@@ -2741,26 +2741,26 @@
                     "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.1.0",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.20",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     },
                     "dependencies": {
                         "extend": {
@@ -2785,8 +2785,8 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 },
                 "xml2js": {
@@ -2794,7 +2794,7 @@
                     "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
                     "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
                     "requires": {
-                        "sax": "0.5.8"
+                        "sax": "0.5.x"
                     }
                 },
                 "xmlbuilder": {
@@ -2810,9 +2810,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "babel-loader": {
@@ -2821,10 +2821,10 @@
             "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "1.0.0",
-                "loader-utils": "1.1.0",
-                "mkdirp": "0.5.1",
-                "util.promisify": "1.0.0"
+                "find-cache-dir": "^1.0.0",
+                "loader-utils": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "util.promisify": "^1.0.0"
             }
         },
         "babel-plugin-emotion": {
@@ -2833,18 +2833,18 @@
             "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@emotion/babel-utils": "0.6.10",
-                "@emotion/hash": "0.6.6",
-                "@emotion/memoize": "0.6.6",
-                "@emotion/stylis": "0.7.1",
-                "babel-plugin-macros": "2.4.2",
-                "babel-plugin-syntax-jsx": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "find-root": "1.1.0",
-                "mkdirp": "0.5.1",
-                "source-map": "0.5.7",
-                "touch": "2.0.2"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@emotion/babel-utils": "^0.6.4",
+                "@emotion/hash": "^0.6.2",
+                "@emotion/memoize": "^0.6.1",
+                "@emotion/stylis": "^0.7.0",
+                "babel-plugin-macros": "^2.0.0",
+                "babel-plugin-syntax-jsx": "^6.18.0",
+                "convert-source-map": "^1.5.0",
+                "find-root": "^1.1.0",
+                "mkdirp": "^0.5.1",
+                "source-map": "^0.5.7",
+                "touch": "^2.0.1"
             }
         },
         "babel-plugin-inline-json-import": {
@@ -2853,7 +2853,7 @@
             "integrity": "sha512-cNQhU7de6V6IWJGwHuC5XJaGL3nu7RUCDAow/fXyHIAf/UNFkTkr/MR7+c1O8a01Z70XtTeq9mamfdU74LHW9A==",
             "dev": true,
             "requires": {
-                "decache": "4.4.0"
+                "decache": "^4.4.0"
             }
         },
         "babel-plugin-macros": {
@@ -2862,8 +2862,8 @@
             "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "5.0.6",
-                "resolve": "1.8.1"
+                "cosmiconfig": "^5.0.5",
+                "resolve": "^1.8.1"
             },
             "dependencies": {
                 "resolve": {
@@ -2872,7 +2872,7 @@
                     "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "1.0.5"
+                        "path-parse": "^1.0.5"
                     }
                 }
             }
@@ -2889,7 +2889,7 @@
             "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-polyfill": {
@@ -2898,9 +2898,9 @@
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -2917,8 +2917,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -2935,10 +2935,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.11",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             },
             "dependencies": {
                 "to-fast-properties": {
@@ -2955,15 +2955,15 @@
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
             "dev": true,
             "requires": {
-                "arr-filter": "1.1.2",
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "array-each": "1.0.1",
-                "array-initial": "1.1.0",
-                "array-last": "1.3.0",
-                "async-done": "1.3.1",
-                "async-settle": "1.0.0",
-                "now-and-later": "2.0.0"
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "bail": {
@@ -2983,13 +2983,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2998,7 +2998,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3007,7 +3007,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -3016,7 +3016,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -3025,9 +3025,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -3050,7 +3050,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -3065,10 +3065,10 @@
             "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "check-types": "7.4.0",
-                "hoopy": "0.1.4",
-                "tryer": "1.0.1"
+                "bluebird": "^3.5.1",
+                "check-types": "^7.3.0",
+                "hoopy": "^0.1.2",
+                "tryer": "^1.0.0"
             }
         },
         "big.js": {
@@ -3095,8 +3095,8 @@
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2"
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -3111,13 +3111,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -3126,7 +3126,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -3137,7 +3137,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -3159,15 +3159,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
                 "iconv-lite": "0.4.23",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.2",
                 "raw-body": "2.3.3",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.16"
             },
             "dependencies": {
                 "iconv-lite": {
@@ -3176,7 +3176,7 @@
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 }
             }
@@ -3192,7 +3192,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -3202,16 +3202,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -3220,7 +3220,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -3249,12 +3249,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -3263,9 +3263,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.2.0",
-                "browserify-des": "1.0.2",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -3274,10 +3274,10 @@
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
             }
         },
         "browserify-mime": {
@@ -3291,8 +3291,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -3301,13 +3301,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "elliptic": "6.4.1",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.1"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -3316,7 +3316,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             }
         },
         "browserslist": {
@@ -3325,9 +3325,9 @@
             "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000887",
-                "electron-to-chromium": "1.3.71",
-                "node-releases": "1.0.0-alpha.12"
+                "caniuse-lite": "^1.0.30000884",
+                "electron-to-chromium": "^1.3.62",
+                "node-releases": "^1.0.0-alpha.11"
             }
         },
         "buffer": {
@@ -3337,8 +3337,8 @@
             "dev": true,
             "requires": {
                 "base64-js": "0.0.8",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-alloc": {
@@ -3347,8 +3347,8 @@
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
             "requires": {
-                "buffer-alloc-unsafe": "1.1.0",
-                "buffer-fill": "1.0.0"
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -3411,19 +3411,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.1.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.3",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.3.0",
-                "unique-filename": "1.1.1",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
             },
             "dependencies": {
                 "lru-cache": {
@@ -3432,8 +3432,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -3444,15 +3444,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "cacheable-request": {
@@ -3490,8 +3490,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "caniuse-lite": {
@@ -3511,10 +3511,10 @@
             "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
             "dev": true,
             "requires": {
-                "get-proxy": "2.1.0",
-                "isurl": "1.0.0",
-                "tunnel-agent": "0.6.0",
-                "url-to-options": "1.0.1"
+                "get-proxy": "^2.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "tunnel-agent": "^0.6.0",
+                "url-to-options": "^1.0.1"
             }
         },
         "center-align": {
@@ -3524,8 +3524,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chai": {
@@ -3534,12 +3534,12 @@
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
             "dev": true,
             "requires": {
-                "assertion-error": "1.1.0",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.8"
+                "assertion-error": "^1.0.1",
+                "check-error": "^1.0.1",
+                "deep-eql": "^3.0.0",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.0.0",
+                "type-detect": "^4.0.0"
             }
         },
         "chai-arrays": {
@@ -3554,7 +3554,7 @@
             "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
             "dev": true,
             "requires": {
-                "check-error": "1.0.2"
+                "check-error": "^1.0.2"
             }
         },
         "chalk": {
@@ -3563,11 +3563,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "character-entities": {
@@ -3617,12 +3617,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash": "4.17.11",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "chokidar": {
@@ -3631,14 +3631,15 @@
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -3647,7 +3648,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -3662,7 +3663,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -3679,7 +3680,7 @@
             "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.1"
+                "tslib": "^1.9.0"
             }
         },
         "ci-info": {
@@ -3694,8 +3695,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "circular-json": {
@@ -3710,7 +3711,7 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.1.3"
             }
         },
         "class-utils": {
@@ -3719,10 +3720,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3731,7 +3732,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -3748,7 +3749,7 @@
             "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "~0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -3765,7 +3766,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "cli-table": {
@@ -3797,9 +3798,9 @@
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3814,7 +3815,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -3837,7 +3838,7 @@
             "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
             "dev": true,
             "requires": {
-                "mimic-response": "1.0.0"
+                "mimic-response": "^1.0.0"
             }
         },
         "clone-stats": {
@@ -3852,9 +3853,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -3869,13 +3870,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -3884,7 +3885,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -3900,7 +3901,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -3916,7 +3917,7 @@
             "dev": true,
             "requires": {
                 "argv": "0.0.2",
-                "request": "2.87.0",
+                "request": "^2.81.0",
                 "urlgrey": "0.4.4"
             }
         },
@@ -3938,9 +3939,9 @@
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
             "dev": true,
             "requires": {
-                "arr-map": "2.0.2",
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "collection-visit": {
@@ -3949,8 +3950,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -3959,7 +3960,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -3985,7 +3986,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -4005,7 +4006,7 @@
             "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
             "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
             "requires": {
-                "json-parser": "1.1.5"
+                "json-parser": "^1.0.0"
             }
         },
         "commondir": {
@@ -4037,10 +4038,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -4055,13 +4056,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -4070,7 +4071,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -4081,8 +4082,8 @@
             "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
             }
         },
         "console-browserify": {
@@ -4091,7 +4092,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "constants-browserify": {
@@ -4136,12 +4137,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
             }
         },
         "copy-descriptor": {
@@ -4156,8 +4157,8 @@
             "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
             "dev": true,
             "requires": {
-                "each-props": "1.3.2",
-                "is-plain-object": "2.0.4"
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
             }
         },
         "copy-webpack-plugin": {
@@ -4166,14 +4167,14 @@
             "integrity": "sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "globby": "7.1.1",
-                "is-glob": "4.0.0",
-                "loader-utils": "1.1.0",
-                "minimatch": "3.0.4",
-                "p-limit": "1.3.0",
-                "serialize-javascript": "1.5.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "globby": "^7.1.1",
+                "is-glob": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "minimatch": "^3.0.4",
+                "p-limit": "^1.0.0",
+                "serialize-javascript": "^1.4.0"
             },
             "dependencies": {
                 "globby": {
@@ -4182,12 +4183,12 @@
                     "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "dir-glob": "2.0.0",
-                        "glob": "7.1.2",
-                        "ignore": "3.3.10",
-                        "pify": "3.0.0",
-                        "slash": "1.0.0"
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "is-glob": {
@@ -4196,7 +4197,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "p-limit": {
@@ -4205,7 +4206,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "1.0.0"
+                        "p-try": "^1.0.0"
                     }
                 }
             }
@@ -4227,9 +4228,9 @@
             "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
             "dev": true,
             "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.11.0",
-                "parse-json": "4.0.0"
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.9.0",
+                "parse-json": "^4.0.0"
             },
             "dependencies": {
                 "parse-json": {
@@ -4238,8 +4239,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 }
             }
@@ -4250,8 +4251,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.1"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-emotion": {
@@ -4260,13 +4261,13 @@
             "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
             "dev": true,
             "requires": {
-                "@emotion/hash": "0.6.6",
-                "@emotion/memoize": "0.6.6",
-                "@emotion/stylis": "0.7.1",
-                "@emotion/unitless": "0.6.7",
-                "csstype": "2.5.7",
-                "stylis": "3.5.3",
-                "stylis-rule-sheet": "0.0.10"
+                "@emotion/hash": "^0.6.2",
+                "@emotion/memoize": "^0.6.1",
+                "@emotion/stylis": "^0.7.0",
+                "@emotion/unitless": "^0.6.2",
+                "csstype": "^2.5.2",
+                "stylis": "^3.5.0",
+                "stylis-rule-sheet": "^0.0.10"
             }
         },
         "create-hash": {
@@ -4275,11 +4276,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "md5.js": "1.3.4",
-                "ripemd160": "2.0.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -4288,12 +4289,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "create-react-class": {
@@ -4302,9 +4303,9 @@
             "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
             "dev": true,
             "requires": {
-                "fbjs": "0.8.17",
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1"
+                "fbjs": "^0.8.9",
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
             }
         },
         "cross-spawn": {
@@ -4313,11 +4314,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "1.0.4",
-                "path-key": "2.0.1",
-                "semver": "5.5.0",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "crypt": {
@@ -4331,17 +4332,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.1",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.3",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "diffie-hellman": "5.0.3",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.17",
-                "public-encrypt": "4.0.2",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css": {
@@ -4350,10 +4351,10 @@
             "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "source-map": "0.1.43",
-                "source-map-resolve": "0.5.2",
-                "urix": "0.1.0"
+                "inherits": "^2.0.1",
+                "source-map": "^0.1.38",
+                "source-map-resolve": "^0.5.1",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -4362,7 +4363,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -4373,18 +4374,18 @@
             "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "css-selector-tokenizer": "0.7.1",
-                "icss-utils": "2.1.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.11",
-                "postcss": "6.0.23",
-                "postcss-modules-extract-imports": "1.2.1",
-                "postcss-modules-local-by-default": "1.2.0",
-                "postcss-modules-scope": "1.1.0",
-                "postcss-modules-values": "1.3.0",
-                "postcss-value-parser": "3.3.1",
-                "source-list-map": "2.0.0"
+                "babel-code-frame": "^6.26.0",
+                "css-selector-tokenizer": "^0.7.0",
+                "icss-utils": "^2.1.0",
+                "loader-utils": "^1.0.2",
+                "lodash": "^4.17.11",
+                "postcss": "^6.0.23",
+                "postcss-modules-extract-imports": "^1.2.0",
+                "postcss-modules-local-by-default": "^1.2.0",
+                "postcss-modules-scope": "^1.1.0",
+                "postcss-modules-values": "^1.3.0",
+                "postcss-value-parser": "^3.3.0",
+                "source-list-map": "^2.0.0"
             },
             "dependencies": {
                 "lodash": {
@@ -4401,10 +4402,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             },
             "dependencies": {
                 "domutils": {
@@ -4413,8 +4414,8 @@
                     "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
                     "dev": true,
                     "requires": {
-                        "dom-serializer": "0.1.0",
-                        "domelementtype": "1.3.0"
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
                     }
                 }
             }
@@ -4425,9 +4426,9 @@
             "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
             "dev": true,
             "requires": {
-                "cssesc": "0.1.0",
-                "fastparse": "1.1.2",
-                "regexpu-core": "1.0.0"
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -4442,9 +4443,9 @@
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
                     "dev": true,
                     "requires": {
-                        "regenerate": "1.4.0",
-                        "regjsgen": "0.2.0",
-                        "regjsparser": "0.1.5"
+                        "regenerate": "^1.2.1",
+                        "regjsgen": "^0.2.0",
+                        "regjsparser": "^0.1.4"
                     }
                 },
                 "regjsgen": {
@@ -4459,7 +4460,7 @@
                     "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
                     "dev": true,
                     "requires": {
-                        "jsesc": "0.5.0"
+                        "jsesc": "~0.5.0"
                     }
                 }
             }
@@ -4470,8 +4471,8 @@
             "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
             "dev": true,
             "requires": {
-                "mdn-data": "1.1.4",
-                "source-map": "0.5.7"
+                "mdn-data": "^1.0.0",
+                "source-map": "^0.5.3"
             }
         },
         "css-what": {
@@ -4507,7 +4508,7 @@
             "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.4"
+                "cssom": "0.3.x"
             }
         },
         "csstype": {
@@ -4528,7 +4529,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.43"
+                "es5-ext": "^0.10.9"
             }
         },
         "d3-array": {
@@ -4552,11 +4553,11 @@
             "integrity": "sha512-lGSiF5SoSqO5/mYGD5FAeGKKS62JdA1EV7HPrU2b5rTX4qEJJtpjaGLJngjnkewQy7UnGstnFd3168wpf5z76w==",
             "dev": true,
             "requires": {
-                "d3-dispatch": "1.0.5",
-                "d3-drag": "1.2.3",
-                "d3-interpolate": "1.3.2",
-                "d3-selection": "1.3.2",
-                "d3-transition": "1.1.3"
+                "d3-dispatch": "1",
+                "d3-drag": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "1",
+                "d3-transition": "1"
             }
         },
         "d3-chord": {
@@ -4565,8 +4566,8 @@
             "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
             "dev": true,
             "requires": {
-                "d3-array": "1.2.4",
-                "d3-path": "1.0.7"
+                "d3-array": "1",
+                "d3-path": "1"
             }
         },
         "d3-collection": {
@@ -4587,7 +4588,7 @@
             "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
             "dev": true,
             "requires": {
-                "d3-array": "1.2.4"
+                "d3-array": "^1.1.1"
             }
         },
         "d3-dispatch": {
@@ -4602,8 +4603,8 @@
             "integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
             "dev": true,
             "requires": {
-                "d3-dispatch": "1.0.5",
-                "d3-selection": "1.3.2"
+                "d3-dispatch": "1",
+                "d3-selection": "1"
             }
         },
         "d3-ease": {
@@ -4618,10 +4619,10 @@
             "integrity": "sha512-p1vcHAUF1qH7yR+e8ip7Bs61AHjLeKkIn8Z2gzwU2lwEf2wkSpWdjXG0axudTHsVFnYGlMkFaEsVy2l8tAg1Gw==",
             "dev": true,
             "requires": {
-                "d3-collection": "1.0.7",
-                "d3-dispatch": "1.0.5",
-                "d3-quadtree": "1.0.1",
-                "d3-timer": "1.0.9"
+                "d3-collection": "1",
+                "d3-dispatch": "1",
+                "d3-quadtree": "1",
+                "d3-timer": "1"
             }
         },
         "d3-format": {
@@ -4654,7 +4655,7 @@
             "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
             "dev": true,
             "requires": {
-                "d3-color": "1.2.3"
+                "d3-color": "1"
             }
         },
         "d3-path": {
@@ -4681,9 +4682,9 @@
             "integrity": "sha512-maYak22afBAvmybeaopd1cVUNTIroEHhWCmh19gEQ+qgOhBkTav8YeP3Uw4OV/K4OksWaQrhhBOE4Rcxgc2JbQ==",
             "dev": true,
             "requires": {
-                "d3-array": "1.2.4",
-                "d3-collection": "1.0.7",
-                "d3-shape": "1.2.2"
+                "d3-array": "^1.2.1",
+                "d3-collection": "^1.0.4",
+                "d3-shape": "^1.2.0"
             }
         },
         "d3-scale": {
@@ -4692,13 +4693,13 @@
             "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dev": true,
             "requires": {
-                "d3-array": "1.2.4",
-                "d3-collection": "1.0.7",
-                "d3-color": "1.2.3",
-                "d3-format": "1.3.2",
-                "d3-interpolate": "1.3.2",
-                "d3-time": "1.0.10",
-                "d3-time-format": "2.1.3"
+                "d3-array": "^1.2.0",
+                "d3-collection": "1",
+                "d3-color": "1",
+                "d3-format": "1",
+                "d3-interpolate": "1",
+                "d3-time": "1",
+                "d3-time-format": "2"
             }
         },
         "d3-selection": {
@@ -4713,7 +4714,7 @@
             "integrity": "sha512-hUGEozlKecFZ2bOSNt7ENex+4Tk9uc/m0TtTEHBvitCBxUNjhzm5hS2GrrVRD/ae4IylSmxGeqX5tWC2rASMlQ==",
             "dev": true,
             "requires": {
-                "d3-path": "1.0.7"
+                "d3-path": "1"
             }
         },
         "d3-time": {
@@ -4728,7 +4729,7 @@
             "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
             "dev": true,
             "requires": {
-                "d3-time": "1.0.10"
+                "d3-time": "1"
             }
         },
         "d3-timer": {
@@ -4743,12 +4744,12 @@
             "integrity": "sha512-tEvo3qOXL6pZ1EzcXxFcPNxC/Ygivu5NoBY6mbzidATAeML86da+JfVIUzon3dNM6UX6zjDx+xbYDmMVtTSjuA==",
             "dev": true,
             "requires": {
-                "d3-color": "1.2.3",
-                "d3-dispatch": "1.0.5",
-                "d3-ease": "1.0.5",
-                "d3-interpolate": "1.3.2",
-                "d3-selection": "1.3.2",
-                "d3-timer": "1.0.9"
+                "d3-color": "1",
+                "d3-dispatch": "1",
+                "d3-ease": "1",
+                "d3-interpolate": "1",
+                "d3-selection": "^1.1.0",
+                "d3-timer": "1"
             }
         },
         "d3-voronoi": {
@@ -4762,7 +4763,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "data-urls": {
@@ -4771,9 +4772,9 @@
             "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
             "dev": true,
             "requires": {
-                "abab": "2.0.0",
-                "whatwg-mimetype": "2.2.0",
-                "whatwg-url": "7.0.0"
+                "abab": "^2.0.0",
+                "whatwg-mimetype": "^2.1.0",
+                "whatwg-url": "^7.0.0"
             }
         },
         "date-now": {
@@ -4809,9 +4810,9 @@
             "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "memoizee": "0.4.12",
-                "object-assign": "4.1.1"
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
             },
             "dependencies": {
                 "debug": {
@@ -4831,7 +4832,7 @@
             "integrity": "sha1-b232uF1+fEQQqTL/wmSJt46azRM=",
             "dev": true,
             "requires": {
-                "callsite": "1.0.0"
+                "callsite": "^1.0.0"
             }
         },
         "decamelize": {
@@ -4852,14 +4853,14 @@
             "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
             "dev": true,
             "requires": {
-                "decompress-tar": "4.1.1",
-                "decompress-tarbz2": "4.1.1",
-                "decompress-targz": "4.1.1",
-                "decompress-unzip": "4.0.1",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.3.0",
-                "pify": "2.3.0",
-                "strip-dirs": "2.1.0"
+                "decompress-tar": "^4.0.0",
+                "decompress-tarbz2": "^4.0.0",
+                "decompress-targz": "^4.0.0",
+                "decompress-unzip": "^4.0.1",
+                "graceful-fs": "^4.1.10",
+                "make-dir": "^1.0.0",
+                "pify": "^2.3.0",
+                "strip-dirs": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -4876,7 +4877,7 @@
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "dev": true,
             "requires": {
-                "mimic-response": "1.0.0"
+                "mimic-response": "^1.0.0"
             }
         },
         "decompress-tar": {
@@ -4885,9 +4886,9 @@
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
             "requires": {
-                "file-type": "5.2.0",
-                "is-stream": "1.1.0",
-                "tar-stream": "1.6.1"
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0",
+                "tar-stream": "^1.5.2"
             },
             "dependencies": {
                 "file-type": {
@@ -4904,11 +4905,11 @@
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
             "requires": {
-                "decompress-tar": "4.1.1",
-                "file-type": "6.2.0",
-                "is-stream": "1.1.0",
-                "seek-bzip": "1.0.5",
-                "unbzip2-stream": "1.2.5"
+                "decompress-tar": "^4.1.0",
+                "file-type": "^6.1.0",
+                "is-stream": "^1.1.0",
+                "seek-bzip": "^1.0.5",
+                "unbzip2-stream": "^1.0.9"
             },
             "dependencies": {
                 "file-type": {
@@ -4925,9 +4926,9 @@
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
             "requires": {
-                "decompress-tar": "4.1.1",
-                "file-type": "5.2.0",
-                "is-stream": "1.1.0"
+                "decompress-tar": "^4.1.1",
+                "file-type": "^5.2.0",
+                "is-stream": "^1.1.0"
             },
             "dependencies": {
                 "file-type": {
@@ -4944,10 +4945,10 @@
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "dev": true,
             "requires": {
-                "file-type": "3.9.0",
-                "get-stream": "2.3.1",
-                "pify": "2.3.0",
-                "yauzl": "2.9.1"
+                "file-type": "^3.8.0",
+                "get-stream": "^2.2.0",
+                "pify": "^2.3.0",
+                "yauzl": "^2.4.2"
             },
             "dependencies": {
                 "file-type": {
@@ -4962,8 +4963,8 @@
                     "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
                     "dev": true,
                     "requires": {
-                        "object-assign": "4.1.1",
-                        "pinkie-promise": "2.0.1"
+                        "object-assign": "^4.0.1",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -4980,7 +4981,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "deep-eql": {
@@ -4989,7 +4990,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.8"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-is": {
@@ -5010,7 +5011,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "5.1.0"
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -5033,8 +5034,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -5043,8 +5044,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -5053,7 +5054,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -5062,7 +5063,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -5071,9 +5072,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -5084,12 +5085,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -5109,8 +5110,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -5143,8 +5144,8 @@
             "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
             "dev": true,
             "requires": {
-                "address": "1.0.3",
-                "debug": "2.6.9"
+                "address": "^1.0.1",
+                "debug": "^2.6.0"
             }
         },
         "diagnostic-channel": {
@@ -5152,7 +5153,7 @@
             "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
             "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.3.0"
             }
         },
         "diagnostic-channel-publishers": {
@@ -5177,9 +5178,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "dir-glob": {
@@ -5188,8 +5189,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             },
             "dependencies": {
                 "path-type": {
@@ -5198,7 +5199,7 @@
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
-                        "pify": "3.0.0"
+                        "pify": "^3.0.0"
                     }
                 }
             }
@@ -5215,7 +5216,7 @@
             "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
             "dev": true,
             "requires": {
-                "esutils": "1.1.6",
+                "esutils": "^1.1.6",
                 "isarray": "0.0.1"
             },
             "dependencies": {
@@ -5239,7 +5240,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "0.3.3"
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -5256,8 +5257,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -5292,7 +5293,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "4.0.2"
+                "webidl-conversions": "^4.0.2"
             }
         },
         "domhandler": {
@@ -5301,7 +5302,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -5310,8 +5311,8 @@
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "download": {
@@ -5320,17 +5321,17 @@
             "integrity": "sha512-0Fe/CAjKycx12IG9We9gYlLP03BEcWTpttg7P5mwfOiQTg584kpuHqP7F61RkUJM+mfEdEU9TJonm0PJp5rQLw==",
             "dev": true,
             "requires": {
-                "caw": "2.0.1",
-                "content-disposition": "0.5.2",
-                "decompress": "4.2.0",
-                "ext-name": "5.0.0",
-                "file-type": "7.7.1",
-                "filenamify": "2.0.0",
-                "get-stream": "3.0.0",
-                "got": "8.3.1",
-                "make-dir": "1.3.0",
-                "p-event": "1.3.0",
-                "pify": "3.0.0"
+                "caw": "^2.0.1",
+                "content-disposition": "^0.5.2",
+                "decompress": "^4.2.0",
+                "ext-name": "^5.0.0",
+                "file-type": "^7.7.1",
+                "filenamify": "^2.0.0",
+                "get-stream": "^3.0.0",
+                "got": "^8.3.1",
+                "make-dir": "^1.2.0",
+                "p-event": "^1.3.0",
+                "pify": "^3.0.0"
             }
         },
         "duplexer": {
@@ -5345,7 +5346,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -5360,10 +5361,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 }
             }
@@ -5380,10 +5381,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -5392,7 +5393,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -5403,8 +5404,8 @@
             "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
             "dev": true,
             "requires": {
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0"
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -5413,7 +5414,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "editorconfig": {
@@ -5422,11 +5423,11 @@
             "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "commander": "2.15.1",
-                "lru-cache": "3.2.0",
-                "semver": "5.5.0",
-                "sigmund": "1.0.1"
+                "bluebird": "^3.0.5",
+                "commander": "^2.9.0",
+                "lru-cache": "^3.2.0",
+                "semver": "^5.1.0",
+                "sigmund": "^1.0.1"
             },
             "dependencies": {
                 "lru-cache": {
@@ -5435,7 +5436,7 @@
                     "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2"
+                        "pseudomap": "^1.0.1"
                     }
                 }
             }
@@ -5464,13 +5465,13 @@
             "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.5",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "emojis-list": {
@@ -5485,8 +5486,8 @@
             "integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-emotion": "9.2.11",
-                "create-emotion": "9.2.12"
+                "babel-plugin-emotion": "^9.2.11",
+                "create-emotion": "^9.2.12"
             }
         },
         "encodeurl": {
@@ -5500,7 +5501,7 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "0.4.21"
+                "iconv-lite": "~0.4.13"
             }
         },
         "end-of-stream": {
@@ -5509,7 +5510,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -5518,9 +5519,9 @@
             "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "memory-fs": "0.4.1",
-                "tapable": "1.1.0"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "tapable": "^1.0.0"
             }
         },
         "entities": {
@@ -5535,25 +5536,25 @@
             "integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
             "dev": true,
             "requires": {
-                "array.prototype.flat": "1.2.1",
-                "cheerio": "1.0.0-rc.2",
-                "function.prototype.name": "1.1.0",
-                "has": "1.0.3",
-                "is-boolean-object": "1.0.0",
-                "is-callable": "1.1.4",
-                "is-number-object": "1.0.3",
-                "is-string": "1.0.4",
-                "is-subset": "0.1.1",
-                "lodash.escape": "4.0.1",
-                "lodash.isequal": "4.5.0",
-                "object-inspect": "1.6.0",
-                "object-is": "1.0.1",
-                "object.assign": "4.1.0",
-                "object.entries": "1.0.4",
-                "object.values": "1.0.4",
-                "raf": "3.4.0",
-                "rst-selector-parser": "2.2.3",
-                "string.prototype.trim": "1.1.2"
+                "array.prototype.flat": "^1.2.1",
+                "cheerio": "^1.0.0-rc.2",
+                "function.prototype.name": "^1.1.0",
+                "has": "^1.0.3",
+                "is-boolean-object": "^1.0.0",
+                "is-callable": "^1.1.4",
+                "is-number-object": "^1.0.3",
+                "is-string": "^1.0.4",
+                "is-subset": "^0.1.1",
+                "lodash.escape": "^4.0.1",
+                "lodash.isequal": "^4.5.0",
+                "object-inspect": "^1.6.0",
+                "object-is": "^1.0.1",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.0.4",
+                "object.values": "^1.0.4",
+                "raf": "^3.4.0",
+                "rst-selector-parser": "^2.2.3",
+                "string.prototype.trim": "^1.1.2"
             },
             "dependencies": {
                 "lodash.escape": {
@@ -5570,13 +5571,13 @@
             "integrity": "sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==",
             "dev": true,
             "requires": {
-                "enzyme-adapter-utils": "1.8.1",
-                "function.prototype.name": "1.1.0",
-                "object.assign": "4.1.0",
-                "object.values": "1.0.4",
-                "prop-types": "15.6.2",
-                "react-is": "16.5.2",
-                "react-test-renderer": "16.5.2"
+                "enzyme-adapter-utils": "^1.8.0",
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "object.values": "^1.0.4",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.5.2",
+                "react-test-renderer": "^16.0.0-0"
             }
         },
         "enzyme-adapter-utils": {
@@ -5585,9 +5586,9 @@
             "integrity": "sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==",
             "dev": true,
             "requires": {
-                "function.prototype.name": "1.1.0",
-                "object.assign": "4.1.0",
-                "prop-types": "15.6.2"
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "prop-types": "^15.6.2"
             }
         },
         "errno": {
@@ -5596,7 +5597,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
             }
         },
         "error-ex": {
@@ -5605,7 +5606,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -5614,11 +5615,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.2.0",
-                "function-bind": "1.1.1",
-                "has": "1.0.3",
-                "is-callable": "1.1.4",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
             }
         },
         "es-to-primitive": {
@@ -5627,9 +5628,9 @@
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.4",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.2"
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
             }
         },
         "es5-ext": {
@@ -5638,9 +5639,9 @@
             "integrity": "sha512-cZd1vezWuTM5qMlasKWqQFioFKwO352nVBzhOTMUf/pKQl5Gcq5EdJzqtSNXKnFQSCJDiQZjCYlYbnzFB657OA==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1",
-                "next-tick": "1.0.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
             }
         },
         "es6-iterator": {
@@ -5649,9 +5650,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.43",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-symbol": {
@@ -5660,8 +5661,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.43"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-weak-map": {
@@ -5670,10 +5671,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.43",
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-carriage": {
@@ -5700,11 +5701,11 @@
             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
             "dev": true,
             "requires": {
-                "esprima": "2.7.3",
-                "estraverse": "1.9.3",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.2.0"
+                "esprima": "^2.7.1",
+                "estraverse": "^1.9.1",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.2.0"
             },
             "dependencies": {
                 "source-map": {
@@ -5714,7 +5715,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -5725,8 +5726,8 @@
             "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             },
             "dependencies": {
                 "estraverse": {
@@ -5748,7 +5749,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             },
             "dependencies": {
                 "estraverse": {
@@ -5783,8 +5784,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.43"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "event-stream": {
@@ -5793,13 +5794,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "events": {
@@ -5814,7 +5815,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": "1.0.2"
+                "original": ">=0.0.5"
             }
         },
         "evp_bytestokey": {
@@ -5823,8 +5824,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.2"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "execa": {
@@ -5833,13 +5834,13 @@
             "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
             "dev": true,
             "requires": {
-                "cross-spawn": "6.0.5",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "expand-brackets": {
@@ -5848,13 +5849,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -5863,7 +5864,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -5872,7 +5873,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -5883,7 +5884,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -5892,11 +5893,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "3.0.0",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -5905,7 +5906,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -5923,7 +5924,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5934,7 +5935,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "express": {
@@ -5943,36 +5944,36 @@
             "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.4",
+                "proxy-addr": "~2.0.4",
                 "qs": "6.5.2",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0",
-                "type-is": "1.6.16",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             }
         },
         "ext-list": {
@@ -5981,7 +5982,7 @@
             "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "^1.28.0"
             }
         },
         "ext-name": {
@@ -5990,8 +5991,8 @@
             "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
             "dev": true,
             "requires": {
-                "ext-list": "2.2.2",
-                "sort-keys-length": "1.0.1"
+                "ext-list": "^2.0.0",
+                "sort-keys-length": "^1.0.0"
             }
         },
         "extend": {
@@ -6005,8 +6006,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -6015,7 +6016,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -6026,9 +6027,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.21",
-                "tmp": "0.0.33"
+                "chardet": "^0.4.0",
+                "iconv-lite": "^0.4.17",
+                "tmp": "^0.0.33"
             },
             "dependencies": {
                 "tmp": {
@@ -6037,7 +6038,7 @@
                     "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.2"
                     }
                 }
             }
@@ -6048,14 +6049,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -6064,7 +6065,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -6073,7 +6074,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6082,7 +6083,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -6091,7 +6092,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -6100,9 +6101,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -6118,9 +6119,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -6151,7 +6152,7 @@
             "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
             "dev": true,
             "requires": {
-                "websocket-driver": "0.7.0"
+                "websocket-driver": ">=0.5.1"
             }
         },
         "fbjs": {
@@ -6160,13 +6161,13 @@
             "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
             "dev": true,
             "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.18"
+                "core-js": "^1.0.0",
+                "isomorphic-fetch": "^2.1.1",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.18"
             },
             "dependencies": {
                 "core-js": {
@@ -6181,7 +6182,7 @@
                     "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
                     "dev": true,
                     "requires": {
-                        "asap": "2.0.6"
+                        "asap": "~2.0.3"
                     }
                 }
             }
@@ -6192,7 +6193,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "figures": {
@@ -6201,7 +6202,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-loader": {
@@ -6210,8 +6211,8 @@
             "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "1.0.0"
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^1.0.0"
             }
         },
         "file-type": {
@@ -6238,9 +6239,9 @@
             "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
             "dev": true,
             "requires": {
-                "filename-reserved-regex": "2.0.0",
-                "strip-outer": "1.0.1",
-                "trim-repeated": "1.0.0"
+                "filename-reserved-regex": "^2.0.0",
+                "strip-outer": "^1.0.0",
+                "trim-repeated": "^1.0.0"
             }
         },
         "filesize": {
@@ -6255,10 +6256,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6267,7 +6268,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6279,12 +6280,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.4.0",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.4.0",
+                "unpipe": "~1.0.0"
             }
         },
         "find-cache-dir": {
@@ -6293,9 +6294,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "1.3.0",
-                "pkg-dir": "2.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
             }
         },
         "find-root": {
@@ -6310,8 +6311,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -6320,10 +6321,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             }
         },
         "fined": {
@@ -6332,11 +6333,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "flagged-respawn": {
@@ -6351,7 +6352,7 @@
             "integrity": "sha512-ji/WMv2jdsE+LaznpkIF9Haax0sdpTBozrz/Dtg4qSRMfbs8oVg4ypJunIRYPiMLvH/ed6OflXbnbTIKJhtgeg==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "~1.1.5"
             }
         },
         "flush-write-stream": {
@@ -6360,8 +6361,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "for-in": {
@@ -6376,7 +6377,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -6395,9 +6396,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
             }
         },
         "forwarded": {
@@ -6412,7 +6413,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -6433,8 +6434,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-constants": {
@@ -6448,9 +6449,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
             "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -6459,8 +6460,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "through2": "2.0.3"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs-walk": {
@@ -6469,7 +6470,7 @@
             "integrity": "sha1-9/yRw64e6tB8mYvF0N1B8tvr0zU=",
             "dev": true,
             "requires": {
-                "async": "1.5.2"
+                "async": "*"
             }
         },
         "fs-write-stream-atomic": {
@@ -6478,10 +6479,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.0.6"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
             }
         },
         "fs.realpath": {
@@ -6489,16 +6490,556 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
+        "fsevents": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "chownr": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "1.2.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "iconv-lite": {
+                    "version": "0.4.21",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safer-buffer": "^2.1.0"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minipass": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "needle": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "npm-bundled": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "4.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "^1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
         "fstream": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -6513,9 +7054,9 @@
             "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "is-callable": "1.1.4"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "is-callable": "^1.1.3"
             }
         },
         "fuzzy": {
@@ -6546,7 +7087,7 @@
             "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
             "dev": true,
             "requires": {
-                "npm-conf": "1.1.3"
+                "npm-conf": "^1.1.0"
             }
         },
         "get-stream": {
@@ -6566,7 +7107,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -6574,12 +7115,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -6588,8 +7129,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -6598,7 +7139,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -6613,7 +7154,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -6624,8 +7165,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -6634,16 +7175,16 @@
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "7.1.2",
-                "glob-parent": "3.1.0",
-                "is-negated-glob": "1.0.0",
-                "ordered-read-streams": "1.0.1",
-                "pumpify": "1.5.1",
-                "readable-stream": "2.3.6",
-                "remove-trailing-separator": "1.1.0",
-                "to-absolute-glob": "2.0.2",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -6658,13 +7199,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -6673,7 +7214,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -6684,10 +7225,10 @@
             "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "dev": true,
             "requires": {
-                "async-done": "1.3.1",
-                "chokidar": "2.0.4",
-                "just-debounce": "1.0.0",
-                "object.defaults": "1.1.0"
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -6696,8 +7237,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "chokidar": {
@@ -6706,18 +7247,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "is-glob": {
@@ -6726,7 +7268,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 }
             }
@@ -6737,8 +7279,8 @@
             "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
             "dev": true,
             "requires": {
-                "min-document": "2.19.0",
-                "process": "0.5.2"
+                "min-document": "^2.19.0",
+                "process": "~0.5.1"
             },
             "dependencies": {
                 "process": {
@@ -6755,9 +7297,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-modules-path": {
@@ -6772,11 +7314,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.1"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globals": {
@@ -6791,11 +7333,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -6812,7 +7354,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "got": {
@@ -6821,23 +7363,23 @@
             "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
             "dev": true,
             "requires": {
-                "@sindresorhus/is": "0.7.0",
-                "cacheable-request": "2.1.4",
-                "decompress-response": "3.3.0",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "into-stream": "3.1.0",
-                "is-retry-allowed": "1.1.0",
-                "isurl": "1.0.0",
-                "lowercase-keys": "1.0.1",
-                "mimic-response": "1.0.0",
-                "p-cancelable": "0.4.1",
-                "p-timeout": "2.0.1",
-                "pify": "3.0.0",
-                "safe-buffer": "5.1.2",
-                "timed-out": "4.0.1",
-                "url-parse-lax": "3.0.0",
-                "url-to-options": "1.0.1"
+                "@sindresorhus/is": "^0.7.0",
+                "cacheable-request": "^2.1.1",
+                "decompress-response": "^3.3.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "into-stream": "^3.1.0",
+                "is-retry-allowed": "^1.1.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "mimic-response": "^1.0.0",
+                "p-cancelable": "^0.4.0",
+                "p-timeout": "^2.0.1",
+                "pify": "^3.0.0",
+                "safe-buffer": "^5.1.1",
+                "timed-out": "^4.0.1",
+                "url-parse-lax": "^3.0.0",
+                "url-to-options": "^1.0.1"
             }
         },
         "graceful-fs": {
@@ -6863,10 +7405,10 @@
             "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "dev": true,
             "requires": {
-                "glob-watcher": "5.0.1",
-                "gulp-cli": "2.0.1",
-                "undertaker": "1.2.0",
-                "vinyl-fs": "3.0.3"
+                "glob-watcher": "^5.0.0",
+                "gulp-cli": "^2.0.0",
+                "undertaker": "^1.0.0",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -6881,9 +7423,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "gulp-cli": {
@@ -6892,24 +7434,24 @@
                     "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "archy": "1.0.0",
-                        "array-sort": "1.0.0",
-                        "color-support": "1.1.3",
-                        "concat-stream": "1.6.2",
-                        "copy-props": "2.0.4",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "interpret": "1.1.0",
-                        "isobject": "3.0.1",
-                        "liftoff": "2.5.0",
-                        "matchdep": "2.0.0",
-                        "mute-stdout": "1.0.1",
-                        "pretty-hrtime": "1.0.3",
-                        "replace-homedir": "1.0.0",
-                        "semver-greatest-satisfied-range": "1.1.0",
-                        "v8flags": "3.1.1",
-                        "yargs": "7.1.0"
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^2.5.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
                     }
                 },
                 "invert-kv": {
@@ -6924,7 +7466,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "lcid": {
@@ -6933,7 +7475,7 @@
                     "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                     "dev": true,
                     "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "os-locale": {
@@ -6942,7 +7484,7 @@
                     "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                     "dev": true,
                     "requires": {
-                        "lcid": "1.0.0"
+                        "lcid": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -6951,9 +7493,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "which-module": {
@@ -6974,19 +7516,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -6995,7 +7537,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -7006,16 +7548,16 @@
             "integrity": "sha512-b6CfmmEtyLDT3afv7wvNin3FJh3eAJy9N26HIXQTbQFP3LzP8XLJrvDe+G9lxFzJt943xgoYFNWUZz3wiJTZdQ==",
             "dev": true,
             "requires": {
-                "azure-storage": "2.10.2",
+                "azure-storage": "^2.10.2",
                 "delayed-stream": "0.0.6",
                 "event-stream": "3.3.4",
-                "mime": "1.6.0",
-                "optimist": "0.6.1",
-                "progress": "1.1.8",
-                "queue": "3.1.0",
-                "streamifier": "0.1.1",
-                "vinyl": "0.4.6",
-                "vinyl-fs": "3.0.3"
+                "mime": "^1.3.4",
+                "optimist": "^0.6.1",
+                "progress": "^1.1.8",
+                "queue": "^3.0.10",
+                "streamifier": "^0.1.1",
+                "vinyl": "^0.4.5",
+                "vinyl-fs": "^3.0.3"
             },
             "dependencies": {
                 "azure-storage": {
@@ -7024,17 +7566,17 @@
                     "integrity": "sha512-pOyGPya9+NDpAfm5YcFfklo57HfjDbYLXxs4lomPwvRxmb0Di/A+a+RkUmEFzaQ8S13CqxK40bRRB0sjj2ZQxA==",
                     "dev": true,
                     "requires": {
-                        "browserify-mime": "1.2.9",
-                        "extend": "3.0.2",
+                        "browserify-mime": "~1.2.9",
+                        "extend": "^3.0.2",
                         "json-edm-parser": "0.1.2",
                         "md5.js": "1.3.4",
-                        "readable-stream": "2.0.6",
-                        "request": "2.87.0",
-                        "underscore": "1.8.3",
-                        "uuid": "3.3.2",
-                        "validator": "9.4.1",
+                        "readable-stream": "~2.0.0",
+                        "request": "^2.86.0",
+                        "underscore": "~1.8.3",
+                        "uuid": "^3.0.0",
+                        "validator": "~9.4.1",
                         "xml2js": "0.2.8",
-                        "xmlbuilder": "9.0.7"
+                        "xmlbuilder": "^9.0.7"
                     }
                 },
                 "clone": {
@@ -7073,8 +7615,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 },
                 "xml2js": {
@@ -7083,7 +7625,7 @@
                     "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
                     "dev": true,
                     "requires": {
-                        "sax": "0.5.8"
+                        "sax": "0.5.x"
                     }
                 }
             }
@@ -7094,9 +7636,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-debounced-watch": {
@@ -7105,9 +7647,9 @@
             "integrity": "sha1-WkfU4kzkY2XOguysMqKjA+QysSo=",
             "dev": true,
             "requires": {
-                "debounce-hashed": "0.1.2",
-                "gulp-watch": "4.3.11",
-                "object-assign": "3.0.0"
+                "debounce-hashed": "^0.1.1",
+                "gulp-watch": "^4.3.4",
+                "object-assign": "^3.0.0"
             },
             "dependencies": {
                 "gulp-watch": {
@@ -7116,16 +7658,16 @@
                     "integrity": "sha1-Fi/FY96fx3DpH5p845VVE6mhGMA=",
                     "dev": true,
                     "requires": {
-                        "anymatch": "1.3.2",
-                        "chokidar": "1.7.0",
-                        "glob-parent": "3.1.0",
-                        "gulp-util": "3.0.8",
-                        "object-assign": "4.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readable-stream": "2.3.6",
-                        "slash": "1.0.0",
-                        "vinyl": "1.2.0",
-                        "vinyl-file": "2.0.0"
+                        "anymatch": "^1.3.0",
+                        "chokidar": "^1.6.1",
+                        "glob-parent": "^3.0.1",
+                        "gulp-util": "^3.0.7",
+                        "object-assign": "^4.1.0",
+                        "path-is-absolute": "^1.0.1",
+                        "readable-stream": "^2.2.2",
+                        "slash": "^1.0.0",
+                        "vinyl": "^1.2.0",
+                        "vinyl-file": "^2.0.0"
                     },
                     "dependencies": {
                         "object-assign": {
@@ -7154,13 +7696,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -7169,7 +7711,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "vinyl": {
@@ -7178,8 +7720,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7191,9 +7733,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -7202,8 +7744,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -7224,10 +7766,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "through2": {
@@ -7236,8 +7778,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -7246,8 +7788,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -7258,9 +7800,9 @@
             "integrity": "sha512-Ky5SKDgM517QZ6Jw9rKhYz+ynX9T4sr72iUW2fbOhqzN74D37DzWZDZnbKLSwdlTbbqt7JFq/JmUmT12qroW+A==",
             "dev": true,
             "requires": {
-                "inline-source": "5.2.7",
-                "plugin-error": "1.0.1",
-                "through2": "2.0.3"
+                "inline-source": "~5.2.6",
+                "plugin-error": "~1.0.1",
+                "through2": "~2.0.0"
             },
             "dependencies": {
                 "plugin-error": {
@@ -7269,10 +7811,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "arr-diff": "4.0.0",
-                        "arr-union": "3.1.0",
-                        "extend-shallow": "3.0.2"
+                        "ansi-colors": "^1.0.1",
+                        "arr-diff": "^4.0.0",
+                        "arr-union": "^3.1.0",
+                        "extend-shallow": "^3.0.2"
                     }
                 }
             }
@@ -7283,11 +7825,11 @@
             "integrity": "sha512-20nYwO5Bec5X6DfXmBmHEtDAyluTkMguhuvCzqwrHDv/NzwOn3qS4ofAMw9L2gnWAmzxKzHAkFO19LNDWyTwlg==",
             "dev": true,
             "requires": {
-                "deepmerge": "2.1.1",
-                "detect-indent": "5.0.0",
-                "js-beautify": "1.7.5",
-                "plugin-error": "1.0.1",
-                "through2": "2.0.3"
+                "deepmerge": "^2.1.0",
+                "detect-indent": "^5.0.0",
+                "js-beautify": "^1.7.5",
+                "plugin-error": "^1.0.1",
+                "through2": "^2.0.3"
             },
             "dependencies": {
                 "plugin-error": {
@@ -7296,10 +7838,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "arr-diff": "4.0.0",
-                        "arr-union": "3.1.0",
-                        "extend-shallow": "3.0.2"
+                        "ansi-colors": "^1.0.1",
+                        "arr-diff": "^4.0.0",
+                        "arr-union": "^3.1.0",
+                        "extend-shallow": "^3.0.2"
                     }
                 }
             }
@@ -7311,10 +7853,10 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "node.extend": "1.1.8",
-                "request": "2.87.0",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -7341,12 +7883,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -7363,17 +7905,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.0.1",
-                "@gulp-sourcemaps/map-sources": "1.0.0",
-                "acorn": "5.5.3",
-                "convert-source-map": "1.5.1",
-                "css": "2.2.3",
-                "debug-fabulous": "1.1.0",
-                "detect-newline": "2.1.0",
-                "graceful-fs": "4.1.11",
-                "source-map": "0.6.1",
-                "strip-bom-string": "1.0.0",
-                "through2": "2.0.3"
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
             },
             "dependencies": {
                 "source-map": {
@@ -7390,12 +7932,12 @@
             "integrity": "sha512-Hhbn5Aa2l3T+tnn0KqsG6RRJmcYEsr3byTL2nBpNBeAK8pqug9Od4AwddU4JEI+hRw7mzZyjRbB8DDWR6paGVA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "1.1.0",
-                "plugin-error": "0.1.2",
-                "source-map": "0.6.1",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "3.0.3"
+                "ansi-colors": "^1.0.1",
+                "plugin-error": "^0.1.2",
+                "source-map": "^0.6.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.1.0",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -7416,16 +7958,16 @@
                     "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "7.1.2",
-                        "glob-parent": "3.1.0",
-                        "is-negated-glob": "1.0.0",
-                        "ordered-read-streams": "1.0.1",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-trailing-separator": "1.1.0",
-                        "to-absolute-glob": "2.0.2",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^7.1.1",
+                        "glob-parent": "^3.1.0",
+                        "is-negated-glob": "^1.0.0",
+                        "ordered-read-streams": "^1.0.0",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.1.5",
+                        "remove-trailing-separator": "^1.0.1",
+                        "to-absolute-glob": "^2.0.0",
+                        "unique-stream": "^2.0.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -7434,7 +7976,7 @@
                     "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.6"
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "process-nextick-args": {
@@ -7449,13 +7991,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "replace-ext": {
@@ -7476,7 +8018,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "unique-stream": {
@@ -7485,8 +8027,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "1.0.1",
-                        "through2-filter": "2.0.0"
+                        "json-stable-stringify": "^1.0.0",
+                        "through2-filter": "^2.0.0"
                     }
                 },
                 "vinyl": {
@@ -7495,12 +8037,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 },
                 "vinyl-fs": {
@@ -7509,23 +8051,23 @@
                     "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
                     "dev": true,
                     "requires": {
-                        "fs-mkdirp-stream": "1.0.0",
-                        "glob-stream": "6.1.0",
-                        "graceful-fs": "4.1.11",
-                        "is-valid-glob": "1.0.0",
-                        "lazystream": "1.0.0",
-                        "lead": "1.0.0",
-                        "object.assign": "4.1.0",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-bom-buffer": "3.0.0",
-                        "remove-bom-stream": "1.2.0",
-                        "resolve-options": "1.1.0",
-                        "through2": "2.0.3",
-                        "to-through": "2.0.0",
-                        "value-or-function": "3.0.0",
-                        "vinyl": "2.1.0",
-                        "vinyl-sourcemap": "1.1.0"
+                        "fs-mkdirp-stream": "^1.0.0",
+                        "glob-stream": "^6.1.0",
+                        "graceful-fs": "^4.0.0",
+                        "is-valid-glob": "^1.0.0",
+                        "lazystream": "^1.0.0",
+                        "lead": "^1.0.0",
+                        "object.assign": "^4.0.4",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.3.3",
+                        "remove-bom-buffer": "^3.0.0",
+                        "remove-bom-stream": "^1.2.0",
+                        "resolve-options": "^1.1.0",
+                        "through2": "^2.0.0",
+                        "to-through": "^2.0.0",
+                        "value-or-function": "^3.0.0",
+                        "vinyl": "^2.0.0",
+                        "vinyl-sourcemap": "^1.1.0"
                     }
                 }
             }
@@ -7536,11 +8078,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -7549,8 +8091,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7562,24 +8104,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -7597,12 +8139,12 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "queue": "4.5.1",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "3.0.3",
-                "yauzl": "2.9.1",
-                "yazl": "2.5.1"
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^3.0.3",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -7623,7 +8165,7 @@
                     "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "replace-ext": {
@@ -7638,12 +8180,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -7654,16 +8196,16 @@
             "integrity": "sha512-q+HLppxXd11z9ndqql4Z0sd5xOAesJjycl0PRaq6ImK7b1BqBRL37YvxEE8ngUdIfpfHa0O9OCoovoggcFpCaQ==",
             "dev": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "chokidar": "2.0.3",
-                "glob-parent": "3.1.0",
-                "gulp-util": "3.0.8",
-                "object-assign": "4.1.1",
-                "path-is-absolute": "1.0.1",
-                "readable-stream": "2.3.6",
-                "slash": "1.0.0",
-                "vinyl": "2.1.0",
-                "vinyl-file": "2.0.0"
+                "anymatch": "^1.3.0",
+                "chokidar": "^2.0.0",
+                "glob-parent": "^3.0.1",
+                "gulp-util": "^3.0.7",
+                "object-assign": "^4.1.0",
+                "path-is-absolute": "^1.0.1",
+                "readable-stream": "^2.2.2",
+                "slash": "^1.0.0",
+                "vinyl": "^2.1.0",
+                "vinyl-file": "^2.0.0"
             },
             "dependencies": {
                 "chokidar": {
@@ -7672,17 +8214,18 @@
                     "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.1.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.0"
                     },
                     "dependencies": {
                         "anymatch": {
@@ -7691,8 +8234,8 @@
                             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                             "dev": true,
                             "requires": {
-                                "micromatch": "3.1.10",
-                                "normalize-path": "2.1.1"
+                                "micromatch": "^3.1.4",
+                                "normalize-path": "^2.1.1"
                             }
                         }
                     }
@@ -7715,7 +8258,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "process-nextick-args": {
@@ -7730,13 +8273,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "replace-ext": {
@@ -7751,7 +8294,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "vinyl": {
@@ -7760,12 +8303,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -7776,7 +8319,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "gzip-size": {
@@ -7785,7 +8328,7 @@
             "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "^0.1.1"
             }
         },
         "handlebars": {
@@ -7794,10 +8337,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "source-map": {
@@ -7806,7 +8349,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -7821,8 +8364,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -7831,7 +8374,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -7840,7 +8383,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -7855,7 +8398,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbol-support-x": {
@@ -7876,7 +8419,7 @@
             "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "dev": true,
             "requires": {
-                "has-symbol-support-x": "1.4.2"
+                "has-symbol-support-x": "^1.4.1"
             }
         },
         "has-value": {
@@ -7885,9 +8428,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -7896,8 +8439,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -7906,7 +8449,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -7916,8 +8459,8 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "hash.js": {
@@ -7926,8 +8469,8 @@
             "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
             }
         },
         "he": {
@@ -7942,9 +8485,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.5",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoist-non-react-statics": {
@@ -7959,7 +8502,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hoopy": {
@@ -7980,7 +8523,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "1.0.5"
+                "whatwg-encoding": "^1.0.1"
             }
         },
         "html-minifier": {
@@ -7989,13 +8532,13 @@
             "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.2.1",
-                "commander": "2.17.1",
-                "he": "1.1.1",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.4.9"
+                "camel-case": "3.0.x",
+                "clean-css": "4.2.x",
+                "commander": "2.17.x",
+                "he": "1.1.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.4.x"
             },
             "dependencies": {
                 "commander": {
@@ -8016,8 +8559,8 @@
                     "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.17.1",
-                        "source-map": "0.6.1"
+                        "commander": "~2.17.1",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -8028,12 +8571,12 @@
             "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
             "dev": true,
             "requires": {
-                "html-minifier": "3.5.20",
-                "loader-utils": "0.2.17",
-                "lodash": "4.17.11",
-                "pretty-error": "2.1.1",
-                "tapable": "1.1.0",
-                "toposort": "1.0.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "tapable": "^1.0.0",
+                "toposort": "^1.0.0",
                 "util.promisify": "1.0.0"
             },
             "dependencies": {
@@ -8043,10 +8586,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
                     }
                 }
             }
@@ -8057,12 +8600,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.7.0",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-cache-semantics": {
@@ -8077,10 +8620,10 @@
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "dev": true,
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.4.0 < 2"
             }
         },
         "http-parser-js": {
@@ -8094,9 +8637,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -8111,16 +8654,16 @@
             "integrity": "sha512-9TdkUpBeEOjz0AnFdUN4i3w8kEbOsVs9/WSeJqWLq2OO6bcKQhVW64Zi+pVd/AMRLpN3QTINb6ZXiELczvdmqQ==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "5.0.6",
-                "execa": "0.9.0",
-                "find-up": "3.0.0",
-                "get-stdin": "6.0.0",
-                "is-ci": "1.2.1",
-                "pkg-dir": "3.0.0",
-                "please-upgrade-node": "3.1.1",
-                "read-pkg": "4.0.1",
-                "run-node": "1.0.0",
-                "slash": "2.0.0"
+                "cosmiconfig": "^5.0.6",
+                "execa": "^0.9.0",
+                "find-up": "^3.0.0",
+                "get-stdin": "^6.0.0",
+                "is-ci": "^1.2.1",
+                "pkg-dir": "^3.0.0",
+                "please-upgrade-node": "^3.1.1",
+                "read-pkg": "^4.0.1",
+                "run-node": "^1.0.0",
+                "slash": "^2.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -8129,9 +8672,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "execa": {
@@ -8140,13 +8683,13 @@
                     "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -8155,7 +8698,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "3.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
                 "get-stdin": {
@@ -8170,8 +8713,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "parse-json": {
@@ -8180,8 +8723,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "path-exists": {
@@ -8196,7 +8739,7 @@
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                     "dev": true,
                     "requires": {
-                        "find-up": "3.0.0"
+                        "find-up": "^3.0.0"
                     }
                 },
                 "read-pkg": {
@@ -8205,9 +8748,9 @@
                     "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
                     "dev": true,
                     "requires": {
-                        "normalize-package-data": "2.4.0",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0"
+                        "normalize-package-data": "^2.3.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0"
                     }
                 },
                 "slash": {
@@ -8223,7 +8766,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
             "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "^2.1.0"
             }
         },
         "icss-replace-symbols": {
@@ -8238,7 +8781,7 @@
             "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.23"
+                "postcss": "^6.0.1"
             }
         },
         "ieee754": {
@@ -8265,8 +8808,8 @@
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "3.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^3.0.0",
+                "resolve-cwd": "^2.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -8275,7 +8818,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "3.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
                 "locate-path": {
@@ -8284,8 +8827,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "path-exists": {
@@ -8300,7 +8843,7 @@
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                     "dev": true,
                     "requires": {
-                        "find-up": "3.0.0"
+                        "find-up": "^3.0.0"
                     }
                 }
             }
@@ -8322,8 +8865,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -8343,12 +8886,12 @@
             "integrity": "sha512-RvMOGMXxAqqve4ld128B7TYyNR2aP1LB38dcSpWFmqXrhKPuey1+yFU6kFUgyH8IWX+gRZdWtHN4eQ9d0IpFZg==",
             "dev": true,
             "requires": {
-                "csso": "3.4.0",
-                "htmlparser2": "3.9.2",
-                "is-plain-obj": "1.1.0",
-                "object-assign": "4.1.1",
-                "svgo": "0.7.2",
-                "uglify-js": "3.3.28"
+                "csso": "3.4.x",
+                "htmlparser2": "3.9.x",
+                "is-plain-obj": "1.1.x",
+                "object-assign": "4.1.x",
+                "svgo": "0.7.x",
+                "uglify-js": "3.3.x"
             },
             "dependencies": {
                 "source-map": {
@@ -8363,8 +8906,8 @@
                     "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.15.1",
-                        "source-map": "0.6.1"
+                        "commander": "~2.15.0",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -8375,20 +8918,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.11",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^2.0.4",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rx-lite": "^4.0.8",
+                "rx-lite-aggregates": "^4.0.8",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -8403,7 +8946,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -8412,9 +8955,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -8429,7 +8972,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -8438,7 +8981,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -8455,8 +8998,8 @@
             "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
             "dev": true,
             "requires": {
-                "from2": "2.3.0",
-                "p-is-promise": "1.1.0"
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
             }
         },
         "invariant": {
@@ -8465,7 +9008,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.4.0"
+                "loose-envify": "^1.0.0"
             }
         },
         "inversify": {
@@ -8497,8 +9040,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -8507,7 +9050,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -8516,7 +9059,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -8533,8 +9076,8 @@
             "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
             "dev": true,
             "requires": {
-                "is-alphabetical": "1.0.2",
-                "is-decimal": "1.0.2"
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0"
             }
         },
         "is-arrayish": {
@@ -8549,7 +9092,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-boolean-object": {
@@ -8569,7 +9112,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {
@@ -8584,7 +9127,7 @@
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "dev": true,
             "requires": {
-                "ci-info": "1.6.0"
+                "ci-info": "^1.5.0"
             }
         },
         "is-data-descriptor": {
@@ -8593,7 +9136,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -8602,7 +9145,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -8625,9 +9168,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -8656,7 +9199,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -8683,7 +9226,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-hexadecimal": {
@@ -8710,7 +9253,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -8719,7 +9262,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -8748,7 +9291,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -8771,7 +9314,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -8780,7 +9323,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -8795,7 +9338,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -8822,7 +9365,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "1.0.3"
+                "has": "^1.0.1"
             }
         },
         "is-relative": {
@@ -8831,7 +9374,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-retry-allowed": {
@@ -8875,7 +9418,7 @@
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "dev": true,
             "requires": {
-                "has-symbols": "1.0.0"
+                "has-symbols": "^1.0.0"
             }
         },
         "is-typedarray": {
@@ -8889,7 +9432,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -8951,8 +9494,8 @@
             "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
             "dev": true,
             "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "3.0.0"
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
             }
         },
         "isstream": {
@@ -8966,20 +9509,20 @@
             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.9",
-                "async": "1.5.2",
-                "escodegen": "1.8.1",
-                "esprima": "2.7.3",
-                "glob": "5.0.15",
-                "handlebars": "4.0.11",
-                "js-yaml": "3.11.0",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "once": "1.4.0",
-                "resolve": "1.1.7",
-                "supports-color": "3.2.3",
-                "which": "1.3.1",
-                "wordwrap": "1.0.0"
+                "abbrev": "1.0.x",
+                "async": "1.x",
+                "escodegen": "1.8.x",
+                "esprima": "2.7.x",
+                "glob": "^5.0.15",
+                "handlebars": "^4.0.1",
+                "js-yaml": "3.x",
+                "mkdirp": "0.5.x",
+                "nopt": "3.x",
+                "once": "1.x",
+                "resolve": "1.1.x",
+                "supports-color": "^3.1.0",
+                "which": "^1.1.1",
+                "wordwrap": "^1.0.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -8994,11 +9537,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "resolve": {
@@ -9013,7 +9556,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -9030,13 +9573,13 @@
             "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
             "dev": true,
             "requires": {
-                "@babel/generator": "7.0.0",
-                "@babel/parser": "7.1.0",
-                "@babel/template": "7.1.0",
-                "@babel/traverse": "7.1.0",
-                "@babel/types": "7.0.0",
-                "istanbul-lib-coverage": "2.0.1",
-                "semver": "5.5.0"
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.1",
+                "semver": "^5.5.0"
             }
         },
         "isurl": {
@@ -9045,8 +9588,8 @@
             "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "dev": true,
             "requires": {
-                "has-to-string-tag-x": "1.4.1",
-                "is-object": "1.0.1"
+                "has-to-string-tag-x": "^1.2.0",
+                "is-object": "^1.0.1"
             }
         },
         "js-beautify": {
@@ -9055,10 +9598,10 @@
             "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
             "dev": true,
             "requires": {
-                "config-chain": "1.1.11",
-                "editorconfig": "0.13.3",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6"
+                "config-chain": "~1.1.5",
+                "editorconfig": "^0.13.2",
+                "mkdirp": "~0.5.0",
+                "nopt": "~3.0.1"
             }
         },
         "js-levenshtein": {
@@ -9079,8 +9622,8 @@
             "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             },
             "dependencies": {
                 "esprima": {
@@ -9103,31 +9646,31 @@
             "integrity": "sha512-QPOggIJ8fquWPLaYYMoh+zqUmdphDtu1ju0QGTitZT1Yd8I5qenPpXM1etzUegu3MjVp8XPzgZxdn8Yj7e40ig==",
             "dev": true,
             "requires": {
-                "abab": "2.0.0",
-                "acorn": "6.0.2",
-                "acorn-globals": "4.3.0",
-                "array-equal": "1.0.0",
-                "cssom": "0.3.4",
-                "cssstyle": "1.1.1",
-                "data-urls": "1.0.1",
-                "domexception": "1.0.1",
-                "escodegen": "1.11.0",
-                "html-encoding-sniffer": "1.0.2",
-                "nwsapi": "2.0.9",
+                "abab": "^2.0.0",
+                "acorn": "^6.0.2",
+                "acorn-globals": "^4.3.0",
+                "array-equal": "^1.0.0",
+                "cssom": "^0.3.4",
+                "cssstyle": "^1.1.1",
+                "data-urls": "^1.0.1",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.11.0",
+                "html-encoding-sniffer": "^1.0.2",
+                "nwsapi": "^2.0.9",
                 "parse5": "5.1.0",
-                "pn": "1.1.0",
-                "request": "2.88.0",
-                "request-promise-native": "1.0.5",
-                "saxes": "3.1.3",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.4.3",
-                "w3c-hr-time": "1.0.1",
-                "webidl-conversions": "4.0.2",
-                "whatwg-encoding": "1.0.5",
-                "whatwg-mimetype": "2.2.0",
-                "whatwg-url": "7.0.0",
-                "ws": "6.1.0",
-                "xml-name-validator": "3.0.0"
+                "pn": "^1.1.0",
+                "request": "^2.88.0",
+                "request-promise-native": "^1.0.5",
+                "saxes": "^3.1.3",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.4.3",
+                "w3c-hr-time": "^1.0.1",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.2.0",
+                "whatwg-url": "^7.0.0",
+                "ws": "^6.1.0",
+                "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -9148,11 +9691,11 @@
                     "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
                     "dev": true,
                     "requires": {
-                        "esprima": "3.1.3",
-                        "estraverse": "4.2.0",
-                        "esutils": "2.0.2",
-                        "optionator": "0.8.2",
-                        "source-map": "0.6.1"
+                        "esprima": "^3.1.3",
+                        "estraverse": "^4.2.0",
+                        "esutils": "^2.0.2",
+                        "optionator": "^0.8.1",
+                        "source-map": "~0.6.1"
                     }
                 },
                 "esprima": {
@@ -9179,8 +9722,8 @@
                     "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "mime-db": {
@@ -9195,7 +9738,7 @@
                     "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.36.0"
+                        "mime-db": "~1.36.0"
                     }
                 },
                 "oauth-sign": {
@@ -9216,26 +9759,26 @@
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.1.0",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.20",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "source-map": {
@@ -9251,8 +9794,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 },
                 "uuid": {
@@ -9267,7 +9810,7 @@
                     "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0"
+                        "async-limiter": "~1.0.0"
                     }
                 }
             }
@@ -9289,7 +9832,7 @@
             "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
             "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
             "requires": {
-                "jsonparse": "1.2.0"
+                "jsonparse": "~1.2.0"
             }
         },
         "json-loader": {
@@ -9309,7 +9852,7 @@
             "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
             "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
             "requires": {
-                "esprima": "2.7.3"
+                "esprima": "^2.7.0"
             }
         },
         "json-schema": {
@@ -9327,7 +9870,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -9341,16 +9884,16 @@
             "integrity": "sha512-ORsw84BuRKMLxfI+HFZuvxRDnsJps53D5fIGr6tLn4ZY+ymcG8XU00E+JJ2wfAiHx5w2QRNmOLE8xHiGAeSfuQ==",
             "dev": true,
             "requires": {
-                "cli-table": "0.3.1",
-                "commander": "2.15.1",
-                "debug": "3.2.6",
-                "flat": "4.0.0",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.flatten": "4.4.0",
-                "lodash.get": "4.4.2",
-                "lodash.set": "4.3.2",
-                "lodash.uniq": "4.5.0",
-                "path-is-absolute": "1.0.1"
+                "cli-table": "^0.3.1",
+                "commander": "^2.8.1",
+                "debug": "^3.1.0",
+                "flat": "^4.0.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.get": "^4.4.0",
+                "lodash.set": "^4.3.0",
+                "lodash.uniq": "^4.5.0",
+                "path-is-absolute": "^1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -9359,7 +9902,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.1.1"
                     }
                 },
                 "ms": {
@@ -9387,7 +9930,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -9444,8 +9987,8 @@
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
             "dev": true,
             "requires": {
-                "default-resolution": "2.0.0",
-                "es6-weak-map": "2.0.2"
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
             }
         },
         "lazy-cache": {
@@ -9461,7 +10004,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -9470,7 +10013,7 @@
             "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "dev": true,
             "requires": {
-                "invert-kv": "2.0.0"
+                "invert-kv": "^2.0.0"
             }
         },
         "lead": {
@@ -9479,7 +10022,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.3"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "leaflet": {
@@ -9494,8 +10037,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "liftoff": {
@@ -9504,14 +10047,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.7.1"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "line-by-line": {
@@ -9525,11 +10068,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -9544,7 +10087,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -9561,9 +10104,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1"
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0"
             }
         },
         "locate-path": {
@@ -9572,8 +10115,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             },
             "dependencies": {
                 "p-limit": {
@@ -9582,7 +10125,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "1.0.0"
+                        "p-try": "^1.0.0"
                     }
                 },
                 "p-locate": {
@@ -9591,7 +10134,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "1.3.0"
+                        "p-limit": "^1.1.0"
                     }
                 },
                 "path-exists": {
@@ -9685,7 +10228,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.flatten": {
@@ -9736,9 +10279,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -9771,15 +10314,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -9788,8 +10331,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "lodash.uniq": {
@@ -9804,7 +10347,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9813,7 +10356,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -9822,9 +10365,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -9839,7 +10382,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -9850,8 +10393,8 @@
             "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
             "dev": true,
             "requires": {
-                "es6-symbol": "3.1.1",
-                "object.assign": "4.1.0"
+                "es6-symbol": "^3.1.1",
+                "object.assign": "^4.1.0"
             }
         },
         "longest": {
@@ -9866,7 +10409,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
         "lower-case": {
@@ -9887,8 +10430,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -9897,7 +10440,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.43"
+                "es5-ext": "~0.10.2"
             }
         },
         "make-dir": {
@@ -9906,7 +10449,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-iterator": {
@@ -9915,7 +10458,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "map-age-cleaner": {
@@ -9924,7 +10467,7 @@
             "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
             "dev": true,
             "requires": {
-                "p-defer": "1.0.0"
+                "p-defer": "^1.0.0"
             }
         },
         "map-cache": {
@@ -9945,7 +10488,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-escapes": {
@@ -9960,8 +10503,8 @@
             "integrity": "sha1-gc4+soZ82RiKILkKzybyP7To7kI=",
             "dev": true,
             "requires": {
-                "bintrees": "1.0.2",
-                "tinyqueue": "1.2.3"
+                "bintrees": "^1.0.1",
+                "tinyqueue": "^1.1.0"
             }
         },
         "matchdep": {
@@ -9970,9 +10513,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "2.0.0",
-                "micromatch": "3.1.10",
-                "resolve": "1.7.1",
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
                 "stack-trace": "0.0.10"
             }
         },
@@ -9993,9 +10536,9 @@
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
             "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
             "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "1.1.6"
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
             }
         },
         "md5.js": {
@@ -10003,8 +10546,8 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "mdast-add-list-metadata": {
@@ -10034,9 +10577,9 @@
             "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
             "dev": true,
             "requires": {
-                "map-age-cleaner": "0.1.2",
-                "mimic-fn": "1.2.0",
-                "p-is-promise": "1.1.0"
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^1.0.0",
+                "p-is-promise": "^1.1.0"
             }
         },
         "memoize-one": {
@@ -10051,14 +10594,14 @@
             "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.43",
-                "es6-weak-map": "2.0.2",
-                "event-emitter": "0.3.5",
-                "is-promise": "2.1.0",
-                "lru-queue": "0.1.0",
-                "next-tick": "1.0.0",
-                "timers-ext": "0.1.5"
+                "d": "1",
+                "es5-ext": "^0.10.30",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.2"
             }
         },
         "memory-fs": {
@@ -10067,8 +10610,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "readable-stream": "2.0.6"
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
             }
         },
         "merge-descriptors": {
@@ -10089,19 +10632,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "miller-rabin": {
@@ -10110,8 +10653,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -10130,7 +10673,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "mimic-fn": {
@@ -10151,7 +10694,7 @@
             "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
             "dev": true,
             "requires": {
-                "dom-walk": "0.1.1"
+                "dom-walk": "^0.1.0"
             }
         },
         "minimalistic-assert": {
@@ -10171,7 +10714,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -10185,16 +10728,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "duplexify": "3.6.0",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.3",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.5.1",
-                "stream-each": "1.2.3",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -10203,7 +10746,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -10214,8 +10757,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -10224,7 +10767,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -10286,7 +10829,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -10297,11 +10840,11 @@
             "integrity": "sha1-LlFJ7UD8XS48px5C21qx/snG2Fw=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "md5": "2.2.1",
-                "mkdirp": "0.5.1",
-                "strip-ansi": "4.0.0",
-                "xml": "1.0.1"
+                "debug": "^2.2.0",
+                "md5": "^2.1.0",
+                "mkdirp": "~0.5.1",
+                "strip-ansi": "^4.0.0",
+                "xml": "^1.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -10316,7 +10859,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -10338,12 +10881,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "copy-concurrently": "1.0.5",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
             }
         },
         "ms": {
@@ -10358,10 +10901,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -10390,24 +10933,31 @@
             "resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.3.tgz",
             "integrity": "sha512-zIUAXzGQOp16VR0Ct89SDstU62hzAPBluNUrUrsdD7MNSRbm/vyqGhEnp+4hnsMjmX3C2wh1cbIEP0joKMFLxw=="
         },
+        "nan": {
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+            "dev": true,
+            "optional": true
+        },
         "nanomatch": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "nearley": {
@@ -10416,11 +10966,11 @@
             "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
             "dev": true,
             "requires": {
-                "moo": "0.4.3",
-                "nomnom": "1.6.2",
-                "railroad-diagrams": "1.0.0",
+                "moo": "^0.4.3",
+                "nomnom": "~1.6.2",
+                "railroad-diagrams": "^1.0.0",
                 "randexp": "0.4.6",
-                "semver": "5.5.0"
+                "semver": "^5.4.1"
             }
         },
         "negotiator": {
@@ -10453,7 +11003,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-fetch": {
@@ -10461,8 +11011,8 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
             }
         },
         "node-has-native-dependencies": {
@@ -10480,28 +11030,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.6",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.3",
-                "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.10",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.4",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -10517,9 +11067,9 @@
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
-                        "base64-js": "1.3.0",
-                        "ieee754": "1.1.11",
-                        "isarray": "1.0.0"
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4",
+                        "isarray": "^1.0.0"
                     }
                 },
                 "process-nextick-args": {
@@ -10534,13 +11084,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -10549,7 +11099,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -10560,7 +11110,7 @@
             "integrity": "sha512-VPB4rTPqpVyWKBHbSa4YPFme3+8WHsOSpvbp0Mfj0bWsC8TEjt4HQrLl1hsBDELlp1nB4lflSgSuGTYiuyaP7Q==",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.3.0"
             }
         },
         "node-stream-zip": {
@@ -10574,8 +11124,8 @@
             "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "has": "1.0.3",
-                "is": "3.3.0"
+                "has": "^1.0.3",
+                "is": "^3.2.1"
             }
         },
         "nomnom": {
@@ -10584,8 +11134,8 @@
             "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
             "dev": true,
             "requires": {
-                "colors": "0.5.1",
-                "underscore": "1.4.4"
+                "colors": "0.5.x",
+                "underscore": "~1.4.4"
             },
             "dependencies": {
                 "colors": {
@@ -10608,7 +11158,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -10617,10 +11167,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -10629,7 +11179,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-url": {
@@ -10638,9 +11188,9 @@
             "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
             "dev": true,
             "requires": {
-                "prepend-http": "2.0.0",
-                "query-string": "5.1.1",
-                "sort-keys": "2.0.0"
+                "prepend-http": "^2.0.0",
+                "query-string": "^5.0.1",
+                "sort-keys": "^2.0.0"
             },
             "dependencies": {
                 "sort-keys": {
@@ -10649,7 +11199,7 @@
                     "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
                     "dev": true,
                     "requires": {
-                        "is-plain-obj": "1.1.0"
+                        "is-plain-obj": "^1.0.0"
                     }
                 }
             }
@@ -10660,7 +11210,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "npm-conf": {
@@ -10669,8 +11219,8 @@
             "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
             "dev": true,
             "requires": {
-                "config-chain": "1.1.11",
-                "pify": "3.0.0"
+                "config-chain": "^1.1.11",
+                "pify": "^3.0.0"
             }
         },
         "npm-run-path": {
@@ -10679,7 +11229,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "nth-check": {
@@ -10688,7 +11238,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "number-is-nan": {
@@ -10715,31 +11265,31 @@
             "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "arrify": "1.0.1",
-                "caching-transform": "2.0.0",
-                "convert-source-map": "1.6.0",
-                "debug-log": "1.0.1",
-                "find-cache-dir": "2.0.0",
-                "find-up": "3.0.0",
-                "foreground-child": "1.5.6",
-                "glob": "7.1.3",
-                "istanbul-lib-coverage": "2.0.1",
-                "istanbul-lib-hook": "2.0.1",
-                "istanbul-lib-instrument": "3.0.0",
-                "istanbul-lib-report": "2.0.2",
-                "istanbul-lib-source-maps": "2.0.1",
-                "istanbul-reports": "2.0.1",
-                "make-dir": "1.3.0",
-                "merge-source-map": "1.1.0",
-                "resolve-from": "4.0.0",
-                "rimraf": "2.6.2",
-                "signal-exit": "3.0.2",
-                "spawn-wrap": "1.4.2",
-                "test-exclude": "5.0.0",
-                "uuid": "3.3.2",
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^2.0.0",
+                "convert-source-map": "^1.6.0",
+                "debug-log": "^1.0.1",
+                "find-cache-dir": "^2.0.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.1",
+                "istanbul-lib-hook": "^2.0.1",
+                "istanbul-lib-instrument": "^3.0.0",
+                "istanbul-lib-report": "^2.0.2",
+                "istanbul-lib-source-maps": "^2.0.1",
+                "istanbul-reports": "^2.0.1",
+                "make-dir": "^1.3.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.0.0",
+                "uuid": "^3.3.2",
                 "yargs": "11.1.0",
-                "yargs-parser": "9.0.2"
+                "yargs-parser": "^9.0.2"
             },
             "dependencies": {
                 "align-text": {
@@ -10747,9 +11297,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2",
-                        "longest": "1.0.1",
-                        "repeat-string": "1.6.1"
+                        "kind-of": "^3.0.2",
+                        "longest": "^1.0.1",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "amdefine": {
@@ -10767,7 +11317,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "default-require-extensions": "2.0.0"
+                        "default-require-extensions": "^2.0.0"
                     }
                 },
                 "archy": {
@@ -10795,7 +11345,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -10809,10 +11359,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "make-dir": "1.3.0",
-                        "md5-hex": "2.0.0",
-                        "package-hash": "2.0.0",
-                        "write-file-atomic": "2.3.0"
+                        "make-dir": "^1.0.0",
+                        "md5-hex": "^2.0.0",
+                        "package-hash": "^2.0.0",
+                        "write-file-atomic": "^2.0.0"
                     }
                 },
                 "camelcase": {
@@ -10827,8 +11377,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "0.1.4",
-                        "lazy-cache": "1.0.4"
+                        "align-text": "^0.1.3",
+                        "lazy-cache": "^1.0.3"
                     }
                 },
                 "cliui": {
@@ -10837,8 +11387,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     },
                     "dependencies": {
@@ -10870,7 +11420,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.1"
                     }
                 },
                 "cross-spawn": {
@@ -10878,8 +11428,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
                     }
                 },
                 "debug": {
@@ -10905,7 +11455,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-bom": "3.0.0"
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "error-ex": {
@@ -10913,7 +11463,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-arrayish": "0.2.1"
+                        "is-arrayish": "^0.2.1"
                     }
                 },
                 "es6-error": {
@@ -10926,13 +11476,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -10940,9 +11490,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "4.1.3",
-                                "shebang-command": "1.2.0",
-                                "which": "1.3.1"
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
                             }
                         }
                     }
@@ -10952,9 +11502,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "commondir": "1.0.1",
-                        "make-dir": "1.3.0",
-                        "pkg-dir": "3.0.0"
+                        "commondir": "^1.0.1",
+                        "make-dir": "^1.0.0",
+                        "pkg-dir": "^3.0.0"
                     }
                 },
                 "find-up": {
@@ -10962,7 +11512,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "3.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
                 "foreground-child": {
@@ -10970,8 +11520,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "4.0.2",
-                        "signal-exit": "3.0.2"
+                        "cross-spawn": "^4",
+                        "signal-exit": "^3.0.0"
                     }
                 },
                 "fs.realpath": {
@@ -10994,12 +11544,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -11012,10 +11562,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "1.5.2",
-                        "optimist": "0.6.1",
-                        "source-map": "0.4.4",
-                        "uglify-js": "2.8.29"
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
                     },
                     "dependencies": {
                         "source-map": {
@@ -11023,7 +11573,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "amdefine": "1.0.1"
+                                "amdefine": ">=0.0.4"
                             }
                         }
                     }
@@ -11048,8 +11598,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -11077,7 +11627,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtin-modules": "1.1.1"
+                        "builtin-modules": "^1.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -11105,7 +11655,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "append-transform": "1.0.0"
+                        "append-transform": "^1.0.0"
                     }
                 },
                 "istanbul-lib-report": {
@@ -11113,9 +11663,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "2.0.1",
-                        "make-dir": "1.3.0",
-                        "supports-color": "5.4.0"
+                        "istanbul-lib-coverage": "^2.0.1",
+                        "make-dir": "^1.3.0",
+                        "supports-color": "^5.4.0"
                     }
                 },
                 "istanbul-lib-source-maps": {
@@ -11123,11 +11673,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "3.1.0",
-                        "istanbul-lib-coverage": "2.0.1",
-                        "make-dir": "1.3.0",
-                        "rimraf": "2.6.2",
-                        "source-map": "0.6.1"
+                        "debug": "^3.1.0",
+                        "istanbul-lib-coverage": "^2.0.1",
+                        "make-dir": "^1.3.0",
+                        "rimraf": "^2.6.2",
+                        "source-map": "^0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -11142,7 +11692,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "4.0.11"
+                        "handlebars": "^4.0.11"
                     }
                 },
                 "json-parse-better-errors": {
@@ -11155,7 +11705,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "lazy-cache": {
@@ -11169,7 +11719,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -11177,10 +11727,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "locate-path": {
@@ -11188,8 +11738,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "lodash.flattendeep": {
@@ -11207,8 +11757,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "make-dir": {
@@ -11216,7 +11766,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pify": "3.0.0"
+                        "pify": "^3.0.0"
                     }
                 },
                 "md5-hex": {
@@ -11224,7 +11774,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "0.1.1"
+                        "md5-o-matic": "^0.1.1"
                     }
                 },
                 "md5-o-matic": {
@@ -11237,7 +11787,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "merge-source-map": {
@@ -11245,7 +11795,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "source-map": "0.6.1"
+                        "source-map": "^0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -11265,7 +11815,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -11298,10 +11848,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "2.7.1",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.3"
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     }
                 },
                 "npm-run-path": {
@@ -11309,7 +11859,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-key": "2.0.1"
+                        "path-key": "^2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -11322,7 +11872,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "optimist": {
@@ -11330,8 +11880,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimist": "0.0.10",
-                        "wordwrap": "0.0.3"
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
                     }
                 },
                 "os-homedir": {
@@ -11344,9 +11894,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "p-finally": {
@@ -11359,7 +11909,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-try": "2.0.0"
+                        "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
@@ -11367,7 +11917,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.0.0"
+                        "p-limit": "^2.0.0"
                     }
                 },
                 "p-try": {
@@ -11380,10 +11930,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "lodash.flattendeep": "4.4.0",
-                        "md5-hex": "2.0.0",
-                        "release-zalgo": "1.0.0"
+                        "graceful-fs": "^4.1.11",
+                        "lodash.flattendeep": "^4.4.0",
+                        "md5-hex": "^2.0.0",
+                        "release-zalgo": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -11391,8 +11941,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "path-exists": {
@@ -11415,7 +11965,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pify": "3.0.0"
+                        "pify": "^3.0.0"
                     }
                 },
                 "pify": {
@@ -11428,7 +11978,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "3.0.0"
+                        "find-up": "^3.0.0"
                     }
                 },
                 "pseudomap": {
@@ -11441,9 +11991,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -11451,8 +12001,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "3.0.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 },
                 "release-zalgo": {
@@ -11460,7 +12010,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "es6-error": "4.1.1"
+                        "es6-error": "^4.0.1"
                     }
                 },
                 "repeat-string": {
@@ -11489,7 +12039,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "0.1.4"
+                        "align-text": "^0.1.1"
                     }
                 },
                 "rimraf": {
@@ -11497,7 +12047,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.3"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -11520,7 +12070,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "1.0.0"
+                        "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -11544,12 +12094,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "foreground-child": "1.5.6",
-                        "mkdirp": "0.5.1",
-                        "os-homedir": "1.0.2",
-                        "rimraf": "2.6.2",
-                        "signal-exit": "3.0.2",
-                        "which": "1.3.1"
+                        "foreground-child": "^1.5.6",
+                        "mkdirp": "^0.5.0",
+                        "os-homedir": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.2",
+                        "which": "^1.3.0"
                     }
                 },
                 "spdx-correct": {
@@ -11557,8 +12107,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-expression-parse": "3.0.0",
-                        "spdx-license-ids": "3.0.0"
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
                     }
                 },
                 "spdx-exceptions": {
@@ -11571,8 +12121,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-exceptions": "2.1.0",
-                        "spdx-license-ids": "3.0.0"
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
                     }
                 },
                 "spdx-license-ids": {
@@ -11585,8 +12135,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -11594,7 +12144,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "strip-bom": {
@@ -11612,7 +12162,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "test-exclude": {
@@ -11620,10 +12170,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arrify": "1.0.1",
-                        "minimatch": "3.0.4",
-                        "read-pkg-up": "4.0.0",
-                        "require-main-filename": "1.0.1"
+                        "arrify": "^1.0.1",
+                        "minimatch": "^3.0.4",
+                        "read-pkg-up": "^4.0.0",
+                        "require-main-filename": "^1.0.1"
                     }
                 },
                 "uglify-js": {
@@ -11632,9 +12182,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -11643,9 +12193,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -11667,8 +12217,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "3.0.0",
-                        "spdx-expression-parse": "3.0.0"
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
                     }
                 },
                 "which": {
@@ -11676,7 +12226,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 },
                 "which-module": {
@@ -11700,8 +12250,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -11714,7 +12264,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                             }
                         },
                         "string-width": {
@@ -11722,9 +12272,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         },
                         "strip-ansi": {
@@ -11732,7 +12282,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "2.1.1"
+                                "ansi-regex": "^2.0.0"
                             }
                         }
                     }
@@ -11747,9 +12297,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "signal-exit": "3.0.2"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "y18n": {
@@ -11767,18 +12317,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     },
                     "dependencies": {
                         "cliui": {
@@ -11786,9 +12336,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "string-width": "2.1.1",
-                                "strip-ansi": "4.0.0",
-                                "wrap-ansi": "2.1.0"
+                                "string-width": "^2.1.1",
+                                "strip-ansi": "^4.0.0",
+                                "wrap-ansi": "^2.0.0"
                             }
                         },
                         "find-up": {
@@ -11796,7 +12346,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "locate-path": "2.0.0"
+                                "locate-path": "^2.0.0"
                             }
                         },
                         "locate-path": {
@@ -11804,8 +12354,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-locate": "2.0.0",
-                                "path-exists": "3.0.0"
+                                "p-locate": "^2.0.0",
+                                "path-exists": "^3.0.0"
                             }
                         },
                         "p-limit": {
@@ -11813,7 +12363,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-try": "1.0.0"
+                                "p-try": "^1.0.0"
                             }
                         },
                         "p-locate": {
@@ -11821,7 +12371,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-limit": "1.3.0"
+                                "p-limit": "^1.1.0"
                             }
                         },
                         "p-try": {
@@ -11836,7 +12386,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -11865,9 +12415,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -11876,7 +12426,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -11885,7 +12435,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -11914,7 +12464,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -11923,10 +12473,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.11"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -11935,10 +12485,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "object.entries": {
@@ -11947,10 +12497,10 @@
             "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0",
-                "function-bind": "1.1.1",
-                "has": "1.0.3"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.6.1",
+                "function-bind": "^1.1.0",
+                "has": "^1.0.1"
             }
         },
         "object.getownpropertydescriptors": {
@@ -11959,8 +12509,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
             }
         },
         "object.map": {
@@ -11969,8 +12519,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.omit": {
@@ -11979,8 +12529,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-own": {
@@ -11989,7 +12539,7 @@
                     "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -12000,7 +12550,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "object.reduce": {
@@ -12009,8 +12559,8 @@
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.values": {
@@ -12019,10 +12569,10 @@
             "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0",
-                "function-bind": "1.1.1",
-                "has": "1.0.3"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.6.1",
+                "function-bind": "^1.1.0",
+                "has": "^1.0.1"
             }
         },
         "on-finished": {
@@ -12039,7 +12589,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -12048,7 +12598,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "opener": {
@@ -12063,8 +12613,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -12087,12 +12637,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "options": {
@@ -12106,7 +12656,7 @@
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "original": {
@@ -12115,7 +12665,7 @@
             "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
             "dev": true,
             "requires": {
-                "url-parse": "1.4.3"
+                "url-parse": "^1.4.3"
             }
         },
         "os-browserify": {
@@ -12130,9 +12680,9 @@
             "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
             "dev": true,
             "requires": {
-                "execa": "0.10.0",
-                "lcid": "2.0.0",
-                "mem": "4.0.0"
+                "execa": "^0.10.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
             }
         },
         "os-tmpdir": {
@@ -12158,7 +12708,7 @@
             "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
             "dev": true,
             "requires": {
-                "p-timeout": "1.2.1"
+                "p-timeout": "^1.1.1"
             },
             "dependencies": {
                 "p-timeout": {
@@ -12167,7 +12717,7 @@
                     "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
                     "dev": true,
                     "requires": {
-                        "p-finally": "1.0.0"
+                        "p-finally": "^1.0.0"
                     }
                 }
             }
@@ -12190,7 +12740,7 @@
             "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
             "dev": true,
             "requires": {
-                "p-try": "2.0.0"
+                "p-try": "^2.0.0"
             },
             "dependencies": {
                 "p-try": {
@@ -12207,7 +12757,7 @@
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
-                "p-limit": "2.0.0"
+                "p-limit": "^2.0.0"
             }
         },
         "p-map": {
@@ -12222,7 +12772,7 @@
             "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
             "dev": true,
             "requires": {
-                "p-finally": "1.0.0"
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -12243,9 +12793,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -12260,13 +12810,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -12275,7 +12825,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -12286,7 +12836,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "parse-asn1": {
@@ -12295,11 +12845,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.2.0",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.17"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-entities": {
@@ -12308,12 +12858,12 @@
             "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
             "dev": true,
             "requires": {
-                "character-entities": "1.2.2",
-                "character-entities-legacy": "1.1.2",
-                "character-reference-invalid": "1.1.2",
-                "is-alphanumerical": "1.0.2",
-                "is-decimal": "1.0.2",
-                "is-hexadecimal": "1.0.2"
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
             }
         },
         "parse-filepath": {
@@ -12322,9 +12872,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -12333,10 +12883,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -12351,7 +12901,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -12362,7 +12912,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -12377,7 +12927,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "9.4.7"
+                "@types/node": "*"
             }
         },
         "parseurl": {
@@ -12410,7 +12960,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -12447,7 +12997,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -12468,9 +13018,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -12493,7 +13043,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pbkdf2": {
@@ -12502,11 +13052,11 @@
             "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "pend": {
@@ -12543,7 +13093,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -12552,7 +13102,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -12561,7 +13111,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 }
             }
@@ -12572,7 +13122,7 @@
             "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
             "dev": true,
             "requires": {
-                "semver-compare": "1.0.0"
+                "semver-compare": "^1.0.0"
             }
         },
         "plugin-error": {
@@ -12581,11 +13131,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -12594,8 +13144,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -12616,7 +13166,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -12639,7 +13189,7 @@
             "integrity": "sha1-aaZWXwsn+na1Jw1cB5sLosjwu6M=",
             "dev": true,
             "requires": {
-                "martinez-polygon-clipping": "0.1.5"
+                "martinez-polygon-clipping": "^0.1.5"
             }
         },
         "posix-character-classes": {
@@ -12654,9 +13204,9 @@
             "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "source-map": "0.6.1",
-                "supports-color": "5.5.0"
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12665,7 +13215,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -12674,9 +13224,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -12697,7 +13247,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -12708,7 +13258,7 @@
             "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
             "dev": true,
             "requires": {
-                "postcss": "6.0.23"
+                "postcss": "^6.0.1"
             }
         },
         "postcss-modules-local-by-default": {
@@ -12717,8 +13267,8 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.1",
-                "postcss": "6.0.23"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             }
         },
         "postcss-modules-scope": {
@@ -12727,8 +13277,8 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.1",
-                "postcss": "6.0.23"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             }
         },
         "postcss-modules-values": {
@@ -12737,8 +13287,8 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.23"
+                "icss-replace-symbols": "^1.1.0",
+                "postcss": "^6.0.1"
             }
         },
         "postcss-value-parser": {
@@ -12777,8 +13327,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "2.0.1",
-                "utila": "0.4.0"
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
             }
         },
         "pretty-hrtime": {
@@ -12816,7 +13366,7 @@
             "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
             "dev": true,
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "promise-inflight": {
@@ -12831,8 +13381,8 @@
             "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1"
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
             }
         },
         "proto-list": {
@@ -12847,7 +13397,7 @@
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "dev": true,
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.8.0"
             }
         },
@@ -12874,11 +13424,11 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "parse-asn1": "5.1.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pump": {
@@ -12887,8 +13437,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -12897,7 +13447,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -12908,9 +13458,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -12941,9 +13491,9 @@
             "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
             "dev": true,
             "requires": {
-                "decode-uri-component": "0.2.0",
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "querystring": {
@@ -12969,7 +13519,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "raf": {
@@ -12978,7 +13528,7 @@
             "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
             "dev": true,
             "requires": {
-                "performance-now": "2.1.0"
+                "performance-now": "^2.1.0"
             }
         },
         "railroad-diagrams": {
@@ -12994,7 +13544,7 @@
             "dev": true,
             "requires": {
                 "discontinuous-range": "1.0.0",
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "randomatic": {
@@ -13003,9 +13553,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -13022,7 +13572,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -13031,8 +13581,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.2"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -13059,7 +13609,7 @@
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 }
             }
@@ -13076,10 +13626,10 @@
             "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.2",
-                "schedule": "0.5.0"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "schedule": "^0.5.0"
             }
         },
         "react-annotation": {
@@ -13098,9 +13648,9 @@
                     "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
                     "dev": true,
                     "requires": {
-                        "fbjs": "0.8.17",
-                        "loose-envify": "1.4.0",
-                        "object-assign": "4.1.1"
+                        "fbjs": "^0.8.16",
+                        "loose-envify": "^1.3.1",
+                        "object-assign": "^4.1.1"
                     }
                 }
             }
@@ -13111,10 +13661,10 @@
             "integrity": "sha1-OFjyTpxN2MvT9wLz901YHKKRcmk=",
             "dev": true,
             "requires": {
-                "base16": "1.0.0",
-                "lodash.curry": "4.1.1",
-                "lodash.flow": "3.5.0",
-                "pure-color": "1.3.0"
+                "base16": "^1.0.0",
+                "lodash.curry": "^4.0.1",
+                "lodash.flow": "^3.3.0",
+                "pure-color": "^1.2.0"
             }
         },
         "react-codemirror": {
@@ -13123,12 +13673,12 @@
             "integrity": "sha1-kUZ7U7H12A2Rai/QtMetuFqQAbo=",
             "dev": true,
             "requires": {
-                "classnames": "2.2.6",
-                "codemirror": "5.42.2",
-                "create-react-class": "15.6.3",
-                "lodash.debounce": "4.0.8",
-                "lodash.isequal": "4.5.0",
-                "prop-types": "15.6.2"
+                "classnames": "^2.2.5",
+                "codemirror": "^5.18.2",
+                "create-react-class": "^15.5.1",
+                "lodash.debounce": "^4.0.8",
+                "lodash.isequal": "^4.5.0",
+                "prop-types": "^15.5.4"
             }
         },
         "react-color": {
@@ -13137,11 +13687,11 @@
             "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.11",
-                "material-colors": "1.2.6",
-                "prop-types": "15.6.2",
-                "reactcss": "1.2.3",
-                "tinycolor2": "1.4.1"
+                "lodash": "^4.0.1",
+                "material-colors": "^1.2.1",
+                "prop-types": "^15.5.10",
+                "reactcss": "^1.2.0",
+                "tinycolor2": "^1.4.1"
             }
         },
         "react-dev-utils": {
@@ -13162,7 +13712,7 @@
                 "inquirer": "3.3.0",
                 "is-root": "1.0.0",
                 "opn": "5.2.0",
-                "react-error-overlay": "4.0.1",
+                "react-error-overlay": "^4.0.1",
                 "recursive-readdir": "2.2.1",
                 "shell-quote": "1.6.1",
                 "sockjs-client": "1.1.5",
@@ -13176,9 +13726,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "lru-cache": {
@@ -13187,8 +13737,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "opn": {
@@ -13197,7 +13747,7 @@
                     "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
                     "dev": true,
                     "requires": {
-                        "is-wsl": "1.1.0"
+                        "is-wsl": "^1.1.0"
                     }
                 }
             }
@@ -13208,10 +13758,10 @@
             "integrity": "sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.2",
-                "schedule": "0.5.0"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "schedule": "^0.5.0"
             }
         },
         "react-error-overlay": {
@@ -13226,12 +13776,12 @@
             "integrity": "sha512-T0G5jURyTsFLoiW6MTr5Q35UHC/B2pmYJ7+VBjk8yMDCEABRmCGy4g6QwxoB4pWg4/xYvVTa/Pbqnsgx/+NLuA==",
             "dev": true,
             "requires": {
-                "fast-levenshtein": "2.0.6",
-                "global": "4.3.2",
-                "hoist-non-react-statics": "2.5.5",
-                "prop-types": "15.6.2",
-                "react-lifecycles-compat": "3.0.4",
-                "shallowequal": "1.1.0"
+                "fast-levenshtein": "^2.0.6",
+                "global": "^4.3.0",
+                "hoist-non-react-statics": "^2.5.0",
+                "prop-types": "^15.6.1",
+                "react-lifecycles-compat": "^3.0.4",
+                "shallowequal": "^1.0.2"
             }
         },
         "react-is": {
@@ -13246,9 +13796,9 @@
             "integrity": "sha1-9bF+gzKanHauOL5cBP2jp/1oSjU=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.2",
-                "react-base16-styling": "0.5.3"
+                "babel-runtime": "^6.6.1",
+                "prop-types": "^15.5.8",
+                "react-base16-styling": "^0.5.1"
             }
         },
         "react-lifecycles-compat": {
@@ -13264,11 +13814,11 @@
             "dev": true,
             "requires": {
                 "mdast-add-list-metadata": "1.0.1",
-                "prop-types": "15.6.2",
-                "remark-parse": "5.0.0",
-                "unified": "6.2.0",
-                "unist-util-visit": "1.4.0",
-                "xtend": "4.0.1"
+                "prop-types": "^15.6.1",
+                "remark-parse": "^5.0.0",
+                "unified": "^6.1.5",
+                "unist-util-visit": "^1.3.0",
+                "xtend": "^4.0.1"
             }
         },
         "react-table": {
@@ -13277,7 +13827,7 @@
             "integrity": "sha1-oK2LSDkxkFLVvvwBJgP7Fh5S7eM=",
             "dev": true,
             "requires": {
-                "classnames": "2.2.6"
+                "classnames": "^2.2.5"
             }
         },
         "react-table-hoc-fixed-columns": {
@@ -13286,9 +13836,9 @@
             "integrity": "sha512-0qEHYHA00kBTwUtQnbrJVPh1Ghgx6C6zwq+1cwY4jvjPu0jhYPoAECx0LosphDioA8aaRgkEwDTHDLYcgN9xFQ==",
             "dev": true,
             "requires": {
-                "classnames": "2.2.6",
-                "emotion": "9.2.12",
-                "uniqid": "5.0.3"
+                "classnames": "^2.2.6",
+                "emotion": "^9.2.3",
+                "uniqid": "^5.0.3"
             }
         },
         "react-test-renderer": {
@@ -13297,10 +13847,10 @@
             "integrity": "sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.2",
-                "react-is": "16.5.2",
-                "schedule": "0.5.0"
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.5.2",
+                "schedule": "^0.5.0"
             }
         },
         "reactcss": {
@@ -13309,7 +13859,7 @@
             "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.0.1"
             }
         },
         "read-pkg": {
@@ -13318,9 +13868,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -13329,8 +13879,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -13338,12 +13888,12 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -13352,10 +13902,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.0.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -13364,7 +13914,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.7.1"
+                "resolve": "^1.1.6"
             }
         },
         "recursive-readdir": {
@@ -13382,7 +13932,7 @@
                     "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.0.0"
                     }
                 }
             }
@@ -13404,7 +13954,7 @@
             "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
             "dev": true,
             "requires": {
-                "regenerate": "1.4.0"
+                "regenerate": "^1.4.0"
             }
         },
         "regenerator-runtime": {
@@ -13419,7 +13969,7 @@
             "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
             "dev": true,
             "requires": {
-                "private": "0.1.8"
+                "private": "^0.1.6"
             }
         },
         "regex-cache": {
@@ -13428,7 +13978,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -13437,8 +13987,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpu-core": {
@@ -13447,12 +13997,12 @@
             "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
             "dev": true,
             "requires": {
-                "regenerate": "1.4.0",
-                "regenerate-unicode-properties": "7.0.0",
-                "regjsgen": "0.4.0",
-                "regjsparser": "0.3.0",
-                "unicode-match-property-ecmascript": "1.0.4",
-                "unicode-match-property-value-ecmascript": "1.0.2"
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.4.0",
+                "regjsparser": "^0.3.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
             }
         },
         "regjsgen": {
@@ -13467,7 +14017,7 @@
             "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -13490,7 +14040,7 @@
             "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
             "dev": true,
             "requires": {
-                "isobject": "2.1.0"
+                "isobject": "^2.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -13510,11 +14060,11 @@
             "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
             "dev": true,
             "requires": {
-                "amdefine": "1.0.1",
+                "amdefine": "^1.0.0",
                 "istanbul": "0.4.5",
-                "minimatch": "3.0.4",
-                "plugin-error": "0.1.2",
-                "source-map": "0.6.1",
+                "minimatch": "^3.0.3",
+                "plugin-error": "^0.1.2",
+                "source-map": "^0.6.1",
                 "through2": "2.0.1"
             },
             "dependencies": {
@@ -13530,8 +14080,8 @@
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.0.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "~2.0.0",
+                        "xtend": "~4.0.0"
                     }
                 }
             }
@@ -13542,21 +14092,21 @@
             "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
             "dev": true,
             "requires": {
-                "collapse-white-space": "1.0.4",
-                "is-alphabetical": "1.0.2",
-                "is-decimal": "1.0.2",
-                "is-whitespace-character": "1.0.2",
-                "is-word-character": "1.0.2",
-                "markdown-escapes": "1.0.2",
-                "parse-entities": "1.2.0",
-                "repeat-string": "1.6.1",
-                "state-toggle": "1.0.1",
+                "collapse-white-space": "^1.0.2",
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "is-word-character": "^1.0.0",
+                "markdown-escapes": "^1.0.0",
+                "parse-entities": "^1.1.0",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
                 "trim": "0.0.1",
-                "trim-trailing-lines": "1.1.1",
-                "unherit": "1.1.1",
-                "unist-util-remove-position": "1.1.2",
-                "vfile-location": "2.0.3",
-                "xtend": "4.0.1"
+                "trim-trailing-lines": "^1.0.0",
+                "unherit": "^1.0.4",
+                "unist-util-remove-position": "^1.0.0",
+                "vfile-location": "^2.0.0",
+                "xtend": "^4.0.1"
             }
         },
         "remove-bom-buffer": {
@@ -13565,8 +14115,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -13575,9 +14125,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.2",
-                "through2": "2.0.3"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -13592,11 +14142,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-converter": "0.1.4",
-                "htmlparser2": "3.3.0",
-                "strip-ansi": "3.0.1",
-                "utila": "0.3.3"
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.1",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "~0.3"
             },
             "dependencies": {
                 "domhandler": {
@@ -13605,7 +14155,7 @@
                     "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "domutils": {
@@ -13614,7 +14164,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "htmlparser2": {
@@ -13623,10 +14173,10 @@
                     "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0",
-                        "domhandler": "2.1.0",
-                        "domutils": "1.1.6",
-                        "readable-stream": "1.0.34"
+                        "domelementtype": "1",
+                        "domhandler": "2.1",
+                        "domutils": "1.1",
+                        "readable-stream": "1.0"
                     }
                 },
                 "isarray": {
@@ -13641,10 +14191,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "utila": {
@@ -13679,9 +14229,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "is-absolute": "1.0.0",
-                "remove-trailing-separator": "1.1.0"
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
             }
         },
         "request": {
@@ -13689,26 +14239,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             }
         },
         "request-progress": {
@@ -13716,7 +14266,7 @@
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
             "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
             "requires": {
-                "throttleit": "1.0.0"
+                "throttleit": "^1.0.0"
             }
         },
         "request-promise-core": {
@@ -13725,7 +14275,7 @@
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.13.1"
             }
         },
         "request-promise-native": {
@@ -13735,8 +14285,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.3.4"
+                "stealthy-require": "^1.1.0",
+                "tough-cookie": ">=2.3.3"
             }
         },
         "require-directory": {
@@ -13762,7 +14312,7 @@
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-cwd": {
@@ -13771,7 +14321,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             }
         },
         "resolve-dir": {
@@ -13780,8 +14330,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-from": {
@@ -13796,7 +14346,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -13811,7 +14361,7 @@
             "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
             "dev": true,
             "requires": {
-                "lowercase-keys": "1.0.1"
+                "lowercase-keys": "^1.0.0"
             }
         },
         "restore-cursor": {
@@ -13820,8 +14370,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -13842,14 +14392,14 @@
             "integrity": "sha512-1MkO4mX4j31GilbMsqdgLNXjmrHo9EUKQFCa82rLye8ltOHnJe0rRaHUSKz2yUClr8l0Qnj1ZTjZHmp6vNTrzQ==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "compare-module-exports": "2.1.0",
-                "lodash.some": "4.6.0",
-                "lodash.template": "4.4.0",
-                "node-libs-browser": "2.1.0",
-                "path-parse": "1.0.5",
-                "wipe-node-cache": "2.1.0",
-                "wipe-webpack-cache": "2.1.0"
+                "babel-runtime": "^6.26.0",
+                "compare-module-exports": "^2.1.0",
+                "lodash.some": "^4.6.0",
+                "lodash.template": "^4.4.0",
+                "node-libs-browser": "^2.1.0",
+                "path-parse": "^1.0.5",
+                "wipe-node-cache": "^2.1.0",
+                "wipe-webpack-cache": "^2.1.0"
             },
             "dependencies": {
                 "lodash.template": {
@@ -13858,8 +14408,8 @@
                     "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.templatesettings": "4.1.0"
+                        "lodash._reinterpolate": "~3.0.0",
+                        "lodash.templatesettings": "^4.0.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -13868,7 +14418,7 @@
                     "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "3.0.0"
+                        "lodash._reinterpolate": "~3.0.0"
                     }
                 }
             }
@@ -13880,7 +14430,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -13889,7 +14439,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -13898,8 +14448,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "roughjs-es5": {
@@ -13908,7 +14458,7 @@
             "integrity": "sha512-NMjzoBgSYk8qEYLSxzxytS20sfdQV7zg119FZjFDjIDwaqodFcf7QwzKbqM64VeAYF61qogaPLk3cs8Gb+TqZA==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.26.0"
             }
         },
         "rst-selector-parser": {
@@ -13917,8 +14467,8 @@
             "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
             "dev": true,
             "requires": {
-                "lodash.flattendeep": "4.4.0",
-                "nearley": "2.15.1"
+                "lodash.flattendeep": "^4.4.0",
+                "nearley": "^2.7.10"
             }
         },
         "run-async": {
@@ -13927,7 +14477,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "run-node": {
@@ -13942,7 +14492,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
             }
         },
         "rx-lite": {
@@ -13957,7 +14507,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "rxjs": {
@@ -13979,7 +14529,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -13998,7 +14548,7 @@
             "integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
             "dev": true,
             "requires": {
-                "xmlchars": "1.3.1"
+                "xmlchars": "^1.3.1"
             }
         },
         "schedule": {
@@ -14007,7 +14557,7 @@
             "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1"
+                "object-assign": "^4.1.1"
             }
         },
         "schema-utils": {
@@ -14016,9 +14566,9 @@
             "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
             "dev": true,
             "requires": {
-                "ajv": "6.5.4",
-                "ajv-errors": "1.0.0",
-                "ajv-keywords": "3.2.0"
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
             },
             "dependencies": {
                 "ajv": {
@@ -14027,10 +14577,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -14053,7 +14603,7 @@
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
             "dev": true,
             "requires": {
-                "commander": "2.8.1"
+                "commander": "~2.8.1"
             },
             "dependencies": {
                 "commander": {
@@ -14062,7 +14612,7 @@
                     "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                     }
                 }
             }
@@ -14073,24 +14623,24 @@
             "integrity": "sha512-29PHBRq/Y/0Zhw2ancuBt19FRPzuCUXMhcy1WHFSxCvSv5XrknQnV0Jiy7vdDoCB4WcGk+zYZPVfqHzZwUNbgg==",
             "dev": true,
             "requires": {
-                "@mapbox/polylabel": "1.0.2",
-                "d3-array": "1.2.4",
-                "d3-bboxCollide": "1.0.4",
-                "d3-brush": "1.0.6",
-                "d3-chord": "1.0.6",
-                "d3-collection": "1.0.7",
-                "d3-contour": "1.3.2",
-                "d3-force": "1.1.2",
-                "d3-glyphedge": "1.2.0",
-                "d3-hexbin": "0.2.2",
-                "d3-hierarchy": "1.1.8",
-                "d3-interpolate": "1.3.2",
-                "d3-polygon": "1.0.5",
+                "@mapbox/polylabel": "1",
+                "d3-array": "^1.2.0",
+                "d3-bboxCollide": "^1.0.3",
+                "d3-brush": "^1.0.4",
+                "d3-chord": "^1.0.4",
+                "d3-collection": "^1.0.1",
+                "d3-contour": "^1.1.1",
+                "d3-force": "^1.0.2",
+                "d3-glyphedge": "^1.2.0",
+                "d3-hexbin": "^0.2.2",
+                "d3-hierarchy": "^1.1.3",
+                "d3-interpolate": "^1.1.5",
+                "d3-polygon": "^1.0.5",
                 "d3-sankey-circular": "0.25.0",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.2",
-                "d3-shape": "1.2.2",
-                "d3-voronoi": "1.1.4",
+                "d3-scale": "^1.0.3",
+                "d3-selection": "^1.1.0",
+                "d3-shape": "^1.0.4",
+                "d3-voronoi": "^1.0.2",
                 "json2csv": "3.11.5",
                 "labella": "1.1.4",
                 "memoize-one": "4.0.0",
@@ -14110,9 +14660,9 @@
                     "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
                     "dev": true,
                     "requires": {
-                        "fbjs": "0.8.17",
-                        "loose-envify": "1.4.0",
-                        "object-assign": "4.1.1"
+                        "fbjs": "^0.8.16",
+                        "loose-envify": "^1.3.1",
+                        "object-assign": "^4.1.1"
                     }
                 }
             }
@@ -14123,12 +14673,12 @@
             "integrity": "sha512-GxyrIyntvs+TXK8KOJKzs3AnvMM7Cb7ywfAeJKEQ/GKMKwaZvQnuGrz3dSImjfH7xvf4E2AmDIggqgHISt1X4Q==",
             "dev": true,
             "requires": {
-                "d3-interpolate": "1.3.2",
-                "d3-scale": "1.0.7",
-                "d3-selection": "1.3.2",
-                "d3-shape": "1.2.2",
-                "d3-transition": "1.1.3",
-                "prop-types": "15.6.2",
+                "d3-interpolate": "^1.1.5",
+                "d3-scale": "^1.0.3",
+                "d3-selection": "^1.1.0",
+                "d3-shape": "^1.0.3",
+                "d3-transition": "^1.0.3",
+                "prop-types": "^15.6.0",
                 "roughjs-es5": "0.1.0"
             }
         },
@@ -14149,7 +14699,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "1.5.0"
+                "sver-compat": "^1.5.0"
             }
         },
         "send": {
@@ -14159,18 +14709,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.3",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.4.0"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
             },
             "dependencies": {
                 "mime": {
@@ -14193,9 +14743,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -14217,10 +14767,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -14229,7 +14779,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -14252,8 +14802,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shallowequal": {
@@ -14268,7 +14818,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -14283,10 +14833,10 @@
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "dev": true,
             "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
             }
         },
         "shortid": {
@@ -14325,14 +14875,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -14341,7 +14891,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -14350,7 +14900,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -14361,9 +14911,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -14372,7 +14922,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -14381,7 +14931,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -14390,7 +14940,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -14399,9 +14949,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -14412,7 +14962,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -14421,7 +14971,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -14432,12 +14982,12 @@
             "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
+                "debug": "^2.6.6",
                 "eventsource": "0.1.6",
-                "faye-websocket": "0.11.1",
-                "inherits": "2.0.3",
-                "json3": "3.3.2",
-                "url-parse": "1.4.3"
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
             }
         },
         "sort-keys": {
@@ -14446,7 +14996,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "sort-keys-length": {
@@ -14455,7 +15005,7 @@
             "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
             "dev": true,
             "requires": {
-                "sort-keys": "1.1.2"
+                "sort-keys": "^1.0.0"
             }
         },
         "source-list-map": {
@@ -14476,11 +15026,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.1",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -14489,8 +15039,8 @@
             "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -14519,8 +15069,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -14535,8 +15085,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -14551,7 +15101,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -14560,7 +15110,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -14574,14 +15124,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             }
         },
         "ssri": {
@@ -14590,7 +15140,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
             }
         },
         "stack-trace": {
@@ -14616,8 +15166,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -14626,7 +15176,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -14649,8 +15199,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-combiner": {
@@ -14659,7 +15209,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-each": {
@@ -14668,8 +15218,8 @@
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -14678,7 +15228,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -14695,11 +15245,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -14714,13 +15264,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -14729,7 +15279,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -14746,7 +15296,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -14773,8 +15323,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -14789,7 +15339,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -14800,9 +15350,9 @@
             "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.0",
+                "function-bind": "^1.0.2"
             }
         },
         "string_decoder": {
@@ -14816,7 +15366,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -14831,8 +15381,8 @@
             "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "2.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "first-chunk-stream": {
@@ -14841,7 +15391,7 @@
                     "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.0.6"
+                        "readable-stream": "^2.0.2"
                     }
                 },
                 "strip-bom": {
@@ -14850,7 +15400,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -14867,7 +15417,7 @@
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
             "requires": {
-                "is-natural-number": "4.0.1"
+                "is-natural-number": "^4.0.1"
             }
         },
         "strip-eof": {
@@ -14887,7 +15437,7 @@
             "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.2"
             }
         },
         "style-loader": {
@@ -14896,8 +15446,8 @@
             "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "1.0.0"
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^1.0.0"
             }
         },
         "styled-jsx": {
@@ -14953,8 +15503,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "svg-inline-loader": {
@@ -14963,9 +15513,9 @@
             "integrity": "sha512-rynplY2eXFrdNomL1FvyTFQlP+dx0WqbzHglmNtA9M4IHRC3no2aPAl3ny9lUpJzFzFMZfWRK5YIclNU+FRePA==",
             "dev": true,
             "requires": {
-                "loader-utils": "0.2.17",
-                "object-assign": "4.1.1",
-                "simple-html-tokenizer": "0.1.1"
+                "loader-utils": "^0.2.11",
+                "object-assign": "^4.0.1",
+                "simple-html-tokenizer": "^0.1.1"
             },
             "dependencies": {
                 "loader-utils": {
@@ -14974,10 +15524,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
                     }
                 }
             }
@@ -14988,7 +15538,7 @@
             "integrity": "sha512-c39AIRQOUXLMD8fQ2rHmK1GOSO3tVuZk61bAXqIT05uhhm3z4VtQFITQSwyhL0WA2uxoJAIhPd2YV0CYQOolSA==",
             "dev": true,
             "requires": {
-                "prop-types": "15.6.2"
+                "prop-types": "^15.5.0"
             }
         },
         "svg-path-bounding-box": {
@@ -14997,7 +15547,7 @@
             "integrity": "sha1-7XPfODyLR4abZQjwWPV0j4gzwHA=",
             "dev": true,
             "requires": {
-                "svgpath": "2.2.1"
+                "svgpath": "^2.0.0"
             }
         },
         "svgo": {
@@ -15006,13 +15556,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
             },
             "dependencies": {
                 "colors": {
@@ -15027,8 +15577,8 @@
                     "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
                     "dev": true,
                     "requires": {
-                        "clap": "1.2.3",
-                        "source-map": "0.5.7"
+                        "clap": "^1.0.9",
+                        "source-map": "^0.5.3"
                     }
                 },
                 "js-yaml": {
@@ -15037,8 +15587,8 @@
                     "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "2.7.3"
+                        "argparse": "^1.0.7",
+                        "esprima": "^2.6.0"
                     }
                 }
             }
@@ -15072,9 +15622,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "tar-stream": {
@@ -15083,13 +15633,13 @@
             "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
             "dev": true,
             "requires": {
-                "bl": "1.2.2",
-                "buffer-alloc": "1.2.0",
-                "end-of-stream": "1.4.1",
-                "fs-constants": "1.0.0",
-                "readable-stream": "2.3.6",
-                "to-buffer": "1.1.1",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.1.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -15098,7 +15648,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 },
                 "process-nextick-args": {
@@ -15113,13 +15663,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -15128,7 +15678,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -15156,8 +15706,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -15172,13 +15722,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -15187,7 +15737,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -15198,8 +15748,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -15220,7 +15770,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "timers-ext": {
@@ -15229,8 +15779,8 @@
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.43",
-                "next-tick": "1.0.0"
+                "es5-ext": "~0.10.14",
+                "next-tick": "1"
             }
         },
         "tinycolor2": {
@@ -15250,7 +15800,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -15259,8 +15809,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "is-negated-glob": "1.0.0"
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-arraybuffer": {
@@ -15287,7 +15837,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -15296,7 +15846,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -15307,10 +15857,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -15319,8 +15869,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "to-through": {
@@ -15329,7 +15879,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.3"
             }
         },
         "toposort": {
@@ -15344,7 +15894,7 @@
             "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
             "dev": true,
             "requires": {
-                "nopt": "1.0.10"
+                "nopt": "~1.0.10"
             },
             "dependencies": {
                 "nopt": {
@@ -15353,7 +15903,7 @@
                     "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1.1.1"
+                        "abbrev": "1"
                     }
                 }
             }
@@ -15363,7 +15913,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tr46": {
@@ -15372,7 +15922,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -15400,7 +15950,7 @@
             "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.2"
             }
         },
         "trim-right": {
@@ -15433,11 +15983,11 @@
             "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "enhanced-resolve": "4.1.0",
-                "loader-utils": "1.1.0",
-                "micromatch": "3.1.10",
-                "semver": "5.5.0"
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^3.1.4",
+                "semver": "^5.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15446,7 +15996,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -15455,9 +16005,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -15472,7 +16022,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -15483,7 +16033,7 @@
             "integrity": "sha512-chcKw0sTApwJxTyKhzbWxI4BTUJ6RStZKUVh2/mfwYqFS09PYy5pvdXZwG35QSkqT5pkdXZlYKBX196RRvEZdQ==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.17.5"
             }
         },
         "tsconfig-paths": {
@@ -15492,11 +16042,11 @@
             "integrity": "sha512-7iE+Q/2E1lgvxD+c0Ot+GFFmgmfIjt/zCayyruXkXQ84BLT85gHXy0WSoQSiuFX9+d+keE/jiON7notV74ZY+A==",
             "dev": true,
             "requires": {
-                "@types/json5": "0.0.29",
-                "deepmerge": "2.1.1",
-                "json5": "1.0.1",
-                "minimist": "1.2.0",
-                "strip-bom": "3.0.0"
+                "@types/json5": "^0.0.29",
+                "deepmerge": "^2.0.1",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
             },
             "dependencies": {
                 "json5": {
@@ -15505,7 +16055,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.0"
+                        "minimist": "^1.2.0"
                     }
                 }
             }
@@ -15516,9 +16066,9 @@
             "integrity": "sha512-S/gOOPOkV8rIL4LurZ1vUdYCVgo15iX9ZMJ6wx6w2OgcpT/G4wMyHB6WM+xheSqGMrWKuxFul+aXpCju3wmj/g==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "enhanced-resolve": "4.1.0",
-                "tsconfig-paths": "3.7.0"
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "tsconfig-paths": "^3.4.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15527,7 +16077,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -15536,9 +16086,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -15553,7 +16103,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -15570,18 +16120,18 @@
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.15.1",
-                "diff": "3.5.0",
-                "glob": "7.1.2",
-                "js-yaml": "3.11.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.7.1",
-                "semver": "5.5.0",
-                "tslib": "1.9.1",
-                "tsutils": "2.27.1"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.12.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15590,7 +16140,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -15599,9 +16149,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -15616,7 +16166,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -15644,7 +16194,7 @@
                     "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
                     "dev": true,
                     "requires": {
-                        "tslib": "1.9.0"
+                        "tslib": "^1.7.1"
                     }
                 }
             }
@@ -15655,7 +16205,7 @@
             "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
             "dev": true,
             "requires": {
-                "tsutils": "2.27.1"
+                "tsutils": "^2.12.1"
             }
         },
         "tsutils": {
@@ -15664,7 +16214,7 @@
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.1"
+                "tslib": "^1.8.1"
             }
         },
         "tty-browserify": {
@@ -15678,7 +16228,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tv4": {
@@ -15699,7 +16249,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
@@ -15715,7 +16265,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.18"
+                "mime-types": "~2.1.18"
             }
         },
         "typed-react-markdown": {
@@ -15724,7 +16274,7 @@
             "integrity": "sha1-HDra9CvB8NjGoJsKyAhfNt8KNn8=",
             "dev": true,
             "requires": {
-                "@types/react": "0.14.57"
+                "@types/react": "^0.14.44"
             },
             "dependencies": {
                 "@types/react": {
@@ -15747,9 +16297,9 @@
             "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "lodash": "4.17.11",
-                "postinstall-build": "5.0.1"
+                "circular-json": "^0.3.1",
+                "lodash": "^4.17.4",
+                "postinstall-build": "^5.0.1"
             }
         },
         "typescript": {
@@ -15769,8 +16319,8 @@
             "integrity": "sha512-A16UqkHtkQOF340cf21LJXchcftyBTPqNOAmP1J8Plu2m3Q8o+2fAYwgFjLXMKP6ooSPjDoOS6z8j9q+1nEnXg==",
             "dev": true,
             "requires": {
-                "commandpost": "1.3.0",
-                "editorconfig": "0.15.0"
+                "commandpost": "^1.0.0",
+                "editorconfig": "^0.15.0"
             },
             "dependencies": {
                 "editorconfig": {
@@ -15779,12 +16329,12 @@
                     "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
                     "dev": true,
                     "requires": {
-                        "@types/commander": "2.12.2",
-                        "@types/semver": "5.5.0",
-                        "commander": "2.15.1",
-                        "lru-cache": "4.1.3",
-                        "semver": "5.5.0",
-                        "sigmund": "1.0.1"
+                        "@types/commander": "^2.11.0",
+                        "@types/semver": "^5.4.0",
+                        "commander": "^2.11.0",
+                        "lru-cache": "^4.1.1",
+                        "semver": "^5.4.1",
+                        "sigmund": "^1.0.1"
                     }
                 },
                 "lru-cache": {
@@ -15793,8 +16343,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -15812,9 +16362,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -15831,8 +16381,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -15850,9 +16400,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -15871,14 +16421,14 @@
             "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "schema-utils": "0.4.7",
-                "serialize-javascript": "1.5.0",
-                "source-map": "0.6.1",
-                "uglify-es": "3.3.9",
-                "webpack-sources": "1.3.0",
-                "worker-farm": "1.6.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "schema-utils": "^0.4.5",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "uglify-es": "^3.3.4",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
             },
             "dependencies": {
                 "ajv": {
@@ -15887,10 +16437,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "commander": {
@@ -15917,8 +16467,8 @@
                     "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.5.4",
-                        "ajv-keywords": "3.2.0"
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
                     }
                 },
                 "source-map": {
@@ -15933,8 +16483,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.13.0",
-                        "source-map": "0.6.1"
+                        "commander": "~2.13.0",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -15955,8 +16505,8 @@
             "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
             "dev": true,
             "requires": {
-                "buffer": "3.6.0",
-                "through": "2.3.8"
+                "buffer": "^3.0.1",
+                "through": "^2.3.6"
             }
         },
         "unc-path-regex": {
@@ -15976,15 +16526,15 @@
             "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "bach": "1.2.0",
-                "collection-map": "1.0.0",
-                "es6-weak-map": "2.0.2",
-                "last-run": "1.1.1",
-                "object.defaults": "1.1.0",
-                "object.reduce": "1.0.1",
-                "undertaker-registry": "1.0.1"
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
             }
         },
         "undertaker-registry": {
@@ -15999,8 +16549,8 @@
             "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "xtend": "4.0.1"
+                "inherits": "^2.0.1",
+                "xtend": "^4.0.1"
             }
         },
         "unicode": {
@@ -16020,8 +16570,8 @@
             "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
             "dev": true,
             "requires": {
-                "unicode-canonical-property-names-ecmascript": "1.0.4",
-                "unicode-property-aliases-ecmascript": "1.0.4"
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
             }
         },
         "unicode-match-property-value-ecmascript": {
@@ -16042,12 +16592,12 @@
             "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
             "dev": true,
             "requires": {
-                "bail": "1.0.3",
-                "extend": "3.0.1",
-                "is-plain-obj": "1.1.0",
-                "trough": "1.0.3",
-                "vfile": "2.3.0",
-                "x-is-string": "0.1.0"
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "trough": "^1.0.0",
+                "vfile": "^2.0.0",
+                "x-is-string": "^0.1.0"
             }
         },
         "union-value": {
@@ -16056,10 +16606,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -16068,7 +16618,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -16077,10 +16627,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -16097,7 +16647,7 @@
             "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
             "dev": true,
             "requires": {
-                "unique-slug": "2.0.1"
+                "unique-slug": "^2.0.0"
             }
         },
         "unique-slug": {
@@ -16106,7 +16656,7 @@
             "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
             "dev": true,
             "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
             }
         },
         "unique-stream": {
@@ -16115,8 +16665,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "unist-util-is": {
@@ -16131,7 +16681,7 @@
             "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "1.4.0"
+                "unist-util-visit": "^1.1.0"
             }
         },
         "unist-util-stringify-position": {
@@ -16146,7 +16696,7 @@
             "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
             "dev": true,
             "requires": {
-                "unist-util-visit-parents": "2.0.1"
+                "unist-util-visit-parents": "^2.0.0"
             },
             "dependencies": {
                 "unist-util-visit-parents": {
@@ -16155,7 +16705,7 @@
                     "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
                     "dev": true,
                     "requires": {
-                        "unist-util-is": "2.1.2"
+                        "unist-util-is": "^2.1.2"
                     }
                 }
             }
@@ -16183,8 +16733,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -16193,9 +16743,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -16240,7 +16790,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -16281,9 +16831,9 @@
             "integrity": "sha512-vugEeXjyYFBCUOpX+ZuaunbK3QXMKaQ3zUnRfIpRBlGkY7QizCnzyyn2ASfcxsvyU3ef+CJppVywnl3Kgf13Gg==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "mime": "2.3.1",
-                "schema-utils": "1.0.0"
+                "loader-utils": "^1.1.0",
+                "mime": "^2.0.3",
+                "schema-utils": "^1.0.0"
             }
         },
         "url-parse": {
@@ -16291,8 +16841,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "url-parse-lax": {
@@ -16301,7 +16851,7 @@
             "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
             "dev": true,
             "requires": {
-                "prepend-http": "2.0.0"
+                "prepend-http": "^2.0.0"
             }
         },
         "url-to-options": {
@@ -16322,7 +16872,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "util": {
@@ -16345,8 +16895,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "object.getownpropertydescriptors": "2.0.3"
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
             }
         },
         "utila": {
@@ -16378,7 +16928,7 @@
             "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -16387,8 +16937,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "validator": {
@@ -16413,9 +16963,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vfile": {
@@ -16424,10 +16974,10 @@
             "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
+                "is-buffer": "^1.1.4",
                 "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "1.1.2",
-                "vfile-message": "1.0.1"
+                "unist-util-stringify-position": "^1.0.0",
+                "vfile-message": "^1.0.0"
             },
             "dependencies": {
                 "replace-ext": {
@@ -16450,7 +17000,7 @@
             "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
             "dev": true,
             "requires": {
-                "unist-util-stringify-position": "1.1.2"
+                "unist-util-stringify-position": "^1.1.1"
             }
         },
         "vinyl": {
@@ -16459,8 +17009,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -16470,12 +17020,12 @@
             "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "2.0.0",
-                "vinyl": "1.2.0"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.3.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^2.0.0",
+                "vinyl": "^1.1.0"
             },
             "dependencies": {
                 "pify": {
@@ -16490,7 +17040,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "vinyl": {
@@ -16499,8 +17049,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -16512,23 +17062,23 @@
             "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "fs-mkdirp-stream": "1.0.0",
-                "glob-stream": "6.1.0",
-                "graceful-fs": "4.1.11",
-                "is-valid-glob": "1.0.0",
-                "lazystream": "1.0.0",
-                "lead": "1.0.0",
-                "object.assign": "4.1.0",
-                "pumpify": "1.5.1",
-                "readable-stream": "2.3.6",
-                "remove-bom-buffer": "3.0.0",
-                "remove-bom-stream": "1.2.0",
-                "resolve-options": "1.1.0",
-                "through2": "2.0.3",
-                "to-through": "2.0.0",
-                "value-or-function": "3.0.0",
-                "vinyl": "2.2.0",
-                "vinyl-sourcemap": "1.1.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -16555,13 +17105,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "replace-ext": {
@@ -16576,7 +17126,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "vinyl": {
@@ -16585,12 +17135,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -16601,8 +17151,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -16617,8 +17167,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -16629,13 +17179,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.1.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -16662,12 +17212,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -16693,20 +17243,20 @@
             "integrity": "sha512-YDj5w0TGOcS8XLIdekT4q6LlLV6hv1ZvuT2aGT3KJll4gMz6dUPDgo2VVAf0i0E8igbbZthwvmaUGRwW9yPIaw==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.1",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.2",
-                "mocha": "4.1.0",
-                "request": "2.88.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.9",
-                "url-parse": "1.4.3",
-                "vinyl-fs": "3.0.3",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.1",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.2",
+                "mocha": "^4.0.1",
+                "request": "^2.88.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-fs": "^3.0.3",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "ajv": {
@@ -16715,10 +17265,10 @@
                     "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "aws4": {
@@ -16778,8 +17328,8 @@
                     "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.9.1",
-                        "har-schema": "2.0.0"
+                        "ajv": "^6.5.5",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "has-flag": {
@@ -16806,7 +17356,7 @@
                     "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.38.0"
+                        "mime-db": "~1.38.0"
                     }
                 },
                 "mocha": {
@@ -16839,26 +17389,26 @@
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.1.3",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.22",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "supports-color": {
@@ -16867,7 +17417,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 },
                 "tough-cookie": {
@@ -16876,8 +17426,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 }
             }
@@ -16931,7 +17481,7 @@
             "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.0.tgz",
             "integrity": "sha512-sXBwIcwG4W5MjnDAfXf0hM5ErOcXxEBlix6QJb5ijf0gtecYygrMAqv8hag7sEg/jCCOKQdXJ4K1iZL3GZcJZg==",
             "requires": {
-                "vscode-languageserver-protocol": "3.10.3"
+                "vscode-languageserver-protocol": "^3.10.0"
             }
         },
         "vscode-languageserver": {
@@ -16939,8 +17489,8 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.4.0.tgz",
             "integrity": "sha512-NO4JQg286YLSdU11Fko6cke19kwSob3O0bhf6xDxIJuDhUbFy0VEPRB5ITc3riVmp13+Ki344xtqJYmqfcmCrg==",
             "requires": {
-                "vscode-languageserver-protocol": "3.10.3",
-                "vscode-uri": "1.0.6"
+                "vscode-languageserver-protocol": "^3.10.0",
+                "vscode-uri": "^1.0.3"
             },
             "dependencies": {
                 "vscode-uri": {
@@ -16955,8 +17505,8 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.3.tgz",
             "integrity": "sha512-R9hKsmXmpIXBLpy6I0eztfAcWU0KHr1lADJiJq+VCmdiHGVUJugMIvU6qVCzLP9wRtZ02AF98j09NAKq10hWeQ==",
             "requires": {
-                "vscode-jsonrpc": "3.6.2",
-                "vscode-languageserver-types": "3.10.1"
+                "vscode-jsonrpc": "^3.6.2",
+                "vscode-languageserver-types": "^3.10.1"
             }
         },
         "vscode-languageserver-types": {
@@ -16980,7 +17530,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "0.1.3"
+                "browser-process-hrtime": "^0.1.2"
             }
         },
         "watchpack": {
@@ -16989,9 +17539,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.4",
-                "graceful-fs": "4.1.11",
-                "neo-async": "2.5.2"
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -17000,8 +17550,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "chokidar": {
@@ -17010,18 +17560,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "is-glob": {
@@ -17030,7 +17581,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 }
             }
@@ -17051,26 +17602,26 @@
                 "@webassemblyjs/helper-module-context": "1.7.8",
                 "@webassemblyjs/wasm-edit": "1.7.8",
                 "@webassemblyjs/wasm-parser": "1.7.8",
-                "acorn": "5.7.3",
-                "acorn-dynamic-import": "3.0.0",
-                "ajv": "6.5.4",
-                "ajv-keywords": "3.2.0",
-                "chrome-trace-event": "1.0.0",
-                "enhanced-resolve": "4.1.0",
-                "eslint-scope": "4.0.0",
-                "json-parse-better-errors": "1.0.2",
-                "loader-runner": "2.3.1",
-                "loader-utils": "1.1.0",
-                "memory-fs": "0.4.1",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "neo-async": "2.5.2",
-                "node-libs-browser": "2.1.0",
-                "schema-utils": "0.4.7",
-                "tapable": "1.1.0",
-                "uglifyjs-webpack-plugin": "1.3.0",
-                "watchpack": "1.6.0",
-                "webpack-sources": "1.3.0"
+                "acorn": "^5.6.2",
+                "acorn-dynamic-import": "^3.0.0",
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0",
+                "chrome-trace-event": "^1.0.0",
+                "enhanced-resolve": "^4.1.0",
+                "eslint-scope": "^4.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^1.1.0",
+                "memory-fs": "~0.4.1",
+                "micromatch": "^3.1.8",
+                "mkdirp": "~0.5.0",
+                "neo-async": "^2.5.0",
+                "node-libs-browser": "^2.0.0",
+                "schema-utils": "^0.4.4",
+                "tapable": "^1.1.0",
+                "uglifyjs-webpack-plugin": "^1.2.4",
+                "watchpack": "^1.5.0",
+                "webpack-sources": "^1.3.0"
             },
             "dependencies": {
                 "acorn": {
@@ -17085,10 +17636,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.4.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -17109,8 +17660,8 @@
                     "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.5.4",
-                        "ajv-keywords": "3.2.0"
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
                     }
                 }
             }
@@ -17121,18 +17672,18 @@
             "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
             "dev": true,
             "requires": {
-                "acorn": "5.7.3",
-                "bfj": "6.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.19.0",
-                "ejs": "2.6.1",
-                "express": "4.16.4",
-                "filesize": "3.6.1",
-                "gzip-size": "5.0.0",
-                "lodash": "4.17.11",
-                "mkdirp": "0.5.1",
-                "opener": "1.5.1",
-                "ws": "6.1.0"
+                "acorn": "^5.7.3",
+                "bfj": "^6.1.1",
+                "chalk": "^2.4.1",
+                "commander": "^2.18.0",
+                "ejs": "^2.6.1",
+                "express": "^4.16.3",
+                "filesize": "^3.6.1",
+                "gzip-size": "^5.0.0",
+                "lodash": "^4.17.10",
+                "mkdirp": "^0.5.1",
+                "opener": "^1.5.1",
+                "ws": "^6.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -17147,7 +17698,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -17156,9 +17707,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "commander": {
@@ -17179,8 +17730,8 @@
                     "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
                     "dev": true,
                     "requires": {
-                        "duplexer": "0.1.1",
-                        "pify": "3.0.0"
+                        "duplexer": "^0.1.1",
+                        "pify": "^3.0.0"
                     }
                 },
                 "has-flag": {
@@ -17201,7 +17752,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "ws": {
@@ -17210,7 +17761,7 @@
                     "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0"
+                        "async-limiter": "~1.0.0"
                     }
                 }
             }
@@ -17221,16 +17772,16 @@
             "integrity": "sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "enhanced-resolve": "4.1.0",
-                "global-modules-path": "2.3.0",
-                "import-local": "2.0.0",
-                "interpret": "1.1.0",
-                "loader-utils": "1.1.0",
-                "supports-color": "5.5.0",
-                "v8-compile-cache": "2.0.2",
-                "yargs": "12.0.2"
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "enhanced-resolve": "^4.1.0",
+                "global-modules-path": "^2.3.0",
+                "import-local": "^2.0.0",
+                "interpret": "^1.1.0",
+                "loader-utils": "^1.1.0",
+                "supports-color": "^5.5.0",
+                "v8-compile-cache": "^2.0.2",
+                "yargs": "^12.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17239,7 +17790,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -17248,9 +17799,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -17265,7 +17816,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -17282,10 +17833,10 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "log-symbols": "2.2.0",
-                "loglevelnext": "1.0.5",
-                "uuid": "3.3.2"
+                "chalk": "^2.1.0",
+                "log-symbols": "^2.1.0",
+                "loglevelnext": "^1.0.1",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17294,7 +17845,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -17303,9 +17854,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.5.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -17320,7 +17871,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -17331,7 +17882,7 @@
             "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.17.5"
             }
         },
         "webpack-node-externals": {
@@ -17346,8 +17897,8 @@
             "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
             "dev": true,
             "requires": {
-                "source-list-map": "2.0.0",
-                "source-map": "0.6.1"
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -17364,8 +17915,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.13",
-                "websocket-extensions": "0.1.3"
+                "http-parser-js": ">=0.4.0",
+                "websocket-extensions": ">=0.1.1"
             }
         },
         "websocket-extensions": {
@@ -17389,7 +17940,7 @@
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 }
             }
@@ -17412,9 +17963,9 @@
             "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "1.0.1",
-                "webidl-conversions": "4.0.2"
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
             }
         },
         "whet.extend": {
@@ -17429,7 +17980,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -17462,7 +18013,7 @@
             "integrity": "sha512-OXzQMGpA7MnQQ8AG+uMl5mWR2ezy6fw1+DMHY+wzYP1qkF1jrek87psLBmhZEj+er4efO/GD4R8jXWFierobaA==",
             "dev": true,
             "requires": {
-                "wipe-node-cache": "2.1.0"
+                "wipe-node-cache": "^2.1.0"
             }
         },
         "wordwrap": {
@@ -17477,7 +18028,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "0.1.7"
+                "errno": "~0.1.7"
             }
         },
         "wrap-ansi": {
@@ -17486,8 +18037,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -17496,7 +18047,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "string-width": {
@@ -17505,9 +18056,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 }
             }
@@ -17522,8 +18073,8 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
             "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
             "requires": {
-                "options": "0.0.6",
-                "ultron": "1.0.2"
+                "options": ">=0.0.5",
+                "ultron": "1.0.x"
             }
         },
         "x-is-string": {
@@ -17549,8 +18100,8 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "requires": {
-                "sax": "1.2.4",
-                "xmlbuilder": "9.0.7"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
             }
         },
         "xmlbuilder": {
@@ -17594,18 +18145,18 @@
             "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
             "dev": true,
             "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "2.0.0",
-                "find-up": "3.0.0",
-                "get-caller-file": "1.0.3",
-                "os-locale": "3.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "4.0.0",
-                "yargs-parser": "10.1.0"
+                "cliui": "^4.0.0",
+                "decamelize": "^2.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^10.1.0"
             },
             "dependencies": {
                 "decamelize": {
@@ -17623,7 +18174,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "3.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
                 "locate-path": {
@@ -17632,8 +18183,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "p-limit": {
@@ -17642,7 +18193,7 @@
                     "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
                     "dev": true,
                     "requires": {
-                        "p-try": "2.0.0"
+                        "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
@@ -17651,7 +18202,7 @@
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.0.0"
+                        "p-limit": "^2.0.0"
                     }
                 },
                 "p-try": {
@@ -17674,7 +18225,7 @@
             "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -17691,8 +18242,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -17701,7 +18252,7 @@
             "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         },
         "zone.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.0.0"
             }
         },
         "@babel/core": {
@@ -19,20 +19,20 @@
             "integrity": "sha512-9EWmD0cQAbcXSc+31RIoYgEHx3KQ2CCSMDBhnXrShWvo45TMw+3/55KVxlhkG53kw9tl87DqINgHDgFVhZJV/Q==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.0.0",
-                "@babel/helpers": "^7.1.0",
-                "@babel/parser": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "convert-source-map": "^1.1.0",
-                "debug": "^3.1.0",
-                "json5": "^0.5.0",
-                "lodash": "^4.17.10",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.0.0",
+                "@babel/helpers": "7.1.0",
+                "@babel/parser": "7.1.0",
+                "@babel/template": "7.1.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0",
+                "convert-source-map": "1.5.1",
+                "debug": "3.2.5",
+                "json5": "0.5.1",
+                "lodash": "4.17.11",
+                "resolve": "1.7.1",
+                "semver": "5.5.0",
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "debug": {
@@ -41,7 +41,7 @@
                     "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "lodash": {
@@ -64,11 +64,11 @@
             "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.10",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/types": "7.0.0",
+                "jsesc": "2.5.1",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             },
             "dependencies": {
                 "lodash": {
@@ -85,7 +85,7 @@
             "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -94,8 +94,8 @@
             "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
             "dev": true,
             "requires": {
-                "@babel/helper-explode-assignable-expression": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-explode-assignable-expression": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-builder-react-jsx": {
@@ -104,8 +104,8 @@
             "integrity": "sha512-ebJ2JM6NAKW0fQEqN8hOLxK84RbRz9OkUhGS/Xd5u56ejMfVbayJ4+LykERZCOUM6faa6Fp3SZNX3fcT16MKHw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0",
-                "esutils": "^2.0.0"
+                "@babel/types": "7.0.0",
+                "esutils": "2.0.2"
             }
         },
         "@babel/helper-call-delegate": {
@@ -114,9 +114,9 @@
             "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.0.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-hoist-variables": "7.0.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-define-map": {
@@ -125,9 +125,9 @@
             "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "lodash": "^4.17.10"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/types": "7.0.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "lodash": {
@@ -144,8 +144,8 @@
             "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-function-name": {
@@ -154,9 +154,9 @@
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -165,7 +165,7 @@
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -174,7 +174,7 @@
             "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -183,7 +183,7 @@
             "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-module-imports": {
@@ -192,7 +192,7 @@
             "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-module-transforms": {
@@ -201,12 +201,12 @@
             "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "lodash": "^4.17.10"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "@babel/template": "7.1.0",
+                "@babel/types": "7.0.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "lodash": {
@@ -223,7 +223,7 @@
             "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -238,7 +238,7 @@
             "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "lodash": {
@@ -255,11 +255,11 @@
             "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-wrap-function": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-wrap-function": "7.1.0",
+                "@babel/template": "7.1.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-replace-supers": {
@@ -268,10 +268,10 @@
             "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.0.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-member-expression-to-functions": "7.0.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-simple-access": {
@@ -280,8 +280,8 @@
             "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/template": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -290,7 +290,7 @@
             "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helper-wrap-function": {
@@ -299,10 +299,10 @@
             "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/template": "7.1.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/helpers": {
@@ -311,9 +311,9 @@
             "integrity": "sha512-V1jXUTNdTpBn37wqqN73U+eBpzlLHmxA4aDaghJBggmzly/FpIJMHXse9lgdzQQT4gs5jZ5NmYxOL8G3ROc29g==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.0",
-                "@babel/traverse": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/template": "7.1.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/highlight": {
@@ -322,9 +322,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -333,7 +333,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -342,9 +342,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -365,7 +365,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -382,9 +382,9 @@
             "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0",
-                "@babel/plugin-syntax-async-generators": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0",
+                "@babel/plugin-syntax-async-generators": "7.0.0"
             }
         },
         "@babel/plugin-proposal-json-strings": {
@@ -393,8 +393,8 @@
             "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-json-strings": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-json-strings": "7.0.0"
             }
         },
         "@babel/plugin-proposal-object-rest-spread": {
@@ -403,8 +403,8 @@
             "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.0.0"
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
@@ -413,8 +413,8 @@
             "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.0.0"
             }
         },
         "@babel/plugin-proposal-unicode-property-regex": {
@@ -423,9 +423,9 @@
             "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0",
-                "regexpu-core": "^4.2.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0",
+                "regexpu-core": "4.2.0"
             }
         },
         "@babel/plugin-syntax-async-generators": {
@@ -434,7 +434,7 @@
             "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -443,7 +443,7 @@
             "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-jsx": {
@@ -452,7 +452,7 @@
             "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -461,7 +461,7 @@
             "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
@@ -470,7 +470,7 @@
             "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-arrow-functions": {
@@ -479,7 +479,7 @@
             "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-async-to-generator": {
@@ -488,9 +488,9 @@
             "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-remap-async-to-generator": "^7.1.0"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-remap-async-to-generator": "7.1.0"
             }
         },
         "@babel/plugin-transform-block-scoped-functions": {
@@ -499,7 +499,7 @@
             "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-block-scoping": {
@@ -508,8 +508,8 @@
             "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "lodash": "^4.17.10"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "lodash": {
@@ -526,14 +526,14 @@
             "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-define-map": "^7.1.0",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-optimise-call-expression": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "globals": "^11.1.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-define-map": "7.1.0",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-optimise-call-expression": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "globals": "11.7.0"
             }
         },
         "@babel/plugin-transform-computed-properties": {
@@ -542,7 +542,7 @@
             "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-destructuring": {
@@ -551,7 +551,7 @@
             "integrity": "sha512-Fr2GtF8YJSXGTyFPakPFB4ODaEKGU04bPsAllAIabwoXdFrPxL0LVXQX5dQWoxOjjgozarJcC9eWGsj0fD6Zsg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-dotall-regex": {
@@ -560,9 +560,9 @@
             "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0",
-                "regexpu-core": "^4.1.3"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0",
+                "regexpu-core": "4.2.0"
             }
         },
         "@babel/plugin-transform-duplicate-keys": {
@@ -571,7 +571,7 @@
             "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-exponentiation-operator": {
@@ -580,8 +580,8 @@
             "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -590,7 +590,7 @@
             "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-function-name": {
@@ -599,8 +599,8 @@
             "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
             "dev": true,
             "requires": {
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-literals": {
@@ -609,7 +609,7 @@
             "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-amd": {
@@ -618,8 +618,8 @@
             "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
@@ -628,9 +628,9 @@
             "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-simple-access": "^7.1.0"
+                "@babel/helper-module-transforms": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-simple-access": "7.1.0"
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -639,8 +639,8 @@
             "integrity": "sha512-8EDKMAsitLkiF/D4Zhe9CHEE2XLh4bfLbb9/Zf3FgXYQOZyZYyg7EAel/aT2A7bHv62jwHf09q2KU/oEexr83g==",
             "dev": true,
             "requires": {
-                "@babel/helper-hoist-variables": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-hoist-variables": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-modules-umd": {
@@ -649,8 +649,8 @@
             "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.1.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-module-transforms": "7.1.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-new-target": {
@@ -659,7 +659,7 @@
             "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-object-super": {
@@ -668,8 +668,8 @@
             "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-replace-supers": "^7.1.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-replace-supers": "7.1.0"
             }
         },
         "@babel/plugin-transform-parameters": {
@@ -678,9 +678,9 @@
             "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
             "dev": true,
             "requires": {
-                "@babel/helper-call-delegate": "^7.1.0",
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-call-delegate": "7.1.0",
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-display-name": {
@@ -689,7 +689,7 @@
             "integrity": "sha512-BX8xKuQTO0HzINxT6j/GiCwoJB0AOMs0HmLbEnAvcte8U8rSkNa/eSCAY+l1OA4JnCVq2jw2p6U8QQryy2fTPg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx": {
@@ -698,9 +698,9 @@
             "integrity": "sha512-0TMP21hXsSUjIQJmu/r7RiVxeFrXRcMUigbKu0BLegJK9PkYodHstaszcig7zxXfaBji2LYUdtqIkHs+hgYkJQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-builder-react-jsx": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.0.0"
+                "@babel/helper-builder-react-jsx": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
@@ -709,8 +709,8 @@
             "integrity": "sha512-pymy+AK12WO4safW1HmBpwagUQRl9cevNX+82AIAtU1pIdugqcH+nuYP03Ja6B+N4gliAaKWAegIBL/ymALPHA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.0.0"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
@@ -719,8 +719,8 @@
             "integrity": "sha512-OSeEpFJEH5dw/TtxTg4nijl4nHBbhqbKL94Xo/Y17WKIf2qJWeIk/QeXACF19lG1vMezkxqruwnTjVizaW7u7w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-syntax-jsx": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-syntax-jsx": "7.0.0"
             }
         },
         "@babel/plugin-transform-regenerator": {
@@ -729,7 +729,7 @@
             "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
             "dev": true,
             "requires": {
-                "regenerator-transform": "^0.13.3"
+                "regenerator-transform": "0.13.3"
             }
         },
         "@babel/plugin-transform-shorthand-properties": {
@@ -738,7 +738,7 @@
             "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-spread": {
@@ -747,7 +747,7 @@
             "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-sticky-regex": {
@@ -756,8 +756,8 @@
             "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0"
             }
         },
         "@babel/plugin-transform-template-literals": {
@@ -766,8 +766,8 @@
             "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-annotate-as-pure": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-annotate-as-pure": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-typeof-symbol": {
@@ -776,7 +776,7 @@
             "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/plugin-transform-unicode-regex": {
@@ -785,9 +785,9 @@
             "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/helper-regex": "^7.0.0",
-                "regexpu-core": "^4.1.3"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/helper-regex": "7.0.0",
+                "regexpu-core": "4.2.0"
             }
         },
         "@babel/preset-env": {
@@ -796,47 +796,47 @@
             "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
-                "@babel/plugin-proposal-json-strings": "^7.0.0",
-                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-                "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
-                "@babel/plugin-syntax-async-generators": "^7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
-                "@babel/plugin-transform-arrow-functions": "^7.0.0",
-                "@babel/plugin-transform-async-to-generator": "^7.1.0",
-                "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
-                "@babel/plugin-transform-block-scoping": "^7.0.0",
-                "@babel/plugin-transform-classes": "^7.1.0",
-                "@babel/plugin-transform-computed-properties": "^7.0.0",
-                "@babel/plugin-transform-destructuring": "^7.0.0",
-                "@babel/plugin-transform-dotall-regex": "^7.0.0",
-                "@babel/plugin-transform-duplicate-keys": "^7.0.0",
-                "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
-                "@babel/plugin-transform-for-of": "^7.0.0",
-                "@babel/plugin-transform-function-name": "^7.1.0",
-                "@babel/plugin-transform-literals": "^7.0.0",
-                "@babel/plugin-transform-modules-amd": "^7.1.0",
-                "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-                "@babel/plugin-transform-modules-systemjs": "^7.0.0",
-                "@babel/plugin-transform-modules-umd": "^7.1.0",
-                "@babel/plugin-transform-new-target": "^7.0.0",
-                "@babel/plugin-transform-object-super": "^7.1.0",
-                "@babel/plugin-transform-parameters": "^7.1.0",
-                "@babel/plugin-transform-regenerator": "^7.0.0",
-                "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-                "@babel/plugin-transform-spread": "^7.0.0",
-                "@babel/plugin-transform-sticky-regex": "^7.0.0",
-                "@babel/plugin-transform-template-literals": "^7.0.0",
-                "@babel/plugin-transform-typeof-symbol": "^7.0.0",
-                "@babel/plugin-transform-unicode-regex": "^7.0.0",
-                "browserslist": "^4.1.0",
-                "invariant": "^2.2.2",
-                "js-levenshtein": "^1.1.3",
-                "semver": "^5.3.0"
+                "@babel/helper-module-imports": "7.0.0",
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "7.1.0",
+                "@babel/plugin-proposal-json-strings": "7.0.0",
+                "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+                "@babel/plugin-proposal-optional-catch-binding": "7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "7.0.0",
+                "@babel/plugin-syntax-async-generators": "7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "7.0.0",
+                "@babel/plugin-transform-arrow-functions": "7.0.0",
+                "@babel/plugin-transform-async-to-generator": "7.1.0",
+                "@babel/plugin-transform-block-scoped-functions": "7.0.0",
+                "@babel/plugin-transform-block-scoping": "7.0.0",
+                "@babel/plugin-transform-classes": "7.1.0",
+                "@babel/plugin-transform-computed-properties": "7.0.0",
+                "@babel/plugin-transform-destructuring": "7.0.0",
+                "@babel/plugin-transform-dotall-regex": "7.0.0",
+                "@babel/plugin-transform-duplicate-keys": "7.0.0",
+                "@babel/plugin-transform-exponentiation-operator": "7.1.0",
+                "@babel/plugin-transform-for-of": "7.0.0",
+                "@babel/plugin-transform-function-name": "7.1.0",
+                "@babel/plugin-transform-literals": "7.0.0",
+                "@babel/plugin-transform-modules-amd": "7.1.0",
+                "@babel/plugin-transform-modules-commonjs": "7.1.0",
+                "@babel/plugin-transform-modules-systemjs": "7.0.0",
+                "@babel/plugin-transform-modules-umd": "7.1.0",
+                "@babel/plugin-transform-new-target": "7.0.0",
+                "@babel/plugin-transform-object-super": "7.1.0",
+                "@babel/plugin-transform-parameters": "7.1.0",
+                "@babel/plugin-transform-regenerator": "7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "7.0.0",
+                "@babel/plugin-transform-spread": "7.0.0",
+                "@babel/plugin-transform-sticky-regex": "7.0.0",
+                "@babel/plugin-transform-template-literals": "7.0.0",
+                "@babel/plugin-transform-typeof-symbol": "7.0.0",
+                "@babel/plugin-transform-unicode-regex": "7.0.0",
+                "browserslist": "4.1.1",
+                "invariant": "2.2.4",
+                "js-levenshtein": "1.1.4",
+                "semver": "5.5.0"
             }
         },
         "@babel/preset-react": {
@@ -845,11 +845,11 @@
             "integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@babel/plugin-transform-react-display-name": "^7.0.0",
-                "@babel/plugin-transform-react-jsx": "^7.0.0",
-                "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-                "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0",
+                "@babel/plugin-transform-react-display-name": "7.0.0",
+                "@babel/plugin-transform-react-jsx": "7.0.0",
+                "@babel/plugin-transform-react-jsx-self": "7.0.0",
+                "@babel/plugin-transform-react-jsx-source": "7.0.0"
             }
         },
         "@babel/runtime": {
@@ -858,7 +858,7 @@
             "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
             "dev": true,
             "requires": {
-                "regenerator-runtime": "^0.12.0"
+                "regenerator-runtime": "0.12.1"
             }
         },
         "@babel/runtime-corejs2": {
@@ -867,8 +867,8 @@
             "integrity": "sha512-drxaPByExlcRDKW4ZLubUO4ZkI8/8ax9k9wve1aEthdLKFzjB7XRkOQ0xoTIWGxqdDnWDElkjYq77bt7yrcYJQ==",
             "dev": true,
             "requires": {
-                "core-js": "^2.5.7",
-                "regenerator-runtime": "^0.12.0"
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.12.1"
             }
         },
         "@babel/template": {
@@ -877,9 +877,9 @@
             "integrity": "sha512-yZ948B/pJrwWGY6VxG6XRFsVTee3IQ7bihq9zFpM00Vydu6z5Xwg0C3J644kxI9WOTzd+62xcIsQ+AT1MGhqhA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/code-frame": "7.0.0",
+                "@babel/parser": "7.1.0",
+                "@babel/types": "7.0.0"
             }
         },
         "@babel/traverse": {
@@ -888,15 +888,15 @@
             "integrity": "sha512-bwgln0FsMoxm3pLOgrrnGaXk18sSM9JNf1/nHC/FksmNGFbYnPWY4GYCfLxyP1KRmfsxqkRpfoa6xr6VuuSxdw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.0.0",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "debug": "^3.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.10"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.0.0",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "@babel/parser": "7.1.0",
+                "@babel/types": "7.0.0",
+                "debug": "3.2.5",
+                "globals": "11.7.0",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "debug": {
@@ -905,7 +905,7 @@
                     "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "lodash": {
@@ -928,9 +928,9 @@
             "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.10",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "2.0.0"
             },
             "dependencies": {
                 "lodash": {
@@ -947,12 +947,12 @@
             "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
             "dev": true,
             "requires": {
-                "@emotion/hash": "^0.6.6",
-                "@emotion/memoize": "^0.6.6",
-                "@emotion/serialize": "^0.9.1",
-                "convert-source-map": "^1.5.1",
-                "find-root": "^1.1.0",
-                "source-map": "^0.7.2"
+                "@emotion/hash": "0.6.6",
+                "@emotion/memoize": "0.6.6",
+                "@emotion/serialize": "0.9.1",
+                "convert-source-map": "1.5.1",
+                "find-root": "1.1.0",
+                "source-map": "0.7.3"
             },
             "dependencies": {
                 "source-map": {
@@ -981,10 +981,10 @@
             "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
             "dev": true,
             "requires": {
-                "@emotion/hash": "^0.6.6",
-                "@emotion/memoize": "^0.6.6",
-                "@emotion/unitless": "^0.6.7",
-                "@emotion/utils": "^0.8.2"
+                "@emotion/hash": "0.6.6",
+                "@emotion/memoize": "0.6.6",
+                "@emotion/unitless": "0.6.7",
+                "@emotion/utils": "0.8.2"
             }
         },
         "@emotion/stylis": {
@@ -1011,11 +1011,11 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.3",
-                "css": "^2.2.1",
-                "normalize-path": "^2.1.1",
-                "source-map": "^0.5.6",
-                "through2": "^2.0.3"
+                "acorn": "5.5.3",
+                "css": "2.2.3",
+                "normalize-path": "2.1.1",
+                "source-map": "0.5.7",
+                "through2": "2.0.3"
             }
         },
         "@gulp-sourcemaps/map-sources": {
@@ -1024,8 +1024,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "^2.0.1",
-                "through2": "^2.0.3"
+                "normalize-path": "2.1.1",
+                "through2": "2.0.3"
             }
         },
         "@jupyterlab/coreutils": {
@@ -1033,16 +1033,16 @@
             "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.1.4.tgz",
             "integrity": "sha512-jSjn+xZj+kJrSWJ2Hz3jpxq0EXNpQrsnf+dD+pnDPc8mAeQ2XVu/x63VZyIDx8u2MELrIodFsUmQTxeudXKlOg==",
             "requires": {
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/coreutils": "^1.3.0",
-                "@phosphor/disposable": "^1.1.2",
-                "@phosphor/signaling": "^1.2.2",
-                "ajv": "~5.1.6",
-                "comment-json": "^1.1.3",
-                "minimist": "~1.2.0",
-                "moment": "~2.21.0",
-                "path-posix": "~1.0.0",
-                "url-parse": "~1.4.3"
+                "@phosphor/algorithm": "1.1.2",
+                "@phosphor/coreutils": "1.3.0",
+                "@phosphor/disposable": "1.1.2",
+                "@phosphor/signaling": "1.2.2",
+                "ajv": "5.1.6",
+                "comment-json": "1.1.3",
+                "minimist": "1.2.0",
+                "moment": "2.21.0",
+                "path-posix": "1.0.0",
+                "url-parse": "1.4.3"
             },
             "dependencies": {
                 "ajv": {
@@ -1050,9 +1050,9 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
                     "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
                     "requires": {
-                        "co": "^4.6.0",
-                        "json-schema-traverse": "^0.3.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "json-schema-traverse": "0.3.1",
+                        "json-stable-stringify": "1.0.1"
                     }
                 }
             }
@@ -1062,11 +1062,11 @@
             "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.0.7.tgz",
             "integrity": "sha512-EbmQH7+9SOBZXq3wOhBII7DQXeOeu7v5v8qPK7hJrjGUWSZhGYGglzm05ou5bP/Q2h+Y+Ar3tYX/LUupR6JuaA==",
             "requires": {
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/coreutils": "^1.3.0",
-                "@phosphor/disposable": "^1.1.2",
-                "@phosphor/messaging": "^1.2.2",
-                "@phosphor/signaling": "^1.2.2"
+                "@phosphor/algorithm": "1.1.2",
+                "@phosphor/coreutils": "1.3.0",
+                "@phosphor/disposable": "1.1.2",
+                "@phosphor/messaging": "1.2.2",
+                "@phosphor/signaling": "1.2.2"
             }
         },
         "@jupyterlab/services": {
@@ -1074,14 +1074,14 @@
             "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.1.4.tgz",
             "integrity": "sha512-EK8WDbqGWsbsYAtd1AbpelaXOrtuHDgV5fNcdXTnHyhvA/uXn/yYRI+mKO2sTjVjAjVL6n/XNomd0czzp+kiGg==",
             "requires": {
-                "@jupyterlab/coreutils": "^2.1.4",
-                "@jupyterlab/observables": "^2.0.7",
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/coreutils": "^1.3.0",
-                "@phosphor/disposable": "^1.1.2",
-                "@phosphor/signaling": "^1.2.2",
-                "node-fetch": "~1.7.3",
-                "ws": "~1.1.4"
+                "@jupyterlab/coreutils": "2.1.4",
+                "@jupyterlab/observables": "2.0.7",
+                "@phosphor/algorithm": "1.1.2",
+                "@phosphor/coreutils": "1.3.0",
+                "@phosphor/disposable": "1.1.2",
+                "@phosphor/signaling": "1.2.2",
+                "node-fetch": "1.7.3",
+                "ws": "1.1.5"
             }
         },
         "@mapbox/polylabel": {
@@ -1090,7 +1090,7 @@
             "integrity": "sha1-xXFGGbZa3QgmOOoGAn5psUUA76Y=",
             "dev": true,
             "requires": {
-                "tinyqueue": "^1.1.0"
+                "tinyqueue": "1.2.3"
             }
         },
         "@nteract/markdown": {
@@ -1099,11 +1099,11 @@
             "integrity": "sha512-nRJuAfX+3n/geJAQj6IqEsbhpiPOjyFlUTzh1bdT2hyLGbd2VdbANXDliWTDKVHOHYWxh0zOLQhRvQ4B6G5QlQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "@nteract/mathjax": "^2.1.4",
-                "babel-runtime": "^6.26.0",
-                "prop-types": "^15.6.1",
-                "react-markdown": "^3.1.4"
+                "@babel/runtime-corejs2": "7.1.2",
+                "@nteract/mathjax": "2.1.4",
+                "babel-runtime": "6.26.0",
+                "prop-types": "15.6.2",
+                "react-markdown": "3.6.0"
             }
         },
         "@nteract/mathjax": {
@@ -1112,9 +1112,9 @@
             "integrity": "sha512-dY+h3iBsfioSg+33uB04LE9tIt79ClbEumXKz7eciS251jXw8VZcmo/YFqldThpgckbCvveNCliM4Y5sTk1gog==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "babel-runtime": "^6.26.0",
-                "prop-types": "^15.6.1"
+                "@babel/runtime-corejs2": "7.1.2",
+                "babel-runtime": "6.26.0",
+                "prop-types": "15.6.2"
             }
         },
         "@nteract/octicons": {
@@ -1123,8 +1123,8 @@
             "integrity": "sha512-spBTHmaD4+W/Ww0UQt1uXmeYGM5GBA5TExdcuDBn3dLWqsfwjf1nTEfygLx4TRtuqImfPAuUHM4iV+2WkXgMBg==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "babel-runtime": "^6.26.0"
+                "@babel/runtime-corejs2": "7.1.2",
+                "babel-runtime": "6.26.0"
             }
         },
         "@nteract/plotly": {
@@ -1139,20 +1139,20 @@
             "integrity": "sha512-lPLmZJSiTn6x3zo3zQM+xgY6XXAg2ocrqhQb+zczfPPlINs9TeOmT39R2+QKO9VycOhPIGlAh1n/IHRQOAE6eQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.0.0",
-                "@babel/runtime-corejs2": "^7.0.0",
-                "@nteract/octicons": "^0.4.3",
-                "@nteract/transform-plotly": "^3.2.3",
-                "d3-time-format": "^2.0.5",
-                "lodash": "^4.17.4",
-                "moment": "^2.18.1",
-                "numeral": "^2.0.6",
-                "react-color": "^2.14.1",
-                "react-hot-loader": "^4.1.2",
-                "react-table": "^6.8.6",
+                "@babel/runtime": "7.1.2",
+                "@babel/runtime-corejs2": "7.1.2",
+                "@nteract/octicons": "0.4.3",
+                "@nteract/transform-plotly": "3.2.3",
+                "d3-time-format": "2.1.3",
+                "lodash": "4.17.11",
+                "moment": "2.21.0",
+                "numeral": "2.0.6",
+                "react-color": "2.14.1",
+                "react-hot-loader": "4.3.11",
+                "react-table": "6.8.6",
                 "react-table-hoc-fixed-columns": "1.0.1",
-                "semiotic": "^1.14.4",
-                "tv4": "^1.3.0"
+                "semiotic": "1.15.1",
+                "tv4": "1.3.0"
             }
         },
         "@nteract/transform-geojson": {
@@ -1161,9 +1161,9 @@
             "integrity": "sha512-7LDEUik1DNr11ajp66LqfEnP+CYi0XtaUVJMKN4U+YyGCYcLqtHi9OkLF6jjGe/6SSyL+ukzVU/LNSRJRMN+dA==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "babel-runtime": "^6.26.0",
-                "leaflet": "^1.0.3"
+                "@babel/runtime-corejs2": "7.1.2",
+                "babel-runtime": "6.26.0",
+                "leaflet": "1.3.4"
             }
         },
         "@nteract/transform-model-debug": {
@@ -1172,8 +1172,8 @@
             "integrity": "sha512-TVNUtTbc0W3cgbdUMFpTqiCWziMpI/7zsR44bwoFScNFmf//HjsQtcXPwj418AHLmywblIeMbtiLFDhrpbpfww==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "babel-runtime": "^6.26.0"
+                "@babel/runtime-corejs2": "7.1.2",
+                "babel-runtime": "6.26.0"
             }
         },
         "@nteract/transform-plotly": {
@@ -1182,10 +1182,10 @@
             "integrity": "sha512-JPBwW39glHcBF6swMIGWERw8+kcVIonoADPhrnseQcyScjx69Kd7tkAy58iCnVrV4fFvOUT1W0lGXSNTkMAh0Q==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "@nteract/plotly": "^1.0.0",
-                "babel-runtime": "^6.26.0",
-                "lodash": "^4.17.4"
+                "@babel/runtime-corejs2": "7.1.2",
+                "@nteract/plotly": "1.0.0",
+                "babel-runtime": "6.26.0",
+                "lodash": "4.17.11"
             }
         },
         "@nteract/transform-vdom": {
@@ -1194,8 +1194,8 @@
             "integrity": "sha512-NIi4hZzmlXeisZoWU77z++hMGYabunNmDj/wNLAmOCAGnGH6rD3ZTszrBOkP2pPlnm0Je3OqJ2Pun3GZKdCOpQ==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "babel-runtime": "^6.26.0"
+                "@babel/runtime-corejs2": "7.1.2",
+                "babel-runtime": "6.26.0"
             }
         },
         "@nteract/transforms": {
@@ -1204,14 +1204,14 @@
             "integrity": "sha512-Y18j197/Dgz9KMOT+G3ocWQTRZcVVPQnMs6AbUgOSUTvoSiPMZb8ZQtIURRXS/1E1oAg05Ch6lVXlbnyClj4Ag==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "@nteract/markdown": "^2.1.4",
-                "@nteract/mathjax": "^2.1.4",
-                "@nteract/transform-vdom": "^2.2.3",
-                "ansi-to-react": "^3.3.3",
-                "babel-runtime": "^6.26.0",
-                "prop-types": "^15.6.1",
-                "react-json-tree": "^0.11.0"
+                "@babel/runtime-corejs2": "7.1.2",
+                "@nteract/markdown": "2.1.4",
+                "@nteract/mathjax": "2.1.4",
+                "@nteract/transform-vdom": "2.2.3",
+                "ansi-to-react": "3.3.3",
+                "babel-runtime": "6.26.0",
+                "prop-types": "15.6.2",
+                "react-json-tree": "0.11.0"
             }
         },
         "@phosphor/algorithm": {
@@ -1224,7 +1224,7 @@
             "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.2.tgz",
             "integrity": "sha1-xMC4uREpkF+zap8kPy273kYtq40=",
             "requires": {
-                "@phosphor/algorithm": "^1.1.2"
+                "@phosphor/algorithm": "1.1.2"
             }
         },
         "@phosphor/coreutils": {
@@ -1237,7 +1237,7 @@
             "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.1.2.tgz",
             "integrity": "sha1-oZLdai5sadXQnTns8zTauTd4Bg4=",
             "requires": {
-                "@phosphor/algorithm": "^1.1.2"
+                "@phosphor/algorithm": "1.1.2"
             }
         },
         "@phosphor/messaging": {
@@ -1245,8 +1245,8 @@
             "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.2.tgz",
             "integrity": "sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=",
             "requires": {
-                "@phosphor/algorithm": "^1.1.2",
-                "@phosphor/collections": "^1.1.2"
+                "@phosphor/algorithm": "1.1.2",
+                "@phosphor/collections": "1.1.2"
             }
         },
         "@phosphor/signaling": {
@@ -1254,7 +1254,7 @@
             "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.2.tgz",
             "integrity": "sha1-P8+Xyojji/s1f+j+a/dRM0elFKk=",
             "requires": {
-                "@phosphor/algorithm": "^1.1.2"
+                "@phosphor/algorithm": "1.1.2"
             }
         },
         "@sindresorhus/is": {
@@ -1287,7 +1287,7 @@
             "integrity": "sha512-/kgYvj5Pwiv/bOlJ6c5GlRF/W6lUGSLrpQGl/7Gg6w7tvBYcf0iF91+wwyuwDYGO2zM0wNpcoPixZVif8I/r6g==",
             "dev": true,
             "requires": {
-                "@types/chai": "*"
+                "@types/chai": "4.1.3"
             }
         },
         "@types/chai-as-promised": {
@@ -1296,7 +1296,7 @@
             "integrity": "sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==",
             "dev": true,
             "requires": {
-                "@types/chai": "*"
+                "@types/chai": "4.1.3"
             }
         },
         "@types/cheerio": {
@@ -1317,7 +1317,7 @@
             "integrity": "sha512-b2oEEnno1LIGKMR7uBEsr40al1UijF1HEpRn0+Yf1xOLl24iQgB7DBpZVMM7y54G5wCNoclDrRO65E6KHPNO2w==",
             "dev": true,
             "requires": {
-                "@types/tern": "*"
+                "@types/tern": "0.22.1"
             }
         },
         "@types/commander": {
@@ -1326,7 +1326,7 @@
             "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
             "dev": true,
             "requires": {
-                "commander": "*"
+                "commander": "2.15.1"
             }
         },
         "@types/copy-webpack-plugin": {
@@ -1335,8 +1335,8 @@
             "integrity": "sha512-/L0m5kc7pKGpsu97TTgAP6YcVRmau2Wj0HpRPQBGEbZXT1DZkdozZPCZHGDWXpxcvWDFTxob2JmYJj3RC7CwFA==",
             "dev": true,
             "requires": {
-                "@types/minimatch": "*",
-                "@types/webpack": "*"
+                "@types/minimatch": "3.0.3",
+                "@types/webpack": "4.4.19"
             }
         },
         "@types/decompress": {
@@ -1345,7 +1345,7 @@
             "integrity": "sha512-2jlSsNAVhrWJtgOV3V85MJ09yRoeUTUWQeeusNYAcJVkUmoVRVElvmkWN0TK+Lgdlyd9pIRyja/DTBcyqD8xyA==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/del": {
@@ -1354,7 +1354,7 @@
             "integrity": "sha512-y6qRq6raBuu965clKgx6FHuiPu3oHdtmzMPXi8Uahsjdq1L6DL5fS/aY5/s71YwM7k6K1QIWvem5vNwlnNGIkQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "*"
+                "@types/glob": "5.0.35"
             }
         },
         "@types/diff-match-patch": {
@@ -1369,9 +1369,9 @@
             "integrity": "sha512-gwRnrp1yFweJhPGBR01nfesxYcml8SayxHEwA6x+1T+Lqez5iMdCRJgt/I9HqpjMi5Mmtb/7MswY6FN4bMypNg==",
             "dev": true,
             "requires": {
-                "@types/decompress": "*",
-                "@types/got": "*",
-                "@types/node": "*"
+                "@types/decompress": "4.2.2",
+                "@types/got": "8.3.1",
+                "@types/node": "9.4.7"
             }
         },
         "@types/enzyme": {
@@ -1380,8 +1380,8 @@
             "integrity": "sha512-jvAbagrpoSNAXeZw2kRpP10eTsSIH8vW1IBLCXbN0pbZsYZU8FvTPMMd5OzSWUKWTQfrbXFUY8e6un/W4NpqIA==",
             "dev": true,
             "requires": {
-                "@types/cheerio": "*",
-                "@types/react": "*"
+                "@types/cheerio": "0.22.9",
+                "@types/react": "16.4.14"
             }
         },
         "@types/enzyme-adapter-react-16": {
@@ -1390,7 +1390,7 @@
             "integrity": "sha512-9eRLBsC/Djkys05BdTWgav8v6fSCjyzjNuLwG2sfa2b2g/VAN10luP0zB0VwtOWFQ0LGjIboJJvIsVdU5gqRmg==",
             "dev": true,
             "requires": {
-                "@types/enzyme": "*"
+                "@types/enzyme": "3.1.14"
             }
         },
         "@types/estree": {
@@ -1405,7 +1405,7 @@
             "integrity": "sha512-LLiivgWKii4JeMzFy3trrxqkRrVSdue8WmbXyHuSJLwNrhIQU5MTrc65jhxEPwMyh5HR1xevSdD+k2nnSRKw9g==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/events": {
@@ -1420,7 +1420,7 @@
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/fs-extra": {
@@ -1429,7 +1429,7 @@
             "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/get-port": {
@@ -1444,9 +1444,9 @@
             "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
-                "@types/minimatch": "*",
-                "@types/node": "*"
+                "@types/events": "1.2.0",
+                "@types/minimatch": "3.0.3",
+                "@types/node": "9.4.7"
             }
         },
         "@types/got": {
@@ -1455,7 +1455,7 @@
             "integrity": "sha512-CGEPw67/Ub6gNMusk062tueurxN+HyjDCvYl4QVBKiSO+fqluXmRX/wSqST/4RtKth4mz8lDZiaZIpXr/uPROg==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/html-minifier": {
@@ -1464,9 +1464,9 @@
             "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
             "dev": true,
             "requires": {
-                "@types/clean-css": "*",
-                "@types/relateurl": "*",
-                "@types/uglify-js": "*"
+                "@types/clean-css": "3.4.30",
+                "@types/relateurl": "0.2.28",
+                "@types/uglify-js": "3.0.4"
             }
         },
         "@types/html-webpack-plugin": {
@@ -1475,9 +1475,9 @@
             "integrity": "sha512-in9rViBsTRB4ZApndZ12It68nGzSMHVK30JD7c49iLIHMFeTPbP7I7wevzMv7re2o0k5TlU6Ry/beyrmgWX7Bg==",
             "dev": true,
             "requires": {
-                "@types/html-minifier": "*",
-                "@types/tapable": "*",
-                "@types/webpack": "*"
+                "@types/html-minifier": "3.5.2",
+                "@types/tapable": "1.0.4",
+                "@types/webpack": "4.4.19"
             }
         },
         "@types/iconv-lite": {
@@ -1486,7 +1486,7 @@
             "integrity": "sha1-qjuL2ivlErGuCgV7lC6GnDcKVWk=",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/istanbul": {
@@ -1501,10 +1501,10 @@
             "integrity": "sha512-XHMNZFQ0Ih3A4/NTWAO15+OsQafPKnQCanN0FYGbsTM/EoI5EoEAvvkF51/DQC2BT5low4tomp7k2RLMlriA5Q==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*",
-                "parse5": "^4.0.0"
+                "@types/events": "1.2.0",
+                "@types/node": "9.4.7",
+                "@types/tough-cookie": "2.3.3",
+                "parse5": "4.0.0"
             },
             "dependencies": {
                 "parse5": {
@@ -1527,8 +1527,8 @@
             "integrity": "sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==",
             "dev": true,
             "requires": {
-                "@types/node": "*",
-                "@types/webpack": "*"
+                "@types/node": "9.4.7",
+                "@types/webpack": "4.4.19"
             }
         },
         "@types/lodash": {
@@ -1543,7 +1543,7 @@
             "integrity": "sha1-k+I0N/zRenucqY0CqmAC6DWEL+g=",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/minimatch": {
@@ -1582,8 +1582,8 @@
             "integrity": "sha512-Gh8irag2dbZ2K6vPn+S8+LNrULuG3zlCgJjVUrvuiUK7waw9d9CFk2A/tZFyGhcMDUyO7tznbx1ZasqlAGjHxA==",
             "dev": true,
             "requires": {
-                "@types/prop-types": "*",
-                "csstype": "^2.2.0"
+                "@types/prop-types": "15.5.6",
+                "csstype": "2.5.7"
             }
         },
         "@types/react-codemirror": {
@@ -1592,8 +1592,8 @@
             "integrity": "sha512-59UY5C5EVaFq/f+p1mkgLpNQELehdCNGTiLuFYacjptTzDDSyMKF4Zrs1z2WJWQSh53vIeuS8i2JrPFyfHjxBw==",
             "dev": true,
             "requires": {
-                "@types/codemirror": "*",
-                "@types/react": "*"
+                "@types/codemirror": "0.0.71",
+                "@types/react": "16.4.14"
             }
         },
         "@types/react-dom": {
@@ -1602,8 +1602,8 @@
             "integrity": "sha512-WF/KAOia7pskV+J8f+UlNuFeCRkJuJAkyyeYPPtNe6suw0y7cWyUP/DPdPXsGUwQEkv2qlLVSrgVaoCm/PmO0Q==",
             "dev": true,
             "requires": {
-                "@types/node": "*",
-                "@types/react": "*"
+                "@types/node": "9.4.7",
+                "@types/react": "16.4.14"
             }
         },
         "@types/react-json-tree": {
@@ -1612,7 +1612,7 @@
             "integrity": "sha512-OyCFv5pHZXVULzjbNXBz+Il+vcYz8RzHl1BXQ297XMBTu4+oqVdZUVgU/PMmndSO05met1KqtKVJaj2K5K79+g==",
             "dev": true,
             "requires": {
-                "@types/react": "*"
+                "@types/react": "16.4.14"
             }
         },
         "@types/relateurl": {
@@ -1627,10 +1627,10 @@
             "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "dev": true,
             "requires": {
-                "@types/caseless": "*",
-                "@types/form-data": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*"
+                "@types/caseless": "0.12.1",
+                "@types/form-data": "2.2.1",
+                "@types/node": "9.4.7",
+                "@types/tough-cookie": "2.3.3"
             }
         },
         "@types/semver": {
@@ -1675,7 +1675,7 @@
             "integrity": "sha512-gyIhOlWPqI8vtYTlRb61HKV7x+3wjpJIQi8mTaweVtEMvhIV6Xajo8FVcNJWeJOBuedRCzK2Uy+uhj/rJmR9oQ==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/tern": {
@@ -1684,7 +1684,7 @@
             "integrity": "sha512-CRzPRkg8hYLwunsj61r+rqPJQbiCIEQqlMMY/0k7krgIsoSaFgGg1ZH2f9qaR1YpenaMl6PnlTtUkCbNH/uo+A==",
             "dev": true,
             "requires": {
-                "@types/estree": "*"
+                "@types/estree": "0.0.39"
             }
         },
         "@types/tmp": {
@@ -1705,7 +1705,7 @@
             "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
             "dev": true,
             "requires": {
-                "source-map": "^0.6.1"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1728,7 +1728,7 @@
             "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@types/webpack": {
@@ -1737,11 +1737,11 @@
             "integrity": "sha512-vO/PuQ9iF9Gy8spN8RUUjt5reu9Z+Tb7iWxeAopCmXaIZaIsOgtY5U6UE2ELlcRUBO1HbNWhy+lQE9G92IJcmQ==",
             "dev": true,
             "requires": {
-                "@types/anymatch": "*",
-                "@types/node": "*",
-                "@types/tapable": "*",
-                "@types/uglify-js": "*",
-                "source-map": "^0.6.0"
+                "@types/anymatch": "1.3.0",
+                "@types/node": "9.4.7",
+                "@types/tapable": "1.0.4",
+                "@types/uglify-js": "3.0.4",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1758,7 +1758,7 @@
             "integrity": "sha512-+qy5xatScNZW4NbIVaiV38XOeHbKRa4FIPeMf2VDpZEon9W/cxjaVR080vRrRGvfq4tRvOusTEypSMxTvjcSzw==",
             "dev": true,
             "requires": {
-                "@types/webpack": "*"
+                "@types/webpack": "4.4.19"
             }
         },
         "@types/winreg": {
@@ -1773,7 +1773,7 @@
             "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "@webassemblyjs/ast": {
@@ -1850,7 +1850,7 @@
             "integrity": "sha512-tOarWChdG1a3y1yqCX0JMDKzrat5tQe4pV6K/TX19BcXsBLYxFQOL1DEDa5KG9syeyvCrvZ+i1+Mv1ExngvktQ==",
             "dev": true,
             "requires": {
-                "@xtuc/ieee754": "^1.2.0"
+                "@xtuc/ieee754": "1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
@@ -1966,8 +1966,8 @@
             "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
             "dev": true,
             "requires": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
+                "jsonparse": "1.2.0",
+                "through": "2.3.8"
             }
         },
         "abab": {
@@ -1988,7 +1988,7 @@
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.18",
+                "mime-types": "2.1.18",
                 "negotiator": "0.6.1"
             }
         },
@@ -2004,7 +2004,7 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0"
+                "acorn": "5.5.3"
             }
         },
         "acorn-globals": {
@@ -2013,8 +2013,8 @@
             "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
             "dev": true,
             "requires": {
-                "acorn": "^6.0.1",
-                "acorn-walk": "^6.0.1"
+                "acorn": "6.0.2",
+                "acorn-walk": "6.1.0"
             },
             "dependencies": {
                 "acorn": {
@@ -2042,10 +2042,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-errors": {
@@ -2066,9 +2066,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2",
-                "longest": "^1.0.1",
-                "repeat-string": "^1.5.2"
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -2077,7 +2077,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -2100,7 +2100,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "^0.1.0"
+                "ansi-wrap": "0.1.0"
             }
         },
         "ansi-cyan": {
@@ -2154,7 +2154,7 @@
             "integrity": "sha512-ma1GhrnEsR70TvGKneM6Fa1UCB76ZTuVjw9KiO/BSBaJfLFjvoiKC+i2BPBqkRoQaLl35I0Vi2g52XmKEKM7VA==",
             "dev": true,
             "requires": {
-                "entities": "^1.1.1"
+                "entities": "1.1.1"
             }
         },
         "ansi-to-react": {
@@ -2163,10 +2163,10 @@
             "integrity": "sha512-Ztq11TxaO157sv5rcVNa+jlPbGZxNtfslxWv5N5mDzyUWDZtwfiQAul/gegIOh5xTjN/FOoc2X6KBBnFsGbZ+g==",
             "dev": true,
             "requires": {
-                "@babel/runtime-corejs2": "^7.0.0",
-                "anser": "^1.4.1",
-                "babel-runtime": "^6.26.0",
-                "escape-carriage": "^1.2.0"
+                "@babel/runtime-corejs2": "7.1.2",
+                "anser": "1.4.7",
+                "babel-runtime": "6.26.0",
+                "escape-carriage": "1.2.0"
             }
         },
         "ansi-wrap": {
@@ -2181,8 +2181,8 @@
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
-                "micromatch": "^2.1.5",
-                "normalize-path": "^2.0.0"
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2191,7 +2191,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "array-unique": {
@@ -2206,9 +2206,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "^1.8.1",
-                        "preserve": "^0.2.0",
-                        "repeat-element": "^1.1.2"
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
                     }
                 },
                 "expand-brackets": {
@@ -2217,7 +2217,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "^0.1.0"
+                        "is-posix-bracket": "0.1.1"
                     }
                 },
                 "extglob": {
@@ -2226,7 +2226,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2241,7 +2241,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 },
                 "kind-of": {
@@ -2250,7 +2250,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "micromatch": {
@@ -2259,19 +2259,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^2.0.0",
-                        "array-unique": "^0.2.1",
-                        "braces": "^1.8.2",
-                        "expand-brackets": "^0.1.4",
-                        "extglob": "^0.3.1",
-                        "filename-regex": "^2.0.0",
-                        "is-extglob": "^1.0.0",
-                        "is-glob": "^2.0.1",
-                        "kind-of": "^3.0.2",
-                        "normalize-path": "^2.0.1",
-                        "object.omit": "^2.0.0",
-                        "parse-glob": "^3.0.4",
-                        "regex-cache": "^0.4.2"
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.4"
                     }
                 }
             }
@@ -2282,7 +2282,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "^1.0.0"
+                "buffer-equal": "1.0.0"
             }
         },
         "applicationinsights": {
@@ -2318,7 +2318,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "argv": {
@@ -2339,7 +2339,7 @@
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "dev": true,
             "requires": {
-                "make-iterator": "^1.0.0"
+                "make-iterator": "1.0.1"
             }
         },
         "arr-flatten": {
@@ -2354,7 +2354,7 @@
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
             "dev": true,
             "requires": {
-                "make-iterator": "^1.0.0"
+                "make-iterator": "1.0.1"
             }
         },
         "arr-union": {
@@ -2399,8 +2399,8 @@
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
             "dev": true,
             "requires": {
-                "array-slice": "^1.0.0",
-                "is-number": "^4.0.0"
+                "array-slice": "1.1.0",
+                "is-number": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2417,7 +2417,7 @@
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0"
+                "is-number": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2452,9 +2452,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "^1.0.0",
-                "get-value": "^2.0.6",
-                "kind-of": "^5.0.2"
+                "default-compare": "1.0.0",
+                "get-value": "2.0.6",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2471,7 +2471,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -2492,9 +2492,9 @@
             "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.10.0",
-                "function-bind": "^1.1.1"
+                "define-properties": "1.1.2",
+                "es-abstract": "1.12.0",
+                "function-bind": "1.1.1"
             }
         },
         "arrify": {
@@ -2520,9 +2520,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "assert": {
@@ -2580,10 +2580,10 @@
             "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.2",
-                "process-nextick-args": "^1.0.7",
-                "stream-exhaust": "^1.0.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0",
+                "process-nextick-args": "1.0.7",
+                "stream-exhaust": "1.0.2"
             }
         },
         "async-each": {
@@ -2604,7 +2604,7 @@
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
             "dev": true,
             "requires": {
-                "async-done": "^1.2.2"
+                "async-done": "1.3.1"
             }
         },
         "asynckit": {
@@ -2624,14 +2624,14 @@
             "integrity": "sha512-slv66OAJB8orL+UUaTI3pKlLorwIvS4ARZzYR9iJJyGsEgOqueMfOMdKySWzZ73vIkEe3fcwFgsKMg4d8zyb1g==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.1.0",
-                "lodash": "^4.17.5",
-                "micromatch": "^3.1.9",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.5.3",
-                "webpack-log": "^1.2.0"
+                "chalk": "2.4.1",
+                "enhanced-resolve": "4.1.0",
+                "loader-utils": "1.1.0",
+                "lodash": "4.17.11",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.5.9",
+                "webpack-log": "1.2.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2640,7 +2640,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -2649,9 +2649,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -2666,7 +2666,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -2686,15 +2686,15 @@
             "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.1.tgz",
             "integrity": "sha512-rnFo1uMIPtilusRCpK91tfY3P4Q7qRsDNwriXdp+OeTIGkGt0cTxL4mhqYfNPYPK+WBQmBdGWhOk+iROM05dcw==",
             "requires": {
-                "browserify-mime": "~1.2.9",
-                "extend": "~1.2.1",
+                "browserify-mime": "1.2.9",
+                "extend": "1.2.1",
                 "json-edm-parser": "0.1.2",
                 "md5.js": "1.3.4",
-                "readable-stream": "~2.0.0",
-                "request": "^2.86.0",
-                "underscore": "~1.8.3",
-                "uuid": "^3.0.0",
-                "validator": "~9.4.1",
+                "readable-stream": "2.0.6",
+                "request": "2.88.0",
+                "underscore": "1.8.3",
+                "uuid": "3.3.2",
+                "validator": "9.4.1",
                 "xml2js": "0.2.8",
                 "xmlbuilder": "0.4.3"
             },
@@ -2714,8 +2714,8 @@
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
                     "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "requires": {
-                        "ajv": "^5.3.0",
-                        "har-schema": "^2.0.0"
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
                     }
                 },
                 "mime-db": {
@@ -2728,7 +2728,7 @@
                     "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
                     "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
                     "requires": {
-                        "mime-db": "~1.36.0"
+                        "mime-db": "1.36.0"
                     }
                 },
                 "oauth-sign": {
@@ -2741,26 +2741,26 @@
                     "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "requires": {
-                        "aws-sign2": "~0.7.0",
-                        "aws4": "^1.8.0",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.6",
-                        "extend": "~3.0.2",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.3.2",
-                        "har-validator": "~5.1.0",
-                        "http-signature": "~1.2.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.19",
-                        "oauth-sign": "~0.9.0",
-                        "performance-now": "^2.1.0",
-                        "qs": "~6.5.2",
-                        "safe-buffer": "^5.1.2",
-                        "tough-cookie": "~2.4.3",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.3.2"
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.8.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.2",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.1.0",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.20",
+                        "oauth-sign": "0.9.0",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
+                        "tough-cookie": "2.4.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.3.2"
                     },
                     "dependencies": {
                         "extend": {
@@ -2785,8 +2785,8 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.29",
+                        "punycode": "1.4.1"
                     }
                 },
                 "xml2js": {
@@ -2794,7 +2794,7 @@
                     "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
                     "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
                     "requires": {
-                        "sax": "0.5.x"
+                        "sax": "0.5.8"
                     }
                 },
                 "xmlbuilder": {
@@ -2810,9 +2810,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             }
         },
         "babel-loader": {
@@ -2821,10 +2821,10 @@
             "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "^1.0.0",
-                "loader-utils": "^1.0.2",
-                "mkdirp": "^0.5.1",
-                "util.promisify": "^1.0.0"
+                "find-cache-dir": "1.0.0",
+                "loader-utils": "1.1.0",
+                "mkdirp": "0.5.1",
+                "util.promisify": "1.0.0"
             }
         },
         "babel-plugin-emotion": {
@@ -2833,18 +2833,18 @@
             "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.0.0",
-                "@emotion/babel-utils": "^0.6.4",
-                "@emotion/hash": "^0.6.2",
-                "@emotion/memoize": "^0.6.1",
-                "@emotion/stylis": "^0.7.0",
-                "babel-plugin-macros": "^2.0.0",
-                "babel-plugin-syntax-jsx": "^6.18.0",
-                "convert-source-map": "^1.5.0",
-                "find-root": "^1.1.0",
-                "mkdirp": "^0.5.1",
-                "source-map": "^0.5.7",
-                "touch": "^2.0.1"
+                "@babel/helper-module-imports": "7.0.0",
+                "@emotion/babel-utils": "0.6.10",
+                "@emotion/hash": "0.6.6",
+                "@emotion/memoize": "0.6.6",
+                "@emotion/stylis": "0.7.1",
+                "babel-plugin-macros": "2.4.2",
+                "babel-plugin-syntax-jsx": "6.18.0",
+                "convert-source-map": "1.5.1",
+                "find-root": "1.1.0",
+                "mkdirp": "0.5.1",
+                "source-map": "0.5.7",
+                "touch": "2.0.2"
             }
         },
         "babel-plugin-inline-json-import": {
@@ -2853,7 +2853,7 @@
             "integrity": "sha512-cNQhU7de6V6IWJGwHuC5XJaGL3nu7RUCDAow/fXyHIAf/UNFkTkr/MR7+c1O8a01Z70XtTeq9mamfdU74LHW9A==",
             "dev": true,
             "requires": {
-                "decache": "^4.4.0"
+                "decache": "4.4.0"
             }
         },
         "babel-plugin-macros": {
@@ -2862,8 +2862,8 @@
             "integrity": "sha512-NBVpEWN4OQ/bHnu1fyDaAaTPAjnhXCEPqr1RwqxrU7b6tZ2hypp+zX4hlNfmVGfClD5c3Sl6Hfj5TJNF5VG5aA==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "^5.0.5",
-                "resolve": "^1.8.1"
+                "cosmiconfig": "5.0.6",
+                "resolve": "1.8.1"
             },
             "dependencies": {
                 "resolve": {
@@ -2872,7 +2872,7 @@
                     "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "1.0.5"
                     }
                 }
             }
@@ -2889,7 +2889,7 @@
             "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-polyfill": {
@@ -2898,9 +2898,9 @@
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "regenerator-runtime": "^0.10.5"
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.10.5"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -2917,8 +2917,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.11.1"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -2935,10 +2935,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "1.0.3"
             },
             "dependencies": {
                 "to-fast-properties": {
@@ -2955,15 +2955,15 @@
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
             "dev": true,
             "requires": {
-                "arr-filter": "^1.1.1",
-                "arr-flatten": "^1.0.1",
-                "arr-map": "^2.0.0",
-                "array-each": "^1.0.0",
-                "array-initial": "^1.0.0",
-                "array-last": "^1.1.1",
-                "async-done": "^1.2.2",
-                "async-settle": "^1.0.0",
-                "now-and-later": "^2.0.0"
+                "arr-filter": "1.1.2",
+                "arr-flatten": "1.1.0",
+                "arr-map": "2.0.2",
+                "array-each": "1.0.1",
+                "array-initial": "1.1.0",
+                "array-last": "1.3.0",
+                "async-done": "1.3.1",
+                "async-settle": "1.0.0",
+                "now-and-later": "2.0.0"
             }
         },
         "bail": {
@@ -2983,13 +2983,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2998,7 +2998,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3007,7 +3007,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -3016,7 +3016,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -3025,9 +3025,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -3050,7 +3050,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "beeper": {
@@ -3065,10 +3065,10 @@
             "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.1",
-                "check-types": "^7.3.0",
-                "hoopy": "^0.1.2",
-                "tryer": "^1.0.0"
+                "bluebird": "3.5.1",
+                "check-types": "7.4.0",
+                "hoopy": "0.1.4",
+                "tryer": "1.0.1"
             }
         },
         "big.js": {
@@ -3095,8 +3095,8 @@
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.3.5",
-                "safe-buffer": "^5.1.1"
+                "readable-stream": "2.3.6",
+                "safe-buffer": "5.1.2"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -3111,13 +3111,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -3126,7 +3126,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -3137,7 +3137,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "bluebird": {
@@ -3159,15 +3159,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "~1.6.3",
+                "depd": "1.1.2",
+                "http-errors": "1.6.3",
                 "iconv-lite": "0.4.23",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.3.0",
                 "qs": "6.5.2",
                 "raw-body": "2.3.3",
-                "type-is": "~1.6.16"
+                "type-is": "1.6.16"
             },
             "dependencies": {
                 "iconv-lite": {
@@ -3176,7 +3176,7 @@
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 }
             }
@@ -3192,7 +3192,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -3202,16 +3202,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -3220,7 +3220,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -3249,12 +3249,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "^1.0.3",
-                "cipher-base": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.3",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-cipher": {
@@ -3263,9 +3263,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "^1.0.4",
-                "browserify-des": "^1.0.0",
-                "evp_bytestokey": "^1.0.0"
+                "browserify-aes": "1.2.0",
+                "browserify-des": "1.0.2",
+                "evp_bytestokey": "1.0.3"
             }
         },
         "browserify-des": {
@@ -3274,10 +3274,10 @@
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "des.js": "^1.0.0",
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.1.2"
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "browserify-mime": {
@@ -3291,8 +3291,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
             }
         },
         "browserify-sign": {
@@ -3301,13 +3301,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.1",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.2",
-                "elliptic": "^6.0.0",
-                "inherits": "^2.0.1",
-                "parse-asn1": "^5.0.0"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "elliptic": "6.4.1",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.1"
             }
         },
         "browserify-zlib": {
@@ -3316,7 +3316,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "~1.0.5"
+                "pako": "1.0.6"
             }
         },
         "browserslist": {
@@ -3325,9 +3325,9 @@
             "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000884",
-                "electron-to-chromium": "^1.3.62",
-                "node-releases": "^1.0.0-alpha.11"
+                "caniuse-lite": "1.0.30000887",
+                "electron-to-chromium": "1.3.71",
+                "node-releases": "1.0.0-alpha.12"
             }
         },
         "buffer": {
@@ -3337,8 +3337,8 @@
             "dev": true,
             "requires": {
                 "base64-js": "0.0.8",
-                "ieee754": "^1.1.4",
-                "isarray": "^1.0.0"
+                "ieee754": "1.1.11",
+                "isarray": "1.0.0"
             }
         },
         "buffer-alloc": {
@@ -3347,8 +3347,8 @@
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
             "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
+                "buffer-alloc-unsafe": "1.1.0",
+                "buffer-fill": "1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -3411,19 +3411,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.5.1",
-                "chownr": "^1.0.1",
-                "glob": "^7.1.2",
-                "graceful-fs": "^4.1.11",
-                "lru-cache": "^4.1.1",
-                "mississippi": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "move-concurrently": "^1.0.1",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "ssri": "^5.2.4",
-                "unique-filename": "^1.1.0",
-                "y18n": "^4.0.0"
+                "bluebird": "3.5.1",
+                "chownr": "1.1.1",
+                "glob": "7.1.2",
+                "graceful-fs": "4.1.11",
+                "lru-cache": "4.1.3",
+                "mississippi": "2.0.0",
+                "mkdirp": "0.5.1",
+                "move-concurrently": "1.0.1",
+                "promise-inflight": "1.0.1",
+                "rimraf": "2.6.2",
+                "ssri": "5.3.0",
+                "unique-filename": "1.1.1",
+                "y18n": "4.0.0"
             },
             "dependencies": {
                 "lru-cache": {
@@ -3432,8 +3432,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 }
             }
@@ -3444,15 +3444,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             }
         },
         "cacheable-request": {
@@ -3490,8 +3490,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "^2.2.0",
-                "upper-case": "^1.1.1"
+                "no-case": "2.3.2",
+                "upper-case": "1.1.3"
             }
         },
         "caniuse-lite": {
@@ -3511,10 +3511,10 @@
             "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
             "dev": true,
             "requires": {
-                "get-proxy": "^2.0.0",
-                "isurl": "^1.0.0-alpha5",
-                "tunnel-agent": "^0.6.0",
-                "url-to-options": "^1.0.1"
+                "get-proxy": "2.1.0",
+                "isurl": "1.0.0",
+                "tunnel-agent": "0.6.0",
+                "url-to-options": "1.0.1"
             }
         },
         "center-align": {
@@ -3524,8 +3524,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "^0.1.3",
-                "lazy-cache": "^1.0.3"
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
             }
         },
         "chai": {
@@ -3534,12 +3534,12 @@
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
             "dev": true,
             "requires": {
-                "assertion-error": "^1.0.1",
-                "check-error": "^1.0.1",
-                "deep-eql": "^3.0.0",
-                "get-func-name": "^2.0.0",
-                "pathval": "^1.0.0",
-                "type-detect": "^4.0.0"
+                "assertion-error": "1.1.0",
+                "check-error": "1.0.2",
+                "deep-eql": "3.0.1",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.8"
             }
         },
         "chai-arrays": {
@@ -3554,7 +3554,7 @@
             "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
             "dev": true,
             "requires": {
-                "check-error": "^1.0.2"
+                "check-error": "1.0.2"
             }
         },
         "chalk": {
@@ -3563,11 +3563,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
             }
         },
         "character-entities": {
@@ -3617,12 +3617,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "~1.2.0",
-                "dom-serializer": "~0.1.0",
-                "entities": "~1.1.1",
-                "htmlparser2": "^3.9.1",
-                "lodash": "^4.15.0",
-                "parse5": "^3.0.1"
+                "css-select": "1.2.0",
+                "dom-serializer": "0.1.0",
+                "entities": "1.1.1",
+                "htmlparser2": "3.9.2",
+                "lodash": "4.17.11",
+                "parse5": "3.0.3"
             }
         },
         "chokidar": {
@@ -3631,15 +3631,14 @@
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "requires": {
-                "anymatch": "^1.3.0",
-                "async-each": "^1.0.0",
-                "fsevents": "^1.0.0",
-                "glob-parent": "^2.0.0",
-                "inherits": "^2.0.1",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^2.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.0.0"
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -3648,7 +3647,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -3663,7 +3662,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -3680,7 +3679,7 @@
             "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
             "dev": true,
             "requires": {
-                "tslib": "^1.9.0"
+                "tslib": "1.9.1"
             }
         },
         "ci-info": {
@@ -3695,8 +3694,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "circular-json": {
@@ -3711,7 +3710,7 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3"
+                "chalk": "1.1.3"
             }
         },
         "class-utils": {
@@ -3720,10 +3719,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -3732,7 +3731,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -3749,7 +3748,7 @@
             "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
             "dev": true,
             "requires": {
-                "source-map": "~0.6.0"
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -3766,7 +3765,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-table": {
@@ -3798,9 +3797,9 @@
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3815,7 +3814,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -3838,7 +3837,7 @@
             "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
             "dev": true,
             "requires": {
-                "mimic-response": "^1.0.0"
+                "mimic-response": "1.0.0"
             }
         },
         "clone-stats": {
@@ -3853,9 +3852,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.3",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -3870,13 +3869,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -3885,7 +3884,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -3901,7 +3900,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "^1.1.2"
+                "q": "1.5.1"
             }
         },
         "code-point-at": {
@@ -3917,7 +3916,7 @@
             "dev": true,
             "requires": {
                 "argv": "0.0.2",
-                "request": "^2.81.0",
+                "request": "2.87.0",
                 "urlgrey": "0.4.4"
             }
         },
@@ -3939,9 +3938,9 @@
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
             "dev": true,
             "requires": {
-                "arr-map": "^2.0.2",
-                "for-own": "^1.0.0",
-                "make-iterator": "^1.0.0"
+                "arr-map": "2.0.2",
+                "for-own": "1.0.0",
+                "make-iterator": "1.0.1"
             }
         },
         "collection-visit": {
@@ -3950,8 +3949,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -3960,7 +3959,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -3986,7 +3985,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -4006,7 +4005,7 @@
             "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
             "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
             "requires": {
-                "json-parser": "^1.0.0"
+                "json-parser": "1.1.5"
             }
         },
         "commondir": {
@@ -4038,10 +4037,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -4056,13 +4055,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -4071,7 +4070,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -4082,8 +4081,8 @@
             "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
             "dev": true,
             "requires": {
-                "ini": "^1.3.4",
-                "proto-list": "~1.2.1"
+                "ini": "1.3.5",
+                "proto-list": "1.2.4"
             }
         },
         "console-browserify": {
@@ -4092,7 +4091,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "^0.1.4"
+                "date-now": "0.1.4"
             }
         },
         "constants-browserify": {
@@ -4137,12 +4136,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "fs-write-stream-atomic": "^1.0.8",
-                "iferr": "^0.1.5",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.0"
+                "aproba": "1.2.0",
+                "fs-write-stream-atomic": "1.0.10",
+                "iferr": "0.1.5",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "copy-descriptor": {
@@ -4157,8 +4156,8 @@
             "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
             "dev": true,
             "requires": {
-                "each-props": "^1.3.0",
-                "is-plain-object": "^2.0.1"
+                "each-props": "1.3.2",
+                "is-plain-object": "2.0.4"
             }
         },
         "copy-webpack-plugin": {
@@ -4167,14 +4166,14 @@
             "integrity": "sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==",
             "dev": true,
             "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "globby": "^7.1.1",
-                "is-glob": "^4.0.0",
-                "loader-utils": "^1.1.0",
-                "minimatch": "^3.0.4",
-                "p-limit": "^1.0.0",
-                "serialize-javascript": "^1.4.0"
+                "cacache": "10.0.4",
+                "find-cache-dir": "1.0.0",
+                "globby": "7.1.1",
+                "is-glob": "4.0.0",
+                "loader-utils": "1.1.0",
+                "minimatch": "3.0.4",
+                "p-limit": "1.3.0",
+                "serialize-javascript": "1.5.0"
             },
             "dependencies": {
                 "globby": {
@@ -4183,12 +4182,12 @@
                     "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
                     "dev": true,
                     "requires": {
-                        "array-union": "^1.0.1",
-                        "dir-glob": "^2.0.0",
-                        "glob": "^7.1.2",
-                        "ignore": "^3.3.5",
-                        "pify": "^3.0.0",
-                        "slash": "^1.0.0"
+                        "array-union": "1.0.2",
+                        "dir-glob": "2.0.0",
+                        "glob": "7.1.2",
+                        "ignore": "3.3.10",
+                        "pify": "3.0.0",
+                        "slash": "1.0.0"
                     }
                 },
                 "is-glob": {
@@ -4197,7 +4196,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "p-limit": {
@@ -4206,7 +4205,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 }
             }
@@ -4228,9 +4227,9 @@
             "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
             "dev": true,
             "requires": {
-                "is-directory": "^0.3.1",
-                "js-yaml": "^3.9.0",
-                "parse-json": "^4.0.0"
+                "is-directory": "0.3.1",
+                "js-yaml": "3.11.0",
+                "parse-json": "4.0.0"
             },
             "dependencies": {
                 "parse-json": {
@@ -4239,8 +4238,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.1",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 }
             }
@@ -4251,8 +4250,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "elliptic": "^6.0.0"
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.1"
             }
         },
         "create-emotion": {
@@ -4261,13 +4260,13 @@
             "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
             "dev": true,
             "requires": {
-                "@emotion/hash": "^0.6.2",
-                "@emotion/memoize": "^0.6.1",
-                "@emotion/stylis": "^0.7.0",
-                "@emotion/unitless": "^0.6.2",
-                "csstype": "^2.5.2",
-                "stylis": "^3.5.0",
-                "stylis-rule-sheet": "^0.0.10"
+                "@emotion/hash": "0.6.6",
+                "@emotion/memoize": "0.6.6",
+                "@emotion/stylis": "0.7.1",
+                "@emotion/unitless": "0.6.7",
+                "csstype": "2.5.7",
+                "stylis": "3.5.3",
+                "stylis-rule-sheet": "0.0.10"
             }
         },
         "create-hash": {
@@ -4276,11 +4275,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.1",
-                "inherits": "^2.0.1",
-                "md5.js": "^1.3.4",
-                "ripemd160": "^2.0.1",
-                "sha.js": "^2.4.0"
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "md5.js": "1.3.4",
+                "ripemd160": "2.0.2",
+                "sha.js": "2.4.11"
             }
         },
         "create-hmac": {
@@ -4289,12 +4288,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "^1.0.3",
-                "create-hash": "^1.1.0",
-                "inherits": "^2.0.1",
-                "ripemd160": "^2.0.0",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "cipher-base": "1.0.4",
+                "create-hash": "1.2.0",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "create-react-class": {
@@ -4303,9 +4302,9 @@
             "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
             "dev": true,
             "requires": {
-                "fbjs": "^0.8.9",
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
+                "fbjs": "0.8.17",
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
             }
         },
         "cross-spawn": {
@@ -4314,11 +4313,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.4",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "crypt": {
@@ -4332,17 +4331,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "^1.0.0",
-                "browserify-sign": "^4.0.0",
-                "create-ecdh": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "create-hmac": "^1.1.0",
-                "diffie-hellman": "^5.0.0",
-                "inherits": "^2.0.1",
-                "pbkdf2": "^3.0.3",
-                "public-encrypt": "^4.0.0",
-                "randombytes": "^2.0.0",
-                "randomfill": "^1.0.3"
+                "browserify-cipher": "1.0.1",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.3",
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "diffie-hellman": "5.0.3",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.17",
+                "public-encrypt": "4.0.2",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
             }
         },
         "css": {
@@ -4351,10 +4350,10 @@
             "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "source-map": "^0.1.38",
-                "source-map-resolve": "^0.5.1",
-                "urix": "^0.1.0"
+                "inherits": "2.0.3",
+                "source-map": "0.1.43",
+                "source-map-resolve": "0.5.2",
+                "urix": "0.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -4363,7 +4362,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -4374,18 +4373,18 @@
             "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "css-selector-tokenizer": "^0.7.0",
-                "icss-utils": "^2.1.0",
-                "loader-utils": "^1.0.2",
-                "lodash": "^4.17.11",
-                "postcss": "^6.0.23",
-                "postcss-modules-extract-imports": "^1.2.0",
-                "postcss-modules-local-by-default": "^1.2.0",
-                "postcss-modules-scope": "^1.1.0",
-                "postcss-modules-values": "^1.3.0",
-                "postcss-value-parser": "^3.3.0",
-                "source-list-map": "^2.0.0"
+                "babel-code-frame": "6.26.0",
+                "css-selector-tokenizer": "0.7.1",
+                "icss-utils": "2.1.0",
+                "loader-utils": "1.1.0",
+                "lodash": "4.17.11",
+                "postcss": "6.0.23",
+                "postcss-modules-extract-imports": "1.2.1",
+                "postcss-modules-local-by-default": "1.2.0",
+                "postcss-modules-scope": "1.1.0",
+                "postcss-modules-values": "1.3.0",
+                "postcss-value-parser": "3.3.1",
+                "source-list-map": "2.0.0"
             },
             "dependencies": {
                 "lodash": {
@@ -4402,10 +4401,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0",
-                "css-what": "2.1",
+                "boolbase": "1.0.0",
+                "css-what": "2.1.0",
                 "domutils": "1.5.1",
-                "nth-check": "~1.0.1"
+                "nth-check": "1.0.1"
             },
             "dependencies": {
                 "domutils": {
@@ -4414,8 +4413,8 @@
                     "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
                     "dev": true,
                     "requires": {
-                        "dom-serializer": "0",
-                        "domelementtype": "1"
+                        "dom-serializer": "0.1.0",
+                        "domelementtype": "1.3.0"
                     }
                 }
             }
@@ -4426,9 +4425,9 @@
             "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
             "dev": true,
             "requires": {
-                "cssesc": "^0.1.0",
-                "fastparse": "^1.1.1",
-                "regexpu-core": "^1.0.0"
+                "cssesc": "0.1.0",
+                "fastparse": "1.1.2",
+                "regexpu-core": "1.0.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -4443,9 +4442,9 @@
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
                     "dev": true,
                     "requires": {
-                        "regenerate": "^1.2.1",
-                        "regjsgen": "^0.2.0",
-                        "regjsparser": "^0.1.4"
+                        "regenerate": "1.4.0",
+                        "regjsgen": "0.2.0",
+                        "regjsparser": "0.1.5"
                     }
                 },
                 "regjsgen": {
@@ -4460,7 +4459,7 @@
                     "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
                     "dev": true,
                     "requires": {
-                        "jsesc": "~0.5.0"
+                        "jsesc": "0.5.0"
                     }
                 }
             }
@@ -4471,8 +4470,8 @@
             "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
             "dev": true,
             "requires": {
-                "mdn-data": "^1.0.0",
-                "source-map": "^0.5.3"
+                "mdn-data": "1.1.4",
+                "source-map": "0.5.7"
             }
         },
         "css-what": {
@@ -4508,7 +4507,7 @@
             "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.4"
             }
         },
         "csstype": {
@@ -4529,7 +4528,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "^0.10.9"
+                "es5-ext": "0.10.43"
             }
         },
         "d3-array": {
@@ -4553,11 +4552,11 @@
             "integrity": "sha512-lGSiF5SoSqO5/mYGD5FAeGKKS62JdA1EV7HPrU2b5rTX4qEJJtpjaGLJngjnkewQy7UnGstnFd3168wpf5z76w==",
             "dev": true,
             "requires": {
-                "d3-dispatch": "1",
-                "d3-drag": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "1",
-                "d3-transition": "1"
+                "d3-dispatch": "1.0.5",
+                "d3-drag": "1.2.3",
+                "d3-interpolate": "1.3.2",
+                "d3-selection": "1.3.2",
+                "d3-transition": "1.1.3"
             }
         },
         "d3-chord": {
@@ -4566,8 +4565,8 @@
             "integrity": "sha512-JXA2Dro1Fxw9rJe33Uv+Ckr5IrAa74TlfDEhE/jfLOaXegMQFQTAgAw9WnZL8+HxVBRXaRGCkrNU7pJeylRIuA==",
             "dev": true,
             "requires": {
-                "d3-array": "1",
-                "d3-path": "1"
+                "d3-array": "1.2.4",
+                "d3-path": "1.0.7"
             }
         },
         "d3-collection": {
@@ -4588,7 +4587,7 @@
             "integrity": "sha512-hoPp4K/rJCu0ladiH6zmJUEz6+u3lgR+GSm/QdM2BBvDraU39Vr7YdDCicJcxP1z8i9B/2dJLgDC1NcvlF8WCg==",
             "dev": true,
             "requires": {
-                "d3-array": "^1.1.1"
+                "d3-array": "1.2.4"
             }
         },
         "d3-dispatch": {
@@ -4603,8 +4602,8 @@
             "integrity": "sha512-8S3HWCAg+ilzjJsNtWW1Mutl74Nmzhb9yU6igspilaJzeZVFktmY6oO9xOh5TDk+BM2KrNFjttZNoJJmDnkjkg==",
             "dev": true,
             "requires": {
-                "d3-dispatch": "1",
-                "d3-selection": "1"
+                "d3-dispatch": "1.0.5",
+                "d3-selection": "1.3.2"
             }
         },
         "d3-ease": {
@@ -4619,10 +4618,10 @@
             "integrity": "sha512-p1vcHAUF1qH7yR+e8ip7Bs61AHjLeKkIn8Z2gzwU2lwEf2wkSpWdjXG0axudTHsVFnYGlMkFaEsVy2l8tAg1Gw==",
             "dev": true,
             "requires": {
-                "d3-collection": "1",
-                "d3-dispatch": "1",
-                "d3-quadtree": "1",
-                "d3-timer": "1"
+                "d3-collection": "1.0.7",
+                "d3-dispatch": "1.0.5",
+                "d3-quadtree": "1.0.1",
+                "d3-timer": "1.0.9"
             }
         },
         "d3-format": {
@@ -4655,7 +4654,7 @@
             "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
             "dev": true,
             "requires": {
-                "d3-color": "1"
+                "d3-color": "1.2.3"
             }
         },
         "d3-path": {
@@ -4682,9 +4681,9 @@
             "integrity": "sha512-maYak22afBAvmybeaopd1cVUNTIroEHhWCmh19gEQ+qgOhBkTav8YeP3Uw4OV/K4OksWaQrhhBOE4Rcxgc2JbQ==",
             "dev": true,
             "requires": {
-                "d3-array": "^1.2.1",
-                "d3-collection": "^1.0.4",
-                "d3-shape": "^1.2.0"
+                "d3-array": "1.2.4",
+                "d3-collection": "1.0.7",
+                "d3-shape": "1.2.2"
             }
         },
         "d3-scale": {
@@ -4693,13 +4692,13 @@
             "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
             "dev": true,
             "requires": {
-                "d3-array": "^1.2.0",
-                "d3-collection": "1",
-                "d3-color": "1",
-                "d3-format": "1",
-                "d3-interpolate": "1",
-                "d3-time": "1",
-                "d3-time-format": "2"
+                "d3-array": "1.2.4",
+                "d3-collection": "1.0.7",
+                "d3-color": "1.2.3",
+                "d3-format": "1.3.2",
+                "d3-interpolate": "1.3.2",
+                "d3-time": "1.0.10",
+                "d3-time-format": "2.1.3"
             }
         },
         "d3-selection": {
@@ -4714,7 +4713,7 @@
             "integrity": "sha512-hUGEozlKecFZ2bOSNt7ENex+4Tk9uc/m0TtTEHBvitCBxUNjhzm5hS2GrrVRD/ae4IylSmxGeqX5tWC2rASMlQ==",
             "dev": true,
             "requires": {
-                "d3-path": "1"
+                "d3-path": "1.0.7"
             }
         },
         "d3-time": {
@@ -4729,7 +4728,7 @@
             "integrity": "sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==",
             "dev": true,
             "requires": {
-                "d3-time": "1"
+                "d3-time": "1.0.10"
             }
         },
         "d3-timer": {
@@ -4744,12 +4743,12 @@
             "integrity": "sha512-tEvo3qOXL6pZ1EzcXxFcPNxC/Ygivu5NoBY6mbzidATAeML86da+JfVIUzon3dNM6UX6zjDx+xbYDmMVtTSjuA==",
             "dev": true,
             "requires": {
-                "d3-color": "1",
-                "d3-dispatch": "1",
-                "d3-ease": "1",
-                "d3-interpolate": "1",
-                "d3-selection": "^1.1.0",
-                "d3-timer": "1"
+                "d3-color": "1.2.3",
+                "d3-dispatch": "1.0.5",
+                "d3-ease": "1.0.5",
+                "d3-interpolate": "1.3.2",
+                "d3-selection": "1.3.2",
+                "d3-timer": "1.0.9"
             }
         },
         "d3-voronoi": {
@@ -4763,7 +4762,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "data-urls": {
@@ -4772,9 +4771,9 @@
             "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^7.0.0"
+                "abab": "2.0.0",
+                "whatwg-mimetype": "2.2.0",
+                "whatwg-url": "7.0.0"
             }
         },
         "date-now": {
@@ -4810,9 +4809,9 @@
             "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
             "dev": true,
             "requires": {
-                "debug": "3.X",
-                "memoizee": "0.4.X",
-                "object-assign": "4.X"
+                "debug": "3.1.0",
+                "memoizee": "0.4.12",
+                "object-assign": "4.1.1"
             },
             "dependencies": {
                 "debug": {
@@ -4832,7 +4831,7 @@
             "integrity": "sha1-b232uF1+fEQQqTL/wmSJt46azRM=",
             "dev": true,
             "requires": {
-                "callsite": "^1.0.0"
+                "callsite": "1.0.0"
             }
         },
         "decamelize": {
@@ -4853,14 +4852,14 @@
             "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
             "dev": true,
             "requires": {
-                "decompress-tar": "^4.0.0",
-                "decompress-tarbz2": "^4.0.0",
-                "decompress-targz": "^4.0.0",
-                "decompress-unzip": "^4.0.1",
-                "graceful-fs": "^4.1.10",
-                "make-dir": "^1.0.0",
-                "pify": "^2.3.0",
-                "strip-dirs": "^2.0.0"
+                "decompress-tar": "4.1.1",
+                "decompress-tarbz2": "4.1.1",
+                "decompress-targz": "4.1.1",
+                "decompress-unzip": "4.0.1",
+                "graceful-fs": "4.1.11",
+                "make-dir": "1.3.0",
+                "pify": "2.3.0",
+                "strip-dirs": "2.1.0"
             },
             "dependencies": {
                 "pify": {
@@ -4877,7 +4876,7 @@
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "dev": true,
             "requires": {
-                "mimic-response": "^1.0.0"
+                "mimic-response": "1.0.0"
             }
         },
         "decompress-tar": {
@@ -4886,9 +4885,9 @@
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
             "requires": {
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0",
-                "tar-stream": "^1.5.2"
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0",
+                "tar-stream": "1.6.1"
             },
             "dependencies": {
                 "file-type": {
@@ -4905,11 +4904,11 @@
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
             "requires": {
-                "decompress-tar": "^4.1.0",
-                "file-type": "^6.1.0",
-                "is-stream": "^1.1.0",
-                "seek-bzip": "^1.0.5",
-                "unbzip2-stream": "^1.0.9"
+                "decompress-tar": "4.1.1",
+                "file-type": "6.2.0",
+                "is-stream": "1.1.0",
+                "seek-bzip": "1.0.5",
+                "unbzip2-stream": "1.2.5"
             },
             "dependencies": {
                 "file-type": {
@@ -4926,9 +4925,9 @@
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
             "requires": {
-                "decompress-tar": "^4.1.1",
-                "file-type": "^5.2.0",
-                "is-stream": "^1.1.0"
+                "decompress-tar": "4.1.1",
+                "file-type": "5.2.0",
+                "is-stream": "1.1.0"
             },
             "dependencies": {
                 "file-type": {
@@ -4945,10 +4944,10 @@
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "dev": true,
             "requires": {
-                "file-type": "^3.8.0",
-                "get-stream": "^2.2.0",
-                "pify": "^2.3.0",
-                "yauzl": "^2.4.2"
+                "file-type": "3.9.0",
+                "get-stream": "2.3.1",
+                "pify": "2.3.0",
+                "yauzl": "2.9.1"
             },
             "dependencies": {
                 "file-type": {
@@ -4963,8 +4962,8 @@
                     "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
                     "dev": true,
                     "requires": {
-                        "object-assign": "^4.0.1",
-                        "pinkie-promise": "^2.0.0"
+                        "object-assign": "4.1.1",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "pify": {
@@ -4981,7 +4980,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "deep-eql": {
@@ -4990,7 +4989,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "^4.0.0"
+                "type-detect": "4.0.8"
             }
         },
         "deep-is": {
@@ -5011,7 +5010,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^5.0.2"
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5034,8 +5033,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "^2.0.5",
-                "object-keys": "^1.0.8"
+                "foreach": "2.0.5",
+                "object-keys": "1.0.11"
             }
         },
         "define-property": {
@@ -5044,8 +5043,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -5054,7 +5053,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -5063,7 +5062,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -5072,9 +5071,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -5085,12 +5084,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "^6.1.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "p-map": "^1.1.1",
-                "pify": "^3.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "6.1.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "p-map": "1.2.0",
+                "pify": "3.0.0",
+                "rimraf": "2.6.2"
             }
         },
         "delayed-stream": {
@@ -5110,8 +5109,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "destroy": {
@@ -5144,8 +5143,8 @@
             "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
             "dev": true,
             "requires": {
-                "address": "^1.0.1",
-                "debug": "^2.6.0"
+                "address": "1.0.3",
+                "debug": "2.6.9"
             }
         },
         "diagnostic-channel": {
@@ -5153,7 +5152,7 @@
             "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
             "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
             "requires": {
-                "semver": "^5.3.0"
+                "semver": "5.5.0"
             }
         },
         "diagnostic-channel-publishers": {
@@ -5178,9 +5177,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "miller-rabin": "^4.0.0",
-                "randombytes": "^2.0.0"
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
             }
         },
         "dir-glob": {
@@ -5189,8 +5188,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "path-type": "^3.0.0"
+                "arrify": "1.0.1",
+                "path-type": "3.0.0"
             },
             "dependencies": {
                 "path-type": {
@@ -5199,7 +5198,7 @@
                     "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 }
             }
@@ -5216,7 +5215,7 @@
             "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
             "dev": true,
             "requires": {
-                "esutils": "^1.1.6",
+                "esutils": "1.1.6",
                 "isarray": "0.0.1"
             },
             "dependencies": {
@@ -5240,7 +5239,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "~0.3"
+                "utila": "0.3.3"
             },
             "dependencies": {
                 "utila": {
@@ -5257,8 +5256,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
+                "domelementtype": "1.1.3",
+                "entities": "1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -5293,7 +5292,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "^4.0.2"
+                "webidl-conversions": "4.0.2"
             }
         },
         "domhandler": {
@@ -5302,7 +5301,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1"
+                "domelementtype": "1.3.0"
             }
         },
         "domutils": {
@@ -5311,8 +5310,8 @@
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0",
-                "domelementtype": "1"
+                "dom-serializer": "0.1.0",
+                "domelementtype": "1.3.0"
             }
         },
         "download": {
@@ -5321,17 +5320,17 @@
             "integrity": "sha512-0Fe/CAjKycx12IG9We9gYlLP03BEcWTpttg7P5mwfOiQTg584kpuHqP7F61RkUJM+mfEdEU9TJonm0PJp5rQLw==",
             "dev": true,
             "requires": {
-                "caw": "^2.0.1",
-                "content-disposition": "^0.5.2",
-                "decompress": "^4.2.0",
-                "ext-name": "^5.0.0",
-                "file-type": "^7.7.1",
-                "filenamify": "^2.0.0",
-                "get-stream": "^3.0.0",
-                "got": "^8.3.1",
-                "make-dir": "^1.2.0",
-                "p-event": "^1.3.0",
-                "pify": "^3.0.0"
+                "caw": "2.0.1",
+                "content-disposition": "0.5.2",
+                "decompress": "4.2.0",
+                "ext-name": "5.0.0",
+                "file-type": "7.7.1",
+                "filenamify": "2.0.0",
+                "get-stream": "3.0.0",
+                "got": "8.3.1",
+                "make-dir": "1.3.0",
+                "p-event": "1.3.0",
+                "pify": "3.0.0"
             }
         },
         "duplexer": {
@@ -5346,7 +5345,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "~1.1.9"
+                "readable-stream": "1.1.14"
             },
             "dependencies": {
                 "isarray": {
@@ -5361,10 +5360,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 }
             }
@@ -5381,10 +5380,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6",
+                "stream-shift": "1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -5393,7 +5392,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                     }
                 }
             }
@@ -5404,8 +5403,8 @@
             "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
             "dev": true,
             "requires": {
-                "is-plain-object": "^2.0.1",
-                "object.defaults": "^1.1.0"
+                "is-plain-object": "2.0.4",
+                "object.defaults": "1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -5414,7 +5413,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "editorconfig": {
@@ -5423,11 +5422,11 @@
             "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.0.5",
-                "commander": "^2.9.0",
-                "lru-cache": "^3.2.0",
-                "semver": "^5.1.0",
-                "sigmund": "^1.0.1"
+                "bluebird": "3.5.1",
+                "commander": "2.15.1",
+                "lru-cache": "3.2.0",
+                "semver": "5.5.0",
+                "sigmund": "1.0.1"
             },
             "dependencies": {
                 "lru-cache": {
@@ -5436,7 +5435,7 @@
                     "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.1"
+                        "pseudomap": "1.0.2"
                     }
                 }
             }
@@ -5465,13 +5464,13 @@
             "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.5",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "emojis-list": {
@@ -5486,8 +5485,8 @@
             "integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-emotion": "^9.2.11",
-                "create-emotion": "^9.2.12"
+                "babel-plugin-emotion": "9.2.11",
+                "create-emotion": "9.2.12"
             }
         },
         "encodeurl": {
@@ -5501,7 +5500,7 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "~0.4.13"
+                "iconv-lite": "0.4.21"
             }
         },
         "end-of-stream": {
@@ -5510,7 +5509,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -5519,9 +5518,9 @@
             "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "memory-fs": "^0.4.0",
-                "tapable": "^1.0.0"
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "tapable": "1.1.0"
             }
         },
         "entities": {
@@ -5536,25 +5535,25 @@
             "integrity": "sha512-QLWx+krGK6iDNyR1KlH5YPZqxZCQaVF6ike1eDJAOg0HvSkSCVImPsdWaNw6v+VrnK92Kg8jIOYhuOSS9sBpyg==",
             "dev": true,
             "requires": {
-                "array.prototype.flat": "^1.2.1",
-                "cheerio": "^1.0.0-rc.2",
-                "function.prototype.name": "^1.1.0",
-                "has": "^1.0.3",
-                "is-boolean-object": "^1.0.0",
-                "is-callable": "^1.1.4",
-                "is-number-object": "^1.0.3",
-                "is-string": "^1.0.4",
-                "is-subset": "^0.1.1",
-                "lodash.escape": "^4.0.1",
-                "lodash.isequal": "^4.5.0",
-                "object-inspect": "^1.6.0",
-                "object-is": "^1.0.1",
-                "object.assign": "^4.1.0",
-                "object.entries": "^1.0.4",
-                "object.values": "^1.0.4",
-                "raf": "^3.4.0",
-                "rst-selector-parser": "^2.2.3",
-                "string.prototype.trim": "^1.1.2"
+                "array.prototype.flat": "1.2.1",
+                "cheerio": "1.0.0-rc.2",
+                "function.prototype.name": "1.1.0",
+                "has": "1.0.3",
+                "is-boolean-object": "1.0.0",
+                "is-callable": "1.1.4",
+                "is-number-object": "1.0.3",
+                "is-string": "1.0.4",
+                "is-subset": "0.1.1",
+                "lodash.escape": "4.0.1",
+                "lodash.isequal": "4.5.0",
+                "object-inspect": "1.6.0",
+                "object-is": "1.0.1",
+                "object.assign": "4.1.0",
+                "object.entries": "1.0.4",
+                "object.values": "1.0.4",
+                "raf": "3.4.0",
+                "rst-selector-parser": "2.2.3",
+                "string.prototype.trim": "1.1.2"
             },
             "dependencies": {
                 "lodash.escape": {
@@ -5571,13 +5570,13 @@
             "integrity": "sha512-ay9eGFpChyUDnjTFMMJHzrb681LF3hPWJLEA7RoLFG9jSWAdAm2V50pGmFV9dYGJgh5HfdiqM+MNvle41Yf/PA==",
             "dev": true,
             "requires": {
-                "enzyme-adapter-utils": "^1.8.0",
-                "function.prototype.name": "^1.1.0",
-                "object.assign": "^4.1.0",
-                "object.values": "^1.0.4",
-                "prop-types": "^15.6.2",
-                "react-is": "^16.5.2",
-                "react-test-renderer": "^16.0.0-0"
+                "enzyme-adapter-utils": "1.8.1",
+                "function.prototype.name": "1.1.0",
+                "object.assign": "4.1.0",
+                "object.values": "1.0.4",
+                "prop-types": "15.6.2",
+                "react-is": "16.5.2",
+                "react-test-renderer": "16.5.2"
             }
         },
         "enzyme-adapter-utils": {
@@ -5586,9 +5585,9 @@
             "integrity": "sha512-s3QB3xQAowaDS2sHhmEqrT13GJC4+n5bG015ZkLv60n9k5vhxxHTQRIneZmQ4hmdCZEBrvUJ89PG6fRI5OEeuQ==",
             "dev": true,
             "requires": {
-                "function.prototype.name": "^1.1.0",
-                "object.assign": "^4.1.0",
-                "prop-types": "^15.6.2"
+                "function.prototype.name": "1.1.0",
+                "object.assign": "4.1.0",
+                "prop-types": "15.6.2"
             }
         },
         "errno": {
@@ -5597,7 +5596,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "~1.0.1"
+                "prr": "1.0.1"
             }
         },
         "error-ex": {
@@ -5606,7 +5605,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "es-abstract": {
@@ -5615,11 +5614,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.1.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4"
             }
         },
         "es-to-primitive": {
@@ -5628,9 +5627,9 @@
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
             }
         },
         "es5-ext": {
@@ -5639,9 +5638,9 @@
             "integrity": "sha512-cZd1vezWuTM5qMlasKWqQFioFKwO352nVBzhOTMUf/pKQl5Gcq5EdJzqtSNXKnFQSCJDiQZjCYlYbnzFB657OA==",
             "dev": true,
             "requires": {
-                "es6-iterator": "~2.0.3",
-                "es6-symbol": "~3.1.1",
-                "next-tick": "1"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "next-tick": "1.0.0"
             }
         },
         "es6-iterator": {
@@ -5650,9 +5649,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.35",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.43",
+                "es6-symbol": "3.1.1"
             }
         },
         "es6-symbol": {
@@ -5661,8 +5660,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.43"
             }
         },
         "es6-weak-map": {
@@ -5671,10 +5670,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.14",
-                "es6-iterator": "^2.0.1",
-                "es6-symbol": "^3.1.1"
+                "d": "1.0.0",
+                "es5-ext": "0.10.43",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
             }
         },
         "escape-carriage": {
@@ -5701,11 +5700,11 @@
             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
             "dev": true,
             "requires": {
-                "esprima": "^2.7.1",
-                "estraverse": "^1.9.1",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.2.0"
+                "esprima": "2.7.3",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.2.0"
             },
             "dependencies": {
                 "source-map": {
@@ -5715,7 +5714,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -5726,8 +5725,8 @@
             "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             },
             "dependencies": {
                 "estraverse": {
@@ -5749,7 +5748,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             },
             "dependencies": {
                 "estraverse": {
@@ -5784,8 +5783,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "~0.10.14"
+                "d": "1.0.0",
+                "es5-ext": "0.10.43"
             }
         },
         "event-stream": {
@@ -5794,13 +5793,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
             }
         },
         "events": {
@@ -5815,7 +5814,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": ">=0.0.5"
+                "original": "1.0.2"
             }
         },
         "evp_bytestokey": {
@@ -5824,8 +5823,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "^1.3.4",
-                "safe-buffer": "^5.1.1"
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.2"
             }
         },
         "execa": {
@@ -5834,13 +5833,13 @@
             "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             }
         },
         "expand-brackets": {
@@ -5849,13 +5848,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -5864,7 +5863,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -5873,7 +5872,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -5884,7 +5883,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             },
             "dependencies": {
                 "fill-range": {
@@ -5893,11 +5892,11 @@
                     "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
                     "dev": true,
                     "requires": {
-                        "is-number": "^2.1.0",
-                        "isobject": "^2.0.0",
-                        "randomatic": "^3.0.0",
-                        "repeat-element": "^1.1.2",
-                        "repeat-string": "^1.5.2"
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "3.0.0",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "is-number": {
@@ -5906,7 +5905,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 },
                 "isobject": {
@@ -5924,7 +5923,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -5935,7 +5934,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
             }
         },
         "express": {
@@ -5944,36 +5943,36 @@
             "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.5",
+                "accepts": "1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.3",
                 "content-disposition": "0.5.2",
-                "content-type": "~1.0.4",
+                "content-type": "1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
+                "methods": "1.1.2",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.4",
+                "proxy-addr": "2.0.4",
                 "qs": "6.5.2",
-                "range-parser": "~1.2.0",
+                "range-parser": "1.2.0",
                 "safe-buffer": "5.1.2",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "~1.4.0",
-                "type-is": "~1.6.16",
+                "statuses": "1.4.0",
+                "type-is": "1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "~1.1.2"
+                "vary": "1.1.2"
             }
         },
         "ext-list": {
@@ -5982,7 +5981,7 @@
             "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "dev": true,
             "requires": {
-                "mime-db": "^1.28.0"
+                "mime-db": "1.33.0"
             }
         },
         "ext-name": {
@@ -5991,8 +5990,8 @@
             "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
             "dev": true,
             "requires": {
-                "ext-list": "^2.0.0",
-                "sort-keys-length": "^1.0.0"
+                "ext-list": "2.2.2",
+                "sort-keys-length": "1.0.1"
             }
         },
         "extend": {
@@ -6006,8 +6005,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -6016,7 +6015,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -6027,9 +6026,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.21",
+                "tmp": "0.0.33"
             },
             "dependencies": {
                 "tmp": {
@@ -6038,7 +6037,7 @@
                     "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "~1.0.2"
+                        "os-tmpdir": "1.0.2"
                     }
                 }
             }
@@ -6049,14 +6048,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -6065,7 +6064,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -6074,7 +6073,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6083,7 +6082,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -6092,7 +6091,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -6101,9 +6100,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -6119,9 +6118,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "time-stamp": "^1.0.0"
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
+                "time-stamp": "1.1.0"
             }
         },
         "fast-deep-equal": {
@@ -6152,7 +6151,7 @@
             "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
             "dev": true,
             "requires": {
-                "websocket-driver": ">=0.5.1"
+                "websocket-driver": "0.7.0"
             }
         },
         "fbjs": {
@@ -6161,13 +6160,13 @@
             "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
             "dev": true,
             "requires": {
-                "core-js": "^1.0.0",
-                "isomorphic-fetch": "^2.1.1",
-                "loose-envify": "^1.0.0",
-                "object-assign": "^4.1.0",
-                "promise": "^7.1.1",
-                "setimmediate": "^1.0.5",
-                "ua-parser-js": "^0.7.18"
+                "core-js": "1.2.7",
+                "isomorphic-fetch": "2.2.1",
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "promise": "7.3.1",
+                "setimmediate": "1.0.5",
+                "ua-parser-js": "0.7.18"
             },
             "dependencies": {
                 "core-js": {
@@ -6182,7 +6181,7 @@
                     "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
                     "dev": true,
                     "requires": {
-                        "asap": "~2.0.3"
+                        "asap": "2.0.6"
                     }
                 }
             }
@@ -6193,7 +6192,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "figures": {
@@ -6202,7 +6201,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "file-loader": {
@@ -6211,8 +6210,8 @@
             "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.0.2",
-                "schema-utils": "^1.0.0"
+                "loader-utils": "1.1.0",
+                "schema-utils": "1.0.0"
             }
         },
         "file-type": {
@@ -6239,9 +6238,9 @@
             "integrity": "sha1-vRYiYsC26Uv7zc8Zo7uzdk94VpU=",
             "dev": true,
             "requires": {
-                "filename-reserved-regex": "^2.0.0",
-                "strip-outer": "^1.0.0",
-                "trim-repeated": "^1.0.0"
+                "filename-reserved-regex": "2.0.0",
+                "strip-outer": "1.0.1",
+                "trim-repeated": "1.0.0"
             }
         },
         "filesize": {
@@ -6256,10 +6255,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6268,7 +6267,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -6280,12 +6279,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.4.0",
-                "unpipe": "~1.0.0"
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "on-finished": "2.3.0",
+                "parseurl": "1.3.2",
+                "statuses": "1.4.0",
+                "unpipe": "1.0.0"
             }
         },
         "find-cache-dir": {
@@ -6294,9 +6293,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^1.0.0",
-                "pkg-dir": "^2.0.0"
+                "commondir": "1.0.1",
+                "make-dir": "1.3.0",
+                "pkg-dir": "2.0.0"
             }
         },
         "find-root": {
@@ -6311,8 +6310,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "findup-sync": {
@@ -6321,10 +6320,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "detect-file": "1.0.0",
+                "is-glob": "3.1.0",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
             }
         },
         "fined": {
@@ -6333,11 +6332,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "is-plain-object": "^2.0.3",
-                "object.defaults": "^1.1.0",
-                "object.pick": "^1.2.0",
-                "parse-filepath": "^1.0.1"
+                "expand-tilde": "2.0.2",
+                "is-plain-object": "2.0.4",
+                "object.defaults": "1.1.0",
+                "object.pick": "1.3.0",
+                "parse-filepath": "1.0.2"
             }
         },
         "flagged-respawn": {
@@ -6352,7 +6351,7 @@
             "integrity": "sha512-ji/WMv2jdsE+LaznpkIF9Haax0sdpTBozrz/Dtg4qSRMfbs8oVg4ypJunIRYPiMLvH/ed6OflXbnbTIKJhtgeg==",
             "dev": true,
             "requires": {
-                "is-buffer": "~1.1.5"
+                "is-buffer": "1.1.6"
             }
         },
         "flush-write-stream": {
@@ -6361,8 +6360,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.4"
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6"
             }
         },
         "for-in": {
@@ -6377,7 +6376,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "foreach": {
@@ -6396,9 +6395,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.18"
             }
         },
         "forwarded": {
@@ -6413,7 +6412,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fresh": {
@@ -6434,8 +6433,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0"
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6"
             }
         },
         "fs-constants": {
@@ -6449,9 +6448,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
             "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
             }
         },
         "fs-mkdirp-stream": {
@@ -6460,8 +6459,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "through2": "^2.0.3"
+                "graceful-fs": "4.1.11",
+                "through2": "2.0.3"
             }
         },
         "fs-walk": {
@@ -6470,7 +6469,7 @@
             "integrity": "sha1-9/yRw64e6tB8mYvF0N1B8tvr0zU=",
             "dev": true,
             "requires": {
-                "async": "*"
+                "async": "1.5.2"
             }
         },
         "fs-write-stream-atomic": {
@@ -6479,10 +6478,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "iferr": "^0.1.5",
-                "imurmurhash": "^0.1.4",
-                "readable-stream": "1 || 2"
+                "graceful-fs": "4.1.11",
+                "iferr": "0.1.5",
+                "imurmurhash": "0.1.4",
+                "readable-stream": "2.0.6"
             }
         },
         "fs.realpath": {
@@ -6490,556 +6489,16 @@
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
-        "fsevents": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.21",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": "^2.1.0"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true
-                },
-                "minipass": {
-                    "version": "2.2.4",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.2.1"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "minimist": "0.0.8"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.10.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.1.10",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.6.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "^7.0.5"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.5.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "^1.0.2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "yallist": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true
-                }
-            }
-        },
         "fstream": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "function-bind": {
@@ -7054,9 +6513,9 @@
             "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "is-callable": "^1.1.3"
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "is-callable": "1.1.4"
             }
         },
         "fuzzy": {
@@ -7087,7 +6546,7 @@
             "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
             "dev": true,
             "requires": {
-                "npm-conf": "^1.1.0"
+                "npm-conf": "1.1.3"
             }
         },
         "get-stream": {
@@ -7107,7 +6566,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -7115,12 +6574,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -7129,8 +6588,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "glob-parent": {
@@ -7139,7 +6598,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "^2.0.0"
+                        "is-glob": "2.0.1"
                     }
                 },
                 "is-extglob": {
@@ -7154,7 +6613,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -7165,8 +6624,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "^3.1.0",
-                "path-dirname": "^1.0.0"
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
             }
         },
         "glob-stream": {
@@ -7175,16 +6634,16 @@
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "glob": "^7.1.1",
-                "glob-parent": "^3.1.0",
-                "is-negated-glob": "^1.0.0",
-                "ordered-read-streams": "^1.0.0",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.1.5",
-                "remove-trailing-separator": "^1.0.1",
-                "to-absolute-glob": "^2.0.0",
-                "unique-stream": "^2.0.2"
+                "extend": "3.0.1",
+                "glob": "7.1.2",
+                "glob-parent": "3.1.0",
+                "is-negated-glob": "1.0.0",
+                "ordered-read-streams": "1.0.1",
+                "pumpify": "1.5.1",
+                "readable-stream": "2.3.6",
+                "remove-trailing-separator": "1.1.0",
+                "to-absolute-glob": "2.0.2",
+                "unique-stream": "2.2.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -7199,13 +6658,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -7214,7 +6673,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -7225,10 +6684,10 @@
             "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "dev": true,
             "requires": {
-                "async-done": "^1.2.0",
-                "chokidar": "^2.0.0",
-                "just-debounce": "^1.0.0",
-                "object.defaults": "^1.1.0"
+                "async-done": "1.3.1",
+                "chokidar": "2.0.4",
+                "just-debounce": "1.0.0",
+                "object.defaults": "1.1.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -7237,8 +6696,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "^3.1.4",
-                        "normalize-path": "^2.1.1"
+                        "micromatch": "3.1.10",
+                        "normalize-path": "2.1.1"
                     }
                 },
                 "chokidar": {
@@ -7247,19 +6706,18 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.0",
-                        "braces": "^2.3.0",
-                        "fsevents": "^1.2.2",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "lodash.debounce": "^4.0.8",
-                        "normalize-path": "^2.1.1",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0",
-                        "upath": "^1.0.5"
+                        "anymatch": "2.0.0",
+                        "async-each": "1.0.1",
+                        "braces": "2.3.2",
+                        "glob-parent": "3.1.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "4.0.0",
+                        "lodash.debounce": "4.0.8",
+                        "normalize-path": "2.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0",
+                        "upath": "1.1.0"
                     }
                 },
                 "is-glob": {
@@ -7268,7 +6726,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -7279,8 +6737,8 @@
             "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
             "dev": true,
             "requires": {
-                "min-document": "^2.19.0",
-                "process": "~0.5.1"
+                "min-document": "2.19.0",
+                "process": "0.5.2"
             },
             "dependencies": {
                 "process": {
@@ -7297,9 +6755,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "^1.0.1",
-                "is-windows": "^1.0.1",
-                "resolve-dir": "^1.0.0"
+                "global-prefix": "1.0.2",
+                "is-windows": "1.0.2",
+                "resolve-dir": "1.0.1"
             }
         },
         "global-modules-path": {
@@ -7314,11 +6772,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.2",
-                "homedir-polyfill": "^1.0.1",
-                "ini": "^1.3.4",
-                "is-windows": "^1.0.1",
-                "which": "^1.2.14"
+                "expand-tilde": "2.0.2",
+                "homedir-polyfill": "1.0.1",
+                "ini": "1.3.5",
+                "is-windows": "1.0.2",
+                "which": "1.3.1"
             }
         },
         "globals": {
@@ -7333,11 +6791,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "^1.0.1",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             },
             "dependencies": {
                 "pify": {
@@ -7354,7 +6812,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.1"
             }
         },
         "got": {
@@ -7363,23 +6821,23 @@
             "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
             "dev": true,
             "requires": {
-                "@sindresorhus/is": "^0.7.0",
-                "cacheable-request": "^2.1.1",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "into-stream": "^3.1.0",
-                "is-retry-allowed": "^1.1.0",
-                "isurl": "^1.0.0-alpha5",
-                "lowercase-keys": "^1.0.0",
-                "mimic-response": "^1.0.0",
-                "p-cancelable": "^0.4.0",
-                "p-timeout": "^2.0.1",
-                "pify": "^3.0.0",
-                "safe-buffer": "^5.1.1",
-                "timed-out": "^4.0.1",
-                "url-parse-lax": "^3.0.0",
-                "url-to-options": "^1.0.1"
+                "@sindresorhus/is": "0.7.0",
+                "cacheable-request": "2.1.4",
+                "decompress-response": "3.3.0",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "into-stream": "3.1.0",
+                "is-retry-allowed": "1.1.0",
+                "isurl": "1.0.0",
+                "lowercase-keys": "1.0.1",
+                "mimic-response": "1.0.0",
+                "p-cancelable": "0.4.1",
+                "p-timeout": "2.0.1",
+                "pify": "3.0.0",
+                "safe-buffer": "5.1.2",
+                "timed-out": "4.0.1",
+                "url-parse-lax": "3.0.0",
+                "url-to-options": "1.0.1"
             }
         },
         "graceful-fs": {
@@ -7405,10 +6863,10 @@
             "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "dev": true,
             "requires": {
-                "glob-watcher": "^5.0.0",
-                "gulp-cli": "^2.0.0",
-                "undertaker": "^1.0.0",
-                "vinyl-fs": "^3.0.0"
+                "glob-watcher": "5.0.1",
+                "gulp-cli": "2.0.1",
+                "undertaker": "1.2.0",
+                "vinyl-fs": "3.0.3"
             },
             "dependencies": {
                 "camelcase": {
@@ -7423,9 +6881,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wrap-ansi": "^2.0.0"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
                     }
                 },
                 "gulp-cli": {
@@ -7434,24 +6892,24 @@
                     "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "^1.0.1",
-                        "archy": "^1.0.0",
-                        "array-sort": "^1.0.0",
-                        "color-support": "^1.1.3",
-                        "concat-stream": "^1.6.0",
-                        "copy-props": "^2.0.1",
-                        "fancy-log": "^1.3.2",
-                        "gulplog": "^1.0.0",
-                        "interpret": "^1.1.0",
-                        "isobject": "^3.0.1",
-                        "liftoff": "^2.5.0",
-                        "matchdep": "^2.0.0",
-                        "mute-stdout": "^1.0.0",
-                        "pretty-hrtime": "^1.0.0",
-                        "replace-homedir": "^1.0.0",
-                        "semver-greatest-satisfied-range": "^1.1.0",
-                        "v8flags": "^3.0.1",
-                        "yargs": "^7.1.0"
+                        "ansi-colors": "1.1.0",
+                        "archy": "1.0.0",
+                        "array-sort": "1.0.0",
+                        "color-support": "1.1.3",
+                        "concat-stream": "1.6.2",
+                        "copy-props": "2.0.4",
+                        "fancy-log": "1.3.2",
+                        "gulplog": "1.0.0",
+                        "interpret": "1.1.0",
+                        "isobject": "3.0.1",
+                        "liftoff": "2.5.0",
+                        "matchdep": "2.0.0",
+                        "mute-stdout": "1.0.1",
+                        "pretty-hrtime": "1.0.3",
+                        "replace-homedir": "1.0.0",
+                        "semver-greatest-satisfied-range": "1.1.0",
+                        "v8flags": "3.1.1",
+                        "yargs": "7.1.0"
                     }
                 },
                 "invert-kv": {
@@ -7466,7 +6924,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "lcid": {
@@ -7475,7 +6933,7 @@
                     "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                     }
                 },
                 "os-locale": {
@@ -7484,7 +6942,7 @@
                     "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                     "dev": true,
                     "requires": {
-                        "lcid": "^1.0.0"
+                        "lcid": "1.0.0"
                     }
                 },
                 "string-width": {
@@ -7493,9 +6951,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "which-module": {
@@ -7516,19 +6974,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0",
-                        "cliui": "^3.2.0",
-                        "decamelize": "^1.1.1",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^1.4.0",
-                        "read-pkg-up": "^1.0.1",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^1.0.2",
-                        "which-module": "^1.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^5.0.0"
+                        "camelcase": "3.0.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.3",
+                        "os-locale": "1.4.0",
+                        "read-pkg-up": "1.0.1",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "1.0.2",
+                        "which-module": "1.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -7537,7 +6995,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^3.0.0"
+                        "camelcase": "3.0.0"
                     }
                 }
             }
@@ -7548,16 +7006,16 @@
             "integrity": "sha512-b6CfmmEtyLDT3afv7wvNin3FJh3eAJy9N26HIXQTbQFP3LzP8XLJrvDe+G9lxFzJt943xgoYFNWUZz3wiJTZdQ==",
             "dev": true,
             "requires": {
-                "azure-storage": "^2.10.2",
+                "azure-storage": "2.10.2",
                 "delayed-stream": "0.0.6",
                 "event-stream": "3.3.4",
-                "mime": "^1.3.4",
-                "optimist": "^0.6.1",
-                "progress": "^1.1.8",
-                "queue": "^3.0.10",
-                "streamifier": "^0.1.1",
-                "vinyl": "^0.4.5",
-                "vinyl-fs": "^3.0.3"
+                "mime": "1.6.0",
+                "optimist": "0.6.1",
+                "progress": "1.1.8",
+                "queue": "3.1.0",
+                "streamifier": "0.1.1",
+                "vinyl": "0.4.6",
+                "vinyl-fs": "3.0.3"
             },
             "dependencies": {
                 "azure-storage": {
@@ -7566,17 +7024,17 @@
                     "integrity": "sha512-pOyGPya9+NDpAfm5YcFfklo57HfjDbYLXxs4lomPwvRxmb0Di/A+a+RkUmEFzaQ8S13CqxK40bRRB0sjj2ZQxA==",
                     "dev": true,
                     "requires": {
-                        "browserify-mime": "~1.2.9",
-                        "extend": "^3.0.2",
+                        "browserify-mime": "1.2.9",
+                        "extend": "3.0.2",
                         "json-edm-parser": "0.1.2",
                         "md5.js": "1.3.4",
-                        "readable-stream": "~2.0.0",
-                        "request": "^2.86.0",
-                        "underscore": "~1.8.3",
-                        "uuid": "^3.0.0",
-                        "validator": "~9.4.1",
+                        "readable-stream": "2.0.6",
+                        "request": "2.87.0",
+                        "underscore": "1.8.3",
+                        "uuid": "3.3.2",
+                        "validator": "9.4.1",
                         "xml2js": "0.2.8",
-                        "xmlbuilder": "^9.0.7"
+                        "xmlbuilder": "9.0.7"
                     }
                 },
                 "clone": {
@@ -7615,8 +7073,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 },
                 "xml2js": {
@@ -7625,7 +7083,7 @@
                     "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
                     "dev": true,
                     "requires": {
-                        "sax": "0.5.x"
+                        "sax": "0.5.8"
                     }
                 }
             }
@@ -7636,9 +7094,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
             }
         },
         "gulp-debounced-watch": {
@@ -7647,9 +7105,9 @@
             "integrity": "sha1-WkfU4kzkY2XOguysMqKjA+QysSo=",
             "dev": true,
             "requires": {
-                "debounce-hashed": "^0.1.1",
-                "gulp-watch": "^4.3.4",
-                "object-assign": "^3.0.0"
+                "debounce-hashed": "0.1.2",
+                "gulp-watch": "4.3.11",
+                "object-assign": "3.0.0"
             },
             "dependencies": {
                 "gulp-watch": {
@@ -7658,16 +7116,16 @@
                     "integrity": "sha1-Fi/FY96fx3DpH5p845VVE6mhGMA=",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^1.3.0",
-                        "chokidar": "^1.6.1",
-                        "glob-parent": "^3.0.1",
-                        "gulp-util": "^3.0.7",
-                        "object-assign": "^4.1.0",
-                        "path-is-absolute": "^1.0.1",
-                        "readable-stream": "^2.2.2",
-                        "slash": "^1.0.0",
-                        "vinyl": "^1.2.0",
-                        "vinyl-file": "^2.0.0"
+                        "anymatch": "1.3.2",
+                        "chokidar": "1.7.0",
+                        "glob-parent": "3.1.0",
+                        "gulp-util": "3.0.8",
+                        "object-assign": "4.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readable-stream": "2.3.6",
+                        "slash": "1.0.0",
+                        "vinyl": "1.2.0",
+                        "vinyl-file": "2.0.0"
                     },
                     "dependencies": {
                         "object-assign": {
@@ -7696,13 +7154,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -7711,7 +7169,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "vinyl": {
@@ -7720,8 +7178,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7733,9 +7191,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
             }
         },
         "gulp-gunzip": {
@@ -7744,8 +7202,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -7766,10 +7224,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "through2": {
@@ -7778,8 +7236,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 },
                 "vinyl": {
@@ -7788,8 +7246,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -7800,9 +7258,9 @@
             "integrity": "sha512-Ky5SKDgM517QZ6Jw9rKhYz+ynX9T4sr72iUW2fbOhqzN74D37DzWZDZnbKLSwdlTbbqt7JFq/JmUmT12qroW+A==",
             "dev": true,
             "requires": {
-                "inline-source": "~5.2.6",
-                "plugin-error": "~1.0.1",
-                "through2": "~2.0.0"
+                "inline-source": "5.2.7",
+                "plugin-error": "1.0.1",
+                "through2": "2.0.3"
             },
             "dependencies": {
                 "plugin-error": {
@@ -7811,10 +7269,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "^1.0.1",
-                        "arr-diff": "^4.0.0",
-                        "arr-union": "^3.1.0",
-                        "extend-shallow": "^3.0.2"
+                        "ansi-colors": "1.1.0",
+                        "arr-diff": "4.0.0",
+                        "arr-union": "3.1.0",
+                        "extend-shallow": "3.0.2"
                     }
                 }
             }
@@ -7825,11 +7283,11 @@
             "integrity": "sha512-20nYwO5Bec5X6DfXmBmHEtDAyluTkMguhuvCzqwrHDv/NzwOn3qS4ofAMw9L2gnWAmzxKzHAkFO19LNDWyTwlg==",
             "dev": true,
             "requires": {
-                "deepmerge": "^2.1.0",
-                "detect-indent": "^5.0.0",
-                "js-beautify": "^1.7.5",
-                "plugin-error": "^1.0.1",
-                "through2": "^2.0.3"
+                "deepmerge": "2.1.1",
+                "detect-indent": "5.0.0",
+                "js-beautify": "1.7.5",
+                "plugin-error": "1.0.1",
+                "through2": "2.0.3"
             },
             "dependencies": {
                 "plugin-error": {
@@ -7838,10 +7296,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "^1.0.1",
-                        "arr-diff": "^4.0.0",
-                        "arr-union": "^3.1.0",
-                        "extend-shallow": "^3.0.2"
+                        "ansi-colors": "1.1.0",
+                        "arr-diff": "4.0.0",
+                        "arr-union": "3.1.0",
+                        "extend-shallow": "3.0.2"
                     }
                 }
             }
@@ -7853,10 +7311,10 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
+                "node.extend": "1.1.8",
+                "request": "2.87.0",
+                "through2": "2.0.3",
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -7883,12 +7341,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -7905,17 +7363,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.X",
-                "@gulp-sourcemaps/map-sources": "1.X",
-                "acorn": "5.X",
-                "convert-source-map": "1.X",
-                "css": "2.X",
-                "debug-fabulous": "1.X",
-                "detect-newline": "2.X",
-                "graceful-fs": "4.X",
-                "source-map": "~0.6.0",
-                "strip-bom-string": "1.X",
-                "through2": "2.X"
+                "@gulp-sourcemaps/identity-map": "1.0.1",
+                "@gulp-sourcemaps/map-sources": "1.0.0",
+                "acorn": "5.5.3",
+                "convert-source-map": "1.5.1",
+                "css": "2.2.3",
+                "debug-fabulous": "1.1.0",
+                "detect-newline": "2.1.0",
+                "graceful-fs": "4.1.11",
+                "source-map": "0.6.1",
+                "strip-bom-string": "1.0.0",
+                "through2": "2.0.3"
             },
             "dependencies": {
                 "source-map": {
@@ -7932,12 +7390,12 @@
             "integrity": "sha512-Hhbn5Aa2l3T+tnn0KqsG6RRJmcYEsr3byTL2nBpNBeAK8pqug9Od4AwddU4JEI+hRw7mzZyjRbB8DDWR6paGVA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "^1.0.1",
-                "plugin-error": "^0.1.2",
-                "source-map": "^0.6.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.1.0",
-                "vinyl-fs": "^3.0.0"
+                "ansi-colors": "1.1.0",
+                "plugin-error": "0.1.2",
+                "source-map": "0.6.1",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0",
+                "vinyl-fs": "3.0.3"
             },
             "dependencies": {
                 "clone": {
@@ -7958,16 +7416,16 @@
                     "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "dev": true,
                     "requires": {
-                        "extend": "^3.0.0",
-                        "glob": "^7.1.1",
-                        "glob-parent": "^3.1.0",
-                        "is-negated-glob": "^1.0.0",
-                        "ordered-read-streams": "^1.0.0",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.1.5",
-                        "remove-trailing-separator": "^1.0.1",
-                        "to-absolute-glob": "^2.0.0",
-                        "unique-stream": "^2.0.2"
+                        "extend": "3.0.1",
+                        "glob": "7.1.2",
+                        "glob-parent": "3.1.0",
+                        "is-negated-glob": "1.0.0",
+                        "ordered-read-streams": "1.0.1",
+                        "pumpify": "1.5.1",
+                        "readable-stream": "2.3.6",
+                        "remove-trailing-separator": "1.1.0",
+                        "to-absolute-glob": "2.0.2",
+                        "unique-stream": "2.2.1"
                     }
                 },
                 "ordered-read-streams": {
@@ -7976,7 +7434,7 @@
                     "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "^2.0.1"
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "process-nextick-args": {
@@ -7991,13 +7449,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "replace-ext": {
@@ -8018,7 +7476,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "unique-stream": {
@@ -8027,8 +7485,8 @@
                     "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
                     "dev": true,
                     "requires": {
-                        "json-stable-stringify": "^1.0.0",
-                        "through2-filter": "^2.0.0"
+                        "json-stable-stringify": "1.0.1",
+                        "through2-filter": "2.0.0"
                     }
                 },
                 "vinyl": {
@@ -8037,12 +7495,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 },
                 "vinyl-fs": {
@@ -8051,23 +7509,23 @@
                     "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
                     "dev": true,
                     "requires": {
-                        "fs-mkdirp-stream": "^1.0.0",
-                        "glob-stream": "^6.1.0",
-                        "graceful-fs": "^4.0.0",
-                        "is-valid-glob": "^1.0.0",
-                        "lazystream": "^1.0.0",
-                        "lead": "^1.0.0",
-                        "object.assign": "^4.0.4",
-                        "pumpify": "^1.3.5",
-                        "readable-stream": "^2.3.3",
-                        "remove-bom-buffer": "^3.0.0",
-                        "remove-bom-stream": "^1.2.0",
-                        "resolve-options": "^1.1.0",
-                        "through2": "^2.0.0",
-                        "to-through": "^2.0.0",
-                        "value-or-function": "^3.0.0",
-                        "vinyl": "^2.0.0",
-                        "vinyl-sourcemap": "^1.1.0"
+                        "fs-mkdirp-stream": "1.0.0",
+                        "glob-stream": "6.1.0",
+                        "graceful-fs": "4.1.11",
+                        "is-valid-glob": "1.0.0",
+                        "lazystream": "1.0.0",
+                        "lead": "1.0.0",
+                        "object.assign": "4.1.0",
+                        "pumpify": "1.5.1",
+                        "readable-stream": "2.3.6",
+                        "remove-bom-buffer": "3.0.0",
+                        "remove-bom-stream": "1.2.0",
+                        "resolve-options": "1.1.0",
+                        "through2": "2.0.3",
+                        "to-through": "2.0.0",
+                        "value-or-function": "3.0.0",
+                        "vinyl": "2.1.0",
+                        "vinyl-sourcemap": "1.1.0"
                     }
                 }
             }
@@ -8078,11 +7536,11 @@
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "event-stream": "~3.3.4",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3",
-                "vinyl": "^1.2.0"
+                "event-stream": "3.3.4",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -8091,8 +7549,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -8104,24 +7562,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.2.0",
+                "fancy-log": "1.3.2",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
             },
             "dependencies": {
                 "object-assign": {
@@ -8139,12 +7597,12 @@
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^3.0.3",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
+                "queue": "4.5.1",
+                "through2": "2.0.3",
+                "vinyl": "2.2.0",
+                "vinyl-fs": "3.0.3",
+                "yauzl": "2.9.1",
+                "yazl": "2.5.1"
             },
             "dependencies": {
                 "clone": {
@@ -8165,7 +7623,7 @@
                     "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
                     "dev": true,
                     "requires": {
-                        "inherits": "~2.0.0"
+                        "inherits": "2.0.3"
                     }
                 },
                 "replace-ext": {
@@ -8180,12 +7638,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -8196,16 +7654,16 @@
             "integrity": "sha512-q+HLppxXd11z9ndqql4Z0sd5xOAesJjycl0PRaq6ImK7b1BqBRL37YvxEE8ngUdIfpfHa0O9OCoovoggcFpCaQ==",
             "dev": true,
             "requires": {
-                "anymatch": "^1.3.0",
-                "chokidar": "^2.0.0",
-                "glob-parent": "^3.0.1",
-                "gulp-util": "^3.0.7",
-                "object-assign": "^4.1.0",
-                "path-is-absolute": "^1.0.1",
-                "readable-stream": "^2.2.2",
-                "slash": "^1.0.0",
-                "vinyl": "^2.1.0",
-                "vinyl-file": "^2.0.0"
+                "anymatch": "1.3.2",
+                "chokidar": "2.0.3",
+                "glob-parent": "3.1.0",
+                "gulp-util": "3.0.8",
+                "object-assign": "4.1.1",
+                "path-is-absolute": "1.0.1",
+                "readable-stream": "2.3.6",
+                "slash": "1.0.0",
+                "vinyl": "2.1.0",
+                "vinyl-file": "2.0.0"
             },
             "dependencies": {
                 "chokidar": {
@@ -8214,18 +7672,17 @@
                     "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.0",
-                        "braces": "^2.3.0",
-                        "fsevents": "^1.1.2",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "normalize-path": "^2.1.1",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0",
-                        "upath": "^1.0.0"
+                        "anymatch": "2.0.0",
+                        "async-each": "1.0.1",
+                        "braces": "2.3.2",
+                        "glob-parent": "3.1.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "4.0.0",
+                        "normalize-path": "2.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0",
+                        "upath": "1.1.0"
                     },
                     "dependencies": {
                         "anymatch": {
@@ -8234,8 +7691,8 @@
                             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                             "dev": true,
                             "requires": {
-                                "micromatch": "^3.1.4",
-                                "normalize-path": "^2.1.1"
+                                "micromatch": "3.1.10",
+                                "normalize-path": "2.1.1"
                             }
                         }
                     }
@@ -8258,7 +7715,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "process-nextick-args": {
@@ -8273,13 +7730,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "replace-ext": {
@@ -8294,7 +7751,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "vinyl": {
@@ -8303,12 +7760,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -8319,7 +7776,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "^1.0.0"
+                "glogg": "1.0.1"
             }
         },
         "gzip-size": {
@@ -8328,7 +7785,7 @@
             "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
             "dev": true,
             "requires": {
-                "duplexer": "^0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "handlebars": {
@@ -8337,10 +7794,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "^1.4.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.4.4",
-                "uglify-js": "^2.6"
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.8.29"
             },
             "dependencies": {
                 "source-map": {
@@ -8349,7 +7806,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": ">=0.0.4"
+                        "amdefine": "1.0.1"
                     }
                 }
             }
@@ -8364,8 +7821,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -8374,7 +7831,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -8383,7 +7840,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -8398,7 +7855,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.1"
             }
         },
         "has-symbol-support-x": {
@@ -8419,7 +7876,7 @@
             "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "dev": true,
             "requires": {
-                "has-symbol-support-x": "^1.4.1"
+                "has-symbol-support-x": "1.4.2"
             }
         },
         "has-value": {
@@ -8428,9 +7885,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "has-values": {
@@ -8439,8 +7896,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -8449,7 +7906,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -8459,8 +7916,8 @@
             "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "hash.js": {
@@ -8469,8 +7926,8 @@
             "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.1"
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.1"
             }
         },
         "he": {
@@ -8485,9 +7942,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hash.js": "1.1.5",
+                "minimalistic-assert": "1.0.1",
+                "minimalistic-crypto-utils": "1.0.1"
             }
         },
         "hoist-non-react-statics": {
@@ -8502,7 +7959,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "^1.0.0"
+                "parse-passwd": "1.0.0"
             }
         },
         "hoopy": {
@@ -8523,7 +7980,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "^1.0.1"
+                "whatwg-encoding": "1.0.5"
             }
         },
         "html-minifier": {
@@ -8532,13 +7989,13 @@
             "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.x",
-                "clean-css": "4.2.x",
-                "commander": "2.17.x",
-                "he": "1.1.x",
-                "param-case": "2.1.x",
-                "relateurl": "0.2.x",
-                "uglify-js": "3.4.x"
+                "camel-case": "3.0.0",
+                "clean-css": "4.2.1",
+                "commander": "2.17.1",
+                "he": "1.1.1",
+                "param-case": "2.1.1",
+                "relateurl": "0.2.7",
+                "uglify-js": "3.4.9"
             },
             "dependencies": {
                 "commander": {
@@ -8559,8 +8016,8 @@
                     "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
                     "dev": true,
                     "requires": {
-                        "commander": "~2.17.1",
-                        "source-map": "~0.6.1"
+                        "commander": "2.17.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -8571,12 +8028,12 @@
             "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
             "dev": true,
             "requires": {
-                "html-minifier": "^3.2.3",
-                "loader-utils": "^0.2.16",
-                "lodash": "^4.17.3",
-                "pretty-error": "^2.0.2",
-                "tapable": "^1.0.0",
-                "toposort": "^1.0.0",
+                "html-minifier": "3.5.20",
+                "loader-utils": "0.2.17",
+                "lodash": "4.17.11",
+                "pretty-error": "2.1.1",
+                "tapable": "1.1.0",
+                "toposort": "1.0.7",
                 "util.promisify": "1.0.0"
             },
             "dependencies": {
@@ -8586,10 +8043,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
+                        "big.js": "3.2.0",
+                        "emojis-list": "2.1.0",
+                        "json5": "0.5.1",
+                        "object-assign": "4.1.1"
                     }
                 }
             }
@@ -8600,12 +8057,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "^1.3.0",
-                "domhandler": "^2.3.0",
-                "domutils": "^1.5.1",
-                "entities": "^1.1.1",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.2"
+                "domelementtype": "1.3.0",
+                "domhandler": "2.4.2",
+                "domutils": "1.7.0",
+                "entities": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6"
             }
         },
         "http-cache-semantics": {
@@ -8620,10 +8077,10 @@
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "dev": true,
             "requires": {
-                "depd": "~1.1.2",
+                "depd": "1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "statuses": "1.4.0"
             }
         },
         "http-parser-js": {
@@ -8637,9 +8094,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
             }
         },
         "https-browserify": {
@@ -8654,16 +8111,16 @@
             "integrity": "sha512-9TdkUpBeEOjz0AnFdUN4i3w8kEbOsVs9/WSeJqWLq2OO6bcKQhVW64Zi+pVd/AMRLpN3QTINb6ZXiELczvdmqQ==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "^5.0.6",
-                "execa": "^0.9.0",
-                "find-up": "^3.0.0",
-                "get-stdin": "^6.0.0",
-                "is-ci": "^1.2.1",
-                "pkg-dir": "^3.0.0",
-                "please-upgrade-node": "^3.1.1",
-                "read-pkg": "^4.0.1",
-                "run-node": "^1.0.0",
-                "slash": "^2.0.0"
+                "cosmiconfig": "5.0.6",
+                "execa": "0.9.0",
+                "find-up": "3.0.0",
+                "get-stdin": "6.0.0",
+                "is-ci": "1.2.1",
+                "pkg-dir": "3.0.0",
+                "please-upgrade-node": "3.1.1",
+                "read-pkg": "4.0.1",
+                "run-node": "1.0.0",
+                "slash": "2.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -8672,9 +8129,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 },
                 "execa": {
@@ -8683,13 +8140,13 @@
                     "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     }
                 },
                 "find-up": {
@@ -8698,7 +8155,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "3.0.0"
                     }
                 },
                 "get-stdin": {
@@ -8713,8 +8170,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "3.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "parse-json": {
@@ -8723,8 +8180,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.1",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 },
                 "path-exists": {
@@ -8739,7 +8196,7 @@
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0"
+                        "find-up": "3.0.0"
                     }
                 },
                 "read-pkg": {
@@ -8748,9 +8205,9 @@
                     "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
                     "dev": true,
                     "requires": {
-                        "normalize-package-data": "^2.3.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0"
+                        "normalize-package-data": "2.4.0",
+                        "parse-json": "4.0.0",
+                        "pify": "3.0.0"
                     }
                 },
                 "slash": {
@@ -8766,7 +8223,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
             "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
             "requires": {
-                "safer-buffer": "^2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "icss-replace-symbols": {
@@ -8781,7 +8238,7 @@
             "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
             "dev": true,
             "requires": {
-                "postcss": "^6.0.1"
+                "postcss": "6.0.23"
             }
         },
         "ieee754": {
@@ -8808,8 +8265,8 @@
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^3.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "3.0.0",
+                "resolve-cwd": "2.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -8818,7 +8275,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "3.0.0"
                     }
                 },
                 "locate-path": {
@@ -8827,8 +8284,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "3.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "path-exists": {
@@ -8843,7 +8300,7 @@
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0"
+                        "find-up": "3.0.0"
                     }
                 }
             }
@@ -8865,8 +8322,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -8886,12 +8343,12 @@
             "integrity": "sha512-RvMOGMXxAqqve4ld128B7TYyNR2aP1LB38dcSpWFmqXrhKPuey1+yFU6kFUgyH8IWX+gRZdWtHN4eQ9d0IpFZg==",
             "dev": true,
             "requires": {
-                "csso": "3.4.x",
-                "htmlparser2": "3.9.x",
-                "is-plain-obj": "1.1.x",
-                "object-assign": "4.1.x",
-                "svgo": "0.7.x",
-                "uglify-js": "3.3.x"
+                "csso": "3.4.0",
+                "htmlparser2": "3.9.2",
+                "is-plain-obj": "1.1.0",
+                "object-assign": "4.1.1",
+                "svgo": "0.7.2",
+                "uglify-js": "3.3.28"
             },
             "dependencies": {
                 "source-map": {
@@ -8906,8 +8363,8 @@
                     "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
                     "dev": true,
                     "requires": {
-                        "commander": "~2.15.0",
-                        "source-map": "~0.6.1"
+                        "commander": "2.15.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -8918,20 +8375,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.0.4",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.11",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rx-lite": "^4.0.8",
-                "rx-lite-aggregates": "^4.0.8",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -8946,7 +8403,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -8955,9 +8412,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -8972,7 +8429,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "supports-color": {
@@ -8981,7 +8438,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -8998,8 +8455,8 @@
             "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
             "dev": true,
             "requires": {
-                "from2": "^2.1.1",
-                "p-is-promise": "^1.1.0"
+                "from2": "2.3.0",
+                "p-is-promise": "1.1.0"
             }
         },
         "invariant": {
@@ -9008,7 +8465,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "inversify": {
@@ -9040,8 +8497,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "^1.0.0",
-                "is-windows": "^1.0.1"
+                "is-relative": "1.0.0",
+                "is-windows": "1.0.2"
             }
         },
         "is-accessor-descriptor": {
@@ -9050,7 +8507,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -9059,7 +8516,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -9076,8 +8533,8 @@
             "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
             "dev": true,
             "requires": {
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0"
+                "is-alphabetical": "1.0.2",
+                "is-decimal": "1.0.2"
             }
         },
         "is-arrayish": {
@@ -9092,7 +8549,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "1.11.0"
             }
         },
         "is-boolean-object": {
@@ -9112,7 +8569,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-callable": {
@@ -9127,7 +8584,7 @@
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "dev": true,
             "requires": {
-                "ci-info": "^1.5.0"
+                "ci-info": "1.6.0"
             }
         },
         "is-data-descriptor": {
@@ -9136,7 +8593,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -9145,7 +8602,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -9168,9 +8625,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -9199,7 +8656,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -9226,7 +8683,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
             }
         },
         "is-hexadecimal": {
@@ -9253,7 +8710,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -9262,7 +8719,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -9291,7 +8748,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0"
+                "is-number": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -9314,7 +8771,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "^1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
@@ -9323,7 +8780,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-plain-obj": {
@@ -9338,7 +8795,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -9365,7 +8822,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-relative": {
@@ -9374,7 +8831,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "^1.0.0"
+                "is-unc-path": "1.0.0"
             }
         },
         "is-retry-allowed": {
@@ -9418,7 +8875,7 @@
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -9432,7 +8889,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "^0.1.2"
+                "unc-path-regex": "0.1.2"
             }
         },
         "is-utf8": {
@@ -9494,8 +8951,8 @@
             "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
             "dev": true,
             "requires": {
-                "node-fetch": "^1.0.1",
-                "whatwg-fetch": ">=0.10.0"
+                "node-fetch": "1.7.3",
+                "whatwg-fetch": "3.0.0"
             }
         },
         "isstream": {
@@ -9509,20 +8966,20 @@
             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.x",
-                "async": "1.x",
-                "escodegen": "1.8.x",
-                "esprima": "2.7.x",
-                "glob": "^5.0.15",
-                "handlebars": "^4.0.1",
-                "js-yaml": "3.x",
-                "mkdirp": "0.5.x",
-                "nopt": "3.x",
-                "once": "1.x",
-                "resolve": "1.1.x",
-                "supports-color": "^3.1.0",
-                "which": "^1.1.1",
-                "wordwrap": "^1.0.0"
+                "abbrev": "1.0.9",
+                "async": "1.5.2",
+                "escodegen": "1.8.1",
+                "esprima": "2.7.3",
+                "glob": "5.0.15",
+                "handlebars": "4.0.11",
+                "js-yaml": "3.11.0",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6",
+                "once": "1.4.0",
+                "resolve": "1.1.7",
+                "supports-color": "3.2.3",
+                "which": "1.3.1",
+                "wordwrap": "1.0.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -9537,11 +8994,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "resolve": {
@@ -9556,7 +9013,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "1.0.0"
                     }
                 }
             }
@@ -9573,13 +9030,13 @@
             "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
             "dev": true,
             "requires": {
-                "@babel/generator": "^7.0.0",
-                "@babel/parser": "^7.0.0",
-                "@babel/template": "^7.0.0",
-                "@babel/traverse": "^7.0.0",
-                "@babel/types": "^7.0.0",
-                "istanbul-lib-coverage": "^2.0.1",
-                "semver": "^5.5.0"
+                "@babel/generator": "7.0.0",
+                "@babel/parser": "7.1.0",
+                "@babel/template": "7.1.0",
+                "@babel/traverse": "7.1.0",
+                "@babel/types": "7.0.0",
+                "istanbul-lib-coverage": "2.0.1",
+                "semver": "5.5.0"
             }
         },
         "isurl": {
@@ -9588,8 +9045,8 @@
             "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "dev": true,
             "requires": {
-                "has-to-string-tag-x": "^1.2.0",
-                "is-object": "^1.0.1"
+                "has-to-string-tag-x": "1.4.1",
+                "is-object": "1.0.1"
             }
         },
         "js-beautify": {
@@ -9598,10 +9055,10 @@
             "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
             "dev": true,
             "requires": {
-                "config-chain": "~1.1.5",
-                "editorconfig": "^0.13.2",
-                "mkdirp": "~0.5.0",
-                "nopt": "~3.0.1"
+                "config-chain": "1.1.11",
+                "editorconfig": "0.13.3",
+                "mkdirp": "0.5.1",
+                "nopt": "3.0.6"
             }
         },
         "js-levenshtein": {
@@ -9622,8 +9079,8 @@
             "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
             },
             "dependencies": {
                 "esprima": {
@@ -9646,31 +9103,31 @@
             "integrity": "sha512-QPOggIJ8fquWPLaYYMoh+zqUmdphDtu1ju0QGTitZT1Yd8I5qenPpXM1etzUegu3MjVp8XPzgZxdn8Yj7e40ig==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "acorn": "^6.0.2",
-                "acorn-globals": "^4.3.0",
-                "array-equal": "^1.0.0",
-                "cssom": "^0.3.4",
-                "cssstyle": "^1.1.1",
-                "data-urls": "^1.0.1",
-                "domexception": "^1.0.1",
-                "escodegen": "^1.11.0",
-                "html-encoding-sniffer": "^1.0.2",
-                "nwsapi": "^2.0.9",
+                "abab": "2.0.0",
+                "acorn": "6.0.2",
+                "acorn-globals": "4.3.0",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.4",
+                "cssstyle": "1.1.1",
+                "data-urls": "1.0.1",
+                "domexception": "1.0.1",
+                "escodegen": "1.11.0",
+                "html-encoding-sniffer": "1.0.2",
+                "nwsapi": "2.0.9",
                 "parse5": "5.1.0",
-                "pn": "^1.1.0",
-                "request": "^2.88.0",
-                "request-promise-native": "^1.0.5",
-                "saxes": "^3.1.3",
-                "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.4.3",
-                "w3c-hr-time": "^1.0.1",
-                "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.5",
-                "whatwg-mimetype": "^2.2.0",
-                "whatwg-url": "^7.0.0",
-                "ws": "^6.1.0",
-                "xml-name-validator": "^3.0.0"
+                "pn": "1.1.0",
+                "request": "2.88.0",
+                "request-promise-native": "1.0.5",
+                "saxes": "3.1.3",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.4.3",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.5",
+                "whatwg-mimetype": "2.2.0",
+                "whatwg-url": "7.0.0",
+                "ws": "6.1.0",
+                "xml-name-validator": "3.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -9691,11 +9148,11 @@
                     "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
                     "dev": true,
                     "requires": {
-                        "esprima": "^3.1.3",
-                        "estraverse": "^4.2.0",
-                        "esutils": "^2.0.2",
-                        "optionator": "^0.8.1",
-                        "source-map": "~0.6.1"
+                        "esprima": "3.1.3",
+                        "estraverse": "4.2.0",
+                        "esutils": "2.0.2",
+                        "optionator": "0.8.2",
+                        "source-map": "0.6.1"
                     }
                 },
                 "esprima": {
@@ -9722,8 +9179,8 @@
                     "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^5.3.0",
-                        "har-schema": "^2.0.0"
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
                     }
                 },
                 "mime-db": {
@@ -9738,7 +9195,7 @@
                     "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "~1.36.0"
+                        "mime-db": "1.36.0"
                     }
                 },
                 "oauth-sign": {
@@ -9759,26 +9216,26 @@
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "~0.7.0",
-                        "aws4": "^1.8.0",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.6",
-                        "extend": "~3.0.2",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.3.2",
-                        "har-validator": "~5.1.0",
-                        "http-signature": "~1.2.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.19",
-                        "oauth-sign": "~0.9.0",
-                        "performance-now": "^2.1.0",
-                        "qs": "~6.5.2",
-                        "safe-buffer": "^5.1.2",
-                        "tough-cookie": "~2.4.3",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.3.2"
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.8.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.2",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.1.0",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.20",
+                        "oauth-sign": "0.9.0",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
+                        "tough-cookie": "2.4.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.3.2"
                     }
                 },
                 "source-map": {
@@ -9794,8 +9251,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.29",
+                        "punycode": "1.4.1"
                     }
                 },
                 "uuid": {
@@ -9810,7 +9267,7 @@
                     "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "~1.0.0"
+                        "async-limiter": "1.0.0"
                     }
                 }
             }
@@ -9832,7 +9289,7 @@
             "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
             "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
             "requires": {
-                "jsonparse": "~1.2.0"
+                "jsonparse": "1.2.0"
             }
         },
         "json-loader": {
@@ -9852,7 +9309,7 @@
             "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
             "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
             "requires": {
-                "esprima": "^2.7.0"
+                "esprima": "2.7.3"
             }
         },
         "json-schema": {
@@ -9870,7 +9327,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -9884,16 +9341,16 @@
             "integrity": "sha512-ORsw84BuRKMLxfI+HFZuvxRDnsJps53D5fIGr6tLn4ZY+ymcG8XU00E+JJ2wfAiHx5w2QRNmOLE8xHiGAeSfuQ==",
             "dev": true,
             "requires": {
-                "cli-table": "^0.3.1",
-                "commander": "^2.8.1",
-                "debug": "^3.1.0",
-                "flat": "^4.0.0",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
-                "lodash.get": "^4.4.0",
-                "lodash.set": "^4.3.0",
-                "lodash.uniq": "^4.5.0",
-                "path-is-absolute": "^1.0.0"
+                "cli-table": "0.3.1",
+                "commander": "2.15.1",
+                "debug": "3.2.6",
+                "flat": "4.0.0",
+                "lodash.clonedeep": "4.5.0",
+                "lodash.flatten": "4.4.0",
+                "lodash.get": "4.4.2",
+                "lodash.set": "4.3.2",
+                "lodash.uniq": "4.5.0",
+                "path-is-absolute": "1.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -9902,7 +9359,7 @@
                     "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "ms": {
@@ -9930,7 +9387,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "4.1.11"
             }
         },
         "jsonify": {
@@ -9987,8 +9444,8 @@
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
             "dev": true,
             "requires": {
-                "default-resolution": "^2.0.0",
-                "es6-weak-map": "^2.0.1"
+                "default-resolution": "2.0.0",
+                "es6-weak-map": "2.0.2"
             }
         },
         "lazy-cache": {
@@ -10004,7 +9461,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.0.6"
             }
         },
         "lcid": {
@@ -10013,7 +9470,7 @@
             "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "dev": true,
             "requires": {
-                "invert-kv": "^2.0.0"
+                "invert-kv": "2.0.0"
             }
         },
         "lead": {
@@ -10022,7 +9479,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "^1.0.2"
+                "flush-write-stream": "1.0.3"
             }
         },
         "leaflet": {
@@ -10037,8 +9494,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "liftoff": {
@@ -10047,14 +9504,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "^3.0.0",
-                "findup-sync": "^2.0.0",
-                "fined": "^1.0.1",
-                "flagged-respawn": "^1.0.0",
-                "is-plain-object": "^2.0.4",
-                "object.map": "^1.0.0",
-                "rechoir": "^0.6.2",
-                "resolve": "^1.1.7"
+                "extend": "3.0.1",
+                "findup-sync": "2.0.0",
+                "fined": "1.1.0",
+                "flagged-respawn": "1.0.0",
+                "is-plain-object": "2.0.4",
+                "object.map": "1.0.1",
+                "rechoir": "0.6.2",
+                "resolve": "1.7.1"
             }
         },
         "line-by-line": {
@@ -10068,11 +9525,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -10087,7 +9544,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                     }
                 }
             }
@@ -10104,9 +9561,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "^3.1.3",
-                "emojis-list": "^2.0.0",
-                "json5": "^0.5.0"
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
             }
         },
         "locate-path": {
@@ -10115,8 +9572,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             },
             "dependencies": {
                 "p-limit": {
@@ -10125,7 +9582,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^1.0.0"
+                        "p-try": "1.0.0"
                     }
                 },
                 "p-locate": {
@@ -10134,7 +9591,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^1.1.0"
+                        "p-limit": "1.3.0"
                     }
                 },
                 "path-exists": {
@@ -10228,7 +9685,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "^3.0.0"
+                "lodash._root": "3.0.1"
             }
         },
         "lodash.flatten": {
@@ -10279,9 +9736,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
             }
         },
         "lodash.restparam": {
@@ -10314,15 +9771,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
             }
         },
         "lodash.templatesettings": {
@@ -10331,8 +9788,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
             }
         },
         "lodash.uniq": {
@@ -10347,7 +9804,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1"
+                "chalk": "2.4.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10356,7 +9813,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -10365,9 +9822,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -10382,7 +9839,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -10393,8 +9850,8 @@
             "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
             "dev": true,
             "requires": {
-                "es6-symbol": "^3.1.1",
-                "object.assign": "^4.1.0"
+                "es6-symbol": "3.1.1",
+                "object.assign": "4.1.0"
             }
         },
         "longest": {
@@ -10409,7 +9866,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "lower-case": {
@@ -10430,8 +9887,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "lru-queue": {
@@ -10440,7 +9897,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.2"
+                "es5-ext": "0.10.43"
             }
         },
         "make-dir": {
@@ -10449,7 +9906,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "make-iterator": {
@@ -10458,7 +9915,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             }
         },
         "map-age-cleaner": {
@@ -10467,7 +9924,7 @@
             "integrity": "sha512-UN1dNocxQq44IhJyMI4TU8phc2m9BddacHRPRjKGLYaF0jqd3xLz0jS0skpAU9WgYyoR4gHtUpzytNBS385FWQ==",
             "dev": true,
             "requires": {
-                "p-defer": "^1.0.0"
+                "p-defer": "1.0.0"
             }
         },
         "map-cache": {
@@ -10488,7 +9945,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "markdown-escapes": {
@@ -10503,8 +9960,8 @@
             "integrity": "sha1-gc4+soZ82RiKILkKzybyP7To7kI=",
             "dev": true,
             "requires": {
-                "bintrees": "^1.0.1",
-                "tinyqueue": "^1.1.0"
+                "bintrees": "1.0.2",
+                "tinyqueue": "1.2.3"
             }
         },
         "matchdep": {
@@ -10513,9 +9970,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "^2.0.0",
-                "micromatch": "^3.0.4",
-                "resolve": "^1.4.0",
+                "findup-sync": "2.0.0",
+                "micromatch": "3.1.10",
+                "resolve": "1.7.1",
                 "stack-trace": "0.0.10"
             }
         },
@@ -10536,9 +9993,9 @@
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
             "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
             "requires": {
-                "charenc": "~0.0.1",
-                "crypt": "~0.0.1",
-                "is-buffer": "~1.1.1"
+                "charenc": "0.0.2",
+                "crypt": "0.0.2",
+                "is-buffer": "1.1.6"
             }
         },
         "md5.js": {
@@ -10546,8 +10003,8 @@
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "mdast-add-list-metadata": {
@@ -10577,9 +10034,9 @@
             "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
             "dev": true,
             "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^1.0.0",
-                "p-is-promise": "^1.1.0"
+                "map-age-cleaner": "0.1.2",
+                "mimic-fn": "1.2.0",
+                "p-is-promise": "1.1.0"
             }
         },
         "memoize-one": {
@@ -10594,14 +10051,14 @@
             "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
             "dev": true,
             "requires": {
-                "d": "1",
-                "es5-ext": "^0.10.30",
-                "es6-weak-map": "^2.0.2",
-                "event-emitter": "^0.3.5",
-                "is-promise": "^2.1",
-                "lru-queue": "0.1",
-                "next-tick": "1",
-                "timers-ext": "^0.1.2"
+                "d": "1.0.0",
+                "es5-ext": "0.10.43",
+                "es6-weak-map": "2.0.2",
+                "event-emitter": "0.3.5",
+                "is-promise": "2.1.0",
+                "lru-queue": "0.1.0",
+                "next-tick": "1.0.0",
+                "timers-ext": "0.1.5"
             }
         },
         "memory-fs": {
@@ -10610,8 +10067,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "^0.1.3",
-                "readable-stream": "^2.0.1"
+                "errno": "0.1.7",
+                "readable-stream": "2.0.6"
             }
         },
         "merge-descriptors": {
@@ -10632,19 +10089,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "miller-rabin": {
@@ -10653,8 +10110,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.0.0",
-                "brorand": "^1.0.1"
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
             }
         },
         "mime": {
@@ -10673,7 +10130,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.33.0"
             }
         },
         "mimic-fn": {
@@ -10694,7 +10151,7 @@
             "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
             "dev": true,
             "requires": {
-                "dom-walk": "^0.1.0"
+                "dom-walk": "0.1.1"
             }
         },
         "minimalistic-assert": {
@@ -10714,7 +10171,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -10728,16 +10185,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "^1.5.0",
-                "duplexify": "^3.4.2",
-                "end-of-stream": "^1.1.0",
-                "flush-write-stream": "^1.0.0",
-                "from2": "^2.1.0",
-                "parallel-transform": "^1.1.0",
-                "pump": "^2.0.1",
-                "pumpify": "^1.3.3",
-                "stream-each": "^1.1.0",
-                "through2": "^2.0.0"
+                "concat-stream": "1.6.2",
+                "duplexify": "3.6.0",
+                "end-of-stream": "1.4.1",
+                "flush-write-stream": "1.0.3",
+                "from2": "2.3.0",
+                "parallel-transform": "1.1.0",
+                "pump": "2.0.1",
+                "pumpify": "1.5.1",
+                "stream-each": "1.2.3",
+                "through2": "2.0.3"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -10746,7 +10203,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                     }
                 }
             }
@@ -10757,8 +10214,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -10767,7 +10224,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -10829,7 +10286,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -10840,11 +10297,11 @@
             "integrity": "sha1-LlFJ7UD8XS48px5C21qx/snG2Fw=",
             "dev": true,
             "requires": {
-                "debug": "^2.2.0",
-                "md5": "^2.1.0",
-                "mkdirp": "~0.5.1",
-                "strip-ansi": "^4.0.0",
-                "xml": "^1.0.0"
+                "debug": "2.6.9",
+                "md5": "2.2.1",
+                "mkdirp": "0.5.1",
+                "strip-ansi": "4.0.0",
+                "xml": "1.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -10859,7 +10316,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -10881,12 +10338,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1",
-                "copy-concurrently": "^1.0.0",
-                "fs-write-stream-atomic": "^1.0.8",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.5.4",
-                "run-queue": "^1.0.3"
+                "aproba": "1.2.0",
+                "copy-concurrently": "1.0.5",
+                "fs-write-stream-atomic": "1.0.10",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "run-queue": "1.0.3"
             }
         },
         "ms": {
@@ -10901,10 +10358,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
             }
         },
         "multipipe": {
@@ -10933,31 +10390,24 @@
             "resolved": "https://registry.npmjs.org/named-js-regexp/-/named-js-regexp-1.3.3.tgz",
             "integrity": "sha512-zIUAXzGQOp16VR0Ct89SDstU62hzAPBluNUrUrsdD7MNSRbm/vyqGhEnp+4hnsMjmX3C2wh1cbIEP0joKMFLxw=="
         },
-        "nan": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-            "dev": true,
-            "optional": true
-        },
         "nanomatch": {
             "version": "1.2.9",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-odd": "^2.0.0",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-odd": "2.0.0",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "nearley": {
@@ -10966,11 +10416,11 @@
             "integrity": "sha512-8IUY/rUrKz2mIynUGh8k+tul1awMKEjeHHC5G3FHvvyAW6oq4mQfNp2c0BMea+sYZJvYcrrM6GmZVIle/GRXGw==",
             "dev": true,
             "requires": {
-                "moo": "^0.4.3",
-                "nomnom": "~1.6.2",
-                "railroad-diagrams": "^1.0.0",
+                "moo": "0.4.3",
+                "nomnom": "1.6.2",
+                "railroad-diagrams": "1.0.0",
                 "randexp": "0.4.6",
-                "semver": "^5.4.1"
+                "semver": "5.5.0"
             }
         },
         "negotiator": {
@@ -11003,7 +10453,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "^1.1.1"
+                "lower-case": "1.1.4"
             }
         },
         "node-fetch": {
@@ -11011,8 +10461,8 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
+                "encoding": "0.1.12",
+                "is-stream": "1.1.0"
             }
         },
         "node-has-native-dependencies": {
@@ -11030,28 +10480,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "^1.1.1",
-                "browserify-zlib": "^0.2.0",
-                "buffer": "^4.3.0",
-                "console-browserify": "^1.1.0",
-                "constants-browserify": "^1.0.0",
-                "crypto-browserify": "^3.11.0",
-                "domain-browser": "^1.1.1",
-                "events": "^1.0.0",
-                "https-browserify": "^1.0.0",
-                "os-browserify": "^0.3.0",
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "^0.11.10",
-                "punycode": "^1.2.4",
-                "querystring-es3": "^0.2.0",
-                "readable-stream": "^2.3.3",
-                "stream-browserify": "^2.0.1",
-                "stream-http": "^2.7.2",
-                "string_decoder": "^1.0.0",
-                "timers-browserify": "^2.0.4",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.6",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.3",
+                "string_decoder": "1.1.1",
+                "timers-browserify": "2.0.10",
                 "tty-browserify": "0.0.0",
-                "url": "^0.11.0",
-                "util": "^0.10.3",
+                "url": "0.11.0",
+                "util": "0.10.4",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -11067,9 +10517,9 @@
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
-                        "base64-js": "^1.0.2",
-                        "ieee754": "^1.1.4",
-                        "isarray": "^1.0.0"
+                        "base64-js": "1.3.0",
+                        "ieee754": "1.1.11",
+                        "isarray": "1.0.0"
                     }
                 },
                 "process-nextick-args": {
@@ -11084,13 +10534,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -11099,7 +10549,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -11110,7 +10560,7 @@
             "integrity": "sha512-VPB4rTPqpVyWKBHbSa4YPFme3+8WHsOSpvbp0Mfj0bWsC8TEjt4HQrLl1hsBDELlp1nB4lflSgSuGTYiuyaP7Q==",
             "dev": true,
             "requires": {
-                "semver": "^5.3.0"
+                "semver": "5.5.0"
             }
         },
         "node-stream-zip": {
@@ -11124,8 +10574,8 @@
             "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "has": "^1.0.3",
-                "is": "^3.2.1"
+                "has": "1.0.3",
+                "is": "3.3.0"
             }
         },
         "nomnom": {
@@ -11134,8 +10584,8 @@
             "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
             "dev": true,
             "requires": {
-                "colors": "0.5.x",
-                "underscore": "~1.4.4"
+                "colors": "0.5.1",
+                "underscore": "1.4.4"
             },
             "dependencies": {
                 "colors": {
@@ -11158,7 +10608,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1"
+                "abbrev": "1.1.1"
             }
         },
         "normalize-package-data": {
@@ -11167,10 +10617,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
             }
         },
         "normalize-path": {
@@ -11179,7 +10629,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "normalize-url": {
@@ -11188,9 +10638,9 @@
             "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
             "dev": true,
             "requires": {
-                "prepend-http": "^2.0.0",
-                "query-string": "^5.0.1",
-                "sort-keys": "^2.0.0"
+                "prepend-http": "2.0.0",
+                "query-string": "5.1.1",
+                "sort-keys": "2.0.0"
             },
             "dependencies": {
                 "sort-keys": {
@@ -11199,7 +10649,7 @@
                     "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
                     "dev": true,
                     "requires": {
-                        "is-plain-obj": "^1.0.0"
+                        "is-plain-obj": "1.1.0"
                     }
                 }
             }
@@ -11210,7 +10660,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "^1.3.2"
+                "once": "1.4.0"
             }
         },
         "npm-conf": {
@@ -11219,8 +10669,8 @@
             "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
             "dev": true,
             "requires": {
-                "config-chain": "^1.1.11",
-                "pify": "^3.0.0"
+                "config-chain": "1.1.11",
+                "pify": "3.0.0"
             }
         },
         "npm-run-path": {
@@ -11229,7 +10679,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "nth-check": {
@@ -11238,7 +10688,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "~1.0.0"
+                "boolbase": "1.0.0"
             }
         },
         "number-is-nan": {
@@ -11265,31 +10715,31 @@
             "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
             "dev": true,
             "requires": {
-                "archy": "^1.0.0",
-                "arrify": "^1.0.1",
-                "caching-transform": "^2.0.0",
-                "convert-source-map": "^1.6.0",
-                "debug-log": "^1.0.1",
-                "find-cache-dir": "^2.0.0",
-                "find-up": "^3.0.0",
-                "foreground-child": "^1.5.6",
-                "glob": "^7.1.3",
-                "istanbul-lib-coverage": "^2.0.1",
-                "istanbul-lib-hook": "^2.0.1",
-                "istanbul-lib-instrument": "^3.0.0",
-                "istanbul-lib-report": "^2.0.2",
-                "istanbul-lib-source-maps": "^2.0.1",
-                "istanbul-reports": "^2.0.1",
-                "make-dir": "^1.3.0",
-                "merge-source-map": "^1.1.0",
-                "resolve-from": "^4.0.0",
-                "rimraf": "^2.6.2",
-                "signal-exit": "^3.0.2",
-                "spawn-wrap": "^1.4.2",
-                "test-exclude": "^5.0.0",
-                "uuid": "^3.3.2",
+                "archy": "1.0.0",
+                "arrify": "1.0.1",
+                "caching-transform": "2.0.0",
+                "convert-source-map": "1.6.0",
+                "debug-log": "1.0.1",
+                "find-cache-dir": "2.0.0",
+                "find-up": "3.0.0",
+                "foreground-child": "1.5.6",
+                "glob": "7.1.3",
+                "istanbul-lib-coverage": "2.0.1",
+                "istanbul-lib-hook": "2.0.1",
+                "istanbul-lib-instrument": "3.0.0",
+                "istanbul-lib-report": "2.0.2",
+                "istanbul-lib-source-maps": "2.0.1",
+                "istanbul-reports": "2.0.1",
+                "make-dir": "1.3.0",
+                "merge-source-map": "1.1.0",
+                "resolve-from": "4.0.0",
+                "rimraf": "2.6.2",
+                "signal-exit": "3.0.2",
+                "spawn-wrap": "1.4.2",
+                "test-exclude": "5.0.0",
+                "uuid": "3.3.2",
                 "yargs": "11.1.0",
-                "yargs-parser": "^9.0.2"
+                "yargs-parser": "9.0.2"
             },
             "dependencies": {
                 "align-text": {
@@ -11297,9 +10747,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2",
-                        "longest": "^1.0.1",
-                        "repeat-string": "^1.5.2"
+                        "kind-of": "3.2.2",
+                        "longest": "1.0.1",
+                        "repeat-string": "1.6.1"
                     }
                 },
                 "amdefine": {
@@ -11317,7 +10767,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "default-require-extensions": "^2.0.0"
+                        "default-require-extensions": "2.0.0"
                     }
                 },
                 "archy": {
@@ -11345,7 +10795,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -11359,10 +10809,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "make-dir": "^1.0.0",
-                        "md5-hex": "^2.0.0",
-                        "package-hash": "^2.0.0",
-                        "write-file-atomic": "^2.0.0"
+                        "make-dir": "1.3.0",
+                        "md5-hex": "2.0.0",
+                        "package-hash": "2.0.0",
+                        "write-file-atomic": "2.3.0"
                     }
                 },
                 "camelcase": {
@@ -11377,8 +10827,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "^0.1.3",
-                        "lazy-cache": "^1.0.3"
+                        "align-text": "0.1.4",
+                        "lazy-cache": "1.0.4"
                     }
                 },
                 "cliui": {
@@ -11387,8 +10837,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
                         "wordwrap": "0.0.2"
                     },
                     "dependencies": {
@@ -11420,7 +10870,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.1"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "cross-spawn": {
@@ -11428,8 +10878,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "which": "1.3.1"
                     }
                 },
                 "debug": {
@@ -11455,7 +10905,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-bom": "^3.0.0"
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "error-ex": {
@@ -11463,7 +10913,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-arrayish": "^0.2.1"
+                        "is-arrayish": "0.2.1"
                     }
                 },
                 "es6-error": {
@@ -11476,13 +10926,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
-                        "is-stream": "^1.1.0",
-                        "npm-run-path": "^2.0.0",
-                        "p-finally": "^1.0.0",
-                        "signal-exit": "^3.0.0",
-                        "strip-eof": "^1.0.0"
+                        "cross-spawn": "5.1.0",
+                        "get-stream": "3.0.0",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -11490,9 +10940,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "^4.0.1",
-                                "shebang-command": "^1.2.0",
-                                "which": "^1.2.9"
+                                "lru-cache": "4.1.3",
+                                "shebang-command": "1.2.0",
+                                "which": "1.3.1"
                             }
                         }
                     }
@@ -11502,9 +10952,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "commondir": "^1.0.1",
-                        "make-dir": "^1.0.0",
-                        "pkg-dir": "^3.0.0"
+                        "commondir": "1.0.1",
+                        "make-dir": "1.3.0",
+                        "pkg-dir": "3.0.0"
                     }
                 },
                 "find-up": {
@@ -11512,7 +10962,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "3.0.0"
                     }
                 },
                 "foreground-child": {
@@ -11520,8 +10970,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^4",
-                        "signal-exit": "^3.0.0"
+                        "cross-spawn": "4.0.2",
+                        "signal-exit": "3.0.2"
                     }
                 },
                 "fs.realpath": {
@@ -11544,12 +10994,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "graceful-fs": {
@@ -11562,10 +11012,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "^1.4.0",
-                        "optimist": "^0.6.1",
-                        "source-map": "^0.4.4",
-                        "uglify-js": "^2.6"
+                        "async": "1.5.2",
+                        "optimist": "0.6.1",
+                        "source-map": "0.4.4",
+                        "uglify-js": "2.8.29"
                     },
                     "dependencies": {
                         "source-map": {
@@ -11573,7 +11023,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "amdefine": ">=0.0.4"
+                                "amdefine": "1.0.1"
                             }
                         }
                     }
@@ -11598,8 +11048,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -11627,7 +11077,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtin-modules": "^1.0.0"
+                        "builtin-modules": "1.1.1"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -11655,7 +11105,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "append-transform": "^1.0.0"
+                        "append-transform": "1.0.0"
                     }
                 },
                 "istanbul-lib-report": {
@@ -11663,9 +11113,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "^2.0.1",
-                        "make-dir": "^1.3.0",
-                        "supports-color": "^5.4.0"
+                        "istanbul-lib-coverage": "2.0.1",
+                        "make-dir": "1.3.0",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "istanbul-lib-source-maps": {
@@ -11673,11 +11123,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^3.1.0",
-                        "istanbul-lib-coverage": "^2.0.1",
-                        "make-dir": "^1.3.0",
-                        "rimraf": "^2.6.2",
-                        "source-map": "^0.6.1"
+                        "debug": "3.1.0",
+                        "istanbul-lib-coverage": "2.0.1",
+                        "make-dir": "1.3.0",
+                        "rimraf": "2.6.2",
+                        "source-map": "0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -11692,7 +11142,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "^4.0.11"
+                        "handlebars": "4.0.11"
                     }
                 },
                 "json-parse-better-errors": {
@@ -11705,7 +11155,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 },
                 "lazy-cache": {
@@ -11719,7 +11169,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -11727,10 +11177,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "parse-json": "^4.0.0",
-                        "pify": "^3.0.0",
-                        "strip-bom": "^3.0.0"
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "4.0.0",
+                        "pify": "3.0.0",
+                        "strip-bom": "3.0.0"
                     }
                 },
                 "locate-path": {
@@ -11738,8 +11188,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "3.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "lodash.flattendeep": {
@@ -11757,8 +11207,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 },
                 "make-dir": {
@@ -11766,7 +11216,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "md5-hex": {
@@ -11774,7 +11224,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "^0.1.1"
+                        "md5-o-matic": "0.1.1"
                     }
                 },
                 "md5-o-matic": {
@@ -11787,7 +11237,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "mimic-fn": "1.2.0"
                     }
                 },
                 "merge-source-map": {
@@ -11795,7 +11245,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "source-map": "^0.6.1"
+                        "source-map": "0.6.1"
                     },
                     "dependencies": {
                         "source-map": {
@@ -11815,7 +11265,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -11848,10 +11298,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
-                        "semver": "2 || 3 || 4 || 5",
-                        "validate-npm-package-license": "^3.0.1"
+                        "hosted-git-info": "2.7.1",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.5.0",
+                        "validate-npm-package-license": "3.0.3"
                     }
                 },
                 "npm-run-path": {
@@ -11859,7 +11309,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "path-key": "^2.0.0"
+                        "path-key": "2.0.1"
                     }
                 },
                 "number-is-nan": {
@@ -11872,7 +11322,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "optimist": {
@@ -11880,8 +11330,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "minimist": "~0.0.1",
-                        "wordwrap": "~0.0.2"
+                        "minimist": "0.0.10",
+                        "wordwrap": "0.0.3"
                     }
                 },
                 "os-homedir": {
@@ -11894,9 +11344,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "0.7.0",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
                     }
                 },
                 "p-finally": {
@@ -11909,7 +11359,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-try": "^2.0.0"
+                        "p-try": "2.0.0"
                     }
                 },
                 "p-locate": {
@@ -11917,7 +11367,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-limit": "2.0.0"
                     }
                 },
                 "p-try": {
@@ -11930,10 +11380,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "lodash.flattendeep": "^4.4.0",
-                        "md5-hex": "^2.0.0",
-                        "release-zalgo": "^1.0.0"
+                        "graceful-fs": "4.1.11",
+                        "lodash.flattendeep": "4.4.0",
+                        "md5-hex": "2.0.0",
+                        "release-zalgo": "1.0.0"
                     }
                 },
                 "parse-json": {
@@ -11941,8 +11391,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1"
+                        "error-ex": "1.3.2",
+                        "json-parse-better-errors": "1.0.2"
                     }
                 },
                 "path-exists": {
@@ -11965,7 +11415,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "pify": "^3.0.0"
+                        "pify": "3.0.0"
                     }
                 },
                 "pify": {
@@ -11978,7 +11428,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0"
+                        "find-up": "3.0.0"
                     }
                 },
                 "pseudomap": {
@@ -11991,9 +11441,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "load-json-file": "^4.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^3.0.0"
+                        "load-json-file": "4.0.0",
+                        "normalize-package-data": "2.4.0",
+                        "path-type": "3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -12001,8 +11451,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "find-up": "^3.0.0",
-                        "read-pkg": "^3.0.0"
+                        "find-up": "3.0.0",
+                        "read-pkg": "3.0.0"
                     }
                 },
                 "release-zalgo": {
@@ -12010,7 +11460,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "es6-error": "^4.0.1"
+                        "es6-error": "4.1.1"
                     }
                 },
                 "repeat-string": {
@@ -12039,7 +11489,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "align-text": "^0.1.1"
+                        "align-text": "0.1.4"
                     }
                 },
                 "rimraf": {
@@ -12047,7 +11497,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.3"
                     }
                 },
                 "safe-buffer": {
@@ -12070,7 +11520,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "^1.0.0"
+                        "shebang-regex": "1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -12094,12 +11544,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "foreground-child": "^1.5.6",
-                        "mkdirp": "^0.5.0",
-                        "os-homedir": "^1.0.1",
-                        "rimraf": "^2.6.2",
-                        "signal-exit": "^3.0.2",
-                        "which": "^1.3.0"
+                        "foreground-child": "1.5.6",
+                        "mkdirp": "0.5.1",
+                        "os-homedir": "1.0.2",
+                        "rimraf": "2.6.2",
+                        "signal-exit": "3.0.2",
+                        "which": "1.3.1"
                     }
                 },
                 "spdx-correct": {
@@ -12107,8 +11557,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-expression-parse": "^3.0.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-expression-parse": "3.0.0",
+                        "spdx-license-ids": "3.0.0"
                     }
                 },
                 "spdx-exceptions": {
@@ -12121,8 +11571,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-exceptions": "^2.1.0",
-                        "spdx-license-ids": "^3.0.0"
+                        "spdx-exceptions": "2.1.0",
+                        "spdx-license-ids": "3.0.0"
                     }
                 },
                 "spdx-license-ids": {
@@ -12135,8 +11585,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -12144,7 +11594,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 },
                 "strip-bom": {
@@ -12162,7 +11612,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "test-exclude": {
@@ -12170,10 +11620,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "arrify": "^1.0.1",
-                        "minimatch": "^3.0.4",
-                        "read-pkg-up": "^4.0.0",
-                        "require-main-filename": "^1.0.1"
+                        "arrify": "1.0.1",
+                        "minimatch": "3.0.4",
+                        "read-pkg-up": "4.0.0",
+                        "require-main-filename": "1.0.1"
                     }
                 },
                 "uglify-js": {
@@ -12182,9 +11632,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "source-map": "0.5.7",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -12193,9 +11643,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "camelcase": "^1.0.2",
-                                "cliui": "^2.1.0",
-                                "decamelize": "^1.0.0",
+                                "camelcase": "1.2.1",
+                                "cliui": "2.1.0",
+                                "decamelize": "1.2.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -12217,8 +11667,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "^3.0.0",
-                        "spdx-expression-parse": "^3.0.0"
+                        "spdx-correct": "3.0.0",
+                        "spdx-expression-parse": "3.0.0"
                     }
                 },
                 "which": {
@@ -12226,7 +11676,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "^2.0.0"
+                        "isexe": "2.0.0"
                     }
                 },
                 "which-module": {
@@ -12250,8 +11700,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -12264,7 +11714,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "number-is-nan": "^1.0.0"
+                                "number-is-nan": "1.0.1"
                             }
                         },
                         "string-width": {
@@ -12272,9 +11722,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
                             }
                         },
                         "strip-ansi": {
@@ -12282,7 +11732,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "^2.0.0"
+                                "ansi-regex": "2.1.1"
                             }
                         }
                     }
@@ -12297,9 +11747,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
-                        "imurmurhash": "^0.1.4",
-                        "signal-exit": "^3.0.2"
+                        "graceful-fs": "4.1.11",
+                        "imurmurhash": "0.1.4",
+                        "signal-exit": "3.0.2"
                     }
                 },
                 "y18n": {
@@ -12317,18 +11767,18 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
-                        "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
-                        "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
-                        "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
+                        "cliui": "4.1.0",
+                        "decamelize": "1.2.0",
+                        "find-up": "2.1.0",
+                        "get-caller-file": "1.0.3",
+                        "os-locale": "2.1.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "9.0.2"
                     },
                     "dependencies": {
                         "cliui": {
@@ -12336,9 +11786,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "string-width": "^2.1.1",
-                                "strip-ansi": "^4.0.0",
-                                "wrap-ansi": "^2.0.0"
+                                "string-width": "2.1.1",
+                                "strip-ansi": "4.0.0",
+                                "wrap-ansi": "2.1.0"
                             }
                         },
                         "find-up": {
@@ -12346,7 +11796,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "locate-path": "^2.0.0"
+                                "locate-path": "2.0.0"
                             }
                         },
                         "locate-path": {
@@ -12354,8 +11804,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-locate": "^2.0.0",
-                                "path-exists": "^3.0.0"
+                                "p-locate": "2.0.0",
+                                "path-exists": "3.0.0"
                             }
                         },
                         "p-limit": {
@@ -12363,7 +11813,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-try": "^1.0.0"
+                                "p-try": "1.0.0"
                             }
                         },
                         "p-locate": {
@@ -12371,7 +11821,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "p-limit": "^1.1.0"
+                                "p-limit": "1.3.0"
                             }
                         },
                         "p-try": {
@@ -12386,7 +11836,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -12415,9 +11865,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -12426,7 +11876,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "kind-of": {
@@ -12435,7 +11885,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -12464,7 +11914,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             }
         },
         "object.assign": {
@@ -12473,10 +11923,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "function-bind": "^1.1.1",
-                "has-symbols": "^1.0.0",
-                "object-keys": "^1.0.11"
+                "define-properties": "1.1.2",
+                "function-bind": "1.1.1",
+                "has-symbols": "1.0.0",
+                "object-keys": "1.0.11"
             }
         },
         "object.defaults": {
@@ -12485,10 +11935,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "^1.0.1",
-                "array-slice": "^1.0.0",
-                "for-own": "^1.0.0",
-                "isobject": "^3.0.0"
+                "array-each": "1.0.1",
+                "array-slice": "1.1.0",
+                "for-own": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "object.entries": {
@@ -12497,10 +11947,10 @@
             "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.6.1",
-                "function-bind": "^1.1.0",
-                "has": "^1.0.1"
+                "define-properties": "1.1.2",
+                "es-abstract": "1.12.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
             }
         },
         "object.getownpropertydescriptors": {
@@ -12509,8 +11959,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "define-properties": "1.1.2",
+                "es-abstract": "1.12.0"
             }
         },
         "object.map": {
@@ -12519,8 +11969,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "^1.0.0",
-                "make-iterator": "^1.0.0"
+                "for-own": "1.0.0",
+                "make-iterator": "1.0.1"
             }
         },
         "object.omit": {
@@ -12529,8 +11979,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             },
             "dependencies": {
                 "for-own": {
@@ -12539,7 +11989,7 @@
                     "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "dev": true,
                     "requires": {
-                        "for-in": "^1.0.1"
+                        "for-in": "1.0.2"
                     }
                 }
             }
@@ -12550,7 +12000,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "object.reduce": {
@@ -12559,8 +12009,8 @@
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
             "dev": true,
             "requires": {
-                "for-own": "^1.0.0",
-                "make-iterator": "^1.0.0"
+                "for-own": "1.0.0",
+                "make-iterator": "1.0.1"
             }
         },
         "object.values": {
@@ -12569,10 +12019,10 @@
             "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.6.1",
-                "function-bind": "^1.1.0",
-                "has": "^1.0.1"
+                "define-properties": "1.1.2",
+                "es-abstract": "1.12.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3"
             }
         },
         "on-finished": {
@@ -12589,7 +12039,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -12598,7 +12048,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "opener": {
@@ -12613,8 +12063,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
             },
             "dependencies": {
                 "minimist": {
@@ -12637,12 +12087,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "options": {
@@ -12656,7 +12106,7 @@
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.0.6"
             }
         },
         "original": {
@@ -12665,7 +12115,7 @@
             "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
             "dev": true,
             "requires": {
-                "url-parse": "^1.4.3"
+                "url-parse": "1.4.3"
             }
         },
         "os-browserify": {
@@ -12680,9 +12130,9 @@
             "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
             "dev": true,
             "requires": {
-                "execa": "^0.10.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
+                "execa": "0.10.0",
+                "lcid": "2.0.0",
+                "mem": "4.0.0"
             }
         },
         "os-tmpdir": {
@@ -12708,7 +12158,7 @@
             "integrity": "sha1-jmtPT2XHK8W2/ii3XtqHT5akoIU=",
             "dev": true,
             "requires": {
-                "p-timeout": "^1.1.1"
+                "p-timeout": "1.2.1"
             },
             "dependencies": {
                 "p-timeout": {
@@ -12717,7 +12167,7 @@
                     "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
                     "dev": true,
                     "requires": {
-                        "p-finally": "^1.0.0"
+                        "p-finally": "1.0.0"
                     }
                 }
             }
@@ -12740,7 +12190,7 @@
             "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
             "dev": true,
             "requires": {
-                "p-try": "^2.0.0"
+                "p-try": "2.0.0"
             },
             "dependencies": {
                 "p-try": {
@@ -12757,7 +12207,7 @@
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
-                "p-limit": "^2.0.0"
+                "p-limit": "2.0.0"
             }
         },
         "p-map": {
@@ -12772,7 +12222,7 @@
             "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
             "dev": true,
             "requires": {
-                "p-finally": "^1.0.0"
+                "p-finally": "1.0.0"
             }
         },
         "p-try": {
@@ -12793,9 +12243,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "~0.2.2",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.1.5"
+                "cyclist": "0.2.2",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -12810,13 +12260,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -12825,7 +12275,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -12836,7 +12286,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "^2.2.0"
+                "no-case": "2.3.2"
             }
         },
         "parse-asn1": {
@@ -12845,11 +12295,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "^4.0.0",
-                "browserify-aes": "^1.0.0",
-                "create-hash": "^1.1.0",
-                "evp_bytestokey": "^1.0.0",
-                "pbkdf2": "^3.0.3"
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.2.0",
+                "create-hash": "1.2.0",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.17"
             }
         },
         "parse-entities": {
@@ -12858,12 +12308,12 @@
             "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
             "dev": true,
             "requires": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
+                "character-entities": "1.2.2",
+                "character-entities-legacy": "1.1.2",
+                "character-reference-invalid": "1.1.2",
+                "is-alphanumerical": "1.0.2",
+                "is-decimal": "1.0.2",
+                "is-hexadecimal": "1.0.2"
             }
         },
         "parse-filepath": {
@@ -12872,9 +12322,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "^1.0.0",
-                "map-cache": "^0.2.0",
-                "path-root": "^0.1.1"
+                "is-absolute": "1.0.0",
+                "map-cache": "0.2.2",
+                "path-root": "0.1.1"
             }
         },
         "parse-glob": {
@@ -12883,10 +12333,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             },
             "dependencies": {
                 "is-extglob": {
@@ -12901,7 +12351,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^1.0.0"
+                        "is-extglob": "1.0.0"
                     }
                 }
             }
@@ -12912,7 +12362,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.1"
             }
         },
         "parse-passwd": {
@@ -12927,7 +12377,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "9.4.7"
             }
         },
         "parseurl": {
@@ -12960,7 +12410,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "^2.0.0"
+                "pinkie-promise": "2.0.1"
             }
         },
         "path-is-absolute": {
@@ -12997,7 +12447,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "^0.1.0"
+                "path-root-regex": "0.1.2"
             }
         },
         "path-root-regex": {
@@ -13018,9 +12468,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             },
             "dependencies": {
                 "pify": {
@@ -13043,7 +12493,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "~2.3"
+                "through": "2.3.8"
             }
         },
         "pbkdf2": {
@@ -13052,11 +12502,11 @@
             "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
             "dev": true,
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "1.2.0",
+                "create-hmac": "1.1.7",
+                "ripemd160": "2.0.2",
+                "safe-buffer": "5.1.2",
+                "sha.js": "2.4.11"
             }
         },
         "pend": {
@@ -13093,7 +12543,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "pkg-dir": {
@@ -13102,7 +12552,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -13111,7 +12561,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^2.0.0"
+                        "locate-path": "2.0.0"
                     }
                 }
             }
@@ -13122,7 +12572,7 @@
             "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
             "dev": true,
             "requires": {
-                "semver-compare": "^1.0.0"
+                "semver-compare": "1.0.0"
             }
         },
         "plugin-error": {
@@ -13131,11 +12581,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
             },
             "dependencies": {
                 "arr-diff": {
@@ -13144,8 +12594,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.0.1",
-                        "array-slice": "^0.2.3"
+                        "arr-flatten": "1.1.0",
+                        "array-slice": "0.2.3"
                     }
                 },
                 "arr-union": {
@@ -13166,7 +12616,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^1.1.0"
+                        "kind-of": "1.1.0"
                     }
                 },
                 "kind-of": {
@@ -13189,7 +12639,7 @@
             "integrity": "sha1-aaZWXwsn+na1Jw1cB5sLosjwu6M=",
             "dev": true,
             "requires": {
-                "martinez-polygon-clipping": "^0.1.5"
+                "martinez-polygon-clipping": "0.1.5"
             }
         },
         "posix-character-classes": {
@@ -13204,9 +12654,9 @@
             "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
+                "chalk": "2.4.1",
+                "source-map": "0.6.1",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13215,7 +12665,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -13224,9 +12674,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -13247,7 +12697,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -13258,7 +12708,7 @@
             "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
             "dev": true,
             "requires": {
-                "postcss": "^6.0.1"
+                "postcss": "6.0.23"
             }
         },
         "postcss-modules-local-by-default": {
@@ -13267,8 +12717,8 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^6.0.1"
+                "css-selector-tokenizer": "0.7.1",
+                "postcss": "6.0.23"
             }
         },
         "postcss-modules-scope": {
@@ -13277,8 +12727,8 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "^0.7.0",
-                "postcss": "^6.0.1"
+                "css-selector-tokenizer": "0.7.1",
+                "postcss": "6.0.23"
             }
         },
         "postcss-modules-values": {
@@ -13287,8 +12737,8 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "^1.1.0",
-                "postcss": "^6.0.1"
+                "icss-replace-symbols": "1.1.0",
+                "postcss": "6.0.23"
             }
         },
         "postcss-value-parser": {
@@ -13327,8 +12777,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "^2.0.1",
-                "utila": "~0.4"
+                "renderkid": "2.0.1",
+                "utila": "0.4.0"
             }
         },
         "pretty-hrtime": {
@@ -13366,7 +12816,7 @@
             "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
             "dev": true,
             "requires": {
-                "asap": "~2.0.3"
+                "asap": "2.0.6"
             }
         },
         "promise-inflight": {
@@ -13381,8 +12831,8 @@
             "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.3.1",
-                "object-assign": "^4.1.1"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1"
             }
         },
         "proto-list": {
@@ -13397,7 +12847,7 @@
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "dev": true,
             "requires": {
-                "forwarded": "~0.1.2",
+                "forwarded": "0.1.2",
                 "ipaddr.js": "1.8.0"
             }
         },
@@ -13424,11 +12874,11 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "^4.1.0",
-                "browserify-rsa": "^4.0.0",
-                "create-hash": "^1.1.0",
-                "parse-asn1": "^5.0.0",
-                "randombytes": "^2.0.1"
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.2.0",
+                "parse-asn1": "5.1.1",
+                "randombytes": "2.0.6"
             }
         },
         "pump": {
@@ -13437,8 +12887,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -13447,7 +12897,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                     }
                 }
             }
@@ -13458,9 +12908,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "^3.6.0",
-                "inherits": "^2.0.3",
-                "pump": "^2.0.0"
+                "duplexify": "3.6.0",
+                "inherits": "2.0.3",
+                "pump": "2.0.1"
             }
         },
         "punycode": {
@@ -13491,9 +12941,9 @@
             "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
             "dev": true,
             "requires": {
-                "decode-uri-component": "^0.2.0",
-                "object-assign": "^4.1.0",
-                "strict-uri-encode": "^1.0.0"
+                "decode-uri-component": "0.2.0",
+                "object-assign": "4.1.1",
+                "strict-uri-encode": "1.1.0"
             }
         },
         "querystring": {
@@ -13519,7 +12969,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.3"
             }
         },
         "raf": {
@@ -13528,7 +12978,7 @@
             "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
             "dev": true,
             "requires": {
-                "performance-now": "^2.1.0"
+                "performance-now": "2.1.0"
             }
         },
         "railroad-diagrams": {
@@ -13544,7 +12994,7 @@
             "dev": true,
             "requires": {
                 "discontinuous-range": "1.0.0",
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "randomatic": {
@@ -13553,9 +13003,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -13572,7 +13022,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "randomfill": {
@@ -13581,8 +13031,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "^2.0.5",
-                "safe-buffer": "^5.1.0"
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "range-parser": {
@@ -13609,7 +13059,7 @@
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 }
             }
@@ -13626,10 +13076,10 @@
             "integrity": "sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "schedule": "^0.5.0"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "schedule": "0.5.0"
             }
         },
         "react-annotation": {
@@ -13648,9 +13098,9 @@
                     "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
                     "dev": true,
                     "requires": {
-                        "fbjs": "^0.8.16",
-                        "loose-envify": "^1.3.1",
-                        "object-assign": "^4.1.1"
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1"
                     }
                 }
             }
@@ -13661,10 +13111,10 @@
             "integrity": "sha1-OFjyTpxN2MvT9wLz901YHKKRcmk=",
             "dev": true,
             "requires": {
-                "base16": "^1.0.0",
-                "lodash.curry": "^4.0.1",
-                "lodash.flow": "^3.3.0",
-                "pure-color": "^1.2.0"
+                "base16": "1.0.0",
+                "lodash.curry": "4.1.1",
+                "lodash.flow": "3.5.0",
+                "pure-color": "1.3.0"
             }
         },
         "react-codemirror": {
@@ -13673,12 +13123,12 @@
             "integrity": "sha1-kUZ7U7H12A2Rai/QtMetuFqQAbo=",
             "dev": true,
             "requires": {
-                "classnames": "^2.2.5",
-                "codemirror": "^5.18.2",
-                "create-react-class": "^15.5.1",
-                "lodash.debounce": "^4.0.8",
-                "lodash.isequal": "^4.5.0",
-                "prop-types": "^15.5.4"
+                "classnames": "2.2.6",
+                "codemirror": "5.42.2",
+                "create-react-class": "15.6.3",
+                "lodash.debounce": "4.0.8",
+                "lodash.isequal": "4.5.0",
+                "prop-types": "15.6.2"
             }
         },
         "react-color": {
@@ -13687,11 +13137,11 @@
             "integrity": "sha512-ssv2ArSZdhTbIs29hyfw8JW+s3G4BCx/ILkwCajWZzrcx/2ZQfRpsaLVt38LAPbxe50LLszlmGtRerA14JzzRw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.0.1",
-                "material-colors": "^1.2.1",
-                "prop-types": "^15.5.10",
-                "reactcss": "^1.2.0",
-                "tinycolor2": "^1.4.1"
+                "lodash": "4.17.11",
+                "material-colors": "1.2.6",
+                "prop-types": "15.6.2",
+                "reactcss": "1.2.3",
+                "tinycolor2": "1.4.1"
             }
         },
         "react-dev-utils": {
@@ -13712,7 +13162,7 @@
                 "inquirer": "3.3.0",
                 "is-root": "1.0.0",
                 "opn": "5.2.0",
-                "react-error-overlay": "^4.0.1",
+                "react-error-overlay": "4.0.1",
                 "recursive-readdir": "2.2.1",
                 "shell-quote": "1.6.1",
                 "sockjs-client": "1.1.5",
@@ -13726,9 +13176,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
+                        "lru-cache": "4.1.3",
+                        "shebang-command": "1.2.0",
+                        "which": "1.3.1"
                     }
                 },
                 "lru-cache": {
@@ -13737,8 +13187,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 },
                 "opn": {
@@ -13747,7 +13197,7 @@
                     "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
                     "dev": true,
                     "requires": {
-                        "is-wsl": "^1.1.0"
+                        "is-wsl": "1.1.0"
                     }
                 }
             }
@@ -13758,10 +13208,10 @@
             "integrity": "sha512-RC8LDw8feuZOHVgzEf7f+cxBr/DnKdqp56VU0lAs1f4UfKc4cU8wU4fTq/mgnvynLQo8OtlPC19NUFh/zjZPuA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "schedule": "^0.5.0"
+                "loose-envify": "1.4.0",
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "schedule": "0.5.0"
             }
         },
         "react-error-overlay": {
@@ -13776,12 +13226,12 @@
             "integrity": "sha512-T0G5jURyTsFLoiW6MTr5Q35UHC/B2pmYJ7+VBjk8yMDCEABRmCGy4g6QwxoB4pWg4/xYvVTa/Pbqnsgx/+NLuA==",
             "dev": true,
             "requires": {
-                "fast-levenshtein": "^2.0.6",
-                "global": "^4.3.0",
-                "hoist-non-react-statics": "^2.5.0",
-                "prop-types": "^15.6.1",
-                "react-lifecycles-compat": "^3.0.4",
-                "shallowequal": "^1.0.2"
+                "fast-levenshtein": "2.0.6",
+                "global": "4.3.2",
+                "hoist-non-react-statics": "2.5.5",
+                "prop-types": "15.6.2",
+                "react-lifecycles-compat": "3.0.4",
+                "shallowequal": "1.1.0"
             }
         },
         "react-is": {
@@ -13796,9 +13246,9 @@
             "integrity": "sha1-9bF+gzKanHauOL5cBP2jp/1oSjU=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.6.1",
-                "prop-types": "^15.5.8",
-                "react-base16-styling": "^0.5.1"
+                "babel-runtime": "6.26.0",
+                "prop-types": "15.6.2",
+                "react-base16-styling": "0.5.3"
             }
         },
         "react-lifecycles-compat": {
@@ -13814,11 +13264,11 @@
             "dev": true,
             "requires": {
                 "mdast-add-list-metadata": "1.0.1",
-                "prop-types": "^15.6.1",
-                "remark-parse": "^5.0.0",
-                "unified": "^6.1.5",
-                "unist-util-visit": "^1.3.0",
-                "xtend": "^4.0.1"
+                "prop-types": "15.6.2",
+                "remark-parse": "5.0.0",
+                "unified": "6.2.0",
+                "unist-util-visit": "1.4.0",
+                "xtend": "4.0.1"
             }
         },
         "react-table": {
@@ -13827,7 +13277,7 @@
             "integrity": "sha1-oK2LSDkxkFLVvvwBJgP7Fh5S7eM=",
             "dev": true,
             "requires": {
-                "classnames": "^2.2.5"
+                "classnames": "2.2.6"
             }
         },
         "react-table-hoc-fixed-columns": {
@@ -13836,9 +13286,9 @@
             "integrity": "sha512-0qEHYHA00kBTwUtQnbrJVPh1Ghgx6C6zwq+1cwY4jvjPu0jhYPoAECx0LosphDioA8aaRgkEwDTHDLYcgN9xFQ==",
             "dev": true,
             "requires": {
-                "classnames": "^2.2.6",
-                "emotion": "^9.2.3",
-                "uniqid": "^5.0.3"
+                "classnames": "2.2.6",
+                "emotion": "9.2.12",
+                "uniqid": "5.0.3"
             }
         },
         "react-test-renderer": {
@@ -13847,10 +13297,10 @@
             "integrity": "sha512-AGbJYbCVx1J6jdUgI4s0hNp+9LxlgzKvXl0ROA3DHTrtjAr00Po1RhDZ/eAq2VC/ww8AHgpDXULh5V2rhEqqJg==",
             "dev": true,
             "requires": {
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "react-is": "^16.5.2",
-                "schedule": "^0.5.0"
+                "object-assign": "4.1.1",
+                "prop-types": "15.6.2",
+                "react-is": "16.5.2",
+                "schedule": "0.5.0"
             }
         },
         "reactcss": {
@@ -13859,7 +13309,7 @@
             "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
             "dev": true,
             "requires": {
-                "lodash": "^4.0.1"
+                "lodash": "4.17.11"
             }
         },
         "read-pkg": {
@@ -13868,9 +13318,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
             }
         },
         "read-pkg-up": {
@@ -13879,8 +13329,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
             }
         },
         "readable-stream": {
@@ -13888,12 +13338,12 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~1.0.6",
-                "string_decoder": "~0.10.x",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
             }
         },
         "readdirp": {
@@ -13902,10 +13352,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "minimatch": "^3.0.2",
-                "readable-stream": "^2.0.2",
-                "set-immediate-shim": "^1.0.1"
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.0.6",
+                "set-immediate-shim": "1.0.1"
             }
         },
         "rechoir": {
@@ -13914,7 +13364,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "^1.1.6"
+                "resolve": "1.7.1"
             }
         },
         "recursive-readdir": {
@@ -13932,7 +13382,7 @@
                     "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.0.0"
+                        "brace-expansion": "1.1.11"
                     }
                 }
             }
@@ -13954,7 +13404,7 @@
             "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0"
+                "regenerate": "1.4.0"
             }
         },
         "regenerator-runtime": {
@@ -13969,7 +13419,7 @@
             "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
             "dev": true,
             "requires": {
-                "private": "^0.1.6"
+                "private": "0.1.8"
             }
         },
         "regex-cache": {
@@ -13978,7 +13428,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -13987,8 +13437,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "regexpu-core": {
@@ -13997,12 +13447,12 @@
             "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
             "dev": true,
             "requires": {
-                "regenerate": "^1.4.0",
-                "regenerate-unicode-properties": "^7.0.0",
-                "regjsgen": "^0.4.0",
-                "regjsparser": "^0.3.0",
-                "unicode-match-property-ecmascript": "^1.0.4",
-                "unicode-match-property-value-ecmascript": "^1.0.2"
+                "regenerate": "1.4.0",
+                "regenerate-unicode-properties": "7.0.0",
+                "regjsgen": "0.4.0",
+                "regjsparser": "0.3.0",
+                "unicode-match-property-ecmascript": "1.0.4",
+                "unicode-match-property-value-ecmascript": "1.0.2"
             }
         },
         "regjsgen": {
@@ -14017,7 +13467,7 @@
             "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
             "dev": true,
             "requires": {
-                "jsesc": "~0.5.0"
+                "jsesc": "0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -14040,7 +13490,7 @@
             "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
             "dev": true,
             "requires": {
-                "isobject": "^2.0.0"
+                "isobject": "2.1.0"
             },
             "dependencies": {
                 "isobject": {
@@ -14060,11 +13510,11 @@
             "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
             "dev": true,
             "requires": {
-                "amdefine": "^1.0.0",
+                "amdefine": "1.0.1",
                 "istanbul": "0.4.5",
-                "minimatch": "^3.0.3",
-                "plugin-error": "^0.1.2",
-                "source-map": "^0.6.1",
+                "minimatch": "3.0.4",
+                "plugin-error": "0.1.2",
+                "source-map": "0.6.1",
                 "through2": "2.0.1"
             },
             "dependencies": {
@@ -14080,8 +13530,8 @@
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "~2.0.0",
-                        "xtend": "~4.0.0"
+                        "readable-stream": "2.0.6",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -14092,21 +13542,21 @@
             "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
             "dev": true,
             "requires": {
-                "collapse-white-space": "^1.0.2",
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-whitespace-character": "^1.0.0",
-                "is-word-character": "^1.0.0",
-                "markdown-escapes": "^1.0.0",
-                "parse-entities": "^1.1.0",
-                "repeat-string": "^1.5.4",
-                "state-toggle": "^1.0.0",
+                "collapse-white-space": "1.0.4",
+                "is-alphabetical": "1.0.2",
+                "is-decimal": "1.0.2",
+                "is-whitespace-character": "1.0.2",
+                "is-word-character": "1.0.2",
+                "markdown-escapes": "1.0.2",
+                "parse-entities": "1.2.0",
+                "repeat-string": "1.6.1",
+                "state-toggle": "1.0.1",
                 "trim": "0.0.1",
-                "trim-trailing-lines": "^1.0.0",
-                "unherit": "^1.0.4",
-                "unist-util-remove-position": "^1.0.0",
-                "vfile-location": "^2.0.0",
-                "xtend": "^4.0.1"
+                "trim-trailing-lines": "1.1.1",
+                "unherit": "1.1.1",
+                "unist-util-remove-position": "1.1.2",
+                "vfile-location": "2.0.3",
+                "xtend": "4.0.1"
             }
         },
         "remove-bom-buffer": {
@@ -14115,8 +13565,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "^1.1.5",
-                "is-utf8": "^0.2.1"
+                "is-buffer": "1.1.6",
+                "is-utf8": "0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -14125,9 +13575,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "^3.0.0",
-                "safe-buffer": "^5.1.0",
-                "through2": "^2.0.3"
+                "remove-bom-buffer": "3.0.0",
+                "safe-buffer": "5.1.2",
+                "through2": "2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -14142,11 +13592,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "^1.1.0",
-                "dom-converter": "~0.1",
-                "htmlparser2": "~3.3.0",
-                "strip-ansi": "^3.0.0",
-                "utila": "~0.3"
+                "css-select": "1.2.0",
+                "dom-converter": "0.1.4",
+                "htmlparser2": "3.3.0",
+                "strip-ansi": "3.0.1",
+                "utila": "0.3.3"
             },
             "dependencies": {
                 "domhandler": {
@@ -14155,7 +13605,7 @@
                     "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1"
+                        "domelementtype": "1.3.0"
                     }
                 },
                 "domutils": {
@@ -14164,7 +13614,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1"
+                        "domelementtype": "1.3.0"
                     }
                 },
                 "htmlparser2": {
@@ -14173,10 +13623,10 @@
                     "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1",
-                        "domhandler": "2.1",
-                        "domutils": "1.1",
-                        "readable-stream": "1.0"
+                        "domelementtype": "1.3.0",
+                        "domhandler": "2.1.0",
+                        "domutils": "1.1.6",
+                        "readable-stream": "1.0.34"
                     }
                 },
                 "isarray": {
@@ -14191,10 +13641,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "utila": {
@@ -14229,9 +13679,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1",
-                "is-absolute": "^1.0.0",
-                "remove-trailing-separator": "^1.1.0"
+                "homedir-polyfill": "1.0.1",
+                "is-absolute": "1.0.0",
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "request": {
@@ -14239,26 +13689,26 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "request-progress": {
@@ -14266,7 +13716,7 @@
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
             "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
             "requires": {
-                "throttleit": "^1.0.0"
+                "throttleit": "1.0.0"
             }
         },
         "request-promise-core": {
@@ -14275,7 +13725,7 @@
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "4.17.11"
             }
         },
         "request-promise-native": {
@@ -14285,8 +13735,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.4"
             }
         },
         "require-directory": {
@@ -14312,7 +13762,7 @@
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "1.0.5"
             }
         },
         "resolve-cwd": {
@@ -14321,7 +13771,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             }
         },
         "resolve-dir": {
@@ -14330,8 +13780,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "^2.0.0",
-                "global-modules": "^1.0.0"
+                "expand-tilde": "2.0.2",
+                "global-modules": "1.0.0"
             }
         },
         "resolve-from": {
@@ -14346,7 +13796,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "^3.0.0"
+                "value-or-function": "3.0.0"
             }
         },
         "resolve-url": {
@@ -14361,7 +13811,7 @@
             "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
             "dev": true,
             "requires": {
-                "lowercase-keys": "^1.0.0"
+                "lowercase-keys": "1.0.1"
             }
         },
         "restore-cursor": {
@@ -14370,8 +13820,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -14392,14 +13842,14 @@
             "integrity": "sha512-1MkO4mX4j31GilbMsqdgLNXjmrHo9EUKQFCa82rLye8ltOHnJe0rRaHUSKz2yUClr8l0Qnj1ZTjZHmp6vNTrzQ==",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "compare-module-exports": "^2.1.0",
-                "lodash.some": "^4.6.0",
-                "lodash.template": "^4.4.0",
-                "node-libs-browser": "^2.1.0",
-                "path-parse": "^1.0.5",
-                "wipe-node-cache": "^2.1.0",
-                "wipe-webpack-cache": "^2.1.0"
+                "babel-runtime": "6.26.0",
+                "compare-module-exports": "2.1.0",
+                "lodash.some": "4.6.0",
+                "lodash.template": "4.4.0",
+                "node-libs-browser": "2.1.0",
+                "path-parse": "1.0.5",
+                "wipe-node-cache": "2.1.0",
+                "wipe-webpack-cache": "2.1.0"
             },
             "dependencies": {
                 "lodash.template": {
@@ -14408,8 +13858,8 @@
                     "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "~3.0.0",
-                        "lodash.templatesettings": "^4.0.0"
+                        "lodash._reinterpolate": "3.0.0",
+                        "lodash.templatesettings": "4.1.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -14418,7 +13868,7 @@
                     "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "~3.0.0"
+                        "lodash._reinterpolate": "3.0.0"
                     }
                 }
             }
@@ -14430,7 +13880,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "^0.1.1"
+                "align-text": "0.1.4"
             }
         },
         "rimraf": {
@@ -14439,7 +13889,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
             }
         },
         "ripemd160": {
@@ -14448,8 +13898,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "^3.0.0",
-                "inherits": "^2.0.1"
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
             }
         },
         "roughjs-es5": {
@@ -14458,7 +13908,7 @@
             "integrity": "sha512-NMjzoBgSYk8qEYLSxzxytS20sfdQV7zg119FZjFDjIDwaqodFcf7QwzKbqM64VeAYF61qogaPLk3cs8Gb+TqZA==",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "rst-selector-parser": {
@@ -14467,8 +13917,8 @@
             "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
             "dev": true,
             "requires": {
-                "lodash.flattendeep": "^4.4.0",
-                "nearley": "^2.7.10"
+                "lodash.flattendeep": "4.4.0",
+                "nearley": "2.15.1"
             }
         },
         "run-async": {
@@ -14477,7 +13927,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "run-node": {
@@ -14492,7 +13942,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "^1.1.1"
+                "aproba": "1.2.0"
             }
         },
         "rx-lite": {
@@ -14507,7 +13957,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "*"
+                "rx-lite": "4.0.8"
             }
         },
         "rxjs": {
@@ -14529,7 +13979,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -14548,7 +13998,7 @@
             "integrity": "sha512-Nc5DXc5A+m3rUDtkS+vHlBWKT7mCKjJPyia7f8YMW773hsXVv2wEHQZGE0zs4+5PLwz9U5Sbl/94Cnd9vHV7Bg==",
             "dev": true,
             "requires": {
-                "xmlchars": "^1.3.1"
+                "xmlchars": "1.3.1"
             }
         },
         "schedule": {
@@ -14557,7 +14007,7 @@
             "integrity": "sha512-HUcJicG5Ou8xfR//c2rPT0lPIRR09vVvN81T9fqfVgBmhERUbDEQoYKjpBxbueJnCPpSu2ujXzOnRQt6x9o/jw==",
             "dev": true,
             "requires": {
-                "object-assign": "^4.1.1"
+                "object-assign": "4.1.1"
             }
         },
         "schema-utils": {
@@ -14566,9 +14016,9 @@
             "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.1.0",
-                "ajv-errors": "^1.0.0",
-                "ajv-keywords": "^3.1.0"
+                "ajv": "6.5.4",
+                "ajv-errors": "1.0.0",
+                "ajv-keywords": "3.2.0"
             },
             "dependencies": {
                 "ajv": {
@@ -14577,10 +14027,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -14603,7 +14053,7 @@
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
             "dev": true,
             "requires": {
-                "commander": "~2.8.1"
+                "commander": "2.8.1"
             },
             "dependencies": {
                 "commander": {
@@ -14612,7 +14062,7 @@
                     "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": ">= 1.0.0"
+                        "graceful-readlink": "1.0.1"
                     }
                 }
             }
@@ -14623,24 +14073,24 @@
             "integrity": "sha512-29PHBRq/Y/0Zhw2ancuBt19FRPzuCUXMhcy1WHFSxCvSv5XrknQnV0Jiy7vdDoCB4WcGk+zYZPVfqHzZwUNbgg==",
             "dev": true,
             "requires": {
-                "@mapbox/polylabel": "1",
-                "d3-array": "^1.2.0",
-                "d3-bboxCollide": "^1.0.3",
-                "d3-brush": "^1.0.4",
-                "d3-chord": "^1.0.4",
-                "d3-collection": "^1.0.1",
-                "d3-contour": "^1.1.1",
-                "d3-force": "^1.0.2",
-                "d3-glyphedge": "^1.2.0",
-                "d3-hexbin": "^0.2.2",
-                "d3-hierarchy": "^1.1.3",
-                "d3-interpolate": "^1.1.5",
-                "d3-polygon": "^1.0.5",
+                "@mapbox/polylabel": "1.0.2",
+                "d3-array": "1.2.4",
+                "d3-bboxCollide": "1.0.4",
+                "d3-brush": "1.0.6",
+                "d3-chord": "1.0.6",
+                "d3-collection": "1.0.7",
+                "d3-contour": "1.3.2",
+                "d3-force": "1.1.2",
+                "d3-glyphedge": "1.2.0",
+                "d3-hexbin": "0.2.2",
+                "d3-hierarchy": "1.1.8",
+                "d3-interpolate": "1.3.2",
+                "d3-polygon": "1.0.5",
                 "d3-sankey-circular": "0.25.0",
-                "d3-scale": "^1.0.3",
-                "d3-selection": "^1.1.0",
-                "d3-shape": "^1.0.4",
-                "d3-voronoi": "^1.0.2",
+                "d3-scale": "1.0.7",
+                "d3-selection": "1.3.2",
+                "d3-shape": "1.2.2",
+                "d3-voronoi": "1.1.4",
                 "json2csv": "3.11.5",
                 "labella": "1.1.4",
                 "memoize-one": "4.0.0",
@@ -14660,9 +14110,9 @@
                     "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
                     "dev": true,
                     "requires": {
-                        "fbjs": "^0.8.16",
-                        "loose-envify": "^1.3.1",
-                        "object-assign": "^4.1.1"
+                        "fbjs": "0.8.17",
+                        "loose-envify": "1.4.0",
+                        "object-assign": "4.1.1"
                     }
                 }
             }
@@ -14673,12 +14123,12 @@
             "integrity": "sha512-GxyrIyntvs+TXK8KOJKzs3AnvMM7Cb7ywfAeJKEQ/GKMKwaZvQnuGrz3dSImjfH7xvf4E2AmDIggqgHISt1X4Q==",
             "dev": true,
             "requires": {
-                "d3-interpolate": "^1.1.5",
-                "d3-scale": "^1.0.3",
-                "d3-selection": "^1.1.0",
-                "d3-shape": "^1.0.3",
-                "d3-transition": "^1.0.3",
-                "prop-types": "^15.6.0",
+                "d3-interpolate": "1.3.2",
+                "d3-scale": "1.0.7",
+                "d3-selection": "1.3.2",
+                "d3-shape": "1.2.2",
+                "d3-transition": "1.1.3",
+                "prop-types": "15.6.2",
                 "roughjs-es5": "0.1.0"
             }
         },
@@ -14699,7 +14149,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "^1.5.0"
+                "sver-compat": "1.5.0"
             }
         },
         "send": {
@@ -14709,18 +14159,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "etag": "~1.8.1",
+                "depd": "1.1.2",
+                "destroy": "1.0.4",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "etag": "1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
+                "http-errors": "1.6.3",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
+                "on-finished": "2.3.0",
+                "range-parser": "1.2.0",
+                "statuses": "1.4.0"
             },
             "dependencies": {
                 "mime": {
@@ -14743,9 +14193,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "~1.0.2",
-                "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
+                "encodeurl": "1.0.2",
+                "escape-html": "1.0.3",
+                "parseurl": "1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -14767,10 +14217,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -14779,7 +14229,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -14802,8 +14252,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.2"
             }
         },
         "shallowequal": {
@@ -14818,7 +14268,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -14833,10 +14283,10 @@
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "dev": true,
             "requires": {
-                "array-filter": "~0.0.0",
-                "array-map": "~0.0.0",
-                "array-reduce": "~0.0.0",
-                "jsonify": "~0.0.0"
+                "array-filter": "0.0.1",
+                "array-map": "0.0.0",
+                "array-reduce": "0.0.0",
+                "jsonify": "0.0.0"
             }
         },
         "shortid": {
@@ -14875,14 +14325,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -14891,7 +14341,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -14900,7 +14350,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -14911,9 +14361,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -14922,7 +14372,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -14931,7 +14381,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -14940,7 +14390,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -14949,9 +14399,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -14962,7 +14412,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -14971,7 +14421,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -14982,12 +14432,12 @@
             "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
             "dev": true,
             "requires": {
-                "debug": "^2.6.6",
+                "debug": "2.6.9",
                 "eventsource": "0.1.6",
-                "faye-websocket": "~0.11.0",
-                "inherits": "^2.0.1",
-                "json3": "^3.3.2",
-                "url-parse": "^1.1.8"
+                "faye-websocket": "0.11.1",
+                "inherits": "2.0.3",
+                "json3": "3.3.2",
+                "url-parse": "1.4.3"
             }
         },
         "sort-keys": {
@@ -14996,7 +14446,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "^1.0.0"
+                "is-plain-obj": "1.1.0"
             }
         },
         "sort-keys-length": {
@@ -15005,7 +14455,7 @@
             "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
             "dev": true,
             "requires": {
-                "sort-keys": "^1.0.0"
+                "sort-keys": "1.1.2"
             }
         },
         "source-list-map": {
@@ -15026,11 +14476,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.1",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -15039,8 +14489,8 @@
             "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -15069,8 +14519,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -15085,8 +14535,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -15101,7 +14551,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2"
+                "through": "2.3.8"
             }
         },
         "split-string": {
@@ -15110,7 +14560,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -15124,14 +14574,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
             }
         },
         "ssri": {
@@ -15140,7 +14590,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "stack-trace": {
@@ -15166,8 +14616,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -15176,7 +14626,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -15199,8 +14649,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "^2.0.2"
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6"
             }
         },
         "stream-combiner": {
@@ -15209,7 +14659,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "~0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "stream-each": {
@@ -15218,8 +14668,8 @@
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "stream-shift": "1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -15228,7 +14678,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                     }
                 }
             }
@@ -15245,11 +14695,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "^3.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.3.6",
-                "to-arraybuffer": "^1.0.0",
-                "xtend": "^4.0.0"
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -15264,13 +14714,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -15279,7 +14729,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -15296,7 +14746,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.0.6"
             }
         },
         "streamifier": {
@@ -15323,8 +14773,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -15339,7 +14789,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -15350,9 +14800,9 @@
             "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.0",
-                "function-bind": "^1.0.2"
+                "define-properties": "1.1.2",
+                "es-abstract": "1.12.0",
+                "function-bind": "1.1.1"
             }
         },
         "string_decoder": {
@@ -15366,7 +14816,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -15381,8 +14831,8 @@
             "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "2.0.0",
+                "strip-bom": "2.0.0"
             },
             "dependencies": {
                 "first-chunk-stream": {
@@ -15391,7 +14841,7 @@
                     "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "^2.0.2"
+                        "readable-stream": "2.0.6"
                     }
                 },
                 "strip-bom": {
@@ -15400,7 +14850,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                     }
                 }
             }
@@ -15417,7 +14867,7 @@
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
             "requires": {
-                "is-natural-number": "^4.0.1"
+                "is-natural-number": "4.0.1"
             }
         },
         "strip-eof": {
@@ -15437,7 +14887,7 @@
             "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.2"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "style-loader": {
@@ -15446,8 +14896,8 @@
             "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "schema-utils": "^1.0.0"
+                "loader-utils": "1.1.0",
+                "schema-utils": "1.0.0"
             }
         },
         "styled-jsx": {
@@ -15503,8 +14953,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "^2.0.1",
-                "es6-symbol": "^3.1.1"
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
             }
         },
         "svg-inline-loader": {
@@ -15513,9 +14963,9 @@
             "integrity": "sha512-rynplY2eXFrdNomL1FvyTFQlP+dx0WqbzHglmNtA9M4IHRC3no2aPAl3ny9lUpJzFzFMZfWRK5YIclNU+FRePA==",
             "dev": true,
             "requires": {
-                "loader-utils": "^0.2.11",
-                "object-assign": "^4.0.1",
-                "simple-html-tokenizer": "^0.1.1"
+                "loader-utils": "0.2.17",
+                "object-assign": "4.1.1",
+                "simple-html-tokenizer": "0.1.1"
             },
             "dependencies": {
                 "loader-utils": {
@@ -15524,10 +14974,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "^3.1.3",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^0.5.0",
-                        "object-assign": "^4.0.1"
+                        "big.js": "3.2.0",
+                        "emojis-list": "2.1.0",
+                        "json5": "0.5.1",
+                        "object-assign": "4.1.1"
                     }
                 }
             }
@@ -15538,7 +14988,7 @@
             "integrity": "sha512-c39AIRQOUXLMD8fQ2rHmK1GOSO3tVuZk61bAXqIT05uhhm3z4VtQFITQSwyhL0WA2uxoJAIhPd2YV0CYQOolSA==",
             "dev": true,
             "requires": {
-                "prop-types": "^15.5.0"
+                "prop-types": "15.6.2"
             }
         },
         "svg-path-bounding-box": {
@@ -15547,7 +14997,7 @@
             "integrity": "sha1-7XPfODyLR4abZQjwWPV0j4gzwHA=",
             "dev": true,
             "requires": {
-                "svgpath": "^2.0.0"
+                "svgpath": "2.2.1"
             }
         },
         "svgo": {
@@ -15556,13 +15006,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "~1.0.1",
-                "colors": "~1.1.2",
-                "csso": "~2.3.1",
-                "js-yaml": "~3.7.0",
-                "mkdirp": "~0.5.1",
-                "sax": "~1.2.1",
-                "whet.extend": "~0.9.9"
+                "coa": "1.0.4",
+                "colors": "1.1.2",
+                "csso": "2.3.2",
+                "js-yaml": "3.7.0",
+                "mkdirp": "0.5.1",
+                "sax": "1.2.4",
+                "whet.extend": "0.9.9"
             },
             "dependencies": {
                 "colors": {
@@ -15577,8 +15027,8 @@
                     "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
                     "dev": true,
                     "requires": {
-                        "clap": "^1.0.9",
-                        "source-map": "^0.5.3"
+                        "clap": "1.2.3",
+                        "source-map": "0.5.7"
                     }
                 },
                 "js-yaml": {
@@ -15587,8 +15037,8 @@
                     "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
                     "dev": true,
                     "requires": {
-                        "argparse": "^1.0.7",
-                        "esprima": "^2.6.0"
+                        "argparse": "1.0.10",
+                        "esprima": "2.7.3"
                     }
                 }
             }
@@ -15622,9 +15072,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
             }
         },
         "tar-stream": {
@@ -15633,13 +15083,13 @@
             "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
             "dev": true,
             "requires": {
-                "bl": "^1.0.0",
-                "buffer-alloc": "^1.1.0",
-                "end-of-stream": "^1.0.0",
-                "fs-constants": "^1.0.0",
-                "readable-stream": "^2.3.0",
-                "to-buffer": "^1.1.0",
-                "xtend": "^4.0.0"
+                "bl": "1.2.2",
+                "buffer-alloc": "1.2.0",
+                "end-of-stream": "1.4.1",
+                "fs-constants": "1.0.0",
+                "readable-stream": "2.3.6",
+                "to-buffer": "1.1.1",
+                "xtend": "4.0.1"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -15648,7 +15098,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "^1.4.0"
+                        "once": "1.4.0"
                     }
                 },
                 "process-nextick-args": {
@@ -15663,13 +15113,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -15678,7 +15128,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -15706,8 +15156,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -15722,13 +15172,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "string_decoder": {
@@ -15737,7 +15187,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 }
             }
@@ -15748,8 +15198,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
             }
         },
         "time-stamp": {
@@ -15770,7 +15220,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "^1.0.4"
+                "setimmediate": "1.0.5"
             }
         },
         "timers-ext": {
@@ -15779,8 +15229,8 @@
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "dev": true,
             "requires": {
-                "es5-ext": "~0.10.14",
-                "next-tick": "1"
+                "es5-ext": "0.10.43",
+                "next-tick": "1.0.0"
             }
         },
         "tinycolor2": {
@@ -15800,7 +15250,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "requires": {
-                "os-tmpdir": "~1.0.1"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -15809,8 +15259,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "^1.0.0",
-                "is-negated-glob": "^1.0.0"
+                "is-absolute": "1.0.0",
+                "is-negated-glob": "1.0.0"
             }
         },
         "to-arraybuffer": {
@@ -15837,7 +15287,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -15846,7 +15296,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -15857,10 +15307,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -15869,8 +15319,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "to-through": {
@@ -15879,7 +15329,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3"
+                "through2": "2.0.3"
             }
         },
         "toposort": {
@@ -15894,7 +15344,7 @@
             "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
             "dev": true,
             "requires": {
-                "nopt": "~1.0.10"
+                "nopt": "1.0.10"
             },
             "dependencies": {
                 "nopt": {
@@ -15903,7 +15353,7 @@
                     "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1"
+                        "abbrev": "1.1.1"
                     }
                 }
             }
@@ -15913,7 +15363,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             }
         },
         "tr46": {
@@ -15922,7 +15372,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             },
             "dependencies": {
                 "punycode": {
@@ -15950,7 +15400,7 @@
             "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.2"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "trim-right": {
@@ -15983,11 +15433,11 @@
             "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
-                "micromatch": "^3.1.4",
-                "semver": "^5.0.1"
+                "chalk": "2.4.1",
+                "enhanced-resolve": "4.1.0",
+                "loader-utils": "1.1.0",
+                "micromatch": "3.1.10",
+                "semver": "5.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15996,7 +15446,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -16005,9 +15455,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -16022,7 +15472,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -16033,7 +15483,7 @@
             "integrity": "sha512-chcKw0sTApwJxTyKhzbWxI4BTUJ6RStZKUVh2/mfwYqFS09PYy5pvdXZwG35QSkqT5pkdXZlYKBX196RRvEZdQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.5"
+                "lodash": "4.17.11"
             }
         },
         "tsconfig-paths": {
@@ -16042,11 +15492,11 @@
             "integrity": "sha512-7iE+Q/2E1lgvxD+c0Ot+GFFmgmfIjt/zCayyruXkXQ84BLT85gHXy0WSoQSiuFX9+d+keE/jiON7notV74ZY+A==",
             "dev": true,
             "requires": {
-                "@types/json5": "^0.0.29",
-                "deepmerge": "^2.0.1",
-                "json5": "^1.0.1",
-                "minimist": "^1.2.0",
-                "strip-bom": "^3.0.0"
+                "@types/json5": "0.0.29",
+                "deepmerge": "2.1.1",
+                "json5": "1.0.1",
+                "minimist": "1.2.0",
+                "strip-bom": "3.0.0"
             },
             "dependencies": {
                 "json5": {
@@ -16055,7 +15505,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.0"
+                        "minimist": "1.2.0"
                     }
                 }
             }
@@ -16066,9 +15516,9 @@
             "integrity": "sha512-S/gOOPOkV8rIL4LurZ1vUdYCVgo15iX9ZMJ6wx6w2OgcpT/G4wMyHB6WM+xheSqGMrWKuxFul+aXpCju3wmj/g==",
             "dev": true,
             "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "tsconfig-paths": "^3.4.0"
+                "chalk": "2.4.1",
+                "enhanced-resolve": "4.1.0",
+                "tsconfig-paths": "3.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -16077,7 +15527,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -16086,9 +15536,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -16103,7 +15553,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -16120,18 +15570,18 @@
             "integrity": "sha1-EeJrzLiK+gLdDZlWyuPUVAtfVMM=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.7.0",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.12.1"
+                "babel-code-frame": "6.26.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.15.1",
+                "diff": "3.5.0",
+                "glob": "7.1.2",
+                "js-yaml": "3.11.0",
+                "minimatch": "3.0.4",
+                "resolve": "1.7.1",
+                "semver": "5.5.0",
+                "tslib": "1.9.1",
+                "tsutils": "2.27.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -16140,7 +15590,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -16149,9 +15599,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.4.0"
                     }
                 },
                 "has-flag": {
@@ -16166,7 +15616,7 @@
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -16194,7 +15644,7 @@
                     "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
                     "dev": true,
                     "requires": {
-                        "tslib": "^1.7.1"
+                        "tslib": "1.9.0"
                     }
                 }
             }
@@ -16205,7 +15655,7 @@
             "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
             "dev": true,
             "requires": {
-                "tsutils": "^2.12.1"
+                "tsutils": "2.27.1"
             }
         },
         "tsutils": {
@@ -16214,7 +15664,7 @@
             "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.9.1"
             }
         },
         "tty-browserify": {
@@ -16228,7 +15678,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tv4": {
@@ -16249,7 +15699,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "type-detect": {
@@ -16265,7 +15715,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.18"
+                "mime-types": "2.1.18"
             }
         },
         "typed-react-markdown": {
@@ -16274,7 +15724,7 @@
             "integrity": "sha1-HDra9CvB8NjGoJsKyAhfNt8KNn8=",
             "dev": true,
             "requires": {
-                "@types/react": "^0.14.44"
+                "@types/react": "0.14.57"
             },
             "dependencies": {
                 "@types/react": {
@@ -16297,9 +15747,9 @@
             "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
             "dev": true,
             "requires": {
-                "circular-json": "^0.3.1",
-                "lodash": "^4.17.4",
-                "postinstall-build": "^5.0.1"
+                "circular-json": "0.3.3",
+                "lodash": "4.17.11",
+                "postinstall-build": "5.0.1"
             }
         },
         "typescript": {
@@ -16319,8 +15769,8 @@
             "integrity": "sha512-A16UqkHtkQOF340cf21LJXchcftyBTPqNOAmP1J8Plu2m3Q8o+2fAYwgFjLXMKP6ooSPjDoOS6z8j9q+1nEnXg==",
             "dev": true,
             "requires": {
-                "commandpost": "^1.0.0",
-                "editorconfig": "^0.15.0"
+                "commandpost": "1.3.0",
+                "editorconfig": "0.15.0"
             },
             "dependencies": {
                 "editorconfig": {
@@ -16329,12 +15779,12 @@
                     "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
                     "dev": true,
                     "requires": {
-                        "@types/commander": "^2.11.0",
-                        "@types/semver": "^5.4.0",
-                        "commander": "^2.11.0",
-                        "lru-cache": "^4.1.1",
-                        "semver": "^5.4.1",
-                        "sigmund": "^1.0.1"
+                        "@types/commander": "2.12.2",
+                        "@types/semver": "5.5.0",
+                        "commander": "2.15.1",
+                        "lru-cache": "4.1.3",
+                        "semver": "5.5.0",
+                        "sigmund": "1.0.1"
                     }
                 },
                 "lru-cache": {
@@ -16343,8 +15793,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "^1.0.2",
-                        "yallist": "^2.1.2"
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
                     }
                 }
             }
@@ -16362,9 +15812,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "source-map": "~0.5.1",
-                "uglify-to-browserify": "~1.0.0",
-                "yargs": "~3.10.0"
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -16381,8 +15831,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -16400,9 +15850,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "camelcase": "^1.0.2",
-                        "cliui": "^2.1.0",
-                        "decamelize": "^1.0.0",
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -16421,14 +15871,14 @@
             "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
             "dev": true,
             "requires": {
-                "cacache": "^10.0.4",
-                "find-cache-dir": "^1.0.0",
-                "schema-utils": "^0.4.5",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-es": "^3.3.4",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
+                "cacache": "10.0.4",
+                "find-cache-dir": "1.0.0",
+                "schema-utils": "0.4.7",
+                "serialize-javascript": "1.5.0",
+                "source-map": "0.6.1",
+                "uglify-es": "3.3.9",
+                "webpack-sources": "1.3.0",
+                "worker-farm": "1.6.0"
             },
             "dependencies": {
                 "ajv": {
@@ -16437,10 +15887,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "commander": {
@@ -16467,8 +15917,8 @@
                     "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-keywords": "^3.1.0"
+                        "ajv": "6.5.4",
+                        "ajv-keywords": "3.2.0"
                     }
                 },
                 "source-map": {
@@ -16483,8 +15933,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "~2.13.0",
-                        "source-map": "~0.6.1"
+                        "commander": "2.13.0",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -16505,8 +15955,8 @@
             "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
             "dev": true,
             "requires": {
-                "buffer": "^3.0.1",
-                "through": "^2.3.6"
+                "buffer": "3.6.0",
+                "through": "2.3.8"
             }
         },
         "unc-path-regex": {
@@ -16526,15 +15976,15 @@
             "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.0.1",
-                "arr-map": "^2.0.0",
-                "bach": "^1.0.0",
-                "collection-map": "^1.0.0",
-                "es6-weak-map": "^2.0.1",
-                "last-run": "^1.1.0",
-                "object.defaults": "^1.0.0",
-                "object.reduce": "^1.0.0",
-                "undertaker-registry": "^1.0.0"
+                "arr-flatten": "1.1.0",
+                "arr-map": "2.0.2",
+                "bach": "1.2.0",
+                "collection-map": "1.0.0",
+                "es6-weak-map": "2.0.2",
+                "last-run": "1.1.1",
+                "object.defaults": "1.1.0",
+                "object.reduce": "1.0.1",
+                "undertaker-registry": "1.0.1"
             }
         },
         "undertaker-registry": {
@@ -16549,8 +15999,8 @@
             "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "xtend": "^4.0.1"
+                "inherits": "2.0.3",
+                "xtend": "4.0.1"
             }
         },
         "unicode": {
@@ -16570,8 +16020,8 @@
             "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
             "dev": true,
             "requires": {
-                "unicode-canonical-property-names-ecmascript": "^1.0.4",
-                "unicode-property-aliases-ecmascript": "^1.0.4"
+                "unicode-canonical-property-names-ecmascript": "1.0.4",
+                "unicode-property-aliases-ecmascript": "1.0.4"
             }
         },
         "unicode-match-property-value-ecmascript": {
@@ -16592,12 +16042,12 @@
             "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
             "dev": true,
             "requires": {
-                "bail": "^1.0.0",
-                "extend": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "trough": "^1.0.0",
-                "vfile": "^2.0.0",
-                "x-is-string": "^0.1.0"
+                "bail": "1.0.3",
+                "extend": "3.0.1",
+                "is-plain-obj": "1.1.0",
+                "trough": "1.0.3",
+                "vfile": "2.3.0",
+                "x-is-string": "0.1.0"
             }
         },
         "union-value": {
@@ -16606,10 +16056,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -16618,7 +16068,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -16627,10 +16077,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -16647,7 +16097,7 @@
             "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
             "dev": true,
             "requires": {
-                "unique-slug": "^2.0.0"
+                "unique-slug": "2.0.1"
             }
         },
         "unique-slug": {
@@ -16656,7 +16106,7 @@
             "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
             "dev": true,
             "requires": {
-                "imurmurhash": "^0.1.4"
+                "imurmurhash": "0.1.4"
             }
         },
         "unique-stream": {
@@ -16665,8 +16115,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
             }
         },
         "unist-util-is": {
@@ -16681,7 +16131,7 @@
             "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "^1.1.0"
+                "unist-util-visit": "1.4.0"
             }
         },
         "unist-util-stringify-position": {
@@ -16696,7 +16146,7 @@
             "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
             "dev": true,
             "requires": {
-                "unist-util-visit-parents": "^2.0.0"
+                "unist-util-visit-parents": "2.0.1"
             },
             "dependencies": {
                 "unist-util-visit-parents": {
@@ -16705,7 +16155,7 @@
                     "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
                     "dev": true,
                     "requires": {
-                        "unist-util-is": "^2.1.2"
+                        "unist-util-is": "2.1.2"
                     }
                 }
             }
@@ -16733,8 +16183,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -16743,9 +16193,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -16790,7 +16240,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             },
             "dependencies": {
                 "punycode": {
@@ -16831,9 +16281,9 @@
             "integrity": "sha512-vugEeXjyYFBCUOpX+ZuaunbK3QXMKaQ3zUnRfIpRBlGkY7QizCnzyyn2ASfcxsvyU3ef+CJppVywnl3Kgf13Gg==",
             "dev": true,
             "requires": {
-                "loader-utils": "^1.1.0",
-                "mime": "^2.0.3",
-                "schema-utils": "^1.0.0"
+                "loader-utils": "1.1.0",
+                "mime": "2.3.1",
+                "schema-utils": "1.0.0"
             }
         },
         "url-parse": {
@@ -16841,8 +16291,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.0.0",
+                "requires-port": "1.0.0"
             }
         },
         "url-parse-lax": {
@@ -16851,7 +16301,7 @@
             "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
             "dev": true,
             "requires": {
-                "prepend-http": "^2.0.0"
+                "prepend-http": "2.0.0"
             }
         },
         "url-to-options": {
@@ -16872,7 +16322,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "^6.0.2"
+                "kind-of": "6.0.2"
             }
         },
         "util": {
@@ -16895,8 +16345,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "define-properties": "1.1.2",
+                "object.getownpropertydescriptors": "2.0.3"
             }
         },
         "utila": {
@@ -16928,7 +16378,7 @@
             "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "^1.0.1"
+                "homedir-polyfill": "1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -16937,8 +16387,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "validator": {
@@ -16963,9 +16413,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vfile": {
@@ -16974,10 +16424,10 @@
             "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
             "dev": true,
             "requires": {
-                "is-buffer": "^1.1.4",
+                "is-buffer": "1.1.6",
                 "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "^1.0.0",
-                "vfile-message": "^1.0.0"
+                "unist-util-stringify-position": "1.1.2",
+                "vfile-message": "1.0.1"
             },
             "dependencies": {
                 "replace-ext": {
@@ -17000,7 +16450,7 @@
             "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
             "dev": true,
             "requires": {
-                "unist-util-stringify-position": "^1.1.1"
+                "unist-util-stringify-position": "1.1.2"
             }
         },
         "vinyl": {
@@ -17009,8 +16459,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
+                "clone": "1.0.4",
+                "clone-stats": "0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -17020,12 +16470,12 @@
             "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.3.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^2.0.0",
-                "vinyl": "^1.1.0"
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "2.0.0",
+                "vinyl": "1.2.0"
             },
             "dependencies": {
                 "pify": {
@@ -17040,7 +16490,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "^0.2.0"
+                        "is-utf8": "0.2.1"
                     }
                 },
                 "vinyl": {
@@ -17049,8 +16499,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -17062,23 +16512,23 @@
             "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "fs-mkdirp-stream": "^1.0.0",
-                "glob-stream": "^6.1.0",
-                "graceful-fs": "^4.0.0",
-                "is-valid-glob": "^1.0.0",
-                "lazystream": "^1.0.0",
-                "lead": "^1.0.0",
-                "object.assign": "^4.0.4",
-                "pumpify": "^1.3.5",
-                "readable-stream": "^2.3.3",
-                "remove-bom-buffer": "^3.0.0",
-                "remove-bom-stream": "^1.2.0",
-                "resolve-options": "^1.1.0",
-                "through2": "^2.0.0",
-                "to-through": "^2.0.0",
-                "value-or-function": "^3.0.0",
-                "vinyl": "^2.0.0",
-                "vinyl-sourcemap": "^1.1.0"
+                "fs-mkdirp-stream": "1.0.0",
+                "glob-stream": "6.1.0",
+                "graceful-fs": "4.1.11",
+                "is-valid-glob": "1.0.0",
+                "lazystream": "1.0.0",
+                "lead": "1.0.0",
+                "object.assign": "4.1.0",
+                "pumpify": "1.5.1",
+                "readable-stream": "2.3.6",
+                "remove-bom-buffer": "3.0.0",
+                "remove-bom-stream": "1.2.0",
+                "resolve-options": "1.1.0",
+                "through2": "2.0.3",
+                "to-through": "2.0.0",
+                "value-or-function": "3.0.0",
+                "vinyl": "2.2.0",
+                "vinyl-sourcemap": "1.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -17105,13 +16555,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "replace-ext": {
@@ -17126,7 +16576,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "vinyl": {
@@ -17135,12 +16585,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -17151,8 +16601,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
+                "through2": "2.0.3",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -17167,8 +16617,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -17179,13 +16629,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "^1.0.2",
-                "convert-source-map": "^1.5.0",
-                "graceful-fs": "^4.1.6",
-                "normalize-path": "^2.1.1",
-                "now-and-later": "^2.0.0",
-                "remove-bom-buffer": "^3.0.0",
-                "vinyl": "^2.0.0"
+                "append-buffer": "1.0.2",
+                "convert-source-map": "1.5.1",
+                "graceful-fs": "4.1.11",
+                "normalize-path": "2.1.1",
+                "now-and-later": "2.0.0",
+                "remove-bom-buffer": "3.0.0",
+                "vinyl": "2.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -17212,12 +16662,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -17243,20 +16693,20 @@
             "integrity": "sha512-YDj5w0TGOcS8XLIdekT4q6LlLV6hv1ZvuT2aGT3KJll4gMz6dUPDgo2VVAf0i0E8igbbZthwvmaUGRwW9yPIaw==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.1",
-                "gulp-untar": "^0.0.7",
-                "gulp-vinyl-zip": "^2.1.2",
-                "mocha": "^4.0.1",
-                "request": "^2.88.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.4.3",
-                "vinyl-fs": "^3.0.3",
-                "vinyl-source-stream": "^1.1.0"
+                "gulp-remote-src-vscode": "0.5.1",
+                "gulp-untar": "0.0.7",
+                "gulp-vinyl-zip": "2.1.2",
+                "mocha": "4.1.0",
+                "request": "2.88.0",
+                "semver": "5.5.0",
+                "source-map-support": "0.5.9",
+                "url-parse": "1.4.3",
+                "vinyl-fs": "3.0.3",
+                "vinyl-source-stream": "1.1.2"
             },
             "dependencies": {
                 "ajv": {
@@ -17265,10 +16715,10 @@
                     "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "aws4": {
@@ -17328,8 +16778,8 @@
                     "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.5.5",
-                        "har-schema": "^2.0.0"
+                        "ajv": "6.9.1",
+                        "har-schema": "2.0.0"
                     }
                 },
                 "has-flag": {
@@ -17356,7 +16806,7 @@
                     "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
                     "dev": true,
                     "requires": {
-                        "mime-db": "~1.38.0"
+                        "mime-db": "1.38.0"
                     }
                 },
                 "mocha": {
@@ -17389,26 +16839,26 @@
                     "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "~0.7.0",
-                        "aws4": "^1.8.0",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.6",
-                        "extend": "~3.0.2",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.3.2",
-                        "har-validator": "~5.1.0",
-                        "http-signature": "~1.2.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.19",
-                        "oauth-sign": "~0.9.0",
-                        "performance-now": "^2.1.0",
-                        "qs": "~6.5.2",
-                        "safe-buffer": "^5.1.2",
-                        "tough-cookie": "~2.4.3",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.3.2"
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.8.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.2",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.1.3",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.22",
+                        "oauth-sign": "0.9.0",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
+                        "tough-cookie": "2.4.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.3.2"
                     }
                 },
                 "supports-color": {
@@ -17417,7 +16867,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                     }
                 },
                 "tough-cookie": {
@@ -17426,8 +16876,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.29",
+                        "punycode": "1.4.1"
                     }
                 }
             }
@@ -17481,7 +16931,7 @@
             "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-4.4.0.tgz",
             "integrity": "sha512-sXBwIcwG4W5MjnDAfXf0hM5ErOcXxEBlix6QJb5ijf0gtecYygrMAqv8hag7sEg/jCCOKQdXJ4K1iZL3GZcJZg==",
             "requires": {
-                "vscode-languageserver-protocol": "^3.10.0"
+                "vscode-languageserver-protocol": "3.10.3"
             }
         },
         "vscode-languageserver": {
@@ -17489,8 +16939,8 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.4.0.tgz",
             "integrity": "sha512-NO4JQg286YLSdU11Fko6cke19kwSob3O0bhf6xDxIJuDhUbFy0VEPRB5ITc3riVmp13+Ki344xtqJYmqfcmCrg==",
             "requires": {
-                "vscode-languageserver-protocol": "^3.10.0",
-                "vscode-uri": "^1.0.3"
+                "vscode-languageserver-protocol": "3.10.3",
+                "vscode-uri": "1.0.6"
             },
             "dependencies": {
                 "vscode-uri": {
@@ -17505,8 +16955,8 @@
             "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.10.3.tgz",
             "integrity": "sha512-R9hKsmXmpIXBLpy6I0eztfAcWU0KHr1lADJiJq+VCmdiHGVUJugMIvU6qVCzLP9wRtZ02AF98j09NAKq10hWeQ==",
             "requires": {
-                "vscode-jsonrpc": "^3.6.2",
-                "vscode-languageserver-types": "^3.10.1"
+                "vscode-jsonrpc": "3.6.2",
+                "vscode-languageserver-types": "3.10.1"
             }
         },
         "vscode-languageserver-types": {
@@ -17530,7 +16980,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "^0.1.2"
+                "browser-process-hrtime": "0.1.3"
             }
         },
         "watchpack": {
@@ -17539,9 +16989,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0"
+                "chokidar": "2.0.4",
+                "graceful-fs": "4.1.11",
+                "neo-async": "2.5.2"
             },
             "dependencies": {
                 "anymatch": {
@@ -17550,8 +17000,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "^3.1.4",
-                        "normalize-path": "^2.1.1"
+                        "micromatch": "3.1.10",
+                        "normalize-path": "2.1.1"
                     }
                 },
                 "chokidar": {
@@ -17560,19 +17010,18 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "^2.0.0",
-                        "async-each": "^1.0.0",
-                        "braces": "^2.3.0",
-                        "fsevents": "^1.2.2",
-                        "glob-parent": "^3.1.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^4.0.0",
-                        "lodash.debounce": "^4.0.8",
-                        "normalize-path": "^2.1.1",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0",
-                        "upath": "^1.0.5"
+                        "anymatch": "2.0.0",
+                        "async-each": "1.0.1",
+                        "braces": "2.3.2",
+                        "glob-parent": "3.1.0",
+                        "inherits": "2.0.3",
+                        "is-binary-path": "1.0.1",
+                        "is-glob": "4.0.0",
+                        "lodash.debounce": "4.0.8",
+                        "normalize-path": "2.1.1",
+                        "path-is-absolute": "1.0.1",
+                        "readdirp": "2.1.0",
+                        "upath": "1.1.0"
                     }
                 },
                 "is-glob": {
@@ -17581,7 +17030,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "^2.1.1"
+                        "is-extglob": "2.1.1"
                     }
                 }
             }
@@ -17602,26 +17051,26 @@
                 "@webassemblyjs/helper-module-context": "1.7.8",
                 "@webassemblyjs/wasm-edit": "1.7.8",
                 "@webassemblyjs/wasm-parser": "1.7.8",
-                "acorn": "^5.6.2",
-                "acorn-dynamic-import": "^3.0.0",
-                "ajv": "^6.1.0",
-                "ajv-keywords": "^3.1.0",
-                "chrome-trace-event": "^1.0.0",
-                "enhanced-resolve": "^4.1.0",
-                "eslint-scope": "^4.0.0",
-                "json-parse-better-errors": "^1.0.2",
-                "loader-runner": "^2.3.0",
-                "loader-utils": "^1.1.0",
-                "memory-fs": "~0.4.1",
-                "micromatch": "^3.1.8",
-                "mkdirp": "~0.5.0",
-                "neo-async": "^2.5.0",
-                "node-libs-browser": "^2.0.0",
-                "schema-utils": "^0.4.4",
-                "tapable": "^1.1.0",
-                "uglifyjs-webpack-plugin": "^1.2.4",
-                "watchpack": "^1.5.0",
-                "webpack-sources": "^1.3.0"
+                "acorn": "5.7.3",
+                "acorn-dynamic-import": "3.0.0",
+                "ajv": "6.5.4",
+                "ajv-keywords": "3.2.0",
+                "chrome-trace-event": "1.0.0",
+                "enhanced-resolve": "4.1.0",
+                "eslint-scope": "4.0.0",
+                "json-parse-better-errors": "1.0.2",
+                "loader-runner": "2.3.1",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "micromatch": "3.1.10",
+                "mkdirp": "0.5.1",
+                "neo-async": "2.5.2",
+                "node-libs-browser": "2.1.0",
+                "schema-utils": "0.4.7",
+                "tapable": "1.1.0",
+                "uglifyjs-webpack-plugin": "1.3.0",
+                "watchpack": "1.6.0",
+                "webpack-sources": "1.3.0"
             },
             "dependencies": {
                 "acorn": {
@@ -17636,10 +17085,10 @@
                     "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "^2.0.1",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.4.1",
-                        "uri-js": "^4.2.2"
+                        "fast-deep-equal": "2.0.1",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.4.1",
+                        "uri-js": "4.2.2"
                     }
                 },
                 "fast-deep-equal": {
@@ -17660,8 +17109,8 @@
                     "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-keywords": "^3.1.0"
+                        "ajv": "6.5.4",
+                        "ajv-keywords": "3.2.0"
                     }
                 }
             }
@@ -17672,18 +17121,18 @@
             "integrity": "sha512-naLWiRfmtH4UJgtUktRTLw6FdoZJ2RvCR9ePbwM9aRMsS/KjFerkPZG9epEvXRAw5d5oPdrs9+3p+afNjxW8Xw==",
             "dev": true,
             "requires": {
-                "acorn": "^5.7.3",
-                "bfj": "^6.1.1",
-                "chalk": "^2.4.1",
-                "commander": "^2.18.0",
-                "ejs": "^2.6.1",
-                "express": "^4.16.3",
-                "filesize": "^3.6.1",
-                "gzip-size": "^5.0.0",
-                "lodash": "^4.17.10",
-                "mkdirp": "^0.5.1",
-                "opener": "^1.5.1",
-                "ws": "^6.0.0"
+                "acorn": "5.7.3",
+                "bfj": "6.1.1",
+                "chalk": "2.4.1",
+                "commander": "2.19.0",
+                "ejs": "2.6.1",
+                "express": "4.16.4",
+                "filesize": "3.6.1",
+                "gzip-size": "5.0.0",
+                "lodash": "4.17.11",
+                "mkdirp": "0.5.1",
+                "opener": "1.5.1",
+                "ws": "6.1.0"
             },
             "dependencies": {
                 "acorn": {
@@ -17698,7 +17147,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -17707,9 +17156,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "commander": {
@@ -17730,8 +17179,8 @@
                     "integrity": "sha512-5iI7omclyqrnWw4XbXAmGhPsABkSIDQonv2K0h61lybgofWa6iZyvrI3r2zsJH4P8Nb64fFVzlvfhs0g7BBxAA==",
                     "dev": true,
                     "requires": {
-                        "duplexer": "^0.1.1",
-                        "pify": "^3.0.0"
+                        "duplexer": "0.1.1",
+                        "pify": "3.0.0"
                     }
                 },
                 "has-flag": {
@@ -17752,7 +17201,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 },
                 "ws": {
@@ -17761,7 +17210,7 @@
                     "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "~1.0.0"
+                        "async-limiter": "1.0.0"
                     }
                 }
             }
@@ -17772,16 +17221,16 @@
             "integrity": "sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.1",
-                "cross-spawn": "^6.0.5",
-                "enhanced-resolve": "^4.1.0",
-                "global-modules-path": "^2.3.0",
-                "import-local": "^2.0.0",
-                "interpret": "^1.1.0",
-                "loader-utils": "^1.1.0",
-                "supports-color": "^5.5.0",
-                "v8-compile-cache": "^2.0.2",
-                "yargs": "^12.0.2"
+                "chalk": "2.4.1",
+                "cross-spawn": "6.0.5",
+                "enhanced-resolve": "4.1.0",
+                "global-modules-path": "2.3.0",
+                "import-local": "2.0.0",
+                "interpret": "1.1.0",
+                "loader-utils": "1.1.0",
+                "supports-color": "5.5.0",
+                "v8-compile-cache": "2.0.2",
+                "yargs": "12.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17790,7 +17239,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -17799,9 +17248,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -17816,7 +17265,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -17833,10 +17282,10 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "^2.1.0",
-                "log-symbols": "^2.1.0",
-                "loglevelnext": "^1.0.1",
-                "uuid": "^3.1.0"
+                "chalk": "2.4.1",
+                "log-symbols": "2.2.0",
+                "loglevelnext": "1.0.5",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17845,7 +17294,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.1"
                     }
                 },
                 "chalk": {
@@ -17854,9 +17303,9 @@
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "has-flag": {
@@ -17871,7 +17320,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -17882,7 +17331,7 @@
             "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.5"
+                "lodash": "4.17.11"
             }
         },
         "webpack-node-externals": {
@@ -17897,8 +17346,8 @@
             "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
             "dev": true,
             "requires": {
-                "source-list-map": "^2.0.0",
-                "source-map": "~0.6.1"
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -17915,8 +17364,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": ">=0.4.0",
-                "websocket-extensions": ">=0.1.1"
+                "http-parser-js": "0.4.13",
+                "websocket-extensions": "0.1.3"
             }
         },
         "websocket-extensions": {
@@ -17940,7 +17389,7 @@
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 }
             }
@@ -17963,9 +17412,9 @@
             "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "whet.extend": {
@@ -17980,7 +17429,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -18013,7 +17462,7 @@
             "integrity": "sha512-OXzQMGpA7MnQQ8AG+uMl5mWR2ezy6fw1+DMHY+wzYP1qkF1jrek87psLBmhZEj+er4efO/GD4R8jXWFierobaA==",
             "dev": true,
             "requires": {
-                "wipe-node-cache": "^2.1.0"
+                "wipe-node-cache": "2.1.0"
             }
         },
         "wordwrap": {
@@ -18028,7 +17477,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "~0.1.7"
+                "errno": "0.1.7"
             }
         },
         "wrap-ansi": {
@@ -18037,8 +17486,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -18047,7 +17496,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "string-width": {
@@ -18056,9 +17505,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 }
             }
@@ -18073,8 +17522,8 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
             "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
             "requires": {
-                "options": ">=0.0.5",
-                "ultron": "1.0.x"
+                "options": "0.0.6",
+                "ultron": "1.0.2"
             }
         },
         "x-is-string": {
@@ -18100,8 +17549,8 @@
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
             "requires": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "sax": "1.2.4",
+                "xmlbuilder": "9.0.7"
             }
         },
         "xmlbuilder": {
@@ -18145,18 +17594,18 @@
             "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^2.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^10.1.0"
+                "cliui": "4.1.0",
+                "decamelize": "2.0.0",
+                "find-up": "3.0.0",
+                "get-caller-file": "1.0.3",
+                "os-locale": "3.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "4.0.0",
+                "yargs-parser": "10.1.0"
             },
             "dependencies": {
                 "decamelize": {
@@ -18174,7 +17623,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "^3.0.0"
+                        "locate-path": "3.0.0"
                     }
                 },
                 "locate-path": {
@@ -18183,8 +17632,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
+                        "p-locate": "3.0.0",
+                        "path-exists": "3.0.0"
                     }
                 },
                 "p-limit": {
@@ -18193,7 +17642,7 @@
                     "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
                     "dev": true,
                     "requires": {
-                        "p-try": "^2.0.0"
+                        "p-try": "2.0.0"
                     }
                 },
                 "p-locate": {
@@ -18202,7 +17651,7 @@
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "^2.0.0"
+                        "p-limit": "2.0.0"
                     }
                 },
                 "p-try": {
@@ -18225,7 +17674,7 @@
             "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -18242,8 +17691,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.0.1"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
             }
         },
         "yazl": {
@@ -18252,7 +17701,7 @@
             "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "requires": {
-                "buffer-crc32": "~0.2.3"
+                "buffer-crc32": "0.2.13"
             }
         },
         "zone.js": {


### PR DESCRIPTION
Fix progress reporting for the new LS

- Remove 'timeout' tracking since a) progress is not a good indicator of analysis completion and b) 60s may or may not be a timeout. LS is reporting its own telemetry anyway.
- Make sure 'begin progress' is called even if there was no explicit notification. The problem is that `onNotification` cannot be attached to `languageClient` until it is ready - but LS may produce call to `beginProgress` while activator is still awaiting on the `languageClient.ready` and hence later `reportProgress` gets ignored.

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] ~~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~~
- [X] ~~Has sufficient logging.~~
- [X] ~~Has telemetry for enhancements.~~
- [X] ~~Unit tests & system/integration tests are added/updated~~
- [X] ~~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~~
- [X] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~~
- [X] ~~The wiki is updated with any design decisions/details.~~

![image](https://user-images.githubusercontent.com/12820357/53685634-1e42be00-3cd2-11e9-9618-190e474dad4e.png)
