### PR TITLE
Make the reasons for stale entries more obvious

### DIFF
--- a/news/3 Code Health/4865.md
+++ b/news/3 Code Health/4865.md
@@ -1,0 +1,1 @@
+Have `tpn` clearly state why a project's license entry in the configuration file is considered stale.

--- a/tpn/tpn/tests/test_config.py
+++ b/tpn/tpn/tests/test_config.py
@@ -76,6 +76,7 @@ def test_sort_version_stale(example_data):
     assert not relevant
     assert "Arch" in stale
     assert stale["Arch"].version == "1.0.3"
+    assert isinstance(stale["Arch"].error, config.StaleVersion)
     assert "Arch" in npm_data
     assert npm_data["Arch"].version == "2.0.0"
 
@@ -86,6 +87,7 @@ def test_sort_project_stale(example_data):
     assert not relevant
     assert "Arch" in stale
     assert stale["Arch"].version == "1.0.3"
+    assert isinstance(stale["Arch"].error, config.UnneededEntry)
     assert "Arch2" in npm_data
 
 


### PR DESCRIPTION
For #4865
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Unit tests & system/integration tests are added/updated