### PR TITLE
Split up pytest.py.

### DIFF
--- a/pythonFiles/testing_tools/adapter/pytest/__init__.py
+++ b/pythonFiles/testing_tools/adapter/pytest/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from __future__ import absolute_import
+
+from ._cli import add_subparser as add_cli_subparser
+from ._discovery import discover

--- a/pythonFiles/testing_tools/adapter/pytest/_cli.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_cli.py
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from __future__ import absolute_import
+
+from ..errors import UnsupportedCommandError
+
+
+def add_subparser(cmd, name, parent):
+    """Add a new subparser to the given parent and add args to it."""
+    parser = parent.add_parser(name)
+    if cmd == 'discover':
+        # For now we don't have any tool-specific CLI options to add.
+        pass
+    else:
+        raise UnsupportedCommandError(cmd)
+    return parser

--- a/pythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -8,20 +8,8 @@ import sys
 
 import pytest
 
-from . import util
-from .errors import UnsupportedCommandError
-from .info import TestInfo, TestPath, ParentInfo
-
-
-def add_cli_subparser(cmd, name, parent):
-    """Add a new subparser to the given parent and add args to it."""
-    parser = parent.add_parser(name)
-    if cmd == 'discover':
-        # For now we don't have any tool-specific CLI options to add.
-        pass
-    else:
-        raise UnsupportedCommandError(cmd)
-    return parser
+from .. import util
+from ..info import TestInfo, TestPath, ParentInfo
 
 
 def discover(pytestargs=None, hidestdio=False,

--- a/pythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -9,7 +9,8 @@ import sys
 import pytest
 
 from .. import util
-from ..info import TestInfo, TestPath, ParentInfo
+from ..info import ParentInfo
+from ._pytest_item import parse_item
 
 
 def discover(pytestargs=None, hidestdio=False,
@@ -77,7 +78,7 @@ class TestCollector(object):
         self._started = True
         self._tests.reset()
         for item in items:
-            test, suiteids = _parse_item(item, self.NORMCASE, self.PATHSEP)
+            test, suiteids = parse_item(item, self.NORMCASE, self.PATHSEP)
             self._tests.add_test(test, suiteids)
 
     # This hook is not specified in the docs, so we also provide
@@ -91,7 +92,7 @@ class TestCollector(object):
             return
         self._tests.reset()
         for item in items:
-            test, suiteids = _parse_item(item, self.NORMCASE, self.PATHSEP)
+            test, suiteids = parse_item(item, self.NORMCASE, self.PATHSEP)
             self._tests.add_test(test, suiteids)
 
 
@@ -196,255 +197,3 @@ class DiscoveredTests(object):
             if (rootdir, suiteid) not in self._parents:
                 self._parents[(rootdir, suiteid)] = suiteinfo
         return final
-
-
-def _parse_item(item, _normcase, _pathsep):
-    """
-    (pytest.Collector)
-        pytest.Session
-        pytest.Package
-        pytest.Module
-        pytest.Class
-        (pytest.File)
-    (pytest.Item)
-        pytest.Function
-    """
-    #_debug_item(item, showsummary=True)
-    kind, _ = _get_item_kind(item)
-    # Figure out the func, suites, and subs.
-    (nodeid, fileid, suiteids, suites, funcid, basename, parameterized
-     ) = _parse_node_id(item.nodeid, kind, _pathsep, _normcase)
-    if kind == 'function':
-        funcname = basename
-        # Note: funcname does not necessarily match item.function.__name__.
-        # This can result from importing a test function from another module.
-        if suites:
-            testfunc = '.'.join(suites) + '.' + funcname
-        else:
-            testfunc = funcname
-    elif kind == 'doctest':
-        testfunc = None
-        funcname = None
-
-    # Figure out the file.
-    relfile = _normcase(fileid)
-    fspath = str(item.fspath)
-    if not _normcase(fspath).endswith(relfile[1:]):
-        print(fspath)
-        print(relfile)
-        raise NotImplementedError
-    testroot = str(item.fspath)[:-len(relfile) + 1]
-    location, fullname = _get_location(item, relfile, _normcase, _pathsep)
-    if kind == 'function':
-        if testfunc and fullname != testfunc + parameterized:
-            print(item.nodeid)
-            print(fullname, suites, testfunc)
-            # TODO: What to do?
-            raise NotImplementedError
-    elif kind == 'doctest':
-        if testfunc and fullname != testfunc + parameterized:
-            print(item.nodeid)
-            print(fullname, testfunc)
-            # TODO: What to do?
-            raise NotImplementedError
-
-    # Sort out the parent.
-    if parameterized:
-        parentid = funcid
-    elif suites:
-        parentid = suiteids[-1]
-    else:
-        parentid = fileid
-
-    # Sort out markers.
-    #  See: https://docs.pytest.org/en/latest/reference.html#marks
-    markers = set()
-    for marker in item.own_markers:
-        if marker.name == 'parameterize':
-            # We've already covered these.
-            continue
-        elif marker.name == 'skip':
-            markers.add('skip')
-        elif marker.name == 'skipif':
-            markers.add('skip-if')
-        elif marker.name == 'xfail':
-            markers.add('expected-failure')
-        # TODO: Support other markers?
-
-    test = TestInfo(
-        id=nodeid,
-        name=item.name,
-        path=TestPath(
-            root=testroot,
-            relfile=relfile,
-            func=testfunc,
-            sub=[parameterized] if parameterized else None,
-            ),
-        source=location,
-        markers=sorted(markers) if markers else None,
-        parentid=parentid,
-        )
-    return test, suiteids
-
-
-def _get_location(item, relfile, _normcase, _pathsep):
-    srcfile, lineno, fullname = item.location
-    srcfile = _normcase(srcfile)
-    if srcfile in (relfile, relfile[len(_pathsep) + 1:]):
-        srcfile = relfile
-    else:
-        # pytest supports discovery of tests imported from other
-        # modules.  This is reflected by a different filename
-        # in item.location.
-        srcfile, lineno = _find_location(
-                srcfile, lineno, relfile, item.function, _pathsep)
-        if not srcfile.startswith('.' + _pathsep):
-            srcfile = '.' + _pathsep + srcfile
-    # from pytest, line numbers are 0-based
-    location = '{}:{}'.format(srcfile, int(lineno) + 1)
-    return location, fullname
-
-
-def _find_location(srcfile, lineno, relfile, func, _pathsep):
-    if sys.version_info > (3,):
-        return srcfile, lineno
-    if (_pathsep + 'unittest' + _pathsep + 'case.py') not in srcfile:
-        return srcfile, lineno
-
-    # Unwrap the decorator (e.g. unittest.skip).
-    srcfile = relfile
-    lineno = -1
-    try:
-        func = func.__closure__[0].cell_contents
-    except (IndexError, AttributeError):
-        return srcfile, lineno
-    else:
-        if callable(func) and func.__code__.co_filename.endswith(relfile[1:]):
-            lineno = func.__code__.co_firstlineno - 1
-    return srcfile, lineno
-
-
-def _parse_node_id(nodeid, kind, _pathsep, _normcase):
-    if not nodeid.startswith('.' + _pathsep):
-        nodeid = '.' + _pathsep + nodeid
-    while '::()::' in nodeid:
-        nodeid = nodeid.replace('::()::', '::')
-
-    fileid, _, remainder = nodeid.partition('::')
-    if not fileid or not remainder:
-        print(nodeid)
-        # TODO: Unexpected!  What to do?
-        raise NotImplementedError
-    fileid = _normcase(fileid)
-    nodeid = fileid + '::' + remainder
-
-    if kind == 'doctest':
-        try:
-            parentid, name = nodeid.split('::')
-        except ValueError:
-            print(nodeid)
-            # TODO: Unexpected!  What to do?
-            raise NotImplementedError
-        funcid = None
-        parameterized = ''
-    else:
-        parameterized = ''
-        if nodeid.endswith(']'):
-            funcid, sep, parameterized = nodeid.partition('[')
-            if not sep:
-                print(nodeid)
-                # TODO: Unexpected!  What to do?
-                raise NotImplementedError
-            parameterized = sep + parameterized
-        else:
-            funcid = nodeid
-        parentid, _, name = funcid.rpartition('::')
-        if not parentid or not name:
-            print(parentid, name)
-            # TODO: What to do?  We expect at least a filename and a function
-            raise NotImplementedError
-
-    suites = []
-    suiteids = []
-    while '::' in parentid:
-        fullid = parentid
-        parentid, _, suitename = fullid.rpartition('::')
-        suiteids.insert(0, fullid)
-        suites.insert(0, suitename)
-    if parentid != fileid:
-        print(nodeid)
-        print(parentid, fileid)
-
-    return nodeid, fileid, suiteids, suites, funcid, name, parameterized
-
-
-def _get_item_kind(item):
-    """Return (kind, isunittest) for the given item."""
-    try:
-        itemtype = item.kind
-    except AttributeError:
-        itemtype = item.__class__.__name__
-
-    if itemtype == 'DoctestItem':
-        return 'doctest', False
-    elif itemtype == 'Function':
-        return 'function', False
-    elif itemtype == 'TestCaseFunction':
-        return 'function', True
-    elif item.hasattr('function'):
-        return 'function', False
-    else:
-        return None, False
-
-
-#############################
-# useful for debugging
-
-def _debug_item(item, showsummary=False):
-    item._debugging = True
-    try:
-        # TODO: Make a PytestTest class to wrap the item?
-        summary = {
-                'id': item.nodeid,
-                'kind': _get_item_kind(item),
-                'class': item.__class__.__name__,
-                'name': item.name,
-                'fspath': item.fspath,
-                'location': item.location,
-                'func': getattr(item, 'function', None),
-                'markers': item.own_markers,
-                #'markers': list(item.iter_markers()),
-                'props': item.user_properties,
-                'attrnames': dir(item),
-                }
-    finally:
-        item._debugging = False
-
-    if showsummary:
-        print(item.nodeid)
-        for key in ('kind', 'class', 'name', 'fspath', 'location', 'func',
-                    'markers', 'props'):
-            print('  {:12} {}'.format(key, summary[key]))
-        print()
-
-    return summary
-
-
-def _group_attr_names(attrnames):
-    grouped = {
-            'dunder': [n for n in attrnames
-                       if n.startswith('__') and n.endswith('__')],
-            'private': [n for n in attrnames if n.startswith('_')],
-            'constants': [n for n in attrnames if n.isupper()],
-            'classes': [n for n in attrnames
-                        if n == n.capitalize() and not n.isupper()],
-            'vars': [n for n in attrnames if n.islower()],
-            }
-    grouped['other'] = [n for n in attrnames
-                          if n not in grouped['dunder']
-                          and n not in grouped['private']
-                          and n not in grouped['constants']
-                          and n not in grouped['classes']
-                          and n not in grouped['vars']
-                          ]
-    return grouped

--- a/pythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -40,11 +40,6 @@ def discover(pytestargs=None, hidestdio=False,
         raise Exception('pytest discovery did not start')
     return (
             _plugin._tests.parents,
-            #[p._replace(
-            #    id=p.id.lstrip('.' + os.path.sep),
-            #    parentid=p.parentid.lstrip('.' + os.path.sep),
-            #    )
-            # for p in _plugin._tests.parents],
             list(_plugin._tests),
             )
 

--- a/pythonFiles/testing_tools/adapter/pytest/_discovery.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_discovery.py
@@ -45,6 +45,7 @@ def discover(pytestargs=None, hidestdio=False,
 
 
 def _adjust_pytest_args(pytestargs):
+    """Return a corrected copy of the given pytest CLI args."""
     pytestargs = list(pytestargs) if pytestargs else []
     # Duplicate entries should be okay.
     pytestargs.insert(0, '--collect-only')
@@ -92,6 +93,7 @@ class TestCollector(object):
 
 
 class DiscoveredTests(object):
+    """A container for the discovered tests and their parents."""
 
     def __init__(self):
         self.reset()
@@ -107,10 +109,12 @@ class DiscoveredTests(object):
         return sorted(self._parents.values(), key=lambda v: (v.root or v.name, v.id))
 
     def reset(self):
+        """Clear out any previously discovered tests."""
         self._parents = {}
         self._tests = []
 
     def add_test(self, test, suiteids):
+        """Add the given test and its parents."""
         parentid = self._ensure_parent(test.path, test.parentid, suiteids)
         test = test._replace(parentid=parentid)
         if not test.id.startswith('.' + os.path.sep):

--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -1,0 +1,240 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from __future__ import absolute_import, print_function
+
+import sys
+
+from ..info import TestInfo, TestPath
+
+
+def parse_item(item, _normcase, _pathsep):
+    """
+    (pytest.Collector)
+        pytest.Session
+        pytest.Package
+        pytest.Module
+        pytest.Class
+        (pytest.File)
+    (pytest.Item)
+        pytest.Function
+    """
+    #_debug_item(item, showsummary=True)
+    kind, _ = _get_item_kind(item)
+    # Figure out the func, suites, and subs.
+    (nodeid, fileid, suiteids, suites, funcid, basename, parameterized
+     ) = _parse_node_id(item.nodeid, kind, _pathsep, _normcase)
+    if kind == 'function':
+        funcname = basename
+        # Note: funcname does not necessarily match item.function.__name__.
+        # This can result from importing a test function from another module.
+        if suites:
+            testfunc = '.'.join(suites) + '.' + funcname
+        else:
+            testfunc = funcname
+    elif kind == 'doctest':
+        testfunc = None
+        funcname = None
+
+    # Figure out the file.
+    relfile = _normcase(fileid)
+    fspath = str(item.fspath)
+    if not _normcase(fspath).endswith(relfile[1:]):
+        print(fspath)
+        print(relfile)
+        raise NotImplementedError
+    testroot = str(item.fspath)[:-len(relfile) + 1]
+    location, fullname = _get_location(item, relfile, _normcase, _pathsep)
+    if kind == 'function':
+        if testfunc and fullname != testfunc + parameterized:
+            print(item.nodeid)
+            print(fullname, suites, testfunc)
+            # TODO: What to do?
+            raise NotImplementedError
+    elif kind == 'doctest':
+        if testfunc and fullname != testfunc + parameterized:
+            print(item.nodeid)
+            print(fullname, testfunc)
+            # TODO: What to do?
+            raise NotImplementedError
+
+    # Sort out the parent.
+    if parameterized:
+        parentid = funcid
+    elif suites:
+        parentid = suiteids[-1]
+    else:
+        parentid = fileid
+
+    # Sort out markers.
+    #  See: https://docs.pytest.org/en/latest/reference.html#marks
+    markers = set()
+    for marker in item.own_markers:
+        if marker.name == 'parameterize':
+            # We've already covered these.
+            continue
+        elif marker.name == 'skip':
+            markers.add('skip')
+        elif marker.name == 'skipif':
+            markers.add('skip-if')
+        elif marker.name == 'xfail':
+            markers.add('expected-failure')
+        # TODO: Support other markers?
+
+    test = TestInfo(
+        id=nodeid,
+        name=item.name,
+        path=TestPath(
+            root=testroot,
+            relfile=relfile,
+            func=testfunc,
+            sub=[parameterized] if parameterized else None,
+            ),
+        source=location,
+        markers=sorted(markers) if markers else None,
+        parentid=parentid,
+        )
+    return test, suiteids
+
+
+def _get_location(item, relfile, _normcase, _pathsep):
+    srcfile, lineno, fullname = item.location
+    srcfile = _normcase(srcfile)
+    if srcfile in (relfile, relfile[len(_pathsep) + 1:]):
+        srcfile = relfile
+    else:
+        # pytest supports discovery of tests imported from other
+        # modules.  This is reflected by a different filename
+        # in item.location.
+        srcfile, lineno = _find_location(
+                srcfile, lineno, relfile, item.function, _pathsep)
+        if not srcfile.startswith('.' + _pathsep):
+            srcfile = '.' + _pathsep + srcfile
+    # from pytest, line numbers are 0-based
+    location = '{}:{}'.format(srcfile, int(lineno) + 1)
+    return location, fullname
+
+
+def _find_location(srcfile, lineno, relfile, func, _pathsep):
+    if sys.version_info > (3,):
+        return srcfile, lineno
+    if (_pathsep + 'unittest' + _pathsep + 'case.py') not in srcfile:
+        return srcfile, lineno
+
+    # Unwrap the decorator (e.g. unittest.skip).
+    srcfile = relfile
+    lineno = -1
+    try:
+        func = func.__closure__[0].cell_contents
+    except (IndexError, AttributeError):
+        return srcfile, lineno
+    else:
+        if callable(func) and func.__code__.co_filename.endswith(relfile[1:]):
+            lineno = func.__code__.co_firstlineno - 1
+    return srcfile, lineno
+
+
+def _parse_node_id(nodeid, kind, _pathsep, _normcase):
+    if not nodeid.startswith('.' + _pathsep):
+        nodeid = '.' + _pathsep + nodeid
+    while '::()::' in nodeid:
+        nodeid = nodeid.replace('::()::', '::')
+
+    fileid, _, remainder = nodeid.partition('::')
+    if not fileid or not remainder:
+        print(nodeid)
+        # TODO: Unexpected!  What to do?
+        raise NotImplementedError
+    fileid = _normcase(fileid)
+    nodeid = fileid + '::' + remainder
+
+    if kind == 'doctest':
+        try:
+            parentid, name = nodeid.split('::')
+        except ValueError:
+            print(nodeid)
+            # TODO: Unexpected!  What to do?
+            raise NotImplementedError
+        funcid = None
+        parameterized = ''
+    else:
+        parameterized = ''
+        if nodeid.endswith(']'):
+            funcid, sep, parameterized = nodeid.partition('[')
+            if not sep:
+                print(nodeid)
+                # TODO: Unexpected!  What to do?
+                raise NotImplementedError
+            parameterized = sep + parameterized
+        else:
+            funcid = nodeid
+        parentid, _, name = funcid.rpartition('::')
+        if not parentid or not name:
+            print(parentid, name)
+            # TODO: What to do?  We expect at least a filename and a function
+            raise NotImplementedError
+
+    suites = []
+    suiteids = []
+    while '::' in parentid:
+        fullid = parentid
+        parentid, _, suitename = fullid.rpartition('::')
+        suiteids.insert(0, fullid)
+        suites.insert(0, suitename)
+    if parentid != fileid:
+        print(nodeid)
+        print(parentid, fileid)
+
+    return nodeid, fileid, suiteids, suites, funcid, name, parameterized
+
+
+def _get_item_kind(item):
+    """Return (kind, isunittest) for the given item."""
+    try:
+        itemtype = item.kind
+    except AttributeError:
+        itemtype = item.__class__.__name__
+
+    if itemtype == 'DoctestItem':
+        return 'doctest', False
+    elif itemtype == 'Function':
+        return 'function', False
+    elif itemtype == 'TestCaseFunction':
+        return 'function', True
+    elif item.hasattr('function'):
+        return 'function', False
+    else:
+        return None, False
+
+
+#############################
+# useful for debugging
+
+def _debug_item(item, showsummary=False):
+    item._debugging = True
+    try:
+        # TODO: Make a PytestTest class to wrap the item?
+        summary = {
+                'id': item.nodeid,
+                'kind': _get_item_kind(item),
+                'class': item.__class__.__name__,
+                'name': item.name,
+                'fspath': item.fspath,
+                'location': item.location,
+                'func': getattr(item, 'function', None),
+                'markers': item.own_markers,
+                #'markers': list(item.iter_markers()),
+                'props': item.user_properties,
+                'attrnames': dir(item),
+                }
+    finally:
+        item._debugging = False
+
+    if showsummary:
+        print(item.nodeid)
+        for key in ('kind', 'class', 'name', 'fspath', 'location', 'func',
+                    'markers', 'props'):
+            print('  {:12} {}'.format(key, summary[key]))
+        print()
+
+    return summary

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -33,3 +33,29 @@ if sys.version_info < (3,):
             StringIO.write(self, msg.decode())
 else:
     StdioStream = StringIO
+
+
+def group_attr_names(attrnames):
+    grouped = {
+            'dunder': [],
+            'private': [],
+            'constants': [],
+            'classes': [],
+            'vars': [],
+            'other': [],
+            }
+    for name in attrnames:
+        if name.startswith('__') and name.endswith('__'):
+            group = 'dunder'
+        elif name.startswith('_'):
+            group = 'private'
+        elif name.isupper():
+            group = 'constants'
+        elif name.islower():
+            group = 'vars'
+        elif name == name.capitalize():
+            group = 'classes'
+        else:
+            group = 'other'
+        grouped[group].append(name)
+    return grouped

--- a/pythonFiles/tests/testing_tools/adapter/pytest/__init__.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_cli.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_cli.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import unittest
+
+from ....util import Stub, StubProxy
+from testing_tools.adapter.errors import UnsupportedCommandError
+from testing_tools.adapter.pytest._cli import add_subparser
+
+
+class StubSubparsers(StubProxy):
+
+    def __init__(self, stub=None, name='subparsers'):
+        super(StubSubparsers, self).__init__(stub, name)
+
+    def add_parser(self, name):
+        self.add_call('add_parser', None, {'name': name})
+        return self.return_add_parser
+
+
+class StubArgParser(StubProxy):
+
+    def __init__(self, stub=None):
+        super(StubArgParser, self).__init__(stub, 'argparser')
+
+    def add_argument(self, *args, **kwargs):
+        self.add_call('add_argument', args, kwargs)
+
+
+
+class AddCLISubparserTests(unittest.TestCase):
+
+    def test_discover(self):
+        stub = Stub()
+        subparsers = StubSubparsers(stub)
+        parser = StubArgParser(stub)
+        subparsers.return_add_parser = parser
+
+        add_subparser('discover', 'pytest', subparsers)
+
+        self.assertEqual(stub.calls, [
+            ('subparsers.add_parser', None, {'name': 'pytest'}),
+            ])
+
+    def test_unsupported_command(self):
+        subparsers = StubSubparsers(name=None)
+        subparsers.return_add_parser = None
+
+        with self.assertRaises(UnsupportedCommandError):
+            add_subparser('run', 'pytest', subparsers)
+        with self.assertRaises(UnsupportedCommandError):
+            add_subparser('debug', 'pytest', subparsers)
+        with self.assertRaises(UnsupportedCommandError):
+            add_subparser('???', 'pytest', subparsers)
+        self.assertEqual(subparsers.calls, [
+            ('add_parser', None, {'name': 'pytest'}),
+            ('add_parser', None, {'name': 'pytest'}),
+            ('add_parser', None, {'name': 'pytest'}),
+            ])

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 from __future__ import print_function, unicode_literals
 
 try:
@@ -11,32 +12,12 @@ import os.path
 import sys
 import unittest
 
-from ...util import Stub, StubProxy
-from testing_tools.adapter.errors import UnsupportedCommandError
+from ....util import Stub, StubProxy
 from testing_tools.adapter.info import TestInfo, TestPath, ParentInfo
-from testing_tools.adapter.pytest import (
-        discover, add_cli_subparser, TestCollector, DiscoveredTests
+from testing_tools.adapter.pytest._discovery import (
+        discover, TestCollector, DiscoveredTests
         )
 import pytest
-
-
-class StubSubparsers(StubProxy):
-
-    def __init__(self, stub=None, name='subparsers'):
-        super(StubSubparsers, self).__init__(stub, name)
-
-    def add_parser(self, name):
-        self.add_call('add_parser', None, {'name': name})
-        return self.return_add_parser
-
-
-class StubArgParser(StubProxy):
-
-    def __init__(self, stub=None):
-        super(StubArgParser, self).__init__(stub, 'argparser')
-
-    def add_argument(self, *args, **kwargs):
-        self.add_call('add_argument', args, kwargs)
 
 
 class StubPyTest(StubProxy):
@@ -166,37 +147,6 @@ class StubPytestConfig(StubProxy):
 
 ##################################
 # tests
-
-class AddCLISubparserTests(unittest.TestCase):
-
-    def test_discover(self):
-        stub = Stub()
-        subparsers = StubSubparsers(stub)
-        parser = StubArgParser(stub)
-        subparsers.return_add_parser = parser
-
-        add_cli_subparser('discover', 'pytest', subparsers)
-
-        self.assertEqual(stub.calls, [
-            ('subparsers.add_parser', None, {'name': 'pytest'}),
-            ])
-
-    def test_unsupported_command(self):
-        subparsers = StubSubparsers(name=None)
-        subparsers.return_add_parser = None
-
-        with self.assertRaises(UnsupportedCommandError):
-            add_cli_subparser('run', 'pytest', subparsers)
-        with self.assertRaises(UnsupportedCommandError):
-            add_cli_subparser('debug', 'pytest', subparsers)
-        with self.assertRaises(UnsupportedCommandError):
-            add_cli_subparser('???', 'pytest', subparsers)
-        self.assertEqual(subparsers.calls, [
-            ('add_parser', None, {'name': 'pytest'}),
-            ('add_parser', None, {'name': 'pytest'}),
-            ('add_parser', None, {'name': 'pytest'}),
-            ])
-
 
 class DiscoverTests(unittest.TestCase):
 

--- a/pythonFiles/tests/testing_tools/adapter/test_functional.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_functional.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 import os


### PR DESCRIPTION
(for #5458)

`pythonFiles/testing_tools/adapter/pytest.py` has gotten too big, with too many different things implemented there.  This PR addresses that by adding a "pytest" subpackage and splitting the code from `pytest.py` up into several modules under that subpackage.  This is a precursor to fixes for #5458.

Note that this PR is almost exclusively moving code around, adding missing docstrings, and removing superfluous comments.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
