### PR TITLE
Change the theme of matplotlib dynamically

### DIFF
--- a/news/2 Fixes/5294.md
+++ b/news/2 Fixes/5294.md
@@ -1,0 +1,1 @@
+Update matplotlib based on theme changes.

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -126,6 +126,7 @@ export namespace Identifiers {
     export const EmptyFileName = '2DB9B899-6519-4E1B-88B0-FA728A274115';
     export const GeneratedThemeName = 'ipython-theme'; // This needs to be all lower class and a valid class name.
     export const HistoryPurpose = 'history';
+    export const MatplotLibDefaultParams = '_VSCode_defaultMatplotlib_Params';
 }
 
 export namespace JupyterCommands {

--- a/src/client/datascience/history/history.ts
+++ b/src/client/datascience/history/history.ts
@@ -29,7 +29,7 @@ import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { IInterpreterService, PythonInterpreter } from '../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import { EditorContexts, Identifiers, Telemetry } from '../constants';
+import { CssMessages, EditorContexts, Identifiers, Telemetry } from '../constants';
 import { JupyterInstallError } from '../jupyter/jupyterInstallError';
 import { JupyterKernelPromiseFailedError } from '../jupyter/jupyterKernelPromiseFailedError';
 import {
@@ -241,6 +241,20 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
 
         // Pass onto our base class.
         super.onMessage(message, payload);
+
+        // After our base class handles some stuff, handle it ourselves too.
+        switch (message) {
+            case CssMessages.GetCssRequest:
+                // Update the jupyter server if we have one:
+                if (this.jupyterServer) {
+                    this.isDark().then(d => this.jupyterServer ? this.jupyterServer.setMatplotLibStyle(d) : Promise.resolve()).ignoreErrors();
+                }
+                break;
+
+            default:
+                break;
+        }
+
     }
 
     public dispose() {
@@ -764,6 +778,9 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
     private async loadJupyterServer(_restart?: boolean): Promise<void> {
         this.logger.logInformation('Getting jupyter server options ...');
 
+        // Wait for the webpanel to pass back our current theme darkness
+        const knownDark = await this.isDark();
+
         // Extract our options
         const options = await this.historyProvider.getNotebookOptions();
 
@@ -771,6 +788,11 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
 
         // Now try to create a notebook server
         this.jupyterServer = await this.jupyterExecution.connectToNotebookServer(options);
+
+        // Before we run any cells, update the dark setting
+        if (this.jupyterServer) {
+            await this.jupyterServer.setMatplotLibStyle(knownDark);
+        }
 
         this.logger.logInformation('Connected to jupyter server.');
     }

--- a/src/client/datascience/history/historyProvider.ts
+++ b/src/client/datascience/history/historyProvider.ts
@@ -6,14 +6,14 @@ import * as uuid from 'uuid/v4';
 import { Disposable, Event, EventEmitter } from 'vscode';
 import * as vsls from 'vsls/vscode';
 
-import { ILiveShareApi, IWorkspaceService } from '../../common/application/types';
+import { ILiveShareApi } from '../../common/application/types';
 import { IAsyncDisposable, IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { IServiceContainer } from '../../ioc/types';
 import { Identifiers, LiveShare, LiveShareCommands, Settings } from '../constants';
 import { PostOffice } from '../liveshare/postOffice';
-import { IHistory, IHistoryProvider, INotebookServerOptions, IThemeFinder } from '../types';
+import { IHistory, IHistoryProvider, INotebookServerOptions } from '../types';
 
 interface ISyncData {
     count: number;
@@ -34,9 +34,7 @@ export class HistoryProvider implements IHistoryProvider, IAsyncDisposable {
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
         @inject(IAsyncDisposableRegistry) asyncRegistry : IAsyncDisposableRegistry,
         @inject(IDisposableRegistry) private disposables: IDisposableRegistry,
-        @inject(IConfigurationService) private configService: IConfigurationService,
-        @inject(IWorkspaceService) private workspaceService: IWorkspaceService,
-        @inject(IThemeFinder) private themeFinder: IThemeFinder
+        @inject(IConfigurationService) private configService: IConfigurationService
         ) {
         asyncRegistry.push(this);
 
@@ -84,16 +82,6 @@ export class HistoryProvider implements IHistoryProvider, IAsyncDisposable {
         const settings = this.configService.getSettings();
         let serverURI: string | undefined = settings.datascience.jupyterServerURI;
         const useDefaultConfig: boolean | undefined = settings.datascience.useDefaultConfigForJupyter;
-        // Check for dark theme, if so set matplot lib to use dark_background settings
-        let darkTheme: boolean | undefined = false;
-        const workbench = this.workspaceService.getConfiguration('workbench');
-        if (workbench) {
-            const theme = workbench.get<string>('colorTheme');
-            const ignoreTheme = this.configService.getSettings().datascience.ignoreVscodeTheme ? true : false;
-            if (theme && !ignoreTheme) {
-                darkTheme = await this.themeFinder.isThemeDark(theme);
-            }
-        }
 
         // For the local case pass in our URI as undefined, that way connect doesn't have to check the setting
         if (serverURI === Settings.JupyterServerLocalLaunch) {
@@ -102,7 +90,6 @@ export class HistoryProvider implements IHistoryProvider, IAsyncDisposable {
 
         return {
             uri: serverURI,
-            usingDarkTheme: darkTheme,
             useDefaultConfig,
             purpose: Identifiers.HistoryPurpose
         };

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -150,7 +150,6 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         connectionInfo: startInfo.connection,
                         currentInterpreter: interpreter,
                         kernelSpec: startInfo.kernelSpec,
-                        usingDarkTheme: options && options.usingDarkTheme ? options.usingDarkTheme : false,
                         workingDir: options ? options.workingDir : undefined,
                         uri: options ? options.uri : undefined,
                         purpose: options ? options.purpose : uuid()

--- a/src/client/datascience/jupyter/jupyterServer.ts
+++ b/src/client/datascience/jupyter/jupyterServer.ts
@@ -375,6 +375,14 @@ export class JupyterServerBase implements INotebookServer {
         return this.connectPromise.promise;
     }
 
+    public async setMatplotLibStyle(useDark: boolean) : Promise<void> {
+        // Reset the matplotlib style based on if dark or not.
+        await this.executeSilently(useDark ?
+            'matplotlib.style.use(\'dark_background\')' :
+            `matplotlib.rcParams.update(${Identifiers.MatplotLibDefaultParams})`);
+
+    }
+
     // Return a copy of the connection information that this server used to connect with
     public getConnectionInfo(): IConnection | undefined {
         if (!this.launchInfo) {
@@ -513,8 +521,10 @@ export class JupyterServerBase implements INotebookServer {
                 await this.changeDirectoryIfPossible(this.launchInfo.workingDir);
             }
 
+            // Force matplotlib to inline and save the default style. We'll use this later if we
+            // get a request to update style
             await this.executeSilently(
-                `%matplotlib inline${os.EOL}import matplotlib.pyplot as plt${(this.launchInfo && this.launchInfo.usingDarkTheme) ? `${os.EOL}from matplotlib import style${os.EOL}style.use(\'dark_background\')` : ''}`,
+                `import matplotlib${os.EOL}%matplotlib inline${os.EOL}${Identifiers.MatplotLibDefaultParams} = dict(matplotlib.rcParams)`,
                 cancelToken
             );
         } catch (e) {

--- a/src/client/datascience/jupyter/jupyterServerFactory.ts
+++ b/src/client/datascience/jupyter/jupyterServerFactory.ts
@@ -98,6 +98,11 @@ export class JupyterServerFactory implements INotebookServer {
         return server.setInitialDirectory(directory);
     }
 
+    public async setMatplotLibStyle(useDark: boolean): Promise<void> {
+        const server = await this.serverFactory.get();
+        return server.setMatplotLibStyle(useDark);
+    }
+
     public executeObservable(code: string, file: string, line: number, id: string, silent: boolean = false): Observable<ICell[]> {
         // Create a wrapper observable around the actual server (because we have to wait for a promise)
         return new Observable<ICell[]>(subscriber => {

--- a/src/client/datascience/jupyter/liveshare/guestJupyterExecution.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterExecution.ts
@@ -110,7 +110,6 @@ export class GuestJupyterExecution extends LiveShareParticipantGuest(JupyterExec
                 result = await super.connectToNotebookServer(
                     {
                         uri: newUri,
-                        usingDarkTheme: options && options.usingDarkTheme,
                         useDefaultConfig: options && options.useDefaultConfig,
                         workingDir: options ? options.workingDir : undefined,
                         purpose

--- a/src/client/datascience/jupyter/liveshare/guestJupyterServer.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterServer.ts
@@ -98,6 +98,10 @@ export class GuestJupyterServer
         return Promise.resolve();
     }
 
+    public async setMatplotLibStyle(_useDark: boolean): Promise<void> {
+        // Guest can't change the style. Maybe output a warning here?
+    }
+
     public executeObservable(code: string, file: string, line: number, id: string): Observable<ICell[]> {
         // Mimic this to the other side and then wait for a response
         this.waitForService().then(s => {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -46,7 +46,6 @@ export interface INotebookServerLaunchInfo
     currentInterpreter: PythonInterpreter | undefined;
     uri: string | undefined; // Different from the connectionInfo as this is the setting used, not the result
     kernelSpec: IJupyterKernelSpec | undefined;
-    usingDarkTheme: boolean;
     workingDir: string | undefined;
     purpose: string | undefined; // Purpose this server is for
 }
@@ -65,6 +64,7 @@ export interface INotebookServer extends IAsyncDisposable {
     waitForConnect(): Promise<INotebookServerLaunchInfo | undefined>;
     getConnectionInfo(): IConnection | undefined;
     getSysInfo() : Promise<ICell | undefined>;
+    setMatplotLibStyle(useDark: boolean) : Promise<void>;
 }
 
 export interface INotebookServerOptions {

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -62,6 +62,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
     private emptyRows: (() => JSX.Element) | undefined;
     private getEmptyRows: ((props: any) => JSX.Element) | undefined;
     private sentDone = false;
+    private postOffice: PostOffice = new PostOffice();
 
     // tslint:disable-next-line:max-func-body-length
     constructor(props: IMainPanelProps, _state: IMainPanelState) {
@@ -98,10 +99,10 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
 
     public componentWillMount() {
         // Add ourselves as a handler for the post office
-        PostOffice.addHandler(this);
+        this.postOffice.addHandler(this);
 
         // Tell the dataviewer code we have started.
-        PostOffice.sendMessage<IDataViewerMapping, 'started'>(DataViewerMessages.Started);
+        this.postOffice.sendMessage<IDataViewerMapping, 'started'>(DataViewerMessages.Started);
     }
 
     public componentDidMount() {
@@ -111,7 +112,8 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
 
     public componentWillUnmount() {
         window.removeEventListener('resize', this.updateDimensions);
-        PostOffice.removeHandler(this);
+        this.postOffice.removeHandler(this);
+        this.postOffice.dispose();
     }
 
     public componentDidUpdate() {
@@ -132,7 +134,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         return (
                 <div className='background'>
                     <div className='main-panel' ref={this.updateContainer}>
-                        <StyleInjector expectingDark={this.props.baseTheme !== 'vscode-light'} />
+                        <StyleInjector expectingDark={this.props.baseTheme !== 'vscode-light'} postOffice={this.postOffice} />
                         {this.container && this.renderGrid()}
                     </div>
                 </div>
@@ -332,7 +334,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
     }
 
     private sendMessage<M extends IDataViewerMapping, T extends keyof M>(type: T, payload?: M[T]) {
-        PostOffice.sendMessage<M, T>(type, payload);
+        this.postOffice.sendMessage<M, T>(type, payload);
     }
 
     private getColumnType(name: string | number) : string | undefined {

--- a/src/datascience-ui/react-common/styleInjector.tsx
+++ b/src/datascience-ui/react-common/styleInjector.tsx
@@ -10,6 +10,7 @@ import { detectBaseTheme } from './themeDetector';
 
 export interface IStyleInjectorProps {
     expectingDark: boolean;
+    postOffice: PostOffice;
     darkChanged?(newDark: boolean): void;
 }
 
@@ -28,19 +29,19 @@ export class StyleInjector extends React.Component<IStyleInjectorProps, IStyleIn
 
     public componentWillMount() {
         // Add ourselves as a handler for the post office
-        PostOffice.addHandler(this);
+        this.props.postOffice.addHandler(this);
     }
 
     public componentWillUnmount() {
         // Remove ourselves as a handler for the post office
-        PostOffice.removeHandler(this);
+        this.props.postOffice.removeHandler(this);
     }
 
     public componentDidMount() {
         if (!this.state.rootCss) {
             // Set to a temporary value.
             this.setState({rootCss: ' '});
-            PostOffice.sendUnsafeMessage(CssMessages.GetCssRequest, { isDark: this.props.expectingDark });
+            this.props.postOffice.sendUnsafeMessage(CssMessages.GetCssRequest, { isDark: this.props.expectingDark });
         }
     }
 
@@ -105,7 +106,7 @@ export class StyleInjector extends React.Component<IStyleInjectorProps, IStyleIn
             const dsSettings = newSettings as IDataScienceExtraSettings;
             if (dsSettings && dsSettings.extraSettings && dsSettings.extraSettings.theme !== this.state.theme) {
                 // User changed the current theme. Rerender
-                PostOffice.sendUnsafeMessage(CssMessages.GetCssRequest, { isDark: this.computeKnownDark() });
+                this.props.postOffice.sendUnsafeMessage(CssMessages.GetCssRequest, { isDark: this.computeKnownDark() });
             }
         }
     }

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -14,7 +14,6 @@ import { Disposable } from 'vscode';
 
 import { createDeferred } from '../../client/common/utils/async';
 import { Identifiers } from '../../client/datascience/constants';
-import { DataViewerMessageListener } from '../../client/datascience/data-viewing/dataViewerMessageListener';
 import { DataViewerMessages } from '../../client/datascience/data-viewing/types';
 import { IDataViewer, IDataViewerProvider, IHistoryProvider, IJupyterExecution } from '../../client/datascience/types';
 import { MainPanel } from '../../datascience-ui/data-explorer/mainPanel';
@@ -22,7 +21,7 @@ import { noop } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 
 // import { asyncDump } from '../common/asyncDump';
-suite('DataViewer tests', () => {
+suite('DataScience DataViewer tests', () => {
     const disposables: Disposable[] = [];
     let dataProvider: IDataViewerProvider;
     let ioc: DataScienceIocContainer;
@@ -55,26 +54,11 @@ suite('DataViewer tests', () => {
     });
 
     function mountWebView(): ReactWrapper<any, Readonly<{}>, React.Component> {
-
         // Setup our webview panel
         ioc.createWebView(() => mount(<MainPanel skipDefault={true} baseTheme={'vscode-light'} forceHeight={200}/>));
 
         // Make sure the data explorer provider and execution factory in the container is created (the extension does this on startup in the extension)
         dataProvider = ioc.get<IDataViewerProvider>(IDataViewerProvider);
-
-        // The history provider create needs to be rewritten to make the history window think the mounted web panel is
-        // ready.
-        const origFunc = (dataProvider as any).create.bind(dataProvider);
-        (dataProvider as any).create = async (v: string): Promise<void> => {
-            const dataViewer = await origFunc(v);
-
-            // During testing the MainPanel sends the init message before our history is created.
-            // Pretend like it's happening now
-            const listener = ((dataViewer as any).messageListener) as DataViewerMessageListener;
-            listener.onMessage(DataViewerMessages.Started, {});
-
-            return dataViewer;
-        };
 
         return ioc.wrapper!;
     }

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -87,6 +87,10 @@ class MockJupyterServer implements INotebookServer {
     public setInitialDirectory(_directory: string): Promise<void> {
         throw new Error('Method not implemented');
     }
+
+    public async setMatplotLibStyle(_useDark: boolean): Promise<void> {
+        noop();
+    }
     public getConnectionInfo(): IConnection | undefined {
         return this.launchInfo ? this.launchInfo.connectionInfo : undefined;
     }

--- a/src/test/datascience/history.functional.test.tsx
+++ b/src/test/datascience/history.functional.test.tsx
@@ -41,7 +41,7 @@ import {
 import { waitForUpdate } from './reactHelpers';
 
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
-suite('History output tests', () => {
+suite('DataScience History output tests', () => {
     const disposables: Disposable[] = [];
     let ioc: DataScienceIocContainer;
 

--- a/src/test/datascience/historyTestHelpers.tsx
+++ b/src/test/datascience/historyTestHelpers.tsx
@@ -10,9 +10,8 @@ import { CancellationToken } from 'vscode';
 
 import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
 import { IDataScienceSettings } from '../../client/common/types';
-import { HistoryMessageListener } from '../../client/datascience/history/historyMessageListener';
 import { HistoryMessages } from '../../client/datascience/history/historyTypes';
-import { IHistory, IHistoryProvider, IJupyterExecution } from '../../client/datascience/types';
+import { IHistory, IJupyterExecution } from '../../client/datascience/types';
 import { CellButton } from '../../datascience-ui/history-react/cellButton';
 import { MainPanel } from '../../datascience-ui/history-react/MainPanel';
 import { updateSettings } from '../../datascience-ui/react-common/settingsReactSide';
@@ -69,27 +68,8 @@ export function runMountedTest(name: string, testFunc: (wrapper: ReactWrapper<an
 //}
 
 export function mountWebView(ioc: DataScienceIocContainer, node: React.ReactElement<any>): ReactWrapper<any, Readonly<{}>, React.Component> {
-
     // Setup our webview panel
     ioc.createWebView(() => mount(node));
-    //ioc.createWebView(() => mount(<MainPanel baseTheme='vscode-light' codeTheme='light_vs' testMode={true} skipDefault={true} />));
-
-    // Make sure the history provider and execution factory in the container is created (the extension does this on startup in the extension)
-    const historyProvider = ioc.get<IHistoryProvider>(IHistoryProvider);
-
-    // The history provider create needs to be rewritten to make the history window think the mounted web panel is
-    // ready.
-    const origFunc = (historyProvider as any).create.bind(historyProvider);
-    (historyProvider as any).create = async (): Promise<void> => {
-        await origFunc();
-        const history = historyProvider.getActive();
-
-        // During testing the MainPanel sends the init message before our history is created.
-        // Pretend like it's happening now
-        const listener = ((history as any).messageListener) as HistoryMessageListener;
-        listener.onMessage(HistoryMessages.Started, {});
-    };
-
     return ioc.wrapper!;
 }
 

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -18,6 +18,7 @@ import { IAsyncDisposableRegistry, IConfigurationService } from '../../client/co
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
 import { generateCells } from '../../client/datascience/cellFactory';
 import { concatMultilineString } from '../../client/datascience/common';
+import { Identifiers } from '../../client/datascience/constants';
 import {
     ICell,
     IConnection,
@@ -98,8 +99,9 @@ export class MockJupyterManager implements IJupyterSessionManager {
         this.kernelSpecs.push({name: '0e8519db-0895-416c-96df-fa80131ecea0', dir: 'C:\\Users\\rchiodo\\AppData\\Roaming\\jupyter\\kernels\\0e8519db-0895-416c-96df-fa80131ecea0'});
 
         // Setup our default cells that happen for everything
-        this.addCell('%matplotlib inline\r\nimport matplotlib.pyplot as plt');
-        this.addCell('%matplotlib inline\r\nimport matplotlib.pyplot as plt\r\nfrom matplotlib import style\r\nstyle.use(\'dark_background\')');
+        this.addCell(`import matplotlib${os.EOL}%matplotlib inline${os.EOL}${Identifiers.MatplotLibDefaultParams} = dict(matplotlib.rcParams)`);
+        this.addCell('matplotlib.style.use(\'dark_background\')');
+        this.addCell(`matplotlib.rcParams.update(${Identifiers.MatplotLibDefaultParams})`);
         this.addCell(`%cd "${path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience')}"`);
         this.addCell('import sys\r\nsys.version', '1.1.1.1');
         this.addCell('import sys\r\nsys.executable', 'python');

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -49,7 +49,7 @@ interface IJupyterServerInterface extends IRoleBasedObject, INotebookServer {
 }
 
 // tslint:disable:no-any no-multiline-string max-func-body-length no-console max-classes-per-file trailing-comma
-suite('Jupyter notebook tests', () => {
+suite('DataScience notebook tests', () => {
     const disposables: Disposable[] = [];
     let jupyterExecution: IJupyterExecution;
     let processFactory: IProcessServiceFactory;

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -21,7 +21,6 @@ import { noop } from '../../client/common/utils/misc';
 import { concatMultilineString } from '../../client/datascience/common';
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
 import { JupyterKernelPromiseFailedError } from '../../client/datascience/jupyter/jupyterKernelPromiseFailedError';
-import { IRoleBasedObject, RoleBasedFactory } from '../../client/datascience/jupyter/liveshare/roleBasedFactory';
 import {
     CellState,
     IConnection,
@@ -37,16 +36,10 @@ import {
     IKnownSearchPathsForInterpreters,
     PythonInterpreter
 } from '../../client/interpreter/contracts';
-import { ClassType } from '../../client/ioc/types';
 import { ICellViewModel } from '../../datascience-ui/history-react/cell';
 import { generateTestState } from '../../datascience-ui/history-react/mainPanelState';
 import { sleep } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
-import { MockJupyterSession } from './mockJupyterSession';
-
-interface IJupyterServerInterface extends IRoleBasedObject, INotebookServer {
-
-}
 
 // tslint:disable:no-any no-multiline-string max-func-body-length no-console max-classes-per-file trailing-comma
 suite('DataScience notebook tests', () => {

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -766,17 +766,6 @@ plt.show()`,
         }
     });
 
-    async function getNotebookSession(server: INotebookServer | undefined): Promise<MockJupyterSession | undefined> {
-        if (server) {
-            // This is kinda fragile. It reliese on impl details to get to the session. Might
-            // just expose it?
-            const innerServerFactory = (server as any).serverFactory as RoleBasedFactory<IJupyterServerInterface, ClassType<IJupyterServerInterface>>;
-            const innerServer = await innerServerFactory.get();
-            assert.ok(innerServer, 'Cannot find the inner server');
-            return (innerServer as any).session as MockJupyterSession;
-        }
-    }
-
     runTest('Invalid kernel spec works', async () => {
         if (ioc.mockJupyter) {
             // Make a dummy class that will fail during launch

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -777,25 +777,6 @@ plt.show()`,
         }
     }
 
-    runTest('Theme modifies execution', async () => {
-        if (ioc.mockJupyter) {
-            let server = await createNotebookServer(true, false, false);
-            let session = await getNotebookSession(server);
-            const light = '%matplotlib inline\nimport matplotlib.pyplot as plt';
-            const dark = '%matplotlib inline\nimport matplotlib.pyplot as plt\nfrom matplotlib import style\nstyle.use(\'dark_background\')';
-
-            assert.ok(session!.getExecutes().indexOf(light) >= 0, 'light not found');
-            assert.ok(session!.getExecutes().indexOf(dark) < 0, 'dark found when not allowed');
-            await server!.dispose();
-
-            server = await createNotebookServer(true, false, true);
-            session = await getNotebookSession(server);
-            assert.ok(session!.getExecutes().indexOf(dark) >= 0, 'dark not found');
-            assert.ok(session!.getExecutes().indexOf(light) < 0, 'light found when not allowed');
-            await server!.dispose();
-        }
-    });
-
     runTest('Invalid kernel spec works', async () => {
         if (ioc.mockJupyter) {
             // Make a dummy class that will fail during launch

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -16,7 +16,7 @@ import { addCode, runMountedTest } from './historyTestHelpers';
 import { waitForUpdate } from './reactHelpers';
 
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
-suite('History variable explorer tests', () => {
+suite('DataScience History variable explorer tests', () => {
     const disposables: Disposable[] = [];
     let ioc: DataScienceIocContainer;
 


### PR DESCRIPTION
For #5294

Make the interactive window apply theming to matplotlib in real time instead of once.
This also fixes an issue if the theme.json can't be found. We will still apply the correct theming to matplotlib.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
