### PR TITLE
Ignore errors when accessing shell info using VSC API

### DIFF
--- a/src/client/common/application/applicationEnvironment.ts
+++ b/src/client/common/application/applicationEnvironment.ts
@@ -7,8 +7,10 @@ import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { parse } from 'semver';
 import * as vscode from 'vscode';
+import { traceDecorators } from '../logger';
 import { IPlatformService } from '../platform/types';
 import { ICurrentProcess, IPathUtils } from '../types';
+import { swallowExceptions } from '../utils/decorators';
 import { OSType } from '../utils/platform';
 import { Channel, IApplicationEnvironment } from './types';
 
@@ -50,6 +52,17 @@ export class ApplicationEnvironment implements IApplicationEnvironment {
         // tslint:disable-next-line:non-literal-require
         return this.packageJson.displayName;
     }
+    /**
+     * At the time of writing this API, the vscode.env.shell isn't officially released in stable version of VS Code.
+     * Using this in stable version seems to throw errors in VSC with messages being displayed to the user about use of
+     * unstable API.
+     * Solution - log and suppress the errors.
+     * @readonly
+     * @type {(string | undefined)}
+     * @memberof ApplicationEnvironment
+     */
+    @swallowExceptions('Failed to get shell from VS Code API')
+    @traceDecorators.error('Failed to get shell from VS Code API')
     public get shell(): string | undefined {
         // tslint:disable-next-line:no-any
         return (vscode.env as any).shell;

--- a/src/client/common/application/applicationEnvironment.ts
+++ b/src/client/common/application/applicationEnvironment.ts
@@ -61,7 +61,6 @@ export class ApplicationEnvironment implements IApplicationEnvironment {
      * @type {(string | undefined)}
      * @memberof ApplicationEnvironment
      */
-    @swallowExceptions('Failed to get shell from VS Code API')
     @traceDecorators.error('Failed to get shell from VS Code API')
     public get shell(): string | undefined {
         // tslint:disable-next-line:no-any


### PR DESCRIPTION
For #6050

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
