### PR TITLE
Opting out of telemetry correctly opts out of A/B testing

### DIFF
--- a/news/2 Fixes/6270.md
+++ b/news/2 Fixes/6270.md
@@ -1,0 +1,1 @@
+Opting out of telemetry correctly opts out of A/B testing

--- a/src/client/common/experiments.ts
+++ b/src/client/common/experiments.ts
@@ -78,7 +78,7 @@ export class ExperimentsManager implements IExperimentsManager {
 
     @swallowExceptions('Failed to activate experiments')
     public async activate(): Promise<void> {
-        if (this.activatedOnce) {
+        if (this.activatedOnce || isTelemetryDisabled(this.workspaceService)) {
             return;
         }
         this.activatedOnce = true;
@@ -123,13 +123,11 @@ export class ExperimentsManager implements IExperimentsManager {
     }
 
     /**
-     * Downloads experiments and updates storage given following conditions are met
-     * * Telemetry is not disabled
-     * * Previously downloaded experiments are no longer valid
+     * Downloads experiments and updates storage given previously downloaded experiments are no longer valid
      */
     @traceDecorators.error('Failed to initialize experiments')
     public async initializeInBackground() {
-        if (isTelemetryDisabled(this.workspaceService) || this.isDownloadedStorageValid.value) {
+        if (this.isDownloadedStorageValid.value) {
             return;
         }
         const downloadedExperiments = await this.httpClient.getJSON<ABExperiments>(configUri, false);

--- a/src/test/common/experiments.unit.test.ts
+++ b/src/test/common/experiments.unit.test.ts
@@ -6,7 +6,7 @@
 // tslint:disable:no-any
 
 import { assert, expect } from 'chai';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, resetCalls, verify, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import { WorkspaceConfiguration } from 'vscode';
 import { ApplicationEnvironment } from '../../client/common/application/applicationEnvironment';
@@ -23,7 +23,7 @@ import { createDeferred, createDeferredFromPromise } from '../../client/common/u
 import { sleep } from '../common';
 
 // tslint:disable-next-line: max-func-body-length
-suite('A/B experiments', () => {
+suite('xA/B experiments', () => {
     let workspaceService: IWorkspaceService;
     let httpClient: IHttpClient;
     let crypto: ICryptoUtils;
@@ -53,15 +53,9 @@ suite('A/B experiments', () => {
     });
 
     async function testInitialization(
-        settings: { globalValue?: boolean } = {},
         downloadError: boolean = false,
         experimentsDownloaded?: any
     ) {
-        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
-        when(workspaceService.getConfiguration('telemetry')).thenReturn(workspaceConfig.object);
-        workspaceConfig.setup(c => c.inspect<boolean>('enableTelemetry'))
-            .returns(() => settings as any)
-            .verifiable(TypeMoq.Times.once());
         if (downloadError) {
             when(httpClient.getJSON(configUri, false)).thenReject(new Error('Kaboom'));
         } else {
@@ -77,18 +71,9 @@ suite('A/B experiments', () => {
             // tslint:disable-next-line:no-empty
         } catch { }
 
-        verify(workspaceService.getConfiguration('telemetry')).once();
-        workspaceConfig.verifyAll();
         isDownloadedStorageValid.verifyAll();
         experimentStorage.verifyAll();
     }
-
-    test('If the users have opted out of telemetry, then they are opted out of AB testing ', async () => {
-        isDownloadedStorageValid.setup(n => n.value).returns(() => false).verifiable(TypeMoq.Times.never());
-
-        // settings = { globalValue: false }
-        await testInitialization({ globalValue: false });
-    });
 
     test('Initializing experiments does not download experiments if storage is valid and contains experiments', async () => {
         isDownloadedStorageValid.setup(n => n.value).returns(() => true).verifiable(TypeMoq.Times.once());
@@ -113,8 +98,8 @@ suite('A/B experiments', () => {
             .returns(() => Promise.resolve(undefined))
             .verifiable(TypeMoq.Times.never());
 
-        // settings = {}, downloadError = false, experimentsDownloaded = experiments
-        await testInitialization({}, false, experiments);
+        // downloadError = false, experimentsDownloaded = experiments
+        await testInitialization(false, experiments);
 
         verify(httpClient.getJSON(configUri, false)).once();
     });
@@ -135,9 +120,31 @@ suite('A/B experiments', () => {
         downloadedExperimentsStorage.setup(n => n.updateValue(anything())).returns(() => Promise.resolve(undefined)).verifiable(TypeMoq.Times.never());
 
         // settings = {}, downloadError = true
-        await testInitialization({}, true);
+        await testInitialization(true);
 
         verify(httpClient.getJSON(configUri, false)).once();
+    });
+
+    test('If the users have opted out of telemetry, then they are opted out of AB testing ', async () => {
+        const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+        const settings = { globalValue: false };
+
+        when(
+            workspaceService.getConfiguration('telemetry')
+        ).thenReturn(workspaceConfig.object);
+        workspaceConfig.setup(c => c.inspect<boolean>('enableTelemetry'))
+            .returns(() => settings as any)
+            .verifiable(TypeMoq.Times.once());
+        downloadedExperimentsStorage
+            .setup(n => n.value)
+            .returns(() => undefined)
+            .verifiable(TypeMoq.Times.never());
+
+        await expManager.activate();
+
+        verify(workspaceService.getConfiguration('telemetry')).once();
+        workspaceConfig.verifyAll();
+        downloadedExperimentsStorage.verifyAll();
     });
 
     test('Ensure experiments can only be activated once', async () => {
@@ -145,38 +152,42 @@ suite('A/B experiments', () => {
         const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
         const settings = {};
 
+        when(
+            workspaceService.getConfiguration('telemetry')
+        ).thenReturn(workspaceConfig.object);
+        workspaceConfig.setup(c => c.inspect<boolean>('enableTelemetry'))
+            .returns(() => settings as any)
+            .verifiable(TypeMoq.Times.once());
+
         downloadedExperimentsStorage
             .setup(n => n.value)
             .returns(() => undefined)
             .verifiable(TypeMoq.Times.once());
-        when(fs.fileExists(anything())).thenResolve(false);
+        when(
+            fs.fileExists(anything())
+        ).thenResolve(false);
         experimentStorage.setup(n => n.value).returns(() => undefined)
             .verifiable(TypeMoq.Times.exactly(2));
         isDownloadedStorageValid
             .setup(n => n.value)
             .returns(() => true)
             .verifiable(TypeMoq.Times.once());
-        when(workspaceService.getConfiguration('telemetry')).thenReturn(workspaceConfig.object);
-        workspaceConfig.setup(c => c.inspect<boolean>('enableTelemetry'))
-            .returns(() => settings as any);
 
         // First activation
         await expManager.activate();
 
-        downloadedExperimentsStorage.reset();
-        downloadedExperimentsStorage
-            .setup(n => n.value)
-            .returns(() => undefined)
-            .verifiable(TypeMoq.Times.never());
+        resetCalls(workspaceService);
 
         // Second activation
         await expManager.activate();
 
-        downloadedExperimentsStorage.verifyAll();
+        verify(workspaceService.getConfiguration(anything())).never();
 
+        workspaceConfig.verifyAll();
         verify(fs.fileExists(anything())).once();
         isDownloadedStorageValid.verifyAll();
         experimentStorage.verifyAll();
+        downloadedExperimentsStorage.verifyAll();
     });
 
     test('Ensure experiments are reliably initialized in the background', async () => {

--- a/src/test/common/experiments.unit.test.ts
+++ b/src/test/common/experiments.unit.test.ts
@@ -23,7 +23,7 @@ import { createDeferred, createDeferredFromPromise } from '../../client/common/u
 import { sleep } from '../common';
 
 // tslint:disable-next-line: max-func-body-length
-suite('xA/B experiments', () => {
+suite('A/B experiments', () => {
     let workspaceService: IWorkspaceService;
     let httpClient: IHttpClient;
     let crypto: ICryptoUtils;
@@ -119,7 +119,7 @@ suite('xA/B experiments', () => {
         isDownloadedStorageValid.setup(n => n.updateValue(true)).returns(() => Promise.resolve(undefined)).verifiable(TypeMoq.Times.never());
         downloadedExperimentsStorage.setup(n => n.updateValue(anything())).returns(() => Promise.resolve(undefined)).verifiable(TypeMoq.Times.never());
 
-        // settings = {}, downloadError = true
+        // downloadError = true
         await testInitialization(true);
 
         verify(httpClient.getJSON(configUri, false)).once();


### PR DESCRIPTION
For #6270 #5042 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
