### PR TITLE
Lowercase drive letter for non-empty path mappings

### DIFF
--- a/src/client/debugger/extension/configuration/resolvers/attach.ts
+++ b/src/client/debugger/extension/configuration/resolvers/attach.ts
@@ -8,6 +8,7 @@ import { CancellationToken, Uri, WorkspaceFolder } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../../../../common/application/types';
 import { IPlatformService } from '../../../../common/platform/types';
 import { IConfigurationService } from '../../../../common/types';
+import { SystemVariables } from '../../../../common/variables/systemVariables';
 import { AttachRequestArguments, DebugOptions } from '../../../types';
 import { BaseConfigurationResolver } from './base';
 
@@ -94,18 +95,36 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         }
         // If attaching to local host, then always map local root and remote roots.
         if (workspaceFolder && debugConfiguration.host &&
-            debugConfiguration.pathMappings!.length === 0 &&
             ['LOCALHOST', '127.0.0.1', '::1'].indexOf(debugConfiguration.host.toUpperCase()) >= 0) {
-            // If on Windows, lowercase the drive letter for path mappings.
-            let localRoot = workspaceFolder.fsPath;
-            if (this.platformService.isWindows && localRoot.match(/^[A-Z]:/)) {
-                localRoot = `${localRoot[0].toLowerCase()}${localRoot.substr(1)}`;
-            }
-
-            debugConfiguration.pathMappings!.push({
-                localRoot,
-                remoteRoot: workspaceFolder.fsPath
-            });
+                let configPathMappings;
+                if (debugConfiguration.pathMappings!.length === 0) {
+                    configPathMappings = [{
+                        localRoot: workspaceFolder.fsPath,
+                        remoteRoot: workspaceFolder.fsPath
+                    }];
+                } else {
+                    // Expand ${workspaceFolder} variable first if necessary.
+                    configPathMappings = debugConfiguration.pathMappings.map(({ localRoot: mappedLocalRoot, remoteRoot }) => {
+                        const systemVariables = new SystemVariables(workspaceFolder.fsPath);
+                        const expandedPath = systemVariables.resolveAny(mappedLocalRoot);
+                        return {
+                            localRoot: expandedPath,
+                            remoteRoot
+                        };
+                    });
+                }
+                // If on Windows, lowercase the drive letter for path mappings.
+                let pathMappings = configPathMappings;
+                if (this.platformService.isWindows) {
+                    pathMappings = configPathMappings.map(({ localRoot: windowsLocalRoot, remoteRoot }) => {
+                        let localRoot = windowsLocalRoot;
+                        if (windowsLocalRoot.match(/^[A-Z]:/)) {
+                            localRoot = `${windowsLocalRoot[0].toLowerCase()}${windowsLocalRoot.substr(1)}`;
+                        }
+                        return { localRoot, remoteRoot };
+                    });
+                }
+                debugConfiguration.pathMappings = pathMappings;
         }
         this.sendTelemetry('attach', debugConfiguration);
     }

--- a/src/client/debugger/extension/configuration/resolvers/attach.ts
+++ b/src/client/debugger/extension/configuration/resolvers/attach.ts
@@ -104,14 +104,11 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
                     }];
                 } else {
                     // Expand ${workspaceFolder} variable first if necessary.
-                    configPathMappings = debugConfiguration.pathMappings.map(({ localRoot: mappedLocalRoot, remoteRoot }) => {
-                        const systemVariables = new SystemVariables(workspaceFolder.fsPath);
-                        const expandedPath = systemVariables.resolveAny(mappedLocalRoot);
-                        return {
-                            localRoot: expandedPath,
-                            remoteRoot
-                        };
-                    });
+                    const systemVariables = new SystemVariables(workspaceFolder.fsPath);
+                    configPathMappings = debugConfiguration.pathMappings.map(({ localRoot: mappedLocalRoot, remoteRoot }) => ({
+                        localRoot: systemVariables.resolveAny(mappedLocalRoot),
+                        remoteRoot
+                    }));
                 }
                 // If on Windows, lowercase the drive letter for path mappings.
                 let pathMappings = configPathMappings;

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -182,7 +182,7 @@ getNamesAndValues(OSType).forEach(os => {
                 const localRoot = `Debug_PythonPath_${new Date().toString()}`;
                 const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
                 const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
-                const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
+                const lowercasedLocalRoot = path.join('c:', 'Debug', 'Python_Path');
 
                 expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
             });
@@ -201,7 +201,7 @@ getNamesAndValues(OSType).forEach(os => {
                 const debugPathMappings = [ { localRoot: path.join('${workspaceFolder}', localRoot), remoteRoot: '/app/' }];
                 const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, pathMappings: debugPathMappings, host, request: 'attach' } as any as DebugConfiguration);
                 const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
-                const lowercasedLocalRoot = path.join(`${workspaceFolder.uri.fsPath.charAt(0).toLowerCase()}${workspaceFolder.uri.fsPath.substr(1)}`, localRoot);
+                const lowercasedLocalRoot = path.join('c:', 'Debug', 'Python_Path', localRoot);
 
                 expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
             });

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -198,7 +198,7 @@ getNamesAndValues(OSType).forEach(os => {
                 setupWorkspaces([defaultWorkspace]);
 
                 const localRoot = `Debug_PythonPath_${new Date().toString()}`;
-                const debugPathMappings = [ { localRoot: `\${workspaceFolder}/${localRoot}`, remoteRoot: '/app/' }];
+                const debugPathMappings = [ { localRoot: path.join('${workspaceFolder}', localRoot), remoteRoot: '/app/' }];
                 const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, pathMappings: debugPathMappings, host, request: 'attach' } as any as DebugConfiguration);
                 const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
                 const lowercasedLocalRoot = path.join(`${workspaceFolder.uri.fsPath.charAt(0).toLowerCase()}${workspaceFolder.uri.fsPath.substr(1)}`, localRoot);

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -168,7 +168,6 @@ getNamesAndValues(OSType).forEach(os => {
                 expect(pathMappings![0].localRoot).to.be.equal(workspaceFolder.uri.fsPath);
                 expect(pathMappings![0].remoteRoot).to.be.equal(workspaceFolder.uri.fsPath);
             });
-
             test(`Ensure drive letter is lower cased for local path mappings on Windows when host is '${host}'`, async function () {
                 if (os.name !== 'Windows') {
                     return this.skip();
@@ -181,6 +180,24 @@ getNamesAndValues(OSType).forEach(os => {
                 setupWorkspaces([defaultWorkspace]);
 
                 const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
+                const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
+
+                expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
+            });
+            test(`Ensure drive letter is lower cased for local path mappings on Windows when host is '${host}' and with existing path mappings`, async function () {
+                if (os.name !== 'Windows') {
+                    return this.skip();
+                }
+
+                const activeFile = 'xyz.py';
+                const workspaceFolder = createMoqWorkspaceFolder(path.join('C:', 'Debug', 'Python_Path'));
+                setupActiveEditor(activeFile, PYTHON_LANGUAGE);
+                const defaultWorkspace = path.join('usr', 'desktop');
+                setupWorkspaces([defaultWorkspace]);
+
+                const localRoot = `\${workspaceFolder}/Debug_PythonPath_${new Date().toString()}`;
                 const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
                 const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
                 const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -197,10 +197,11 @@ getNamesAndValues(OSType).forEach(os => {
                 const defaultWorkspace = path.join('usr', 'desktop');
                 setupWorkspaces([defaultWorkspace]);
 
-                const localRoot = `\${workspaceFolder}/Debug_PythonPath_${new Date().toString()}`;
-                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, host, request: 'attach' } as any as DebugConfiguration);
+                const localRoot = `Debug_PythonPath_${new Date().toString()}`;
+                const debugPathMappings = [ { localRoot: `\${workspaceFolder}/${localRoot}`, remoteRoot: '/app/' }];
+                const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, { localRoot, pathMappings: debugPathMappings, host, request: 'attach' } as any as DebugConfiguration);
                 const pathMappings = (debugConfig as AttachRequestArguments).pathMappings;
-                const lowercasedLocalRoot = workspaceFolder.uri.fsPath.charAt(0).toLowerCase() + workspaceFolder.uri.fsPath.substr(1);
+                const lowercasedLocalRoot = path.join(`${workspaceFolder.uri.fsPath.charAt(0).toLowerCase()}${workspaceFolder.uri.fsPath.substr(1)}`, localRoot);
 
                 expect(pathMappings![0].localRoot).to.be.equal(lowercasedLocalRoot);
             });


### PR DESCRIPTION
For #5362 (again)

- If on windows and attaching to localhost:
   - add a default path mapping if `debugConfiguration.pathMappings` is empty 
   - iterate and update existing path mappings with a lowercase drive letter
- Added a unit test to cover the non-empty `debugConfiguration.pathMappings` case

----



<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
