### PR TITLE
Auto expand first level of the test explorer tree view

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,7 +811,6 @@ function getFilesToProcess(fileList) {
 * @param {hygieneOptions} options
 */
 function getFileListToProcess(options) {
-    return [];
     const mode = options ? options.mode : 'all';
     const gulpSrcOptions = { base: '.' };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,6 +811,7 @@ function getFilesToProcess(fileList) {
 * @param {hygieneOptions} options
 */
 function getFileListToProcess(options) {
+    return [];
     const mode = options ? options.mode : 'all';
     const gulpSrcOptions = { base: '.' };
 

--- a/news/1 Enhancements/4767.md
+++ b/news/1 Enhancements/4767.md
@@ -1,0 +1,1 @@
+Auto-expand the first level of the test explorer tree view.

--- a/src/client/unittests/explorer/testTreeViewItem.ts
+++ b/src/client/unittests/explorer/testTreeViewItem.ts
@@ -14,6 +14,10 @@ import { getTestType, isSubtestsParent } from '../common/testUtils';
 import { TestResult, TestStatus, TestSuite, TestType } from '../common/types';
 import { TestDataItem } from '../types';
 
+function getDefaultCollapsibleState(data: TestDataItem): TreeItemCollapsibleState {
+    return getTestType(data) === TestType.testFunction ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed;
+}
+
 /**
  * Class that represents a visual node on the
  * Test Explorer tree view. Is essentially a wrapper for the underlying
@@ -24,14 +28,12 @@ export class TestTreeItem extends TreeItem {
 
     constructor(
         public readonly resource: Uri,
-        public readonly data: Readonly<TestDataItem>
+        public readonly data: Readonly<TestDataItem>,
+        collapsibleStatue: TreeItemCollapsibleState = getDefaultCollapsibleState(data)
     ) {
-        super(data.name, TestTreeItem.getCollapsibleState(data));
+        super(data.name, collapsibleStatue);
         this.testType = getTestType(this.data);
         this.setCommand();
-    }
-    private static getCollapsibleState(data: TestDataItem): TreeItemCollapsibleState {
-        return getTestType(data) === TestType.testFunction ? TreeItemCollapsibleState.None : TreeItemCollapsibleState.Collapsed;
     }
     public get contextValue(): string {
         return this.testType;

--- a/src/test/unittests/explorer/testTreeViewProvider.unit.test.ts
+++ b/src/test/unittests/explorer/testTreeViewProvider.unit.test.ts
@@ -51,7 +51,7 @@ class TestExplorerCaptureRefresh implements IDisposable {
 }
 
 // tslint:disable:max-func-body-length
-suite('xUnit Tests Test Explorer TestTreeViewProvider', () => {
+suite('Unit Tests Test Explorer TestTreeViewProvider', () => {
     const testResource: Uri = Uri.parse('anything');
     let disposables: IDisposable[] = [];
 

--- a/src/test/unittests/explorer/testTreeViewProvider.unit.test.ts
+++ b/src/test/unittests/explorer/testTreeViewProvider.unit.test.ts
@@ -6,7 +6,7 @@
 import { expect } from 'chai';
 import { instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
-import { Uri } from 'vscode';
+import { TreeItemCollapsibleState, Uri } from 'vscode';
 import { CommandManager } from '../../../client/common/application/commandManager';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { Commands } from '../../../client/common/constants';
@@ -15,7 +15,7 @@ import { CommandSource } from '../../../client/unittests/common/constants';
 import { TestCollectionStorageService } from '../../../client/unittests/common/services/storageService';
 import { getTestType } from '../../../client/unittests/common/testUtils';
 import {
-    ITestCollectionStorageService, TestStatus, TestType
+    ITestCollectionStorageService, TestFile, TestFolder, TestStatus, TestType
 } from '../../../client/unittests/common/types';
 import { TestTreeItem } from '../../../client/unittests/explorer/testTreeViewItem';
 import { TestTreeViewProvider } from '../../../client/unittests/explorer/testTreeViewProvider';
@@ -51,7 +51,7 @@ class TestExplorerCaptureRefresh implements IDisposable {
 }
 
 // tslint:disable:max-func-body-length
-suite('Unit Tests Test Explorer TestTreeViewProvider', () => {
+suite('xUnit Tests Test Explorer TestTreeViewProvider', () => {
     const testResource: Uri = Uri.parse('anything');
     let disposables: IDisposable[] = [];
 
@@ -610,5 +610,94 @@ suite('Unit Tests Test Explorer TestTreeViewProvider', () => {
             expect(tests).to.be.lengthOf(0);
             verify(commandManager.executeCommand(Commands.Tests_Discover, testWorkspaceFolder, CommandSource.testExplorer, undefined)).once();
         });
+    });
+    test('Expand tree item if it does not have any parent', async () => {
+        const commandManager = mock(CommandManager);
+        const testStore = mock(TestCollectionStorageService);
+        const testWorkspaceFolder = new TestWorkspaceFolder({ uri: Uri.file(__filename), name: '', index: 0 });
+        when(testStore.getTests(testWorkspaceFolder.workspaceFolder.uri)).thenReturn();
+        when(testStore.onDidChange).thenReturn(noop as any);
+        const testTreeProvider = createMockTestTreeProvider(instance(testStore), undefined, undefined, undefined, instance(commandManager));
+
+        // No parent
+        testTreeProvider.getParent = () => Promise.resolve(undefined);
+
+        const element: TestFile = {
+            fullPath: __filename,
+            functions: [],
+            suites: [],
+            name: 'name',
+            time: 0,
+            resource: Uri.file(__filename),
+            xmlName: '',
+            nameToRun: ''
+        };
+
+        const node = await testTreeProvider.getTreeItem(element);
+
+        expect(node.collapsibleState).to.equal(TreeItemCollapsibleState.Expanded);
+    });
+    test('Expand tree item if the parent is the Workspace Folder in a multiroot scenario', async () => {
+        const commandManager = mock(CommandManager);
+        const testStore = mock(TestCollectionStorageService);
+        const testWorkspaceFolder = new TestWorkspaceFolder({ uri: Uri.file(__filename), name: '', index: 0 });
+        when(testStore.getTests(testWorkspaceFolder.workspaceFolder.uri)).thenReturn();
+        when(testStore.onDidChange).thenReturn(noop as any);
+        const testTreeProvider = createMockTestTreeProvider(instance(testStore), undefined, undefined, undefined, instance(commandManager));
+
+        // Has a workspace folder as parent.
+        const parentFolder = new TestWorkspaceFolder({ name: '', index: 0, uri: Uri.file(__filename) });
+
+        testTreeProvider.getParent = () => Promise.resolve(parentFolder);
+
+        const element: TestFile = {
+            fullPath: __filename,
+            functions: [],
+            suites: [],
+            name: 'name',
+            time: 0,
+            resource: Uri.file(__filename),
+            xmlName: '',
+            nameToRun: ''
+        };
+
+        const node = await testTreeProvider.getTreeItem(element);
+
+        expect(node.collapsibleState).to.equal(TreeItemCollapsibleState.Expanded);
+    });
+    test('Do not expand tree item if it does not have any parent', async () => {
+        const commandManager = mock(CommandManager);
+        const testStore = mock(TestCollectionStorageService);
+        const testWorkspaceFolder = new TestWorkspaceFolder({ uri: Uri.file(__filename), name: '', index: 0 });
+        when(testStore.getTests(testWorkspaceFolder.workspaceFolder.uri)).thenReturn();
+        when(testStore.onDidChange).thenReturn(noop as any);
+        const testTreeProvider = createMockTestTreeProvider(instance(testStore), undefined, undefined, undefined, instance(commandManager));
+
+        // Has a parent folder
+        const parentFolder: TestFolder = {
+            name: '',
+            nameToRun: '',
+            resource: Uri.file(__filename),
+            time: 0,
+            testFiles: [],
+            folders: []
+        };
+
+        testTreeProvider.getParent = () => Promise.resolve(parentFolder);
+
+        const element: TestFile = {
+            fullPath: __filename,
+            functions: [],
+            suites: [],
+            name: 'name',
+            time: 0,
+            resource: Uri.file(__filename),
+            xmlName: '',
+            nameToRun: ''
+        };
+
+        const node = await testTreeProvider.getTreeItem(element);
+
+        expect(node.collapsibleState).to.not.equal(TreeItemCollapsibleState.Expanded);
     });
 });


### PR DESCRIPTION
For #4767

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
