### PR TITLE
When debugging, the extension correctly uses custom .env files + Update tooltip

### DIFF
--- a/news/1 Enhancements/4849.md
+++ b/news/1 Enhancements/4849.md
@@ -1,0 +1,1 @@
+Include number of skipped tests in Test Data item tooltip

--- a/news/2 Fixes/4537.md
+++ b/news/2 Fixes/4537.md
@@ -1,0 +1,1 @@
+When debugging, the extension correctly uses custom .env files

--- a/src/client/debugger/extension/configuration/resolvers/launch.ts
+++ b/src/client/debugger/extension/configuration/resolvers/launch.ts
@@ -63,7 +63,8 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
             debugConfiguration.cwd = workspaceFolder.fsPath;
         }
         if (typeof debugConfiguration.envFile !== 'string' && workspaceFolder) {
-            const envFile = path.join(workspaceFolder.fsPath, '.env');
+            const settings = this.configurationService.getSettings(workspaceFolder);
+            const envFile = settings.envFile ? settings.envFile : path.join(workspaceFolder.fsPath, '.env');
             debugConfiguration.envFile = envFile;
         }
         if (typeof debugConfiguration.stopOnEntry !== 'boolean') {

--- a/src/client/debugger/extension/configuration/resolvers/launch.ts
+++ b/src/client/debugger/extension/configuration/resolvers/launch.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
-import * as path from 'path';
 import { CancellationToken, Uri, WorkspaceFolder } from 'vscode';
 import { InvalidPythonPathInDebuggerServiceId } from '../../../../application/diagnostics/checks/invalidPythonPathInDebugger';
 import { IDiagnosticsService, IInvalidPythonPathInDebuggerService } from '../../../../application/diagnostics/types';
@@ -64,8 +63,7 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
         }
         if (typeof debugConfiguration.envFile !== 'string' && workspaceFolder) {
             const settings = this.configurationService.getSettings(workspaceFolder);
-            const envFile = settings.envFile ? settings.envFile : path.join(workspaceFolder.fsPath, '.env');
-            debugConfiguration.envFile = envFile;
+            debugConfiguration.envFile = settings.envFile;
         }
         if (typeof debugConfiguration.stopOnEntry !== 'boolean') {
             debugConfiguration.stopOnEntry = false;

--- a/src/client/unittests/explorer/testTreeViewItem.ts
+++ b/src/client/unittests/explorer/testTreeViewItem.ts
@@ -79,6 +79,9 @@ export class TestTreeItem extends TreeItem {
             if (result.functionsPassed === undefined) {
                 return '';
             }
+            if (result.functionsDidNotRun) {
+                return `${result.functionsFailed} failed, ${result.functionsDidNotRun} not run and ${result.functionsPassed} passed in ${+result.time.toFixed(3)} seconds`;
+            }
             return `${result.functionsFailed} failed, ${result.functionsPassed} passed in ${+result.time.toFixed(3)} seconds`;
         }
         switch (this.data.status) {

--- a/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
@@ -78,7 +78,7 @@ suite('Debugging - Config Resolver Launch', () => {
         const settings = TypeMoq.Mock.ofType<IPythonSettings>();
         settings.setup(s => s.pythonPath).returns(() => pythonPath);
         if (workspaceFolder) {
-            settings.setup(s => s.envFile).returns(() => path.join(workspaceFolder!.uri.fsPath, '.env'));
+            settings.setup(s => s.envFile).returns(() => path.join(workspaceFolder!.uri.fsPath, '.env2'));
         }
         confgService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
         setupOs(isWindows, isMac, isLinux);
@@ -126,7 +126,7 @@ suite('Debugging - Config Resolver Launch', () => {
         expect(debugConfig).to.have.property('cwd');
         expect(debugConfig!.cwd!.toLowerCase()).to.be.equal(__dirname.toLowerCase());
         expect(debugConfig).to.have.property('envFile');
-        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(__dirname, '.env').toLowerCase());
+        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(__dirname, '.env2').toLowerCase());
         expect(debugConfig).to.have.property('env');
         // tslint:disable-next-line:no-any
         expect(Object.keys((debugConfig as any).env)).to.have.lengthOf(0);
@@ -148,7 +148,7 @@ suite('Debugging - Config Resolver Launch', () => {
         expect(debugConfig).to.have.property('cwd');
         expect(debugConfig!.cwd!.toLowerCase()).to.be.equal(__dirname.toLowerCase());
         expect(debugConfig).to.have.property('envFile');
-        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(__dirname, '.env').toLowerCase());
+        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(__dirname, '.env2').toLowerCase());
         expect(debugConfig).to.have.property('env');
         // tslint:disable-next-line:no-any
         expect(Object.keys((debugConfig as any).env)).to.have.lengthOf(0);
@@ -171,7 +171,7 @@ suite('Debugging - Config Resolver Launch', () => {
         expect(debugConfig).to.have.property('cwd');
         expect(debugConfig!.cwd!.toLowerCase()).to.be.equal(filePath.toLowerCase());
         expect(debugConfig).to.have.property('envFile');
-        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(filePath, '.env').toLowerCase());
+        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(filePath, '.env2').toLowerCase());
         expect(debugConfig).to.have.property('env');
         // tslint:disable-next-line:no-any
         expect(Object.keys((debugConfig as any).env)).to.have.lengthOf(0);
@@ -234,7 +234,7 @@ suite('Debugging - Config Resolver Launch', () => {
         expect(debugConfig).to.have.property('cwd');
         expect(debugConfig!.cwd!.toLowerCase()).to.be.equal(filePath.toLowerCase());
         expect(debugConfig).to.have.property('envFile');
-        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(filePath, '.env').toLowerCase());
+        expect(debugConfig!.envFile!.toLowerCase()).to.be.equal(path.join(filePath, '.env2').toLowerCase());
         expect(debugConfig).to.have.property('env');
         // tslint:disable-next-line:no-any
         expect(Object.keys((debugConfig as any).env)).to.have.lengthOf(0);

--- a/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
@@ -41,7 +41,7 @@ suite('Debugging - Config Resolver Launch', () => {
         folder.setup(f => f.uri).returns(() => Uri.file(folderPath));
         return folder.object;
     }
-    function setupIoc(pythonPath: string, isWindows: boolean = false, isMac: boolean = false, isLinux: boolean = false) {
+    function setupIoc(pythonPath: string, workspaceFolder?: WorkspaceFolder, isWindows: boolean = false, isMac: boolean = false, isLinux: boolean = false) {
         const confgService = TypeMoq.Mock.ofType<IConfigurationService>();
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         documentManager = TypeMoq.Mock.ofType<IDocumentManager>();
@@ -77,6 +77,9 @@ suite('Debugging - Config Resolver Launch', () => {
 
         const settings = TypeMoq.Mock.ofType<IPythonSettings>();
         settings.setup(s => s.pythonPath).returns(() => pythonPath);
+        if (workspaceFolder) {
+            settings.setup(s => s.envFile).returns(() => path.join(workspaceFolder!.uri.fsPath, '.env'));
+        }
         confgService.setup(c => c.getSettings(TypeMoq.It.isAny())).returns(() => settings.object);
         setupOs(isWindows, isMac, isLinux);
 
@@ -109,7 +112,7 @@ suite('Debugging - Config Resolver Launch', () => {
         const pythonPath = `PythonPath_${new Date().toString()}`;
         const workspaceFolder = createMoqWorkspaceFolder(__dirname);
         const pythonFile = 'xyz.py';
-        setupIoc(pythonPath);
+        setupIoc(pythonPath, workspaceFolder);
 
         setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
 
@@ -132,7 +135,7 @@ suite('Debugging - Config Resolver Launch', () => {
         const pythonPath = `PythonPath_${new Date().toString()}`;
         const workspaceFolder = createMoqWorkspaceFolder(__dirname);
         const pythonFile = 'xyz.py';
-        setupIoc(pythonPath);
+        setupIoc(pythonPath, workspaceFolder);
         setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
 
         const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { noDebug: true } as any as DebugConfiguration);
@@ -153,7 +156,7 @@ suite('Debugging - Config Resolver Launch', () => {
     test('Defaults should be returned when an empty object is passed without Workspace Folder, no workspaces and active file', async () => {
         const pythonPath = `PythonPath_${new Date().toString()}`;
         const pythonFile = 'xyz.py';
-        setupIoc(pythonPath);
+        setupIoc(pythonPath, createMoqWorkspaceFolder(path.dirname(pythonFile)));
         setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
         setupWorkspaces([]);
 
@@ -215,9 +218,9 @@ suite('Debugging - Config Resolver Launch', () => {
     test('Defaults should be returned when an empty object is passed without Workspace Folder, with a workspace and an active python file', async () => {
         const pythonPath = `PythonPath_${new Date().toString()}`;
         const activeFile = 'xyz.py';
-        setupIoc(pythonPath);
-        setupActiveEditor(activeFile, PYTHON_LANGUAGE);
         const defaultWorkspace = path.join('usr', 'desktop');
+        setupIoc(pythonPath, createMoqWorkspaceFolder(defaultWorkspace));
+        setupActiveEditor(activeFile, PYTHON_LANGUAGE);
         setupWorkspaces([defaultWorkspace]);
 
         const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, {} as DebugConfiguration);
@@ -314,7 +317,7 @@ suite('Debugging - Config Resolver Launch', () => {
         const pythonPath = `PythonPath_${new Date().toString()}`;
         const workspaceFolder = createMoqWorkspaceFolder(__dirname);
         const pythonFile = 'xyz.py';
-        setupIoc(pythonPath, isWindows, isMac, isLinux);
+        setupIoc(pythonPath, undefined, isWindows, isMac, isLinux);
         setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
 
         const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, {} as DebugConfiguration);
@@ -342,7 +345,7 @@ suite('Debugging - Config Resolver Launch', () => {
         const workspaceFolder = createMoqWorkspaceFolder(workspacePath);
         const pythonFile = 'xyz.py';
 
-        setupIoc(pythonPath, isWindows, isMac, isLinux);
+        setupIoc(pythonPath, undefined, isWindows, isMac, isLinux);
         setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
 
         if (pyramidExists) {


### PR DESCRIPTION
For #4537 #4849

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
