### PR TITLE
Use a document selector pattern only in multi-root

### DIFF
--- a/news/2 Fixes/5333.md
+++ b/news/2 Fixes/5333.md
@@ -1,0 +1,1 @@
+Restrict files from being processed by `Language Server` only when in a mult-root workspace.

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -6,7 +6,7 @@
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
 import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, Event, EventEmitter, OutputChannel, Position, TextDocument } from 'vscode';
-import { LanguageClientOptions, ProvideCompletionItemsSignature, RevealOutputChannelOn } from 'vscode-languageclient';
+import { DocumentFilter, DocumentSelector, LanguageClientOptions, ProvideCompletionItemsSignature, RevealOutputChannelOn } from 'vscode-languageclient';
 import { IWorkspaceService } from '../../common/application/types';
 import { isTestExecution, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import { traceDecorators, traceError } from '../../common/logger';
@@ -103,17 +103,10 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
         this.excludedFiles = this.getExcludedFiles();
         this.typeshedPaths = this.getTypeshedPaths();
         const workspaceFolder = this.workspace.getWorkspaceFolder(this.resource);
-        const documentSelector = [
-            { scheme: 'file', language: PYTHON_LANGUAGE },
-            { scheme: 'untitled', language: PYTHON_LANGUAGE }
-        ];
-        if (workspaceFolder) {
-            // tslint:disable-next-line:no-any
-            (documentSelector[0] as any).pattern = `${workspaceFolder.uri.fsPath}/**/*`;
-        }
-        // Options to control the language client
+        const documentSelector = this.getDocumentSelector(this.resource);
+        // Options to control the language client.
         return {
-            // Register the server for Python documents
+            // Register the server for Python documents.
             documentSelector,
             workspaceFolder,
             synchronize: {
@@ -147,6 +140,19 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
                 }
             }
         };
+    }
+    protected getDocumentSelector(resource: Resource): DocumentSelector {
+        const documentSelector: DocumentFilter[] = [
+            { scheme: 'file', language: PYTHON_LANGUAGE },
+            { scheme: 'untitled', language: PYTHON_LANGUAGE }
+        ];
+        // Set the document selector only when in a multi-root workspace scenario.
+        const workspaceFolder = this.workspace.getWorkspaceFolder(resource);
+        if (workspaceFolder && Array.isArray(this.workspace.workspaceFolders) && this.workspace.workspaceFolders!.length > 1) {
+            // tslint:disable-next-line:no-any
+            documentSelector[0].pattern = `${workspaceFolder.uri.fsPath}/**/*`;
+        }
+        return documentSelector;
     }
     protected getExcludedFiles(): string[] {
         const list: string[] = ['**/Lib/**', '**/site-packages/**'];

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
-import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, Event, EventEmitter, OutputChannel, Position, TextDocument } from 'vscode';
+import { CancellationToken, CompletionContext, ConfigurationChangeEvent, Disposable, Event, EventEmitter, OutputChannel, Position, TextDocument, WorkspaceFolder } from 'vscode';
 import { DocumentFilter, DocumentSelector, LanguageClientOptions, ProvideCompletionItemsSignature, RevealOutputChannelOn } from 'vscode-languageclient';
 import { IWorkspaceService } from '../../common/application/types';
 import { isTestExecution, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
@@ -103,7 +103,7 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
         this.excludedFiles = this.getExcludedFiles();
         this.typeshedPaths = this.getTypeshedPaths();
         const workspaceFolder = this.workspace.getWorkspaceFolder(this.resource);
-        const documentSelector = this.getDocumentSelector(this.resource);
+        const documentSelector = this.getDocumentSelector(workspaceFolder);
         // Options to control the language client.
         return {
             // Register the server for Python documents.
@@ -141,13 +141,12 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
             }
         };
     }
-    protected getDocumentSelector(resource: Resource): DocumentSelector {
+    protected getDocumentSelector(workspaceFolder?: WorkspaceFolder): DocumentSelector {
         const documentSelector: DocumentFilter[] = [
             { scheme: 'file', language: PYTHON_LANGUAGE },
             { scheme: 'untitled', language: PYTHON_LANGUAGE }
         ];
         // Set the document selector only when in a multi-root workspace scenario.
-        const workspaceFolder = this.workspace.getWorkspaceFolder(resource);
         if (workspaceFolder && Array.isArray(this.workspace.workspaceFolders) && this.workspace.workspaceFolders!.length > 1) {
             // tslint:disable-next-line:no-any
             documentSelector[0].pattern = `${workspaceFolder.uri.fsPath}/**/*`;

--- a/src/test/activation/languageServer/analysisOptions.unit.test.ts
+++ b/src/test/activation/languageServer/analysisOptions.unit.test.ts
@@ -204,7 +204,7 @@ suite('Language Server - Analysis Options', () => {
 
         expect(settingsChangedInvokedCount).to.be.equal(1);
     });
-    test('Ensure search pattern is provided when there are no workspace folders', () => {
+    test('Ensure search pattern is not provided when there are no workspaces', () => {
         when(workspace.workspaceFolders).thenReturn([]);
 
         const expectedSelector = [
@@ -216,7 +216,7 @@ suite('Language Server - Analysis Options', () => {
 
         expect(selector).to.deep.equal(expectedSelector);
     });
-    test('Ensure search pattern is only provided in multi-root workspaces', () => {
+    test('Ensure search pattern is not provided in single-root workspaces', () => {
         const workspaceFolder: WorkspaceFolder = { name: '', index: 0, uri: Uri.file(__dirname) };
         when(workspace.workspaceFolders).thenReturn([workspaceFolder]);
 

--- a/src/test/activation/languageServer/analysisOptions.unit.test.ts
+++ b/src/test/activation/languageServer/analysisOptions.unit.test.ts
@@ -16,7 +16,7 @@ import { WorkspaceService } from '../../../client/common/application/workspace';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { PathUtils } from '../../../client/common/platform/pathUtils';
-import { IConfigurationService, IDisposable, IExtensionContext, IOutputChannel, IPathUtils, IPythonExtensionBanner, Resource } from '../../../client/common/types';
+import { IConfigurationService, IDisposable, IExtensionContext, IOutputChannel, IPathUtils, IPythonExtensionBanner } from '../../../client/common/types';
 import { EnvironmentVariablesProvider } from '../../../client/common/variables/environmentVariablesProvider';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';

--- a/src/test/activation/languageServer/analysisOptions.unit.test.ts
+++ b/src/test/activation/languageServer/analysisOptions.unit.test.ts
@@ -26,7 +26,7 @@ import { sleep } from '../../core';
 
 // tslint:disable:no-unnecessary-override no-any chai-vague-errors no-unused-expression max-func-body-length
 
-suite('xLanguage Server - Analysis Options', () => {
+suite('Language Server - Analysis Options', () => {
     class TestClass extends LanguageServerAnalysisOptions {
         public getDocumentSelector(resource: Resource): DocumentSelector {
             return super.getDocumentSelector(resource);


### PR DESCRIPTION
For #5333

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
