### PR TITLE
Remove an extraneous leading 'python.' from 'python.enableSourceMapSupport'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "onCommand:python.datascience.selectjupyteruri",
         "onCommand:python.datascience.exportfileasnotebook",
         "onCommand:python.datascience.exportfileandoutputasnotebook",
-        "onCommand:python.python.enableSourceMapSupport"
+        "onCommand:python.enableSourceMapSupport"
     ],
     "main": "./out/client/extension",
     "contributes": {


### PR DESCRIPTION
For #4613 

Key in package.json for `python.enableSourceMapSupport` had an extra leading `python.`.

Didn't seem to have any negative effect either way.

---


- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
