### PR TITLE
Dispose codewatcher when document is closed

### DIFF
--- a/news/2 Fixes/6582.md
+++ b/news/2 Fixes/6582.md
@@ -1,0 +1,1 @@
+Fix problem where we retrieved and rendered old codelenses for multiple imports of jupyter notebooks if cells in the resultant import file were executed without saving the file to disk

--- a/src/client/datascience/editor-integration/codelensprovider.ts
+++ b/src/client/datascience/editor-integration/codelensprovider.ts
@@ -60,10 +60,8 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     }
 
     private onDidCloseTextDocument(_e: vscode.TextDocument) {
-        // This event is triggered when the text document is no longer visible. It may still be open in a different panel and/or hidden. Only delete its codewatcher if it's not visible.
-        const isVisible: boolean = this.documentManager.visibleTextEditors.filter(textEditor => textEditor.document.fileName === _e.fileName).length > 0;
         const index = this.activeCodeWatchers.findIndex(item => item.getFileName() === _e.fileName);
-        if (!isVisible && index >= 0) {
+        if (index >= 0) {
             this.activeCodeWatchers.splice(index, 1);
         }
     }


### PR DESCRIPTION
For #6582

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
