### PR TITLE
Fix executeInFileDir doesn't work when file is not in a workspace

### DIFF
--- a/news/2 Fixes/1062.md
+++ b/news/2 Fixes/1062.md
@@ -1,0 +1,2 @@
+Fix executeInFileDir doesn't work when file is not in a workspace
+(thanks [Bet4](https://github.com/bet4it/))

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -81,7 +81,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         }
         const fileDirPath = path.dirname(file.fsPath);
         const wkspace = this.workspace.getWorkspaceFolder(file);
-        if (wkspace && fileDirPath !== wkspace.uri.fsPath && fileDirPath.length > 0) {
+        if ((!wkspace || fileDirPath !== wkspace.uri.fsPath) && fileDirPath.length > 0) {
             await this.getTerminalService(file).sendText(`cd ${fileDirPath.fileToCommandArgument()}`);
         }
     }

--- a/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
+++ b/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
@@ -184,7 +184,7 @@ suite('Terminal - Code Execution', () => {
                 await ensureWeDoNotSetCurrentDirectoryBeforeExecutingFileInSameDirectory(true);
             });
 
-            async function ensureWeDoNotSetCurrentDirectoryBeforeExecutingFileNotInSameDirectory(isWindows: boolean): Promise<void> {
+            async function ensureWeSetCurrentDirectoryBeforeExecutingFileNotInSameDirectory(isWindows: boolean): Promise<void> {
                 const file = Uri.file(path.join('c', 'path', 'to', 'file with spaces in path', 'one.py'));
                 terminalSettings.setup(t => t.executeInFileDir).returns(() => true);
                 workspace.setup(w => w.getWorkspaceFolder(TypeMoq.It.isAny())).returns(() => undefined);
@@ -194,13 +194,13 @@ suite('Terminal - Code Execution', () => {
 
                 await executor.executeFile(file);
 
-                terminalService.verify(async t => t.sendText(TypeMoq.It.isAny()), TypeMoq.Times.never());
+                terminalService.verify(async t => t.sendText(TypeMoq.It.isAny()), TypeMoq.Times.once());
             }
-            test('Ensure we do not set current directory before executing file if file is not in a workspace (non windows)', async () => {
-                await ensureWeDoNotSetCurrentDirectoryBeforeExecutingFileNotInSameDirectory(false);
+            test('Ensure we set current directory before executing file if file is not in a workspace (non windows)', async () => {
+                await ensureWeSetCurrentDirectoryBeforeExecutingFileNotInSameDirectory(false);
             });
-            test('Ensure we do not set current directory before executing file if file is not in a workspace (windows)', async () => {
-                await ensureWeDoNotSetCurrentDirectoryBeforeExecutingFileNotInSameDirectory(true);
+            test('Ensure we set current directory before executing file if file is not in a workspace (windows)', async () => {
+                await ensureWeSetCurrentDirectoryBeforeExecutingFileNotInSameDirectory(true);
             });
 
             async function testFileExecution(isWindows: boolean, pythonPath: string, terminalArgs: string[], file: Uri): Promise<void> {


### PR DESCRIPTION
For #1062

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.