### PR TITLE
Leave Azdo timeout as the default of 60m

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -24,9 +24,6 @@ jobs:
 
 - job: 'CI'
 
-  timeoutInMinutes: 30
-  cancelTimeoutInMinutes: 3
-
   strategy:
     matrix:
       # Each member of this list must contain these values:
@@ -257,4 +254,3 @@ jobs:
 
   steps:
     - template: templates/test_phases.yml
-

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -22,9 +22,6 @@ jobs:
 
 - job: 'Nightly'
 
-  timeoutInMinutes: 30
-  cancelTimeoutInMinutes: 3
-
   strategy:
     matrix:
       # Each member of this list must contain these values:
@@ -436,4 +433,3 @@ jobs:
 
   steps:
     - template: templates/test_phases.yml
-

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -25,9 +25,6 @@ jobs:
 
 - job: 'PR'
 
-  timeoutInMinutes: 30
-  cancelTimeoutInMinutes: 3
-
   strategy:
     matrix:
       # Each member of this list must contain these values:

--- a/news/3 Code Health/4914.md
+++ b/news/3 Code Health/4914.md
@@ -1,0 +1,1 @@
+Remove hardcoded Azdo Pipeline of 30m, leaving it to the default of 60m.


### PR DESCRIPTION
For #4941

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
