### PR TITLE
Fix debugging cells with more than one blank line on the end.

### DIFF
--- a/news/2 Fixes/6719.md
+++ b/news/2 Fixes/6719.md
@@ -1,0 +1,1 @@
+Fix stepping when more than one blank line at the end of a cell.

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -208,9 +208,9 @@ export class CellHashProvider implements ICellHashProvider, IInteractiveWindowLi
             const startOffset = doc.offsetAt(new Position(cell.line, 0));
             const endOffset = doc.offsetAt(endLine.rangeIncludingLineBreak.end);
 
-            // Jupyter also removes blank lines at the end.
+            // Jupyter also removes blank lines at the end. Make sure only one
             let lastLine = stripped[stripped.length - 1];
-            while (lastLine && (lastLine.length === 0 || lastLine === '\n')) {
+            while (lastLine !== undefined && (lastLine.length === 0 || lastLine === '\n')) {
                 stripped.splice(stripped.length - 1, 1);
                 lastLine = stripped[stripped.length - 1];
             }

--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -186,7 +186,7 @@ suite('DataScience Debugger tests', () => {
     });
 
     test('Debug cell with breakpoint', async () => {
-        await debugCell('#%%\nprint("bar")\nprint("baz")', new Range(new Position(3, 0), new Position(3, 0)));
+        await debugCell('#%%\nprint("bar")\nprint("baz")\n\n\n', new Range(new Position(3, 0), new Position(3, 0)));
     });
 
     test('Debug cell with breakpoint in another file', async () => {


### PR DESCRIPTION
For #6719

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
