### PR TITLE
Return relfile and location as-is (do no normcase).

### DIFF
--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -826,11 +826,11 @@ class CollectorTests(unittest.TestCase):
                     name='test_spam',
                     path=TestPath(
                         root=testroot,
-                        relfile=r'.\x\y\z\test_eggs.py',
+                        relfile=r'.\X\Y\Z\test_eggs.py',
                         func='SpamTests.test_spam',
                         sub=None,
                         ),
-                    source=r'.\x\y\z\test_eggs.py:{}'.format(13),
+                    source=r'.\X\Y\Z\test_eggs.py:{}'.format(13),
                     markers=None,
                     parentid=r'.\x\y\z\test_eggs.py::SpamTests',
                     ),


### PR DESCRIPTION
(for #6758)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
