### PR TITLE
WIP - Display test explorer when tests have been configured

### DIFF
--- a/news/1 Enhancements/4828.md
+++ b/news/1 Enhancements/4828.md
@@ -1,0 +1,1 @@
+Display test explorer when tests have been configured.

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -60,6 +60,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
  * @extends {ICommandNameWithoutArgumentTypeMapping}
  */
 export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgumentTypeMapping {
+    ['workbench.view.extension.test']: [];
     ['setContext']: [string, boolean];
     ['revealLine']: [{ lineNumber: number; at: 'top' | 'center' | 'bottom' }];
     ['python._loadLanguageServerExtension']: {}[];
@@ -84,6 +85,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Tests_Configure]: [undefined, undefined | CommandSource, undefined | Uri];
     [Commands.Tests_Picker_UI]: [undefined, undefined | CommandSource, Uri, TestFunction[]];
     [Commands.Tests_Picker_UI_Debug]: [undefined, undefined | CommandSource, Uri, TestFunction[]];
+    [Commands.Test_Display_Test_Explorer]: [];
     // When command is invoked from a tree node, first argument is the node data.
     [Commands.runTestNode]: [TestDataItem];
     // When command is invoked from a tree node, first argument is the node data.

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -31,6 +31,7 @@ export namespace Commands {
     export const Tests_Ask_To_Stop_Discovery = 'python.askToStopTestDiscovery';
     export const Tests_Stop = 'python.stopTests';
     export const Test_Reveal_Test_Item = 'python.revealTestItem';
+    export const Test_Display_Test_Explorer = 'python.displayTestExplorer';
     export const ViewOutput = 'python.viewOutput';
     export const Tests_ViewOutput = 'python.viewTestOutput';
     export const Tests_Select_And_Run_Method = 'python.selectAndRunTestMethod';

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -100,7 +100,7 @@ export type TestRunTelemetry = {
     tool: TestTool;
     scope: 'currentFile' | 'all' | 'file' | 'class' | 'function' | 'failed';
     debugging: boolean;
-    triggerSource: 'ui' | 'codelens' | 'commandpalette' | 'auto' | 'testExplorer';
+    triggerSource: 'ui' | 'codelens' | 'commandpalette' | 'auto' | 'testExplorer' | 'autoActivate';
     failed: boolean;
 };
 export type TestDiscoverytTelemetry = {

--- a/src/client/testing/common/constants.ts
+++ b/src/client/testing/common/constants.ts
@@ -3,10 +3,32 @@ import { TestProvider, UnitTestProduct } from './types';
 
 export const CANCELLATION_REASON = 'cancelled_user_request';
 export enum CommandSource {
+    /**
+     * Tests discovery/run was triggered by extension as part of activation process.
+     * If extension has identified the fact that user has tests, then we automatically discover those tests.
+     */
+    autoActivate = 'autoActivate',
+    /**
+     * Tests discovery/run was triggered by extension automatically.
+     * E.g. when user changes configuration settings related to tests.
+     */
     auto = 'auto',
+    /**
+     * Tests discovery/run was triggered by user through the UI.
+     * This excludes command Palette, codelenses & test explorer
+     */
     ui = 'ui',
+    /**
+     * Tests discovery/run was triggered by user through code lenses.
+     */
     codelens = 'codelens',
+    /**
+     * Tests discovery/run was triggered by user through the command palette.
+     */
     commandPalette = 'commandpalette',
+    /**
+     * Tests discovery/run was triggered by user through the test explorer.
+     */
     testExplorer = 'testExplorer'
 }
 export const TEST_OUTPUT_CHANNEL = 'TEST_OUTPUT_CHANNEL';

--- a/src/client/testing/explorer/autoDisplayTestExplorer.ts
+++ b/src/client/testing/explorer/autoDisplayTestExplorer.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { IExtensionActivationService } from '../../activation/types';
+import { ICommandManager } from '../../common/application/types';
+import { Commands } from '../../common/constants';
+import { IDisposable, IDisposableRegistry, Resource } from '../../common/types';
+import { CommandSource } from '../common/constants';
+import { Tests } from '../common/types';
+import { ITestManagementService } from '../types';
+
+@injectable()
+export class AutoDisplayTestExplorer implements IExtensionActivationService {
+    private readonly disposables: IDisposable[] = [];
+    private activated = false;
+    constructor(
+        @inject(ICommandManager) private readonly cmdManager: ICommandManager,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+        @inject(ITestManagementService) private readonly managementService: ITestManagementService
+    ) {
+        disposableRegistry.push(this);
+    }
+
+    public async activate(_resource: Resource): Promise<void> {
+        if (this.activated) {
+            return;
+        }
+        this.managementService.onTestsDiscovered(this.onTestsDiscovered, this, this.disposables);
+        this.activated = true;
+    }
+    /**
+     * If tests have been automatically discovered, then display the test explorer.
+     *
+     * @param {{ triggerSource: CommandSource; tests?: Tests }} eventArgs
+     * @memberof AutoDisplayTestExplorer
+     */
+    public async onTestsDiscovered(eventArgs: { triggerSource: CommandSource; tests?: Tests }): Promise<void> {
+        if (eventArgs.triggerSource === CommandSource.auto) {
+            await this.cmdManager.executeCommand(Commands.Test_Display_Test_Explorer);
+        }
+    }
+    public dispose(): void {
+        this.disposables.forEach(item => item.dispose());
+    }
+}

--- a/src/client/testing/explorer/treeView.ts
+++ b/src/client/testing/explorer/treeView.ts
@@ -36,8 +36,14 @@ export class TreeViewService implements IExtensionActivationService, IDisposable
         this._treeView = this.appShell.createTreeView('python_tests', { showCollapseAll: true, treeDataProvider: this.treeViewProvider });
         this.disposables.push(this._treeView);
         this.disposables.push(this.commandManager.registerCommand(Commands.Test_Reveal_Test_Item, this.onRevealTestItem, this));
+        this.disposables.push(this.commandManager.registerCommand(Commands.Test_Display_Test_Explorer, this.show, this));
     }
     public async onRevealTestItem(testItem: TestDataItem): Promise<void> {
         await this.treeView.reveal(testItem);
+    }
+    public async show(): Promise<void> {
+        if (!this.treeView.visible){
+            await this.commandManager.executeCommand('workbench.view.extension.test');
+        }
     }
 }

--- a/src/client/testing/serviceRegistry.ts
+++ b/src/client/testing/serviceRegistry.ts
@@ -34,6 +34,7 @@ import { UnitTestConfigurationService } from './configuration';
 import { TestConfigurationManagerFactory } from './configurationFactory';
 import { TestResultDisplay } from './display/main';
 import { TestDisplay } from './display/picker';
+import { AutoDisplayTestExplorer } from './explorer/autoDisplayTestExplorer';
 import { TestExplorerCommandHandler } from './explorer/commandHandlers';
 import { FailedTestHandler } from './explorer/failedTestHandler';
 import { TestTreeViewProvider } from './explorer/testTreeViewProvider';
@@ -117,6 +118,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ITestExplorerCommandHandler>(ITestExplorerCommandHandler, TestExplorerCommandHandler);
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, TreeViewService);
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, FailedTestHandler);
+    serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, AutoDisplayTestExplorer);
 
     serviceManager.addFactory<ITestManager>(ITestManagerFactory, (context) => {
         return (testProvider: TestProvider, workspaceFolder: Uri, rootDirectory: string) => {

--- a/src/client/testing/types.ts
+++ b/src/client/testing/types.ts
@@ -46,10 +46,11 @@ export interface ITestDisplay {
 export const ITestManagementService = Symbol('ITestManagementService');
 export interface ITestManagementService {
     readonly onDidStatusChange: Event<WorkspaceTestStatus>;
+    readonly onTestsDiscovered: Event<{ triggerSource: CommandSource; tests?: Tests }>;
     activate(symbolProvider: DocumentSymbolProvider): Promise<void>;
     getTestManager(displayTestNotConfiguredMessage: boolean, resource?: Uri): Promise<ITestManager | undefined | void>;
     discoverTestsForDocument(doc: TextDocument): Promise<void>;
-    autoDiscoverTests(resource: Resource): Promise<void>;
+    autoDiscoverTests(resource: Resource, triggerSource: CommandSource): Promise<void>;
     discoverTests(cmdSource: CommandSource, resource?: Uri, ignoreCache?: boolean, userInitiated?: boolean, quietMode?: boolean): Promise<void>;
     stopTests(resource: Uri): Promise<void>;
     displayStopUI(message: string): Promise<void>;

--- a/src/test/testing/explorer/autoDisplayTestExplorer.unit.test.ts
+++ b/src/test/testing/explorer/autoDisplayTestExplorer.unit.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as assert from 'assert';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Uri } from 'vscode';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { ICommandManager } from '../../../client/common/application/types';
+import { Commands } from '../../../client/common/constants';
+import { IDisposableRegistry } from '../../../client/common/types';
+import { getNamesAndValues } from '../../../client/common/utils/enum';
+import { CommandSource } from '../../../client/testing/common/constants';
+import { Tests } from '../../../client/testing/common/types';
+import { AutoDisplayTestExplorer } from '../../../client/testing/explorer/autoDisplayTestExplorer';
+import { UnitTestManagementService } from '../../../client/testing/main';
+import { ITestManagementService } from '../../../client/testing/types';
+
+// tslint:disable:no-any
+
+suite('Unit Tests Test Explorer - Automatically Display', () => {
+    let commandManager: ICommandManager;
+    let testManagementService: ITestManagementService;
+    let disposableRegistry: IDisposableRegistry;
+    let autoDisplayTestExplorer: AutoDisplayTestExplorer;
+    setup(() => {
+        commandManager = mock(CommandManager);
+        testManagementService = mock(UnitTestManagementService);
+        disposableRegistry = [];
+        autoDisplayTestExplorer = new AutoDisplayTestExplorer(instance(commandManager), disposableRegistry, instance(testManagementService));
+    });
+
+    test('Class is registered as a disposable item', async () => {
+        expect(disposableRegistry).to.contain(autoDisplayTestExplorer);
+    });
+    test('Activation will register event handler once (with and without resource)', async () => {
+        const onTestsDiscoveredStub = sinon.stub();
+        when(testManagementService.onTestsDiscovered).thenReturn(onTestsDiscoveredStub);
+
+        await autoDisplayTestExplorer.activate(Uri.file(__filename));
+        await autoDisplayTestExplorer.activate(undefined);
+        await autoDisplayTestExplorer.activate(Uri.file(__filename));
+        await autoDisplayTestExplorer.activate(undefined);
+
+        assert.ok(onTestsDiscoveredStub.calledOnceWith(autoDisplayTestExplorer.onTestsDiscovered, autoDisplayTestExplorer, []));
+    });
+    test('Dispose event handler', async () => {
+        const onTestsDiscoveredStub = sinon.stub();
+        when(testManagementService.onTestsDiscovered).thenReturn(onTestsDiscoveredStub);
+        const disposable = {
+            dispose: sinon.stub()
+        };
+        onTestsDiscoveredStub.callsFake((_: any, __: any, disposables: any[]) => {
+            disposables.push(disposable);
+        });
+
+        await autoDisplayTestExplorer.activate(undefined);
+        autoDisplayTestExplorer.dispose();
+
+        assert.ok(disposable.dispose.calledOnce);
+    });
+    getNamesAndValues<CommandSource>(CommandSource).forEach(cmdSource => {
+        test(`Display test explorer only if command source is 'auto' (without tests and ${cmdSource.name})`, async () => {
+            when(commandManager.executeCommand(anything())).thenResolve();
+
+            await autoDisplayTestExplorer.onTestsDiscovered({ triggerSource: cmdSource.value });
+
+            verify(commandManager.executeCommand(Commands.Test_Display_Test_Explorer)).times(cmdSource.value === CommandSource.auto ? 1 : 0)
+        });
+        test(`Display test explorer only if command source is 'auto' (tests and ${cmdSource.name})`, async () => {
+            when(commandManager.executeCommand(anything())).thenResolve();
+
+            const tests: Tests = {
+                rootTestFolders: [],
+                summary: { errors: 0, failures: 0, passed: 0, skipped: 0 },
+                testFiles: [], testFolders: [], testFunctions: [], testSuites: []
+            };
+            await autoDisplayTestExplorer.onTestsDiscovered({ triggerSource: cmdSource.value, tests });
+
+            verify(commandManager.executeCommand(Commands.Test_Display_Test_Explorer)).times(cmdSource.value === CommandSource.auto ? 1 : 0)
+        });
+    });
+});

--- a/src/test/testing/explorer/treeView.unit.test.ts
+++ b/src/test/testing/explorer/treeView.unit.test.ts
@@ -39,13 +39,14 @@ suite('Unit Tests Test Explorer Tree View', () => {
         await treeViewService.activate(Uri.file(__filename));
         verify(appShell.createTreeView('python_tests', deepEqual({ showCollapseAll: true, treeDataProvider: instance(treeViewProvider) }))).once();
     });
-    test('Activation will add command handlers (without a resource)', async () => {
+    test('Activation will add command handlers once (with & without a resource)', async () => {
         await treeViewService.activate(undefined);
-        verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevealTestItem, treeViewService)).once();
-    });
-    test('Activation will add command handlers (with a resource)', async () => {
+        await treeViewService.activate(undefined);
         await treeViewService.activate(Uri.file(__filename));
+        await treeViewService.activate(Uri.file(__filename));
+
         verify(commandManager.registerCommand(Commands.Test_Reveal_Test_Item, treeViewService.onRevealTestItem, treeViewService)).once();
+        verify(commandManager.registerCommand(Commands.Test_Display_Test_Explorer, treeViewService.show, treeViewService)).once();
     });
     test('Invoking the command handler will reveal the node in the tree', async () => {
         const data = {} as any;
@@ -59,5 +60,19 @@ suite('Unit Tests Test Explorer Tree View', () => {
         await treeViewService.onRevealTestItem(data);
 
         treeView.verifyAll();
+    });
+    test('Command used to display test explorer is not invoked if test explorer is not already visible', async () => {
+        (treeViewService as any)._treeView = { visible: true };
+
+        await treeViewService.show();
+
+        verify(commandManager.executeCommand('workbench.view.extension.test')).never();
+    });
+    test('Command used to display test explorer is invoked if test explorer is not visible', async () => {
+        (treeViewService as any)._treeView = { visible: false };
+
+        await treeViewService.show();
+
+        verify(commandManager.executeCommand('workbench.view.extension.test')).once();
     });
 });

--- a/src/test/testing/main.unit.test.ts
+++ b/src/test/testing/main.unit.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as assert from 'assert';
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinon from 'sinon';
+import { anything, instance, mock, when } from 'ts-mockito';
+import { Disposable, OutputChannel, Uri } from 'vscode';
+import { DocumentManager } from '../../client/common/application/documentManager';
+import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
+import { WorkspaceService } from '../../client/common/application/workspace';
+import { PythonSettings } from '../../client/common/configSettings';
+import { ConfigurationService } from '../../client/common/configuration/service';
+import { IConfigurationService, IDisposableRegistry, IOutputChannel, IPythonSettings } from '../../client/common/types';
+import { getNamesAndValues } from '../../client/common/utils/enum';
+import { ServiceContainer } from '../../client/ioc/container';
+import { IServiceContainer } from '../../client/ioc/types';
+import { CommandSource, TEST_OUTPUT_CHANNEL } from '../../client/testing/common/constants';
+import { Tests, TestStatus } from '../../client/testing/common/types';
+import { TestResultDisplay } from '../../client/testing/display/main';
+import { UnitTestManagementService } from '../../client/testing/main';
+import { TestManager } from '../../client/testing/nosetest/main';
+import { ITestResultDisplay } from '../../client/testing/types';
+import { noop } from '../core';
+
+use(chaiAsPromised);
+
+// tslint:disable:no-any max-func-body-length
+suite('Unit Tests Test Explorer - Automatically Display', () => {
+    let testManagementService: UnitTestManagementService;
+    let serviceContainer: IServiceContainer;
+    let workspaceService: IWorkspaceService;
+    let configService: IConfigurationService;
+    let settings: IPythonSettings;
+    let testResultsDisplay: ITestResultDisplay;
+    const sandbox = sinon.sandbox.create();
+    const tests: Tests = {
+        rootTestFolders: [],
+        summary: { errors: 0, failures: 0, passed: 0, skipped: 0 },
+        testFiles: [], testFolders: [], testFunctions: [], testSuites: []
+    };
+
+    setup(() => {
+        configService = mock(ConfigurationService);
+        workspaceService = mock(WorkspaceService);
+        serviceContainer = mock(ServiceContainer);
+        settings = mock(PythonSettings);
+        testResultsDisplay = mock(TestResultDisplay);
+
+        when(configService.getSettings(anything())).thenReturn(instance(settings));
+        when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(instance(configService));
+        when(serviceContainer.get<Disposable[]>(IDisposableRegistry)).thenReturn([]);
+        when(serviceContainer.get<OutputChannel>(IOutputChannel, TEST_OUTPUT_CHANNEL)).thenReturn({} as any);
+        when(serviceContainer.get<IWorkspaceService>(IWorkspaceService)).thenReturn(instance(workspaceService));
+        when(serviceContainer.get<IDocumentManager>(IDocumentManager)).thenReturn(instance(mock(DocumentManager)));
+        when(serviceContainer.get<ITestResultDisplay>(ITestResultDisplay)).thenReturn(instance(testResultsDisplay));
+    });
+    teardown(() => {
+        sandbox.restore();
+    });
+    test('Invoking activate will result in auto discovery of tests', async () => {
+        sandbox.stub(UnitTestManagementService.prototype, 'registerHandlers');
+        sandbox.stub(UnitTestManagementService.prototype, 'registerCommands');
+        sandbox.stub(UnitTestManagementService.prototype, 'registerSymbolProvider');
+        const autoDiscoverTestsStub = sandbox.stub(UnitTestManagementService.prototype, 'autoDiscoverTests');
+        autoDiscoverTestsStub.callsFake(() => Promise.resolve());
+
+        testManagementService = new UnitTestManagementService(instance(serviceContainer));
+        await testManagementService.activate({} as any);
+
+        assert.ok(autoDiscoverTestsStub.calledOnceWithExactly(undefined, CommandSource.autoActivate));
+    });
+
+    getNamesAndValues<CommandSource>(CommandSource).forEach(cmdSource => {
+        test(`Auto discovery will propagate triggerSource to discover tests (${cmdSource.name})`, async () => {
+            const resource = Uri.file(__dirname);
+            const autoDiscoverTestsStub = sandbox.stub(UnitTestManagementService.prototype, 'discoverTests');
+            autoDiscoverTestsStub.callsFake(() => Promise.resolve());
+            when(settings.testing).thenReturn({ nosetestsEnabled: true } as any);
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+
+            testManagementService = new UnitTestManagementService(instance(serviceContainer));
+
+            await testManagementService.autoDiscoverTests(resource, cmdSource.value);
+
+            assert.ok(autoDiscoverTestsStub.calledOnceWithExactly(cmdSource.value, resource, true));
+        });
+        test(`When tests are discovered TestDiscovered event is fired (${cmdSource.name})`, async () => {
+            const testManager = mock(TestManager);
+            const getTestManagerStub = sandbox.stub(UnitTestManagementService.prototype, 'getTestManager');
+            const instanceTestManager = instance(testManager);
+            (instanceTestManager as any).then = undefined;
+            getTestManagerStub.resolves(instanceTestManager);
+            when(testResultsDisplay.displayDiscoverStatus(anything(), anything())).thenResolve();
+            when(testManager.status).thenReturn(TestStatus.Idle);
+            when(testManager.discoverTests(anything(), anything(), anything(), anything(), anything())).thenResolve(tests);
+
+            testManagementService = new UnitTestManagementService(instance(serviceContainer));
+            const eventFireStub = sinon.stub();
+            testManagementService._onTestsDiscovered.fire = eventFireStub;
+            await testManagementService.discoverTests(cmdSource.value, Uri.file(__dirname));
+
+            assert.ok(eventFireStub.calledOnce);
+            assert.ok(eventFireStub.calledOnceWithExactly({ triggerSource: cmdSource.value, tests }));
+        });
+        test(`When tests are not discovered TestDiscovered event is not fired (${cmdSource.name})`, async () => {
+            const testManager = mock(TestManager);
+            const getTestManagerStub = sandbox.stub(UnitTestManagementService.prototype, 'getTestManager');
+            const instanceTestManager = instance(testManager);
+            (instanceTestManager as any).then = undefined;
+            getTestManagerStub.rejects(new Error('Failed'));
+            when(testResultsDisplay.displayDiscoverStatus(anything(), anything())).thenResolve();
+            when(testManager.status).thenReturn(TestStatus.Idle);
+            when(testManager.discoverTests(anything(), anything(), anything(), anything(), anything())).thenResolve(tests);
+
+            testManagementService = new UnitTestManagementService(instance(serviceContainer));
+            const eventFireStub = sinon.stub();
+            testManagementService._onTestsDiscovered.fire = eventFireStub;
+            const promise = testManagementService.discoverTests(cmdSource.value, Uri.file(__dirname));
+            await promise.catch(noop);
+
+            assert.ok(eventFireStub.notCalled);
+            await expect(promise).to.eventually.be.rejectedWith('Failed');
+        });
+    });
+});

--- a/src/test/testing/serviceRegistry.unit.test.ts
+++ b/src/test/testing/serviceRegistry.unit.test.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { instance, mock, verify } from 'ts-mockito';
+import { IExtensionActivationService } from '../../client/activation/types';
+import { ServiceManager } from '../../client/ioc/serviceManager';
+import { AutoDisplayTestExplorer } from '../../client/testing/explorer/autoDisplayTestExplorer';
+import { registerTypes } from '../../client/testing/serviceRegistry';
+
+suite('Unit Tests Test Explorer - Register Classes in IOC container', () => {
+    test('AutoDisplayTestExplorer class is registered', async () => {
+        const serviceContainer = mock(ServiceManager);
+
+        registerTypes(instance(serviceContainer));
+
+        verify(serviceContainer.addSingleton<IExtensionActivationService>(IExtensionActivationService, AutoDisplayTestExplorer)).once();
+    });
+});


### PR DESCRIPTION
For #4828

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
