### PR TITLE
fix(client/linters/mypy): call mypy incorrectly

### DIFF
--- a/news/2 Fixes/5326.md
+++ b/news/2 Fixes/5326.md
@@ -1,0 +1,2 @@
+Use relative paths when invoking mypy.
+(thanks to [yxliang01](https://github.com/yxliang01))

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -4,6 +4,7 @@ import { Product } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { BaseLinter } from './baseLinter';
 import { ILintMessage } from './types';
+import * as path from 'path';
 
 export const REGEX = '(?<file>[^:]+):(?<line>\\d+)(:(?<column>\\d+))?: (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
 
@@ -13,7 +14,9 @@ export class MyPy extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const messages = await this.run([document.uri.fsPath], document, cancellation, REGEX);
+        const cwd = this.getWorkspaceRootPath(document);
+        const relativePath = path.relative(cwd,document.uri.fsPath);
+        const messages = await this.runrelativePath document, cancellation, REGEX);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.mypyCategorySeverity);
             msg.code = msg.type;

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -15,8 +15,8 @@ export class MyPy extends BaseLinter {
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
         const cwd = this.getWorkspaceRootPath(document);
-        const relativePath = path.relative(cwd,document.uri.fsPath);
-        const messages = await this.runrelativePath document, cancellation, REGEX);
+        const relativePath = path.relative(cwd, document.uri.fsPath);
+        const messages = await this.run([relativePath], document, cancellation, REGEX);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.mypyCategorySeverity);
             msg.code = msg.type;

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -1,10 +1,10 @@
+import * as path from 'path';
 import { CancellationToken, OutputChannel, TextDocument } from 'vscode';
 import '../common/extensions';
 import { Product } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { BaseLinter } from './baseLinter';
 import { ILintMessage } from './types';
-import * as path from 'path';
 
 export const REGEX = '(?<file>[^:]+):(?<line>\\d+)(:(?<column>\\d+))?: (?<type>\\w+): (?<message>.*)\\r?(\\n|$)';
 

--- a/src/test/linters/mypy.unit.test.ts
+++ b/src/test/linters/mypy.unit.test.ts
@@ -6,12 +6,20 @@
 // tslint:disable:no-object-literal-type-assertion
 
 import { expect } from 'chai';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { CancellationToken, CancellationTokenSource, TextDocument, Uri } from 'vscode';
+import { Product } from '../../client/common/types';
+import { ServiceContainer } from '../../client/ioc/container';
 import { parseLine } from '../../client/linters/baseLinter';
-import { REGEX } from '../../client/linters/mypy';
-import { ILintMessage } from '../../client/linters/types';
+import { LinterManager } from '../../client/linters/linterManager';
+import { MyPy, REGEX } from '../../client/linters/mypy';
+import { ILinterManager, ILintMessage, LintMessageSeverity } from '../../client/linters/types';
+import { MockOutputChannel } from '../mockClasses';
 
 // This following is a real-world example. See gh=2380.
-// tslint:disable-next-line:no-multiline-string
+// tslint:disable:no-multiline-string no-any max-func-body-length
 const output = `
 provider.pyi:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 provider.pyi:11: error: Name 'not_declared_var' is not defined
@@ -29,7 +37,7 @@ suite('Linting - MyPy', () => {
                 line: 10,
                 type: 'error',
                 provider: 'mypy'
-             } as ILintMessage],
+            } as ILintMessage],
             [lines[2], {
                 code: undefined,
                 message: 'Name \'not_declared_var\' is not defined',
@@ -37,7 +45,7 @@ suite('Linting - MyPy', () => {
                 line: 11,
                 type: 'error',
                 provider: 'mypy'
-             } as ILintMessage],
+            } as ILintMessage],
             [lines[3], {
                 code: undefined,
                 message: 'Expression has type "Any"',
@@ -45,12 +53,79 @@ suite('Linting - MyPy', () => {
                 line: 12,
                 type: 'error',
                 provider: 'mypy'
-             } as ILintMessage]
+            } as ILintMessage]
         ];
         for (const [line, expected] of tests) {
             const msg = parseLine(line, REGEX, 'mypy');
 
             expect(msg).to.deep.equal(expected);
         }
+    });
+    class TestMyPyLinter extends MyPy {
+        // tslint:disable: no-unnecessary-override
+        public async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
+            return super.runLinter(document, cancellation);
+        }
+        public getWorkspaceRootPath(document: TextDocument): string {
+            return super.getWorkspaceRootPath(document);
+        }
+        public async run(args: string[], document: TextDocument, cancellation: CancellationToken, regEx: string = REGEX): Promise<ILintMessage[]> {
+            return super.run(args, document, cancellation, regEx);
+        }
+        public parseMessagesSeverity(error: string, severity: any): LintMessageSeverity {
+            return super.parseMessagesSeverity(error, severity);
+        }
+    }
+    suite('Test Linter', () => {
+        let linter: TestMyPyLinter;
+        let getWorkspaceRootPathStub: sinon.SinonStub<[TextDocument], string>;
+        let runStub: sinon.SinonStub<[string[], TextDocument, CancellationToken, (string | undefined)?], Promise<ILintMessage[]>>;
+        const token = new CancellationTokenSource().token;
+        teardown(() => sinon.restore());
+        setup(() => {
+            const linterManager = mock(LinterManager);
+            when(linterManager.getLinterInfo(anything())).thenReturn({ product: Product.mypy } as any);
+            const serviceContainer = mock(ServiceContainer);
+            when(serviceContainer.get<ILinterManager>(ILinterManager)).thenReturn(instance(linterManager));
+            getWorkspaceRootPathStub = sinon.stub(TestMyPyLinter.prototype, 'getWorkspaceRootPath');
+            runStub = sinon.stub(TestMyPyLinter.prototype, 'run');
+            linter = new TestMyPyLinter(instance(mock(MockOutputChannel)), instance(serviceContainer));
+        });
+
+        test('Get cwd based on document', async () => {
+            const fileUri = Uri.file(path.join('a', 'b', 'c', 'd', 'e', 'filename.py'));
+            const cwd = path.join('a', 'b', 'c');
+            const doc = { uri: fileUri } as any as TextDocument;
+            getWorkspaceRootPathStub.callsFake(() => cwd);
+            runStub.callsFake(() => Promise.resolve([]));
+
+            await linter.runLinter(doc, token);
+
+            expect(getWorkspaceRootPathStub.callCount).to.equal(1);
+            expect(getWorkspaceRootPathStub.args[0]).to.deep.equal([doc]);
+        });
+        test('Pass relative path of document to linter', async () => {
+            const fileUri = Uri.file(path.join('a', 'b', 'c', 'd', 'e', 'filename.py'));
+            const cwd = path.join('a', 'b', 'c');
+            const doc = { uri: fileUri } as any as TextDocument;
+            getWorkspaceRootPathStub.callsFake(() => cwd);
+            runStub.callsFake(() => Promise.resolve([]));
+
+            await linter.runLinter(doc, token);
+
+            expect(runStub.callCount).to.equal(1);
+            expect(runStub.args[0]).to.deep.equal([[path.relative(cwd, fileUri.fsPath)], doc, token, REGEX]);
+        });
+        test('Return empty messages', async () => {
+            const fileUri = Uri.file(path.join('a', 'b', 'c', 'd', 'e', 'filename.py'));
+            const cwd = path.join('a', 'b', 'c');
+            const doc = { uri: fileUri } as any as TextDocument;
+            getWorkspaceRootPathStub.callsFake(() => cwd);
+            runStub.callsFake(() => Promise.resolve([]));
+
+            const messages = await linter.runLinter(doc, token);
+
+            expect(messages).to.be.deep.equal([]);
+        });
     });
 });


### PR DESCRIPTION
It's supposed to call `mypy` in the root package directory with the relative path to the python file being checked. This commit enforces this behavior.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Appropriate comments and documentation strings in the code
- [X] Has sufficient logging.
- [X] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [X] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [X] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [X] ~The wiki is updated with any design decisions/details.~

Before this PR is merged, you may use https://gist.github.com/yxliang01/b975fffa0b145d75ed1dba5b3a9ad960 as the `mypy` wrapper to achieve the same effect.

Thanks @harpaj for the idea.
Related to https://github.com/microsoft/vscode-python/issues/5326