### PR TITLE
correctly show variables after jupyter restart

### DIFF
--- a/news/2 Fixes/5244.md
+++ b/news/2 Fixes/5244.md
@@ -1,0 +1,1 @@
+Variables not cleared after a kernel restart

--- a/package.json
+++ b/package.json
@@ -1240,7 +1240,7 @@
                 },
                 "python.dataScience.variableExplorerExclude": {
                     "type": "string",
-                    "default": "module;builtin_function_or_method",
+                    "default": "module;function;builtin_function_or_method",
                     "description": "Types to exclude from showing in the Python Interactive variable explorer",
                     "scope": "resource"
                 },

--- a/pythonFiles/datascience/getJupyterVariableList.py
+++ b/pythonFiles/datascience/getJupyterVariableList.py
@@ -2,25 +2,27 @@
 # Tested on 2.7 and 3.6
 from sys import getsizeof as _VSCODE_getsizeof
 import json as _VSCODE_json
-from IPython import get_ipython
+from IPython import get_ipython as _VSCODE_get_ipython
 
 # _VSCode_supportsDataExplorer will contain our list of data explorer supported types
 _VSCode_supportsDataExplorer = "['list', 'Series', 'dict', 'ndarray', 'DataFrame']"
 
 # who_ls is a Jupyter line magic to fetch currently defined vars
-_VSCode_JupyterVars = get_ipython().run_line_magic('who_ls', '')
+_VSCode_JupyterVars = _VSCODE_get_ipython().run_line_magic('who_ls', '')
 
 _VSCode_output = []
-for var in _VSCode_JupyterVars:
+for _VSCode_var in _VSCode_JupyterVars:
     try:
-        _VSCode_type = type(eval(var))
-        _VSCode_output.append({'name': var, 'type': _VSCode_type.__name__, 'size': _VSCODE_getsizeof(var), 'supportsDataExplorer': _VSCode_type.__name__ in _VSCode_supportsDataExplorer })
+        _VSCode_type = type(eval(_VSCode_var))
+        _VSCode_output.append({'name': _VSCode_var, 'type': _VSCode_type.__name__, 'size': _VSCODE_getsizeof(_VSCode_var), 'supportsDataExplorer': _VSCode_type.__name__ in _VSCode_supportsDataExplorer })
         del _VSCode_type
+        del _VSCode_var
     except:
         pass
 
 print(_VSCODE_json.dumps(_VSCode_output))
 
+del _VSCODE_get_ipython
 del _VSCode_output
 del _VSCode_supportsDataExplorer
 del _VSCode_JupyterVars

--- a/src/client/datascience/history/history.ts
+++ b/src/client/datascience/history/history.ts
@@ -44,6 +44,7 @@ import {
     IJupyterExecution,
     IJupyterVariable,
     IJupyterVariables,
+    IJupyterVariablesResponse,
     INotebookExporter,
     INotebookServer,
     InterruptResult,
@@ -918,13 +919,14 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
         }
     }
 
-    private requestVariables = async (executionCount: number): Promise<void> => {
+    private requestVariables = async (requestExecutionCount: number): Promise<void> => {
         // Request our new list of variables
-        let vars: IJupyterVariable[] = await this.jupyterVariables.getVariables();
+        const vars: IJupyterVariable[] = await this.jupyterVariables.getVariables();
+        const variablesResponse: IJupyterVariablesResponse = {executionCount: requestExecutionCount, variables: vars };
 
         // Tag all of our jupyter variables with the execution count of the request
-        vars.forEach((value: IJupyterVariable) => {
-            value.executionCount = executionCount;
+        variablesResponse.variables.forEach((value: IJupyterVariable) => {
+            value.executionCount = requestExecutionCount;
         });
 
         const settings = this.configuration.getSettings();
@@ -932,12 +934,12 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
 
         if (excludeString) {
             const excludeArray = excludeString.split(';');
-            vars = vars.filter((value) => {
+            variablesResponse.variables = variablesResponse.variables.filter((value) => {
                return excludeArray.indexOf(value.type) === -1;
             });
         }
 
-        this.postMessage(HistoryMessages.GetVariablesResponse, vars).ignoreErrors();
+        this.postMessage(HistoryMessages.GetVariablesResponse, variablesResponse).ignoreErrors();
     }
 
     // tslint:disable-next-line: no-any

--- a/src/client/datascience/history/historyTypes.ts
+++ b/src/client/datascience/history/historyTypes.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { CssMessages, IGetCssRequest, IGetCssResponse, SharedMessages } from '../constants';
-import { ICell, IHistoryInfo, IJupyterVariable } from '../types';
+import { ICell, IHistoryInfo, IJupyterVariable, IJupyterVariablesResponse } from '../types';
 
 export namespace HistoryMessages {
     export const StartCell = 'start_cell';
@@ -97,7 +97,7 @@ export class IHistoryMapping {
     public [HistoryMessages.Activate] : never | undefined;
     public [HistoryMessages.ShowDataViewer]: string;
     public [HistoryMessages.GetVariablesRequest]: number;
-    public [HistoryMessages.GetVariablesResponse]: IJupyterVariable[];
+    public [HistoryMessages.GetVariablesResponse]: IJupyterVariablesResponse;
     public [HistoryMessages.GetVariableValueRequest]: IJupyterVariable;
     public [HistoryMessages.GetVariableValueResponse]: IJupyterVariable;
     public [CssMessages.GetCssRequest] : IGetCssRequest;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -281,6 +281,12 @@ export interface IJupyterVariables {
     getDataFrameRows(targetVariable: IJupyterVariable, start: number, end: number) : Promise<JSONObject>;
 }
 
+// Wrapper to hold an execution count for our variable requests
+export interface IJupyterVariablesResponse {
+    executionCount: number;
+    variables: IJupyterVariable[];
+}
+
 export const IDataViewerProvider = Symbol('IDataViewerProvider');
 export interface IDataViewerProvider {
     create(variable: string) : Promise<IDataViewer>;

--- a/src/datascience-ui/history-react/MainPanel.tsx
+++ b/src/datascience-ui/history-react/MainPanel.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 import { CellMatcher } from '../../client/datascience/cellMatcher';
 import { generateMarkdownFromCodeLines } from '../../client/datascience/common';
 import { HistoryMessages, IHistoryMapping } from '../../client/datascience/history/historyTypes';
-import { CellState, ICell, IHistoryInfo, IJupyterVariable } from '../../client/datascience/types';
+import { CellState, ICell, IHistoryInfo, IJupyterVariable, IJupyterVariablesResponse } from '../../client/datascience/types';
 import { IMessageHandler, PostOffice } from '../react-common/postOffice';
 import { getSettings, updateSettings } from '../react-common/settingsReactSide';
 import { StyleInjector } from '../react-common/styleInjector';
@@ -784,16 +784,16 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
     // tslint:disable-next-line:no-any
     private getVariablesResponse = (payload?: any) => {
         if (payload) {
-            const variables = payload as IJupyterVariable[];
+            const variablesResponse = payload as IJupyterVariablesResponse;
 
             // Check to see if we have moved to a new execution count only send our update if we are on the same count as the request
-            if (variables.length > 0 && variables[0].executionCount !== undefined && variables[0].executionCount === this.currentExecutionCount) {
+            if (variablesResponse.executionCount === this.currentExecutionCount) {
                 if (this.variableExplorerRef.current) {
-                    this.variableExplorerRef.current.newVariablesData(variables);
+                    this.variableExplorerRef.current.newVariablesData(variablesResponse.variables);
                 }
 
                 // Now put out a request for all of the sub values for the variables
-                variables.forEach(this.refreshVariable);
+                variablesResponse.variables.forEach(this.refreshVariable);
             }
         }
     }


### PR DESCRIPTION
For #5244

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
