### PR TITLE
Conda activation fails when there is a space in the env name

### DIFF
--- a/news/2 Fixes/4243.md
+++ b/news/2 Fixes/4243.md
@@ -1,0 +1,1 @@
+Conda activation fails when there is a space in the env name

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -67,7 +67,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
                     `source ${activatePath}`;
                 return [
                     firstActivate,
-                    `conda activate ${envInfo.name}`
+                    `conda activate ${envInfo.name.toCommandArgument()}`
                 ];
             }
         }


### PR DESCRIPTION
For #4273 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[x] Has sufficient logging.~
- ~[x] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[x] The wiki is updated with any design decisions/details.~
