### PR TITLE
Exclude smoke tests against VSC Insiders to prevent CI failing

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -28,7 +28,7 @@ jobs:
 - template: templates/uitest_jobs.yml
   parameters:
     # Test only against stable version of VSC.
-    # vscodeChannels: ['stable']
+    vscodeChannels: ['stable']
     # Run only smoke tests against 3.7 and 2.7 (exclude others).
     jobs:
     - test: "Smoke"


### PR DESCRIPTION
We don't want CI to fail just because UI Tests fail against VSC insiders.
We run UI Tests against insiders in the nightly UI Tests pipeline.
Not, doing this could fail the CI hence causing the VSIX not getting uploaded into blob store (i.e. no insiders version of VSIX will be uploaded).