### PR TITLE
Ensure return value of `setTimeout` is either one of number of NodeJs.Timer

### DIFF
--- a/src/client/common/utils/decorators.ts
+++ b/src/client/common/utils/decorators.ts
@@ -56,7 +56,7 @@ export function debounceAsync(wait?: number) {
 
 export function makeDebounceDecorator(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction>) {
+    return function(_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<VoidFunction>) {
         // We could also make use of _debounce() options.  For instance,
         // the following causes the original method to be called
         // immediately:
@@ -71,7 +71,7 @@ export function makeDebounceDecorator(wait?: number) {
         const options = {};
         const originalMethod = descriptor.value!;
         const debounced = _debounce(
-            function (this: any) {
+            function(this: any) {
                 return originalMethod.apply(this, arguments as any);
             },
             wait,
@@ -83,28 +83,29 @@ export function makeDebounceDecorator(wait?: number) {
 
 export function makeDebounceAsyncDecorator(wait?: number) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<AsyncVoidFunction>) {
-        type StateInformation = { started: boolean; deferred: Deferred<any> | undefined; timer: number | undefined };
+    return function(_target: any, _propertyName: string, descriptor: TypedPropertyDescriptor<AsyncVoidFunction>) {
+        type StateInformation = { started: boolean; deferred: Deferred<any> | undefined; timer: NodeJS.Timer | number | undefined };
         const originalMethod = descriptor.value!;
         const state: StateInformation = { started: false, deferred: undefined, timer: undefined };
 
         // Lets defer execution using a setTimeout for the given time.
-        (descriptor as any).value = function (this: any) {
+        (descriptor as any).value = function(this: any) {
             const existingDeferred: Deferred<any> | undefined = state.deferred;
             if (existingDeferred && state.started) {
                 return existingDeferred.promise;
             }
 
             // Clear previous timer.
-            const existingDeferredCompleted = (existingDeferred && existingDeferred.completed);
-            const deferred = state.deferred = (!existingDeferred || existingDeferredCompleted) ? createDeferred<any>() : existingDeferred;
+            const existingDeferredCompleted = existingDeferred && existingDeferred.completed;
+            const deferred = (state.deferred = !existingDeferred || existingDeferredCompleted ? createDeferred<any>() : existingDeferred);
             if (state.timer) {
-                clearTimeout(state.timer);
+                clearTimeout(state.timer as any);
             }
 
             state.timer = setTimeout(async () => {
                 state.started = true;
-                originalMethod.apply(this)
+                originalMethod
+                    .apply(this)
                     .then(r => {
                         state.started = false;
                         deferred.resolve(r);
@@ -113,7 +114,7 @@ export function makeDebounceAsyncDecorator(wait?: number) {
                         state.started = false;
                         deferred.reject(ex);
                     });
-            }, wait);
+            }, wait || 0);
             return deferred.promise;
         };
     };
@@ -127,16 +128,16 @@ export function clearCachedResourceSpecificIngterpreterData(key: string, resourc
     cache.clear();
 }
 export function cacheResourceSpecificInterpreterData(key: string, expiryDurationMs: number, vscode: VSCodeType = require('vscode')) {
-    return function (_target: Object, _propertyName: string, descriptor: TypedPropertyDescriptor<PromiseFunctionWithFirstArgOfResource>) {
+    return function(_target: Object, _propertyName: string, descriptor: TypedPropertyDescriptor<PromiseFunctionWithFirstArgOfResource>) {
         const originalMethod = descriptor.value!;
-        descriptor.value = async function (...args: [Uri | undefined, ...any[]]) {
+        descriptor.value = async function(...args: [Uri | undefined, ...any[]]) {
             const cache = new InMemoryInterpreterSpecificCache(key, expiryDurationMs, args, vscode);
             if (cache.hasData) {
                 traceVerbose(`Cached data exists ${key}, ${args[0] ? args[0].fsPath : '<No Resource>'}`);
                 return Promise.resolve(cache.data);
             }
             const promise = originalMethod.apply(this, args) as Promise<any>;
-            promise.then(result => cache.data = result).ignoreErrors();
+            promise.then(result => (cache.data = result)).ignoreErrors();
             return promise;
         };
     };
@@ -151,11 +152,11 @@ export function cacheResourceSpecificInterpreterData(key: string, expiryDuration
  */
 export function swallowExceptions(scopeName: string) {
     // tslint:disable-next-line:no-any no-function-expression
-    return function (_target: any, propertyName: string, descriptor: TypedPropertyDescriptor<any>) {
+    return function(_target: any, propertyName: string, descriptor: TypedPropertyDescriptor<any>) {
         const originalMethod = descriptor.value!;
         const errorMessage = `Python Extension (Error in ${scopeName}, method:${propertyName}):`;
         // tslint:disable-next-line:no-any no-function-expression
-        descriptor.value = function (...args: any[]) {
+        descriptor.value = function(...args: any[]) {
             try {
                 // tslint:disable-next-line:no-invalid-this no-use-before-declare no-unsafe-any
                 const result = originalMethod.apply(this, args);
@@ -183,10 +184,10 @@ export function swallowExceptions(scopeName: string) {
 type PromiseFunction = (...any: any[]) => Promise<any>;
 
 export function displayProgress(title: string, location = ProgressLocation.Window) {
-    return function (_target: Object, _propertyName: string, descriptor: TypedPropertyDescriptor<PromiseFunction>) {
+    return function(_target: Object, _propertyName: string, descriptor: TypedPropertyDescriptor<PromiseFunction>) {
         const originalMethod = descriptor.value!;
         // tslint:disable-next-line:no-any no-function-expression
-        descriptor.value = async function (...args: any[]) {
+        descriptor.value = async function(...args: any[]) {
             const progressOptions: ProgressOptions = { location, title };
             // tslint:disable-next-line:no-invalid-this
             const promise = originalMethod.apply(this, args);

--- a/src/client/datascience/jupyter/jupyterConnection.ts
+++ b/src/client/datascience/jupyter/jupyterConnection.ts
@@ -36,25 +36,26 @@ export type JupyterServerInfo = {
 
 class JupyterConnectionWaiter {
     private startPromise: Deferred<IConnection>;
-    private launchTimeout: NodeJS.Timer;
+    private launchTimeout: NodeJS.Timer | number;
     private configService: IConfigurationService;
     private logger: ILogger;
     private fileSystem: IFileSystem;
     private notebook_dir: string;
-    private getServerInfo : (cancelToken?: CancellationToken) => Promise<JupyterServerInfo[] | undefined>;
-    private createConnection : (b: string, t: string, p: Disposable) => IConnection;
-    private launchResult : ObservableExecutionResult<string>;
-    private cancelToken : CancellationToken | undefined;
+    private getServerInfo: (cancelToken?: CancellationToken) => Promise<JupyterServerInfo[] | undefined>;
+    private createConnection: (b: string, t: string, p: Disposable) => IConnection;
+    private launchResult: ObservableExecutionResult<string>;
+    private cancelToken: CancellationToken | undefined;
     private stderr: string[] = [];
     private connectionDisposed = false;
 
     constructor(
-        launchResult : ObservableExecutionResult<string>,
+        launchResult: ObservableExecutionResult<string>,
         notebookFile: string,
         getServerInfo: (cancelToken?: CancellationToken) => Promise<JupyterServerInfo[] | undefined>,
         createConnection: (b: string, t: string, p: Disposable) => IConnection,
         serviceContainer: IServiceContainer,
-        cancelToken?: CancellationToken) {
+        cancelToken?: CancellationToken
+    ) {
         this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
         this.logger = serviceContainer.get<ILogger>(ILogger);
         this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
@@ -85,24 +86,26 @@ class JupyterConnectionWaiter {
         // Listen for crashes
         let exitCode = '0';
         if (launchResult.proc) {
-            launchResult.proc.on('exit', (c) => exitCode = c ? c.toString() : '0');
+            launchResult.proc.on('exit', c => (exitCode = c ? c.toString() : '0'));
         }
 
         // Listen on stderr for its connection information
-        launchResult.out.subscribe((output : Output<string>) => {
-            if (output.source === 'stderr') {
-                this.stderr.push(output.out);
-                this.extractConnectionInformation(output.out);
-            } else {
-                this.output(output.out);
-            }
-        },
-        (e) => this.rejectStartPromise(e.message),
-        // If the process dies, we can't extract connection information.
-        () => this.rejectStartPromise(localize.DataScience.jupyterServerCrashed().format(exitCode)));
+        launchResult.out.subscribe(
+            (output: Output<string>) => {
+                if (output.source === 'stderr') {
+                    this.stderr.push(output.out);
+                    this.extractConnectionInformation(output.out);
+                } else {
+                    this.output(output.out);
+                }
+            },
+            e => this.rejectStartPromise(e.message),
+            // If the process dies, we can't extract connection information.
+            () => this.rejectStartPromise(localize.DataScience.jupyterServerCrashed().format(exitCode))
+        );
     }
 
-    public waitForConnection() : Promise<IConnection> {
+    public waitForConnection(): Promise<IConnection> {
         return this.startPromise.promise;
     }
 
@@ -167,9 +170,11 @@ class JupyterConnectionWaiter {
 
         if (httpMatch && this.notebook_dir && this.startPromise && !this.startPromise.completed && this.getServerInfo) {
             // .then so that we can keep from pushing aync up to the subscribed observable function
-            this.getServerInfo(this.cancelToken).then(serverInfos => {
-                this.getJupyterURL(serverInfos, data);
-            }).ignoreErrors();
+            this.getServerInfo(this.cancelToken)
+                .then(serverInfos => {
+                    this.getJupyterURL(serverInfos, data);
+                })
+                .ignoreErrors();
         }
 
         // Sometimes jupyter will return a 403 error. Not sure why. We used
@@ -183,7 +188,8 @@ class JupyterConnectionWaiter {
     }
 
     private resolveStartPromise = (baseUrl: string, token: string) => {
-        clearTimeout(this.launchTimeout);
+        // tslint:disable-next-line: no-any
+        clearTimeout(this.launchTimeout as any);
         if (!this.startPromise.rejected) {
             const connection = this.createConnection(baseUrl, token, this.launchResult);
             const origDispose = connection.dispose.bind(connection);
@@ -198,12 +204,12 @@ class JupyterConnectionWaiter {
 
     // tslint:disable-next-line:no-any
     private rejectStartPromise = (message: string) => {
-        clearTimeout(this.launchTimeout);
+        // tslint:disable-next-line: no-any
+        clearTimeout(this.launchTimeout as any);
         if (!this.startPromise.resolved) {
             this.startPromise.reject(new JupyterConnectError(message, this.stderr.join('\n')));
         }
     }
-
 }
 
 // Represents an active connection to a running jupyter notebook
@@ -222,24 +228,24 @@ export class JupyterConnection implements IConnection {
 
         // If the local process exits, set our exit code and fire our event
         if (childProc) {
-            childProc.on('exit', (c) => {
+            childProc.on('exit', c => {
                 this.localProcExitCode = c;
                 this.eventEmitter.fire(c);
             });
         }
     }
 
-    public get disconnected() : Event<number> {
+    public get disconnected(): Event<number> {
         return this.eventEmitter.event;
     }
 
     public static waitForConnection(
         notebookFile: string,
         getServerInfo: (cancelToken?: CancellationToken) => Promise<JupyterServerInfo[] | undefined>,
-        notebookExecution : ObservableExecutionResult<string>,
+        notebookExecution: ObservableExecutionResult<string>,
         serviceContainer: IServiceContainer,
-        cancelToken?: CancellationToken) {
-
+        cancelToken?: CancellationToken
+    ) {
         // Create our waiter. It will sit here and wait for the connection information from the jupyter process starting up.
         const waiter = new JupyterConnectionWaiter(
             notebookExecution,
@@ -247,7 +253,8 @@ export class JupyterConnection implements IConnection {
             getServerInfo,
             (baseUrl: string, token: string, processDisposable: Disposable) => new JupyterConnection(baseUrl, token, processDisposable, notebookExecution.proc),
             serviceContainer,
-            cancelToken);
+            cancelToken
+        );
 
         return waiter.waitForConnection();
     }

--- a/src/client/telemetry/importTracker.ts
+++ b/src/client/telemetry/importTracker.ts
@@ -40,17 +40,14 @@ const testExecution = isTestExecution();
 
 @injectable()
 export class ImportTracker implements IImportTracker {
-
-    private pendingDocs = new Map<string, NodeJS.Timer>();
+    private pendingDocs = new Map<string, NodeJS.Timer | number>();
     private sentMatches: Set<string> = new Set<string>();
     // tslint:disable-next-line:no-require-imports
     private hashFn = require('hash.js').sha256;
 
-    constructor(
-        @inject(IDocumentManager) private documentManager: IDocumentManager
-    ) {
-        this.documentManager.onDidOpenTextDocument((t) => this.onOpenedOrSavedDocument(t));
-        this.documentManager.onDidSaveTextDocument((t) => this.onOpenedOrSavedDocument(t));
+    constructor(@inject(IDocumentManager) private documentManager: IDocumentManager) {
+        this.documentManager.onDidOpenTextDocument(t => this.onOpenedOrSavedDocument(t));
+        this.documentManager.onDidSaveTextDocument(t => this.onOpenedOrSavedDocument(t));
     }
 
     public async activate(): Promise<void> {
@@ -58,15 +55,17 @@ export class ImportTracker implements IImportTracker {
         this.documentManager.textDocuments.forEach(d => this.onOpenedOrSavedDocument(d));
     }
 
-    private getDocumentLines(document: TextDocument) : (string | undefined)[] {
+    private getDocumentLines(document: TextDocument): (string | undefined)[] {
         const array = Array<string>(Math.min(document.lineCount, MAX_DOCUMENT_LINES)).fill('');
-        return array.map((_a: string, i: number) => {
-            const line = document.lineAt(i);
-            if (line && !line.isEmptyOrWhitespace) {
-                return line.text;
-            }
-            return undefined;
-        }).filter((f: string | undefined) => f);
+        return array
+            .map((_a: string, i: number) => {
+                const line = document.lineAt(i);
+                if (line && !line.isEmptyOrWhitespace) {
+                    return line.text;
+                }
+                return undefined;
+            })
+            .filter((f: string | undefined) => f);
     }
 
     private onOpenedOrSavedDocument(document: TextDocument) {
@@ -80,7 +79,8 @@ export class ImportTracker implements IImportTracker {
         // If already scheduled, cancel.
         const currentTimeout = this.pendingDocs.get(document.fileName);
         if (currentTimeout) {
-            clearTimeout(currentTimeout);
+            // tslint:disable-next-line: no-any
+            clearTimeout(currentTimeout as any);
             this.pendingDocs.delete(document.fileName);
         }
 
@@ -108,8 +108,10 @@ export class ImportTracker implements IImportTracker {
         this.sentMatches.add(packageName);
         // Hash the package name so that we will never accidentally see a
         // user's private package name.
-        const hash = this.hashFn().update(packageName).digest('hex');
-        sendTelemetryEvent(EventName.HASHED_PACKAGE_NAME, undefined, {hashedName: hash});
+        const hash = this.hashFn()
+            .update(packageName)
+            .digest('hex');
+        sendTelemetryEvent(EventName.HASHED_PACKAGE_NAME, undefined, { hashedName: hash });
     }
 
     private lookForImports(lines: (string | undefined)[]) {

--- a/src/test/common/socketCallbackHandler.test.ts
+++ b/src/test/common/socketCallbackHandler.test.ts
@@ -86,7 +86,7 @@ class MockSocketClient {
     private socket?: net.Socket;
     private socketStream?: SocketStream;
     private def?: Deferred<any>;
-    constructor(private port: number) { }
+    constructor(private port: number) {}
     public get SocketStream(): SocketStream {
         if (this.socketStream === undefined) {
             throw Error('not listening');
@@ -104,7 +104,7 @@ class MockSocketClient {
         }
         this.socketStream = new SocketStream(this.socket, new Buffer(''));
         this.def.resolve();
-        this.socket.on('error', () => { });
+        this.socket.on('error', () => {});
         this.socket.on('data', (data: Buffer) => {
             try {
                 this.SocketStream.Append(data);
@@ -156,7 +156,7 @@ class MockSocketClient {
 // Defines a Mocha test suite to group tests of similar kind together
 suite('SocketCallbackHandler', () => {
     let socketServer: SocketServer;
-    setup(() => socketServer = new SocketServer());
+    setup(() => (socketServer = new SocketServer()));
     teardown(() => socketServer.Stop());
 
     test('Succesfully starts without any specific host or port', async () => {
@@ -213,20 +213,20 @@ suite('SocketCallbackHandler', () => {
         await socketClient.start();
 
         const def = createDeferred<any>();
-        let timeOut: NodeJS.Timer | undefined = setTimeout(() => {
+        let timeOut: NodeJS.Timer | undefined | number = setTimeout(() => {
             def.reject('Handshake not completed in allocated time');
         }, 5000);
 
         callbackHandler.on('handshake', () => {
             if (timeOut) {
-                clearTimeout(timeOut);
+                clearTimeout(timeOut as any);
                 timeOut = undefined;
             }
             def.reject('handshake should fail, but it succeeded!');
         });
         callbackHandler.on('error', (actual: string | number, expected: string, message: string) => {
             if (timeOut) {
-                clearTimeout(timeOut);
+                clearTimeout(timeOut as any);
                 timeOut = undefined;
             }
             if (actual === 0 && message === 'pids not the same') {


### PR DESCRIPTION
For #4472

* As we're compiling code for both nodejs and browser environment using the same `tsconfig` file, things get messy.
* Compiler gets confused by the signature of `setTimeout`. In browser world this returns a `number`, in nodejs this returns `NodeJs.Timer`.
* As a result of this, the compiler can throw weird errors at times. Basically compiler knows there are two definitions of `setTimeout` and this causes problems.
* The changes ensure we accept both types, and when using `clearTimeout` we cast to `any`.

This is a temporary solution, proper solution is to address #5072 (but that's not an hours job).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
