### PR TITLE
Handle failures with conda activation

### DIFF
--- a/news/3 Code Health/4424.md
+++ b/news/3 Code Health/4424.md
@@ -1,1 +1,2 @@
-Add more logging to diagnose issues getting the Python Interactive window to show up
+Add more logging to diagnose issues getting the Python Interactive window to show up.
+Add checks for conda activation never finishing.

--- a/package.nls.json
+++ b/package.nls.json
@@ -96,6 +96,7 @@
     "DataScience.notebookCheckForImportDontAskAgain": "Don't Ask Again",
     "DataScience.notebookCheckForImportTitle": "Do you want to import the Jupyter Notebook into Python code?",
     "DataScience.jupyterNotSupported": "Running cells requires Jupyter notebooks to be installed.",
+    "DataScience.jupyterNotSupportedBecauseOfEnvironment": "Activating {0} to run Jupyter failed with {1}.",
     "DataScience.jupyterNbConvertNotSupported": "Importing notebooks requires Jupyter nbconvert to be installed.",
     "DataScience.jupyterLaunchNoURL": "Failed to find the URL of the launched Jupyter notebook server",
     "DataScience.jupyterLaunchTimedOut": "The Jupyter notebook server failed to launch in time",

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -32,7 +32,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         return new PythonExecutionService(this.serviceContainer, processService, pythonPath);
     }
     public async createActivatedEnvironment(options: ExecutionFactoryCreateWithEnvironmentOptions): Promise<IPythonExecutionService> {
-        const envVars = await this.activationHelper.getActivatedEnvironmentVariables(options.resource, options.interpreter);
+        const envVars = await this.activationHelper.getActivatedEnvironmentVariables(options.resource, options.interpreter, options.allowEnvironmentFetchExceptions);
         const hasEnvVars = envVars && Object.keys(envVars).length > 0;
         sendTelemetryEvent(EventName.PYTHON_INTERPRETER_ACTIVATION_ENVIRONMENT_VARIABLES, undefined, { hasEnvVars });
         if (!hasEnvVars) {

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -60,6 +60,7 @@ export type ExecutionFactoryCreationOptions = {
 export type ExecutionFactoryCreateWithEnvironmentOptions = {
     resource?: Uri;
     interpreter?: PythonInterpreter;
+    allowEnvironmentFetchExceptions?: boolean;
 };
 export interface IPythonExecutionFactory {
     create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService>;

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -79,6 +79,7 @@ export namespace DataScience {
     export const notebookCheckForImportNo = localize('DataScience.notebookCheckForImportNo', 'Later');
     export const notebookCheckForImportDontAskAgain = localize('DataScience.notebookCheckForImportDontAskAgain', 'Don\'t Ask Again');
     export const jupyterNotSupported = localize('DataScience.jupyterNotSupported', 'Jupyter is not installed');
+    export const jupyterNotSupportedBecauseOfEnvironment = localize('DataScience.jupyterNotSupportedBecauseOfEnvironment', 'Activating {0} to run Jupyter failed with {1}');
     export const jupyterNbConvertNotSupported = localize('DataScience.jupyterNbConvertNotSupported', 'Jupyter nbconvert is not installed');
     export const jupyterLaunchTimedOut = localize('DataScience.jupyterLaunchTimedOut', 'The Jupyter notebook server failed to launch in time');
     export const jupyterLaunchNoURL = localize('DataScience.jupyterLaunchNoURL', 'Failed to find the URL of the launched Jupyter notebook server');

--- a/src/client/datascience/history.ts
+++ b/src/client/datascience/history.ts
@@ -836,12 +836,13 @@ export class History implements IHistory {
                 }
             }
 
-            return usableInterpreter ? true: false;
+            return usableInterpreter ? true : false;
 
         } catch (e) {
             // Can't find a usable interpreter, show the error.
             if (activeInterpreter) {
-                throw new Error(localize.DataScience.jupyterNotSupportedBecauseOfEnvironment().format(activeInterpreter.displayName, e.toString())); 
+                const displayName = activeInterpreter.displayName ? activeInterpreter.displayName : activeInterpreter.path;
+                throw new Error(localize.DataScience.jupyterNotSupportedBecauseOfEnvironment().format(displayName, e.toString()));
             } else {
                 throw new JupyterInstallError(localize.DataScience.jupyterNotSupported(), localize.DataScience.pythonInteractiveHelpLink());
             }

--- a/src/client/datascience/history.ts
+++ b/src/client/datascience/history.ts
@@ -859,8 +859,11 @@ export class History implements IHistory {
             if (!usable) {
                 // Not loading anymore
                 status.dispose();
+
+                // Indicate failing.
+                throw new JupyterInstallError(localize.DataScience.jupyterNotSupported(), localize.DataScience.pythonInteractiveHelpLink());
             }
-            
+
             // Get the web panel to show first
             await this.loadWebPanel();
 

--- a/src/client/datascience/history.ts
+++ b/src/client/datascience/history.ts
@@ -27,7 +27,7 @@ import { IFileSystem } from '../common/platform/types';
 import { IConfigurationService, IDisposable, IDisposableRegistry, ILogger } from '../common/types';
 import { createDeferred, Deferred } from '../common/utils/async';
 import * as localize from '../common/utils/localize';
-import { IInterpreterService } from '../interpreter/contracts';
+import { IInterpreterService, PythonInterpreter } from '../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../telemetry';
 import { EditorContexts, Identifiers, Telemetry } from './constants';
 import { HistoryMessageListener } from './historyMessageListener';
@@ -815,21 +815,12 @@ export class History implements IHistory {
         }
     }
 
-    private load = async (): Promise<void> => {
-        // Status depends upon if we're about to connect to existing server or not.
-        const status = (await this.jupyterExecution.getServer(await this.historyProvider.getNotebookOptions())) ?
-            this.setStatus(localize.DataScience.connectingToJupyter()) : this.setStatus(localize.DataScience.startingJupyter());
-
-        // Check to see if we support ipykernel or not
+    private async checkUsable() : Promise<boolean> {
+        let activeInterpreter : PythonInterpreter | undefined;
         try {
+            activeInterpreter = await this.interpreterService.getActiveInterpreter();
             const usableInterpreter = await this.jupyterExecution.getUsableJupyterPython();
-            if (!usableInterpreter) {
-                // Not loading anymore
-                status.dispose();
-
-                // Nobody is useable, throw an exception
-                throw new JupyterInstallError(localize.DataScience.jupyterNotSupported(), localize.DataScience.pythonInteractiveHelpLink());
-            } else {
+            if (usableInterpreter) {
                 // See if the usable interpreter is not our active one. If so, show a warning
                 // Only do this if not the guest in a liveshare session
                 const api = await this.liveShare.getApi();
@@ -845,6 +836,31 @@ export class History implements IHistory {
                 }
             }
 
+            return usableInterpreter ? true: false;
+
+        } catch (e) {
+            // Can't find a usable interpreter, show the error.
+            if (activeInterpreter) {
+                throw new Error(localize.DataScience.jupyterNotSupportedBecauseOfEnvironment().format(activeInterpreter.displayName, e.toString())); 
+            } else {
+                throw new JupyterInstallError(localize.DataScience.jupyterNotSupported(), localize.DataScience.pythonInteractiveHelpLink());
+            }
+        }
+    }
+
+    private load = async (): Promise<void> => {
+        // Status depends upon if we're about to connect to existing server or not.
+        const status = (await this.jupyterExecution.getServer(await this.historyProvider.getNotebookOptions())) ?
+            this.setStatus(localize.DataScience.connectingToJupyter()) : this.setStatus(localize.DataScience.startingJupyter());
+
+        // Check to see if we support ipykernel or not
+        try {
+            const usable = await this.checkUsable();
+            if (!usable) {
+                // Not loading anymore
+                status.dispose();
+            }
+            
             // Get the web panel to show first
             await this.loadWebPanel();
 

--- a/src/client/datascience/jupyter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/jupyterCommand.ts
@@ -71,7 +71,7 @@ class InterpreterJupyterCommand implements IJupyterCommand {
     constructor(args: string[], pythonExecutionFactory: IPythonExecutionFactory, interpreter: PythonInterpreter) {
         this.requiredArgs = args;
         this.interpreterPromise = Promise.resolve(interpreter);
-        this.pythonLauncher = pythonExecutionFactory.createActivatedEnvironment({ resource: undefined, interpreter });
+        this.pythonLauncher = pythonExecutionFactory.createActivatedEnvironment({ resource: undefined, interpreter, allowEnvironmentFetchExceptions: true });
     }
 
     public interpreter() : Promise<PythonInterpreter | undefined> {

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -356,7 +356,8 @@ export class JupyterExecutionBase implements IJupyterExecution {
         const bestInterpreter = await this.getUsableJupyterPython(cancelToken);
         if (bestInterpreter) {
             const newOptions: SpawnOptions = { mergeStdOutErr: true, token: cancelToken };
-            const launcher = await this.executionFactory.createActivatedEnvironment({ resource: undefined, interpreter: bestInterpreter });
+            const launcher = await this.executionFactory.createActivatedEnvironment(
+                { resource: undefined, interpreter: bestInterpreter, allowEnvironmentFetchExceptions: true });
             const file = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'datascience', 'getServerInfo.py');
             const serverInfoString = await launcher.exec([file], newOptions);
 
@@ -732,14 +733,14 @@ export class JupyterExecutionBase implements IJupyterExecution {
             }
         }
 
-        // Return result
+        // Return results
         return this.commands.hasOwnProperty(command) ? this.commands[command] : undefined;
     }
 
     private doesModuleExist = async (module: string, interpreter: PythonInterpreter, cancelToken?: CancellationToken): Promise<boolean> => {
         if (interpreter && interpreter !== null) {
             const newOptions: SpawnOptions = { throwOnStdErr: true, encoding: 'utf8', token: cancelToken };
-            const pythonService = await this.executionFactory.createActivatedEnvironment({ resource: undefined, interpreter });
+            const pythonService = await this.executionFactory.createActivatedEnvironment({ resource: undefined, interpreter, allowEnvironmentFetchExceptions: true });
             try {
                 // Special case for ipykernel
                 const actualModule = module === JupyterCommands.KernelCreateCommand ? module : 'jupyter';

--- a/src/client/interpreter/activation/service.ts
+++ b/src/client/interpreter/activation/service.ts
@@ -6,7 +6,7 @@ import '../../common/extensions';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 
-import { LogOptions, traceDecorators, traceVerbose } from '../../common/logger';
+import { LogOptions, traceDecorators, traceVerbose, traceError } from '../../common/logger';
 import { IPlatformService } from '../../common/platform/types';
 import { IProcessServiceFactory } from '../../common/process/types';
 import { ITerminalHelper } from '../../common/terminal/types';
@@ -26,6 +26,7 @@ import { IEnvironmentActivationService } from './types';
 
 const getEnvironmentPrefix = 'e8b39361-0157-4923-80e1-22d70d46dee6';
 const cacheDuration = 10 * 60 * 1000;
+const getEnvironmentTimeout = 30000;
 
 // The shell under which we'll execute activation scripts.
 const defaultShells = {
@@ -51,39 +52,54 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
         this.disposables.forEach(d => d.dispose());
     }
     @traceDecorators.verbose('getActivatedEnvironmentVariables', LogOptions.Arguments)
-    @swallowExceptions('getActivatedEnvironmentVariables')
     @captureTelemetry(EventName.PYTHON_INTERPRETER_ACTIVATION_ENVIRONMENT_VARIABLES, { failed: false }, true)
     @cacheResourceSpecificInterpreterData('ActivatedEnvironmentVariables', cacheDuration)
-    public async getActivatedEnvironmentVariables(resource: Resource, interpreter?: PythonInterpreter): Promise<NodeJS.ProcessEnv | undefined> {
+    public async getActivatedEnvironmentVariables(resource: Resource, interpreter?: PythonInterpreter, allowExceptions?: boolean): Promise<NodeJS.ProcessEnv | undefined> {
         const shell = defaultShells[this.platform.osType];
         if (!shell) {
             return;
         }
 
-        const activationCommands = await this.helper.getEnvironmentActivationShellCommands(resource, interpreter);
-        traceVerbose(`Activation Commands received ${activationCommands}`);
-        if (!activationCommands || !Array.isArray(activationCommands) || activationCommands.length === 0) {
-            return;
+        try {
+            const activationCommands = await this.helper.getEnvironmentActivationShellCommands(resource, interpreter);
+            traceVerbose(`Activation Commands received ${activationCommands}`);
+            if (!activationCommands || !Array.isArray(activationCommands) || activationCommands.length === 0) {
+                return;
+            }
+    
+            // Run the activate command collect the environment from it.
+            const activationCommand = this.fixActivationCommands(activationCommands).join(' && ');
+            const processService = await this.processServiceFactory.create(resource);
+            const customEnvVars = await this.envVarsService.getEnvironmentVariables(resource);
+            const hasCustomEnvVars = Object.keys(customEnvVars).length;
+            const env = hasCustomEnvVars ? customEnvVars : this.currentProcess.env;
+            traceVerbose(`${hasCustomEnvVars ? 'Has' : 'No'} Custom Env Vars`);
+    
+            // In order to make sure we know where the environment output is,
+            // put in a dummy echo we can look for
+            const printEnvPyFile = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'printEnvVariables.py');
+            const command = `${activationCommand} && echo '${getEnvironmentPrefix}' && python ${printEnvPyFile.fileToCommandArgument()}`;
+            traceVerbose(`Activating Environment to capture Environment variables, ${command}`);
+    
+            // Conda activate can hang on certain systems. Fail after 30 seconds. 
+            // See the discussion from hidesoon in this bug: https://github.com/Microsoft/vscode-python/issues/4424
+            // His issue is conda never finishing during activate. This is a conda issue, but we
+            // should at least tell the user.
+            const result = await processService.shellExec(command, { env, shell, timeout: getEnvironmentTimeout });
+            if (result.stderr && result.stderr.length > 0) {
+                throw new Error(`StdErr from ShellExec, ${result.stderr}`);
+            }
+            return this.parseEnvironmentOutput(result.stdout);
+        } catch (e) {
+            // Some callers want this to bubble out, others don't
+            if (allowExceptions) {
+                throw e;
+            } else {
+                traceError('getActivatedEnvironmentVariables', e);
+            }
         }
 
-        // Run the activate command collect the environment from it.
-        const activationCommand = this.fixActivationCommands(activationCommands).join(' && ');
-        const processService = await this.processServiceFactory.create(resource);
-        const customEnvVars = await this.envVarsService.getEnvironmentVariables(resource);
-        const hasCustomEnvVars = Object.keys(customEnvVars).length;
-        const env = hasCustomEnvVars ? customEnvVars : this.currentProcess.env;
-        traceVerbose(`${hasCustomEnvVars ? 'Has' : 'No'} Custom Env Vars`);
 
-        // In order to make sure we know where the environment output is,
-        // put in a dummy echo we can look for
-        const printEnvPyFile = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'printEnvVariables.py');
-        const command = `${activationCommand} && echo '${getEnvironmentPrefix}' && python ${printEnvPyFile.fileToCommandArgument()}`;
-        traceVerbose(`Activating Environment to capture Environment variables, ${command}`);
-        const result = await processService.shellExec(command, { env, shell });
-        if (result.stderr && result.stderr.length > 0) {
-            throw new Error(`StdErr from ShellExec, ${result.stderr}`);
-        }
-        return this.parseEnvironmentOutput(result.stdout);
     }
     protected onDidEnvironmentVariablesChange(affectedResource: Resource) {
         clearCachedResourceSpecificIngterpreterData('ActivatedEnvironmentVariables', affectedResource);

--- a/src/client/interpreter/activation/service.ts
+++ b/src/client/interpreter/activation/service.ts
@@ -91,12 +91,12 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
             }
             return this.parseEnvironmentOutput(result.stdout);
         } catch (e) {
+            traceError('getActivatedEnvironmentVariables', e);
+            
             // Some callers want this to bubble out, others don't
             if (allowExceptions) {
                 throw e;
-            } else {
-                traceError('getActivatedEnvironmentVariables', e);
-            }
+            } 
         }
 
 

--- a/src/client/interpreter/activation/types.ts
+++ b/src/client/interpreter/activation/types.ts
@@ -8,5 +8,5 @@ import { PythonInterpreter } from '../contracts';
 
 export const IEnvironmentActivationService = Symbol('IEnvironmentActivationService');
 export interface IEnvironmentActivationService {
-    getActivatedEnvironmentVariables(resource: Resource, interpreter?: PythonInterpreter): Promise<NodeJS.ProcessEnv | undefined>;
+    getActivatedEnvironmentVariables(resource: Resource, interpreter?: PythonInterpreter, allowExceptions?: boolean): Promise<NodeJS.ProcessEnv | undefined>;
 }

--- a/src/test/interpreters/activation/service.unit.test.ts
+++ b/src/test/interpreters/activation/service.unit.test.ts
@@ -163,7 +163,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
                         const options = capture(processService.shellExec).first()[1];
 
                         const expectedShell = defaultShells[osType.value];
-                        expect(options).to.deep.equal({ shell: expectedShell, env: envVars });
+                        expect(options).to.deep.equal({ shell: expectedShell, env: envVars, timeout: 30000 });
                     });
                     test('Use current process variables if there are no custom variables', async () => {
                         const cmd = ['1', '2'];
@@ -187,7 +187,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
                         const options = capture(processService.shellExec).first()[1];
 
                         const expectedShell = defaultShells[osType.value];
-                        expect(options).to.deep.equal({ shell: expectedShell, env: envVars });
+                        expect(options).to.deep.equal({ shell: expectedShell, env: envVars, timeout: 30000 });
                     });
                     test('Error must be swallowed when activation fails', async () => {
                         const cmd = ['1', '2'];


### PR DESCRIPTION
For #4424

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
