### PR TITLE
Explicitly hide pytest output during discovery.

### DIFF
--- a/pythonFiles/normalizeForInterpreter.py
+++ b/pythonFiles/normalizeForInterpreter.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 import ast
 import io
 import operator
@@ -26,6 +29,8 @@ def _tokenize(source):
     """Tokenize Python source code."""
     # Using an undocumented API as the documented one in Python 2.7 does not work as needed
     # cross-version.
+    if sys.version_info < (3,) and isinstance(source, str):
+        source = source.decode()
     return tokenize.generate_tokens(io.StringIO(source).readline)
 
 

--- a/pythonFiles/testing_tools/adapter/__main__.py
+++ b/pythonFiles/testing_tools/adapter/__main__.py
@@ -49,7 +49,8 @@ def parse_args(
             subsub = add_subparser(cmdname, toolname, subsubs)
             if cmdname == 'discover':
                 subsub.add_argument('--simple', action='store_true')
-                subsub.add_argument('--show-' + toolname, action='store_true')
+                subsub.add_argument('--no-hide-stdio', dest='hidestdio',
+                                    action='store_false')
                 subsub.add_argument('--pretty', action='store_true')
 
     # Parse the args!

--- a/pythonFiles/testing_tools/adapter/__main__.py
+++ b/pythonFiles/testing_tools/adapter/__main__.py
@@ -50,6 +50,7 @@ def parse_args(
             if cmdname == 'discover':
                 subsub.add_argument('--simple', action='store_true')
                 subsub.add_argument('--show-' + toolname, action='store_true')
+                subsub.add_argument('--pretty', action='store_true')
 
     # Parse the args!
     if '--' in argv:
@@ -87,7 +88,6 @@ def main(toolname, cmdname, subargs, toolargs,
 
     parents, result = run(toolargs, **subargs)
     report_result(result, parents,
-                  debug=('-v' in toolargs or '--verbose' in toolargs),
                   **subargs
                   )
 

--- a/pythonFiles/testing_tools/adapter/__main__.py
+++ b/pythonFiles/testing_tools/adapter/__main__.py
@@ -40,31 +40,30 @@ def parse_args(
     # Add "run" and "debug" subcommands when ready.
     for cmdname in ['discover']:
         sub = cmdsubs.add_parser(cmdname)
-        if cmdname == 'discover':
-            sub.add_argument('--simple', action='store_true')
-            sub.add_argument('--show-pytest', action='store_true')
         subsubs = sub.add_subparsers(dest='tool')
         for toolname in sorted(TOOLS):
             try:
                 add_subparser = TOOLS[toolname]['_add_subparser']
             except KeyError:
                 continue
-            add_subparser(cmdname, toolname, subsubs)
+            subsub = add_subparser(cmdname, toolname, subsubs)
+            if cmdname == 'discover':
+                subsub.add_argument('--simple', action='store_true')
+                subsub.add_argument('--show-' + toolname, action='store_true')
 
     # Parse the args!
-    args, toolargs = parser.parse_known_args(argv)
+    if '--' in argv:
+        seppos = argv.index('--')
+        toolargs = argv[seppos + 1:]
+        argv = argv[:seppos]
+    else:
+        toolargs = []
+    args = parser.parse_args(argv)
     ns = vars(args)
 
     cmd = ns.pop('cmd')
     if not cmd:
         parser.error('missing command')
-    if cmd == 'discover':
-        if '--simple' in toolargs:
-            toolargs.remove('--simple')
-            ns['simple'] = True
-        if '--show-pytest' in toolargs:
-            toolargs.remove('--show-pytest')
-            ns['show_pytest'] = True
 
     tool = ns.pop('tool')
     if not tool:

--- a/pythonFiles/testing_tools/adapter/pytest.py
+++ b/pythonFiles/testing_tools/adapter/pytest.py
@@ -23,16 +23,16 @@ def add_cli_subparser(cmd, name, parent):
     return parser
 
 
-def discover(pytestargs=None, show_pytest=False,
+def discover(pytestargs=None, hidestdio=False,
              _pytest_main=pytest.main, _plugin=None, **_ignored):
     """Return the results of test discovery."""
     if _plugin is None:
         _plugin = TestCollector()
 
-    pytestargs = _adjust_pytest_args(pytestargs, show_pytest=show_pytest)
+    pytestargs = _adjust_pytest_args(pytestargs)
     # We use this helper rather than "-pno:terminal" due to possible
     # platform-dependent issues.
-    with util.hide_stdio() if not show_pytest else util.noop_cm():
+    with util.hide_stdio() if hidestdio else util.noop_cm():
         ec = _pytest_main(pytestargs, [_plugin])
     if ec != 0:
         raise Exception('pytest discovery failed (exit code {})'.format(ec))
@@ -49,7 +49,7 @@ def discover(pytestargs=None, show_pytest=False,
             )
 
 
-def _adjust_pytest_args(pytestargs, show_pytest):
+def _adjust_pytest_args(pytestargs):
     pytestargs = list(pytestargs) if pytestargs else []
     # Duplicate entries should be okay.
     pytestargs.insert(0, '--collect-only')

--- a/pythonFiles/testing_tools/adapter/pytest.py
+++ b/pythonFiles/testing_tools/adapter/pytest.py
@@ -24,7 +24,7 @@ def add_cli_subparser(cmd, name, parent):
 
 
 def discover(pytestargs=None, show_pytest=False,
-             _pytest_main=pytest.main, _plugin=None, **kwargs):
+             _pytest_main=pytest.main, _plugin=None, **_ignored):
     """Return the results of test discovery."""
     if _plugin is None:
         _plugin = TestCollector()

--- a/pythonFiles/testing_tools/adapter/pytest.py
+++ b/pythonFiles/testing_tools/adapter/pytest.py
@@ -7,6 +7,7 @@ import os.path
 
 import pytest
 
+from . import util
 from .errors import UnsupportedCommandError
 from .info import TestInfo, TestPath, ParentInfo
 
@@ -29,7 +30,10 @@ def discover(pytestargs=None, show_pytest=False,
         _plugin = TestCollector()
 
     pytestargs = _adjust_pytest_args(pytestargs, show_pytest=show_pytest)
-    ec = _pytest_main(pytestargs, [_plugin])
+    # We use this helper rather than "-pno:terminal" due to possible
+    # platform-dependent issues.
+    with util.hide_stdio() if not show_pytest else util.noop_cm():
+        ec = _pytest_main(pytestargs, [_plugin])
     if ec != 0:
         raise Exception('pytest discovery failed (exit code {})'.format(ec))
     if not _plugin._started:
@@ -49,8 +53,6 @@ def _adjust_pytest_args(pytestargs, show_pytest):
     pytestargs = list(pytestargs) if pytestargs else []
     # Duplicate entries should be okay.
     pytestargs.insert(0, '--collect-only')
-    if not show_pytest:
-        pytestargs.insert(0, '-pno:terminal')
     # TODO: pull in code from:
     #  src/client/unittests/pytest/services/discoveryService.ts
     #  src/client/unittests/pytest/services/argsService.ts

--- a/pythonFiles/testing_tools/adapter/report.py
+++ b/pythonFiles/testing_tools/adapter/report.py
@@ -7,7 +7,7 @@ import json
 
 
 def report_discovered(tests, parents, debug=False, simple=False,
-                      _send=print, **kwargs):
+                      _send=print, **_ignored):
     """Serialize the discovered tests and write to stdout."""
     if simple:
         data = [{

--- a/pythonFiles/testing_tools/adapter/report.py
+++ b/pythonFiles/testing_tools/adapter/report.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import json
 
 
-def report_discovered(tests, parents, debug=False, simple=False,
+def report_discovered(tests, parents, pretty=False, simple=False,
                       _send=print, **_ignored):
     """Serialize the discovered tests and write to stdout."""
     if simple:
@@ -62,7 +62,7 @@ def report_discovered(tests, parents, debug=False, simple=False,
             } for root in sorted(byroot)]
 
     kwargs = {}
-    if debug:
+    if pretty:
         # human-formatted
         kwargs = dict(
             sort_keys=True,

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import contextlib
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO  # 2.7
+import sys
+
+
+@contextlib.contextmanager
+def noop_cm():
+    yield
+
+
+@contextlib.contextmanager
+def hide_stdio():
+    """Swallow stdout and stderr."""
+    buf = StringIO()
+    sys.stdout = buf
+    sys.stderr = buf
+    try:
+        yield buf
+    finally:
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -17,11 +17,17 @@ def noop_cm():
 @contextlib.contextmanager
 def hide_stdio():
     """Swallow stdout and stderr."""
-    buf = StringIO()
-    sys.stdout = buf
-    sys.stderr = buf
+    ignored = IgnoredIO()
+    sys.stdout = ignored
+    sys.stderr = ignored
     try:
         yield
     finally:
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
+
+
+class IgnoredIO(StringIO):
+    """A noop "file"."""
+    def write(self, msg):
+        pass

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -21,7 +21,7 @@ def hide_stdio():
     sys.stdout = buf
     sys.stderr = buf
     try:
-        yield buf
+        yield
     finally:
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__

--- a/pythonFiles/tests/testing_tools/adapter/test___main__.py
+++ b/pythonFiles/tests/testing_tools/adapter/test___main__.py
@@ -56,7 +56,7 @@ class ParseDiscoverTests(unittest.TestCase):
         self.assertEqual(tool, 'pytest')
         self.assertEqual(cmd, 'discover')
         self.assertEqual(args, {'pretty': False,
-                                'show_pytest': False,
+                                'hidestdio': True,
                                 'simple': False})
         self.assertEqual(toolargs, [])
 
@@ -76,7 +76,7 @@ class ParseDiscoverTests(unittest.TestCase):
         self.assertEqual(tool, 'pytest')
         self.assertEqual(cmd, 'discover')
         self.assertEqual(args, {'pretty': False,
-                                'show_pytest': False,
+                                'hidestdio': True,
                                 'simple': False})
         self.assertEqual(toolargs, [
             '--strict',
@@ -85,6 +85,22 @@ class ParseDiscoverTests(unittest.TestCase):
             '--no-cov',
             '-d',
             ])
+
+    def test_pytest_opts(self):
+        tool, cmd, args, toolargs = parse_args([
+            'discover',
+            'pytest',
+            '--simple',
+            '--no-hide-stdio',
+            '--pretty',
+            ])
+
+        self.assertEqual(tool, 'pytest')
+        self.assertEqual(cmd, 'discover')
+        self.assertEqual(args, {'pretty': True,
+                                'hidestdio': False,
+                                'simple': True})
+        self.assertEqual(toolargs, [])
 
     def test_unsupported_tool(self):
         with self.assertRaises(SystemExit):

--- a/pythonFiles/tests/testing_tools/adapter/test___main__.py
+++ b/pythonFiles/tests/testing_tools/adapter/test___main__.py
@@ -75,7 +75,6 @@ class ParseDiscoverTests(unittest.TestCase):
         self.assertEqual(cmd, 'discover')
         self.assertEqual(args, {'show_pytest': False, 'simple': False})
         self.assertEqual(toolargs, [
-            '--',
             '--strict',
             '--ignore', 'spam,ham,eggs',
             '--pastebin=xyz',

--- a/pythonFiles/tests/testing_tools/adapter/test___main__.py
+++ b/pythonFiles/tests/testing_tools/adapter/test___main__.py
@@ -55,7 +55,9 @@ class ParseDiscoverTests(unittest.TestCase):
 
         self.assertEqual(tool, 'pytest')
         self.assertEqual(cmd, 'discover')
-        self.assertEqual(args, {'show_pytest': False, 'simple': False})
+        self.assertEqual(args, {'pretty': False,
+                                'show_pytest': False,
+                                'simple': False})
         self.assertEqual(toolargs, [])
 
     def test_pytest_full(self):
@@ -73,7 +75,9 @@ class ParseDiscoverTests(unittest.TestCase):
 
         self.assertEqual(tool, 'pytest')
         self.assertEqual(cmd, 'discover')
-        self.assertEqual(args, {'show_pytest': False, 'simple': False})
+        self.assertEqual(args, {'pretty': False,
+                                'show_pytest': False,
+                                'simple': False})
         self.assertEqual(toolargs, [
             '--strict',
             '--ignore', 'spam,ham,eggs',
@@ -111,8 +115,7 @@ class MainTests(unittest.TestCase):
 
         self.assertEqual(tool.calls, [
             ('spamspamspam.discover', ([],), {'spam': 'eggs'}),
-            ('reporter.report', (tests, parents), {'debug': False,
-                                                   'spam': 'eggs'}),
+            ('reporter.report', (tests, parents), {'spam': 'eggs'}),
             ])
 
     def test_unsupported_tool(self):

--- a/pythonFiles/tests/testing_tools/adapter/test_pytest.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_pytest.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 try:
     from io import StringIO

--- a/pythonFiles/tests/testing_tools/adapter/test_pytest.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_pytest.py
@@ -250,7 +250,7 @@ class DiscoverTests(unittest.TestCase):
 
         sys.stdout = buf
         try:
-            discover([], show_pytest=False,
+            discover([], hidestdio=True,
                      _pytest_main=fake_pytest_main, _plugin=plugin)
         finally:
             sys.stdout = sys.__stdout__
@@ -279,7 +279,7 @@ class DiscoverTests(unittest.TestCase):
 
         sys.stdout = buf
         try:
-            discover([], show_pytest=True,
+            discover([], hidestdio=False,
                      _pytest_main=fake_pytest_main, _plugin=plugin)
         finally:
             sys.stdout = sys.__stdout__

--- a/pythonFiles/tests/testing_tools/adapter/test_pytest.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_pytest.py
@@ -364,7 +364,7 @@ class CollectorTests(unittest.TestCase):
                     # ignored (pytest-supported)
                     'parameterize', 'usefixtures', 'filterwarnings',
                     # ignored (custom)
-                    'timeout', 
+                    'timeout',
                     ]],
                 ),
             ])

--- a/pythonFiles/tests/testing_tools/adapter/test_pytest.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_pytest.py
@@ -194,7 +194,6 @@ class AddCLISubparserTests(unittest.TestCase):
 class DiscoverTests(unittest.TestCase):
 
     DEFAULT_ARGS = [
-        '-pno:terminal',
         '--collect-only',
         ]
 

--- a/pythonFiles/tests/testing_tools/adapter/test_pytest.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_pytest.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-from __future__ import print_function, unicode_literals
+from __future__ import print_function
 
 try:
     from io import StringIO


### PR DESCRIPTION
(for #4810)

This change includes 2 things:

* do not rely on "-pno:terminal" in pytest discovery
* pytest CLI args are only after "--"