### PR TITLE
Split out test-phases from PR validation into YAML step-template

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -246,6 +246,54 @@ steps:
       buildPlatform: '$(Agent.Os)-Py$(pythonVersion)'
       buildConfiguration: 'UnitTests'
 
+  # Run the News tool tests.
+  #
+  # This task only runs if the string 'pythonUnitTests' exists in variable `TestsToRun`
+  #
+  # Example command line (windows pwsh):
+  # > python -m pip install -U -r news/requirements.txt
+  # > python -m pytest tpn --color=yes --junit-xml=python-news-junit.xml
+  - script: |
+      python -m pip install --upgrade -r news/requirements.txt
+      python -m pytest news --color=yes --junit-xml=$COMMON_TESTRESULTSDIRECTORY/python-news-junit.xml
+    displayName: 'Run Python tests for news'
+    condition: and(succeeded(), contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
+
+  # Upload the test results to Azure DevOps to facilitate test reporting in their UX.
+  - task: PublishTestResults@2
+    displayName: 'Publish News test results'
+    condition: and(contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
+    inputs:
+      testResultsFiles: 'python-news-junit.xml'
+      searchFolder: '$(Common.TestResultsDirectory)'
+      testRunTitle: 'NEWS-$(Platform)-Py$(pythonVersion)'
+      buildPlatform: '$(Platform)-Py$(pythonVersion)'
+      buildConfiguration: 'Unittests'
+
+  # Run the TPN tool tests.
+  #
+  # This task only runs if the string 'pythonUnitTests' exists in variable `TestsToRun`
+  #
+  # Example command line (windows pwsh):
+  # > python -m pip install -U -r tpn/requirements.txt
+  # > python -m pytest tpn --color=yes --junit-xml=python-tpn-junit.xml
+  - script: |
+      python -m pip install --upgrade -r tpn/requirements.txt
+      python -m pytest tpn --color=yes --junit-xml=$COMMON_TESTRESULTSDIRECTORY/python-tpn-junit.xml
+    displayName: 'Run Python tests for TPN tool'
+    condition: and(contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
+
+  # Upload the test results to Azure DevOps to facilitate test reporting in their UX.
+  - task: PublishTestResults@2
+    displayName: 'Publish JUnit test results'
+    condition: and(contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
+    inputs:
+      testResultsFiles: 'python-tpn-junit.xml'
+      searchFolder: '$(Common.TestResultsDirectory)'
+      testRunTitle: 'TPN-$(Platform)-Py$(pythonVersion)'
+      buildPlatform: '$(Platform)-Py$(pythonVersion)'
+      buildConfiguration: 'Unittests'
+
   # Start the X virtual frame buffer (X-windows in memory only) on Linux. Linux VMs do not
   # provide a desktop so VS Code cannot properly launch there. To get around this we use the
   # xvfb service to emulate a desktop instead. See

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -127,7 +127,6 @@ steps:
   # Example command line (windows pwsh):
   # > npm run test:unittests
   - bash: |
-      npm run cover:enable
       npm run test:unittests:cover
     displayName: 'run test:unittest'
     condition: and(succeeded(), contains(variables['TestsToRun'], 'testUnitTests'))
@@ -245,54 +244,6 @@ steps:
       testRunTitle: 'tpn-$(Agent.Os)-Py$(pythonVersion)'
       buildPlatform: '$(Agent.Os)-Py$(pythonVersion)'
       buildConfiguration: 'UnitTests'
-
-  # Run the News tool tests.
-  #
-  # This task only runs if the string 'pythonUnitTests' exists in variable `TestsToRun`
-  #
-  # Example command line (windows pwsh):
-  # > python -m pip install -U -r news/requirements.txt
-  # > python -m pytest tpn --color=yes --junit-xml=python-news-junit.xml
-  - script: |
-      python -m pip install --upgrade -r news/requirements.txt
-      python -m pytest news --color=yes --junit-xml=$COMMON_TESTRESULTSDIRECTORY/python-news-junit.xml
-    displayName: 'Run Python tests for news'
-    condition: and(succeeded(), contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
-
-  # Upload the test results to Azure DevOps to facilitate test reporting in their UX.
-  - task: PublishTestResults@2
-    displayName: 'Publish News test results'
-    condition: and(contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
-    inputs:
-      testResultsFiles: 'python-news-junit.xml'
-      searchFolder: '$(Common.TestResultsDirectory)'
-      testRunTitle: 'NEWS-$(Platform)-Py$(pythonVersion)'
-      buildPlatform: '$(Platform)-Py$(pythonVersion)'
-      buildConfiguration: 'Unittests'
-
-  # Run the TPN tool tests.
-  #
-  # This task only runs if the string 'pythonUnitTests' exists in variable `TestsToRun`
-  #
-  # Example command line (windows pwsh):
-  # > python -m pip install -U -r tpn/requirements.txt
-  # > python -m pytest tpn --color=yes --junit-xml=python-tpn-junit.xml
-  - script: |
-      python -m pip install --upgrade -r tpn/requirements.txt
-      python -m pytest tpn --color=yes --junit-xml=$COMMON_TESTRESULTSDIRECTORY/python-tpn-junit.xml
-    displayName: 'Run Python tests for TPN tool'
-    condition: and(contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
-
-  # Upload the test results to Azure DevOps to facilitate test reporting in their UX.
-  - task: PublishTestResults@2
-    displayName: 'Publish JUnit test results'
-    condition: and(contains(variables['TestsToRun'], 'pythonUnitTests'), startsWith(variables['PythonVersion'], '3'))
-    inputs:
-      testResultsFiles: 'python-tpn-junit.xml'
-      searchFolder: '$(Common.TestResultsDirectory)'
-      testRunTitle: 'TPN-$(Platform)-Py$(pythonVersion)'
-      buildPlatform: '$(Platform)-Py$(pythonVersion)'
-      buildConfiguration: 'Unittests'
 
   # Start the X virtual frame buffer (X-windows in memory only) on Linux. Linux VMs do not
   # provide a desktop so VS Code cannot properly launch there. To get around this we use the

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -83,7 +83,7 @@ steps:
 
   # Show all versions installed/available on PATH if in verbose mode.
   # Example command line (windows pwsh):
-  # > Write-Host Node ver: $(& node -v) NPM Ver: $(& npm -v) Python ver: $(& python --version)"
+  # > Write-Host "Node ver: $(& node -v) NPM Ver: $(& npm -v) Python ver: $(& python --version)"
   - bash: |
       echo AVAILABLE DEPENDENCY VERSIONS
       echo Node Version = `node -v`
@@ -127,6 +127,7 @@ steps:
   # Example command line (windows pwsh):
   # > npm run test:unittests
   - bash: |
+      npm run cover:enable
       npm run test:unittests:cover
     displayName: 'run test:unittest'
     condition: and(succeeded(), contains(variables['TestsToRun'], 'testUnitTests'))

--- a/pythonFiles/tests/test_normalize_for_interpreter.py
+++ b/pythonFiles/tests/test_normalize_for_interpreter.py
@@ -11,18 +11,16 @@ import normalizeForInterpreter
 class TestNormalizationScript(object):
     """Basic unit tests for the normalization script."""
 
-
     @pytest.mark.skipif(sys.version_info.major == 2,
-                    reason="normalizeForInterpreter not working for 2.7, see GH #4805")
+                        reason="normalizeForInterpreter not working for 2.7, see GH #4805")
     def test_basicNormalization(self, capsys):
         src = 'print("this is a test")'
         normalizeForInterpreter.normalize_lines(src)
         captured = capsys.readouterr()
         assert captured.out == src
 
-
     @pytest.mark.skipif(sys.version_info.major == 2,
-                    reason="normalizeForInterpreter not working for 2.7, see GH #4805")
+                        reason="normalizeForInterpreter not working for 2.7, see GH #4805")
     def test_moreThanOneLine(self, capsys):
         src = textwrap.dedent("""\
             # Some rando comment
@@ -30,14 +28,13 @@ class TestNormalizationScript(object):
             def show_something():
                 print("Something")
             """
-        )
+                              )
         normalizeForInterpreter.normalize_lines(src)
         captured = capsys.readouterr()
         assert captured.out == src
 
-
     @pytest.mark.skipif(sys.version_info.major == 2,
-                    reason="normalizeForInterpreter not working for 2.7, see GH #4805")
+                        reason="normalizeForInterpreter not working for 2.7, see GH #4805")
     def test_withHangingIndent(self, capsys):
         src = textwrap.dedent("""\
             x = 22
@@ -48,14 +45,13 @@ class TestNormalizationScript(object):
             if result == 42:
                 print("The answer to life, the universe, and everything")
             """
-        )
+                              )
         normalizeForInterpreter.normalize_lines(src)
         captured = capsys.readouterr()
         assert captured.out == src
 
-
     @pytest.mark.skipif(sys.version_info.major == 2,
-                    reason="normalizeForInterpreter not working for 2.7, see GH #4805")
+                        reason="normalizeForInterpreter not working for 2.7, see GH #4805")
     def test_clearOutExtraneousNewlines(self, capsys):
         src = textwrap.dedent("""\
             value_x = 22
@@ -67,7 +63,7 @@ class TestNormalizationScript(object):
             print(value_x + value_y + value_z)
 
             """
-        )
+                              )
         expectedResult = textwrap.dedent("""\
             value_x = 22
             value_y = 30
@@ -75,14 +71,13 @@ class TestNormalizationScript(object):
             print(value_x + value_y + value_z)
 
             """
-        )
+                                         )
         normalizeForInterpreter.normalize_lines(src)
         result = capsys.readouterr()
         assert result.out == expectedResult
 
-
     @pytest.mark.skipif(sys.version_info.major == 2,
-                    reason="normalizeForInterpreter not working for 2.7, see GH #4805")
+                        reason="normalizeForInterpreter not working for 2.7, see GH #4805")
     def test_clearOutExtraLinesAndWhitespace(self, capsys):
         src = textwrap.dedent("""\
             if True:
@@ -95,7 +90,7 @@ class TestNormalizationScript(object):
             print(x + y + z)
 
             """
-        )
+                              )
         expectedResult = textwrap.dedent("""\
             if True:
                 x = 22
@@ -105,7 +100,7 @@ class TestNormalizationScript(object):
             print(x + y + z)
 
             """
-        )
+                                         )
         normalizeForInterpreter.normalize_lines(src)
         result = capsys.readouterr()
         assert result.out == expectedResult


### PR DESCRIPTION
Preliminary PR, for #4034 and others.

- [x] Split out test phase 'steps' into a YAML `step template`. 
  - This is to facilitate re-use across CI processes
- [x] Ensure all Python unit tests are running properly in PR/CI builds

---

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] The wiki is updated with any design decisions/details.
