### PR TITLE
Nest subtests under their function in the test explorer.

### DIFF
--- a/news/1 Enhancements/4503.md
+++ b/news/1 Enhancements/4503.md
@@ -1,0 +1,1 @@
+Show sub-tests in a subtree in the test explorer.

--- a/src/client/unittests/common/testUtils.ts
+++ b/src/client/unittests/common/testUtils.ts
@@ -314,9 +314,6 @@ export function getParent(tests: Tests, data: TestDataItem): TestDataItem | unde
         }
         case TestType.testSuite: {
             const suite = data as TestSuite;
-            // const parentSuite = tests.testSuites.find(item => item.testSuite.suites.some(child => child === data));
-            // const parentFile = tests.testFiles.find(item=> item.suites.find(data)
-            // return item && (item.parentTestSuite || item.parentTestFile);
             if (isSubtestsParent(suite)) {
                 const fn = suite.functions[0];
                 const parent = tests.testSuites.find(item => item.testSuite.functions.indexOf(fn) >= 0);
@@ -341,8 +338,6 @@ export function getParent(tests: Tests, data: TestDataItem): TestDataItem | unde
                 return parentSuite.testSuite;
             }
             return tests.testFiles.find(item => item.functions.indexOf(fn) >= 0);
-            // const item = findFlattendTestFunction(tests, data as TestFunction);
-            // return item && (item.parentTestSuite || item.parentTestFile);
         }
         default: {
             throw new Error('Unknown test type');
@@ -388,20 +383,6 @@ function getParentTestFolderForFolder(tests: Tests, folder: TestFolder): TestFol
         return;
     }
     return tests.testFolders.find(item => item.folders.some(child => child === folder));
-    // function getParentFolder(folders: TestFolder[], item: TestFolder): TestFolder {
-    //     const index = folders.indexOf(item);
-    //     if (index) {
-    //         return folders[index];
-    //     }
-    //     for (const f of folders) {
-    //         const found = getParentFolder(f.folders, item);
-    //         if (found) {
-    //             return found;
-    //         }
-    //     }
-    // }
-
-    // return getParentFolder(tests.testFolders, folder);
 }
 
 /**

--- a/src/client/unittests/common/testUtils.ts
+++ b/src/client/unittests/common/testUtils.ts
@@ -317,6 +317,14 @@ export function getParent(tests: Tests, data: TestDataItem): TestDataItem | unde
             // const parentSuite = tests.testSuites.find(item => item.testSuite.suites.some(child => child === data));
             // const parentFile = tests.testFiles.find(item=> item.suites.find(data)
             // return item && (item.parentTestSuite || item.parentTestFile);
+            if (isSubtestsParent(suite)) {
+                const fn = suite.functions[0];
+                const parent = tests.testSuites.find(item => item.testSuite.functions.indexOf(fn) >= 0);
+                if (parent) {
+                    return parent.testSuite;
+                }
+                return tests.testFiles.find(item => item.functions.indexOf(fn) >= 0);
+            }
             const parentSuite = tests.testSuites.find(item => item.testSuite.suites.indexOf(suite) >= 0);
             if (parentSuite) {
                 return parentSuite.testSuite;
@@ -325,6 +333,9 @@ export function getParent(tests: Tests, data: TestDataItem): TestDataItem | unde
         }
         case TestType.testFunction: {
             const fn = data as TestFunction;
+            if (fn.subtestParent) {
+                return fn.subtestParent.asSuite;
+            }
             const parentSuite = tests.testSuites.find(item => item.testSuite.functions.indexOf(fn) >= 0);
             if (parentSuite) {
                 return parentSuite.testSuite;
@@ -427,22 +438,30 @@ export function findFlattendTestSuite(tests: Tests, suite: TestSuite): Flattened
  */
 export function getChildren(item: TestDataItem): TestDataItem[] {
     switch (getTestType(item)) {
-        case TestType.testFile: {
-            return [
-                ...(item as TestFile).functions,
-                ...(item as TestFile).suites
-            ];
-        }
         case TestType.testFolder: {
             return [
                 ...(item as TestFolder).folders,
                 ...(item as TestFolder).testFiles
             ];
         }
-        case TestType.testSuite: {
+        case TestType.testFile: {
+            const [subSuites, functions] = divideSubtests((item as TestFile).functions);
             return [
-                ...(item as TestSuite).functions,
-                ...(item as TestSuite).suites
+                ...functions,
+                ...(item as TestFile).suites,
+                ...subSuites
+            ];
+        }
+        case TestType.testSuite: {
+            let subSuites: TestSuite[] = [];
+            let functions = (item as TestSuite).functions;
+            if (!isSubtestsParent((item as TestSuite))) {
+                [subSuites, functions] = divideSubtests((item as TestSuite).functions);
+            }
+            return [
+                ...functions,
+                ...(item as TestSuite).suites,
+                ...subSuites
             ];
         }
         case TestType.testFunction: {
@@ -452,6 +471,34 @@ export function getChildren(item: TestDataItem): TestDataItem[] {
             throw new Error('Unknown Test Type');
         }
     }
+}
+
+function divideSubtests(mixed: TestFunction[]): [TestSuite[], TestFunction[]] {
+    const suites: TestSuite[] = [];
+    const functions: TestFunction[] = [];
+    mixed.forEach(func => {
+        if (!func.subtestParent) {
+            functions.push(func);
+            return;
+        }
+        const parent = func.subtestParent.asSuite;
+        if (suites.indexOf(parent) < 0) {
+            suites.push(parent);
+        }
+    });
+    return [suites, functions];
+}
+
+export function isSubtestsParent(suite: TestSuite): boolean {
+    const functions = suite.functions;
+    if (functions.length === 0) {
+        return false;
+    }
+    const subtestParent = functions[0].subtestParent;
+    if (subtestParent === undefined) {
+        return false;
+    }
+    return subtestParent.asSuite === suite;
 }
 
 export function copyTestResults(source: Tests, target: Tests): void {
@@ -511,4 +558,4 @@ function copyValueTypes<T>(source: T, target: T): void {
             target[key] = value;
         }
     });
-}
+ }

--- a/src/client/unittests/common/types.ts
+++ b/src/client/unittests/common/types.ts
@@ -72,7 +72,13 @@ export type TestFunction = TestResult & {
     resource: Uri;
     name: string;
     nameToRun: string;
-    subtestParent?: TestFunction;
+    subtestParent?: SubtestParent;
+};
+
+export type SubtestParent = TestResult & {
+    name: string;
+    nameToRun: string;
+    asSuite: TestSuite;
 };
 
 export type TestResult = Node & {

--- a/src/client/unittests/common/types.ts
+++ b/src/client/unittests/common/types.ts
@@ -72,6 +72,7 @@ export type TestFunction = TestResult & {
     resource: Uri;
     name: string;
     nameToRun: string;
+    funcName?: string;  // used if is subtest
 };
 
 export type TestResult = Node & {

--- a/src/client/unittests/common/types.ts
+++ b/src/client/unittests/common/types.ts
@@ -72,7 +72,7 @@ export type TestFunction = TestResult & {
     resource: Uri;
     name: string;
     nameToRun: string;
-    funcName?: string;  // used if is subtest
+    subtestParent?: TestFunction;
 };
 
 export type TestResult = Node & {

--- a/src/client/unittests/explorer/testTreeViewItem.ts
+++ b/src/client/unittests/explorer/testTreeViewItem.ts
@@ -10,8 +10,8 @@ import { Commands } from '../../common/constants';
 import { getIcon } from '../../common/utils/icons';
 import { noop } from '../../common/utils/misc';
 import { Icons } from '../common/constants';
-import { getTestType } from '../common/testUtils';
-import { TestResult, TestStatus, TestType } from '../common/types';
+import { getTestType, isSubtestsParent } from '../common/testUtils';
+import { TestResult, TestStatus, TestSuite, TestType } from '../common/types';
 import { TestDataItem } from '../types';
 
 /**
@@ -114,6 +114,10 @@ export class TestTreeItem extends TreeItem {
                 break;
             }
             case TestType.testSuite: {
+                if (isSubtestsParent(this.data as TestSuite)) {
+                    this.command = { command: Commands.navigateToTestFunction, title: 'Open', arguments: [this.resource, this.data, false] };
+                    break;
+                }
                 this.command = { command: Commands.navigateToTestSuite, title: 'Open', arguments: [this.resource, this.data, false] };
                 break;
             }

--- a/src/client/unittests/pytest/services/parserService.ts
+++ b/src/client/unittests/pytest/services/parserService.ts
@@ -153,7 +153,7 @@ export class TestsParser implements ITestsParser {
         let currentPackage: string = '';
         const resource = Uri.file(rootDirectory);
 
-        // tslint:disable-next-line:cyclomatic-complexity
+        // tslint:disable-next-line:cyclomatic-complexity max-func-body-length
         lines.forEach(line => {
             const trimmedLine = line.trim();
             let name: string = '';

--- a/src/client/unittests/pytest/services/parserService.ts
+++ b/src/client/unittests/pytest/services/parserService.ts
@@ -206,7 +206,16 @@ export class TestsParser implements ITestsParser {
                 name = name.trimQuotes();
 
                 const rawName = `${parentNode!.item.nameToRun}::${name}`;
-                const fn: TestFunction = { resource, name: name, nameToRun: rawName, time: 0 };
+                const fn: TestFunction = {
+                    resource: resource,
+                    name: name,
+                    nameToRun: rawName,
+                    time: 0
+                };
+                const pos = name.indexOf('[');
+                if (pos > 0 && name.endsWith(']')) {
+                    fn.funcName = name.substring(0, pos);
+                }
                 parentNode!.item.functions.push(fn);
                 return;
             }

--- a/src/client/unittests/pytest/services/parserService.ts
+++ b/src/client/unittests/pytest/services/parserService.ts
@@ -219,8 +219,6 @@ export class TestsParser implements ITestsParser {
                 name = extractBetweenDelimiters(trimmedLine, '<Instance ', '>').trimQuotes();
                 // tslint:disable-next-line:prefer-type-cast
                 const suite = (parentNode!.item as TestSuite);
-                // suite.rawName = suite.rawName + '::()';
-                // suite.xmlName = suite.xmlName + '.()';
                 suite.isInstance = true;
                 return;
             }

--- a/src/test/unittests/common/testUtils.unit.test.ts
+++ b/src/test/unittests/common/testUtils.unit.test.ts
@@ -4,48 +4,76 @@
 'use strict';
 
 import * as assert from 'assert';
+import * as path from 'path';
 import { Uri } from 'vscode';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
-import { getParent, getTestFile, getTestFolder, getTestFunction, getTestSuite, getTestType } from '../../../client/unittests/common/testUtils';
-import { FlattenedTestFunction, FlattenedTestSuite, TestFile, TestFolder, TestFunction, Tests, TestSuite, TestType } from '../../../client/unittests/common/types';
-import { TestDataItem, TestWorkspaceFolder } from '../../../client/unittests/types';
+import {
+    getChildren, getParent, getTestFile, getTestFolder, getTestFunction,
+    getTestSuite, getTestType
+} from '../../../client/unittests/common/testUtils';
+import {
+    FlattenedTestFunction, FlattenedTestSuite, SubtestParent, TestFile,
+    TestFolder, TestFunction, Tests, TestSuite, TestType
+} from '../../../client/unittests/common/types';
+import {
+    TestDataItem, TestWorkspaceFolder
+} from '../../../client/unittests/types';
 
 // tslint:disable:prefer-template
 
-export function createMockTestDataItem<T extends TestDataItem>(type: TestType, nameSuffix: string = '') {
+function longestCommonSubstring(strings: string[]): string {
+    strings = strings.concat().sort();
+    let substr = strings.shift() || '';
+    strings.forEach(str => {
+        for (const [idx, ch] of [...substr].entries()) {
+            if (str[idx] !== ch) {
+                substr = substr.substring(0, idx);
+                break;
+            }
+        }
+    });
+    return substr;
+}
+
+export function createMockTestDataItem<T extends TestDataItem>(
+    type: TestType,
+    nameSuffix: string = '',
+    name?: string,
+    nameToRun?: string
+) {
     const folder: TestFolder = {
         resource: Uri.file(__filename),
         folders: [],
-        name: 'Some Folder' + nameSuffix,
-        nameToRun: ' Some Folder' + nameSuffix,
+        name: name || 'Some Folder' + nameSuffix,
+        nameToRun: nameToRun || name || ' Some Folder' + nameSuffix,
         testFiles: [],
         time: 0
     };
     const file: TestFile = {
         resource: Uri.file(__filename),
-        name: 'Some File' + nameSuffix,
-        nameToRun: ' Some File' + nameSuffix,
+        name: name || 'Some File' + nameSuffix,
+        nameToRun: nameToRun || name || ' Some File' + nameSuffix,
         fullPath: __filename,
-        xmlName: 'some xml name' + nameSuffix,
+        xmlName: name || 'some xml name' + nameSuffix,
         functions: [],
         suites: [],
         time: 0
     };
     const func: TestFunction = {
         resource: Uri.file(__filename),
-        name: 'Some Function' + nameSuffix,
-        nameToRun: ' Some Function' + nameSuffix,
+        name: name || 'Some Function' + nameSuffix,
+        nameToRun: nameToRun || name || ' Some Function' + nameSuffix,
         time: 0
     };
     const suite: TestSuite = {
         resource: Uri.file(__filename),
-        name: 'Some Suite' + nameSuffix,
-        nameToRun: ' Some Suite' + nameSuffix,
+        name: name || 'Some Suite' + nameSuffix,
+        nameToRun: nameToRun || name || ' Some Suite' + nameSuffix,
         functions: [],
         isInstance: true,
         isUnitTest: false,
         suites: [],
-        xmlName: 'some name' + nameSuffix,
+        xmlName: name || 'some name' + nameSuffix,
         time: 0
     };
 
@@ -64,6 +92,59 @@ export function createMockTestDataItem<T extends TestDataItem>(type: TestType, n
             throw new Error('Unknown type');
     }
 }
+
+export function createSubtestParent(funcs: TestFunction[]): SubtestParent {
+    const name = longestCommonSubstring(funcs.map(func => func.name));
+    const nameToRun = longestCommonSubstring(funcs.map(func => func.nameToRun));
+    const subtestParent: SubtestParent = {
+        name: name,
+        nameToRun: nameToRun,
+        asSuite: {
+            resource: Uri.file(__filename),
+            name: name,
+            nameToRun: nameToRun,
+            functions: funcs,
+            suites: [],
+            isUnitTest: false,
+            isInstance: false,
+            xmlName: '',
+            time: 0
+        },
+        time: 0
+    };
+    funcs.forEach(func => {
+        func.subtestParent = subtestParent;
+    });
+    return subtestParent;
+}
+
+export function createTests(
+    folders: TestFolder[],
+    files: TestFile[],
+    suites: TestSuite[],
+    funcs: TestFunction[]
+): Tests {
+    // tslint:disable:no-any
+    return {
+        summary: { errors: 0, skipped: 0, passed: 0, failures: 0 },
+        rootTestFolders: folders.length > 0 ? [folders[0]] : [],
+        testFolders: folders,
+        testFiles: files,
+        testSuites: suites.map(suite => {
+            return {
+                testSuite: suite,
+                xmlClassName: suite.xmlName
+            } as any;
+        }),
+        testFunctions: funcs.map(func => {
+            return {
+                testFunction: func,
+                xmlClassName: func.name
+            } as any;
+        })
+    };
+}
+
 // tslint:disable:max-func-body-length no-any
 suite('Unit Tests - TestUtils', () => {
     test('Get TestType for Folders', () => {
@@ -319,5 +400,78 @@ suite('Unit Tests - TestUtils', () => {
         assert.equal(getParent(tests, fn3), suite1);
         assert.equal(getParent(tests, fn4), suite1);
         assert.equal(getParent(tests, fn5), suite3);
+    });
+    test('Get parent of parameterized function', () => {
+        const folder = createMockTestDataItem<TestFolder>(TestType.testFolder);
+        const file = createMockTestDataItem<TestFile>(TestType.testFile);
+        const func1 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const func2 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const func3 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const subParent1 = createSubtestParent([func2, func3]);
+        const suite = createMockTestDataItem<TestSuite>(TestType.testSuite);
+        const func4 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const func5 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const func6 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const subParent2 = createSubtestParent([func5, func6]);
+        folder.testFiles.push(file);
+        file.functions.push(func1);
+        file.functions.push(func2);
+        file.functions.push(func3);
+        file.suites.push(suite);
+        suite.functions.push(func4);
+        suite.functions.push(func5);
+        suite.functions.push(func6);
+        const tests = createTests(
+            [folder],
+            [file],
+            [suite],
+            [func1, func2, func3, func4, func5, func6]
+        );
+
+        assert.equal(getParent(tests, folder), undefined);
+        assert.equal(getParent(tests, file), folder);
+        assert.equal(getParent(tests, func1), file);
+        assert.equal(getParent(tests, subParent1.asSuite), file);
+        assert.equal(getParent(tests, func2), subParent1.asSuite);
+        assert.equal(getParent(tests, func3), subParent1.asSuite);
+        assert.equal(getParent(tests, suite), file);
+        assert.equal(getParent(tests, func4), suite);
+        assert.equal(getParent(tests, subParent2.asSuite), suite);
+        assert.equal(getParent(tests, func5), subParent2.asSuite);
+        assert.equal(getParent(tests, func6), subParent2.asSuite);
+    });
+    test('Get children of parameterized function', () => {
+        const filename = path.join('tests', 'test_spam.py');
+        const folder = createMockTestDataItem<TestFolder>(TestType.testFolder, 'tests');
+        const file = createMockTestDataItem<TestFile>(TestType.testFile, filename);
+        const func1 = createMockTestDataItem<TestFunction>(TestType.testFunction, 'test_x');
+        const func2 = createMockTestDataItem<TestFunction>(TestType.testFunction, 'test_y');
+        const func3 = createMockTestDataItem<TestFunction>(TestType.testFunction, 'test_z');
+        const subParent1 = createSubtestParent([func2, func3]);
+        const suite = createMockTestDataItem<TestSuite>(TestType.testSuite);
+        const func4 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const func5 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const func6 = createMockTestDataItem<TestFunction>(TestType.testFunction);
+        const subParent2 = createSubtestParent([func5, func6]);
+        folder.testFiles.push(file);
+        file.functions.push(func1);
+        file.functions.push(func2);
+        file.functions.push(func3);
+        file.suites.push(suite);
+        suite.functions.push(func4);
+        suite.functions.push(func5);
+        suite.functions.push(func6);
+
+        assert.deepEqual(getChildren(folder), [file]);
+        assert.deepEqual(getChildren(file), [func1, suite, subParent1.asSuite]);
+        assert.deepEqual(getChildren(func1), []);
+        assert.deepEqual(getChildren(subParent1.asSuite), [func2, func3]);
+        assert.deepEqual(getChildren(func2), []);
+        assert.deepEqual(getChildren(func3), []);
+        assert.deepEqual(getChildren(suite), [func4, subParent2.asSuite]);
+        assert.deepEqual(getChildren(func4), []);
+        assert.deepEqual(getChildren(subParent2.asSuite), [func5, func6]);
+        assert.deepEqual(getChildren(func5), []);
+        assert.deepEqual(getChildren(func6), []);
     });
 });

--- a/src/test/unittests/explorer/testTreeViewItem.unit.test.ts
+++ b/src/test/unittests/explorer/testTreeViewItem.unit.test.ts
@@ -6,12 +6,18 @@
 import { expect } from 'chai';
 import { Uri } from 'vscode';
 import {
+    Commands
+} from '../../../client/common/constants';
+import {
     TestFile, TestFolder,
-    TestFunction, TestSuite
+    TestFunction, TestSuite, TestType
 } from '../../../client/unittests/common/types';
 import {
     TestTreeItem
 } from '../../../client/unittests/explorer/testTreeViewItem';
+import {
+    createMockTestDataItem, createSubtestParent
+} from '../common/testUtils.unit.test';
 import { getTestExplorerViewItemData } from './explorerTestData';
 
 suite('Unit Tests Test Explorer View Items', () => {
@@ -25,7 +31,7 @@ suite('Unit Tests Test Explorer View Items', () => {
         [testFolder, testFile, testFunction, testSuite, testSuiteFunction] = getTestExplorerViewItemData();
     });
 
-    test('Test folder created into test view item', () => {
+    test('Test root folder created into test view item', () => {
         const viewItem = new TestTreeItem(resource, testFolder);
         expect(viewItem.contextValue).is.equal('testFolder');
     });
@@ -35,18 +41,38 @@ suite('Unit Tests Test Explorer View Items', () => {
         expect(viewItem.contextValue).is.equal('testFile');
     });
 
-    test('Test folder created into test view item', () => {
+    test('Test suite created into test view item', () => {
         const viewItem = new TestTreeItem(resource, testSuite);
         expect(viewItem.contextValue).is.equal('testSuite');
     });
 
-    test('Test folder created into test view item', () => {
+    test('Test function created into test view item', () => {
         const viewItem = new TestTreeItem(resource, testFunction);
         expect(viewItem.contextValue).is.equal('testFunction');
     });
 
-    test('Test folder created into test view item', () => {
+    test('Test suite function created into test view item', () => {
         const viewItem = new TestTreeItem(resource, testSuiteFunction);
+        expect(viewItem.contextValue).is.equal('testFunction');
+    });
+
+    test('Test subtest parent created into test view item', () => {
+        const subtestParent = createSubtestParent([
+            createMockTestDataItem<TestFunction>(TestType.testFunction, 'test_x'),
+            createMockTestDataItem<TestFunction>(TestType.testFunction, 'test_y')
+        ]);
+
+        const viewItem = new TestTreeItem(resource, subtestParent.asSuite);
+
+        expect(viewItem.contextValue).is.equal('testSuite');
+        expect(viewItem.command!.command).is.equal(Commands.navigateToTestFunction);
+    });
+
+    test('Test subtest created into test view item', () => {
+        createSubtestParent([testFunction]);  // sets testFunction.subtestParent
+
+        const viewItem = new TestTreeItem(resource, testFunction);
+
         expect(viewItem.contextValue).is.equal('testFunction');
     });
 });

--- a/src/test/unittests/pytest/pytest.testparser.unit.test.ts
+++ b/src/test/unittests/pytest/pytest.testparser.unit.test.ts
@@ -148,7 +148,7 @@ collected 2 items
             name: 'test_with_subtests',
             nameToRun: 'tests/test_spam.py::test_with_subtests',
             asSuite: {
-                resource: Uri.file(__filename),
+                resource: Uri.file('/home/user/test/pytest_scenario'),
                 name: 'test_with_subtests',
                 nameToRun: 'tests/test_spam.py::test_with_subtests',
                 functions: [

--- a/src/test/unittests/pytest/pytest.testparser.unit.test.ts
+++ b/src/test/unittests/pytest/pytest.testparser.unit.test.ts
@@ -12,12 +12,16 @@ import { OSType } from '../../../client/common/utils/platform';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { TestsHelper } from '../../../client/unittests/common/testUtils';
 import { TestFlatteningVisitor } from '../../../client/unittests/common/testVisitors/flatteningVisitor';
-import { FlattenedTestFunction, TestDiscoveryOptions, Tests } from '../../../client/unittests/common/types';
+import {
+    FlattenedTestFunction, SubtestParent, TestDiscoveryOptions, Tests
+} from '../../../client/unittests/common/types';
 import { TestsParser as PyTestsParser } from '../../../client/unittests/pytest/services/parserService';
 import { getOSType } from '../../common';
 import { PytestDataPlatformType, pytestScenarioData } from './pytest_unittest_parser_data';
 
 use(chaipromise);
+
+// tslint:disable:max-func-body-length
 
 // The PyTest test parsing is done via the stdout result of the
 // `pytest --collect-only` command.
@@ -30,6 +34,44 @@ use(chaipromise);
 // created a JSON structure that defines all the tests - see file
 // `pytest_unittest_parser_data.ts` in this folder.
 suite('Unit Tests - PyTest - Test Parser used in discovery', () => {
+    let serviceContainer: typeMoq.IMock<IServiceContainer>;
+    let appShell: typeMoq.IMock<IApplicationShell>;
+    let cmdMgr: typeMoq.IMock<ICommandManager>;
+
+    setup(() => {
+        serviceContainer = typeMoq.Mock.ofType<IServiceContainer>(undefined, typeMoq.MockBehavior.Strict);
+
+        appShell = typeMoq.Mock.ofType<IApplicationShell>(undefined, typeMoq.MockBehavior.Strict);
+        serviceContainer.setup(s => s.get(typeMoq.It.isValue(IApplicationShell), typeMoq.It.isAny()))
+            .returns(() => appShell.object);
+
+       cmdMgr = typeMoq.Mock.ofType<ICommandManager>(undefined, typeMoq.MockBehavior.Strict);
+        serviceContainer.setup(s => s.get(typeMoq.It.isValue(ICommandManager), typeMoq.It.isAny()))
+            .returns(() => cmdMgr.object);
+    });
+
+    function makeOptions(rootdir: string): TestDiscoveryOptions {
+        const outChannel = typeMoq.Mock.ofType<OutputChannel>(undefined, typeMoq.MockBehavior.Strict);
+        const cancelToken = typeMoq.Mock.ofType<CancellationToken>(undefined, typeMoq.MockBehavior.Strict);
+        cancelToken.setup(c => c.isCancellationRequested)
+            .returns(() => false);
+        const wsFolder = typeMoq.Mock.ofType<Uri>(undefined, typeMoq.MockBehavior.Strict);
+
+        return {
+            args: [],
+            cwd: rootdir,
+            ignoreCache: true,
+            outChannel: outChannel.object,
+            token: cancelToken.object,
+            workspaceFolder: wsFolder.object
+        };
+    }
+
+    function makeParser(): PyTestsParser {
+        const testFlattener: TestFlatteningVisitor = new TestFlatteningVisitor();
+        const testHlp: TestsHelper = new TestsHelper(testFlattener, serviceContainer.object);
+        return new PyTestsParser(testHlp);
+    }
 
     // Build tests for the test data that is relevant for this platform.
     const testPlatformType: PytestDataPlatformType =
@@ -43,45 +85,12 @@ suite('Unit Tests - PyTest - Test Parser used in discovery', () => {
                 `PyTest${testScenario.pytest_version_spec}: ${testScenario.description}`;
 
             test(testDescription, async () => {
-                // Setup the service container for use by the parser.
-                const serviceContainer = typeMoq.Mock.ofType<IServiceContainer>();
-                const appShell = typeMoq.Mock.ofType<IApplicationShell>();
-                const cmdMgr = typeMoq.Mock.ofType<ICommandManager>();
-                serviceContainer.setup(s => s.get(typeMoq.It.isValue(IApplicationShell), typeMoq.It.isAny()))
-                    .returns(() => {
-                        return appShell.object;
-                    });
-                serviceContainer.setup(s => s.get(typeMoq.It.isValue(ICommandManager), typeMoq.It.isAny()))
-                    .returns(() => {
-                        return cmdMgr.object;
-                    });
-
-                // Create mocks used in the test discovery setup.
-                const outChannel = typeMoq.Mock.ofType<OutputChannel>();
-                const cancelToken = typeMoq.Mock.ofType<CancellationToken>();
-                cancelToken.setup(c => c.isCancellationRequested).returns(() => false);
-                const wsFolder = typeMoq.Mock.ofType<Uri>();
-
-                // Create the test options for the mocked-up test. All data is either
-                // mocked or is taken from the JSON test data itself.
-                const options: TestDiscoveryOptions = {
-                    args: [],
-                    cwd: testScenario.rootdir,
-                    ignoreCache: true,
-                    outChannel: outChannel.object,
-                    token: cancelToken.object,
-                    workspaceFolder: wsFolder.object
-                };
-
-                // Setup the parser.
-                const testFlattener: TestFlatteningVisitor = new TestFlatteningVisitor();
-                const testHlp: TestsHelper = new TestsHelper(testFlattener, serviceContainer.object);
-                const parser = new PyTestsParser(testHlp);
-
                 // Each test scenario has a 'stdout' member that is an array of
                 // stdout lines. Join them here such that the parser can operate
                 // on stdout-like data.
                 const stdout: string = testScenario.stdout.join('\n');
+                const options = makeOptions(testScenario.rootdir);
+                const parser = makeParser();
 
                 const parsedTests: Tests = parser.parse(stdout, options);
 
@@ -106,5 +115,54 @@ suite('Unit Tests - PyTest - Test Parser used in discovery', () => {
 
             });
         }
+    });
+
+    test('Handle parameterized tests', () => {
+        // tslint:disable-next-line:no-multiline-string
+        const stdout = `
+============================= test session starts =============================
+platform linux -- Python 3.7.1, pytest-4.2.1, py-1.7.0, pluggy-0.8.1
+rootdir: /home/user/test/pytest_scenario, inifile:
+collected 2 items
+<Package /home/user/test/pytest_scenario/tests>
+  <Module test_spam.py>
+    <Function test_with_subtests[1-2]>
+    <Function test_with_subtests[3-4]>
+
+======================== no tests ran in 0.36 seconds =========================`;
+        const options = makeOptions('/home/user/test/pytest_scenario');
+        const parser = makeParser();
+
+        const tests: Tests = parser.parse(stdout, options);
+
+        expect(tests.testFunctions.length).is.equal(2);
+        expect(tests.testFunctions[0].testFunction.name)
+            .is.equal('test_with_subtests[1-2]');
+        expect(tests.testFunctions[0].testFunction.nameToRun)
+            .is.equal('tests/test_spam.py::test_with_subtests[1-2]');
+        expect(tests.testFunctions[1].testFunction.name)
+            .is.equal('test_with_subtests[3-4]');
+        expect(tests.testFunctions[1].testFunction.nameToRun)
+            .is.equal('tests/test_spam.py::test_with_subtests[3-4]');
+        const parent: SubtestParent = {
+            name: 'test_with_subtests',
+            nameToRun: 'tests/test_spam.py::test_with_subtests',
+            asSuite: {
+                name: 'test_with_subtests',
+                nameToRun: 'tests/test_spam.py::test_with_subtests',
+                functions: [
+                    tests.testFunctions[0].testFunction,
+                    tests.testFunctions[1].testFunction
+                ],
+                suites: [],
+                isUnitTest: false,
+                isInstance: false,
+                xmlName: '',
+                time: 0
+            },
+            time: 0
+        };
+        expect(tests.testFunctions[0].testFunction.subtestParent).is.deep.equal(parent);
+        expect(tests.testFunctions[1].testFunction.subtestParent).is.deep.equal(parent);
     });
 });

--- a/src/test/unittests/pytest/pytest.testparser.unit.test.ts
+++ b/src/test/unittests/pytest/pytest.testparser.unit.test.ts
@@ -148,6 +148,7 @@ collected 2 items
             name: 'test_with_subtests',
             nameToRun: 'tests/test_spam.py::test_with_subtests',
             asSuite: {
+                resource: Uri.file(__filename),
                 name: 'test_with_subtests',
                 nameToRun: 'tests/test_spam.py::test_with_subtests',
                 functions: [

--- a/src/test/unittests/pytest/pytest_unittest_parser_data.ts
+++ b/src/test/unittests/pytest/pytest_unittest_parser_data.ts
@@ -2078,5 +2078,28 @@ export const pytestScenarioData: PytestDiscoveryScenario[] =
                 "",
                 "======================== no tests ran in 0.36 seconds ========================="
             ]
+        },
+        {
+            pytest_version_spec: ">= 4.1",
+            platform: PytestDataPlatformType.NonWindows,
+            description: "Parameterized tests",
+            rootdir: "/home/user/test/pytest_scenario",
+            test_functions: [
+                "tests/test_spam.py::test_with_subtests[1-2]",
+                "tests/test_spam.py::test_with_subtests[3-4]"
+            ],
+            functionCount: 2,
+            stdout: [
+                "============================= test session starts ==============================",
+                "platform linux -- Python 3.7.1, pytest-4.2.1, py-1.7.0, pluggy-0.8.1",
+                "rootdir: /home/user/test/pytest_scenario, inifile:",
+                "collected 2 items",
+                "<Package /home/user/test/pytest_scenario/tests>",
+                "  <Module test_spam.py>",
+                "    <Function test_with_subtests[1-2]>",
+                "    <Function test_with_subtests[3-4]>",
+                "",
+                "========================= no tests ran in 0.02 seconds ========================="
+            ]
         }
     ];


### PR DESCRIPTION
(for #4503)

[WARNING} The approach I took is a bit of a hack.  Changing the structure of the `Tests` data is a huge undertaking.  So I tucked the necessary UI-related data in as a tag-along. :)

I'm addressing telemetry in a follow-up PR.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] The wiki is updated with any design decisions/details.
