### PR TITLE
Ensure prompt is displayed to install pylint when user has configured pylint

### DIFF
--- a/news/2 Fixes/5087.md
+++ b/news/2 Fixes/5087.md
@@ -1,0 +1,1 @@
+No prompt displayed to install pylint

--- a/src/client/linters/linterInfo.ts
+++ b/src/client/linters/linterInfo.ts
@@ -82,7 +82,7 @@ export class PylintLinterInfo extends LinterInfo {
         }
         // If we're using new LS, then by default Pylint is disabled (unless the user provides a value).
         const inspection = this.workspaceService.getConfiguration('python', resource).inspect<boolean>('linting.pylintEnabled');
-        if (!inspection || (inspection.globalValue === undefined && (inspection.workspaceFolderValue === undefined || inspection.workspaceValue === undefined))) {
+        if (!inspection || (inspection.globalValue === undefined && (inspection.workspaceFolderValue === undefined && inspection.workspaceValue === undefined))) {
             return false;
         }
         return enabled;

--- a/src/test/linters/linterinfo.unit.test.ts
+++ b/src/test/linters/linterinfo.unit.test.ts
@@ -53,22 +53,37 @@ suite('Linter Info - Pylint', () => {
 
         expect(linterInfo.isEnabled()).to.be.false;
     });
-    test('Test enabled when using Language Server and Pylint is configured', async () => {
-        const config = mock(ConfigurationService);
-        const workspaceService = mock(WorkspaceService);
-        const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
+    const testsForisEnabled =
+        [
+            {
+                testName: 'When workspaceFolder setting is provided',
+                inspection: { workspaceFolderValue: true }
+            },
+            {
+                testName: 'When workspace setting is provided',
+                inspection: { workspaceValue: true }
+            },
+            {
+                testName: 'When global setting is provided',
+                inspection: { globalValue: true }
+            }
+        ];
 
-        const inspection = {
-            globalValue: 'something',
-            workspaceFolderValue: 'something',
-            workspaceValue: 'something'
-        };
-        const pythonConfig = {
-            inspect: () => inspection
-        };
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
-        when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
+    suite('Test is enabled when using Language Server and Pylint is configured', () => {
+        testsForisEnabled.forEach(testParams => {
+            test(testParams.testName, async () => {
+                const config = mock(ConfigurationService);
+                const workspaceService = mock(WorkspaceService);
+                const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
 
-        expect(linterInfo.isEnabled()).to.be.true;
+                const pythonConfig = {
+                    inspect: () => testParams.inspection
+                };
+                when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
+                when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
+
+                expect(linterInfo.isEnabled()).to.be.true;
+            });
+        });
     });
 });


### PR DESCRIPTION
For #5087 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
