### PR TITLE
Fix overwriting of cwd in test discovery path list

### DIFF
--- a/news/2 Fixes/6417.md
+++ b/news/2 Fixes/6417.md
@@ -1,0 +1,1 @@
+Fix overwriting of cwd in the path list when discovering tests.

--- a/pythonFiles/testing_tools/run_adapter.py
+++ b/pythonFiles/testing_tools/run_adapter.py
@@ -5,7 +5,10 @@
 import os.path
 import sys
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(1,
+                os.path.dirname(
+                    os.path.dirname(
+                        os.path.abspath(__file__))))
 
 from testing_tools.adapter.__main__ import parse_args, main
 

--- a/pythonFiles/testing_tools/run_adapter.py
+++ b/pythonFiles/testing_tools/run_adapter.py
@@ -4,9 +4,8 @@
 # Replace the "." entry.
 import os.path
 import sys
-sys.path[0] = os.path.dirname(
-    os.path.dirname(
-        os.path.abspath(__file__)))
+
+sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from testing_tools.adapter.__main__ import parse_args, main
 


### PR DESCRIPTION
For #6417 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
