### PR TITLE
Append --pre to black installation command when pipenv is used

### DIFF
--- a/news/2 Fixes/5171.md
+++ b/news/2 Fixes/5171.md
@@ -1,0 +1,1 @@
+Append `--pre` to black installation command so pipenv can properly resolve it.

--- a/news/2 Fixes/5171.md
+++ b/news/2 Fixes/5171.md
@@ -1,1 +1,2 @@
 Append `--pre` to black installation command so pipenv can properly resolve it.
+(thanks [Erin O'Connell](https://github.com/erinxocon))

--- a/src/client/common/installer/pipEnvInstaller.ts
+++ b/src/client/common/installer/pipEnvInstaller.ts
@@ -31,8 +31,12 @@ export class PipEnvInstaller extends ModuleInstaller implements IModuleInstaller
         return interpreters && interpreters.length > 0;
     }
     protected async getExecutionInfo(moduleName: string, _resource?: Uri): Promise<ExecutionInfo> {
+        const args = ['install', moduleName, '--dev'];
+        if (moduleName === 'black') {
+            args.push('--pre');
+        };
         return {
-            args: ['install', moduleName, '--dev'],
+            args: args,
             execPath: pipenvName
         };
     }

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -217,6 +217,9 @@ suite('Module Installer', () => {
                                 test(`Test args (${product.name})`, async () => {
                                     setActiveInterpreter();
                                     const expectedArgs = ['install', moduleName, '--dev'];
+                                    if (moduleName === 'black') {
+                                        expectedArgs.push('--pre')
+                                    }
                                     await installModuleAndVerifyCommand(pipenvName, expectedArgs);
                                 });
                             }


### PR DESCRIPTION
Black is currently in pre-prelease on pypi, hence pipenv fails to install it when vscode-python invokes it.  This fixes that with a special case for black that applies the `--pre` flag when it is installed.  This will allow all pre-releases in a pipfile so if a user doesn't want to have pre-release packages and still wants to use black, they should install black globally and make sure it's in their path.  Then you can set the proper settings in vscode to tell it where the black executable is located.

For #5171

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
