### PR TITLE
James-flynn-ie/5604 update Pytest unit testing settings label

### DIFF
--- a/news/1 Enhancements/5604.md
+++ b/news/1 Enhancements/5604.md
@@ -1,0 +1,2 @@
+Updated label for "Enable unit testing for Pytest" to remove the word "unit".
+(thanks [James Flynn](https://github.com/james-flynn-ie/))

--- a/package.json
+++ b/package.json
@@ -1930,7 +1930,7 @@
                 "python.testing.pyTestEnabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Enable unit testing using pytest.",
+                    "description": "Enable testing using pytest.",
                     "scope": "resource"
                 },
                 "python.testing.pyTestPath": {


### PR DESCRIPTION
For #5604 

Removed the word 'unit' from the Settings label 'Enable unit testing using Pytest'.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[x] Appropriate comments and documentation strings in the code~
- ~[x] Has sufficient logging.~
- ~[x] Has telemetry for enhancements.~
- ~[x] Unit tests & system/integration tests are added/updated~
- ~[x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[x] The wiki is updated with any design decisions/details.~
