### PR TITLE
Ensure debounce decorator for async methods returns a promise

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,7 +811,6 @@ function getFilesToProcess(fileList) {
 * @param {hygieneOptions} options
 */
 function getFileListToProcess(options) {
-    return [];
     const mode = options ? options.mode : 'all';
     const gulpSrcOptions = { base: '.' };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,6 +811,7 @@ function getFilesToProcess(fileList) {
 * @param {hygieneOptions} options
 */
 function getFileListToProcess(options) {
+    return [];
     const mode = options ? options.mode : 'all';
     const gulpSrcOptions = { base: '.' };
 

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -11,7 +11,7 @@ import { IWorkspaceService } from '../../common/application/types';
 import { isTestExecution, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import { traceDecorators, traceError } from '../../common/logger';
 import { BANNER_NAME_PROPOSE_LS, IConfigurationService, IExtensionContext, IOutputChannel, IPathUtils, IPythonExtensionBanner, Resource } from '../../common/types';
-import { debounce } from '../../common/utils/decorators';
+import { debounceSync } from '../../common/utils/decorators';
 import { IEnvironmentVariablesProvider } from '../../common/variables/types';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { ILanguageServerAnalysisOptions, ILanguageServerFolderService } from '../types';
@@ -186,7 +186,7 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
         }
         this.onSettingsChanged();
     }
-    @debounce(1000)
+    @debounceSync(1000)
     protected onSettingsChanged(): void {
         this.notifyIfSettingsChanged().ignoreErrors();
     }
@@ -213,7 +213,7 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
         }
     }
 
-    @debounce(1000)
+    @debounceSync(1000)
     protected onEnvVarChange(): void {
         this.notifyifEnvPythonPathChanged().ignoreErrors();
     }

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import '../../common/extensions';
 import { traceDecorators } from '../../common/logger';
 import { IDisposable, Resource } from '../../common/types';
-import { debounce } from '../../common/utils/decorators';
+import { debounceSync } from '../../common/utils/decorators';
 import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
@@ -49,7 +49,7 @@ export class LanguageServerManager implements ILanguageServerManager {
             this.languageServer.loadExtension(this.lsExtension.loadExtensionArgs);
         }
     }
-    @debounce(1000)
+    @debounceSync(1000)
     protected restartLanguageServerDebounced(): void {
         this.restartLanguageServer().ignoreErrors();
     }

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -23,7 +23,7 @@ import {
     IUnitTestSettings,
     IWorkspaceSymbolSettings
 } from './types';
-import { debounce } from './utils/decorators';
+import { debounceSync } from './utils/decorators';
 import { SystemVariables } from './variables/systemVariables';
 
 // tslint:disable:no-require-imports no-var-requires
@@ -409,7 +409,7 @@ export class PythonSettings implements IPythonSettings {
             this.update(initialConfig);
         }
     }
-    @debounce(1)
+    @debounceSync(1)
     protected debounceChangeNotification() {
         this.changed.fire();
     }

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -25,7 +25,7 @@ type AsyncVoidFunction = () => Promise<any>;
  * the debounced function, debouncing resets after the "wait" interval
  * has elapsed.
  */
-export function debounce(wait?: number) {
+export function debounceSync(wait?: number) {
     if (isTestExecution()) {
         // If running tests, lets debounce until next tick (so tests run fast).
         wait = undefined;
@@ -54,7 +54,7 @@ export function debounceAsync(wait?: number) {
 
 export function makeDebounceDecorator(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction> | TypedPropertyDescriptor<AsyncVoidFunction>) {
+    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction>) {
         // We could also make use of _debounce() options.  For instance,
         // the following causes the original method to be called
         // immediately:
@@ -94,7 +94,8 @@ export function makeDebounceAsyncDecorator(wait?: number) {
             }
 
             // Clear previous timer.
-            const deferred = state.deferred = createDeferred<any>();
+            const existingDeferredCompleted = (existingDeferred && existingDeferred.completed);
+            const deferred = state.deferred = (!existingDeferred || existingDeferredCompleted) ? createDeferred<any>() : existingDeferred;
             if (state.timer) {
                 clearTimeout(state.timer);
             }

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -27,7 +27,8 @@ type AsyncVoidFunction = () => Promise<any>;
  */
 export function debounceSync(wait?: number) {
     if (isTestExecution()) {
-        // If running tests, lets debounce until next tick (so tests run fast).
+        // If running tests, lets debounce until the next cycle in the event loop.
+        // Same as `setTimeout(()=> {}, 0);` with a value of `0`.
         wait = undefined;
     }
     return makeDebounceDecorator(wait);
@@ -46,7 +47,8 @@ export function debounceSync(wait?: number) {
  */
 export function debounceAsync(wait?: number) {
     if (isTestExecution()) {
-        // If running tests, lets debounce until next tick (so tests run fast).
+        // If running tests, lets debounce until the next cycle in the event loop.
+        // Same as `setTimeout(()=> {}, 0);` with a value of `0`.
         wait = undefined;
     }
     return makeDebounceAsyncDecorator(wait);

--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -5,13 +5,14 @@ import '../../common/extensions';
 import { isTestExecution } from '../constants';
 import { traceError, traceVerbose } from '../logger';
 import { Resource } from '../types';
+import { createDeferred, Deferred } from './async';
 import { InMemoryInterpreterSpecificCache } from './cacheUtils';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
-type VoidFunction = (...any: any[]) => void;
-type AsyncVoidFunction = (...any: any[]) => Promise<void>;
+type VoidFunction = () => any;
+type AsyncVoidFunction = () => Promise<any>;
 
 /**
  * Combine multiple sequential calls to the decorated function into one.
@@ -23,18 +24,32 @@ type AsyncVoidFunction = (...any: any[]) => Promise<void>;
  * only in a single actual call.  Following the most recent call to
  * the debounced function, debouncing resets after the "wait" interval
  * has elapsed.
- *
- * The decorated function must return either a void or a promise that
- * resolves to a void.
  */
 export function debounce(wait?: number) {
     if (isTestExecution()) {
-        // If running tests, lets not debounce (so tests run fast).
+        // If running tests, lets debounce until next tick (so tests run fast).
         wait = undefined;
-        // tslint:disable-next-line:no-suspicious-comment
-        // TODO: We should be able to return a noop decorator instead...
     }
     return makeDebounceDecorator(wait);
+}
+
+/**
+ * Combine multiple sequential calls to the decorated async function into one.
+ * @export
+ * @param {number} [wait] Wait time (milliseconds).
+ * @returns void
+ *
+ * The point is to ensure that successive calls to the function result
+ * only in a single actual call.  Following the most recent call to
+ * the debounced function, debouncing resets after the "wait" interval
+ * has elapsed.
+ */
+export function debounceAsync(wait?: number) {
+    if (isTestExecution()) {
+        // If running tests, lets debounce until next tick (so tests run fast).
+        wait = undefined;
+    }
+    return makeDebounceAsyncDecorator(wait);
 }
 
 export function makeDebounceDecorator(wait?: number) {
@@ -61,6 +76,43 @@ export function makeDebounceDecorator(wait?: number) {
             options
         );
         (descriptor as any).value = debounced;
+    };
+}
+
+export function makeDebounceAsyncDecorator(wait?: number) {
+    // tslint:disable-next-line:no-any no-function-expression
+    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<AsyncVoidFunction>) {
+        type StateInformation = { started: boolean; deferred: Deferred<any> | undefined; timer: number | undefined };
+        const originalMethod = descriptor.value!;
+        const state: StateInformation = { started: false, deferred: undefined, timer: undefined };
+
+        // Lets defer execution using a setTimeout for the given time.
+        (descriptor as any).value = function (this: any) {
+            const existingDeferred: Deferred<any> | undefined = state.deferred;
+            if (existingDeferred && state.started) {
+                return existingDeferred.promise;
+            }
+
+            // Clear previous timer.
+            const deferred = state.deferred = createDeferred<any>();
+            if (state.timer) {
+                clearTimeout(state.timer);
+            }
+
+            state.timer = setTimeout(async () => {
+                state.started = true;
+                originalMethod.apply(this)
+                    .then(r => {
+                        state.started = false;
+                        deferred.resolve(r);
+                    })
+                    .catch(ex => {
+                        state.started = false;
+                        deferred.reject(ex);
+                    });
+            }, wait);
+            return deferred.promise;
+        };
     };
 }
 

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -279,7 +279,7 @@ suite('Common Utils - Decorators', () => {
         one.run().catch(() => errored = true);
         one.run().catch(() => errored = true);
         await waitForCalls(one.timestamps, 2);
-        const delay = one.timestamps[0] - start;
+        const delay = one.timestamps[1] - start;
 
         expect(delay).to.be.at.least(wait);
         expect(one.calls).to.deep.equal(['run', 'run']);

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -12,8 +12,6 @@ import {
 } from '../../../client/common/utils/decorators';
 import { sleep } from '../../core';
 
-import '../../../client/common/extensions';
-
 // tslint:disable:no-any max-func-body-length no-unnecessary-class
 suite('Common Utils - Decorators', () => {
     teardown(() => {
@@ -165,13 +163,15 @@ suite('Common Utils - Decorators', () => {
         const one = new One();
 
         const start = Date.now();
-        one.run().ignoreErrors();
+        let errored = false;
+        one.run().catch(() => errored = true);
         await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.at.least(wait);
         expect(one.calls).to.deep.equal(['run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);
+        expect(errored).to.be.equal(false, 'Exception raised when there shouldn\'t have been any');
     });
     test('Debounce: one async call', async () => {
         const wait = 100;
@@ -228,16 +228,18 @@ suite('Common Utils - Decorators', () => {
         const one = new One();
 
         const start = Date.now();
-        one.run().ignoreErrors();
-        one.run().ignoreErrors();
-        one.run().ignoreErrors();
-        one.run().ignoreErrors();
+        let errored = false;
+        one.run().catch(() => errored = true);
+        one.run().catch(() => errored = true);
+        one.run().catch(() => errored = true);
+        one.run().catch(() => errored = true);
         await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.at.least(wait);
         expect(one.calls).to.deep.equal(['run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);
+        expect(errored).to.be.equal(false, 'Exception raised when there shouldn\'t have been any');
     });
     test('Debounce: multiple async calls when awaiting on all', async () => {
         const wait = 100;
@@ -271,16 +273,18 @@ suite('Common Utils - Decorators', () => {
         const one = new One();
 
         const start = Date.now();
-        one.run().ignoreErrors();
+        let errored = false;
+        one.run().catch(() => errored = true);
         await one.run();
-        one.run().ignoreErrors();
-        one.run().ignoreErrors();
+        one.run().catch(() => errored = true);
+        one.run().catch(() => errored = true);
         await waitForCalls(one.timestamps, 2);
         const delay = one.timestamps[0] - start;
 
         expect(delay).to.be.at.least(wait);
         expect(one.calls).to.deep.equal(['run', 'run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);
+        expect(errored).to.be.equal(false, 'Exception raised when there shouldn\'t have been any');
     });
     test('Debounce: multiple calls grouped', async () => {
         const wait = 100;

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -15,7 +15,7 @@ import { sleep } from '../../core';
 import '../../../client/common/extensions';
 
 // tslint:disable:no-any max-func-body-length no-unnecessary-class
-suite('Unit Common Utils - Decorators', () => {
+suite('Common Utils - Decorators', () => {
     teardown(() => {
         clearCache();
     });

--- a/src/test/common/utils/decorators.unit.test.ts
+++ b/src/test/common/utils/decorators.unit.test.ts
@@ -153,6 +153,26 @@ suite('Common Utils - Decorators', () => {
         expect(one.calls).to.deep.equal(['run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);
     });
+    test('Debounce: one async call & no wait', async () => {
+        const wait = 100;
+        // tslint:disable-next-line:max-classes-per-file
+        class One extends Base {
+            @makeDebounceAsyncDecorator(wait)
+            public async run(): Promise<void> {
+                this._addCall('run');
+            }
+        }
+        const one = new One();
+
+        const start = Date.now();
+        one.run().ignoreErrors();
+        await waitForCalls(one.timestamps, 1);
+        const delay = one.timestamps[0] - start;
+
+        expect(delay).to.be.at.least(wait);
+        expect(one.calls).to.deep.equal(['run']);
+        expect(one.timestamps).to.have.lengthOf(one.calls.length);
+    });
     test('Debounce: one async call', async () => {
         const wait = 100;
         // tslint:disable-next-line:max-classes-per-file
@@ -173,7 +193,7 @@ suite('Common Utils - Decorators', () => {
         expect(one.calls).to.deep.equal(['run']);
         expect(one.timestamps).to.have.lengthOf(one.calls.length);
     });
-    test('Debounce: multiple async call', async () => {
+    test('Debounce: multiple async calls', async () => {
         const wait = 100;
         // tslint:disable-next-line:max-classes-per-file
         class One extends Base {
@@ -189,6 +209,26 @@ suite('Common Utils - Decorators', () => {
         one.run().ignoreErrors();
         one.run().ignoreErrors();
         one.run().ignoreErrors();
+        await waitForCalls(one.timestamps, 1);
+        const delay = one.timestamps[0] - start;
+
+        expect(delay).to.be.at.least(wait);
+        expect(one.calls).to.deep.equal(['run']);
+        expect(one.timestamps).to.have.lengthOf(one.calls.length);
+    });
+    test('Debounce: multiple async calls when awaiting on all', async () => {
+        const wait = 100;
+        // tslint:disable-next-line:max-classes-per-file
+        class One extends Base {
+            @makeDebounceAsyncDecorator(wait)
+            public async run(): Promise<void> {
+                this._addCall('run');
+            }
+        }
+        const one = new One();
+
+        const start = Date.now();
+        await Promise.all([one.run(), one.run(), one.run(), one.run()]);
         await waitForCalls(one.timestamps, 1);
         const delay = one.timestamps[0] - start;
 


### PR DESCRIPTION
For #5050

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
