### PR TITLE
Account for files not belong to a workspace

### DIFF
--- a/news/2 Fixes/6624.md
+++ b/news/2 Fixes/6624.md
@@ -1,0 +1,1 @@
+Account for files being opened in Visual Studio Code that do not belong to a workspace.

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
 import { Uri } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../common/application/types';
 import '../common/extensions';
-import { traceDecorators } from '../common/logger';
 import { IFileSystem } from '../common/platform/types';
 import { IConfigurationService, IPersistentStateFactory, Resource } from '../common/types';
 import { Common, Linters } from '../common/utils/localize';

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -10,7 +10,7 @@ import { IApplicationShell, IWorkspaceService } from '../common/application/type
 import '../common/extensions';
 import { traceDecorators } from '../common/logger';
 import { IFileSystem } from '../common/platform/types';
-import { IConfigurationService, IPersistentStateFactory } from '../common/types';
+import { IConfigurationService, IPersistentStateFactory, Resource } from '../common/types';
 import { Common, Linters } from '../common/utils/localize';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
@@ -95,12 +95,11 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * @param linterProduct Linter to check in the current workspace environment.
      * @param resource Context information for workspace.
      */
-    @traceDecorators.error('Failed to discover if linter pylint is available')
-    public async isLinterAvailable(linterInfo: ILinterInfo, resource?: Uri): Promise<boolean | undefined> {
+    public async isLinterAvailable(linterInfo: ILinterInfo, resource: Resource): Promise<boolean | undefined> {
         if (!this.workspaceService.hasWorkspaceFolders) {
             return false;
         }
-        const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource)! : this.workspaceService.workspaceFolders![0];
+        const workspaceFolder = this.workspaceService.getWorkspaceFolder(resource) || this.workspaceService.workspaceFolders![0];
         let isAvailable = false;
         for (const configName of linterInfo.configFileNames) {
             const configPath = path.join(workspaceFolder.uri.fsPath, configName);


### PR DESCRIPTION
For #6224

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
