### PR TITLE
Update to plotly.js 1.48.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1466,9 +1466,9 @@
             }
         },
         "@nteract/plotly": {
-            "version": "1.47.1",
-            "resolved": "https://registry.npmjs.org/@nteract/plotly/-/plotly-1.47.1.tgz",
-            "integrity": "sha512-ciCgkiXJxZnbqSsRiqvB/KjGjVAPjSW0mbgaOiwdY+A9hP+oXhHlTjuzorDdv/A5WEmARhUATyhdIe1A6Wn0jg==",
+            "version": "1.48.3",
+            "resolved": "https://registry.npmjs.org/@nteract/plotly/-/plotly-1.48.3.tgz",
+            "integrity": "sha512-1Km5MtjyUL9POZjU6LMzH/npFUYIC6vewH0Gd2Ua1FON3qN1KCRoJ8em5Gkp+K57QJRpMET1F4z4N9d3U9HOqA==",
             "dev": true
         },
         "@nteract/transform-dataresource": {

--- a/package.json
+++ b/package.json
@@ -2261,7 +2261,7 @@
         "@babel/preset-react": "^7.0.0",
         "@babel/register": "^7.4.4",
         "@istanbuljs/nyc-config-typescript": "^0.1.3",
-        "@nteract/plotly": "^1.47.1",
+        "@nteract/plotly": "^1.48.3",
         "@nteract/transform-dataresource": "^4.3.5",
         "@nteract/transform-geojson": "^3.2.3",
         "@nteract/transform-model-debug": "^3.2.3",


### PR DESCRIPTION
This PR updates the bundled version of plotly.js to 1.48.3 in order to support rendering plotly figures with plotly.py 3.10.0.  Thanks!

cc @nicolaskruchten