### PR TITLE
Have announce.py handle the prepending of news to the changelog

### DIFF
--- a/news/.vscode/settings.json
+++ b/news/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "python.jediEnabled": false,
+    "python.formatting.provider": "black",
+    "python.unitTest.pyTestArgs": [
+        "."
+    ],
+    "python.unitTest.unittestEnabled": false,
+    "python.unitTest.nosetestsEnabled": false,
+    "python.unitTest.pyTestEnabled": true
+}

--- a/news/.vscode/settings.json
+++ b/news/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "python.jediEnabled": false,
     "python.formatting.provider": "black",
+    "editor.formatOnSave": true,
     "python.unitTest.pyTestArgs": [
         "."
     ],

--- a/news/announce.py
+++ b/news/announce.py
@@ -3,11 +3,13 @@
 
 """Generate the changelog.
 
-Usage: announce [--dry_run | --interim | --final] [<directory>]
+Usage: announce [--dry_run | --interim | --final] [--update <news_file>] [<directory>]
 
 """
 import dataclasses
+import datetime
 import enum
+import json
 import operator
 import os
 import pathlib
@@ -148,12 +150,29 @@ class RunType(enum.Enum):
     final = 2
 
 
-def main(run_type, directory):
+def complete_news(version, entry, previous_news):
+    """Prepend a news entry to the previous news file."""
+    title, _, previous_news = previous_news.partition("\n")
+    title = title.strip()
+    previous_news = previous_news.strip()
+    section_title = f"### {version} ({datetime.Date.today().strftime('%d %b %Y')})"
+    return f"{title}\n\n{section_title}\n{entry}\n\n{previous_news}"
+
+
+def main(run_type, directory, news_file=None):
     directory = pathlib.Path(directory)
     data = gather(directory)
     markdown = changelog_markdown(data)
     if run_type != RunType.dry_run:
-        print(markdown)
+        if news_file:
+            with open(news_file, "r", encoding="utf-8") as file:
+                previous_news = file.read()
+            package_config_path = pathlib.Path(news_file).parent / "package.json"
+            config = json.load(package_config_path)
+            with open(news_file, "w", encoding="utf-8") as file:
+                file.write(complete_news(config["version"], markdown, previous_news))
+        else:
+            print(markdown)
     if run_type == RunType.final:
         cleanup(data)
 
@@ -167,4 +186,4 @@ if __name__ == "__main__":
     else:
         run_type = RunType.interim
     directory = arguments["<directory>"] or pathlib.Path(__file__).parent
-    main(run_type, directory)
+    main(run_type, directory, arguments["--update"])

--- a/news/announce.py
+++ b/news/announce.py
@@ -3,7 +3,7 @@
 
 """Generate the changelog.
 
-Usage: announce [--dry_run | --interim | --final] [--update <news_file>] [<directory>]
+Usage: announce [--dry_run | --interim | --final] [--update=<news_file>] [<directory>]
 
 """
 import dataclasses
@@ -104,9 +104,6 @@ def entry_markdown(entry):
     formatted_lines.extend(f"{indent}{line}" for line in entry_lines[1:])
     formatted_lines.append(f"{indent}{issue_md}")
     return "\n".join(formatted_lines)
-    return ENTRY_TEMPLATE.format(
-        entry=entry.description.strip(), issue=entry.issue_number, issue_url=issue_url
-    )
 
 
 def changelog_markdown(data):
@@ -155,8 +152,8 @@ def complete_news(version, entry, previous_news):
     title, _, previous_news = previous_news.partition("\n")
     title = title.strip()
     previous_news = previous_news.strip()
-    section_title = f"### {version} ({datetime.Date.today().strftime('%d %b %Y')})"
-    return f"{title}\n\n{section_title}\n{entry}\n\n{previous_news}"
+    section_title = f"## {version} ({datetime.date.today().strftime('%d %b %Y')})"
+    return f"{title}\n\n\n{section_title}\n\n{entry.strip()}\n\n\n{previous_news}"
 
 
 def main(run_type, directory, news_file=None):
@@ -168,7 +165,7 @@ def main(run_type, directory, news_file=None):
             with open(news_file, "r", encoding="utf-8") as file:
                 previous_news = file.read()
             package_config_path = pathlib.Path(news_file).parent / "package.json"
-            config = json.load(package_config_path)
+            config = json.loads(package_config_path.read_text())
             with open(news_file, "w", encoding="utf-8") as file:
                 file.write(complete_news(config["version"], markdown, previous_news))
         else:

--- a/news/announce.py
+++ b/news/announce.py
@@ -166,8 +166,9 @@ def main(run_type, directory, news_file=None):
                 previous_news = file.read()
             package_config_path = pathlib.Path(news_file).parent / "package.json"
             config = json.loads(package_config_path.read_text())
+            new_news = complete_news(config["version"], markdown, previous_news)
             with open(news_file, "w", encoding="utf-8") as file:
-                file.write(complete_news(config["version"], markdown, previous_news))
+                file.write(new_news)
         else:
             print(markdown)
     if run_type == RunType.final:

--- a/news/test_announce.py
+++ b/news/test_announce.py
@@ -165,6 +165,35 @@ def test_cleanup(directory, monkeypatch):
     assert rm_path == entries[0].path
 
 
+TITLE = "# Our most excellent changelog"
+OLD_NEWS = f"""{title}
+
+## 2018.12.0 (31 Dec 2018)
+
+We did things!
+
+## 2017.11.16 (16 Nov 2017)
+
+We started going stuff.
+"""
+NEW_NEWS = """We fixed all the things!
+
+### Code Health
+
+We deleted all the code to fix all the things. ;)
+"""
+
+
+def test_complete_news():
+    version = "2019.3.0"
+    news = ann.complete_news(version, )
+    # XXX Title isn't lost
+    # XXX Newlines aren't weird
+    # XXX Version is correct
+    # XXX new entry insserted appropriately
+    # XXX Older entries preserved
+
+
 def test_cli():
     for option in ("--" + opt for opt in ["dry_run", "interim", "final"]):
         args = docopt.docopt(ann.__doc__, [option])
@@ -174,3 +203,5 @@ def test_cli():
     args = docopt.docopt(ann.__doc__, ["--dry_run", "./news"])
     assert args["--dry_run"]
     assert args["<directory>"] == "./news"
+
+# XXX --update

--- a/news/test_announce.py
+++ b/news/test_announce.py
@@ -167,7 +167,8 @@ def test_cleanup(directory, monkeypatch):
 
 
 TITLE = "# Our most excellent changelog"
-OLD_NEWS = f"""## 2018.12.0 (31 Dec 2018)
+OLD_NEWS = f"""\
+## 2018.12.0 (31 Dec 2018)
 
 We did things!
 
@@ -175,7 +176,8 @@ We did things!
 
 We started going stuff.
 """
-NEW_NEWS = """We fixed all the things!
+NEW_NEWS = """\
+We fixed all the things!
 
 ### Code Health
 
@@ -188,7 +190,6 @@ def test_complete_news():
     date = datetime.date.today().strftime("%d %b %Y")
     news = ann.complete_news(version, NEW_NEWS, f"{TITLE}\n\n\n{OLD_NEWS}")
     expected = f"{TITLE}\n\n\n## {version} ({date})\n\n{NEW_NEWS.strip()}\n\n\n{OLD_NEWS.strip()}"
-    print(news)
     assert news == expected
 
 

--- a/news/test_announce.py
+++ b/news/test_announce.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import codecs
+import datetime
 import pathlib
 
 import docopt
@@ -166,9 +167,7 @@ def test_cleanup(directory, monkeypatch):
 
 
 TITLE = "# Our most excellent changelog"
-OLD_NEWS = f"""{title}
-
-## 2018.12.0 (31 Dec 2018)
+OLD_NEWS = f"""## 2018.12.0 (31 Dec 2018)
 
 We did things!
 
@@ -186,12 +185,11 @@ We deleted all the code to fix all the things. ;)
 
 def test_complete_news():
     version = "2019.3.0"
-    news = ann.complete_news(version, )
-    # XXX Title isn't lost
-    # XXX Newlines aren't weird
-    # XXX Version is correct
-    # XXX new entry insserted appropriately
-    # XXX Older entries preserved
+    date = datetime.date.today().strftime("%d %b %Y")
+    news = ann.complete_news(version, NEW_NEWS, f"{TITLE}\n\n\n{OLD_NEWS}")
+    expected = f"{TITLE}\n\n\n## {version} ({date})\n\n{NEW_NEWS.strip()}\n\n\n{OLD_NEWS.strip()}"
+    print(news)
+    assert news == expected
 
 
 def test_cli():
@@ -203,5 +201,6 @@ def test_cli():
     args = docopt.docopt(ann.__doc__, ["--dry_run", "./news"])
     assert args["--dry_run"]
     assert args["<directory>"] == "./news"
-
-# XXX --update
+    args = docopt.docopt(ann.__doc__, ["--update", "CHANGELOG.md", "./news"])
+    assert args["--update"] == "CHANGELOG.md"
+    assert args["<directory>"] == "./news"


### PR DESCRIPTION
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Unit tests & system/integration tests are added/updated
