### PR TITLE
Updated icons and tooltip in test explorer indicating status of test files/suites

### DIFF
--- a/news/1 Enhancements/4583.md
+++ b/news/1 Enhancements/4583.md
@@ -1,0 +1,1 @@
+Update icons and tooltip in test explorer indicating status of test files/suites

--- a/resources/dark/status-error.svg
+++ b/resources/dark/status-error.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" enable-background="new 0 0 16 16" height="16" width="16"><circle cx="8" cy="8" r="6" fill="#F6F6F6"/><path d="M8 3C5.238 3 3 5.238 3 8s2.238 5 5 5 5-2.238 5-5-2.238-5-5-5zm3 7l-1 1-2-2-2 2-1-1 2-2.027L5 6l1-1 2 2 2-2 1 1-2 1.973L11 10z" fill="#E51400"/><path fill="#fff" d="M11 6l-1-1-2 2-2-2-1 1 2 1.973L5 10l1 1 2-2 2 2 1-1-2-2.027z"/></svg>
+<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 612 792;" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#E44061;}
+</style><g><path fill="#E51400" class="st0" d="M562,396c0-141.4-114.6-256-256-256S50,254.6,50,396s114.6,256,256,256S562,537.4,562,396L562,396z M356.8,396   L475,514.2L424.2,565L306,446.8L187.8,565L137,514.2L255.2,396L137,277.8l50.8-50.8L306,345.2L424.2,227l50.8,50.8L356.8,396   L356.8,396z"/></g></svg>

--- a/resources/dark/status-ok.svg
+++ b/resources/dark/status-ok.svg
@@ -1,1 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><polygon points="5.382,13 2.382,7 6.618,7 7,7.764 9.382,3 13.618,3 8.618,13" fill="#F6F6F6"/><path d="M12 4l-4 8h-2l-2-4h2l1 2 3-6h2z" fill="#424242"/></svg>
+<?xml version="1.0" ?><svg id="Layer_1" style="enable-background:new 0 0 612 792;" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><style type="text/css">
+	.st0{fill:#41AD49;}
+</style><g><path class="st0" d="M562,396c0-141.4-114.6-256-256-256S50,254.6,50,396s114.6,256,256,256S562,537.4,562,396L562,396z    M501.7,296.3l-241,241l0,0l-17.2,17.2L110.3,421.3l58.8-58.8l74.5,74.5l199.4-199.4L501.7,296.3L501.7,296.3z"/></g></svg>

--- a/src/client/unittests/common/services/testResultsService.ts
+++ b/src/client/unittests/common/services/testResultsService.ts
@@ -25,9 +25,7 @@ export class TestResultsService implements ITestResultsService {
         this.updateTestSuiteAndFileResults(test);
     }
     private updateParentStatus(tests: Tests, status: TestStatus): void {
-        const visitor = (item: TestDataItem) => {
-            item.status = status;
-        };
+        const visitor = (item: TestDataItem) => item.status = status;
         tests.testFiles.forEach(item => {
             if (typeof item.passed === 'boolean') {
                 if (status === TestStatus.Pass ? item.passed : !item.passed) {
@@ -39,12 +37,12 @@ export class TestResultsService implements ITestResultsService {
     private updateTestFolderResults(testFolder: TestFolder): void {
         let totalTime = 0;
         let allFilesPassed = true;
-        let allFilesSkipped = true;
+        let noFilesRan = true;
 
         testFolder.testFiles.forEach(fl => {
             totalTime += fl.time;
             if (typeof fl.passed === 'boolean') {
-                allFilesSkipped = false;
+                noFilesRan = false;
                 if (!fl.passed) {
                     allFilesPassed = false;
                 }
@@ -55,13 +53,13 @@ export class TestResultsService implements ITestResultsService {
         });
 
         let allFoldersPassed = true;
-        let allFoldersSkipped = true;
+        let noFoldersRan = true;
 
         testFolder.folders.forEach(folder => {
             totalTime += folder.time;
             this.updateTestFolderResults(folder);
             if (typeof folder.passed === 'boolean') {
-                allFoldersSkipped = false;
+                noFoldersRan = false;
                 if (!folder.passed) {
                     allFoldersPassed = false;
                 }
@@ -72,7 +70,7 @@ export class TestResultsService implements ITestResultsService {
         });
 
         testFolder.time = totalTime;
-        if (allFilesSkipped && allFoldersSkipped) {
+        if (noFilesRan && noFoldersRan) {
             testFolder.passed = undefined;
             testFolder.status = TestStatus.Unknown;
         } else {
@@ -83,12 +81,12 @@ export class TestResultsService implements ITestResultsService {
     private updateTestSuiteAndFileResults(test: TestSuite | TestFile): void {
         let totalTime = 0;
         let allFunctionsPassed = true;
-        let allFunctionsSkipped = true;
+        let noFunctionsRan = true;
 
         test.functions.forEach(fn => {
             totalTime += fn.time;
             if (typeof fn.passed === 'boolean') {
-                allFunctionsSkipped = false;
+                noFunctionsRan = false;
                 if (fn.passed) {
                     test.functionsPassed! += 1;
                 } else {
@@ -99,13 +97,13 @@ export class TestResultsService implements ITestResultsService {
         });
 
         let allSuitesPassed = true;
-        let allSuitesSkipped = true;
+        let noSuitesRan = true;
 
         test.suites.forEach(suite => {
             this.updateTestSuiteResults(suite);
             totalTime += suite.time;
             if (typeof suite.passed === 'boolean') {
-                allSuitesSkipped = false;
+                noSuitesRan = false;
                 if (!suite.passed) {
                     allSuitesPassed = false;
                 }
@@ -116,7 +114,7 @@ export class TestResultsService implements ITestResultsService {
         });
 
         test.time = totalTime;
-        if (allSuitesSkipped && allFunctionsSkipped) {
+        if (noSuitesRan && noFunctionsRan) {
             test.passed = undefined;
             test.status = TestStatus.Unknown;
         } else {

--- a/src/client/unittests/common/services/testsStatusService.ts
+++ b/src/client/unittests/common/services/testsStatusService.ts
@@ -48,8 +48,10 @@ export class TestsStatusUpdaterService implements ITestsStatusUpdaterService {
         }
         const predicate = (item: TestDataItem) => item.status === TestStatus.Fail || item.status === TestStatus.Error;
         const visitor = (item: TestDataItem) => {
-            item.status = TestStatus.Running;
-            this.storage.update(resource, item);
+            if (item.status && predicate(item)){
+                item.status = TestStatus.Running;
+                this.storage.update(resource, item);
+            }
         };
         const failedItems = [
             ...tests.testFunctions.map(f => f.testFunction).filter(predicate),

--- a/src/client/unittests/common/services/testsStatusService.ts
+++ b/src/client/unittests/common/services/testsStatusService.ts
@@ -48,7 +48,7 @@ export class TestsStatusUpdaterService implements ITestsStatusUpdaterService {
         }
         const predicate = (item: TestDataItem) => item.status === TestStatus.Fail || item.status === TestStatus.Error;
         const visitor = (item: TestDataItem) => {
-            if (item.status && predicate(item)){
+            if (item.status && predicate(item)) {
                 item.status = TestStatus.Running;
                 this.storage.update(resource, item);
             }

--- a/src/client/unittests/explorer/testTreeViewItem.ts
+++ b/src/client/unittests/explorer/testTreeViewItem.ts
@@ -53,6 +53,10 @@ export abstract class TestTreeItem extends TreeItem {
             case TestStatus.Running: {
                 return getIcon(Icons.discovering);
             }
+            case TestStatus.Idle:
+            case TestStatus.Unknown: {
+                return getIcon(Icons.unknown);
+            }
             default: {
                 switch (this.testType) {
                     case TestType.testFile: {
@@ -73,6 +77,31 @@ export abstract class TestTreeItem extends TreeItem {
      */
     public get parent(): TestDataItem {
         return this.parentData;
+    }
+
+    public get tooltip(): string {
+        if (!this.data) {
+            return '';
+        }
+        if (this.testType !== TestType.testFunction) {
+            return `${this.data.functionsFailed} failed, ${this.data.functionsPassed} passed in ${this.data.time} seconds`;
+        }
+        switch (this.data.status) {
+            case TestStatus.Error:
+            case TestStatus.Fail: {
+                return `Failed in ${this.data.time} seconds`;
+            }
+            case TestStatus.Pass: {
+                return `Passed in ${this.data.time} seconds`;
+            }
+            case TestStatus.Discovering:
+            case TestStatus.Running: {
+                return 'Loading...';
+            }
+            default: {
+                return '';
+            }
+        }
     }
 
     /**

--- a/src/test/unittests/common/services/testStatusService.unit.test.ts
+++ b/src/test/unittests/common/services/testStatusService.unit.test.ts
@@ -155,6 +155,7 @@ suite('Unit Tests - Tests Status Updater', () => {
         tests.testFiles[3].status = TestStatus.Error;
         tests.testFunctions[2].testFunction.status = TestStatus.Fail;
         tests.testFunctions[3].testFunction.status = TestStatus.Error;
+        tests.testFunctions[4].testFunction.status = TestStatus.Pass;
         tests.testSuites[1].testSuite.status = TestStatus.Fail;
         tests.testSuites[2].testSuite.status = TestStatus.Error;
 
@@ -168,7 +169,11 @@ suite('Unit Tests - Tests Status Updater', () => {
 
         // Update status of test functions and suites.
         const updatedItems: TestDataItem[] = [];
-        const visitor = (item: TestDataItem) => updatedItems.push(item);
+        const visitor = (item: TestDataItem) => {
+            if (item.status && item.status !== TestStatus.Pass) {
+                updatedItems.push(item);
+            }
+        };
         const failedItems = [
             tests.testFunctions[2].testFunction,
             tests.testFunctions[3].testFunction,
@@ -181,6 +186,9 @@ suite('Unit Tests - Tests Status Updater', () => {
             assert.equal(item.status, TestStatus.Running);
             verify(storage.update(workspaceUri, item)).once();
         }
+
+        // Only items with status Fail & Error should be modified
+        assert.equal(tests.testFunctions[4].testFunction.status, TestStatus.Pass);
 
         // Should only be called for failed items.
         verify(storage.update(workspaceUri, anything())).times(updatedItems.length);


### PR DESCRIPTION
For #4583 #4689 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] The wiki is updated with any design decisions/details.
