### PR TITLE
Send `pathMappings` to dba when attaching to child proc

### DIFF
--- a/news/2 Fixes/3568.md
+++ b/news/2 Fixes/3568.md
@@ -1,0 +1,1 @@
+Provide `pathMappings` to debugger when attaching to child processes.

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -7,9 +7,10 @@ import { inject, injectable } from 'inversify';
 import { DebugConfiguration, DebugSession, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../../common/application/types';
 import { noop } from '../../../common/utils/misc';
+import { SystemVariables } from '../../../common/variables/systemVariables';
 import { captureTelemetry } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
-import { AttachRequestArguments } from '../../types';
+import { AttachRequestArguments, LaunchRequestArguments } from '../../types';
 import { ChildProcessLaunchData, IChildProcessAttachService } from './types';
 
 /**
@@ -34,22 +35,48 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
             this.appShell.showErrorMessage(`Failed to launch debugger for child process ${data.processId}`).then(noop, noop);
         }
     }
-    protected getRelatedWorkspaceFolder(data: ChildProcessLaunchData): WorkspaceFolder | undefined {
+    public getRelatedWorkspaceFolder(data: ChildProcessLaunchData): WorkspaceFolder | undefined {
         const workspaceFolder = data.rootStartRequest.arguments.workspaceFolder;
         if (!this.workspaceService.hasWorkspaceFolders || !workspaceFolder) {
             return;
         }
         return this.workspaceService.workspaceFolders!.find(ws => ws.uri.fsPath === workspaceFolder);
     }
-    protected getAttachConfiguration(data: ChildProcessLaunchData): AttachRequestArguments & DebugConfiguration {
+    public getAttachConfiguration(data: ChildProcessLaunchData): AttachRequestArguments & DebugConfiguration {
         const args = data.rootStartRequest.arguments;
         // tslint:disable-next-line:no-any
         const config = JSON.parse(JSON.stringify(args)) as any as (AttachRequestArguments & DebugConfiguration);
-
+        // tslint:disable-next-line: no-any
+        this.fixPathMappings(config as any);
         config.host = args.request === 'attach' ? args.host! : 'localhost';
         config.port = data.port;
         config.name = `Child Process ${data.processId}`;
         config.request = 'attach';
         return config;
+    }
+    /**
+     * Since we're attaching we need to provide path mappings.
+     * If not provided, we cannot add breakpoints as we don't have mappings to the actual source.
+     * This is because attach automatically assumes remote debugging.
+     * Also remember, this code gets executed only when dynamically attaching to child processes.
+     * Resolves https://github.com/microsoft/vscode-python/issues/3568
+     */
+    public fixPathMappings(config: LaunchRequestArguments & AttachRequestArguments & DebugConfiguration) {
+        if (!config.workspaceFolder) {
+            return;
+        }
+        if (Array.isArray(config.pathMappings) && config.pathMappings.length > 0) {
+            return;
+        }
+        // If user has provided a `cwd` in their `launch.json`, then we need to use
+        // the `cwd` as the localRoot.
+        // We cannot expect the debugger to assume remote root is the same as the cwd,
+        // As debugger doesn't necessarily know whether the process being attached to is
+        // a child process or not.
+        const systemVariables = new SystemVariables(config.workspaceFolder);
+        const localRoot = config.cwd && config.cwd.length > 0 ? systemVariables.resolveAny(config.cwd) : config.workspaceFolder;
+        config.pathMappings = [
+            { remoteRoot: '.', localRoot }
+        ];
     }
 }

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -23,7 +23,7 @@ getNamesAndValues(OSType).forEach(os => {
     if (os.value === OSType.Unknown) {
         return;
     }
-    suite(`xDebugging - Config Resolver attach, OS = ${os.name}`, () => {
+    suite(`Debugging - Config Resolver attach, OS = ${os.name}`, () => {
         let serviceContainer: TypeMoq.IMock<IServiceContainer>;
         let debugProvider: DebugConfigurationProvider;
         let platformService: TypeMoq.IMock<IPlatformService>;


### PR DESCRIPTION
For #3568

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
