### PR TITLE
Feature/5602 update run test label

### DIFF
--- a/news/1 Enhancements/5602.md
+++ b/news/1 Enhancements/5602.md
@@ -1,0 +1,2 @@
+Changes placeholder label in testConfigurationManager.ts from 'Select the directory containing the unit tests' to 'Select the directory containing the tests'.
+(thanks [James Flynn](https://github.com/james-flynn-ie/))

--- a/src/client/testing/common/managers/testConfigurationManager.ts
+++ b/src/client/testing/common/managers/testConfigurationManager.ts
@@ -40,7 +40,7 @@ export abstract class TestConfigurationManager implements ITestConfigurationMana
             ignoreFocusOut: true,
             matchOnDescription: true,
             matchOnDetail: true,
-            placeHolder: 'Select the directory containing the unit tests'
+            placeHolder: 'Select the directory containing the tests'
         };
         let items: QuickPickItem[] = subDirs
             .map(dir => {


### PR DESCRIPTION
For #5602 

Changes placeholder label in testConfigurationManager.ts from 'Select the directory containing the unit tests' to 'Select the directory containing the tests'.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Appropriate comments and documentation strings in the code~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
