### PR TITLE
Fix python test in news folder

### DIFF
--- a/news/announce.py
+++ b/news/announce.py
@@ -152,7 +152,8 @@ def complete_news(version, entry, previous_news):
     title, _, previous_news = previous_news.partition("\n")
     title = title.strip()
     previous_news = previous_news.strip()
-    section_title = f"## {version} ({datetime.date.today().strftime('%d %B %Y')})"
+    section_title = (f"## {version} ({datetime.date.today().strftime('%d %B %Y')})"
+                     ).replace("(0", "(")
     # TODO: Insert the "Thank you!" section (in monthly releases)?
     return f"{title}\n\n{section_title}\n\n{entry.strip()}\n\n\n{previous_news}"
 

--- a/news/test_announce.py
+++ b/news/test_announce.py
@@ -187,7 +187,8 @@ We deleted all the code to fix all the things. ;)
 
 def test_complete_news():
     version = "2019.3.0"
-    date = datetime.date.today().strftime("%d %B %Y")
+    # Remove leading `0`.
+    date = datetime.date.today().strftime("%d %B %Y").lstrip("0")
     news = ann.complete_news(version, NEW_NEWS, f"{TITLE}\n\n\n{OLD_NEWS}")
     expected = f"{TITLE}\n\n## {version} ({date})\n\n{NEW_NEWS.strip()}\n\n\n{OLD_NEWS.strip()}"
     assert news == expected


### PR DESCRIPTION
For #6397

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
