### PR TITLE
Fix sorting of number only lists (#5416)

### DIFF
--- a/news/2 Fixes/5414.md
+++ b/news/2 Fixes/5414.md
@@ -1,0 +1,1 @@
+Fix sorting of lists.

--- a/news/2 Fixes/5414.md
+++ b/news/2 Fixes/5414.md
@@ -1,1 +1,1 @@
-Fix sorting of lists.
+Fix sorting of lists with numbers and missing entries.

--- a/pythonFiles/datascience/getJupyterVariableDataFrameInfo.py
+++ b/pythonFiles/datascience/getJupyterVariableDataFrameInfo.py
@@ -23,8 +23,9 @@ else:
     _VSCODE_columnTypes = []
     _VSCODE_columnNames = []
     if _VSCODE_targetVariable['type'] == 'list':
-        _VSCODE_columnTypes = ['string'] # Might be able to be more specific here?
-        _VSCODE_columnNames = ['_VSCode_JupyterValuesColumn']
+        _VSCODE_evalResult = _VSCODE_pd.DataFrame(_VSCODE_evalResult)
+        _VSCODE_columnTypes = list(_VSCODE_evalResult.dtypes)
+        _VSCODE_columnNames = list(_VSCODE_evalResult)
     elif _VSCODE_targetVariable['type'] == 'Series':
         _VSCODE_evalResult = _VSCODE_pd.Series.to_frame(_VSCODE_evalResult)
         _VSCODE_columnTypes = list(_VSCODE_evalResult.dtypes)

--- a/pythonFiles/datascience/getJupyterVariableDataFrameRows.py
+++ b/pythonFiles/datascience/getJupyterVariableDataFrameRows.py
@@ -16,7 +16,7 @@ _VSCODE_endRow = min(_VSCode_JupyterEndRow, _VSCODE_targetVariable['rowCount'])
 # Assume we have a dataframe. If not, turn our eval result into a dataframe
 _VSCODE_df = _VSCODE_evalResult
 if (_VSCODE_targetVariable['type'] == 'list'):
-    _VSCODE_df = _VSCODE_pd.DataFrame({'_VSCode_JupyterValuesColumn':_VSCODE_evalResult})
+    _VSCODE_df = _VSCODE_pd.DataFrame(_VSCODE_evalResult)
 elif (_VSCODE_targetVariable['type'] == 'Series'):
     _VSCODE_df = _VSCODE_pd.Series.to_frame(_VSCODE_evalResult)
 elif _VSCODE_targetVariable['type'] == 'dict':

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -366,8 +366,8 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         // or it will take too long
         const comparer = isStringColumn ?
             (a: any, b: any): number => {
-                const aVal = a[sortColumn] as string;
-                const bVal = b[sortColumn] as string;
+                const aVal = a[sortColumn].toString();
+                const bVal = b[sortColumn].toString();
                 const aStr = aVal ? aVal.substring(0, Math.min(aVal.length, MaxStringCompare)) : aVal;
                 const bStr = bVal ? bVal.substring(0, Math.min(bVal.length, MaxStringCompare)) : bVal;
                 const result = aStr > bStr ? -1 : 1;

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -366,8 +366,8 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         // or it will take too long
         const comparer = isStringColumn ?
             (a: any, b: any): number => {
-                const aVal = a[sortColumn].toString();
-                const bVal = b[sortColumn].toString();
+                const aVal = a[sortColumn] ? a[sortColumn].toString() : '';
+                const bVal = b[sortColumn] ? b[sortColumn].toString() : '';
                 const aStr = aVal ? aVal.substring(0, Math.min(aVal.length, MaxStringCompare)) : aVal;
                 const bStr = bVal ? bVal.substring(0, Math.min(bVal.length, MaxStringCompare)) : bVal;
                 const result = aStr > bStr ? -1 : 1;


### PR DESCRIPTION
* Fix sorting problem with number only lists

For #5414

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
