### PR TITLE
Always use the same jedi environment

### DIFF
--- a/news/2 Fixes/4687.md
+++ b/news/2 Fixes/4687.md
@@ -1,0 +1,2 @@
+Ensure `Jedi` uses the currently selected intepreter.
+(thanks [Selim Belhaouane](https://github.com/selimb))

--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -562,7 +562,8 @@ class JediCompletion(object):
                 jedi.api.names(
                     source=request.get('source', None),
                     path=request.get('path', ''),
-                    all_scopes=True),
+                    all_scopes=True,
+                    environment=self.environment),
                 request['id'])
 
         script = jedi.Script(


### PR DESCRIPTION
Fix completion.py to always pass the same environment to jedi, instead of letting it infer a default one.

For #4504 

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [x] ~Has telemetry for enhancements.~
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
