### PR TITLE
Fixed a typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1274,7 +1274,7 @@
                 "python.diagnostics.sourceMapsEnabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable source map support for meaningful strack traces in error logs.",
+                    "description": "Enable source map support for meaningful stack traces in error logs.",
                     "scope": "application"
                 },
                 "python.autoComplete.addBrackets": {


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
