### PR TITLE
Move IHttpClient to the common types.

### DIFF
--- a/src/client/activation/languageServer/downloader.ts
+++ b/src/client/activation/languageServer/downloader.ts
@@ -10,14 +10,14 @@ import { IApplicationShell, IWorkspaceService } from '../../common/application/t
 import { STANDARD_OUTPUT_CHANNEL } from '../../common/constants';
 import '../../common/extensions';
 import { IFileSystem } from '../../common/platform/types';
-import { IOutputChannel, Resource } from '../../common/types';
+import { IHttpClient, IOutputChannel, Resource } from '../../common/types';
 import { createDeferred } from '../../common/utils/async';
 import { Common, LanguageService } from '../../common/utils/localize';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import {
-    IHttpClient, ILanguageServerDownloader, ILanguageServerFolderService,
+    ILanguageServerDownloader, ILanguageServerFolderService,
     IPlatformData
 } from '../types';
 

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -3,7 +3,6 @@
 
 'use strict';
 
-import { Request as RequestResult } from 'request';
 import { SemVer } from 'semver';
 import { Event } from 'vscode';
 import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
@@ -37,12 +36,6 @@ export enum LanguageServerActivator {
 export const ILanguageServerActivator = Symbol('ILanguageServerActivator');
 export interface ILanguageServerActivator extends IDisposable {
     activate(resource: Resource): Promise<void>;
-}
-
-export const IHttpClient = Symbol('IHttpClient');
-export interface IHttpClient {
-    downloadFile(uri: string): Promise<RequestResult>;
-    getJSON<T>(uri: string): Promise<T>;
 }
 
 export type FolderVersionPair = { path: string; version: SemVer };

--- a/src/client/common/net/httpClient.ts
+++ b/src/client/common/net/httpClient.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as requestTypes from 'request';
-import { IHttpClient } from '../../activation/types';
+import { IHttpClient } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { IWorkspaceService } from '../application/types';
 

--- a/src/client/common/nuget/nugetRepository.ts
+++ b/src/client/common/nuget/nugetRepository.ts
@@ -5,7 +5,7 @@
 
 import { inject, injectable } from 'inversify';
 import { parse, SemVer } from 'semver';
-import { IHttpClient } from '../../activation/types';
+import { IHttpClient } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { INugetRepository, NugetPackage } from './types';
 

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IHttpClient } from '../activation/types';
 import { IServiceManager } from '../ioc/types';
 import { ImportTracker } from '../telemetry/importTracker';
 import { IImportTracker } from '../telemetry/types';
@@ -64,6 +63,7 @@ import {
     IEditorUtils,
     IExtensions,
     IFeatureDeprecationManager,
+    IHttpClient,
     IInstaller,
     ILogger,
     IPathUtils,

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -3,6 +3,7 @@
 'use strict';
 
 import { Socket } from 'net';
+import { Request as RequestResult } from 'request';
 import { ConfigurationTarget, DiagnosticSeverity, Disposable, DocumentSymbolProvider, Event, Extension, ExtensionContext, OutputChannel, Uri, WorkspaceEdit } from 'vscode';
 import { CommandsWithoutArgs } from './application/commands';
 import { EnvironmentVariables } from './variables/types';
@@ -329,6 +330,12 @@ export const ISocketServer = Symbol('ISocketServer');
 export interface ISocketServer extends Disposable {
     readonly client: Promise<Socket>;
     Start(options?: { port?: number; host?: string }): Promise<number>;
+}
+
+export const IHttpClient = Symbol('IHttpClient');
+export interface IHttpClient {
+    downloadFile(uri: string): Promise<RequestResult>;
+    getJSON<T>(uri: string): Promise<T>;
 }
 
 export const IExtensionContext = Symbol('ExtensionContext');

--- a/src/test/common/nuget/azureBobStoreRepository.functional.test.ts
+++ b/src/test/common/nuget/azureBobStoreRepository.functional.test.ts
@@ -9,11 +9,11 @@ import * as typeMoq from 'typemoq';
 import { WorkspaceConfiguration } from 'vscode';
 import { LanguageServerPackageStorageContainers } from '../../../client/activation/languageServer/languageServerPackageRepository';
 import { LanguageServerPackageService } from '../../../client/activation/languageServer/languageServerPackageService';
-import { IHttpClient } from '../../../client/activation/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { AzureBlobStoreNugetRepository } from '../../../client/common/nuget/azureBlobStoreNugetRepository';
 import { INugetService } from '../../../client/common/nuget/types';
 import { PlatformService } from '../../../client/common/platform/platformService';
+import { IHttpClient } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 
 const azureBlobStorageAccount = 'https://pvsc.blob.core.windows.net';

--- a/src/test/common/nuget/nugetRepository.unit.test.ts
+++ b/src/test/common/nuget/nugetRepository.unit.test.ts
@@ -6,8 +6,8 @@
 import { expect } from 'chai';
 import { SemVer } from 'semver';
 import * as typeMoq from 'typemoq';
-import { IHttpClient } from '../../../client/activation/types';
 import { NugetRepository } from '../../../client/common/nuget/nugetRepository';
+import { IHttpClient } from '../../../client/common/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 
 suite('Nuget on Nuget Repo', () => {


### PR DESCRIPTION
(for #2772)

This is a simple change, to reduce churn in a later PR.  Here we *only* move an interface to a more general location.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [ ] ~Appropriate comments and documentation strings in the code~
- [ ] ~Has sufficient logging.~
- [ ] ~Has telemetry for enhancements.~
- [ ] ~Unit tests & system/integration tests are added/updated~
- [ ] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] ~The wiki is updated with any design decisions/details.~
