### PR TITLE
Add comments for debugger telemetry.

### DIFF
--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -12,12 +12,12 @@ import { EXTENSION_ROOT_DIR, isTestExecution, PVSC_EXTENSION_ID } from '../commo
 import { traceInfo } from '../common/logger';
 import { StopWatch } from '../common/utils/stopWatch';
 import { Telemetry } from '../datascience/constants';
+import { ConsoleType } from '../debugger/types';
 import { LinterId } from '../linters/types';
 import { EventName } from './constants';
 import {
     CodeExecutionTelemetry,
     DebuggerConfigurationPromtpsTelemetry,
-    DebuggerTelemetry,
     DiagnosticsAction,
     DiagnosticsMessages,
     EditorLoadTelemetry,
@@ -270,7 +270,127 @@ function getCallsite(frame: stackTrace.StackFrame) {
 export interface IEventNamePropertyMapping {
     [EventName.COMPLETION]: never | undefined;
     [EventName.COMPLETION_ADD_BRACKETS]: { enabled: boolean };
-    [EventName.DEBUGGER]: DebuggerTelemetry;
+    /**
+     * Telemetry captured when staring the debugger.
+     */
+    [EventName.DEBUGGER]: {
+        /**
+         * Trigger for starting the debugger.
+         * - `launch`: Launch/start new code and debug it.
+         * - `attach`: Attach to an exiting python process (remote debugging).
+         * - `test`: Debugging python tests.
+         *
+         * @type {('launch' | 'attach' | 'test')}
+         */
+        trigger: 'launch' | 'attach' | 'test';
+        /**
+         * Type of console used.
+         *  -`internalConsole`: Use VS Code debug console (no shells/terminals).
+         * - `integratedTerminal`: Use VS Code terminal.
+         * - `externalTerminal`: Use an External terminal.
+         *
+         * @type {ConsoleType}
+         */
+        console?: ConsoleType;
+        /**
+         * Whether user has defined environment variables.
+         * Could have been defined in launch.json or the env file (defined in `settings.json`).
+         * Default `env file` is `.env` in the workspace folder.
+         *
+         * @type {boolean}
+         */
+        hasEnvVars: boolean;
+        /**
+         * Whether there are any CLI arguments that need to be passed into the program being debugged.
+         *
+         * @type {boolean}
+         */
+        hasArgs: boolean;
+        /**
+         * Whether the user is debugging `django`.
+         *
+         * @type {boolean}
+         */
+        django: boolean;
+        /**
+         * Whether the user is debugging `flask`.
+         *
+         * @type {boolean}
+         */
+        flask: boolean;
+        /**
+         * Whether the user is debugging `jinja` templates.
+         *
+         * @type {boolean}
+         */
+        jinja: boolean;
+        /**
+         * Whether user is attaching to a local python program (attach scenario).
+         *
+         * @type {boolean}
+         */
+        isLocalhost: boolean;
+        /**
+         * Whether debugging a module.
+         *
+         * @type {boolean}
+         */
+        isModule: boolean;
+        /**
+         * Whether debugging with `sudo`.
+         *
+         * @type {boolean}
+         */
+        isSudo: boolean;
+        /**
+         * Whether required to stop upon entry.
+         *
+         * @type {boolean}
+         */
+        stopOnEntry: boolean;
+        /**
+         * Whether required to display return types in debugger.
+         *
+         * @type {boolean}
+         */
+        showReturnValue: boolean;
+        /**
+         * Whether debugging `pyramid`.
+         *
+         * @type {boolean}
+         */
+        pyramid: boolean;
+        /**
+         * Whether debugging a subprocess.
+         *
+         * @type {boolean}
+         */
+        subProcess: boolean;
+        /**
+         * Whether debugging `watson`.
+         *
+         * @type {boolean}
+         */
+        watson: boolean;
+        /**
+         * Whether degbugging `pyspark`.
+         *
+         * @type {boolean}
+         */
+        pyspark: boolean;
+        /**
+         * Whether using `gevent` when deugging.
+         *
+         * @type {boolean}
+         */
+        gevent: boolean;
+        /**
+         * Whether debugging `scrapy`.
+         *
+         * @type {boolean}
+         */
+        scrapy: boolean;
+    };
     [EventName.DEBUGGER_ATTACH_TO_CHILD_PROCESS]: never | undefined;
     [EventName.DEBUGGER_CONFIGURATION_PROMPTS]: DebuggerConfigurationPromtpsTelemetry;
     [EventName.DEBUGGER_CONFIGURATION_PROMPTS_IN_LAUNCH_JSON]: never | undefined;

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -5,11 +5,11 @@
 import { DiagnosticCodes } from '../application/diagnostics/constants';
 import { TerminalShellType } from '../common/terminal/types';
 import { DebugConfigurationType } from '../debugger/extension/types';
-import { ConsoleType } from '../debugger/types';
 import { AutoSelectionRule } from '../interpreter/autoSelection/types';
 import { InterpreterType } from '../interpreter/contracts';
 import { LinterId } from '../linters/types';
-import { PlatformErrors } from './constants';
+import { IEventNamePropertyMapping } from '../telemetry/index'
+import { EventName, PlatformErrors } from './constants';
 
 export type EditorLoadTelemetry = {
     condaVersion: string | undefined;
@@ -71,26 +71,7 @@ export type PythonInterpreterTelemetry = {
 export type CodeExecutionTelemetry = {
     scope: 'file' | 'selection';
 };
-export type DebuggerTelemetry = {
-    trigger: 'launch' | 'attach' | 'test';
-    console?: ConsoleType;
-    hasEnvVars: boolean;
-    hasArgs: boolean;
-    django: boolean;
-    flask: boolean;
-    jinja: boolean;
-    isLocalhost: boolean;
-    isModule: boolean;
-    isSudo: boolean;
-    stopOnEntry: boolean;
-    showReturnValue: boolean;
-    pyramid: boolean;
-    subProcess: boolean;
-    watson: boolean;
-    pyspark: boolean;
-    gevent: boolean;
-    scrapy: boolean;
-};
+export type DebuggerTelemetry = IEventNamePropertyMapping[EventName.DEBUGGER];
 export type DebuggerPerformanceTelemetry = {
     duration: number;
     action: 'stepIn' | 'stepOut' | 'continue' | 'next' | 'launch';


### PR DESCRIPTION
For #5216
Added comments for debugger telemetry.
@Anapo14 had a debugger related telemetry. Figured this was a good opportunity to add the comments to that section.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [n/a] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
