### PR TITLE
Auto expand failed tests in test explorer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -811,7 +811,6 @@ function getFilesToProcess(fileList) {
 * @param {hygieneOptions} options
 */
 function getFileListToProcess(options) {
-    return [];
     const mode = options ? options.mode : 'all';
     const gulpSrcOptions = { base: '.' };
 

--- a/news/1 Enhancements/4386.md
+++ b/news/1 Enhancements/4386.md
@@ -1,0 +1,1 @@
+Auto expand tree view in `Test Explorer` to display failed tests.

--- a/src/client/common/application/applicationShell.ts
+++ b/src/client/common/application/applicationShell.ts
@@ -5,7 +5,7 @@
 // tslint:disable:no-var-requires no-any unified-signatures
 
 import { injectable } from 'inversify';
-import { CancellationToken, Disposable, env, InputBox, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, Progress, ProgressOptions, QuickPick, QuickPickItem, QuickPickOptions, SaveDialogOptions, StatusBarAlignment, StatusBarItem, Uri, window, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
+import { CancellationToken, Disposable, env, InputBox, InputBoxOptions, MessageItem, MessageOptions, OpenDialogOptions, Progress, ProgressOptions, QuickPick, QuickPickItem, QuickPickOptions, SaveDialogOptions, StatusBarAlignment, StatusBarItem, TreeView, TreeViewOptions, Uri, window, WorkspaceFolder, WorkspaceFolderPickOptions } from 'vscode';
 import { IApplicationShell } from './types';
 
 @injectable()
@@ -75,4 +75,8 @@ export class ApplicationShell implements IApplicationShell {
     public createInputBox(): InputBox {
         return window.createInputBox();
     }
+    public createTreeView<T>(viewId: string, options: TreeViewOptions<T>): TreeView<T> {
+        return window.createTreeView<T>(viewId, options);
+    }
+
 }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -70,6 +70,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Tests_Select_And_Run_File]: [undefined, CommandSource];
     [Commands.Tests_Run_Current_File]: [undefined, CommandSource];
     [Commands.Tests_Stop]: [undefined, Uri];
+    [Commands.Test_Reveal_Test_Item]: [TestDataItem];
     // When command is invoked from a tree node, first argument is the node data.
     [Commands.Tests_Run]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri, undefined | TestsToRun];
     // When command is invoked from a tree node, first argument is the node data.

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -37,6 +37,8 @@ import {
     TextEditorOptionsChangeEvent,
     TextEditorSelectionChangeEvent,
     TextEditorViewColumnChangeEvent,
+    TreeView,
+    TreeViewOptions,
     Uri,
     ViewColumn,
     WorkspaceConfiguration,
@@ -331,6 +333,14 @@ export interface IApplicationShell {
      * @return The thenable the task-callback returned.
      */
     withProgress<R>(options: ProgressOptions, task: (progress: Progress<{ message?: string; increment?: number }>, token: CancellationToken) => Thenable<R>): Thenable<R>;
+
+    /**
+     * Create a [TreeView](#TreeView) for the view contributed using the extension point `views`.
+     * @param viewId Id of the view contributed using the extension point `views`.
+     * @param options Options for creating the [TreeView](#TreeView)
+     * @returns a [TreeView](#TreeView).
+     */
+    createTreeView<T>(viewId: string, options: TreeViewOptions<T>): TreeView<T>;
 }
 
 export const ICommandManager = Symbol('ICommandManager');

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -30,6 +30,7 @@ export namespace Commands {
     export const Tests_Ask_To_Stop_Test = 'python.askToStopUnitTests';
     export const Tests_Ask_To_Stop_Discovery = 'python.askToStopUnitTestDiscovery';
     export const Tests_Stop = 'python.stopUnitTests';
+    export const Test_Reveal_Test_Item = 'python.revealTestItem';
     export const ViewOutput = 'python.viewOutput';
     export const Tests_ViewOutput = 'python.viewTestOutput';
     export const Tests_Select_And_Run_Method = 'python.selectAndRunTestMethod';

--- a/src/client/unittests/explorer/failedTestHandler.ts
+++ b/src/client/unittests/explorer/failedTestHandler.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { IExtensionActivationService } from '../../activation/types';
+import { ICommandManager } from '../../common/application/types';
+import { Commands } from '../../common/constants';
+import '../../common/extensions';
+import { IDisposable, IDisposableRegistry, Resource } from '../../common/types';
+import { debounceAsync } from '../../common/utils/decorators';
+import { getTestType } from '../common/testUtils';
+import { ITestCollectionStorageService, TestStatus, TestType } from '../common/types';
+import { TestDataItem } from '../types';
+
+@injectable()
+export class FailedTestHandler implements IExtensionActivationService, IDisposable {
+    private readonly disposables: IDisposable[] = [];
+    private readonly failedItems: TestDataItem[] = [];
+    constructor(@inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(ITestCollectionStorageService) private readonly storage: ITestCollectionStorageService) {
+        disposableRegistry.push(this);
+    }
+    public dispose() {
+        this.disposables.forEach(d => d.dispose());
+    }
+    public async activate(_resource: Resource): Promise<void> {
+        this.storage.onDidChange(this.onDidChangeTestData, this, this.disposables);
+    }
+    public onDidChangeTestData(args: { uri: Uri; data?: TestDataItem }): void {
+        if (args.data && (args.data.status === TestStatus.Error || args.data.status === TestStatus.Fail)) {
+            const type = getTestType(args.data);
+            if (type === TestType.testFunction || type === TestType.testSuite) {
+                this.failedItems.push(args.data);
+                this.revealFailedNodes().ignoreErrors();
+            }
+        }
+    }
+
+    @debounceAsync(500)
+    private async revealFailedNodes(): Promise<void> {
+        while (this.failedItems.length > 0) {
+            const item = this.failedItems.pop()!;
+            await this.commandManager.executeCommand(Commands.Test_Reveal_Test_Item, item);
+        }
+    }
+}

--- a/src/client/unittests/explorer/failedTestHandler.ts
+++ b/src/client/unittests/explorer/failedTestHandler.ts
@@ -31,12 +31,10 @@ export class FailedTestHandler implements IExtensionActivationService, IDisposab
         this.storage.onDidChange(this.onDidChangeTestData, this, this.disposables);
     }
     public onDidChangeTestData(args: { uri: Uri; data?: TestDataItem }): void {
-        if (args.data && (args.data.status === TestStatus.Error || args.data.status === TestStatus.Fail)) {
-            const type = getTestType(args.data);
-            if (type === TestType.testFunction || type === TestType.testSuite) {
-                this.failedItems.push(args.data);
-                this.revealFailedNodes().ignoreErrors();
-            }
+        if (args.data && (args.data.status === TestStatus.Error || args.data.status === TestStatus.Fail) &&
+            getTestType(args.data) === TestType.testFunction) {
+            this.failedItems.push(args.data);
+            this.revealFailedNodes().ignoreErrors();
         }
     }
 

--- a/src/client/unittests/explorer/treeView.ts
+++ b/src/client/unittests/explorer/treeView.ts
@@ -30,9 +30,9 @@ export class TreeViewService implements IExtensionActivationService, IDisposable
     public async activate(_resource: Resource): Promise<void> {
         this._treeView = this.appShell.createTreeView('python_tests', { showCollapseAll: true, treeDataProvider: this.treeViewProvider });
         this.disposables.push(this._treeView);
-        this.disposables.push(this.commandManager.registerCommand(Commands.Test_Reveal_Test_Item, this.onRevalTestItem, this));
+        this.disposables.push(this.commandManager.registerCommand(Commands.Test_Reveal_Test_Item, this.onRevealTestItem, this));
     }
-    public async onRevalTestItem(testItem: TestDataItem): Promise<void> {
+    public async onRevealTestItem(testItem: TestDataItem): Promise<void> {
         await this.treeView.reveal(testItem);
     }
 }

--- a/src/client/unittests/explorer/treeView.ts
+++ b/src/client/unittests/explorer/treeView.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { TreeView } from 'vscode';
+import { IExtensionActivationService } from '../../activation/types';
+import { IApplicationShell, ICommandManager } from '../../common/application/types';
+import { Commands } from '../../common/constants';
+import { IDisposable, IDisposableRegistry, Resource } from '../../common/types';
+import { ITestTreeViewProvider, TestDataItem } from '../types';
+
+@injectable()
+export class TreeViewService implements IExtensionActivationService, IDisposable {
+    private _treeView!: TreeView<TestDataItem>;
+    private readonly disposables: IDisposable[] = [];
+    public get treeView(): TreeView<TestDataItem> {
+        return this._treeView;
+    }
+    constructor(@inject(ITestTreeViewProvider) private readonly treeViewProvider: ITestTreeViewProvider,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+        @inject(IApplicationShell) private readonly appShell: IApplicationShell,
+        @inject(ICommandManager) private readonly commandManager: ICommandManager) {
+        disposableRegistry.push(this);
+    }
+    public dispose() {
+        this.disposables.forEach(d => d.dispose());
+    }
+    public async activate(_resource: Resource): Promise<void> {
+        this._treeView = this.appShell.createTreeView('python_tests', { showCollapseAll: true, treeDataProvider: this.treeViewProvider });
+        this.disposables.push(this._treeView);
+        this.disposables.push(this.commandManager.registerCommand(Commands.Test_Reveal_Test_Item, this.onRevalTestItem, this));
+    }
+    public async onRevalTestItem(testItem: TestDataItem): Promise<void> {
+        await this.treeView.reveal(testItem);
+    }
+}

--- a/src/client/unittests/main.ts
+++ b/src/client/unittests/main.ts
@@ -6,7 +6,7 @@ import { inject, injectable } from 'inversify';
 import {
     ConfigurationChangeEvent, Disposable,
     DocumentSymbolProvider, Event,
-    EventEmitter, OutputChannel, TextDocument, Uri, window
+    EventEmitter, OutputChannel, TextDocument, Uri
 } from 'vscode';
 import {
     IApplicationShell, ICommandManager, IDocumentManager, IWorkspaceService
@@ -32,7 +32,7 @@ import {
     TestFunction, TestStatus, TestsToRun
 } from './common/types';
 import {
-    ITestDisplay, ITestResultDisplay, ITestTreeViewProvider,
+    ITestDisplay, ITestResultDisplay,
     IUnitTestConfigurationService, IUnitTestManagementService,
     TestWorkspaceFolder,
     WorkspaceTestStatus
@@ -84,14 +84,9 @@ export class UnitTestManagementService implements IUnitTestManagementService, Di
         }
         this.activatedOnce = true;
         this.workspaceTestManagerService = this.serviceContainer.get<IWorkspaceTestManagerService>(IWorkspaceTestManagerService);
-        const disposablesRegistry = this.serviceContainer.get<Disposable[]>(IDisposableRegistry);
 
         this.registerHandlers();
         this.registerCommands();
-
-        const testViewProvider = this.serviceContainer.get<ITestTreeViewProvider>(ITestTreeViewProvider);
-        const disposable = window.registerTreeDataProvider('python_tests', testViewProvider);
-        disposablesRegistry.push(disposable);
 
         this.autoDiscoverTests(undefined)
             .catch(ex => this.serviceContainer.get<ILogger>(ILogger).logError('Failed to auto discover tests upon activation', ex));

--- a/src/client/unittests/serviceRegistry.ts
+++ b/src/client/unittests/serviceRegistry.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { Uri } from 'vscode';
+import { IExtensionActivationService } from '../activation/types';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { ArgumentsHelper } from './common/argumentsHelper';
 import { NOSETEST_PROVIDER, PYTEST_PROVIDER, UNITTEST_PROVIDER } from './common/constants';
@@ -31,7 +32,9 @@ import { TestConfigurationManagerFactory } from './configurationFactory';
 import { TestResultDisplay } from './display/main';
 import { TestDisplay } from './display/picker';
 import { TestExplorerCommandHandler } from './explorer/commandHandlers';
+import { FailedTestHandler } from './explorer/failedTestHandler';
 import { TestTreeViewProvider } from './explorer/testTreeViewProvider';
+import { TreeViewService } from './explorer/treeView';
 import { UnitTestManagementService } from './main';
 import { registerTypes as registerNavigationTypes } from './navigation/serviceRegistry';
 import { ITestExplorerCommandHandler } from './navigation/types';
@@ -50,8 +53,8 @@ import {
     IArgumentsHelper, IArgumentsService, ITestConfigSettingsService,
     ITestConfigurationManagerFactory, ITestDataItemResource, ITestDisplay,
     ITestManagerRunner, ITestResultDisplay, ITestTreeViewProvider,
-    IUnitTestConfigurationService, IUnitTestDiagnosticService,
-    IUnitTestHelper, IUnitTestManagementService
+    IUnitTestConfigurationService,
+    IUnitTestDiagnosticService, IUnitTestHelper, IUnitTestManagementService
 } from './types';
 import { UnitTestHelper } from './unittest/helper';
 import { TestManager as UnitTestTestManager } from './unittest/main';
@@ -109,6 +112,8 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ITestTreeViewProvider>(ITestTreeViewProvider, TestTreeViewProvider);
     serviceManager.addSingleton<ITestDataItemResource>(ITestDataItemResource, TestTreeViewProvider);
     serviceManager.addSingleton<ITestExplorerCommandHandler>(ITestExplorerCommandHandler, TestExplorerCommandHandler);
+    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, TreeViewService);
+    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, FailedTestHandler);
 
     serviceManager.addFactory<ITestManager>(ITestManagerFactory, (context) => {
         return (testProvider: TestProvider, workspaceFolder: Uri, rootDirectory: string) => {

--- a/src/test/unittests/explorer/failedTestHandler.unit.test.ts
+++ b/src/test/unittests/explorer/failedTestHandler.unit.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Uri } from 'vscode';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { ICommandManager } from '../../../client/common/application/types';
+import { Commands } from '../../../client/common/constants';
+import { TestCollectionStorageService } from '../../../client/unittests/common/services/storageService';
+import { ITestCollectionStorageService, TestFunction, TestStatus, TestSuite } from '../../../client/unittests/common/types';
+import { FailedTestHandler } from '../../../client/unittests/explorer/failedTestHandler';
+import { noop, sleep } from '../../core';
+
+// tslint:disable:no-any
+
+suite('Unit Tests Test Explorer View Items', () => {
+    let failedTestHandler: FailedTestHandler;
+    let commandManager: ICommandManager;
+    let testStorageService: ITestCollectionStorageService;
+    setup(() => {
+        commandManager = mock(CommandManager);
+        testStorageService = mock(TestCollectionStorageService);
+        failedTestHandler = new FailedTestHandler([], instance(commandManager), instance(testStorageService));
+    });
+
+    test('Activation will add command handlers (without a resource)', async () => {
+        when(testStorageService.onDidChange).thenReturn(noop as any);
+
+        await failedTestHandler.activate(undefined);
+
+        verify(testStorageService.onDidChange).once();
+    });
+    test('Activation will add command handlers (with a resource)', async () => {
+        when(testStorageService.onDidChange).thenReturn(noop as any);
+
+        await failedTestHandler.activate(Uri.file(__filename));
+
+        verify(testStorageService.onDidChange).once();
+    });
+    test('Change handler will invoke the command to reveal the nodes (for failed and errored items)', async () => {
+        const uri = Uri.file(__filename);
+        const failedFunc1: TestFunction = { name: 'fn1', time: 0, resource: uri, nameToRun: 'fn1', status: TestStatus.Error };
+        const failedFunc2: TestFunction = { name: 'fn2', time: 0, resource: uri, nameToRun: 'fn2', status: TestStatus.Fail };
+        const failedSuite1: TestSuite = {
+            name: 'suite1', time: 0, resource: uri, nameToRun: 'suite1',
+            functions: [], isInstance: false, isUnitTest: false, suites: [], xmlName: 'suite1',
+            status: TestStatus.Error
+        };
+        when(commandManager.executeCommand(Commands.Test_Reveal_Test_Item, anything())).thenResolve();
+
+        failedTestHandler.onDidChangeTestData({ uri, data: failedFunc1 });
+        failedTestHandler.onDidChangeTestData({ uri, data: failedFunc2 });
+        failedTestHandler.onDidChangeTestData({ uri, data: failedSuite1 });
+
+        // wait for debouncing to take effect.
+        await sleep(1);
+
+        verify(commandManager.executeCommand(Commands.Test_Reveal_Test_Item, anything())).times(3);
+        verify(commandManager.executeCommand(Commands.Test_Reveal_Test_Item, failedFunc1)).once();
+        verify(commandManager.executeCommand(Commands.Test_Reveal_Test_Item, failedFunc2)).once();
+        verify(commandManager.executeCommand(Commands.Test_Reveal_Test_Item, failedSuite1)).once();
+    });
+});

--- a/src/test/unittests/explorer/treeView.unit.test.ts
+++ b/src/test/unittests/explorer/treeView.unit.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import * as typemoq from 'typemoq';
+import { TreeView, Uri } from 'vscode';
+import { ApplicationShell } from '../../../client/common/application/applicationShell';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { IApplicationShell, ICommandManager } from '../../../client/common/application/types';
+import { Commands } from '../../../client/common/constants';
+import { TestTreeViewProvider } from '../../../client/unittests/explorer/testTreeViewProvider';
+import { TreeViewService } from '../../../client/unittests/explorer/treeView';
+import { ITestTreeViewProvider, TestDataItem } from '../../../client/unittests/types';
+
+// tslint:disable:no-any
+
+suite('Unit Tests Test Explorer Tree View', () => {
+    let treeViewService: TreeViewService;
+    let treeView: typemoq.IMock<TreeView<TestDataItem>>;
+    let commandManager: ICommandManager;
+    let appShell: IApplicationShell;
+    let treeViewProvider: ITestTreeViewProvider;
+    setup(() => {
+        commandManager = mock(CommandManager);
+        treeViewProvider = mock(TestTreeViewProvider);
+        appShell = mock(ApplicationShell);
+        treeView = typemoq.Mock.ofType<TreeView<TestDataItem>>();
+        treeViewService = new TreeViewService(instance(treeViewProvider), [],
+            instance(appShell), instance(commandManager));
+    });
+
+    test('Activation will create the treeview (without a resource)', async () => {
+        await treeViewService.activate(undefined);
+        verify(appShell.createTreeView('python_tests', deepEqual({ showCollapseAll: true, treeDataProvider: instance(treeViewProvider) }))).once();
+    });
+    test('Activation will create the treeview (with a resource)', async () => {
+        await treeViewService.activate(Uri.file(__filename));
+        verify(appShell.createTreeView('python_tests', deepEqual({ showCollapseAll: true, treeDataProvider: instance(treeViewProvider) }))).once();
+    });
+    test('Activation will add command handlers (without a resource)', async () => {
+        await treeViewService.activate(undefined);
+        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevalTestItem, treeViewService)).once();
+    });
+    test('Activation will add command handlers (with a resource)', async () => {
+        await treeViewService.activate(Uri.file(__filename));
+        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevalTestItem, treeViewService)).once();
+    });
+    test('Invoking the command handler will reveal the node in the tree', async () => {
+        const data = {} as any;
+        treeView
+            .setup(t => t.reveal(typemoq.It.isAny()))
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.once());
+        when(appShell.createTreeView('python_tests', anything())).thenReturn(treeView.object);
+
+        await treeViewService.activate(undefined);
+        await treeViewService.onRevalTestItem(data);
+
+        treeView.verifyAll();
+    });
+});

--- a/src/test/unittests/explorer/treeView.unit.test.ts
+++ b/src/test/unittests/explorer/treeView.unit.test.ts
@@ -41,11 +41,11 @@ suite('Unit Tests Test Explorer Tree View', () => {
     });
     test('Activation will add command handlers (without a resource)', async () => {
         await treeViewService.activate(undefined);
-        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevalTestItem, treeViewService)).once();
+        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevealTestItem, treeViewService)).once();
     });
     test('Activation will add command handlers (with a resource)', async () => {
         await treeViewService.activate(Uri.file(__filename));
-        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevalTestItem, treeViewService)).once();
+        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevealTestItem, treeViewService)).once();
     });
     test('Invoking the command handler will reveal the node in the tree', async () => {
         const data = {} as any;
@@ -56,7 +56,7 @@ suite('Unit Tests Test Explorer Tree View', () => {
         when(appShell.createTreeView('python_tests', anything())).thenReturn(treeView.object);
 
         await treeViewService.activate(undefined);
-        await treeViewService.onRevalTestItem(data);
+        await treeViewService.onRevealTestItem(data);
 
         treeView.verifyAll();
     });


### PR DESCRIPTION
For #4386

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
