### PR TITLE
Enable experiment for always displaying the test explorer

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -1,1 +1,14 @@
-[]
+[
+    {
+        "name": "AlwaysDisplayTestExplorer - experiment",
+        "salt": "AlwaysDisplayTestExplorer",
+        "min": 80,
+        "max": 100
+    },
+    {
+        "name": "AlwaysDisplayTestExplorer - control",
+        "salt": "AlwaysDisplayTestExplorer",
+        "min": 0,
+        "max": 20
+    }
+]

--- a/src/client/common/experimentGroups.ts
+++ b/src/client/common/experimentGroups.ts
@@ -4,5 +4,5 @@ export const LSEnabled = 'LS - enabled';
 // Experiment to check whether to always display the test explorer.
 export enum AlwaysDisplayTestExplorerGroups {
     control = 'AlwaysDisplayTestExplorer - control',
-    enabled = 'AlwaysDisplayTestExplorer - enabled'
+    experiment = 'AlwaysDisplayTestExplorer - experiment'
 }

--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -74,7 +74,7 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
     }
     public checkExperiments() {
         const experiments = this.serviceContainer.get<IExperimentsManager>(IExperimentsManager);
-        if (experiments.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)) {
+        if (experiments.inExperiment(AlwaysDisplayTestExplorerGroups.experiment)) {
             const commandManager = this.serviceContainer.get<ICommandManager>(ICommandManager);
             commandManager.executeCommand('setContext', 'testsDiscovered', true).then(noop, noop);
         } else {

--- a/src/test/testing/main.unit.test.ts
+++ b/src/test/testing/main.unit.test.ts
@@ -47,22 +47,22 @@ suite('Unit Tests - ManagementService', () => {
         });
 
         test('Execute command if in experiment', async () => {
-            when(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).thenReturn(true);
+            when(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.experiment)).thenReturn(true);
 
             await testManagementService.activate(instance(mock(JediSymbolProvider)));
 
             verify(commandManager.executeCommand('setContext', 'testsDiscovered', true)).once();
-            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).once();
+            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.experiment)).once();
             verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.control)).never();
             verify(experiment.sendTelemetryIfInExperiment(anything())).never();
         });
         test('If not in experiment, check and send Telemetry for control group and do not execute command', async () => {
-            when(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).thenReturn(false);
+            when(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.experiment)).thenReturn(false);
 
             await testManagementService.activate(instance(mock(JediSymbolProvider)));
 
             verify(commandManager.executeCommand('setContext', 'testsDiscovered', anything())).never();
-            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.enabled)).once();
+            verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.experiment)).once();
             verify(experiment.inExperiment(AlwaysDisplayTestExplorerGroups.control)).never();
             verify(experiment.sendTelemetryIfInExperiment(AlwaysDisplayTestExplorerGroups.control)).once();
         });


### PR DESCRIPTION
For #6211

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
