### PR TITLE
Fixes to activation of Conda environments

### DIFF
--- a/news/2 Fixes/5929.md
+++ b/news/2 Fixes/5929.md
@@ -1,0 +1,1 @@
+Fixes to activation of Conda environments

--- a/src/client/common/terminal/helper.ts
+++ b/src/client/common/terminal/helper.ts
@@ -52,12 +52,8 @@ export class TerminalHelper implements ITerminalHelper {
         this.sendTelemetry(resource, terminalShellType, EventName.PYTHON_INTERPRETER_ACTIVATION_FOR_TERMINAL, promise).ignoreErrors();
         return promise;
     }
-    public async getEnvironmentActivationShellCommands(resource: Resource, interpreter?: PythonInterpreter): Promise<string[] | undefined> {
-        if (this.platform.osType === OSType.Unknown){
-            return;
-        }
-        const shell = this.shellDetector.identifyTerminalShell();
-        if (!shell) {
+    public async getEnvironmentActivationShellCommands(resource: Resource, shell: TerminalShellType, interpreter?: PythonInterpreter): Promise<string[] | undefined> {
+        if (this.platform.osType === OSType.Unknown) {
             return;
         }
         const providers = [this.bashCShellFish, this.commandPromptAndPowerShell];

--- a/src/client/common/terminal/types.ts
+++ b/src/client/common/terminal/types.ts
@@ -57,7 +57,7 @@ export interface ITerminalHelper {
     identifyTerminalShell(terminal?: Terminal): TerminalShellType;
     buildCommandForTerminal(terminalShellType: TerminalShellType, command: string, args: string[]): string;
     getEnvironmentActivationCommands(terminalShellType: TerminalShellType, resource?: Uri): Promise<string[] | undefined>;
-    getEnvironmentActivationShellCommands(resource: Resource, interpreter?: PythonInterpreter): Promise<string[] | undefined>;
+    getEnvironmentActivationShellCommands(resource: Resource, shell: TerminalShellType, interpreter?: PythonInterpreter): Promise<string[] | undefined>;
 }
 
 export const ITerminalActivator = Symbol('ITerminalActivator');

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -315,9 +315,10 @@ suite('Terminal Service helpers', () => {
                     test('Activation command for Shell must be empty for unknown os', async () => {
                         when(platformService.osType).thenReturn(OSType.Unknown);
 
-                        const cmd = await helper.getEnvironmentActivationShellCommands(resource, interpreter);
-
-                        expect(cmd).to.equal(undefined, 'Command must be undefined');
+                        for (const item of getNamesAndValues<TerminalShellType>(TerminalShellType)) {
+                            const cmd = await helper.getEnvironmentActivationShellCommands(resource, item.value, interpreter);
+                            expect(cmd).to.equal(undefined, 'Command must be undefined');
+                        }
                     });
                 });
                 [undefined, pythonInterpreter].forEach(interpreter => {
@@ -332,7 +333,7 @@ suite('Terminal Service helpers', () => {
                             when(bashActivationProvider.isShellSupported(shellToExpect)).thenReturn(false);
                             when(cmdActivationProvider.isShellSupported(shellToExpect)).thenReturn(false);
 
-                            const cmd = await helper.getEnvironmentActivationShellCommands(resource, interpreter);
+                            const cmd = await helper.getEnvironmentActivationShellCommands(resource, shellToExpect, interpreter);
 
                             expect(cmd).to.equal(undefined, 'Command must be undefined');
                             verify(pythonSettings.terminal).once();

--- a/src/test/interpreters/activation/service.unit.test.ts
+++ b/src/test/interpreters/activation/service.unit.test.ts
@@ -9,7 +9,6 @@ import { SemVer } from 'semver';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { Uri, workspace as workspaceType, WorkspaceConfiguration } from 'vscode';
-
 import { PlatformService } from '../../../client/common/platform/platformService';
 import { IPlatformService } from '../../../client/common/platform/types';
 import { CurrentProcess } from '../../../client/common/process/currentProcess';
@@ -111,19 +110,19 @@ suite('Interprters Activation - Python Environment Variables', () => {
                     setup(initSetup);
                     test('getEnvironmentActivationShellCommands will be invoked', async () => {
                         when(platform.osType).thenReturn(osType.value);
-                        when(helper.getEnvironmentActivationShellCommands(resource, interpreter)).thenResolve();
+                        when(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).thenResolve();
 
                         const env = await service.getActivatedEnvironmentVariables(resource, interpreter);
 
                         verify(platform.osType).once();
                         expect(env).to.equal(undefined, 'Should not have any variables');
-                        verify(helper.getEnvironmentActivationShellCommands(resource, interpreter)).once();
+                        verify(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).once();
                     });
                     test('Validate command used to activation and printing env vars', async () => {
                         const cmd = ['1', '2'];
                         const envVars = { one: '1', two: '2' };
                         when(platform.osType).thenReturn(osType.value);
-                        when(helper.getEnvironmentActivationShellCommands(resource, interpreter)).thenResolve(cmd);
+                        when(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).thenResolve(cmd);
                         when(processServiceFactory.create(resource)).thenResolve(instance(processService));
                         when(envVarsService.getEnvironmentVariables(resource)).thenResolve(envVars);
 
@@ -131,7 +130,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
 
                         verify(platform.osType).once();
                         expect(env).to.equal(undefined, 'Should not have any variables');
-                        verify(helper.getEnvironmentActivationShellCommands(resource, interpreter)).once();
+                        verify(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).once();
                         verify(processServiceFactory.create(resource)).once();
                         verify(envVarsService.getEnvironmentVariables(resource)).once();
                         verify(processService.shellExec(anything(), anything())).once();
@@ -147,7 +146,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
                         const cmd = ['1', '2'];
                         const envVars = { one: '1', two: '2' };
                         when(platform.osType).thenReturn(osType.value);
-                        when(helper.getEnvironmentActivationShellCommands(resource, interpreter)).thenResolve(cmd);
+                        when(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).thenResolve(cmd);
                         when(processServiceFactory.create(resource)).thenResolve(instance(processService));
                         when(envVarsService.getEnvironmentVariables(resource)).thenResolve(envVars);
 
@@ -155,7 +154,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
 
                         verify(platform.osType).once();
                         expect(env).to.equal(undefined, 'Should not have any variables');
-                        verify(helper.getEnvironmentActivationShellCommands(resource, interpreter)).once();
+                        verify(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).once();
                         verify(processServiceFactory.create(resource)).once();
                         verify(envVarsService.getEnvironmentVariables(resource)).once();
                         verify(processService.shellExec(anything(), anything())).once();
@@ -169,7 +168,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
                         const cmd = ['1', '2'];
                         const envVars = { one: '1', two: '2' };
                         when(platform.osType).thenReturn(osType.value);
-                        when(helper.getEnvironmentActivationShellCommands(resource, interpreter)).thenResolve(cmd);
+                        when(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).thenResolve(cmd);
                         when(processServiceFactory.create(resource)).thenResolve(instance(processService));
                         when(envVarsService.getEnvironmentVariables(resource)).thenResolve({});
                         when(currentProcess.env).thenReturn(envVars);
@@ -178,7 +177,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
 
                         verify(platform.osType).once();
                         expect(env).to.equal(undefined, 'Should not have any variables');
-                        verify(helper.getEnvironmentActivationShellCommands(resource, interpreter)).once();
+                        verify(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).once();
                         verify(processServiceFactory.create(resource)).once();
                         verify(envVarsService.getEnvironmentVariables(resource)).once();
                         verify(processService.shellExec(anything(), anything())).once();
@@ -193,7 +192,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
                         const cmd = ['1', '2'];
                         const envVars = { one: '1', two: '2' };
                         when(platform.osType).thenReturn(osType.value);
-                        when(helper.getEnvironmentActivationShellCommands(resource, interpreter)).thenResolve(cmd);
+                        when(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).thenResolve(cmd);
                         when(processServiceFactory.create(resource)).thenResolve(instance(processService));
                         when(envVarsService.getEnvironmentVariables(resource)).thenResolve(envVars);
                         when(processService.shellExec(anything(), anything())).thenReject(new Error('kaboom'));
@@ -202,7 +201,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
 
                         verify(platform.osType).once();
                         expect(env).to.equal(undefined, 'Should not have any variables');
-                        verify(helper.getEnvironmentActivationShellCommands(resource, interpreter)).once();
+                        verify(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).once();
                         verify(processServiceFactory.create(resource)).once();
                         verify(envVarsService.getEnvironmentVariables(resource)).once();
                         verify(processService.shellExec(anything(), anything())).once();
@@ -213,7 +212,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
                         const varsFromEnv = { one: '11', two: '22', HELLO: 'xxx' };
                         const stdout = `${getEnvironmentPrefix}${EOL}${JSON.stringify(varsFromEnv)}`;
                         when(platform.osType).thenReturn(osType.value);
-                        when(helper.getEnvironmentActivationShellCommands(resource, interpreter)).thenResolve(cmd);
+                        when(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).thenResolve(cmd);
                         when(processServiceFactory.create(resource)).thenResolve(instance(processService));
                         when(envVarsService.getEnvironmentVariables(resource)).thenResolve(envVars);
                         when(processService.shellExec(anything(), anything())).thenResolve({ stdout: stdout });
@@ -222,7 +221,7 @@ suite('Interprters Activation - Python Environment Variables', () => {
 
                         verify(platform.osType).once();
                         expect(env).to.deep.equal(varsFromEnv);
-                        verify(helper.getEnvironmentActivationShellCommands(resource, interpreter)).once();
+                        verify(helper.getEnvironmentActivationShellCommands(resource, anything(), interpreter)).once();
                         verify(processServiceFactory.create(resource)).once();
                         verify(envVarsService.getEnvironmentVariables(resource)).once();
                         verify(processService.shellExec(anything(), anything())).once();


### PR DESCRIPTION
For #5929

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
