### PR TITLE
Do not error out if coverage upload fails

### DIFF
--- a/build/ci/templates/generate_upload_coverage.yml
+++ b/build/ci/templates/generate_upload_coverage.yml
@@ -17,6 +17,7 @@ steps:
 
     - bash: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
       displayName: 'Upload coverage to coveralls'
+      continueOnError: true
       condition: contains(variables['TestsToRun'], 'testUnitTests')
       failOnStderr: false
       # Set necessary env variables for coveralls, as they don't support Azure Devops.


### PR DESCRIPTION
For #6340 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
