### PR TITLE
GetRemoteLauncherCommand should wrap path to ptvsd_launcher.py in quotes

### DIFF
--- a/news/2 Fixes/4966.md
+++ b/news/2 Fixes/4966.md
@@ -1,0 +1,1 @@
+getRemoteLauncherCommand should wrap path to ptvsd_launcher.py in quotes

--- a/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
@@ -9,24 +9,24 @@ import * as path from 'path';
 import { EXTENSION_ROOT_DIR } from '../../../common/constants';
 import { IDebugLauncherScriptProvider, IRemoteDebugLauncherScriptProvider, LocalDebugOptions, RemoteDebugOptions } from '../types';
 
-const script = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
+const pathToScript = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
 export class NoDebugLauncherScriptProvider implements IDebugLauncherScriptProvider<LocalDebugOptions> {
-    public getLauncherArgs(options: LocalDebugOptions): string[] {
+    public getLauncherArgs(options: LocalDebugOptions, script: string = pathToScript): string[] {
         const customDebugger = options.customDebugger ? '--custom' : '--default';
-        return [script, customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
+        return [script.fileToCommandArgument(), customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
 export class DebuggerLauncherScriptProvider implements IDebugLauncherScriptProvider<LocalDebugOptions>  {
-    public getLauncherArgs(options: LocalDebugOptions): string[] {
+    public getLauncherArgs(options: LocalDebugOptions, script: string = pathToScript): string[] {
         const customDebugger = options.customDebugger ? '--custom' : '--default';
-        return [script, customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
+        return [script.fileToCommandArgument(), customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
 export class RemoteDebuggerLauncherScriptProvider implements IRemoteDebugLauncherScriptProvider {
-    public getLauncherArgs(options: RemoteDebugOptions): string[] {
+    public getLauncherArgs(options: RemoteDebugOptions, script: string = pathToScript): string[] {
         const waitArgs = options.waitUntilDebuggerAttaches ? ['--wait'] : [];
-        return [script, '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
+        return [script.fileToCommandArgument(), '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
     }
 }

--- a/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
@@ -5,28 +5,32 @@
 
 // tslint:disable:max-classes-per-file
 
+import { optional } from 'inversify';
 import * as path from 'path';
 import { EXTENSION_ROOT_DIR } from '../../../common/constants';
 import { IDebugLauncherScriptProvider, IRemoteDebugLauncherScriptProvider, LocalDebugOptions, RemoteDebugOptions } from '../types';
 
 const pathToScript = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
 export class NoDebugLauncherScriptProvider implements IDebugLauncherScriptProvider<LocalDebugOptions> {
-    public getLauncherArgs(options: LocalDebugOptions, script: string = pathToScript): string[] {
+    constructor(@optional() private script: string = pathToScript) { }
+    public getLauncherArgs(options: LocalDebugOptions): string[] {
         const customDebugger = options.customDebugger ? '--custom' : '--default';
-        return [script.fileToCommandArgument(), customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
+        return [this.script.fileToCommandArgument(), customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
 export class DebuggerLauncherScriptProvider implements IDebugLauncherScriptProvider<LocalDebugOptions>  {
-    public getLauncherArgs(options: LocalDebugOptions, script: string = pathToScript): string[] {
+    constructor(@optional() private script: string = pathToScript) { }
+    public getLauncherArgs(options: LocalDebugOptions): string[] {
         const customDebugger = options.customDebugger ? '--custom' : '--default';
-        return [script.fileToCommandArgument(), customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
+        return [this.script.fileToCommandArgument(), customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
 export class RemoteDebuggerLauncherScriptProvider implements IRemoteDebugLauncherScriptProvider {
-    public getLauncherArgs(options: RemoteDebugOptions, script: string = pathToScript): string[] {
+    constructor(@optional() private script: string = pathToScript) { }
+    public getLauncherArgs(options: RemoteDebugOptions): string[] {
         const waitArgs = options.waitUntilDebuggerAttaches ? ['--wait'] : [];
-        return [script.fileToCommandArgument(), '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
+        return [this.script.fileToCommandArgument(), '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
     }
 }

--- a/src/client/debugger/debugAdapter/types.ts
+++ b/src/client/debugger/debugAdapter/types.ts
@@ -13,7 +13,7 @@ export type LocalDebugOptions = { port: number; host: string; customDebugger?: b
 export type RemoteDebugOptions = LocalDebugOptions & { waitUntilDebuggerAttaches: boolean };
 
 export interface IDebugLauncherScriptProvider<T> {
-    getLauncherArgs(options: T, script?: string): string[];
+    getLauncherArgs(options: T): string[];
 }
 
 export interface ILocalDebugLauncherScriptProvider extends IDebugLauncherScriptProvider<LocalDebugOptions> {

--- a/src/client/debugger/debugAdapter/types.ts
+++ b/src/client/debugger/debugAdapter/types.ts
@@ -13,7 +13,7 @@ export type LocalDebugOptions = { port: number; host: string; customDebugger?: b
 export type RemoteDebugOptions = LocalDebugOptions & { waitUntilDebuggerAttaches: boolean };
 
 export interface IDebugLauncherScriptProvider<T> {
-    getLauncherArgs(options: T): string[];
+    getLauncherArgs(options: T, script?: string): string[];
 }
 
 export interface ILocalDebugLauncherScriptProvider extends IDebugLauncherScriptProvider<LocalDebugOptions> {

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -33,32 +33,32 @@ suite('Debugger - Launcher Script Provider', () => {
     testsForLaunchProvider.forEach(testParams => {
         suite(testParams.testName, async () => {
             test('Test debug launcher args', async () => {
-                const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 }, testParams.path);
+                const args = new DebuggerLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234 });
                 const expectedArgs = [testParams.expectedPath, '--default', '--client', '--host', 'something', '--port', '1234'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });
             test('Test non-debug launcher args', async () => {
-                const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 }, testParams.path);
+                const args = new NoDebugLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234 });
                 const expectedArgs = [testParams.expectedPath, '--default', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });
             test('Test debug launcher args and custom ptvsd', async () => {
-                const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true }, testParams.path);
+                const args = new DebuggerLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
                 const expectedArgs = [testParams.expectedPath, '--custom', '--client', '--host', 'something', '--port', '1234'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });
             test('Test non-debug launcher args and custom ptvsd', async () => {
-                const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true }, testParams.path);
+                const args = new NoDebugLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
                 const expectedArgs = [testParams.expectedPath, '--custom', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });
             test('Test remote debug launcher args (and do not wait for debugger to attach)', async () => {
-                const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false }, testParams.path);
+                const args = new RemoteDebuggerLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false });
                 const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });
             test('Test remote debug launcher args (and wait for debugger to attach)', async () => {
-                const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true }, testParams.path);
+                const args = new RemoteDebuggerLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true });
                 const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -11,38 +11,57 @@ import { DebuggerLauncherScriptProvider, NoDebugLauncherScriptProvider, RemoteDe
 
 const expectedPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
 
+// tslint:disable-next-line:max-func-body-length
 suite('Debugger - Launcher Script Provider', () => {
     test('Ensure launcher script exists', async () => {
         expect(await fs.pathExists(expectedPath)).to.be.deep.equal(true, 'Debugger launcher script does not exist');
     });
-    test('Test debug launcher args', async () => {
-        const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 });
-        const expectedArgs = [expectedPath, '--default', '--client', '--host', 'something', '--port', '1234'];
-        expect(args).to.be.deep.equal(expectedArgs);
-    });
-    test('Test non-debug launcher args', async () => {
-        const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 });
-        const expectedArgs = [expectedPath, '--default', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
-        expect(args).to.be.deep.equal(expectedArgs);
-    });
-    test('Test debug launcher args and custom ptvsd', async () => {
-        const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
-        const expectedArgs = [expectedPath, '--custom', '--client', '--host', 'something', '--port', '1234'];
-        expect(args).to.be.deep.equal(expectedArgs);
-    });
-    test('Test non-debug launcher args and custom ptvsd', async () => {
-        const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
-        const expectedArgs = [expectedPath, '--custom', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
-        expect(args).to.be.deep.equal(expectedArgs);
-    });
-    test('Test remote debug launcher args (and do not wait for debugger to attach)', async () => {
-        const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false });
-        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234'];
-        expect(args).to.be.deep.equal(expectedArgs);
-    });
-    test('Test remote debug launcher args (and wait for debugger to attach)', async () => {
-        const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true });
-        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
-        expect(args).to.be.deep.equal(expectedArgs);
+    const testsForLaunchProvider =
+        [
+            {
+                testName: 'When path to ptvsd launcher does not contains spaces',
+                path: path.join('path', 'to', 'ptvsd_launcher'),
+                expectedPath: 'path/to/ptvsd_launcher'
+            },
+            {
+                testName: 'When path to ptvsd launcher contains spaces',
+                path: path.join('path', 'to', 'ptvsd_launcher', 'with spaces'),
+                expectedPath: '"path/to/ptvsd_launcher/with spaces"'
+            }
+        ];
+
+    testsForLaunchProvider.forEach(testParams => {
+        suite(testParams.testName, async () => {
+            test('Test debug launcher args', async () => {
+                const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 }, testParams.path);
+                const expectedArgs = [testParams.expectedPath, '--default', '--client', '--host', 'something', '--port', '1234'];
+                expect(args).to.be.deep.equal(expectedArgs);
+            });
+            test('Test non-debug launcher args', async () => {
+                const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234 }, testParams.path);
+                const expectedArgs = [testParams.expectedPath, '--default', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
+                expect(args).to.be.deep.equal(expectedArgs);
+            });
+            test('Test debug launcher args and custom ptvsd', async () => {
+                const args = new DebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true }, testParams.path);
+                const expectedArgs = [testParams.expectedPath, '--custom', '--client', '--host', 'something', '--port', '1234'];
+                expect(args).to.be.deep.equal(expectedArgs);
+            });
+            test('Test non-debug launcher args and custom ptvsd', async () => {
+                const args = new NoDebugLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, customDebugger: true }, testParams.path);
+                const expectedArgs = [testParams.expectedPath, '--custom', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
+                expect(args).to.be.deep.equal(expectedArgs);
+            });
+            test('Test remote debug launcher args (and do not wait for debugger to attach)', async () => {
+                const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false }, testParams.path);
+                const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234'];
+                expect(args).to.be.deep.equal(expectedArgs);
+            });
+            test('Test remote debug launcher args (and wait for debugger to attach)', async () => {
+                const args = new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true }, testParams.path);
+                const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
+                expect(args).to.be.deep.equal(expectedArgs);
+            });
+        });
     });
 });

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -6,11 +6,10 @@
 // tslint:disable:no-any
 
 import { expect } from 'chai';
-import * as path from 'path';
 import { buildApi } from '../client/api';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 
-const expectedPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
+const expectedPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
 
 suite('Extension API Debugger', () => {
     test('Test debug launcher args (no-wait)', async () => {


### PR DESCRIPTION
For #4966 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Appropriate comments and documentation strings in the code~
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
