### PR TITLE
Don't use activate from inside conda environments

### DIFF
--- a/news/2 Fixes/4402.md
+++ b/news/2 Fixes/4402.md
@@ -1,0 +1,1 @@
+Use the correct activation script for conda environments

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -250,16 +250,6 @@ export class CondaService implements ICondaService {
         const condaExe = this.platform.isWindows ? 'conda.exe' : 'conda';
         const scriptsDir = this.platform.isWindows ? 'Scripts' : 'bin';
         const interpreterDir = interpreterPath ? path.dirname(interpreterPath) : '';
-        let condaPath = path.join(interpreterDir, condaExe);
-        if (await this.fileSystem.fileExists(condaPath)) {
-            return condaPath;
-        }
-        // Conda path has changed locations, check the new location in the scripts directory after checking
-        // the old location
-        condaPath = path.join(interpreterDir, scriptsDir, condaExe);
-        if (await this.fileSystem.fileExists(condaPath)) {
-            return condaPath;
-        }
 
         // Might be in a situation where this is not the default python env, but rather one running
         // from a virtualenv
@@ -267,7 +257,7 @@ export class CondaService implements ICondaService {
         if (envsPos > 0) {
             // This should be where the original python was run from when the environment was created.
             const originalPath = interpreterDir.slice(0, envsPos);
-            condaPath = path.join(originalPath, condaExe);
+            let condaPath = path.join(originalPath, condaExe);
 
             if (await this.fileSystem.fileExists(condaPath)) {
                 return condaPath;
@@ -278,6 +268,17 @@ export class CondaService implements ICondaService {
             if (await this.fileSystem.fileExists(condaPath)) {
                 return condaPath;
             }
+        }
+
+        let condaPath = path.join(interpreterDir, condaExe);
+        if (await this.fileSystem.fileExists(condaPath)) {
+            return condaPath;
+        }
+        // Conda path has changed locations, check the new location in the scripts directory after checking
+        // the old location
+        condaPath = path.join(interpreterDir, scriptsDir, condaExe);
+        if (await this.fileSystem.fileExists(condaPath)) {
+            return condaPath;
         }
     }
 


### PR DESCRIPTION
In contrast to virtualenv-created environments, conda environments are not activated from the inside. In constrast, the environment activation is done from the outside via the conda executable that created the environment.

Fixes #4402


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [x] The wiki is updated with any design decisions/details.
