### PR TITLE
fixup password for old version

### DIFF
--- a/src/client/datascience/jupyter/jupyterPasswordConnect.ts
+++ b/src/client/datascience/jupyter/jupyterPasswordConnect.ts
@@ -110,8 +110,8 @@ export class JupyterPasswordConnect implements IJupyterPasswordConnect {
 
         const response = await fetchFunction(`${url}login?`, {
             method: 'post',
-            headers: { Cookie: `_xsrf=${xsrfCookie}`, Connection: 'keep-alive' },
-            body: postParams,
+            headers: { Cookie: `_xsrf=${xsrfCookie}`, Connection: 'keep-alive', 'content-type': 'application/x-www-form-urlencoded;charset=UTF-8' },
+            body: postParams.toString(),
             redirect: 'manual'
         });
 

--- a/src/test/datascience/jupyterPasswordConnect.unit.test.ts
+++ b/src/test/datascience/jupyterPasswordConnect.unit.test.ts
@@ -53,7 +53,7 @@ suite('JupyterPasswordConnect', () => {
         //tslint:disable-next-line:no-http-string
         fetchMock.setup(fm => fm('http://TESTNAME:8888/login?', typemoq.It.isObjectWith({
             method: 'post',
-            headers: { Cookie: `_xsrf=${xsrfValue}`, Connection: 'keep-alive' }
+            headers: { Cookie: `_xsrf=${xsrfValue}`, Connection: 'keep-alive', 'content-type': 'application/x-www-form-urlencoded;charset=UTF-8' }
         }))).returns(() => Promise.resolve(mockSessionResponse.object)).verifiable(typemoq.Times.once());
 
         //tslint:disable-next-line:no-http-string


### PR DESCRIPTION
Had to downgrade node-fetch in the following CS: 
https://github.com/microsoft/vscode-python/pull/5962

This change fixes up the password code to use that older version of node-fetch.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
