### PR TITLE
Disable quoting paths sent to the debugger as args

### DIFF
--- a/news/2 Fixes/5861.md
+++ b/news/2 Fixes/5861.md
@@ -1,0 +1,1 @@
+Disable quoting of paths sent to the debugger as arguments.

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { traceError } from './common/logger';
-import { RemoteDebuggerLauncherScriptProvider } from './debugger/debugAdapter/DebugClients/launcherProvider';
+import { RemoteDebuggerExternalLauncherScriptProvider } from './debugger/debugAdapter/DebugClients/launcherProvider';
 
 /*
  * Do not introduce any breaking changes to this API.
@@ -42,7 +42,7 @@ export function buildApi(ready: Promise<any>) {
         }),
         debug: {
             async getRemoteLauncherCommand(host: string, port: number, waitUntilDebuggerAttaches: boolean = true): Promise<string[]> {
-                return new RemoteDebuggerLauncherScriptProvider().getLauncherArgs({ host, port, waitUntilDebuggerAttaches });
+                return new RemoteDebuggerExternalLauncherScriptProvider().getLauncherArgs({ host, port, waitUntilDebuggerAttaches });
             }
         }
     };

--- a/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
@@ -15,7 +15,7 @@ export class NoDebugLauncherScriptProvider implements IDebugLauncherScriptProvid
     constructor(@optional() private script: string = pathToScript) { }
     public getLauncherArgs(options: LocalDebugOptions): string[] {
         const customDebugger = options.customDebugger ? '--custom' : '--default';
-        return [this.script.fileToCommandArgument(), customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
+        return [this.script, customDebugger, '--nodebug', '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
@@ -23,11 +23,26 @@ export class DebuggerLauncherScriptProvider implements IDebugLauncherScriptProvi
     constructor(@optional() private script: string = pathToScript) { }
     public getLauncherArgs(options: LocalDebugOptions): string[] {
         const customDebugger = options.customDebugger ? '--custom' : '--default';
-        return [this.script.fileToCommandArgument(), customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
+        return [this.script, customDebugger, '--client', '--host', options.host, '--port', options.port.toString()];
     }
 }
 
 export class RemoteDebuggerLauncherScriptProvider implements IRemoteDebugLauncherScriptProvider {
+    constructor(@optional() private script: string = pathToScript) { }
+    public getLauncherArgs(options: RemoteDebugOptions): string[] {
+        const waitArgs = options.waitUntilDebuggerAttaches ? ['--wait'] : [];
+        return [this.script, '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
+    }
+}
+
+/**
+ * This class is used to provide the launch scripts so external code can launch the debugger.
+ * As we're passing command arguments, we need to ensure the file paths are quoted.
+ * @export
+ * @class RemoteDebuggerExternalLauncherScriptProvider
+ * @implements {IRemoteDebugLauncherScriptProvider}
+ */
+export class RemoteDebuggerExternalLauncherScriptProvider implements IRemoteDebugLauncherScriptProvider {
     constructor(@optional() private script: string = pathToScript) { }
     public getLauncherArgs(options: RemoteDebugOptions): string[] {
         const waitArgs = options.waitUntilDebuggerAttaches ? ['--wait'] : [];

--- a/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
+++ b/src/client/debugger/debugAdapter/DebugClients/launcherProvider.ts
@@ -27,14 +27,6 @@ export class DebuggerLauncherScriptProvider implements IDebugLauncherScriptProvi
     }
 }
 
-export class RemoteDebuggerLauncherScriptProvider implements IRemoteDebugLauncherScriptProvider {
-    constructor(@optional() private script: string = pathToScript) { }
-    public getLauncherArgs(options: RemoteDebugOptions): string[] {
-        const waitArgs = options.waitUntilDebuggerAttaches ? ['--wait'] : [];
-        return [this.script, '--default', '--host', options.host, '--port', options.port.toString()].concat(waitArgs);
-    }
-}
-
 /**
  * This class is used to provide the launch scripts so external code can launch the debugger.
  * As we're passing command arguments, we need to ensure the file paths are quoted.

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { EXTENSION_ROOT_DIR } from '../../../../client/common/constants';
-import { DebuggerLauncherScriptProvider, NoDebugLauncherScriptProvider, RemoteDebuggerLauncherScriptProvider } from '../../../../client/debugger/debugAdapter/DebugClients/launcherProvider';
+import { DebuggerLauncherScriptProvider, NoDebugLauncherScriptProvider, RemoteDebuggerLauncherScriptProvider, RemoteDebuggerExternalLauncherScriptProvider } from '../../../../client/debugger/debugAdapter/DebugClients/launcherProvider';
 
 const expectedPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
 
@@ -26,7 +26,7 @@ suite('Debugger - Launcher Script Provider', () => {
             {
                 testName: 'When path to ptvsd launcher contains spaces',
                 path: path.join('path', 'to', 'ptvsd_launcher', 'with spaces'),
-                expectedPath: '"path/to/ptvsd_launcher/with spaces"'
+                expectedPath: 'path/to/ptvsd_launcher/with spaces'
             }
         ];
 
@@ -64,4 +64,32 @@ suite('Debugger - Launcher Script Provider', () => {
             });
         });
     });
+
+    suite('External Debug Launcher', () =>
+        [
+            {
+                testName: 'When path to ptvsd launcher does not contains spaces',
+                path: path.join('path', 'to', 'ptvsd_launcher'),
+                expectedPath: 'path/to/ptvsd_launcher'
+            },
+            {
+                testName: 'When path to ptvsd launcher contains spaces',
+                path: path.join('path', 'to', 'ptvsd_launcher', 'with spaces'),
+                expectedPath: '"path/to/ptvsd_launcher/with spaces"'
+            }
+        ].forEach(testParams => {
+            suite(testParams.testName, async () => {
+                test('Test remote debug launcher args (and do not wait for debugger to attach)', async () => {
+                    const args = new RemoteDebuggerExternalLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false });
+                    const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234'];
+                    expect(args).to.be.deep.equal(expectedArgs);
+                });
+                test('Test remote debug launcher args (and wait for debugger to attach)', async () => {
+                    const args = new RemoteDebuggerExternalLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true });
+                    const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
+                    expect(args).to.be.deep.equal(expectedArgs);
+                });
+            });
+        });
+});
 });

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -55,7 +55,7 @@ suite('Debugger - Launcher Script Provider', () => {
         });
     });
 
-    suite('External Debug Launcher', () =>
+    suite('External Debug Launcher', () => {
         [
             {
                 testName: 'When path to ptvsd launcher does not contains spaces',
@@ -81,5 +81,5 @@ suite('Debugger - Launcher Script Provider', () => {
                 });
             });
         });
-});
+    });
 });

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { EXTENSION_ROOT_DIR } from '../../../../client/common/constants';
-import { DebuggerLauncherScriptProvider, NoDebugLauncherScriptProvider, RemoteDebuggerLauncherScriptProvider, RemoteDebuggerExternalLauncherScriptProvider } from '../../../../client/debugger/debugAdapter/DebugClients/launcherProvider';
+import { DebuggerLauncherScriptProvider, NoDebugLauncherScriptProvider, RemoteDebuggerExternalLauncherScriptProvider } from '../../../../client/debugger/debugAdapter/DebugClients/launcherProvider';
 
 const expectedPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
 
@@ -50,16 +50,6 @@ suite('Debugger - Launcher Script Provider', () => {
             test('Test non-debug launcher args and custom ptvsd', async () => {
                 const args = new NoDebugLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, customDebugger: true });
                 const expectedArgs = [testParams.expectedPath, '--custom', '--nodebug', '--client', '--host', 'something', '--port', '1234'];
-                expect(args).to.be.deep.equal(expectedArgs);
-            });
-            test('Test remote debug launcher args (and do not wait for debugger to attach)', async () => {
-                const args = new RemoteDebuggerLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: false });
-                const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234'];
-                expect(args).to.be.deep.equal(expectedArgs);
-            });
-            test('Test remote debug launcher args (and wait for debugger to attach)', async () => {
-                const args = new RemoteDebuggerLauncherScriptProvider(testParams.path).getLauncherArgs({ host: 'something', port: 1234, waitUntilDebuggerAttaches: true });
-                const expectedArgs = [testParams.expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
                 expect(args).to.be.deep.equal(expectedArgs);
             });
         });

--- a/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
+++ b/src/test/debugger/debugAdapter/debugClients/launcherProvider.unit.test.ts
@@ -21,12 +21,12 @@ suite('Debugger - Launcher Script Provider', () => {
             {
                 testName: 'When path to ptvsd launcher does not contains spaces',
                 path: path.join('path', 'to', 'ptvsd_launcher'),
-                expectedPath: 'path/to/ptvsd_launcher'
+                expectedPath: path.join('path', 'to', 'ptvsd_launcher')
             },
             {
                 testName: 'When path to ptvsd launcher contains spaces',
                 path: path.join('path', 'to', 'ptvsd_launcher', 'with spaces'),
-                expectedPath: 'path/to/ptvsd_launcher/with spaces'
+                expectedPath: path.join('path', 'to', 'ptvsd_launcher', 'with spaces')
             }
         ];
 


### PR DESCRIPTION
For #5861

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
