### PR TITLE
Debounce async

### DIFF
--- a/news/3 Code Health/4641.md
+++ b/news/3 Code Health/4641.md
@@ -1,0 +1,1 @@
+Support debouncing decorated async methods.

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -11,11 +11,20 @@ import { InMemoryInterpreterSpecificCache } from './cacheUtils';
 const _debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
 type VoidFunction = (...any: any[]) => void;
+
 /**
- * Debounces a function execution. Function must return either a void or a promise that resolves to a void.
+ * Combine multiple sequential calls to the decorated function into one.
  * @export
- * @param {number} [wait] Wait time.
+ * @param {number} [wait] Wait time (milliseconds).
  * @returns void
+ *
+ * The point is to ensure that successive calls to the function result
+ * only in a single actual call.  Following the most recent call to
+ * the debounced function, debouncing resets after the "wait" interval
+ * has elapsed.
+ *
+ * The decorated function must return either a void or a promise that
+ * resolves to a void.
  */
 export function debounce(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -13,12 +13,6 @@ const _debounce = require('lodash/debounce') as typeof import('lodash/debounce')
 type VoidFunction = (...any: any[]) => void;
 type AsyncVoidFunction = (...any: any[]) => Promise<void>;
 
-function makeNoopDecorator() {
-    return function (_target: any, _propertyName: string, _descriptor: TypedPropertyDescriptor<VoidFunction> | TypedPropertyDescriptor<AsyncVoidFunction>) {
-        // Do nothing.
-    };
-}
-
 /**
  * Combine multiple sequential calls to the decorated function into one.
  * @export
@@ -36,7 +30,9 @@ function makeNoopDecorator() {
 export function debounce(wait?: number) {
     if (isTestExecution()) {
         // If running tests, lets not debounce (so tests run fast).
-        return makeNoopDecorator();
+        wait = undefined;
+        // tslint:disable-next-line:no-suspicious-comment
+        // TODO: We should be able to return a noop decorator instead...
     }
     return makeDebounceDecorator(wait);
 }
@@ -57,7 +53,6 @@ export function makeDebounceDecorator(wait?: number) {
         // See https://lodash.com/docs/#debounce.
         const options = {};
         const originalMethod = descriptor.value!;
-        // tslint:disable-next-line:no-invalid-this no-any
         const debounced = _debounce(
             function (this: any) {
                 return originalMethod.apply(this, arguments as any);

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -10,10 +10,11 @@ import { InMemoryInterpreterSpecificCache } from './cacheUtils';
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
-export type VoidFunction = (...any: any[]) => void;
+type VoidFunction = (...any: any[]) => void;
+type AsyncVoidFunction = (...any: any[]) => Promise<void>;
 
 function makeNoopDecorator() {
-    return function (_target: any, _propertyName: string, _descriptor: TypedPropertyDescriptor<VoidFunction>) {
+    return function (_target: any, _propertyName: string, _descriptor: TypedPropertyDescriptor<VoidFunction> | TypedPropertyDescriptor<AsyncVoidFunction>) {
         // Do nothing.
     };
 }
@@ -42,7 +43,7 @@ export function debounce(wait?: number) {
 
 export function makeDebounceDecorator(wait?: number, options?: any) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction>) {
+    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction> | TypedPropertyDescriptor<AsyncVoidFunction>) {
         const originalMethod = descriptor.value!;
         // tslint:disable-next-line:no-invalid-this no-any
         const debounced = _debounce(

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -41,9 +41,21 @@ export function debounce(wait?: number) {
     return makeDebounceDecorator(wait);
 }
 
-export function makeDebounceDecorator(wait?: number, options?: any) {
+export function makeDebounceDecorator(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
     return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction> | TypedPropertyDescriptor<AsyncVoidFunction>) {
+        // We could also make use of _debounce() options.  For instance,
+        // the following causes the original method to be called
+        // immediately:
+        //
+        //   {leading: true, trailing: false}
+        //
+        // The default is:
+        //
+        //   {leading: false, trailing: true}
+        //
+        // See https://lodash.com/docs/#debounce.
+        const options = {};
         const originalMethod = descriptor.value!;
         // tslint:disable-next-line:no-invalid-this no-any
         const debounced = _debounce(

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -171,6 +171,26 @@ suite('Common Utils - Decorators', () => {
         expect(one.calls).to.deep.equal(['run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);
     });
+    test('Debounce: one async call', async () => {
+        const wait = 100;
+        // tslint:disable-next-line:max-classes-per-file
+        class One extends Base {
+            @makeDebounceDecorator(wait)
+            public async run(): Promise<void> {
+                this._addCall('run');
+            }
+        }
+        const one = new One();
+
+        const start = Date.now();
+        await one.run();
+        await one._waitForCalls(1);
+        const delay = one.timestamps[0] - start;
+
+        expect(delay).to.be.at.least(wait);
+        expect(one.calls).to.deep.equal(['run']);
+        expect(one.timestamps).to.have.lengthOf(one.calls.length);
+    });
     test('Debounce: multiple calls grouped', async () => {
         const wait = 100;
         // tslint:disable-next-line:max-classes-per-file

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -111,24 +111,24 @@ suite('Common Utils - Decorators', () => {
             this.calls = [];
             this.timestamps = [];
         }
-        public async _waitForCalls(count: number, delay = 10, timeout = 1000) {
-            const steps = timeout / delay;
-            for (let i = 0; i < steps; i += 1) {
-                if (this.timestamps.length >= count) {
-                    return;
-                }
-                await sleep(delay);
-            }
-            if (this.timestamps.length < count) {
-                throw Error(`timed out after ${timeout}ms`);
-            }
-        }
         protected _addCall(funcname: string, timestamp?: number): void {
             if (!timestamp) {
                 timestamp = Date.now();
             }
             this.calls.push(funcname);
             this.timestamps.push(timestamp);
+        }
+    }
+    async function waitForCalls(timestamps: number[], count: number, delay = 10, timeout = 1000) {
+        const steps = timeout / delay;
+        for (let i = 0; i < steps; i += 1) {
+            if (timestamps.length >= count) {
+                return;
+            }
+            await sleep(delay);
+        }
+        if (timestamps.length < count) {
+            throw Error(`timed out after ${timeout}ms`);
         }
     }
     test('Debounce: execute early', async () => {
@@ -144,7 +144,7 @@ suite('Common Utils - Decorators', () => {
 
         const start = Date.now();
         one.run();
-        await one._waitForCalls(1);
+        await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.below(wait);
@@ -164,7 +164,7 @@ suite('Common Utils - Decorators', () => {
 
         const start = Date.now();
         one.run();
-        await one._waitForCalls(1);
+        await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.at.least(wait);
@@ -184,7 +184,7 @@ suite('Common Utils - Decorators', () => {
 
         const start = Date.now();
         await one.run();
-        await one._waitForCalls(1);
+        await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.at.least(wait);
@@ -206,7 +206,7 @@ suite('Common Utils - Decorators', () => {
         one.run();
         one.run();
         one.run();
-        await one._waitForCalls(1);
+        await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.at.least(wait);
@@ -227,7 +227,7 @@ suite('Common Utils - Decorators', () => {
         one.run();
         await sleep(wait);
         one.run();
-        await one._waitForCalls(2);
+        await waitForCalls(one.timestamps, 2);
 
         expect(one.calls).to.deep.equal(['run', 'run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -131,26 +131,6 @@ suite('Common Utils - Decorators', () => {
             throw Error(`timed out after ${timeout}ms`);
         }
     }
-    test('Debounce: execute early', async () => {
-        const wait = 1000;
-        // tslint:disable-next-line:max-classes-per-file
-        class One extends Base {
-            @makeDebounceDecorator(wait, {leading: true})
-            public run(): void {
-                this._addCall('run');
-            }
-        }
-        const one = new One();
-
-        const start = Date.now();
-        one.run();
-        await waitForCalls(one.timestamps, 1);
-        const delay = one.timestamps[0] - start;
-
-        expect(delay).to.be.below(wait);
-        expect(one.calls).to.deep.equal(['run']);
-        expect(one.timestamps).to.have.lengthOf(one.calls.length);
-    });
     test('Debounce: one sync call', async () => {
         const wait = 100;
         // tslint:disable-next-line:max-classes-per-file


### PR DESCRIPTION
(for #4641)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
