### PR TITLE
 Ignore the extension's Python files when debugging.

### DIFF
--- a/.github/test_plan.md
+++ b/.github/test_plan.md
@@ -297,6 +297,8 @@ class FailingTests(unittest.TestCase):
     - [ ] `Run Test` works
     - [ ] `Debug Test` works
     - [ ] Module/suite setup methods are also run (run the `test_setup` method to verify)
+- [ ] while debugging tests, an uncaught exception in a test does not
+      cause ptvsd to raise SystemExit
 
 #### [`pytest`](https://code.visualstudio.com/docs/python/unit-testing#_pytest-configuration-settings)
 ```python

--- a/news/2 Fixes/3201.md
+++ b/news/2 Fixes/3201.md
@@ -1,0 +1,1 @@
+Ignore the extension's Python files when debugging.

--- a/pythonFiles/ptvsd_launcher.py
+++ b/pythonFiles/ptvsd_launcher.py
@@ -19,13 +19,11 @@ try:
         sys.path.insert(0, ptvs_lib_path)
     try:
         import ptvsd
-        import ptvsd.debugger as vspd
         from ptvsd.__main__ import main
         ptvsd_loaded = True
     except ImportError:
         ptvsd_loaded = False
         raise
-    vspd.DONT_DEBUG.append(os.path.normcase(__file__))
 except:
     traceback.print_exc()
     print('''

--- a/pythonFiles/testlauncher.py
+++ b/pythonFiles/testlauncher.py
@@ -20,8 +20,6 @@ def exclude_current_file_from_debugger():
     # Load the debugger package
     try:
         import ptvsd
-        import ptvsd.debugger as vspd
-        vspd.DONT_DEBUG.append(os.path.normcase(__file__))
     except:
         traceback.print_exc()
         print('''

--- a/pythonFiles/visualstudio_py_testlauncher.py
+++ b/pythonFiles/visualstudio_py_testlauncher.py
@@ -222,7 +222,7 @@ def main():
     (opts, _) = parser.parse_args()
 
     if opts.debug:
-        from ptvsd.visualstudio_py_debugger import DONT_DEBUG, DEBUG_ENTRYPOINTS, get_code
+        from ptvsd.visualstudio_py_debugger import DEBUG_ENTRYPOINTS, get_code
 
     sys.path[0] = os.getcwd()
     if opts.result_port:
@@ -238,7 +238,7 @@ def main():
         sys.stderr = _TestOutput(sys.stderr, is_stdout = False)
 
     if opts.debug:
-        DONT_DEBUG.append(os.path.normcase(__file__))
+        # TODO: Stop using this internal API? (See #3201.)
         DEBUG_ENTRYPOINTS.add(get_code(main))
 
         pass

--- a/src/client/unittests/common/debugLauncher.ts
+++ b/src/client/unittests/common/debugLauncher.ts
@@ -72,6 +72,13 @@ export class DebugLauncher implements ITestDebugLauncher {
                 request: 'test'
             };
         }
+        if (!debugConfig.rules) {
+            debugConfig.rules = [];
+        }
+        debugConfig.rules.push({
+            path: path.join(EXTENSION_ROOT_DIR, 'pythonFiles'),
+            include: false
+        });
         this.applyDefaults(debugConfig!, workspaceFolder, configSettings);
 
         return this.convertConfigToArgs(debugConfig!, workspaceFolder, options);

--- a/src/test/providers/foldingProvider.test.ts
+++ b/src/test/providers/foldingProvider.test.ts
@@ -14,9 +14,12 @@ suite('Provider - Folding Provider', () => {
     const docStringFileAndExpectedFoldingRanges: FileFoldingRanges[] = [
         {
             file: path.join(pythonFilesPath, 'attach_server.py'), ranges: [
-                new FoldingRange(0, 14), new FoldingRange(44, 73, FoldingRangeKind.Comment),
-                new FoldingRange(95, 143), new FoldingRange(149, 150, FoldingRangeKind.Comment),
-                new FoldingRange(305, 313), new FoldingRange(320, 322)
+                new FoldingRange(0, 14),
+                new FoldingRange(44, 73, FoldingRangeKind.Comment),
+                new FoldingRange(98, 146),
+                new FoldingRange(152, 153, FoldingRangeKind.Comment),
+                new FoldingRange(312, 320),
+                new FoldingRange(327, 329)
             ]
         },
         {

--- a/src/test/pythonFiles/folding/attach_server.py
+++ b/src/test/pythonFiles/folding/attach_server.py
@@ -83,9 +83,12 @@ INFO = to_bytes('INFO')
 ATCH = to_bytes('ATCH')
 REPL = to_bytes('REPL')
 
+PY_ROOT = os.path.normcase(__file__)
+while os.path.basename(PY_ROOT) != 'pythonFiles':
+    PY_ROOT = os.path.dirname(PY_ROOT)
+
 _attach_enabled = False
 _attached = threading.Event()
-vspd.DONT_DEBUG.append(os.path.normcase(__file__))
 
 
 class AttachAlreadyEnabledError(Exception):
@@ -238,6 +241,10 @@ def enable_attach(secret, address = ('0.0.0.0', DEFAULT_PORT), certfile = None, 
 
                 elif response == ATCH:
                     debug_options = vspd.parse_debug_options(read_string(client))
+                    debug_options.setdefault('rules', []).append({
+                        'path': PY_ROOT,
+                        'include': False,
+                        })
                     if redirect_output:
                         debug_options.add('RedirectOutput')
 

--- a/src/test/pythonFiles/folding/noComments.py
+++ b/src/test/pythonFiles/folding/noComments.py
@@ -35,9 +35,12 @@ INFO = to_bytes('INFO')
 ATCH = to_bytes('ATCH')
 REPL = to_bytes('REPL')
 
+PY_ROOT = os.path.normcase(__file__)
+while os.path.basename(PY_ROOT) != 'pythonFiles':
+    PY_ROOT = os.path.dirname(PY_ROOT)
+
 _attach_enabled = False
 _attached = threading.Event()
-vspd.DONT_DEBUG.append(os.path.normcase(__file__))
 
 
 class AttachAlreadyEnabledError(Exception):
@@ -187,6 +190,10 @@ def enable_attach(secret, address = ('0.0.0.0', DEFAULT_PORT), certfile = None, 
 
                 elif response == ATCH:
                     debug_options = vspd.parse_debug_options(read_string(client))
+                    debug_options.setdefault('rules', []).append({
+                        'path': PY_ROOT,
+                        'include': False,
+                        })
                     if redirect_output:
                         debug_options.add('RedirectOutput')
 

--- a/src/test/pythonFiles/folding/noDocStrings.py
+++ b/src/test/pythonFiles/folding/noDocStrings.py
@@ -83,9 +83,12 @@ INFO = to_bytes('INFO')
 ATCH = to_bytes('ATCH')
 REPL = to_bytes('REPL')
 
+PY_ROOT = os.path.normcase(__file__)
+while os.path.basename(PY_ROOT) != 'pythonFiles':
+    PY_ROOT = os.path.dirname(PY_ROOT)
+
 _attach_enabled = False
 _attached = threading.Event()
-vspd.DONT_DEBUG.append(os.path.normcase(__file__))
 
 
 class AttachAlreadyEnabledError(Exception):
@@ -187,6 +190,10 @@ def enable_attach(secret, address = ('0.0.0.0', DEFAULT_PORT), certfile = None, 
 
                 elif response == ATCH:
                     debug_options = vspd.parse_debug_options(read_string(client))
+                    debug_options.setdefault('rules', []).append({
+                        'path': PY_ROOT,
+                        'include': False,
+                        })
                     if redirect_output:
                         debug_options.add('RedirectOutput')
 

--- a/src/test/pythonFiles/folding/visualstudio_py_repl.py
+++ b/src/test/pythonFiles/folding/visualstudio_py_repl.py
@@ -71,6 +71,10 @@ except NameError:
 
 DEBUG = os.environ.get('DEBUG_REPL') is not None
 
+PY_ROOT = os.path.normcase(__file__)
+while os.path.basename(PY_ROOT) != 'pythonFiles':
+    PY_ROOT = os.path.dirname(PY_ROOT)
+
 __all__ = ['ReplBackend', 'BasicReplBackend', 'BACKEND']
 
 def _debug_write(out):
@@ -349,6 +353,10 @@ class ReplBackend(object):
         port = read_int(self.conn)
         id = read_string(self.conn)
         debug_options = visualstudio_py_debugger.parse_debug_options(read_string(self.conn))
+        debug_options.setdefault('rules', []).append({
+            'path': PY_ROOT,
+            'include': False,
+            })
         self.attach_process(port, id, debug_options)
 
     _COMMANDS = {
@@ -380,7 +388,6 @@ class ReplBackend(object):
         from os import path
         sys.path.append(path.dirname(__file__))
         import visualstudio_py_debugger
-        visualstudio_py_debugger.DONT_DEBUG.append(path.normcase(__file__))
         new_thread = visualstudio_py_debugger.new_thread()
         sys.settrace(new_thread.trace_func)
         visualstudio_py_debugger.intercept_threads(True)

--- a/src/test/unittests/common/debugLauncher.unit.test.ts
+++ b/src/test/unittests/common/debugLauncher.unit.test.ts
@@ -197,6 +197,9 @@ suite('Unit Tests - Debug Launcher', () => {
         if (!expected) {
             expected = getDefaultDebugConfig();
         }
+        expected.rules = [
+            { path: path.join(EXTENSION_ROOT_DIR, 'pythonFiles'), include: false }
+        ];
         expected.program = testLaunchScript;
         expected.args = options.args;
         if (!expected.cwd) {


### PR DESCRIPTION
(for #3201)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
