### PR TITLE
Fix use of timers in unit test scenario for cacheUtils.

### DIFF
--- a/news/3 Code Health/4776.md
+++ b/news/3 Code Health/4776.md
@@ -1,0 +1,1 @@
+Remove the use of timers in unittest code. Simulate the passing of time instead.

--- a/src/client/common/utils/cacheUtils.ts
+++ b/src/client/common/utils/cacheUtils.ts
@@ -83,7 +83,7 @@ export class InMemoryInterpreterSpecificCache<T> {
         if (!store.has(key) || !data) {
             return false;
         }
-        if (data.expiry < Date.now()) {
+        if (this.hasExpired(data.expiry)) {
             store.delete(key);
             return false;
         }
@@ -120,5 +120,16 @@ export class InMemoryInterpreterSpecificCache<T> {
         const store = getCacheStore(this.resource, this.vscode);
         const key = getCacheKeyFromFunctionArgs(this.keyPrefix, this.args);
         store.delete(key);
+    }
+
+    /**
+     * Has this data expired?
+     * (protected class member to allow for reliable non-data-time-based testing)
+     *
+     * @param expiry The date to be tested for expiry.
+     * @returns true if the data expired, false otherwise.
+     */
+    protected hasExpired(expiry: number): boolean {
+        return expiry < Date.now();
     }
 }

--- a/src/client/common/utils/cacheUtils.ts
+++ b/src/client/common/utils/cacheUtils.ts
@@ -70,7 +70,7 @@ export class InMemoryInterpreterSpecificCache<T> {
     private readonly resource: Resource;
     private readonly args: any[];
     constructor(private readonly keyPrefix: string,
-        private readonly expiryDurationMs: number,
+        protected readonly expiryDurationMs: number,
         args: [Uri | undefined, ...any[]],
         private readonly vscode: VSCodeType = require('vscode')) {
         this.resource = args[0];
@@ -112,7 +112,7 @@ export class InMemoryInterpreterSpecificCache<T> {
         const store = getCacheStore(this.resource, this.vscode);
         const key = getCacheKeyFromFunctionArgs(this.keyPrefix, this.args);
         store.set(key, {
-            expiry: Date.now() + this.expiryDurationMs,
+            expiry: this.calculateExpiry(),
             value
         });
     }
@@ -131,5 +131,15 @@ export class InMemoryInterpreterSpecificCache<T> {
      */
     protected hasExpired(expiry: number): boolean {
         return expiry < Date.now();
+    }
+
+    /**
+     * When should this data item expire?
+     * (protected class method to allow for reliable non-data-time-based testing)
+     *
+     * @returns number representing the expiry time for this item.
+     */
+    protected calculateExpiry(): number {
+        return Date.now() + this.expiryDurationMs;
     }
 }

--- a/src/test/common/utils/cacheUtils.unit.test.ts
+++ b/src/test/common/utils/cacheUtils.unit.test.ts
@@ -34,6 +34,11 @@ class TestInMemoryInterpreterSpecificCache extends InMemoryInterpreterSpecificCa
     public set simulatedElapsedMs(value: number) {
         this.elapsed = value;
     }
+
+    protected calculateExpiry(): number {
+        return this.expiryDurationMs;
+    }
+
     protected hasExpired(expiry: number): boolean {
         return expiry < this.elapsed;
     }

--- a/src/test/common/utils/cacheUtils.unit.test.ts
+++ b/src/test/common/utils/cacheUtils.unit.test.ts
@@ -6,9 +6,6 @@
 import { expect } from 'chai';
 import { Uri } from 'vscode';
 import { clearCache, InMemoryInterpreterSpecificCache } from '../../../client/common/utils/cacheUtils';
-import { OSType } from '../../../client/common/utils/platform';
-import { isOs } from '../../common';
-import { sleep } from '../../core';
 
 type CacheUtilsTestScenario = {
     scenarioDesc: string;
@@ -30,6 +27,17 @@ const scenariosToTest: CacheUtilsTestScenario[] = [
         dataToStore: { date: new Date(), hello: 1234 }
     }
 ];
+
+class TestInMemoryInterpreterSpecificCache extends InMemoryInterpreterSpecificCache<string | undefined | { date: number; hello: number }> {
+    public elapsed: number = 0;
+
+    public set simulatedElapsedMs(value: number) {
+        this.elapsed = value;
+    }
+    protected hasExpired(expiry: number): boolean {
+        return expiry < this.elapsed;
+    }
+}
 
 // tslint:disable:no-any max-func-body-length
 suite('Common Utils - CacheUtils', () => {
@@ -104,34 +112,28 @@ suite('Common Utils - CacheUtils', () => {
             expect(cache.hasData).to.be.equal(false, 'Must not have data');
             expect(cache.data).to.be.deep.equal(undefined, 'Must not have data');
         });
-        test(`Data is stored in cache and expired data is not returned: ${scenario.scenarioDesc}`, async function () {
-            if (isOs(OSType.OSX)) {
-                // This test is failing on MacOS, for the simple string and undefined scenario.
-                // See GH #4776
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
+        test(`Data is stored in cache and expired data is not returned: ${scenario.scenarioDesc}`, async () => {
             const pythonPath = 'Some Python Path';
             const vsc = createMockVSC(pythonPath);
             const resource = Uri.parse('a');
-            const cache = new InMemoryInterpreterSpecificCache('Something', 100, [resource], vsc);
+            const cache = new TestInMemoryInterpreterSpecificCache('Something', 100, [resource], vsc);
 
             expect(cache.hasData).to.be.equal(false, 'Must not have any data before caching.');
             cache.data = scenario.dataToStore;
             expect(cache.hasData).to.be.equal(true, 'Must have data after setting the first time.');
             expect(cache.data).to.be.deep.equal(scenario.dataToStore);
 
-            await sleep(10);
+            cache.simulatedElapsedMs = 10;
             expect(cache.hasData).to.be.equal(true, 'Must have data after waiting for 10ms');
-            expect(cache.data).to.be.deep.equal(scenario.dataToStore);
+            expect(cache.data).to.be.deep.equal(scenario.dataToStore, 'Data should be intact and unchanged in cache after 10ms');
 
-            await sleep(50);
+            cache.simulatedElapsedMs = 50;
             expect(cache.hasData).to.be.equal(true, 'Must have data after waiting 50ms');
-            expect(cache.data).to.be.deep.equal(scenario.dataToStore);
+            expect(cache.data).to.be.deep.equal(scenario.dataToStore, 'Data should be intact and unchanged in cache after 50ms');
 
-            await sleep(110);
+            cache.simulatedElapsedMs = 110;
             expect(cache.hasData).to.be.equal(false, 'Must not have data after waiting 110ms');
-            expect(cache.data).to.be.deep.equal(undefined, 'Must not have data stored after waiting for the specified timeout.');
+            expect(cache.data).to.be.deep.equal(undefined, 'Must not have data stored after 100ms timeout expires.');
         });
         test(`Data is stored in cache (with workspaces): ${scenario.scenarioDesc}`, () => {
             const pythonPath = 'Some Python Path';


### PR DESCRIPTION
For #4776

- simulate passing of time for time-based testing

---

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
