### PR TITLE
Fix multiline comments with text on first line.

### DIFF
--- a/news/2 Fixes/4791.md
+++ b/news/2 Fixes/4791.md
@@ -1,0 +1,1 @@
+Multiline comments with text on the first line break Python Interactive window execution.

--- a/src/client/datascience/common.ts
+++ b/src/client/datascience/common.ts
@@ -85,12 +85,17 @@ export function parseForComments(
     for (const l of lines) {
         const trim = l.trim();
         // Multiline is triple quotes of either kind
-        const isMultiline = trim === '\'\'\'' || trim === '\"\"\"';
+        const isMultiline = trim.startsWith('\'\'\'') || trim.startsWith('\"\"\"');
         if (insideMultiline) {
             if (!isMultiline) {
                 foundCommentLine(l, pos);
             } else {
                 insideMultiline = false;
+
+                // Might end with text too
+                if (trim.length > 3) {
+                    foundNonCommentLine(trim.slice(3), pos);
+                }
             }
         } else {
             if (!isMultiline) {
@@ -101,6 +106,11 @@ export function parseForComments(
                 }
             } else {
                 insideMultiline = true;
+
+                // Might end with text too
+                if (trim.length > 3) {
+                    foundCommentLine(trim.slice(3), pos);
+                }
             }
         }
         pos += 1;

--- a/src/test/datascience/datascience.unit.test.ts
+++ b/src/test/datascience/datascience.unit.test.ts
@@ -104,6 +104,10 @@ suite('Data Science Tests', () => {
         assert.equal(cells.length, 1, 'Code cell multline failed');
         assert.equal(cells[0].data.cell_type, 'code', 'Code cell not generated');
         assert.equal(cells[0].data.source.length, 5, 'Lines for cell not emitted');
+        cells = generateCells(undefined, '#%% [markdown] \n\"\"\"# a\nb\n\'\'\'', 'foo', 0, true, '1');
+        assert.equal(cells.length, 1, 'Markdown cell multline failed');
+        assert.equal(cells[0].data.cell_type, 'markdown', 'Markdown cell not generated');
+        assert.equal(cells[0].data.source.length, 2, 'Lines for cell not emitted');
     });
 
 });


### PR DESCRIPTION
For #4791

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
