### PR TITLE
Corrected analysisOptions.ts bug

### DIFF
--- a/news/2 Fixes/5579.md
+++ b/news/2 Fixes/5579.md
@@ -1,0 +1,1 @@
+Corrected analysisOptions.ts bug

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -225,7 +225,7 @@ export class LanguageServerAnalysisOptions implements ILanguageServerAnalysisOpt
 
     protected async notifyifEnvPythonPathChanged(): Promise<void> {
         const vars = await this.envVarsProvider.getEnvironmentVariables();
-        const envPythonPath = vars.PYTHONPATH;
+        const envPythonPath = vars.PYTHONPATH || '';
 
         if (this.envPythonPath !== envPythonPath) {
             this.didChange.fire();

--- a/src/client/common/installer/pipEnvInstaller.ts
+++ b/src/client/common/installer/pipEnvInstaller.ts
@@ -34,7 +34,7 @@ export class PipEnvInstaller extends ModuleInstaller implements IModuleInstaller
         const args = ['install', moduleName, '--dev'];
         if (moduleName === 'black') {
             args.push('--pre');
-        };
+        }
         return {
             args: args,
             execPath: pipenvName


### PR DESCRIPTION
For #5579

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)