### PR TITLE
Use HTTP for LS download when "http.proxyStrictSSL" setting is false.

### DIFF
--- a/.github/test_plan.md
+++ b/.github/test_plan.md
@@ -123,6 +123,7 @@ SPAM='hello ${WHO}'
 
 #### Language server
 
+- [ ] LS is downloaded using HTTP (no SSL) when the "http.proxyStrictSSL" setting is false
 - [ ] Installing [`requests`](https://pypi.org/project/requests/) in virtual environment is detected
     - [ ] Import of `requests` without package installed is flagged as unresolved
     - [ ] Create a virtual environment

--- a/news/1 Enhancements/2849.md
+++ b/news/1 Enhancements/2849.md
@@ -1,0 +1,1 @@
+Download the language server using HTTP if "http.proxyStrictSSL" is set to true.

--- a/src/client/activation/languageServer/activator.ts
+++ b/src/client/activation/languageServer/activator.ts
@@ -26,13 +26,13 @@ import {
  */
 @injectable()
 export class LanguageServerExtensionActivator implements ILanguageServerActivator {
+    private resource?: Resource;
     constructor(
         @inject(ILanguageServerManager) private readonly manager: ILanguageServerManager,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(ILanguageServerDownloader) private readonly lsDownloader: ILanguageServerDownloader,
-        @inject(ILanguageServerFolderService)
-        private readonly languageServerFolderService: ILanguageServerFolderService,
+        @inject(ILanguageServerFolderService) private readonly languageServerFolderService: ILanguageServerFolderService,
         @inject(IConfigurationService) private readonly configurationService: IConfigurationService
     ) { }
     @traceDecorators.error('Failed to activate language server')
@@ -42,6 +42,7 @@ export class LanguageServerExtensionActivator implements ILanguageServerActivato
                 ? this.workspace.workspaceFolders![0].uri
                 : undefined;
         }
+        this.resource = resource;
         await this.ensureLanguageServerIsAvailable(resource);
         await this.manager.start(resource);
     }
@@ -58,7 +59,7 @@ export class LanguageServerExtensionActivator implements ILanguageServerActivato
         const languageServerFolderPath = path.join(EXTENSION_ROOT_DIR, languageServerFolder);
         const mscorlib = path.join(languageServerFolderPath, 'mscorlib.dll');
         if (!(await this.fs.fileExists(mscorlib))) {
-            await this.lsDownloader.downloadLanguageServer(languageServerFolderPath);
+            await this.lsDownloader.downloadLanguageServer(languageServerFolderPath, this.resource);
         }
     }
 }

--- a/src/client/activation/languageServer/activator.ts
+++ b/src/client/activation/languageServer/activator.ts
@@ -55,7 +55,7 @@ export class LanguageServerExtensionActivator implements ILanguageServerActivato
         if (!settings.downloadLanguageServer) {
             return;
         }
-        const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName();
+        const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName(resource);
         const languageServerFolderPath = path.join(EXTENSION_ROOT_DIR, languageServerFolder);
         const mscorlib = path.join(languageServerFolderPath, 'mscorlib.dll');
         if (!(await this.fs.fileExists(mscorlib))) {

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -38,7 +38,7 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
     }
     public async initialize(resource: Resource) {
         this.resource = resource;
-        this.languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName();
+        this.languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName(resource);
 
         let disposable = this.workspace.onDidChangeConfiguration(this.onSettingsChangedHandler, this);
         this.disposables.push(disposable);

--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -38,17 +38,12 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
     ) {
     }
 
-    public async getDownloadInfo(resource?: Resource) {
+    public async getDownloadInfo(resource: Resource) {
         const info = await this.lsFolderService.getLatestLanguageServerVersion()
             .then(item => item!);
 
         let uri = info.uri;
         if (uri.startsWith('https:')) {
-            if (!resource) {
-                resource = this.workspace.hasWorkspaceFolders
-                    ? this.workspace.workspaceFolders![0].uri
-                    : undefined;
-            }
             const cfg = this.workspace.getConfiguration('http', resource);
             if (!cfg.get<boolean>('proxyStrictSSL', true)) {
                 // tslint:disable-next-line:no-http-string
@@ -58,7 +53,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
 
         return [uri, info.version.raw];
     }
-    public async downloadLanguageServer(destinationFolder: string, resource?: Resource): Promise<void> {
+    public async downloadLanguageServer(destinationFolder: string, resource: Resource): Promise<void> {
         const [downloadUri, lsVersion] = await this.getDownloadInfo(resource);
         const timer: StopWatch = new StopWatch();
         let success: boolean = true;

--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -6,7 +6,7 @@
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
 import { ProgressLocation, window } from 'vscode';
-import { IApplicationShell } from '../../common/application/types';
+import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import '../../common/extensions';
 import { IFileSystem } from '../../common/platform/types';
@@ -33,7 +33,8 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
         @inject(IHttpClient) private readonly httpClient: IHttpClient,
         @inject(ILanguageServerFolderService) private readonly lsFolderService: ILanguageServerFolderService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
-        @inject(IFileSystem) private readonly fs: IFileSystem
+        @inject(IFileSystem) private readonly fs: IFileSystem,
+        @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
     ) {
     }
 
@@ -41,6 +42,8 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
         const info = await this.lsFolderService.getLatestLanguageServerVersion()
             .then(item => item!);
         const uri = info.uri;
+        // tslint:disable-next-line:no-unused-expression
+        this.workspace;
         return [uri, info.version.raw];
     }
     public async downloadLanguageServer(destinationFolder: string): Promise<void> {

--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -75,10 +75,11 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_ERROR, undefined, { error: 'Failed to download (platform)' }, err);
             throw new Error(err);
         } finally {
+            const usedSSL = downloadUri.startsWith('https:');
             sendTelemetryEvent(
                 EventName.PYTHON_LANGUAGE_SERVER_DOWNLOADED,
                 timer.elapsedTime,
-                { success, lsVersion }
+                { success, lsVersion, usedSSL }
             );
         }
 

--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -55,7 +55,8 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             this.output.appendLine(LanguageService.downloadFailedOutputMessage());
             this.output.appendLine(err);
             success = false;
-            this.showMessageAndOptionallyShowOutput(LanguageService.lsFailedToDownload()).ignoreErrors();
+            this.showMessageAndOptionallyShowOutput(LanguageService.lsFailedToDownload())
+                .ignoreErrors();
             sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_ERROR, undefined, { error: 'Failed to download (platform)' }, err);
             throw new Error(err);
         } finally {
@@ -73,7 +74,8 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             this.output.appendLine(LanguageService.extractionFailedOutputMessage());
             this.output.appendLine(err);
             success = false;
-            this.showMessageAndOptionallyShowOutput(LanguageService.lsFailedToExtract()).ignoreErrors();
+            this.showMessageAndOptionallyShowOutput(LanguageService.lsFailedToExtract())
+                .ignoreErrors();
             sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_ERROR, undefined, { error: 'Failed to extract (platform)' }, err);
             throw new Error(err);
         } finally {

--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -39,7 +39,7 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
     }
 
     public async getDownloadInfo(resource: Resource) {
-        const info = await this.lsFolderService.getLatestLanguageServerVersion()
+        const info = await this.lsFolderService.getLatestLanguageServerVersion(resource)
             .then(item => item!);
 
         let uri = info.uri;

--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -38,12 +38,13 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
     }
 
     public async getDownloadInfo() {
-        return this.lsFolderService.getLatestLanguageServerVersion().then(item => item!);
+        const info = await this.lsFolderService.getLatestLanguageServerVersion()
+            .then(item => item!);
+        const uri = info.uri;
+        return [uri, info.version.raw];
     }
     public async downloadLanguageServer(destinationFolder: string): Promise<void> {
-        const downloadInfo = await this.getDownloadInfo();
-        const downloadUri = downloadInfo.uri;
-        const lsVersion = downloadInfo.version.raw;
+        const [downloadUri, lsVersion] = await this.getDownloadInfo();
         const timer: StopWatch = new StopWatch();
         let success: boolean = true;
         let localTempFilePath = '';

--- a/src/client/activation/languageServer/languageClientFactory.ts
+++ b/src/client/activation/languageServer/languageClientFactory.ts
@@ -51,8 +51,8 @@ export class BaseLanguageClientFactory implements ILanguageClientFactory {
 export class DownloadedLanguageClientFactory implements ILanguageClientFactory {
     constructor(@inject(IPlatformData) private readonly platformData: IPlatformData,
         @inject(ILanguageServerFolderService) private readonly languageServerFolderService: ILanguageServerFolderService) { }
-    public async createLanguageClient(_resource: Resource, clientOptions: LanguageClientOptions, env?: NodeJS.ProcessEnv): Promise<LanguageClient> {
-        const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName();
+    public async createLanguageClient(resource: Resource, clientOptions: LanguageClientOptions, env?: NodeJS.ProcessEnv): Promise<LanguageClient> {
+        const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName(resource);
         const serverModule = path.join(EXTENSION_ROOT_DIR, languageServerFolder, this.platformData.engineExecutableName);
         const options = { stdio: 'pipe', env };
         const serverOptions: ServerOptions = {
@@ -75,8 +75,8 @@ export class DownloadedLanguageClientFactory implements ILanguageClientFactory {
 export class SimpleLanguageClientFactory implements ILanguageClientFactory {
     constructor(@inject(IPlatformData) private readonly platformData: IPlatformData,
         @inject(ILanguageServerFolderService) private readonly languageServerFolderService: ILanguageServerFolderService) { }
-    public async createLanguageClient(_resource: Resource, clientOptions: LanguageClientOptions, env?: NodeJS.ProcessEnv): Promise<LanguageClient> {
-        const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName();
+    public async createLanguageClient(resource: Resource, clientOptions: LanguageClientOptions, env?: NodeJS.ProcessEnv): Promise<LanguageClient> {
+        const languageServerFolder = await this.languageServerFolderService.getLanguageServerFolderName(resource);
         const options = { stdio: 'pipe', env };
         const serverModule = path.join(EXTENSION_ROOT_DIR, languageServerFolder, this.platformData.engineDllName);
         const serverOptions: ServerOptions = {

--- a/src/client/activation/languageServer/languageServerFolderService.ts
+++ b/src/client/activation/languageServer/languageServerFolderService.ts
@@ -10,7 +10,7 @@ import { EXTENSION_ROOT_DIR } from '../../common/constants';
 import { traceDecorators } from '../../common/logger';
 import { NugetPackage } from '../../common/nuget/types';
 import { IFileSystem } from '../../common/platform/types';
-import { IConfigurationService } from '../../common/types';
+import { IConfigurationService, Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { FolderVersionPair, IDownloadChannelRule, ILanguageServerFolderService, ILanguageServerPackageService } from '../types';
 
@@ -21,7 +21,7 @@ export class LanguageServerFolderService implements ILanguageServerFolderService
     constructor(@inject(IServiceContainer) private readonly serviceContainer: IServiceContainer) { }
 
     @traceDecorators.verbose('Get language server folder name')
-    public async getLanguageServerFolderName(): Promise<string> {
+    public async getLanguageServerFolderName(resource: Resource): Promise<string> {
         const currentFolder = await this.getCurrentLanguageServerDirectory();
         let serverVersion: NugetPackage | undefined;
 
@@ -30,7 +30,7 @@ export class LanguageServerFolderService implements ILanguageServerFolderService
             return path.basename(currentFolder.path);
         }
 
-        serverVersion = await this.getLatestLanguageServerVersion()
+        serverVersion = await this.getLatestLanguageServerVersion(resource)
             .catch(() => undefined);
 
         if (currentFolder && (!serverVersion || serverVersion.version.compare(currentFolder.version) <= 0)) {
@@ -41,9 +41,9 @@ export class LanguageServerFolderService implements ILanguageServerFolderService
     }
 
     @traceDecorators.verbose('Get latest version of Language Server')
-    public getLatestLanguageServerVersion(): Promise<NugetPackage | undefined> {
+    public getLatestLanguageServerVersion(resource: Resource): Promise<NugetPackage | undefined> {
         const lsPackageService = this.serviceContainer.get<ILanguageServerPackageService>(ILanguageServerPackageService);
-        return lsPackageService.getLatestNugetPackageVersion();
+        return lsPackageService.getLatestNugetPackageVersion(resource);
     }
     public async shouldLookForNewLanguageServer(currentFolder?: FolderVersionPair): Promise<boolean> {
         const configService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);

--- a/src/client/activation/languageServer/languageServerPackageService.ts
+++ b/src/client/activation/languageServer/languageServerPackageService.ts
@@ -10,7 +10,9 @@ import { PVSC_EXTENSION_ID } from '../../common/constants';
 import { traceDecorators, traceVerbose } from '../../common/logger';
 import { INugetRepository, INugetService, NugetPackage } from '../../common/nuget/types';
 import { IPlatformService } from '../../common/platform/types';
-import { IConfigurationService, IExtensions, LanguageServerDownloadChannels } from '../../common/types';
+import {
+    IConfigurationService, IExtensions, LanguageServerDownloadChannels, Resource
+} from '../../common/types';
 import { OSType } from '../../common/utils/platform';
 import { IServiceContainer } from '../../ioc/types';
 import { ILanguageServerPackageService, PlatformName } from '../types';
@@ -46,12 +48,12 @@ export class LanguageServerPackageService implements ILanguageServerPackageServi
     }
 
     @traceDecorators.verbose('Get latest language server nuget package version')
-    public async getLatestNugetPackageVersion(): Promise<NugetPackage> {
+    public async getLatestNugetPackageVersion(resource: Resource): Promise<NugetPackage> {
         const downloadChannel = this.getLanguageServerDownloadChannel();
         const nugetRepo = this.serviceContainer.get<INugetRepository>(INugetRepository, downloadChannel);
         const packageName = this.getNugetPackageName();
         traceVerbose(`Listing packages for ${downloadChannel} for ${packageName}`);
-        const packages = await nugetRepo.getPackages(packageName);
+        const packages = await nugetRepo.getPackages(packageName, resource);
 
         return this.getValidPackage(packages);
     }

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -57,7 +57,6 @@ export interface ILanguageServerFolderService {
 export const ILanguageServerDownloader = Symbol('ILanguageServerDownloader');
 
 export interface ILanguageServerDownloader {
-    getDownloadInfo(): Promise<NugetPackage>;
     downloadLanguageServer(destinationFolder: string): Promise<void>;
 }
 

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -57,7 +57,7 @@ export interface ILanguageServerFolderService {
 export const ILanguageServerDownloader = Symbol('ILanguageServerDownloader');
 
 export interface ILanguageServerDownloader {
-    downloadLanguageServer(destinationFolder: string): Promise<void>;
+    downloadLanguageServer(destinationFolder: string, resource?: Resource): Promise<void>;
 }
 
 export const ILanguageServerPackageService = Symbol('ILanguageServerPackageService');

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -57,7 +57,7 @@ export interface ILanguageServerFolderService {
 export const ILanguageServerDownloader = Symbol('ILanguageServerDownloader');
 
 export interface ILanguageServerDownloader {
-    downloadLanguageServer(destinationFolder: string, resource?: Resource): Promise<void>;
+    downloadLanguageServer(destinationFolder: string, resource: Resource): Promise<void>;
 }
 
 export const ILanguageServerPackageService = Symbol('ILanguageServerPackageService');

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -49,8 +49,8 @@ export type FolderVersionPair = { path: string; version: SemVer };
 export const ILanguageServerFolderService = Symbol('ILanguageServerFolderService');
 
 export interface ILanguageServerFolderService {
-    getLanguageServerFolderName(): Promise<string>;
-    getLatestLanguageServerVersion(): Promise<NugetPackage | undefined>;
+    getLanguageServerFolderName(resource: Resource): Promise<string>;
+    getLatestLanguageServerVersion(resource: Resource): Promise<NugetPackage | undefined>;
     getCurrentLanguageServerDirectory(): Promise<FolderVersionPair | undefined>;
 }
 
@@ -63,7 +63,7 @@ export interface ILanguageServerDownloader {
 export const ILanguageServerPackageService = Symbol('ILanguageServerPackageService');
 export interface ILanguageServerPackageService {
     getNugetPackageName(): string;
-    getLatestNugetPackageVersion(): Promise<NugetPackage>;
+    getLatestNugetPackageVersion(resource: Resource): Promise<NugetPackage>;
     getLanguageServerDownloadChannel(): LanguageServerDownloadChannels;
 }
 

--- a/src/client/common/nuget/azureBlobStoreNugetRepository.ts
+++ b/src/client/common/nuget/azureBlobStoreNugetRepository.ts
@@ -50,14 +50,27 @@ export class AzureBlobStoreNugetRepository implements INugetRepository {
                     if (error) {
                         return reject(error);
                     }
-                    resolve(result.entries.map(item => {
-                        return {
-                            package: item.name,
-                            uri: `${azureCDNBlobStorageAccount}/${azureBlobStorageContainer}/${item.name}`,
-                            version: nugetService.getVersionFromPackageFileName(item.name)
-                        };
-                    }));
+                    resolve(this.convertResults(
+                        result.entries,
+                        azureCDNBlobStorageAccount,
+                        azureBlobStorageContainer,
+                        nugetService
+                    ));
                 });
+        });
+    }
+    private convertResults(
+        results: IBlobResult[],
+        azureCDNBlobStorageAccount: string,
+        azureBlobStorageContainer: string,
+        nugetService: INugetService
+    ): NugetPackage[] {
+        return results.map(item => {
+            return {
+                package: item.name,
+                uri: `${azureCDNBlobStorageAccount}/${azureBlobStorageContainer}/${item.name}`,
+                version: nugetService.getVersionFromPackageFileName(item.name)
+            };
         });
     }
     private async getBlobStore(uri: string, resource: Resource) {
@@ -73,4 +86,8 @@ export class AzureBlobStoreNugetRepository implements INugetRepository {
         const az = await import('azure-storage') as typeof import('azure-storage');
         return az.createBlobServiceAnonymous(uri);
     }
+}
+
+interface IBlobResult {
+    name: string;
 }

--- a/src/client/common/nuget/types.ts
+++ b/src/client/common/nuget/types.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { SemVer } from 'semver';
+import { Resource } from '../types';
 export type NugetPackage = { package: string; version: SemVer; uri: string };
 
 export const INugetService = Symbol('INugetService');
@@ -14,5 +15,5 @@ export interface INugetService {
 
 export const INugetRepository = Symbol('INugetRepository');
 export interface INugetRepository {
-    getPackages(packageName: string): Promise<NugetPackage[]>;
+    getPackages(packageName: string, resource: Resource): Promise<NugetPackage[]>;
 }

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -30,6 +30,7 @@ export type FormatTelemetry = {
 export type LanguageServerVersionTelemetry = {
     success: boolean;
     lsVersion?: string;
+    usedSSL?: boolean;
 };
 
 export type LanguageServerErrorTelemetry = {

--- a/src/test/activation/languageServer/activator.unit.test.ts
+++ b/src/test/activation/languageServer/activator.unit.test.ts
@@ -81,7 +81,7 @@ suite('Language Server - Activator', () => {
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(lsFolderService.getLanguageServerFolderName()).never();
-        verify(lsDownloader.downloadLanguageServer(anything())).never();
+        verify(lsDownloader.downloadLanguageServer(anything(), anything())).never();
     });
     test('Do not download LS if not required', async () => {
         const languageServerFolder = 'Some folder name';
@@ -99,7 +99,7 @@ suite('Language Server - Activator', () => {
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(lsFolderService.getLanguageServerFolderName()).once();
-        verify(lsDownloader.downloadLanguageServer(anything())).never();
+        verify(lsDownloader.downloadLanguageServer(anything(), anything())).never();
     });
     test('Start language server after downloading', async () => {
         const deferred = createDeferred<void>();

--- a/src/test/activation/languageServer/activator.unit.test.ts
+++ b/src/test/activation/languageServer/activator.unit.test.ts
@@ -112,13 +112,14 @@ suite('Language Server - Activator', () => {
         when(settings.downloadLanguageServer).thenReturn(true);
         when(lsFolderService.getLanguageServerFolderName()).thenResolve(languageServerFolder);
         when(fs.fileExists(mscorlib)).thenResolve(false);
-        when(lsDownloader.downloadLanguageServer(languageServerFolderPath)).thenReturn(deferred.promise);
+        when(lsDownloader.downloadLanguageServer(languageServerFolderPath, undefined))
+            .thenReturn(deferred.promise);
 
         const promise = activator.activate(undefined);
         await sleep(1);
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(lsFolderService.getLanguageServerFolderName()).once();
-        verify(lsDownloader.downloadLanguageServer(anything())).once();
+        verify(lsDownloader.downloadLanguageServer(anything(), undefined)).once();
 
         verify(manager.start(undefined)).never();
 

--- a/src/test/activation/languageServer/activator.unit.test.ts
+++ b/src/test/activation/languageServer/activator.unit.test.ts
@@ -80,7 +80,7 @@ suite('Language Server - Activator', () => {
 
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
-        verify(lsFolderService.getLanguageServerFolderName()).never();
+        verify(lsFolderService.getLanguageServerFolderName(anything())).never();
         verify(lsDownloader.downloadLanguageServer(anything(), anything())).never();
     });
     test('Do not download LS if not required', async () => {
@@ -91,14 +91,15 @@ suite('Language Server - Activator', () => {
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
         when(manager.start(undefined)).thenResolve();
         when(settings.downloadLanguageServer).thenReturn(true);
-        when(lsFolderService.getLanguageServerFolderName()).thenResolve(languageServerFolder);
+        when(lsFolderService.getLanguageServerFolderName(anything()))
+            .thenResolve(languageServerFolder);
         when(fs.fileExists(mscorlib)).thenResolve(true);
 
         await activator.activate(undefined);
 
         verify(manager.start(undefined)).once();
         verify(workspaceService.hasWorkspaceFolders).once();
-        verify(lsFolderService.getLanguageServerFolderName()).once();
+        verify(lsFolderService.getLanguageServerFolderName(anything())).once();
         verify(lsDownloader.downloadLanguageServer(anything(), anything())).never();
     });
     test('Start language server after downloading', async () => {
@@ -110,7 +111,8 @@ suite('Language Server - Activator', () => {
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
         when(manager.start(undefined)).thenResolve();
         when(settings.downloadLanguageServer).thenReturn(true);
-        when(lsFolderService.getLanguageServerFolderName()).thenResolve(languageServerFolder);
+        when(lsFolderService.getLanguageServerFolderName(anything()))
+            .thenResolve(languageServerFolder);
         when(fs.fileExists(mscorlib)).thenResolve(false);
         when(lsDownloader.downloadLanguageServer(languageServerFolderPath, undefined))
             .thenReturn(deferred.promise);
@@ -118,7 +120,7 @@ suite('Language Server - Activator', () => {
         const promise = activator.activate(undefined);
         await sleep(1);
         verify(workspaceService.hasWorkspaceFolders).once();
-        verify(lsFolderService.getLanguageServerFolderName()).once();
+        verify(lsFolderService.getLanguageServerFolderName(anything())).once();
         verify(lsDownloader.downloadLanguageServer(anything(), undefined)).once();
 
         verify(manager.start(undefined)).never();

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -10,7 +10,7 @@ import { SemVer } from 'semver';
 import * as TypeMoq from 'typemoq';
 import { LanguageServerDownloader } from '../../../client/activation/languageServer/downloader';
 import { ILanguageServerFolderService, IPlatformData } from '../../../client/activation/types';
-import { IApplicationShell } from '../../../client/common/application/types';
+import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IOutputChannel } from '../../../client/common/types';
 import { Common, LanguageService } from '../../../client/common/utils/localize';
@@ -19,15 +19,18 @@ import { Common, LanguageService } from '../../../client/common/utils/localize';
 suite('Activation - Downloader', () => {
     let languageServerDownloader: LanguageServerDownloader;
     let folderService: TypeMoq.IMock<ILanguageServerFolderService>;
+    let workspaceService: TypeMoq.IMock<IWorkspaceService>;
     setup(() => {
         folderService = TypeMoq.Mock.ofType<ILanguageServerFolderService>(undefined, TypeMoq.MockBehavior.Strict);
+        workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>(undefined, TypeMoq.MockBehavior.Strict);
         languageServerDownloader = new LanguageServerDownloader(
             undefined as any,
             undefined as any,
             undefined as any,
             folderService.object,
             undefined as any,
-            undefined as any
+            undefined as any,
+            workspaceService.object
         );
     });
 
@@ -92,7 +95,8 @@ suite('Activation - Downloader', () => {
                 undefined as any,
                 folderService.object,
                 appShell.object,
-                fs.object
+                fs.object,
+                workspaceService.object
             );
             languageServerExtractorTest = new LanguageServerExtractorTest(
                 platformData.object,
@@ -100,7 +104,8 @@ suite('Activation - Downloader', () => {
                 undefined as any,
                 folderService.object,
                 appShell.object,
-                fs.object
+                fs.object,
+                workspaceService.object
             );
         });
         test('Display error message if LS downloading fails', async () => {

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -50,7 +50,7 @@ suite('Activation - Downloader', () => {
 
         const pkg = makePkgInfo('ls', 'https://a.b.com/x/y/z/ls.nupkg');
         folderService
-            .setup(f => f.getLatestLanguageServerVersion())
+            .setup(f => f.getLatestLanguageServerVersion(undefined))
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
@@ -83,7 +83,7 @@ suite('Activation - Downloader', () => {
 
         const pkg = makePkgInfo('ls', 'https://a.b.com/x/y/z/ls.nupkg');
         folderService
-            .setup(f => f.getLatestLanguageServerVersion())
+            .setup(f => f.getLatestLanguageServerVersion(undefined))
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
@@ -108,7 +108,7 @@ suite('Activation - Downloader', () => {
 
         const pkg = makePkgInfo('ls', 'https://a.b.com/x/y/z/ls.nupkg');
         folderService
-            .setup(f => f.getLatestLanguageServerVersion())
+            .setup(f => f.getLatestLanguageServerVersion(undefined))
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
@@ -125,7 +125,7 @@ suite('Activation - Downloader', () => {
         // tslint:disable-next-line:no-http-string
         const pkg = makePkgInfo('ls', 'http://a.b.com/x/y/z/ls.nupkg');
         folderService
-            .setup(f => f.getLatestLanguageServerVersion())
+            .setup(f => f.getLatestLanguageServerVersion(undefined))
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
@@ -140,7 +140,7 @@ suite('Activation - Downloader', () => {
     test('Get download info - bogus URL', async () => {
         const pkg = makePkgInfo('ls', 'xyz');
         folderService
-            .setup(f => f.getLatestLanguageServerVersion())
+            .setup(f => f.getLatestLanguageServerVersion(undefined))
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
@@ -216,7 +216,7 @@ suite('Activation - Downloader', () => {
         test('Display error message if LS downloading fails', async () => {
             const pkg = makePkgInfo('ls', 'xyz');
             folderService
-                .setup(f => f.getLatestLanguageServerVersion())
+                .setup(f => f.getLatestLanguageServerVersion(undefined))
                 .returns(() => Promise.resolve(pkg))
                 .verifiable(TypeMoq.Times.once());
             output.setup(o => o.appendLine(LanguageService.downloadFailedOutputMessage()))
@@ -239,7 +239,7 @@ suite('Activation - Downloader', () => {
         test('Display error message if LS extraction fails', async () => {
             const pkg = makePkgInfo('ls', 'xyz');
             folderService
-                .setup(f => f.getLatestLanguageServerVersion())
+                .setup(f => f.getLatestLanguageServerVersion(undefined))
                 .returns(() => Promise.resolve(pkg))
                 .verifiable(TypeMoq.Times.once());
             output.setup(o => o.appendLine(LanguageService.extractionFailedOutputMessage()))

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -87,7 +87,7 @@ suite('Activation - Downloader', () => {
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const [uri, version] = await languageServerDownloader.getDownloadInfo();
+        const [uri, version] = await languageServerDownloader.getDownloadInfo(undefined);
 
         folderService.verifyAll();
         workspaceService.verifyAll();

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -28,16 +28,17 @@ suite('Activation - Downloader', () => {
     });
 
     test('Get download uri', async () => {
-        const pkg = { uri: 'xyz' } as any;
+        const pkg = { uri: 'xyz', version: { raw: '1.2.3' } } as any;
         folderService
             .setup(f => f.getLatestLanguageServerVersion())
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const info = await languageServerDownloader.getDownloadInfo();
+        const [uri, version] = await languageServerDownloader.getDownloadInfo();
 
         folderService.verifyAll();
-        expect(info).to.deep.equal(pkg);
+        expect(uri).to.deep.equal(pkg.uri);
+        expect(version).to.deep.equal(pkg.version.raw);
     });
     suite('Test LanguageServerDownloader.downloadLanguageServer', () => {
         class LanguageServerDownloaderTest extends LanguageServerDownloader {

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -34,8 +34,11 @@ suite('Activation - Downloader', () => {
         );
     });
 
-    test('Get download uri', async () => {
-        const pkg = { uri: 'xyz', version: { raw: '1.2.3' } } as any;
+    test('Get download info - HTTPS', async () => {
+        const pkg = {
+            uri: 'https://a.b.com/x/y/z.nupkg',
+            version: { raw: '1.2.3' }
+        } as any;
         folderService
             .setup(f => f.getLatestLanguageServerVersion())
             .returns(() => Promise.resolve(pkg))
@@ -44,9 +47,48 @@ suite('Activation - Downloader', () => {
         const [uri, version] = await languageServerDownloader.getDownloadInfo();
 
         folderService.verifyAll();
+        workspaceService.verifyAll();
         expect(uri).to.deep.equal(pkg.uri);
         expect(version).to.deep.equal(pkg.version.raw);
     });
+
+    test('Get download info - HTTP', async () => {
+        const pkg = {
+            // tslint:disable-next-line:no-http-string
+            uri: 'http://a.b.com/x/y/z.nupkg',
+            version: { raw: '1.2.3' }
+        } as any;
+        folderService
+            .setup(f => f.getLatestLanguageServerVersion())
+            .returns(() => Promise.resolve(pkg))
+            .verifiable(TypeMoq.Times.once());
+
+        const [uri, version] = await languageServerDownloader.getDownloadInfo();
+
+        folderService.verifyAll();
+        workspaceService.verifyAll();
+        expect(uri).to.deep.equal(pkg.uri);
+        expect(version).to.deep.equal(pkg.version.raw);
+    });
+
+    test('Get download info - bogus URL', async () => {
+        const pkg = {
+            uri: 'xyz',
+            version: { raw: '1.2.3' }
+        } as any;
+        folderService
+            .setup(f => f.getLatestLanguageServerVersion())
+            .returns(() => Promise.resolve(pkg))
+            .verifiable(TypeMoq.Times.once());
+
+        const [uri, version] = await languageServerDownloader.getDownloadInfo();
+
+        folderService.verifyAll();
+        workspaceService.verifyAll();
+        expect(uri).to.deep.equal(pkg.uri);
+        expect(version).to.deep.equal(pkg.version.raw);
+    });
+
     // tslint:disable-next-line:max-func-body-length
     suite('Test LanguageServerDownloader.downloadLanguageServer', () => {
         const failure = new Error('kaboom');

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -35,10 +35,7 @@ suite('Activation - Downloader', () => {
     });
 
     test('Get download info - HTTPS', async () => {
-        const pkg = {
-            uri: 'https://a.b.com/x/y/z.nupkg',
-            version: { raw: '1.2.3' }
-        } as any;
+        const pkg = makePkgInfo('ls', 'https://a.b.com/x/y/z/ls.nupkg');
         folderService
             .setup(f => f.getLatestLanguageServerVersion())
             .returns(() => Promise.resolve(pkg))
@@ -53,11 +50,8 @@ suite('Activation - Downloader', () => {
     });
 
     test('Get download info - HTTP', async () => {
-        const pkg = {
-            // tslint:disable-next-line:no-http-string
-            uri: 'http://a.b.com/x/y/z.nupkg',
-            version: { raw: '1.2.3' }
-        } as any;
+        // tslint:disable-next-line:no-http-string
+        const pkg = makePkgInfo('ls', 'http://a.b.com/x/y/z/ls.nupkg');
         folderService
             .setup(f => f.getLatestLanguageServerVersion())
             .returns(() => Promise.resolve(pkg))
@@ -72,10 +66,7 @@ suite('Activation - Downloader', () => {
     });
 
     test('Get download info - bogus URL', async () => {
-        const pkg = {
-            uri: 'xyz',
-            version: { raw: '1.2.3' }
-        } as any;
+        const pkg = makePkgInfo('ls', 'xyz');
         folderService
             .setup(f => f.getLatestLanguageServerVersion())
             .returns(() => Promise.resolve(pkg))
@@ -151,7 +142,7 @@ suite('Activation - Downloader', () => {
             );
         });
         test('Display error message if LS downloading fails', async () => {
-            const pkg = { uri: 'xyz', package: 'abc', version: new SemVer('0.0.0') } as any;
+            const pkg = makePkgInfo('ls', 'xyz');
             folderService
                 .setup(f => f.getLatestLanguageServerVersion())
                 .returns(() => Promise.resolve(pkg))
@@ -174,7 +165,7 @@ suite('Activation - Downloader', () => {
             platformData.verifyAll();
         });
         test('Display error message if LS extraction fails', async () => {
-            const pkg = { uri: 'xyz', package: 'abc', version: new SemVer('0.0.0') } as any;
+            const pkg = makePkgInfo('ls', 'xyz');
             folderService
                 .setup(f => f.getLatestLanguageServerVersion())
                 .returns(() => Promise.resolve(pkg))
@@ -197,3 +188,11 @@ suite('Activation - Downloader', () => {
         });
     });
 });
+
+function makePkgInfo(name: string, uri: string, version: string = '0.0.0') {
+    return {
+        package: name,
+        uri: uri,
+        version: new SemVer(version)
+    } as any;
+}

--- a/src/test/activation/languageServer/languageClientFactory.unit.test.ts
+++ b/src/test/activation/languageServer/languageClientFactory.unit.test.ts
@@ -83,7 +83,8 @@ suite('Language Server - LanguageClient Factory', () => {
         const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
         const languageServerFolder = 'some folder name';
         const engineDllName = 'xyz.dll';
-        when(lsFolderService.getLanguageServerFolderName()).thenResolve(languageServerFolder);
+        when(lsFolderService.getLanguageServerFolderName(anything()))
+            .thenResolve(languageServerFolder);
         when(platformData.engineExecutableName).thenReturn(engineDllName);
 
         const serverModule = path.join(EXTENSION_ROOT_DIR, languageServerFolder, engineDllName);
@@ -105,7 +106,7 @@ suite('Language Server - LanguageClient Factory', () => {
 
         const client = await factory.createLanguageClient(uri, options, { FOO: 'bar' });
 
-        verify(lsFolderService.getLanguageServerFolderName()).once();
+        verify(lsFolderService.getLanguageServerFolderName(anything())).once();
         verify(platformData.engineExecutableName).atLeast(1);
         verify(platformData.engineDllName).never();
         verify(platformData.platformName).never();
@@ -119,7 +120,7 @@ suite('Language Server - LanguageClient Factory', () => {
         const options = typemoq.Mock.ofType<LanguageClientOptions>().object;
         const languageServerFolder = 'some folder name';
         const engineDllName = 'xyz.dll';
-        when(lsFolderService.getLanguageServerFolderName()).thenResolve(languageServerFolder);
+        when(lsFolderService.getLanguageServerFolderName(anything())).thenResolve(languageServerFolder);
         when(platformData.engineDllName).thenReturn(engineDllName);
 
         const serverModule = path.join(EXTENSION_ROOT_DIR, languageServerFolder, engineDllName);
@@ -141,7 +142,7 @@ suite('Language Server - LanguageClient Factory', () => {
 
         const client = await factory.createLanguageClient(uri, options, { FOO: 'bar' });
 
-        verify(lsFolderService.getLanguageServerFolderName()).once();
+        verify(lsFolderService.getLanguageServerFolderName(anything())).once();
         verify(platformData.engineExecutableName).never();
         verify(platformData.engineDllName).once();
         verify(platformData.platformName).never();

--- a/src/test/activation/languageServer/languageServerPackageService.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.test.ts
@@ -7,6 +7,7 @@
 
 import { expect } from 'chai';
 import * as typeMoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
 import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
@@ -31,7 +32,11 @@ suite('Language Server Package Service', () => {
         const platformService = new PlatformService();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IPlatformService))).returns(() => platformService);
         const workspace = typeMoq.Mock.ofType<IWorkspaceService>();
-        workspace.setup(w => w.getConfiguration('http', undefined));
+        const cfg = typeMoq.Mock.ofType<WorkspaceConfiguration>();
+        cfg.setup(c => c.get('proxyStrictSSL', true))
+            .returns(() => true);
+        workspace.setup(w => w.getConfiguration('http', undefined))
+            .returns(() => cfg.object);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IWorkspaceService)))
             .returns(() => workspace.object);
         const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;

--- a/src/test/activation/languageServer/languageServerPackageService.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.test.ts
@@ -39,7 +39,7 @@ suite('Language Server Package Service', () => {
         const platform = typeMoq.Mock.ofType<IPlatformService>();
         const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object, platform.object);
         const packageName = lsPackageService.getNugetPackageName();
-        const packages = await nugetRepo.getPackages(packageName);
+        const packages = await nugetRepo.getPackages(packageName, undefined);
 
         const latestReleases = packages
             .filter(item => nugetService.isReleaseVersion(item.version))

--- a/src/test/activation/languageServer/languageServerPackageService.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'chai';
 import * as typeMoq from 'typemoq';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
-import { IApplicationEnvironment } from '../../../client/common/application/types';
+import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
 import { NugetService } from '../../../client/common/nuget/nugetService';
 import { INugetRepository, INugetService } from '../../../client/common/nuget/types';
@@ -30,6 +30,10 @@ suite('Language Server Package Service', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nugetService);
         const platformService = new PlatformService();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IPlatformService))).returns(() => platformService);
+        const workspace = typeMoq.Mock.ofType<IWorkspaceService>();
+        workspace.setup(w => w.getConfiguration('http', undefined));
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(IWorkspaceService)))
+            .returns(() => workspace.object);
         const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
         const nugetRepo = new AzureBlobStoreNugetRepository(serviceContainer.object, azureBlobStorageAccount, defaultStorageChannel, azureCDNBlobStorageAccount);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetRepository))).returns(() => nugetRepo);

--- a/src/test/activation/languageServer/languageServerPackageService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.unit.test.ts
@@ -85,7 +85,7 @@ suite('Language', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nuget.object);
 
         repo
-            .setup(n => n.getPackages(typeMoq.It.isValue(packageName)))
+            .setup(n => n.getPackages(typeMoq.It.isValue(packageName), typeMoq.It.isAny()))
             .returns(() => Promise.resolve(packages))
             .verifiable(typeMoq.Times.once());
         nuget
@@ -93,7 +93,7 @@ suite('Language', () => {
             .returns(() => true)
             .verifiable(typeMoq.Times.atLeastOnce());
 
-        const info = await lsPackageService.getLatestNugetPackageVersion();
+        const info = await lsPackageService.getLatestNugetPackageVersion(undefined);
 
         repo.verifyAll();
         nuget.verifyAll();
@@ -117,11 +117,11 @@ suite('Language', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nuget);
 
         repo
-            .setup(n => n.getPackages(typeMoq.It.isValue(packageName)))
+            .setup(n => n.getPackages(typeMoq.It.isValue(packageName), typeMoq.It.isAny()))
             .returns(() => Promise.resolve(packages))
             .verifiable(typeMoq.Times.once());
 
-        const info = await lsPackageService.getLatestNugetPackageVersion();
+        const info = await lsPackageService.getLatestNugetPackageVersion(undefined);
 
         repo.verifyAll();
         expect(info).to.deep.equal(expectedPackage);
@@ -142,11 +142,11 @@ suite('Language', () => {
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService))).returns(() => nuget);
 
         repo
-            .setup(n => n.getPackages(typeMoq.It.isValue(packageName)))
+            .setup(n => n.getPackages(typeMoq.It.isValue(packageName), typeMoq.It.isAny()))
             .returns(() => Promise.resolve(packages))
             .verifiable(typeMoq.Times.once());
 
-        const info = await lsPackageService.getLatestNugetPackageVersion();
+        const info = await lsPackageService.getLatestNugetPackageVersion(undefined);
 
         repo.verifyAll();
         const expectedPackage: NugetPackage = {

--- a/src/test/common/nuget/azureBobStoreRepository.functional.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.functional.test.ts
@@ -6,6 +6,7 @@
 import { expect } from 'chai';
 import { SemVer } from 'semver';
 import * as typeMoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
 import { IHttpClient } from '../../../client/activation/types';
@@ -22,13 +23,18 @@ suite('Nuget Azure Storage Repository', () => {
     let serviceContainer: typeMoq.IMock<IServiceContainer>;
     let httpClient: typeMoq.IMock<IHttpClient>;
     let workspace: typeMoq.IMock<IWorkspaceService>;
+    let cfg: typeMoq.IMock<WorkspaceConfiguration>;
     let repo: AzureBlobStoreNugetRepository;
     setup(() => {
         serviceContainer = typeMoq.Mock.ofType<IServiceContainer>();
         httpClient = typeMoq.Mock.ofType<IHttpClient>();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IHttpClient))).returns(() => httpClient.object);
+        cfg = typeMoq.Mock.ofType<WorkspaceConfiguration>();
+        cfg.setup(c => c.get('proxyStrictSSL', true))
+            .returns(() => true);
         workspace = typeMoq.Mock.ofType<IWorkspaceService>();
-        workspace.setup(w => w.getConfiguration('http', undefined));
+        workspace.setup(w => w.getConfiguration('http', undefined))
+            .returns(() => cfg.object);
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IWorkspaceService)))
             .returns(() => workspace.object);
 

--- a/src/test/common/nuget/azureBobStoreRepository.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.test.ts
@@ -44,7 +44,7 @@ suite('Nuget Azure Storage Repository', () => {
         appEnv.setup(e => e.packageJson).returns(() => packageJson);
         const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object, platformService);
         const packageName = lsPackageService.getNugetPackageName();
-        const packages = await repo.getPackages(packageName);
+        const packages = await repo.getPackages(packageName, undefined);
 
         expect(packages).to.be.length.greaterThan(0);
     });

--- a/src/test/common/nuget/azureBobStoreRepository.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.test.ts
@@ -9,7 +9,7 @@ import * as typeMoq from 'typemoq';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
 import { IHttpClient } from '../../../client/activation/types';
-import { IApplicationEnvironment } from '../../../client/common/application/types';
+import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
 import { INugetService } from '../../../client/common/nuget/types';
 import { PlatformService } from '../../../client/common/platform/platformService';
@@ -21,11 +21,16 @@ const azureCDNBlobStorageAccount = 'https://pvsc.azureedge.net';
 suite('Nuget Azure Storage Repository', () => {
     let serviceContainer: typeMoq.IMock<IServiceContainer>;
     let httpClient: typeMoq.IMock<IHttpClient>;
+    let workspace: typeMoq.IMock<IWorkspaceService>;
     let repo: AzureBlobStoreNugetRepository;
     setup(() => {
         serviceContainer = typeMoq.Mock.ofType<IServiceContainer>();
         httpClient = typeMoq.Mock.ofType<IHttpClient>();
         serviceContainer.setup(c => c.get(typeMoq.It.isValue(IHttpClient))).returns(() => httpClient.object);
+        workspace = typeMoq.Mock.ofType<IWorkspaceService>();
+        workspace.setup(w => w.getConfiguration('http', undefined));
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(IWorkspaceService)))
+            .returns(() => workspace.object);
 
         const nugetService = typeMoq.Mock.ofType<INugetService>();
         nugetService.setup(n => n.getVersionFromPackageFileName(typeMoq.It.isAny())).returns(() => new SemVer('1.1.1'));

--- a/src/test/common/nuget/azureBobStoreRepository.unit.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.unit.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { SemVer } from 'semver';
+import * as typeMoq from 'typemoq';
+import { WorkspaceConfiguration } from 'vscode';
+import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
+import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
+import { IHttpClient } from '../../../client/activation/types';
+import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
+import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
+import { INugetService } from '../../../client/common/nuget/types';
+import { PlatformService } from '../../../client/common/platform/platformService';
+import { IServiceContainer } from '../../../client/ioc/types';
+
+suite('Nuget Azure Storage Repository', () => {
+    const azureBlobStorageAccount = 'https://pvsc.blob.core.windows.net';
+    const azureCDNBlobStorageAccount = 'https://pvsc.azureedge.net';
+    const defaultStorageChannel = LanguageServerPackageStorageContainers.stable;
+
+    let serviceContainer: typeMoq.IMock<IServiceContainer>;
+    let httpClient: typeMoq.IMock<IHttpClient>;
+    let workspace: typeMoq.IMock<IWorkspaceService>;
+    let cfg: typeMoq.IMock<WorkspaceConfiguration>;
+
+    let repo: AzureBlobStoreNugetRepository;
+    let strictSSL: boolean;
+
+    setup(() => {
+        serviceContainer = typeMoq.Mock.ofType<IServiceContainer>(undefined, typeMoq.MockBehavior.Strict);
+        httpClient = typeMoq.Mock.ofType<IHttpClient>(undefined, typeMoq.MockBehavior.Strict);
+        workspace = typeMoq.Mock.ofType<IWorkspaceService>(undefined, typeMoq.MockBehavior.Strict);
+        const nugetService = typeMoq.Mock.ofType<INugetService>(undefined, typeMoq.MockBehavior.Strict);
+        cfg = typeMoq.Mock.ofType<WorkspaceConfiguration>(undefined, typeMoq.MockBehavior.Strict);
+
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(IHttpClient)))
+            .returns(() => httpClient.object);
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(IWorkspaceService)))
+            .returns(() => workspace.object);
+        serviceContainer.setup(c => c.get(typeMoq.It.isValue(INugetService)))
+            .returns(() => nugetService.object);
+
+        nugetService.setup(n => n.getVersionFromPackageFileName(typeMoq.It.isAny()))
+            .returns(() => new SemVer('1.1.1'));
+        workspace.setup(w => w.getConfiguration('http', undefined))
+            .returns(() => cfg.object);
+        cfg.setup(c => c.get('proxyStrictSSL', true))
+            .returns(() => strictSSL);
+
+        repo = new AzureBlobStoreNugetRepository(
+            serviceContainer.object,
+            azureBlobStorageAccount,
+            defaultStorageChannel,
+            azureCDNBlobStorageAccount
+        );
+        strictSSL = true;
+    });
+
+    test('Get all packages (HTTPS)', async function () {
+        // tslint:disable-next-line:no-invalid-this
+        this.timeout(15000);
+        const platformService = new PlatformService();
+        const packageJson = { languageServerVersion: '0.1.0' };
+        const appEnv = typeMoq.Mock.ofType<IApplicationEnvironment>();
+        appEnv.setup(e => e.packageJson).returns(() => packageJson);
+        const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object, platformService);
+        const packageName = lsPackageService.getNugetPackageName();
+        const packages = await repo.getPackages(packageName, undefined);
+
+        expect(packages).to.be.length.greaterThan(0);
+    });
+
+    test('Get all packages (HTTP)', async function () {
+        // tslint:disable-next-line:no-invalid-this
+        this.timeout(15000);
+        strictSSL = false;
+        const platformService = new PlatformService();
+        const packageJson = { languageServerVersion: '0.1.0' };
+        const appEnv = typeMoq.Mock.ofType<IApplicationEnvironment>();
+        appEnv.setup(e => e.packageJson).returns(() => packageJson);
+        const lsPackageService = new LanguageServerPackageService(serviceContainer.object, appEnv.object, platformService);
+        const packageName = lsPackageService.getNugetPackageName();
+        const packages = await repo.getPackages(packageName, undefined);
+
+        expect(packages).to.be.length.greaterThan(0);
+    });
+});


### PR DESCRIPTION
(for #2849)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
