### PR TITLE
Use namespace commands for refactor keys

### DIFF
--- a/news/3 Code Health/5204.md
+++ b/news/3 Code Health/5204.md
@@ -1,0 +1,2 @@
+Fix typo and use constants instead of hardcoded command names.
+(thanks [Allan Wang](https://github.com/AllanWang))

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -38,7 +38,7 @@ export namespace Commands {
     export const Tests_Select_And_Run_File = 'python.selectAndRunTestFile';
     export const Tests_Run_Current_File = 'python.runCurrentTestFile';
     export const Refactor_Extract_Variable = 'python.refactorExtractVariable';
-    export const Refaactor_Extract_Method = 'python.refactorExtractMethod';
+    export const Refactor_Extract_Method = 'python.refactorExtractMethod';
     export const Update_SparkLibrary = 'python.updateSparkLibrary';
     export const Build_Workspace_Symbols = 'python.buildWorkspaceSymbols';
     export const Start_REPL = 'python.startREPL';

--- a/src/client/providers/simpleRefactorProvider.ts
+++ b/src/client/providers/simpleRefactorProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Commands } from '../common/constants';
 import { getTextEditsFromPatch } from '../common/editor';
 import { IConfigurationService, IInstaller, Product } from '../common/types';
 import { StopWatch } from '../common/utils/stopWatch';
@@ -15,7 +16,7 @@ let installer: IInstaller;
 
 export function activateSimplePythonRefactorProvider(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel, serviceContainer: IServiceContainer) {
     installer = serviceContainer.get<IInstaller>(IInstaller);
-    let disposable = vscode.commands.registerCommand('python.refactorExtractVariable', () => {
+    let disposable = vscode.commands.registerCommand(Commands.Refactor_Extract_Variable, () => {
         const stopWatch = new StopWatch();
         const promise = extractVariable(context.extensionPath,
             vscode.window.activeTextEditor!,
@@ -26,7 +27,7 @@ export function activateSimplePythonRefactorProvider(context: vscode.ExtensionCo
     });
     context.subscriptions.push(disposable);
 
-    disposable = vscode.commands.registerCommand('python.refactorExtractMethod', () => {
+    disposable = vscode.commands.registerCommand(Commands.Refactor_Extract_Method, () => {
         const stopWatch = new StopWatch();
         const promise = extractMethod(context.extensionPath,
             vscode.window.activeTextEditor!,


### PR DESCRIPTION
The constants for both refactor commands were not used. The string literal itself was referenced in the refactor provider, so I changed it to the command constant. I also fixed the typo in `refactor`