### PR TITLE
Test explorer - beaker icon should be hidden when tests are disabled

### DIFF
--- a/news/2 Fixes/4494.md
+++ b/news/2 Fixes/4494.md
@@ -1,0 +1,1 @@
+Test explorer - beaker icon should be hidden when tests are disabled

--- a/src/client/unittests/display/main.ts
+++ b/src/client/unittests/display/main.ts
@@ -153,6 +153,7 @@ export class TestResultDisplay implements ITestResultDisplay {
         for (const setting of settingsToDisable) {
             await configurationService.updateSetting(setting, false).catch(noop);
         }
+        this.cmdManager.executeCommand('setContext', 'testsDiscovered', false);
     }
 
     private updateWithDiscoverSuccess(tests: Tests, quietMode: boolean = false) {

--- a/src/test/unittests/display/main.unit.test.ts
+++ b/src/test/unittests/display/main.unit.test.ts
@@ -284,7 +284,8 @@ suite('Unit Tests - TestResultDisplay', () => {
             .verifiable(typeMoq.Times.once());
 
         statusBar.setup(s => s.show()).verifiable(typeMoq.Times.once());
-
+        cmdManager.setup(c => c.executeCommand(typeMoq.It.isAny(), typeMoq.It.isAny(), typeMoq.It.isAny()))
+            .verifiable(typeMoq.Times.once());
         createTestResultDisplay();
         const def = createDeferred<Tests>();
 
@@ -312,6 +313,7 @@ suite('Unit Tests - TestResultDisplay', () => {
         appShell.verifyAll();
         statusBar.verify(s => s.command = typeMoq.It.isValue(Commands.Tests_View_UI), typeMoq.Times.atLeastOnce());
         configurationService.verifyAll();
+        cmdManager.verifyAll();
     });
     test('Ensure corresponding command is executed when there are errors and user choses to configure test framework', async () => {
         const statusBar = typeMoq.Mock.ofType<StatusBarItem>();

--- a/src/test/unittests/display/main.unit.test.ts
+++ b/src/test/unittests/display/main.unit.test.ts
@@ -10,6 +10,7 @@ import * as typeMoq from 'typemoq';
 import { StatusBarItem, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager } from '../../../client/common/application/types';
 import { Commands } from '../../../client/common/constants';
+import '../../../client/common/extensions';
 import { IConfigurationService, IPythonSettings, IUnitTestSettings } from '../../../client/common/types';
 import { createDeferred } from '../../../client/common/utils/async';
 import { UnitTests } from '../../../client/common/utils/localize';
@@ -284,7 +285,7 @@ suite('Unit Tests - TestResultDisplay', () => {
             .verifiable(typeMoq.Times.once());
 
         statusBar.setup(s => s.show()).verifiable(typeMoq.Times.once());
-        cmdManager.setup(c => c.executeCommand(typeMoq.It.isAny(), typeMoq.It.isAny(), typeMoq.It.isAny()))
+        cmdManager.setup(c => c.executeCommand(typeMoq.It.isValue('setContext'), typeMoq.It.isValue('testsDiscovered'), typeMoq.It.isValue(false)))
             .verifiable(typeMoq.Times.once());
         createTestResultDisplay();
         const def = createDeferred<Tests>();


### PR DESCRIPTION
For #4494 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] ~Has sufficient logging.~
- [ ] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [ ] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] ~The wiki is updated with any design decisions/details.~
