### PR TITLE
Accomadate trailing commas in parsed launch.json

### DIFF
--- a/news/2 Fixes/4543.md
+++ b/news/2 Fixes/4543.md
@@ -1,0 +1,1 @@
+Accomodate trailing commands in the JSON contents of `launch.json` file.

--- a/news/2 Fixes/4543.md
+++ b/news/2 Fixes/4543.md
@@ -1,1 +1,1 @@
-Accomodate trailing commands in the JSON contents of `launch.json` file.
+Accomadate trailing commands in the JSON contents of `launch.json` file.

--- a/src/client/testing/common/debugLauncher.ts
+++ b/src/client/testing/common/debugLauncher.ts
@@ -1,6 +1,6 @@
 import { inject, injectable, named } from 'inversify';
+import { parse } from 'jsonc-parser';
 import * as path from 'path';
-import * as stripJsonComments from 'strip-json-comments';
 import { DebugConfiguration, Uri, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../common/application/types';
 import { EXTENSION_ROOT_DIR } from '../../common/constants';
@@ -12,9 +12,7 @@ import { DebuggerTypeName } from '../../debugger/constants';
 import { IDebugConfigurationResolver } from '../../debugger/extension/configuration/types';
 import { LaunchRequestArguments } from '../../debugger/types';
 import { IServiceContainer } from '../../ioc/types';
-import {
-    ITestDebugConfig, ITestDebugLauncher, LaunchOptions, TestProvider
-} from './types';
+import { ITestDebugConfig, ITestDebugLauncher, LaunchOptions, TestProvider } from './types';
 
 @injectable()
 export class DebugLauncher implements ITestDebugLauncher {
@@ -103,9 +101,8 @@ export class DebugLauncher implements ITestDebugLauncher {
             return [];
         }
         try {
-            let text = await this.fs.readFile(filename);
-            text = stripJsonComments(text);
-            const parsed = JSON.parse(text);
+            const text = await this.fs.readFile(filename);
+            const parsed = parse(text, [], { allowTrailingComma: true, disallowComments: false });
             if (!parsed.version || !parsed.configurations || !Array.isArray(parsed.configurations)) {
                 throw Error('malformed launch.json');
             }


### PR DESCRIPTION
For #4543

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
