### PR TITLE
Add pytest-xdist's -n to the list of supported options for pytest

### DIFF
--- a/news/2 Fixes/6293.md
+++ b/news/2 Fixes/6293.md
@@ -1,0 +1,1 @@
+Add pytest-xdist's -n option to the list of supported pytest options.

--- a/src/client/testing/pytest/services/argsService.ts
+++ b/src/client/testing/pytest/services/argsService.ts
@@ -8,6 +8,7 @@ import { IServiceContainer } from '../../../ioc/types';
 import { IArgumentsHelper, IArgumentsService, TestFilter } from '../../types';
 
 const OptionsWithArguments = ['-c', '-k', '-m', '-o', '-p', '-r', '-W',
+     '-n', // -n is for pytest-xdist
     '--assert', '--basetemp', '--capture', '--color', '--confcutdir',
     '--cov', '--cov-config', '--cov-fail-under', '--cov-report',
     '--deselect', '--dist', '--doctest-glob',

--- a/src/client/testing/pytest/services/argsService.ts
+++ b/src/client/testing/pytest/services/argsService.ts
@@ -8,7 +8,7 @@ import { IServiceContainer } from '../../../ioc/types';
 import { IArgumentsHelper, IArgumentsService, TestFilter } from '../../types';
 
 const OptionsWithArguments = ['-c', '-k', '-m', '-o', '-p', '-r', '-W',
-     '-n', // -n is for pytest-xdist
+    '-n', // -n is a pytest-xdist option
     '--assert', '--basetemp', '--capture', '--color', '--confcutdir',
     '--cov', '--cov-config', '--cov-fail-under', '--cov-report',
     '--deselect', '--dist', '--doctest-glob',

--- a/src/test/testing/pytest/pytest.argsService.unit.test.ts
+++ b/src/test/testing/pytest/pytest.argsService.unit.test.ts
@@ -95,10 +95,17 @@ suite('ArgsService: pytest', () => {
         expect(knownOptions.withArgs.length).to.not.equal(0);
         expect(knownOptions.withoutArgs.length).to.not.equal(0);
     });
-    test('Test calling ArgumentsService.getOptionValue', () => {
+    test('Test calling ArgumentsService.getOptionValue with the option followed by the value', () => {
         const knownOptionsWithValues = argumentsService.getKnownOptions().withArgs;
         knownOptionsWithValues.forEach(option => {
             const args = ['--foo', '--bar', 'arg1', option, 'value1'];
+            expect(argumentsService.getOptionValue(args, option)).to.deep.equal('value1');
+        });
+    });
+    test('Test calling ArgumentsService.getOptionValue with the inline option syntax', () => {
+        const knownOptionsWithValues = argumentsService.getKnownOptions().withArgs;
+        knownOptionsWithValues.forEach(option => {
+            const args = ['--foo', '--bar', 'arg1', `${option}=value1`];
             expect(argumentsService.getOptionValue(args, option)).to.deep.equal('value1');
         });
     });

--- a/src/test/testing/pytest/pytest.argsService.unit.test.ts
+++ b/src/test/testing/pytest/pytest.argsService.unit.test.ts
@@ -90,4 +90,16 @@ suite('ArgsService: pytest', () => {
         expect(testDirs[1]).to.equal(dir);
         expect(testDirs[2]).to.equal(dir2);
     });
+    test('Test getting the list of known options for pytest', () => {
+        const knownOptions = argumentsService.getKnownOptions();
+        expect(knownOptions.withArgs.length).to.not.equal(0);
+        expect(knownOptions.withoutArgs.length).to.not.equal(0);
+    });
+    test('Test calling ArgumentsService.getOptionValue', () => {
+        const knownOptionsWithValues = argumentsService.getKnownOptions().withArgs;
+        knownOptionsWithValues.forEach(option => {
+            const args = ['--foo', '--bar', 'arg1', option, 'value1'];
+            expect(argumentsService.getOptionValue(args, option)).to.deep.equal('value1');
+        });
+    });
 });


### PR DESCRIPTION
For #6293 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
