### PR TITLE
Prompt to turn on Pylint if a pylintrc file is found

### DIFF
--- a/news/1 Enhancements/4941.md
+++ b/news/1 Enhancements/4941.md
@@ -1,0 +1,1 @@
+Prompt to turn on Pylint if a pylintrc file is found

--- a/src/client/linters/constants.ts
+++ b/src/client/linters/constants.ts
@@ -17,3 +17,5 @@ export const LINTERID_BY_PRODUCT = new Map<Product, LinterId>([
     [Product.pydocstyle, 'pydocstyle'],
     [Product.pylama, 'pylama']
 ]);
+
+export const PYLINT_CONFIG = '.pylintrc';

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -4,11 +4,13 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
+import * as path from 'path';
 import { Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../common/application/types';
 import '../common/extensions';
 import { traceError } from '../common/logger';
-import { IConfigurationService, IInstaller, Product } from '../common/types';
+import { IFileSystem } from '../common/platform/types';
+import { IConfigurationService, Product } from '../common/types';
 import { Linters } from '../common/utils/localize';
 import { IAvailableLinterActivator, ILinterInfo } from './types';
 
@@ -16,8 +18,8 @@ import { IAvailableLinterActivator, ILinterInfo } from './types';
 export class AvailableLinterActivator implements IAvailableLinterActivator {
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(IInstaller) private installer: IInstaller,
-        @inject(IWorkspaceService) private workspaceConfig: IWorkspaceService,
+        @inject(IFileSystem) private fs: IFileSystem,
+        @inject(IWorkspaceService) private workspaceService: IWorkspaceService,
         @inject(IConfigurationService) private configService: IConfigurationService
     ) { }
 
@@ -94,7 +96,12 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * @param resource Context information for workspace.
      */
     public async isLinterAvailable(linterProduct: Product, resource?: Uri): Promise<boolean | undefined> {
-        return this.installer.isInstalled(linterProduct, resource)
+        if (!this.workspaceService.hasWorkspaceFolders) {
+            return false;
+        }
+        const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource)! : this.workspaceService.workspaceFolders![0];
+        const filePath = path.join(workspaceFolder.uri.fsPath, '.pylintrc');
+        return this.fs.fileExists(filePath)
             .catch((reason) => {
                 // report and continue, assume the linter is unavailable.
                 traceError(`[WARNING]: Failed to discover if linter ${linterProduct} is installed.`, reason);
@@ -111,7 +118,7 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * @returns true if the linter has not been configured at the user, workspace, or workspace-folder scope. false otherwise.
      */
     public isLinterUsingDefaultConfiguration(linterInfo: ILinterInfo, resource?: Uri): boolean {
-        const ws = this.workspaceConfig.getConfiguration('python.linting', resource);
+        const ws = this.workspaceService.getConfiguration('python.linting', resource);
         const pe = ws!.inspect(linterInfo.enabledSettingName);
         return (pe!.globalValue === undefined && pe!.workspaceValue === undefined && pe!.workspaceFolderValue === undefined);
     }

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -12,6 +12,7 @@ import { traceError } from '../common/logger';
 import { IFileSystem } from '../common/platform/types';
 import { IConfigurationService, Product } from '../common/types';
 import { Linters } from '../common/utils/localize';
+import { PYLINT_CONFIG } from './constants';
 import { IAvailableLinterActivator, ILinterInfo } from './types';
 
 @injectable()
@@ -100,7 +101,7 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
             return false;
         }
         const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource)! : this.workspaceService.workspaceFolders![0];
-        const filePath = path.join(workspaceFolder.uri.fsPath, '.pylintrc');
+        const filePath = path.join(workspaceFolder.uri.fsPath, PYLINT_CONFIG);
         return this.fs.fileExists(filePath)
             .catch((reason) => {
                 // report and continue, assume the linter is unavailable.

--- a/src/test/linters/linter.availability.unit.test.ts
+++ b/src/test/linters/linter.availability.unit.test.ts
@@ -9,8 +9,9 @@ import { Uri, WorkspaceConfiguration } from 'vscode';
 import {
     IApplicationShell, IWorkspaceService
 } from '../../client/common/application/types';
+import { IFileSystem } from '../../client/common/platform/types';
 import {
-    IConfigurationService, IInstaller, IPythonSettings, Product
+    IConfigurationService, IPythonSettings, Product
 } from '../../client/common/types';
 import { AvailableLinterActivator } from '../../client/linters/linterAvailability';
 import { LinterInfo } from '../../client/linters/linterInfo';
@@ -25,11 +26,11 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = false;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock] = getDependenciesForAvailabilityTests();
         setupConfigurationServiceForJediSettingsTest(jediEnabledValue, configServiceMock);
 
         // call
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
 
         // check expectaions
         expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be disabled when python.jediEnabled is true');
@@ -42,10 +43,10 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = true;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock] = getDependenciesForAvailabilityTests();
         setupConfigurationServiceForJediSettingsTest(jediEnabledValue, configServiceMock);
 
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
 
         expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be enabled when python.jediEnabled defaults to false');
         workspaceServiceMock.verifyAll();
@@ -58,10 +59,10 @@ suite('Linter Availability Provider tests', () => {
         const pylintWorkspaceFolderValue = undefined;
         const expectedResult = true;
 
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
         setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, workspaceServiceMock);
 
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
 
         const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
 
@@ -76,10 +77,10 @@ suite('Linter Availability Provider tests', () => {
         const pylintWorkspaceFolderValue = undefined;
         const expectedResult = false;
 
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
         setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, workspaceServiceMock);
 
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
 
         const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
         expect(result).to.equal(expectedResult, 'Available linter prompt should not be shown when linter is configured for workspace.');
@@ -94,9 +95,9 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = false;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
         setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, workspaceServiceMock);
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
 
         const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
         expect(result).to.equal(expectedResult, 'Available linter prompt should not be shown when linter is configured for user.');
@@ -111,9 +112,9 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = false;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
         setupWorkspaceMockForLinterConfiguredTests(pylintUserValue, pylintWorkspaceValue, pylintWorkspaceFolderValue, workspaceServiceMock);
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
 
         const result = availabilityProvider.isLinterUsingDefaultConfiguration(linterInfo);
         expect(result).to.equal(expectedResult, 'Available linter prompt should not be shown when linter is configured for workspace-folder.');
@@ -122,7 +123,7 @@ suite('Linter Availability Provider tests', () => {
 
     async function testForLinterPromptResponse(promptReply: { title: string; enabled: boolean } | undefined): Promise<boolean> {
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock] = getDependenciesForAvailabilityTests();
         const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
 
         const linterInfo = new class extends LinterInfo {
@@ -147,7 +148,7 @@ suite('Linter Availability Provider tests', () => {
             .verifiable(TypeMoq.Times.once());
 
         // perform test
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
         const result = await availabilityProvider.promptToConfigureAvailableLinter(linterInfo);
         if (promptReply) {
             expect(linterInfo.testIsEnabled).to.equal(promptReply.enabled, 'LinterInfo test class was not updated as a result of the test.');
@@ -205,7 +206,7 @@ suite('Linter Availability Provider tests', () => {
 
     async function performTestOfOverallImplementation(options: AvailablityTestOverallOptions): Promise<boolean> {
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
         appShellMock.setup(ap => ap.showInformationMessage(
             TypeMoq.It.isValue(`Linter ${linterInfo.id} is installed but not enabled.`),
             TypeMoq.It.isAny(),
@@ -215,7 +216,16 @@ suite('Linter Availability Provider tests', () => {
             .returns(() => options.promptReply as any)
             .verifiable(TypeMoq.Times.once());
 
-        installerMock.setup(im => im.isInstalled(linterInfo.product, TypeMoq.It.isAny()))
+        const workspaceFolder = { uri: Uri.parse('full/path/to/workspace'), name: '', index: 0 };
+        workspaceServiceMock
+            .setup(c => c.hasWorkspaceFolders)
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
+        workspaceServiceMock
+            .setup(c => c.workspaceFolders)
+            .returns(() => [workspaceFolder])
+            .verifiable(TypeMoq.Times.once());
+        fsMock.setup(fs => fs.fileExists(TypeMoq.It.isAny()))
             .returns(async () => options.linterIsInstalled)
             .verifiable(TypeMoq.Times.once());
 
@@ -228,7 +238,7 @@ suite('Linter Availability Provider tests', () => {
         );
 
         // perform test
-        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider: IAvailableLinterActivator = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
         return availabilityProvider.promptIfLinterAvailable(linterInfo);
     }
 
@@ -324,15 +334,16 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = true;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
-        setupInstallerForAvailabilityTest(linterInfo, linterIsInstalled, installerMock);
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        setupInstallerForAvailabilityTest(linterInfo, linterIsInstalled, fsMock, workspaceServiceMock);
 
         // perform test
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
         const result = await availabilityProvider.isLinterAvailable(linterInfo.product);
 
         expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
-        installerMock.verifyAll();
+        fsMock.verifyAll();
+        workspaceServiceMock.verifyAll();
     });
 
     test('Discovery of linter is available in the environment returns false when it succeeds and is not present', async () => {
@@ -341,15 +352,16 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = false;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
-        setupInstallerForAvailabilityTest(linterInfo, linterIsInstalled, installerMock);
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        setupInstallerForAvailabilityTest(linterInfo, linterIsInstalled, fsMock, workspaceServiceMock);
 
         // perform test
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
         const result = await availabilityProvider.isLinterAvailable(linterInfo.product);
 
         expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
-        installerMock.verifyAll();
+        fsMock.verifyAll();
+        workspaceServiceMock.verifyAll();
     });
 
     test('Discovery of linter is available in the environment returns false when it fails', async () => {
@@ -357,17 +369,29 @@ suite('Linter Availability Provider tests', () => {
         const expectedResult = false;
 
         // arrange
-        const [appShellMock, installerMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
-        installerMock.setup(im => im.isInstalled(linterInfo.product, TypeMoq.It.isAny()))
-            .returns(() => Promise.reject('error testfail'))
+        const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, linterInfo] = getDependenciesForAvailabilityTests();
+        const workspaceFolder = { uri: Uri.parse('full/path/to/workspace'), name: '', index: 0 };
+        workspaceServiceMock
+            .setup(c => c.hasWorkspaceFolders)
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
+        workspaceServiceMock
+            .setup(c => c.workspaceFolders)
+            .returns(() => [workspaceFolder]);
+        workspaceServiceMock
+            .setup(c => c.getWorkspaceFolder(TypeMoq.It.isAny()))
+            .returns(() => workspaceFolder);
+        fsMock.setup(fs => fs.fileExists(TypeMoq.It.isAny()))
+            .returns(async () => Promise.reject('error testfail'))
             .verifiable(TypeMoq.Times.once());
 
         // perform test
-        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, installerMock.object, workspaceServiceMock.object, configServiceMock.object);
+        const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object);
         const result = await availabilityProvider.isLinterAvailable(linterInfo.product);
 
         expect(result).to.equal(expectedResult, 'Expected promptToConfigureAvailableLinter to return true because the configuration was updated.');
-        installerMock.verifyAll();
+        fsMock.verifyAll();
+        workspaceServiceMock.verifyAll();
     });
 });
 
@@ -418,20 +442,31 @@ function setupConfigurationServiceForJediSettingsTest(
     return [configServiceMock, pythonSettings];
 }
 
-function setupInstallerForAvailabilityTest(linterInfo: LinterInfo, linterIsInstalled: boolean, installerMock: TypeMoq.IMock<IInstaller>): TypeMoq.IMock<IInstaller> {
-    if (!installerMock) {
-        installerMock = TypeMoq.Mock.ofType<IInstaller>();
+function setupInstallerForAvailabilityTest(_linterInfo: LinterInfo, linterIsInstalled: boolean, fsMock: TypeMoq.IMock<IFileSystem>, workspaceServiceMock: TypeMoq.IMock<IWorkspaceService>): TypeMoq.IMock<IFileSystem> {
+    if (!fsMock) {
+        fsMock = TypeMoq.Mock.ofType<IFileSystem>();
     }
-    installerMock.setup(im => im.isInstalled(linterInfo.product, TypeMoq.It.isAny()))
+    const workspaceFolder = { uri: Uri.parse('full/path/to/workspace'), name: '', index: 0 };
+    workspaceServiceMock
+        .setup(c => c.hasWorkspaceFolders)
+        .returns(() => true)
+        .verifiable(TypeMoq.Times.once());
+    workspaceServiceMock
+        .setup(c => c.workspaceFolders)
+        .returns(() => [workspaceFolder]);
+    workspaceServiceMock
+        .setup(c => c.getWorkspaceFolder(TypeMoq.It.isAny()))
+        .returns(() => workspaceFolder);
+    fsMock.setup(fs => fs.fileExists(TypeMoq.It.isAny()))
         .returns(async () => linterIsInstalled)
         .verifiable(TypeMoq.Times.once());
 
-    return installerMock;
+    return fsMock;
 }
 
 function getDependenciesForAvailabilityTests(): [
     TypeMoq.IMock<IApplicationShell>,
-    TypeMoq.IMock<IInstaller>,
+    TypeMoq.IMock<IFileSystem>,
     TypeMoq.IMock<IWorkspaceService>,
     TypeMoq.IMock<IConfigurationService>,
     LinterInfo
@@ -439,7 +474,7 @@ function getDependenciesForAvailabilityTests(): [
     const configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
     return [
         TypeMoq.Mock.ofType<IApplicationShell>(),
-        TypeMoq.Mock.ofType<IInstaller>(),
+        TypeMoq.Mock.ofType<IFileSystem>(),
         TypeMoq.Mock.ofType<IWorkspaceService>(),
         TypeMoq.Mock.ofType<IConfigurationService>(),
         new LinterInfo(Product.pylint, 'pylint', configServiceMock.object, ['.pylintrc', 'pylintrc'])


### PR DESCRIPTION
For #4941 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Has sufficient logging.
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
