### PR TITLE
Fixes pytest discovery: Not all pytest items have `own_markers`

### DIFF
--- a/news/2 Fixes/6463.md
+++ b/news/2 Fixes/6463.md
@@ -1,0 +1,1 @@
+Fixes a bug in pytest test discovery

--- a/news/2 Fixes/6463.md
+++ b/news/2 Fixes/6463.md
@@ -1,1 +1,1 @@
-Fixes a bug in pytest test discovery
+Fixes a bug in pytest test discovery.  Patch by Rainer Dreyer.

--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -188,7 +188,7 @@ def parse_item(item, _normcase, _pathsep):
     # Sort out markers.
     #  See: https://docs.pytest.org/en/latest/reference.html#marks
     markers = set()
-    for marker in item.own_markers:
+    for marker in getattr(item, 'own_markers', []):
         if marker.name == 'parameterize':
             # We've already covered these.
             continue


### PR DESCRIPTION
For #6463

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Appropriate comments and documentation strings in the code~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
