### PR TITLE
Display tip to users about changing interpreters

### DIFF
--- a/news/1 Enhancements/5180.md
+++ b/news/1 Enhancements/5180.md
@@ -1,0 +1,1 @@
+Display a tip to the user informing them of the ability to change the interpreter from the statusbar.

--- a/package.nls.json
+++ b/package.nls.json
@@ -251,5 +251,6 @@
     "DataScience.liveShareInvalid": "One or more guests in the session do not have the Python [extension](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) installed.\r\nYour Live Share session cannot continue and will be closed.",
     "diagnostics.updateSettings": "Yes, update settings",
     "Common.noIWillDoItLater": "No, I will do it later",
+    "Common.gotIt": "Got it!",
     "Interpreters.selectInterpreterTip": "Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -250,5 +250,6 @@
     "DataScience.valuesColumn": "values",
     "DataScience.liveShareInvalid": "One or more guests in the session do not have the Python [extension](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) installed.\r\nYour Live Share session cannot continue and will be closed.",
     "diagnostics.updateSettings": "Yes, update settings",
-    "Common.noIWillDoItLater": "No, I will do it later"
+    "Common.noIWillDoItLater": "No, I will do it later",
+    "Interpreters.selectInterpreterTip": "Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar"
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -26,6 +26,7 @@ export namespace Diagnostics {
 
 export namespace Common {
     export const canceled = localize('Common.canceled', 'Canceled');
+    export const gotIt = localize('Common.gotIt', 'Got it!');
     export const loadingExtension = localize('Common.loadingPythonExtension', 'Python extension loading...');
     export const openOutputPanel = localize('Common.openOutputPanel', 'Show output');
     export const noIWillDoItLater = localize('Common.noIWillDoItLater', 'No, I will do it later');
@@ -51,6 +52,7 @@ export namespace Interpreters {
     export const loading = localize('Interpreters.LoadingInterpreters', 'Loading Python Interpreters');
     export const refreshing = localize('Interpreters.RefreshingInterpreters', 'Refreshing Python Interpreters');
     export const environmentPromptMessage = localize('Interpreters.environmentPromptMessage', 'We noticed a new virtual environment has been created. Do you want to select it for the workspace folder?');
+    export const selectInterpreterTip = localize('Interpreters.selectInterpreterTip', 'Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar');
 }
 
 export namespace Linters {

--- a/src/client/interpreter/display/interpreterSelectionTip.ts
+++ b/src/client/interpreter/display/interpreterSelectionTip.ts
@@ -12,14 +12,16 @@ import { Common, Interpreters } from '../../common/utils/localize';
 @injectable()
 export class InterpreterSelectionTip implements IExtensionActivationService {
     private readonly storage: IPersistentState<boolean>;
+    private displayedInSession: boolean = false;
     constructor(@inject(IApplicationShell) private readonly shell: IApplicationShell,
         @inject(IPersistentStateFactory) private readonly factory: IPersistentStateFactory) {
         this.storage = this.factory.createGlobalPersistentState('InterpreterSelectionTip', false);
     }
     public async activate(_resource: Resource): Promise<void> {
-        if (this.storage.value) {
+        if (this.storage.value || this.displayedInSession) {
             return;
         }
+        this.displayedInSession = true;
         await this.showTip();
     }
     private async showTip() {

--- a/src/client/interpreter/display/interpreterSelectionTip.ts
+++ b/src/client/interpreter/display/interpreterSelectionTip.ts
@@ -7,6 +7,7 @@ import { inject, injectable } from 'inversify';
 import { IExtensionActivationService } from '../../activation/types';
 import { IApplicationShell } from '../../common/application/types';
 import { IPersistentState, IPersistentStateFactory, Resource } from '../../common/types';
+import { swallowExceptions } from '../../common/utils/decorators';
 import { Common, Interpreters } from '../../common/utils/localize';
 
 @injectable()
@@ -22,13 +23,14 @@ export class InterpreterSelectionTip implements IExtensionActivationService {
             return;
         }
         this.displayedInSession = true;
-        await this.showTip();
+        this.showTip().ignoreErrors();
     }
+    @swallowExceptions('Failed to display tip')
     private async showTip() {
         const selection = await this.shell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt());
         if (selection !== Common.gotIt()) {
             return;
         }
-        this.storage.updateValue(true);
+        await this.storage.updateValue(true);
     }
 }

--- a/src/client/interpreter/display/interpreterSelectionTip.ts
+++ b/src/client/interpreter/display/interpreterSelectionTip.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { IExtensionActivationService } from '../../activation/types';
+import { IApplicationShell } from '../../common/application/types';
+import { IPersistentState, IPersistentStateFactory, Resource } from '../../common/types';
+import { Common, Interpreters } from '../../common/utils/localize';
+
+@injectable()
+export class InterpreterSelectionTip implements IExtensionActivationService {
+    private readonly storage: IPersistentState<boolean>;
+    constructor(@inject(IApplicationShell) private readonly shell: IApplicationShell,
+        @inject(IPersistentStateFactory) private readonly factory: IPersistentStateFactory) {
+        this.storage = this.factory.createGlobalPersistentState('InterpreterSelectionTip', false);
+    }
+    public async activate(_resource: Resource): Promise<void> {
+        if (this.storage.value) {
+            return;
+        }
+        await this.showTip();
+    }
+    private async showTip() {
+        const selection = await this.shell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt());
+        if (selection !== Common.gotIt()) {
+            return;
+        }
+        this.storage.updateValue(true);
+    }
+}

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -46,6 +46,7 @@ import {
     WORKSPACE_VIRTUAL_ENV_SERVICE
 } from './contracts';
 import { InterpreterDisplay } from './display';
+import { InterpreterSelectionTip } from './display/interpreterSelectionTip';
 import { InterpreterLocatorProgressStatubarHandler } from './display/progressDisplay';
 import { ShebangCodeLensProvider } from './display/shebangCodeLensProvider';
 import { InterpreterHelper } from './helpers';
@@ -80,6 +81,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
     serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, VirtualEnvironmentPrompt);
+    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, InterpreterSelectionTip);
     serviceManager.addSingleton<IPythonInPathCommandProvider>(IPythonInPathCommandProvider, PythonInPathCommandProvider);
 
     serviceManager.add<IInterpreterWatcher>(IInterpreterWatcher, WorkspaceVirtualEnvWatcherService, WORKSPACE_VIRTUAL_ENV_SERVICE);

--- a/src/test/interpreters/display/interpreterSelectionTip.unit.test.ts
+++ b/src/test/interpreters/display/interpreterSelectionTip.unit.test.ts
@@ -41,6 +41,19 @@ suite('Interpreters - Interpreter Selection Tip', () => {
         verify(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).once();
         verify(storage.updateValue(true)).never();
     });
+    test('Show tip once per session', async () => {
+        when(storage.value).thenReturn(false);
+        when(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).thenResolve();
+
+        await Promise.all([
+            selectionTip.activate(undefined),
+            selectionTip.activate(undefined),
+            selectionTip.activate(undefined)
+        ]);
+
+        verify(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).once();
+        verify(storage.updateValue(true)).never();
+    });
     test('Show tip and track it', async () => {
         when(storage.value).thenReturn(false);
         when(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).thenResolve(Common.gotIt() as any);

--- a/src/test/interpreters/display/interpreterSelectionTip.unit.test.ts
+++ b/src/test/interpreters/display/interpreterSelectionTip.unit.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { ApplicationShell } from '../../../client/common/application/applicationShell';
+import { IApplicationShell } from '../../../client/common/application/types';
+import { PersistentState, PersistentStateFactory } from '../../../client/common/persistentState';
+import { IPersistentState } from '../../../client/common/types';
+import { Common, Interpreters } from '../../../client/common/utils/localize';
+import { InterpreterSelectionTip } from '../../../client/interpreter/display/interpreterSelectionTip';
+
+// tslint:disable:no-any
+suite('Interpreters - Interpreter Selection Tip', () => {
+    let selectionTip: InterpreterSelectionTip;
+    let appShell: IApplicationShell;
+    let storage: IPersistentState<boolean>;
+    setup(() => {
+        const factory = mock(PersistentStateFactory);
+        storage = mock(PersistentState);
+        appShell = mock(ApplicationShell);
+
+        when(factory.createGlobalPersistentState('InterpreterSelectionTip', false)).thenReturn(instance(storage));
+
+        selectionTip = new InterpreterSelectionTip(instance(appShell), instance(factory));
+    });
+    test('Do not show tip', async () => {
+        when(storage.value).thenReturn(true);
+
+        await selectionTip.activate(undefined);
+
+        verify(appShell.showInformationMessage(anything(), anything())).never();
+    });
+    test('Show tip and do not track it', async () => {
+        when(storage.value).thenReturn(false);
+        when(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).thenResolve();
+
+        await selectionTip.activate(undefined);
+
+        verify(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).once();
+        verify(storage.updateValue(true)).never();
+    });
+    test('Show tip and track it', async () => {
+        when(storage.value).thenReturn(false);
+        when(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).thenResolve(Common.gotIt() as any);
+
+        await selectionTip.activate(undefined);
+
+        verify(appShell.showInformationMessage(Interpreters.selectInterpreterTip(), Common.gotIt())).once();
+        verify(storage.updateValue(true)).once();
+    });
+});


### PR DESCRIPTION
For #5180

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
	