### PR TITLE
Lowercase drive letter on localhost path mappings on Windows

### DIFF
--- a/news/2 Fixes/5362.md
+++ b/news/2 Fixes/5362.md
@@ -1,0 +1,1 @@
+Fix localhost path mappings to lowercase the drive letter on Windows.

--- a/src/client/debugger/extension/configuration/resolvers/attach.ts
+++ b/src/client/debugger/extension/configuration/resolvers/attach.ts
@@ -96,8 +96,14 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         if (workspaceFolder && debugConfiguration.host &&
             debugConfiguration.pathMappings!.length === 0 &&
             ['LOCALHOST', '127.0.0.1', '::1'].indexOf(debugConfiguration.host.toUpperCase()) >= 0) {
+            // If on Windows, lowercase the drive letter for path mappings.
+            let localRoot = workspaceFolder.fsPath;
+            if (this.platformService.isWindows && localRoot.match(/^[A-Z]:/)) {
+                localRoot = `${localRoot[0].toLowerCase()}${localRoot.substr(1)}`;
+            }
+
             debugConfiguration.pathMappings!.push({
-                localRoot: workspaceFolder.fsPath,
+                localRoot,
                 remoteRoot: workspaceFolder.fsPath
             });
         }

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -169,49 +169,37 @@ getNamesAndValues(OSType).forEach(os => {
                 expect(pathMappings![0].remoteRoot).to.be.equal(workspaceFolder.uri.fsPath);
             });
 
-            if (os.name === 'Windows') {
-                test(`Ensure drive letter is lower cased for local path mappings on Windows when host is '${host}'`, async () => {
-                    const activeFile = 'xyz.py';
-                    const workspaceFolder = createMoqWorkspaceFolder(path.join('C:', 'Debug', 'Python_Path'));
-                    setupActiveEditor(activeFile, PYTHON_LANGUAGE);
-                    const defaultWorkspace = path.join('usr', 'desktop');
-                    setupWorkspaces([defaultWorkspace]);
+            test(`Ensure drive letter is lower cased for local path mappings on Windows when host is '${host}'`, async function () {
+                if (os.name !== 'Windows') {
+                    return this.skip();
+                }
 
-                    const localRoot = `Debug_PythonPath_${new Date().toString()}`;
-                    const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
-                    const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
-                    const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(path.join('C:', 'Debug', 'Python_Path'));
+                setupActiveEditor(activeFile, PYTHON_LANGUAGE);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
 
-                    expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
-                });
-                test(`Ensure local path mappings are not modified when not pointing to a local drive when host is '${host}'`, async () => {
-                    const activeFile = 'xyz.py';
-                    const workspaceFolder = createMoqWorkspaceFolder(path.join('Server', 'Debug', 'Python_Path'));
-                    setupActiveEditor(activeFile, PYTHON_LANGUAGE);
-                    const defaultWorkspace = path.join('usr', 'desktop');
-                    setupWorkspaces([defaultWorkspace]);
+                const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
+                const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
 
-                    const localRoot = `Debug_PythonPath_${new Date().toString()}`;
-                    const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
-                    const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
+                expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
+            });
+            test(`Ensure local path mappings are not modified when not pointing to a local drive when host is '${host}'`, async () => {
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(path.join('Server', 'Debug', 'Python_Path'));
+                setupActiveEditor(activeFile, PYTHON_LANGUAGE);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
 
-                    expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
-                });
-            } else {
-                test(`Ensure local path mappings are not modified and when host is '${host}'`, async () => {
-                    const activeFile = 'xyz.py';
-                    const workspaceFolder = createMoqWorkspaceFolder(path.join('C:', 'Debug', 'Python_Path'));
-                    setupActiveEditor(activeFile, PYTHON_LANGUAGE);
-                    const defaultWorkspace = path.join('usr', 'desktop');
-                    setupWorkspaces([defaultWorkspace]);
+                const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
 
-                    const localRoot = `Debug_PythonPath_${new Date().toString()}`;
-                    const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
-                    const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
-
-                    expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
-                });
-            }
+                expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
+            });
         });
         ['192.168.1.123', 'don.debugger.com'].forEach(host => {
             test(`Ensure path mappings are not automatically added when host is '${host}'`, async () => {

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -170,9 +170,9 @@ getNamesAndValues(OSType).forEach(os => {
             });
 
             if (os.name === 'Windows') {
-                test(`Ensure drive letter is lower cased for local path mappings on Windows when host is ${host}`, async () => {
+                test(`Ensure drive letter is lower cased for local path mappings on Windows when host is '${host}'`, async () => {
                     const activeFile = 'xyz.py';
-                    const workspaceFolder = createMoqWorkspaceFolder('C:/Debug/Python_Path');
+                    const workspaceFolder = createMoqWorkspaceFolder(path.join('C:', 'Debug', 'Python_Path'));
                     setupActiveEditor(activeFile, PYTHON_LANGUAGE);
                     const defaultWorkspace = path.join('usr', 'desktop');
                     setupWorkspaces([defaultWorkspace]);
@@ -183,6 +183,33 @@ getNamesAndValues(OSType).forEach(os => {
                     const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
 
                     expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
+                });
+                test(`Ensure local path mappings are not modified when not pointing to a local drive when host is '${host}'`, async () => {
+                    const activeFile = 'xyz.py';
+                    const workspaceFolder = createMoqWorkspaceFolder(path.join('Server', 'Debug', 'Python_Path'));
+                    setupActiveEditor(activeFile, PYTHON_LANGUAGE);
+                    const defaultWorkspace = path.join('usr', 'desktop');
+                    setupWorkspaces([defaultWorkspace]);
+
+                    const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                    const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                    const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
+
+                    expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
+                });
+            } else {
+                test(`Ensure local path mappings are not modified and when host is '${host}'`, async () => {
+                    const activeFile = 'xyz.py';
+                    const workspaceFolder = createMoqWorkspaceFolder(path.join('C:', 'Debug', 'Python_Path'));
+                    setupActiveEditor(activeFile, PYTHON_LANGUAGE);
+                    const defaultWorkspace = path.join('usr', 'desktop');
+                    setupWorkspaces([defaultWorkspace]);
+
+                    const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                    const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                    const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
+
+                    expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
                 });
             }
         });

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -168,6 +168,23 @@ getNamesAndValues(OSType).forEach(os => {
                 expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
                 expect(pathMappings![0].remoteRoot).to.be.equal(workspaceFolder.uri.fsPath);
             });
+
+            if (os.name === 'Windows') {
+                test(`Ensure drive letter is lower cased for local path mappings on Windows when host is ${host}`, async () => {
+                    const activeFile = 'xyz.py';
+                    const workspaceFolder = createMoqWorkspaceFolder('C:/Debug/Python_Path');
+                    setupActiveEditor(activeFile, PYTHON_LANGUAGE);
+                    const defaultWorkspace = path.join('usr', 'desktop');
+                    setupWorkspaces([defaultWorkspace]);
+
+                    const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                    const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                    const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
+                    const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
+
+                    expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
+                });
+            }
         });
         ['192.168.1.123', 'don.debugger.com'].forEach(host => {
             test(`Ensure path mappings are not automatically added when host is '${host}'`, async () => {


### PR DESCRIPTION
For #5382

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [ ] ~Has sufficient logging.~
- [ ] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [ ] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] ~The wiki is updated with any design decisions/details.~
