### PR TITLE
Cleanup Build pipelines

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -130,16 +130,6 @@ steps:
     inputs:
       targets: 'prePublishNonBundle'
 
-  # Run tslint on the project source to ensure that the added code adheres
-  # to the # code standards we are trying to maintain.
-  # Example command line (windows pwsh):
-  # > npx tslint ./src/**/*.ts{,x}
-  - bash: |
-      npx tslint ./src/**/*.ts{,x}
-      #npx gulp hygiene
-    displayName: 'code hygiene'
-    condition: and(succeeded(), contains(variables['TestsToRun'], 'runHygiene'))
-
   # Run the typescript unit tests.
   #
   # This will only run if the string 'testUnitTests' exists in variable `TestsToRun`

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -56,7 +56,7 @@ jobs:
         # UploadBinary: [true|false] - upload test binaries to Azure if true. False if not set.
       'Win-Py3.7 Unit':
         VMImageName: 'vs2017-win2016'
-        TestsToRun: 'runHygiene, testUnitTests, pythonUnitTests, pythonInternalTools'
+        TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools'
         NeedsPythonTestReqs: true
       'Win-Py2.7 Unit':
         PythonVersion: '2.7'
@@ -81,7 +81,7 @@ jobs:
       'Mac-Py2.7 Unit+Single':
         PythonVersion: '2.7'
         VMImageName: 'macos-10.13'
-        TestsToRun: 'testUnitTests, pythonUnitTests, testSingleWorkspace'
+        TestsToRun: 'pythonUnitTests, testSingleWorkspace'
         NeedsPythonTestReqs: true
       'Linux-Py3.7 Unit':
         PythonVersion: '3.7'
@@ -101,7 +101,7 @@ jobs:
       'Linux-Py2.7 Unit+Single':
         PythonVersion: '2.7'
         VMImageName: 'ubuntu-16.04'
-        TestsToRun: 'testUnitTests, pythonUnitTests, testSingleWorkspace'
+        TestsToRun: 'pythonUnitTests, testSingleWorkspace'
         NeedsPythonTestReqs: true
       'Linux-Py3.7 Functional':
         PythonVersion: '3.7'


### PR DESCRIPTION
For #4472

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
