### PR TITLE
Add support for live reloading of Django and Flask apps when debugging

### DIFF
--- a/news/1 Enhancements/3473.md
+++ b/news/1 Enhancements/3473.md
@@ -1,0 +1,1 @@
+Add support for live reloading of Django and Flask apps when debugging.

--- a/news/1 Enhancements/5116.md
+++ b/news/1 Enhancements/5116.md
@@ -1,0 +1,1 @@
+Removed `--nothreading` flag from the `Django` debug configuration.

--- a/resources/default.launch.json
+++ b/resources/default.launch.json
@@ -33,11 +33,10 @@
         "program": "${workspaceFolder}/manage.py",
         "console": "integratedTerminal",
         "args": [
-            "runserver",
-            "--noreload",
-            "--nothreading"
+            "runserver"
         ],
-        "django": true
+        "django": true,
+        "subProcess": true
     },
     {
         "name": "Python: Flask",
@@ -49,10 +48,10 @@
         },
         "args": [
             "run",
-            "--no-debugger",
-            "--no-reload"
+            "--no-debugger"
         ],
-        "jinja": true
+        "jinja": true,
+        "subProcess": true
     },
     {
         "name": "Python: Current File (External Terminal)",

--- a/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
@@ -36,10 +36,10 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
             request: 'launch',
             program: program || defaultProgram,
             args: [
-                'runserver',
-                '--noreload'
+                'runserver'
             ],
-            django: true
+            django: true,
+            subProcess: true
         };
         if (!program) {
             const selectedProgram = await input.showInputBox({

--- a/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
@@ -37,8 +37,7 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
             program: program || defaultProgram,
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };

--- a/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
@@ -36,10 +36,10 @@ export class FlaskLaunchDebugConfigurationProvider implements IDebugConfiguratio
             },
             args: [
                 'run',
-                '--no-debugger',
-                '--no-reload'
+                '--no-debugger'
             ],
-            jinja: true
+            jinja: true,
+            subProcess: true
         };
 
         if (!application) {

--- a/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
@@ -137,8 +137,7 @@ suite('Debugging - Configuration Provider Django', () => {
             program: 'xyz.py',
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };
@@ -161,8 +160,7 @@ suite('Debugging - Configuration Provider Django', () => {
             program: 'hello',
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };
@@ -188,8 +186,7 @@ suite('Debugging - Configuration Provider Django', () => {
             program: defaultProgram,
             args: [
                 'runserver',
-                '--noreload',
-                '--nothreading'
+                '--noreload'
             ],
             django: true
         };

--- a/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
@@ -136,10 +136,10 @@ suite('Debugging - Configuration Provider Django', () => {
             request: 'launch',
             program: 'xyz.py',
             args: [
-                'runserver',
-                '--noreload'
+                'runserver'
             ],
-            django: true
+            django: true,
+            subProcess: true
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -159,10 +159,10 @@ suite('Debugging - Configuration Provider Django', () => {
             request: 'launch',
             program: 'hello',
             args: [
-                'runserver',
-                '--noreload'
+                'runserver'
             ],
-            django: true
+            django: true,
+            subProcess: true
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -185,10 +185,10 @@ suite('Debugging - Configuration Provider Django', () => {
             request: 'launch',
             program: defaultProgram,
             args: [
-                'runserver',
-                '--noreload'
+                'runserver'
             ],
-            django: true
+            django: true,
+            subProcess: true
         };
 
         expect(state.config).to.be.deep.equal(config);

--- a/src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
@@ -71,10 +71,10 @@ suite('Debugging - Configuration Provider Flask', () => {
             },
             args: [
                 'run',
-                '--no-debugger',
-                '--no-reload'
+                '--no-debugger'
             ],
-            jinja: true
+            jinja: true,
+            subProcess: true
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -100,10 +100,10 @@ suite('Debugging - Configuration Provider Flask', () => {
             },
             args: [
                 'run',
-                '--no-debugger',
-                '--no-reload'
+                '--no-debugger'
             ],
-            jinja: true
+            jinja: true,
+            subProcess: true
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -129,10 +129,10 @@ suite('Debugging - Configuration Provider Flask', () => {
             },
             args: [
                 'run',
-                '--no-debugger',
-                '--no-reload'
+                '--no-debugger'
             ],
-            jinja: true
+            jinja: true,
+            subProcess: true
         };
 
         expect(state.config).to.be.deep.equal(config);


### PR DESCRIPTION
For #3473

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
