### PR TITLE
Testing tools adapter py2

### DIFF
--- a/build/ci/templates/compile-and-validate.yml
+++ b/build/ci/templates/compile-and-validate.yml
@@ -156,7 +156,7 @@ jobs:
         arguments: '-m pip install --upgrade -r ./build/test-requirements.txt'
 
 
-    - bash: 'python -m pythonFiles.tests'
+    - bash: 'python pythonFiles/tests/run_all.py'
       displayName: 'run pythonFiles unit tests'
 
 

--- a/pythonFiles/testing_tools/adapter/errors.py
+++ b/pythonFiles/testing_tools/adapter/errors.py
@@ -1,11 +1,13 @@
 
 class UnsupportedToolError(ValueError):
     def __init__(self, tool):
-        super().__init__('unsupported tool {!r}'.format(tool))
+        msg = 'unsupported tool {!r}'.format(tool)
+        super(UnsupportedToolError, self).__init__(msg)
         self.tool = tool
 
 
 class UnsupportedCommandError(ValueError):
     def __init__(self, cmd):
-        super().__init__('unsupported cmd {!r}'.format(cmd))
+        msg = 'unsupported cmd {!r}'.format(cmd)
+        super(UnsupportedCommandError, self).__init__(msg)
         self.cmd = cmd

--- a/pythonFiles/testing_tools/adapter/pytest.py
+++ b/pythonFiles/testing_tools/adapter/pytest.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os.path
 
 import pytest

--- a/pythonFiles/testing_tools/adapter/report.py
+++ b/pythonFiles/testing_tools/adapter/report.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+
 import json
 
 
 def report_discovered(tests, debug=False,
-               _send=print):
+                      _send=print):
     """Serialize the discovered tests and write to stdout."""
     data = [{
             'id': test.id,

--- a/pythonFiles/tests/__main__.py
+++ b/pythonFiles/tests/__main__.py
@@ -10,11 +10,16 @@ DATASCIENCE_ROOT = os.path.join(SRC_ROOT, 'datascience')
 TESTING_TOOLS_ROOT = os.path.join(SRC_ROOT, 'testing_tools')
 
 
-if __name__ == '__main__':
+def main(argv=sys.argv[1:]):
     sys.path.insert(1, DATASCIENCE_ROOT)
     sys.path.insert(1, TESTING_TOOLS_ROOT)
     ec = pytest.main([
         '--rootdir', SRC_ROOT,
         TEST_ROOT,
-        ] + sys.argv[1:])
+        ] + argv)
+    return ec
+
+
+if __name__ == '__main__':
+    ec = main()
     sys.exit(ec)

--- a/pythonFiles/tests/run_all.py
+++ b/pythonFiles/tests/run_all.py
@@ -1,0 +1,13 @@
+# Replace the "." entry.
+import os.path
+import sys
+sys.path[0] = os.path.dirname(
+    os.path.dirname(
+        os.path.abspath(__file__)))
+
+from tests.__main__ import main
+
+
+if __name__ == '__main__':
+    ec = main()
+    sys.exit(ec)

--- a/pythonFiles/tests/testing_tools/adapter/test___main__.py
+++ b/pythonFiles/tests/testing_tools/adapter/test___main__.py
@@ -9,7 +9,7 @@ from testing_tools.adapter.__main__ import (
 class StubTool(StubProxy):
 
     def __init__(self, name, stub=None):
-        super().__init__(stub, name)
+        super(StubTool, self).__init__(stub, name)
         self.return_discover = None
 
     def discover(self, args, **kwargs):
@@ -22,7 +22,7 @@ class StubTool(StubProxy):
 class StubReporter(StubProxy):
 
     def __init__(self, stub=None):
-        super().__init__(stub, 'reporter')
+        super(StubReporter, self).__init__(stub, 'reporter')
 
     def report(self, discovered, **kwargs):
         self.add_call('report', (discovered,), kwargs or None)

--- a/pythonFiles/tests/testing_tools/adapter/test_pytest.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_pytest.py
@@ -12,7 +12,7 @@ from testing_tools.adapter.pytest import (
 class StubSubparsers(StubProxy):
 
     def __init__(self, stub=None, name='subparsers'):
-        super().__init__(stub, name)
+        super(StubSubparsers, self).__init__(stub, name)
 
     def add_parser(self, name):
         self.add_call('add_parser', None, {'name': name})
@@ -22,7 +22,7 @@ class StubSubparsers(StubProxy):
 class StubArgParser(StubProxy):
 
     def __init__(self, stub=None):
-        super().__init__(stub, 'argparser')
+        super(StubArgParser, self).__init__(stub, 'argparser')
 
     def add_argument(self, *args, **kwargs):
         self.add_call('add_argument', args, kwargs)
@@ -31,7 +31,7 @@ class StubArgParser(StubProxy):
 class StubPyTest(StubProxy):
 
     def __init__(self, stub=None):
-        super().__init__(stub, 'pytest')
+        super(StubPyTest, self).__init__(stub, 'pytest')
         self.return_main = 0
 
     def main(self, args, plugins):
@@ -42,7 +42,7 @@ class StubPyTest(StubProxy):
 class StubPlugin(StubProxy):
 
     def __init__(self, stub=None):
-        super().__init__(stub, 'plugin')
+        super(StubPlugin, self).__init__(stub, 'plugin')
 
     def __getattr__(self, name):
         if not name.startswith('pytest_'):
@@ -67,7 +67,7 @@ class FakeMarker(object):
 class StubPytestItem(StubProxy):
 
     def __init__(self, stub=None, **attrs):
-        super().__init__(stub, 'pytest.Item')
+        super(StubPytestItem, self).__init__(stub, 'pytest.Item')
         self.__dict__.update(attrs)
         if 'own_markers' not in attrs:
             self.own_markers = ()
@@ -82,7 +82,7 @@ class StubPytestItem(StubProxy):
 class StubPytestSession(StubProxy):
 
     def __init__(self, stub=None):
-        super().__init__(stub, 'pytest.Session')
+        super(StubPytestSession, self).__init__(stub, 'pytest.Session')
 
     def __getattr__(self, name):
         self.add_call(name + ' (attr)', None, None)
@@ -94,7 +94,7 @@ class StubPytestSession(StubProxy):
 class StubPytestConfig(StubProxy):
 
     def __init__(self, stub=None):
-        super().__init__(stub, 'pytest.Config')
+        super(StubPytestConfig, self).__init__(stub, 'pytest.Config')
 
     def __getattr__(self, name):
         self.add_call(name + ' (attr)', None, None)


### PR DESCRIPTION
(for #4033-ish)

This is a fix to #4208 and #4605 which makes sure `pythonFiles/tests` (and `pythonFiles/testing_tools`) works under Python 2.7.