### PR TITLE
Show an icon for "unknown" test status.

### DIFF
--- a/news/2 Fixes/4578.md
+++ b/news/2 Fixes/4578.md
@@ -1,0 +1,1 @@
+Show an "unknown" icon when test status is unknown.

--- a/resources/dark/status-unknown.svg
+++ b/resources/dark/status-unknown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" enable-background="new 0 0 16 16" height="16" width="16">
+  <circle cx="8" cy="8" r="6" fill="yellow"/>
+  <text x="5" y="12" fill="#E51400">?</text>
+</svg>

--- a/resources/light/status-unknown.svg
+++ b/resources/light/status-unknown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" enable-background="new 0 0 16 16" height="16" width="16">
+  <circle cx="8" cy="8" r="6" fill="yellow"/>
+  <text x="5" y="12" fill="#E51400">?</text>
+</svg>

--- a/src/client/unittests/common/constants.ts
+++ b/src/client/unittests/common/constants.ts
@@ -23,5 +23,6 @@ export const UNITTEST_PROVIDER: TestProvider = 'unittest';
 export enum Icons {
     discovering = 'discovering-tests.svg',
     passed = 'status-ok.svg',
-    failed = 'status-error.svg'
+    failed = 'status-error.svg',
+    unknown = 'status-unknown.svg'
 }

--- a/src/client/unittests/explorer/testTreeViewItem.ts
+++ b/src/client/unittests/explorer/testTreeViewItem.ts
@@ -62,7 +62,7 @@ export abstract class TestTreeItem extends TreeItem {
                         return ThemeIcon.Folder;
                     }
                     default: {
-                        return '';
+                        return getIcon(Icons.unknown);
                     }
                 }
             }


### PR DESCRIPTION
(for #4578)

Note: the icons are basic place-holders.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- ~[ ] Unit tests & system/integration tests are added/updated~
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
