### PR TITLE
Force functional tests to exit when done with tests

### DIFF
--- a/build/.mocha.functional.opts
+++ b/build/.mocha.functional.opts
@@ -5,5 +5,6 @@
 --recursive
 --colors
 --timeout=120000
+--exit
 --reporter mocha-multi-reporters
 --reporter-options configFile=build/.mocha-multi-reporters.config

--- a/news/2 Fixes/4992.md
+++ b/news/2 Fixes/4992.md
@@ -1,0 +1,1 @@
+Force mocha to exit so that hanging promises (which might be from Jupyter) don't stop tests from running.


### PR DESCRIPTION
For #4992 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
