### PR TITLE
Remove existing positional args when running a single test on pytest

### DIFF
--- a/news/2 Fixes/5757.md
+++ b/news/2 Fixes/5757.md
@@ -1,0 +1,1 @@
+Remove existing positional arguments when running single pytest tests.

--- a/src/client/testing/common/argumentsHelper.ts
+++ b/src/client/testing/common/argumentsHelper.ts
@@ -44,29 +44,30 @@ export class ArgumentsHelper implements IArgumentsHelper {
         }
     }
     public getPositionalArguments(args: string[], optionsWithArguments: string[] = [], optionsWithoutArguments: string[] = []): string[] {
-        let lastIndexOfOption = -1;
+        const nonPositionalIndexes: number[] = [];
         args.forEach((arg, index) => {
             if (optionsWithoutArguments.indexOf(arg) !== -1) {
-                lastIndexOfOption = index;
+                nonPositionalIndexes.push(index);
                 return;
             } else if (optionsWithArguments.indexOf(arg) !== -1) {
+                nonPositionalIndexes.push(index);
                 // Cuz the next item is the value.
-                lastIndexOfOption = index + 1;
+                nonPositionalIndexes.push(index + 1);
             } else if (optionsWithArguments.findIndex(item => arg.startsWith(`${item}=`)) !== -1) {
-                lastIndexOfOption = index;
+                nonPositionalIndexes.push(index);
                 return;
             } else if (arg.startsWith('-')) {
                 // Ok this is an unknown option, lets treat this as one without values.
                 this.logger.logWarning(`Unknown command line option passed into args parser for tests '${arg}'. Please report on https://github.com/Microsoft/vscode-python/issues/new`);
-                lastIndexOfOption = index;
+                nonPositionalIndexes.push(index);
                 return;
             } else if (args.indexOf('=') > 0) {
                 // Ok this is an unknown option with a value
                 this.logger.logWarning(`Unknown command line option passed into args parser for tests '${arg}'. Please report on https://github.com/Microsoft/vscode-python/issues/new`);
-                lastIndexOfOption = index;
+                nonPositionalIndexes.push(index);
             }
         });
-        return args.slice(lastIndexOfOption + 1);
+        return args.filter((_, index) => nonPositionalIndexes.indexOf(index) === -1);
     }
     public filterArguments(args: string[], optionsWithArguments: string[] = [], optionsWithoutArguments: string[] = []): string[] {
         let ignoreIndex = -1;

--- a/src/client/testing/common/argumentsHelper.ts
+++ b/src/client/testing/common/argumentsHelper.ts
@@ -61,7 +61,7 @@ export class ArgumentsHelper implements IArgumentsHelper {
                 this.logger.logWarning(`Unknown command line option passed into args parser for tests '${arg}'. Please report on https://github.com/Microsoft/vscode-python/issues/new`);
                 nonPositionalIndexes.push(index);
                 return;
-            } else if (args.indexOf('=') > 0) {
+            } else if (arg.indexOf('=') > 0) {
                 // Ok this is an unknown option with a value
                 this.logger.logWarning(`Unknown command line option passed into args parser for tests '${arg}'. Please report on https://github.com/Microsoft/vscode-python/issues/new`);
                 nonPositionalIndexes.push(index);

--- a/src/test/common/argumentsHelper.unit.test.ts
+++ b/src/test/common/argumentsHelper.unit.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { anyString, instance, mock, when } from 'ts-mockito';
+import { Logger } from '../../client/common/logger';
+import { ILogger } from '../../client/common/types';
+import { ServiceContainer } from '../../client/ioc/container';
+import { IServiceContainer } from '../../client/ioc/types';
+import { ArgumentsHelper } from '../../client/testing/common/argumentsHelper';
+
+// tslint:disable-next-line: max-func-body-length
+suite('ArgumentsHelper tests', () => {
+    let argumentsHelper: ArgumentsHelper;
+
+    setup(() => {
+        const logger: ILogger = mock(Logger);
+        when(logger.logWarning(anyString())).thenReturn();
+        const serviceContainer: IServiceContainer = mock(ServiceContainer);
+        when(serviceContainer.get<ILogger>(ILogger)).thenReturn(instance(logger));
+
+        argumentsHelper = new ArgumentsHelper(instance(serviceContainer));
+    });
+
+    test('getOptionValues with an option should return the arg value after the option', () => {
+        const args = ['arg1', '--foo', 'arg2'];
+        const result = argumentsHelper.getOptionValues(args, '--foo');
+
+        expect(result).to.be.a('string');
+        expect(result).to.equal('arg2');
+    });
+
+    test('getOptionValues with a non-existent option should return nothing', () => {
+        const args = ['arg1', '--foo', 'arg2'];
+        const result = argumentsHelper.getOptionValues(args, '--bar');
+
+        expect(result).to.be.a('undefined');
+    });
+
+    test('getOptionValues with an option followed by = should return the value part of the arg', () => {
+        const args = ['arg1', '--foo=arg2', 'arg2'];
+        const result = argumentsHelper.getOptionValues(args, '--foo');
+
+        expect(result).to.be.a('string');
+        expect(result).to.equal('arg2');
+    });
+
+    test('getOptionValues with an option repeated multiple times should return an array of values', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar', '--foo', 'arg3'];
+        const result = argumentsHelper.getOptionValues(args, '--foo') as string[];
+
+        expect(result).to.be.a('array');
+        expect(result).to.have.length(2);
+        expect(result[0]).to.equal('arg2');
+        expect(result[1]).to.equal('arg3');
+    });
+
+    test('getPositionalArguments with both options parameters should return correct positional arguments', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
+        const optionsWithArguments = ['--bar'];
+        const optionsWithoutArguments = ['--foo'];
+        const result = argumentsHelper.getPositionalArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.have.length(3);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
+    });
+
+    test('getPositionalArguments with optionsWithArguments with inline `option=value` syntax should return correct positional arguments', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar=arg3', 'arg4'];
+        const optionsWithArguments = ['--bar'];
+        const optionsWithoutArguments = ['--foo'];
+        const result = argumentsHelper.getPositionalArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.have.length(3);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
+    });
+
+    test('getPositionalArguments with no options parameter should be the same as passing empty arrays', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
+        const optionsWithArguments: string[] = [];
+        const optionsWithoutArguments: string[] = [];
+        const result = argumentsHelper.getPositionalArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.deep.equal(argumentsHelper.getPositionalArguments(args));
+        expect(result).to.have.length(4);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg3', 'arg4']);
+    });
+
+    test('filterArguments with both options parameters should return correct filtered arguments', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
+        const optionsWithArguments = ['--bar'];
+        const optionsWithoutArguments = ['--foo'];
+        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.have.length(3);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
+    });
+
+    test('filterArguments with optionsWithArguments with inline `option=value` syntax should return correct filtered arguments', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar=arg3', 'arg4'];
+        const optionsWithArguments = ['--bar'];
+        const optionsWithoutArguments = ['--foo'];
+        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.have.length(3);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
+    });
+
+    test('filterArguments should ignore wildcard args', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
+        const optionsWithArguments = ['--bar'];
+        const optionsWithoutArguments = ['--fo*'];
+        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.have.length(3);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
+    });
+
+    test('filterArguments with no options parameter should be the same as passing empty arrays', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
+        const optionsWithArguments: string[] = [];
+        const optionsWithoutArguments: string[] = [];
+        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.deep.equal(argumentsHelper.filterArguments(args));
+        expect(result).to.have.length(6);
+        expect(result).to.deep.equal(args);
+    });
+});

--- a/src/test/common/argumentsHelper.unit.test.ts
+++ b/src/test/common/argumentsHelper.unit.test.ts
@@ -44,7 +44,7 @@ suite('ArgumentsHelper tests', () => {
     });
 
     test('getPositionalArguments with unknown arguments with inline `option=value` syntax should return correct positional arguments', () => {
-        const args = ['arg1', '--foo', 'arg2', '--bar=arg3', 'arg4'];
+        const args = ['arg1', '--foo', 'arg2', 'bar=arg3', 'arg4'];
         const optionsWithArguments: string[] = [];
         const optionsWithoutArguments = ['--foo'];
         const result = argumentsHelper.getPositionalArguments(args, optionsWithArguments, optionsWithoutArguments);

--- a/src/test/common/argumentsHelper.unit.test.ts
+++ b/src/test/common/argumentsHelper.unit.test.ts
@@ -43,6 +43,16 @@ suite('ArgumentsHelper tests', () => {
         expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
     });
 
+    test('getPositionalArguments with unknown arguments with inline `option=value` syntax should return correct positional arguments', () => {
+        const args = ['arg1', '--foo', 'arg2', '--bar=arg3', 'arg4'];
+        const optionsWithArguments: string[] = [];
+        const optionsWithoutArguments = ['--foo'];
+        const result = argumentsHelper.getPositionalArguments(args, optionsWithArguments, optionsWithoutArguments);
+
+        expect(result).to.have.length(3);
+        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
+    });
+
     test('getPositionalArguments with no options parameter should be the same as passing empty arrays', () => {
         const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
         const optionsWithArguments: string[] = [];

--- a/src/test/common/argumentsHelper.unit.test.ts
+++ b/src/test/common/argumentsHelper.unit.test.ts
@@ -24,39 +24,6 @@ suite('ArgumentsHelper tests', () => {
         argumentsHelper = new ArgumentsHelper(instance(serviceContainer));
     });
 
-    test('getOptionValues with an option should return the arg value after the option', () => {
-        const args = ['arg1', '--foo', 'arg2'];
-        const result = argumentsHelper.getOptionValues(args, '--foo');
-
-        expect(result).to.be.a('string');
-        expect(result).to.equal('arg2');
-    });
-
-    test('getOptionValues with a non-existent option should return nothing', () => {
-        const args = ['arg1', '--foo', 'arg2'];
-        const result = argumentsHelper.getOptionValues(args, '--bar');
-
-        expect(result).to.be.a('undefined');
-    });
-
-    test('getOptionValues with an option followed by = should return the value part of the arg', () => {
-        const args = ['arg1', '--foo=arg2', 'arg2'];
-        const result = argumentsHelper.getOptionValues(args, '--foo');
-
-        expect(result).to.be.a('string');
-        expect(result).to.equal('arg2');
-    });
-
-    test('getOptionValues with an option repeated multiple times should return an array of values', () => {
-        const args = ['arg1', '--foo', 'arg2', '--bar', '--foo', 'arg3'];
-        const result = argumentsHelper.getOptionValues(args, '--foo') as string[];
-
-        expect(result).to.be.a('array');
-        expect(result).to.have.length(2);
-        expect(result[0]).to.equal('arg2');
-        expect(result[1]).to.equal('arg3');
-    });
-
     test('getPositionalArguments with both options parameters should return correct positional arguments', () => {
         const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
         const optionsWithArguments = ['--bar'];
@@ -86,46 +53,5 @@ suite('ArgumentsHelper tests', () => {
         expect(result).to.deep.equal(argumentsHelper.getPositionalArguments(args));
         expect(result).to.have.length(4);
         expect(result).to.deep.equal(['arg1', 'arg2', 'arg3', 'arg4']);
-    });
-
-    test('filterArguments with both options parameters should return correct filtered arguments', () => {
-        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
-        const optionsWithArguments = ['--bar'];
-        const optionsWithoutArguments = ['--foo'];
-        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
-
-        expect(result).to.have.length(3);
-        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
-    });
-
-    test('filterArguments with optionsWithArguments with inline `option=value` syntax should return correct filtered arguments', () => {
-        const args = ['arg1', '--foo', 'arg2', '--bar=arg3', 'arg4'];
-        const optionsWithArguments = ['--bar'];
-        const optionsWithoutArguments = ['--foo'];
-        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
-
-        expect(result).to.have.length(3);
-        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
-    });
-
-    test('filterArguments should ignore wildcard args', () => {
-        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
-        const optionsWithArguments = ['--bar'];
-        const optionsWithoutArguments = ['--fo*'];
-        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
-
-        expect(result).to.have.length(3);
-        expect(result).to.deep.equal(['arg1', 'arg2', 'arg4']);
-    });
-
-    test('filterArguments with no options parameter should be the same as passing empty arrays', () => {
-        const args = ['arg1', '--foo', 'arg2', '--bar', 'arg3', 'arg4'];
-        const optionsWithArguments: string[] = [];
-        const optionsWithoutArguments: string[] = [];
-        const result = argumentsHelper.filterArguments(args, optionsWithArguments, optionsWithoutArguments);
-
-        expect(result).to.deep.equal(argumentsHelper.filterArguments(args));
-        expect(result).to.have.length(6);
-        expect(result).to.deep.equal(args);
     });
 });

--- a/src/test/common/argumentsHelper.unit.test.ts
+++ b/src/test/common/argumentsHelper.unit.test.ts
@@ -11,7 +11,6 @@ import { ServiceContainer } from '../../client/ioc/container';
 import { IServiceContainer } from '../../client/ioc/types';
 import { ArgumentsHelper } from '../../client/testing/common/argumentsHelper';
 
-// tslint:disable-next-line: max-func-body-length
 suite('ArgumentsHelper tests', () => {
     let argumentsHelper: ArgumentsHelper;
 

--- a/src/test/testing/nosetest/nosetest.argsService.unit.test.ts
+++ b/src/test/testing/nosetest/nosetest.argsService.unit.test.ts
@@ -34,7 +34,7 @@ suite('ArgsService: nosetest', () => {
 
     test('Test getting the test folder in nosetest', () => {
         const dir = path.join('a', 'b', 'c');
-        const args = ['anzy', '--one', '--three', dir];
+        const args = ['--one', '--three', dir];
         const testDirs = argumentsService.getTestFolders(args);
         expect(testDirs).to.be.lengthOf(1);
         expect(testDirs[0]).to.equal(dir);
@@ -44,8 +44,9 @@ suite('ArgsService: nosetest', () => {
         const dir2 = path.join('a', 'b', '2');
         const args = ['anzy', '--one', '--three', dir, dir2];
         const testDirs = argumentsService.getTestFolders(args);
-        expect(testDirs).to.be.lengthOf(2);
-        expect(testDirs[0]).to.equal(dir);
-        expect(testDirs[1]).to.equal(dir2);
+        expect(testDirs).to.be.lengthOf(3);
+        expect(testDirs[0]).to.equal('anzy');
+        expect(testDirs[1]).to.equal(dir);
+        expect(testDirs[2]).to.equal(dir2);
     });
 });

--- a/src/test/testing/pytest/pytest.argsService.unit.test.ts
+++ b/src/test/testing/pytest/pytest.argsService.unit.test.ts
@@ -34,7 +34,14 @@ suite('ArgsService: pytest', () => {
 
     test('Test getting the test folder in pytest', () => {
         const dir = path.join('a', 'b', 'c');
-        const args = ['anzy', '--one', '--rootdir', dir];
+        const args = ['--one', '--rootdir', dir];
+        const testDirs = argumentsService.getTestFolders(args);
+        expect(testDirs).to.be.lengthOf(1);
+        expect(testDirs[0]).to.equal(dir);
+    });
+    test('Test getting the test folder in pytest (with folder before the arguments)', () => {
+        const dir = path.join('a', 'b', 'c');
+        const args = [dir, '--one', '--rootdir'];
         const testDirs = argumentsService.getTestFolders(args);
         expect(testDirs).to.be.lengthOf(1);
         expect(testDirs[0]).to.equal(dir);
@@ -59,7 +66,7 @@ suite('ArgsService: pytest', () => {
     });
     test('Test getting the test folder in pytest (with single positional dir)', () => {
         const dir = path.join('a', 'b', 'c');
-        const args = ['anzy', '--one', dir];
+        const args = ['--one', dir];
         const testDirs = argumentsService.getTestFolders(args);
         expect(testDirs).to.be.lengthOf(1);
         expect(testDirs[0]).to.equal(dir);
@@ -67,7 +74,7 @@ suite('ArgsService: pytest', () => {
     test('Test getting the test folder in pytest (with multiple positional dirs)', () => {
         const dir = path.join('a', 'b', 'c');
         const dir2 = path.join('a', 'b', '2');
-        const args = ['anzy', '--one', dir, dir2];
+        const args = ['--one', dir, dir2];
         const testDirs = argumentsService.getTestFolders(args);
         expect(testDirs).to.be.lengthOf(2);
         expect(testDirs[0]).to.equal(dir);
@@ -78,8 +85,9 @@ suite('ArgsService: pytest', () => {
         const dir2 = path.join('a', 'b', '2');
         const args = ['anzy', '--one', dir, dir2, path.join(dir, 'one.py')];
         const testDirs = argumentsService.getTestFolders(args);
-        expect(testDirs).to.be.lengthOf(2);
-        expect(testDirs[0]).to.equal(dir);
-        expect(testDirs[1]).to.equal(dir2);
+        expect(testDirs).to.be.lengthOf(3);
+        expect(testDirs[0]).to.equal('anzy');
+        expect(testDirs[1]).to.equal(dir);
+        expect(testDirs[2]).to.equal(dir2);
     });
 });


### PR DESCRIPTION
For #5757 

Positional arguments are not always the last ones in the args list: in the repro case in https://github.com/microsoft/vscode-python/issues/5757#issuecomment-505362961 the arg list is `[ "tests", "-sv"]`. This PR makes the parsing of positional args more flexible: instead of slicing the args array and keeping everything after the last option, we filter out non-positional args.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
