### PR TITLE
Allows test discovery when flake8-plugin to pytest is set to run

### DIFF
--- a/news/2 Fixes/5491.md
+++ b/news/2 Fixes/5491.md
@@ -1,0 +1,1 @@
+fixes for pytest tests discovery when flake8 pytest plugin is enabled

--- a/news/2 Fixes/5491.md
+++ b/news/2 Fixes/5491.md
@@ -1,1 +1,2 @@
-fixes for pytest tests discovery when flake8 pytest plugin is enabled
+Fix pytest tests discovery for when flake8 pytest plugin is enabled.
+(thanks [Mayeul d'Avezac](https://github.com/mdavezac))

--- a/pythonFiles/testing_tools/adapter/pytest.py
+++ b/pythonFiles/testing_tools/adapter/pytest.py
@@ -228,7 +228,7 @@ def _parse_item(item, _normcase, _pathsep):
             testfunc = '.'.join(suites) + '.' + funcname
         else:
             testfunc = funcname
-    elif kind == 'doctest':
+    else:
         testfunc = None
         funcname = None
 
@@ -397,7 +397,7 @@ def _get_item_kind(item):
         return 'function', False
     elif itemtype == 'TestCaseFunction':
         return 'function', True
-    elif item.hasattr('function'):
+    elif hasattr(item, 'function'):
         return 'function', False
     else:
         return None, False


### PR DESCRIPTION
I've set my repo to run flake8 automatically via setup.cfg flags to pytest.
It uncovered two issues in the pytest adapter:

- `item.hasattr(x)` called rather than `hasattr(item, x)`, however `item` may not have a `hasattr` method.
- also uncovered a path where the testfunc variable is never defined.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
