### PR TITLE
User python interpreter prescribed by CI

### DIFF
--- a/news/3 Code Health/4920.md
+++ b/news/3 Code Health/4920.md
@@ -1,0 +1,1 @@
+Use the `Python` interpreter prescribed by CI instead of trying to locate the best possible one.

--- a/src/test/linters/lint.functional.test.ts
+++ b/src/test/linters/lint.functional.test.ts
@@ -41,7 +41,7 @@ import {
     LinterId,
     LintMessageSeverity
 } from '../../client/linters/types';
-import { deleteFile } from '../common';
+import { deleteFile, PYTHON_PATH } from '../common';
 import {
     BaseTestFixture,
     getLinterID,
@@ -49,10 +49,6 @@ import {
     newMockDocument,
     throwUnknownProduct
 } from './common';
-
-// CI sets "python" to Python 3, but running locally it would be
-// Python 2.  The env var allos local test execution against Python 3.
-const PYTHON = process.env.PVSC_TEST_PYTHON_EXE ? process.env.PVSC_TEST_PYTHON_EXE : 'python';
 
 const workspaceDir = path.join(__dirname, '..', '..', '..', 'src', 'test');
 const workspaceUri = Uri.file(workspaceDir);
@@ -150,7 +146,7 @@ function getMessages(product: Product): ILintMessage[] {
         }
         case Product.pep8: {
             return pep8MessagesToBeReturned;
-    }
+        }
         case Product.pydocstyle: {
             return pydocstyleMessagesToBeReturned;
         }
@@ -187,31 +183,8 @@ async function getInfoForConfig(product: Product) {
     };
 }
 
-function resolveExecutable(filename: string): string {
-    if (fs.existsSync(filename)) {
-        return filename;
-    }
-    if (filename.indexOf(path.sep) > -1) {
-        throw Error(`could not find executable '${filename}'`);
-    }
-    const pathSep = process.platform === 'win32' ? ';' : ':';
-    if (process.platform === 'win32') {
-        if (!filename.endsWith('.exe')) {
-            filename += '.exe';
-        }
-    }
-    for (const entry of process.env.PATH!.split(pathSep)) {
-        const resolved = path.join(entry, filename);
-        if (fs.existsSync(resolved)) {
-            return resolved;
-        }
-    }
-    throw Error(`could not find executable '${filename}'`);
-}
-
 class TestFixture extends BaseTestFixture {
     constructor(
-        python: string,
         printLogs = false
     ) {
         const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>(undefined, TypeMoq.MockBehavior.Strict);
@@ -238,7 +211,7 @@ class TestFixture extends BaseTestFixture {
         );
 
         this.pythonSettings.setup(s => s.pythonPath)
-            .returns(() => python);
+            .returns(() => PYTHON_PATH);
     }
 
     private static newPythonToolExecService(
@@ -299,15 +272,6 @@ suite('Linting Functional Tests', () => {
     // These are integration tests that mock out everything except
     // the filesystem and process execution.
 
-    let pythonExecutable = '';
-
-    function getPython(): string {
-        if (pythonExecutable === '') {
-            pythonExecutable = resolveExecutable(PYTHON);
-        }
-        return pythonExecutable;
-    }
-
     // tslint:disable-next-line:no-any
     async function testLinterMessages(
         fixture: TestFixture,
@@ -339,7 +303,7 @@ suite('Linting Functional Tests', () => {
         }
     }
     for (const product of LINTERID_BY_PRODUCT.keys()) {
-        test(getProductName(product), async function() {
+        test(getProductName(product), async function () {
             // tslint:disable-next-line:no-suspicious-comment
             // TODO: Add coverage for these linters.
             if ([Product.bandit, Product.mypy, Product.pylama, Product.prospector].some(p => p === product)) {
@@ -347,16 +311,14 @@ suite('Linting Functional Tests', () => {
                 this.skip();
             }
 
-            const fixture = new TestFixture(
-                getPython()
-            );
+            const fixture = new TestFixture();
             const messagesToBeReturned = getMessages(product);
             await testLinterMessages(fixture, product, fileToLint, messagesToBeReturned);
         });
     }
     for (const product of LINTERID_BY_PRODUCT.keys()) {
         // tslint:disable-next-line:max-func-body-length
-        test(`${getProductName(product)} with config in root`, async function() {
+        test(`${getProductName(product)} with config in root`, async function () {
             // tslint:disable-next-line:no-suspicious-comment
             // TODO: Add coverage for these linters.
             if ([Product.bandit, Product.mypy, Product.pylama, Product.prospector].some(p => p === product)) {
@@ -364,9 +326,7 @@ suite('Linting Functional Tests', () => {
                 this.skip();
             }
 
-            const fixture = new TestFixture(
-                getPython()
-            );
+            const fixture = new TestFixture();
             if (product === Product.pydocstyle) {
                 fixture.lintingSettings.pylintUseMinimalCheckers = false;
             }
@@ -411,13 +371,11 @@ suite('Linting Functional Tests', () => {
         );
 
         assert.equal(messages.length, messageCountToBeReceived,
-                     'Expected number of lint errors does not match lint error count');
+            'Expected number of lint errors does not match lint error count');
     }
     test('Three line output counted as one message', async () => {
         const maxErrors = 5;
-        const fixture = new TestFixture(
-            getPython()
-        );
+        const fixture = new TestFixture();
         fixture.lintingSettings.maxNumberOfProblems = maxErrors;
         await testLinterMessageCount(
             fixture,


### PR DESCRIPTION
For #4920

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
