### PR TITLE
Add dev flag to poetry installer

### DIFF
--- a/news/2 Fixes/5496.md
+++ b/news/2 Fixes/5496.md
@@ -1,1 +1,2 @@
-Fix poetry dependency adding
+Add dev flag to poetry installer.
+(thanks [Yan Pashkovsky](https://github.com/Yanpas))

--- a/news/2 Fixes/5496.md
+++ b/news/2 Fixes/5496.md
@@ -1,0 +1,1 @@
+Fix poetry dependency adding

--- a/src/client/common/installer/poetryInstaller.ts
+++ b/src/client/common/installer/poetryInstaller.ts
@@ -61,7 +61,7 @@ export class PoetryInstaller extends ModuleInstaller implements IModuleInstaller
     protected async getExecutionInfo(moduleName: string, resource?: Uri): Promise<ExecutionInfo> {
         const execPath = this.configurationService.getSettings(resource).poetryPath;
         return {
-            args: ['add', moduleName],
+            args: ['add', '--dev', moduleName],
             execPath
         };
     }

--- a/src/test/common/installer/poetryInstaller.unit.test.ts
+++ b/src/test/common/installer/poetryInstaller.unit.test.ts
@@ -120,6 +120,6 @@ suite('Module Installer - Poetry', () => {
 
         const info = await poetryInstaller.getExecutionInfo('something', uri);
 
-        assert.deepEqual(info, { args: ['add', 'something'], execPath: 'poetry path' });
+        assert.deepEqual(info, { args: ['add', '--dev', 'something'], execPath: 'poetry path' });
     });
 });


### PR DESCRIPTION
For #5496

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [x] The wiki is updated with any design decisions/details.

By default new dependencies like yapf, autopep8 are installed to all dependencies, `--dev` installs them to `tool.poetry.dev-dependencies`