### PR TITLE
Experiment to always displaying test explorer

### DIFF
--- a/news/1 Enhancements/6211.md
+++ b/news/1 Enhancements/6211.md
@@ -1,0 +1,1 @@
+Added experiment to always display the test explorer.

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -60,7 +60,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
  * @extends {ICommandNameWithoutArgumentTypeMapping}
  */
 export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgumentTypeMapping {
-    ['setContext']: ['testsDiscovered', boolean];
+    ['setContext']: [string, boolean];
     ['revealLine']: [{ lineNumber: number; at: 'top' | 'center' | 'bottom' }];
     ['python._loadLanguageServerExtension']: {}[];
     ['python.SelectAndInsertDebugConfiguration']: [TextDocument, Position, CancellationToken];

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -60,7 +60,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
  * @extends {ICommandNameWithoutArgumentTypeMapping}
  */
 export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgumentTypeMapping {
-    ['setContext']: [string, boolean];
+    ['setContext']: ['testsDiscovered', boolean];
     ['revealLine']: [{ lineNumber: number; at: 'top' | 'center' | 'bottom' }];
     ['python._loadLanguageServerExtension']: {}[];
     ['python.SelectAndInsertDebugConfiguration']: [TextDocument, Position, CancellationToken];

--- a/src/client/common/experimentGroups.ts
+++ b/src/client/common/experimentGroups.ts
@@ -1,2 +1,8 @@
 export const LSControl = 'LS - control';
 export const LSEnabled = 'LS - enabled';
+
+// Experiment to check whether to always display the test explorer.
+export enum AlwaysDisplayTestExplorerGroups {
+    control = 'AlwaysDisplayTestExplorer - control',
+    enabled = 'AlwaysDisplayTestExplorer - enabled'
+}

--- a/src/test/testing/main.unit.test.ts
+++ b/src/test/testing/main.unit.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as sinon from 'sinon';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Disposable } from 'vscode';
+import { CommandManager } from '../../client/common/application/commandManager';
+import { ICommandManager } from '../../client/common/application/types';
+import { AlwaysDisplayTestExplorerGroups } from '../../client/common/experimentGroups';
+import { ExperimentsManager } from '../../client/common/experiments';
+import { IDisposableRegistry, IExperimentsManager } from '../../client/common/types';
+import { ServiceContainer } from '../../client/ioc/container';
+import { IServiceContainer } from '../../client/ioc/types';
+import { JediSymbolProvider } from '../../client/providers/symbolProvider';
+import { UnitTestManagementService } from '../../client/testing/main';
+
+suite('Unit Tests - ManagementService', () => {
+    suite('Experiments', () => {
+        let serviceContainer: IServiceContainer;
+        let sandbox: sinon.SinonSandbox;
+        let experiment: IExperimentsManager;
+        let commandManager: ICommandManager;
+        let testManagementService: UnitTestManagementService;
+        setup(() => {
+            serviceContainer = mock(ServiceContainer);
+            sandbox = sinon.createSandbox();
+
+            sandbox.stub(UnitTestManagementService.prototype, 'registerSymbolProvider');
+            sandbox.stub(UnitTestManagementService.prototype, 'registerCommands');
+            sandbox.stub(UnitTestManagementService.prototype, 'registerHandlers');
+            sandbox.stub(UnitTestManagementService.prototype, 'autoDiscoverTests').callsFake(() => Promise.resolve());
+
+            experiment = mock(ExperimentsManager);
+            commandManager = mock(CommandManager);
+
+            when(serviceContainer.get<Disposable[]>(IDisposableRegistry)).thenReturn([]);
+            when(serviceContainer.get<IExperimentsManager>(IExperimentsManager)).thenReturn(instance(experiment));
+            when(serviceContainer.get<ICommandManager>(ICommandManager)).thenReturn(instance(commandManager));
+            when(commandManager.executeCommand(anything(), anything(), anything())).thenResolve();
+
+            testManagementService = new UnitTestManagementService(instance(serviceContainer));
+        });
+        teardown(() => {
+            sandbox.restore();
+        });
+
+        test('Execute command if in experiment', async () => {
+            when(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).thenReturn(true);
+
+            await testManagementService.activate(instance(mock(JediSymbolProvider)));
+
+            verify(commandManager.executeCommand('setContext', 'testsDiscovered', true)).once();
+            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).once();
+            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.control)).never();
+            verify(experiment.sendTelemetryIfInExperiment(anything())).never();
+        });
+        test('If not in experiment, check and send Telemetry for control group and do not execute command', async () => {
+            when(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).thenReturn(false);
+
+            await testManagementService.activate(instance(mock(JediSymbolProvider)));
+
+            verify(commandManager.executeCommand('setContext', 'testsDiscovered', anything())).never();
+            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).once();
+            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.control)).never();
+            verify(experiment.sendTelemetryIfInExperiment(AlwaysDisplayTestExplorerGroups.control)).once();
+        });
+    });
+});


### PR DESCRIPTION
For #6211

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
