### PR TITLE
Add a --no-functional CLI flag for running tests.

### DIFF
--- a/pythonFiles/tests/__main__.py
+++ b/pythonFiles/tests/__main__.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import argparse
 import os.path
 import sys
 
@@ -13,16 +14,35 @@ DATASCIENCE_ROOT = os.path.join(SRC_ROOT, 'datascience')
 TESTING_TOOLS_ROOT = os.path.join(SRC_ROOT, 'testing_tools')
 
 
-def main(argv=sys.argv[1:]):
+def parse_args():
+    parser = argparse.ArgumentParser()
+    # To mark a test as functional:  (decorator) @pytest.mark.functional
+    parser.add_argument('--no-functional', dest='markers',
+                        action='append_const', const='not functional')
+    args, remainder = parser.parse_known_args()
+
+    ns = vars(args)
+
+    return ns, remainder
+
+
+def main(pytestargs, markers=None):
     sys.path.insert(1, DATASCIENCE_ROOT)
     sys.path.insert(1, TESTING_TOOLS_ROOT)
-    ec = pytest.main([
+
+    pytestargs = [
         '--rootdir', SRC_ROOT,
         TEST_ROOT,
-        ] + argv)
+        ] + pytestargs
+    for marker in reversed(markers or ()):
+        pytestargs.insert(0, marker)
+        pytestargs.insert(0, '-m')
+
+    ec = pytest.main(pytestargs)
     return ec
 
 
 if __name__ == '__main__':
-    ec = main()
+    mainkwargs, pytestargs = parse_args()
+    ec = main(pytestargs, **mainkwargs)
     sys.exit(ec)

--- a/pythonFiles/tests/run_all.py
+++ b/pythonFiles/tests/run_all.py
@@ -8,9 +8,10 @@ sys.path[0] = os.path.dirname(
     os.path.dirname(
         os.path.abspath(__file__)))
 
-from tests.__main__ import main
+from tests.__main__ import main, parse_args
 
 
 if __name__ == '__main__':
-    ec = main()
+    mainkwargs, pytestargs = parse_args()
+    ec = main(pytestargs, **mainkwargs)
     sys.exit(ec)


### PR DESCRIPTION
(for #4739)

This will facilitate optionally skipping functional tests (under `pythonFiles` for the sake of speed.  Functional tests (or suites) will be marked with the "functional" marker:

```python
@pytest.mark.functional
def test_spam():
    ...

@pytest.mark.functional
class TestSpam:
    def test_x(self):
        ...
```

FWIW, I considered using pytest hooks for this (via a `conftest.py` file), but worried that it might impact use of pytest by our users.