### PR TITLE
snippet changes

### DIFF
--- a/snippets/python.json
+++ b/snippets/python.json
@@ -169,13 +169,14 @@
         "description": "Code snippet for an abstract class method"
     },
     "class": {
-        "prefix": "class",
-        "body": [
-            "class ${1:classname}(${2:object}):",
-            "\t${3:pass}"
-        ],
-        "description": "Code snippet for a class definition"
-    },
+		"prefix": "class",
+		"body": [
+			"class ${1:classname}(${2:object}):",
+			"\tdef __init__(self):",
+			"\t\tsuper(${1:classname}, self).__init__()",
+		],
+		"description": "Code snippet for a class definition"
+	},
     "lambda": {
         "prefix": "lambda",
         "body": [
@@ -240,4 +241,19 @@
         "body": "import pudb; pudb.set_trace()",
         "description": "Code snippet for pudb debug"
     },
+    "__magic__": {
+		"prefix": "__",
+		"body": [
+			"__${1:init}__",
+		],
+		"description": "Code snippet for Python magic methods"
+	},
+	"if __name__ == \"__main__\"": {
+		"prefix": "ifmain",
+		"body": [
+			"if __name__ == \"__main__\":",
+			"\t${1:main()}$0",
+		],
+		"description": "Code snippet for running code only if the current file was executed directly"
+	},
 }


### PR DESCRIPTION
This pull request adds two new snippet and changes one snippet.
The changes are inspired by [snippets used in the Atom Python package](https://github.com/atom/language-python/blob/master/snippets/language-python.cson)

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~~Has sufficient logging.~~
- [x] ~~Has telemetry for enhancements.~~
- [x] ~~Unit tests & system/integration tests are added/updated~~
- [x] ~~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~~
- [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~~
- [x] ~~The wiki is updated with any design decisions/details.~~
