### PR TITLE
add Debug Console in default launch.json

### DIFF
--- a/resources/default.launch.json
+++ b/resources/default.launch.json
@@ -60,5 +60,12 @@
         "request": "launch",
         "program": "${file}",
         "console": "externalTerminal"
+    },
+    {
+        "name": "Python: Current File (Debug Console)",
+        "type": "python",
+        "request": "launch",
+        "program": "${file}",
+        "console": "none"
     }
 ]


### PR DESCRIPTION
added Debug Console option in default launch.json. It is found that Internal Terminal will not accept second time debug.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
