### PR TITLE
Removed `--nothreading` flag from Django debug config

### DIFF
--- a/news/1 Enhancements/5116.md
+++ b/news/1 Enhancements/5116.md
@@ -1,0 +1,1 @@
+Removed `--nothreading` flag from the `Django` debug configuration.

--- a/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
@@ -37,8 +37,7 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
             program: program || defaultProgram,
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };

--- a/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
@@ -137,8 +137,7 @@ suite('Debugging - Configuration Provider Django', () => {
             program: 'xyz.py',
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };
@@ -161,8 +160,7 @@ suite('Debugging - Configuration Provider Django', () => {
             program: 'hello',
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };
@@ -188,8 +186,7 @@ suite('Debugging - Configuration Provider Django', () => {
             program: defaultProgram,
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };


### PR DESCRIPTION
For #5116

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
