### PR TITLE
enable var exp by default and add telemetry

### DIFF
--- a/news/1 Enhancements/5337.md
+++ b/news/1 Enhancements/5337.md
@@ -1,0 +1,1 @@
+Add telemetry for variable explorer and turn on by default

--- a/package.json
+++ b/package.json
@@ -1234,8 +1234,8 @@
                 },
                 "python.dataScience.showJupyterVariableExplorer": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "Show the variable explorer in the Python Interactive window. (experimental)",
+                    "default": true,
+                    "description": "Show the variable explorer in the Python Interactive window.",
                     "scope": "resource"
                 },
                 "python.dataScience.variableExplorerExclude": {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -107,7 +107,9 @@ export enum Telemetry {
     RunFileInteractive = 'DATASCIENCE.RUN_FILE_INTERACTIVE',
     PandasNotInstalled = 'DATASCIENCE.SHOW_DATA_NO_PANDAS',
     PandasTooOld = 'DATASCIENCE.SHOW_DATA_PANDAS_TOO_OLD',
-    DataScienceSettings = 'DATASCIENCE.SETTINGS'
+    DataScienceSettings = 'DATASCIENCE.SETTINGS',
+    VariableExplorerToggled = 'DATASCIENCE.VARIABLE_EXPLORER_TOGGLE',
+    VariableExplorerVariableCount = 'DATASCIENCE.VARIABLE_EXPLORER_VARIABLE_COUNT'
  }
 
 export namespace HelpLinks {

--- a/src/client/datascience/history/history.ts
+++ b/src/client/datascience/history/history.ts
@@ -216,6 +216,10 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
                 this.logTelemetry(Telemetry.CollapseAll);
                 break;
 
+            case HistoryMessages.VariableExplorerToggle:
+                this.variableExplorerToggle(payload);
+                break;
+
             case HistoryMessages.AddedSysInfo:
                 this.dispatchMessage(message, payload, this.onAddedSysInfo);
                 break;
@@ -940,6 +944,7 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
         }
 
         this.postMessage(HistoryMessages.GetVariablesResponse, variablesResponse).ignoreErrors();
+        sendTelemetryEvent(Telemetry.VariableExplorerVariableCount, undefined, { variableCount: variablesResponse.variables.length });
     }
 
     // tslint:disable-next-line: no-any
@@ -949,6 +954,17 @@ export class History extends WebViewHost<IHistoryMapping> implements IHistory  {
             // Request our variable value
             const varValue: IJupyterVariable = await this.jupyterVariables.getValue(targetVar);
             this.postMessage(HistoryMessages.GetVariableValueResponse, varValue).ignoreErrors();
+        }
+    }
+
+    // tslint:disable-next-line: no-any
+    private variableExplorerToggle = (payload?: any) => {
+        // Direct undefined check as false boolean will skip code
+        if (payload !== undefined) {
+            const openValue = payload as boolean;
+
+            // Log the state in our Telemetry
+            sendTelemetryEvent(Telemetry.VariableExplorerToggled, undefined, { open: openValue });
         }
     }
 }

--- a/src/client/datascience/history/historyTypes.ts
+++ b/src/client/datascience/history/historyTypes.ts
@@ -34,6 +34,7 @@ export namespace HistoryMessages {
     export const GetVariablesResponse = 'get_variables_response';
     export const GetVariableValueRequest = 'get_variable_value_request';
     export const GetVariableValueResponse = 'get_variable_value_response';
+    export const VariableExplorerToggle = 'variable_explorer_toggle';
 }
 
 // These are the messages that will mirror'd to guest/hosts in
@@ -100,6 +101,7 @@ export class IHistoryMapping {
     public [HistoryMessages.GetVariablesResponse]: IJupyterVariablesResponse;
     public [HistoryMessages.GetVariableValueRequest]: IJupyterVariable;
     public [HistoryMessages.GetVariableValueResponse]: IJupyterVariable;
+    public [HistoryMessages.VariableExplorerToggle]: boolean;
     public [CssMessages.GetCssRequest] : IGetCssRequest;
     public [CssMessages.GetCssResponse] : IGetCssResponse;
 }

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -360,6 +360,8 @@ export interface IEventNamePropertyMapping {
     [Telemetry.StartJupyter]: never | undefined;
     [Telemetry.SubmitCellThroughInput]: never | undefined;
     [Telemetry.Undo]: never | undefined;
+    [Telemetry.VariableExplorerToggled]: { open: boolean };
+    [Telemetry.VariableExplorerVariableCount]: { variableCount: number };
     [EventName.UNITTEST_NAVIGATE_TEST_FILE]: never | undefined;
     [EventName.UNITTEST_NAVIGATE_TEST_FUNCTION]: { focus_code: boolean };
     [EventName.UNITTEST_NAVIGATE_TEST_SUITE]: { focus_code: boolean };

--- a/src/datascience-ui/history-react/MainPanel.tsx
+++ b/src/datascience-ui/history-react/MainPanel.tsx
@@ -264,6 +264,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         canUndo: this.canUndo(),
         canRedo: this.canRedo(),
         refreshVariables: this.refreshVariables,
+        variableExplorerToggled: this.variableExplorerToggled,
         onHeightChange: this.onHeaderHeightChange,
         baseTheme: baseTheme
        };
@@ -753,6 +754,10 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
                 this.sendMessage(HistoryMessages.SubmitNewCell, { code, id: editCell.cell.id });
             }
         }
+    }
+
+    private variableExplorerToggled = (open: boolean) => {
+        this.sendMessage(HistoryMessages.VariableExplorerToggle, open);
     }
 
     // When the variable explorer wants to refresh state (say if it was expanded)

--- a/src/datascience-ui/history-react/headerPanel.tsx
+++ b/src/datascience-ui/history-react/headerPanel.tsx
@@ -36,6 +36,7 @@ export interface IHeaderPanelProps {
     clearAll(): void;
     showDataExplorer(targetVariable: string): void;
     refreshVariables(): void;
+    variableExplorerToggled(open: boolean): void;
     onHeightChange(newHeight: number): void;
 }
 
@@ -76,7 +77,12 @@ export class HeaderPanel extends React.Component<IHeaderPanelProps> {
                     </CellButton>
                 </MenuBar>
                 {progressBar}
-                <VariableExplorer baseTheme={this.props.baseTheme} showDataExplorer={this.props.showDataExplorer} refreshVariables={this.props.refreshVariables} onHeightChange={this.onVariableHeightChange} ref={this.props.variableExplorerRef} />
+                <VariableExplorer baseTheme={this.props.baseTheme}
+                 showDataExplorer={this.props.showDataExplorer}
+                 refreshVariables={this.props.refreshVariables}
+                 onHeightChange={this.onVariableHeightChange}
+                 variableExplorerToggled={this.props.variableExplorerToggled}
+                 ref={this.props.variableExplorerRef} />
             </div>
         );
     }

--- a/src/datascience-ui/history-react/variableExplorer.tsx
+++ b/src/datascience-ui/history-react/variableExplorer.tsx
@@ -22,6 +22,7 @@ interface IVariableExplorerProps {
     refreshVariables(): void;
     onHeightChange(): void;
     showDataExplorer(targetVariable: string): void;
+    variableExplorerToggled(open: boolean): void;
 }
 
 interface IVariableExplorerState {
@@ -150,6 +151,9 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
         if (!this.state.open) {
             this.props.refreshVariables();
         }
+
+        // Notify of the toggle, reverse it as the state is not updated yet
+        this.props.variableExplorerToggled(!this.state.open);
     }
 
     private updateHeight = () => {


### PR DESCRIPTION
For #5337

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [X] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
