### PR TITLE
Append  --allow-prereleases to black installation command when Poetry is used

### DIFF
--- a/news/2 Fixes/5756.md
+++ b/news/2 Fixes/5756.md
@@ -1,0 +1,1 @@
+Append `--allow-prereleases` to black installation command so pipenv can properly resolve it.

--- a/src/client/common/installer/poetryInstaller.ts
+++ b/src/client/common/installer/poetryInstaller.ts
@@ -60,8 +60,12 @@ export class PoetryInstaller extends ModuleInstaller implements IModuleInstaller
     }
     protected async getExecutionInfo(moduleName: string, resource?: Uri): Promise<ExecutionInfo> {
         const execPath = this.configurationService.getSettings(resource).poetryPath;
+        const args = ['add', '--dev', moduleName];
+        if (moduleName === 'black') {
+            args.push('--allow-prereleases');
+        }
         return {
-            args: ['add', '--dev', moduleName],
+            args,
             execPath
         };
     }

--- a/src/test/common/installer/poetryInstaller.unit.test.ts
+++ b/src/test/common/installer/poetryInstaller.unit.test.ts
@@ -122,4 +122,15 @@ suite('Module Installer - Poetry', () => {
 
         assert.deepEqual(info, { args: ['add', '--dev', 'something'], execPath: 'poetry path' });
     });
+    test('Get executable info when installing black', async () => {
+        const uri = Uri.file(__dirname);
+        const settings = mock(PythonSettings);
+
+        when(configurationService.getSettings(uri)).thenReturn(instance(settings));
+        when(settings.poetryPath).thenReturn('poetry path');
+
+        const info = await poetryInstaller.getExecutionInfo('black', uri);
+
+        assert.deepEqual(info, { args: ['add', '--dev', 'black', '--allow-prereleases'], execPath: 'poetry path' });
+    });
 });


### PR DESCRIPTION
Similar to #5393.

For #5756 (it has been mistakenly closed as a duplicate of #5171, but the latter was about Pipenv and the former is about Poetry :)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~~Appropriate comments and documentation strings in the code~~
- [x] ~~Has sufficient logging.~~
- [x] ~~Has telemetry for enhancements.~~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~~
- [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~~
- [x] ~~The wiki is updated with any design decisions/details.~~
