### PR TITLE
Use configuration api and provide Resource when retrieving settings

### DIFF
--- a/news/2 Fixes/4486.md
+++ b/news/2 Fixes/4486.md
@@ -1,0 +1,1 @@
+Use configuration api and provide Resource when retrieving settings

--- a/src/client/common/application/workspace.ts
+++ b/src/client/common/application/workspace.ts
@@ -24,7 +24,11 @@ export class WorkspaceService implements IWorkspaceService {
         return Array.isArray(workspace.workspaceFolders) && workspace.workspaceFolders.length > 0;
     }
     public getConfiguration(section?: string, resource?: Uri): WorkspaceConfiguration {
-        return workspace.getConfiguration(section, resource);
+        if (resource) {
+            return workspace.getConfiguration(section, resource);
+        } else {
+            return workspace.getConfiguration(section, null);
+        }
     }
     public getWorkspaceFolder(uri: Resource): WorkspaceFolder | undefined {
         return uri ? workspace.getWorkspaceFolder(uri) : undefined;

--- a/src/client/common/application/workspace.ts
+++ b/src/client/common/application/workspace.ts
@@ -24,11 +24,7 @@ export class WorkspaceService implements IWorkspaceService {
         return Array.isArray(workspace.workspaceFolders) && workspace.workspaceFolders.length > 0;
     }
     public getConfiguration(section?: string, resource?: Uri): WorkspaceConfiguration {
-        if (resource) {
-            return workspace.getConfiguration(section, resource);
-        } else {
-            return workspace.getConfiguration(section, null);
-        }
+        return workspace.getConfiguration(section, resource || null);
     }
     public getWorkspaceFolder(uri: Resource): WorkspaceFolder | undefined {
         return uri ? workspace.getWorkspaceFolder(uri) : undefined;

--- a/src/client/common/configuration/service.ts
+++ b/src/client/common/configuration/service.ts
@@ -30,12 +30,7 @@ export class ConfigurationService implements IConfigurationService {
             settingsInfo = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService);
         }
 
-        let configSection: WorkspaceConfiguration;
-        if (settingsInfo.uri) {
-            configSection = workspace.getConfiguration(section, settingsInfo.uri);
-        } else {
-            configSection = workspace.getConfiguration(section, null);
-        }
+        const configSection = workspace.getConfiguration(section, settingsInfo.uri ? settingsInfo.uri : null);
         const currentValue = configSection.inspect(setting);
 
         if (currentValue !== undefined &&

--- a/src/client/common/configuration/service.ts
+++ b/src/client/common/configuration/service.ts
@@ -30,7 +30,12 @@ export class ConfigurationService implements IConfigurationService {
             settingsInfo = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService);
         }
 
-        const configSection = this.workspaceService.getConfiguration(section, settingsInfo.uri);
+        let configSection: WorkspaceConfiguration;
+        if (settingsInfo.uri) {
+            configSection = workspace.getConfiguration(section, settingsInfo.uri);
+        } else {
+            configSection = workspace.getConfiguration(section, null);
+        }
         const currentValue = configSection.inspect(setting);
 
         if (currentValue !== undefined &&

--- a/src/client/common/configuration/service.ts
+++ b/src/client/common/configuration/service.ts
@@ -30,7 +30,7 @@ export class ConfigurationService implements IConfigurationService {
             settingsInfo = PythonSettings.getSettingsUriAndTarget(resource, this.workspaceService);
         }
 
-        const configSection = workspace.getConfiguration(section, settingsInfo.uri);
+        const configSection = this.workspaceService.getConfiguration(section, settingsInfo.uri);
         const currentValue = configSection.inspect(setting);
 
         if (currentValue !== undefined &&

--- a/src/client/providers/updateSparkLibraryProvider.ts
+++ b/src/client/providers/updateSparkLibraryProvider.ts
@@ -10,7 +10,7 @@ export function activateUpdateSparkLibraryProvider(): vscode.Disposable {
 }
 
 function updateSparkLibrary() {
-    const pythonConfig = vscode.workspace.getConfiguration('python');
+    const pythonConfig = vscode.workspace.getConfiguration('python', null);
     const extraLibPath = 'autoComplete.extraPaths';
     // tslint:disable-next-line:no-invalid-template-strings
     const sparkHomePath = '${env:SPARK_HOME}';

--- a/src/client/sourceMapSupport.ts
+++ b/src/client/sourceMapSupport.ts
@@ -18,7 +18,7 @@ const setting = 'sourceMapsEnabled';
 export class SourceMapSupport {
     private readonly config: WorkspaceConfiguration;
     constructor(private readonly vscode: VSCode) {
-        this.config = this.vscode.workspace.getConfiguration('python.diagnostics', undefined);
+        this.config = this.vscode.workspace.getConfiguration('python.diagnostics', null);
     }
     public async initialize(): Promise<void> {
         if (!this.enabled) {
@@ -66,7 +66,7 @@ export class SourceMapSupport {
     }
 }
 export function initialize(vscode: VSCode = require('vscode')) {
-    if (!vscode.workspace.getConfiguration('python.diagnostics', undefined).get('sourceMapsEnabled', false)) {
+    if (!vscode.workspace.getConfiguration('python.diagnostics', null).get('sourceMapsEnabled', false)) {
         new SourceMapSupport(vscode).disable().ignoreErrors();
         return;
     }

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -60,7 +60,12 @@ async function disposePythonSettings() {
 
 export async function updateSetting(setting: PythonSettingKeys, value: {} | undefined, resource: Uri | undefined, configTarget: ConfigurationTarget) {
     const vscode = require('vscode') as typeof import('vscode');
-    const settings = vscode.workspace.getConfiguration('python', resource);
+    let settings: import('vscode').WorkspaceConfiguration;
+    if (resource) {
+        settings = vscode.workspace.getConfiguration('python', resource);
+    } else {
+        settings = vscode.workspace.getConfiguration('python', null);
+    }
     const currentValue = settings.inspect(setting);
     if (currentValue !== undefined && ((configTarget === vscode.ConfigurationTarget.Global && currentValue.globalValue === value) ||
         (configTarget === vscode.ConfigurationTarget.Workspace && currentValue.workspaceValue === value) ||
@@ -160,7 +165,12 @@ async function setPythonPathInWorkspace(resource: string | Uri | undefined, conf
         return;
     }
     const resourceUri = typeof resource === 'string' ? vscode.Uri.file(resource) : resource;
-    const settings = vscode.workspace.getConfiguration('python', resourceUri);
+    let settings: import('vscode').WorkspaceConfiguration;
+    if (resourceUri) {
+        settings = vscode.workspace.getConfiguration('python', resourceUri);
+    } else {
+        settings = vscode.workspace.getConfiguration('python', null);
+    }
     const value = settings.inspect<string>('pythonPath');
     const prop: 'workspaceFolderValue' | 'workspaceValue' = config === vscode.ConfigurationTarget.Workspace ? 'workspaceValue' : 'workspaceFolderValue';
     if (value && value[prop] !== pythonPath) {

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -60,12 +60,7 @@ async function disposePythonSettings() {
 
 export async function updateSetting(setting: PythonSettingKeys, value: {} | undefined, resource: Uri | undefined, configTarget: ConfigurationTarget) {
     const vscode = require('vscode') as typeof import('vscode');
-    let settings: import('vscode').WorkspaceConfiguration;
-    if (resource) {
-        settings = vscode.workspace.getConfiguration('python', resource);
-    } else {
-        settings = vscode.workspace.getConfiguration('python', null);
-    }
+    const settings = vscode.workspace.getConfiguration('python', resource || null);
     const currentValue = settings.inspect(setting);
     if (currentValue !== undefined && ((configTarget === vscode.ConfigurationTarget.Global && currentValue.globalValue === value) ||
         (configTarget === vscode.ConfigurationTarget.Workspace && currentValue.workspaceValue === value) ||
@@ -165,12 +160,7 @@ async function setPythonPathInWorkspace(resource: string | Uri | undefined, conf
         return;
     }
     const resourceUri = typeof resource === 'string' ? vscode.Uri.file(resource) : resource;
-    let settings: import('vscode').WorkspaceConfiguration;
-    if (resourceUri) {
-        settings = vscode.workspace.getConfiguration('python', resourceUri);
-    } else {
-        settings = vscode.workspace.getConfiguration('python', null);
-    }
+    const settings = vscode.workspace.getConfiguration('python', resourceUri || null);
     const value = settings.inspect<string>('pythonPath');
     const prop: 'workspaceFolderValue' | 'workspaceValue' = config === vscode.ConfigurationTarget.Workspace ? 'workspaceValue' : 'workspaceFolderValue';
     if (value && value[prop] !== pythonPath) {


### PR DESCRIPTION
For #4486 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [ ] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
