### PR TITLE
Normalize paths in stack traces

### DIFF
--- a/news/3 Code Health/6460.md
+++ b/news/3 Code Health/6460.md
@@ -1,0 +1,1 @@
+Normalize path separators in stack traces.

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -247,7 +247,9 @@ function getStackTrace(ex: Error): string {
             trace += '\n\tat <anonymous>';
         }
     }
-    return trace.trim();
+    // Ensure we always use `/` as path seperators.
+    // This way stack traces (with relative paths) comming from different OS will always look the same.
+    return trace.trim().replace(/\\/g, '/');
 }
 
 function getCallsite(frame: stackTrace.StackFrame) {

--- a/src/test/telemetry/index.unit.test.ts
+++ b/src/test/telemetry/index.unit.test.ts
@@ -13,7 +13,6 @@ import { IWorkspaceService } from '../../client/common/application/types';
 import { WorkspaceService } from '../../client/common/application/workspace';
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
 import { clearTelemetryReporter, isTelemetryDisabled, sendTelemetryEvent } from '../../client/telemetry';
-import { correctPathForOsType } from '../common';
 
 suite('Telemetry', () => {
     let workspaceService: IWorkspaceService;
@@ -132,7 +131,7 @@ suite('Telemetry', () => {
     test('Send Error Telemetry', () => {
         rewiremock.enable();
         const error = new Error('Boo');
-        error.stack = correctPathForOsType(['Error: Boo',
+        error.stack = ['Error: Boo',
             `at Context.test (${EXTENSION_ROOT_DIR}/src/test/telemetry/index.unit.test.ts:50:23)`,
             `at callFn (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runnable.js:372:21)`,
             `at Test.Runnable.run (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runnable.js:364:7)`,
@@ -149,7 +148,7 @@ suite('Telemetry', () => {
             `at Immediate.<anonymous> (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runner.js:347:5)`,
             'at runCallback (timers.js:789:20)',
             'at tryOnImmediate (timers.js:751:5)',
-            'at processImmediate [as _immediateCallback] (timers.js:722:5)'].join('\n\t'));
+            'at processImmediate [as _immediateCallback] (timers.js:722:5)'].join('\n\t');
         rewiremock('vscode-extension-telemetry').with({ default: Reporter });
 
         const eventName = 'Testing';
@@ -171,7 +170,7 @@ suite('Telemetry', () => {
         expect(Reporter.properties).to.deep.equal([expectedErrorProperties, properties]);
         expect(stackTrace).to.be.length.greaterThan(1);
 
-        const expectedStack = correctPathForOsType(['at Context.test <pvsc>/src/test/telemetry/index.unit.test.ts:50:23\n\tat callFn <pvsc>/node_modules/mocha/lib/runnable.js:372:21',
+        const expectedStack = ['at Context.test <pvsc>/src/test/telemetry/index.unit.test.ts:50:23\n\tat callFn <pvsc>/node_modules/mocha/lib/runnable.js:372:21',
             'at Test.Runnable.run <pvsc>/node_modules/mocha/lib/runnable.js:364:7',
             'at Runner.runTest <pvsc>/node_modules/mocha/lib/runner.js:455:10',
             'at  <pvsc>/node_modules/mocha/lib/runner.js:573:12',
@@ -186,19 +185,19 @@ suite('Telemetry', () => {
             'at Immediate <pvsc>/node_modules/mocha/lib/runner.js:347:5',
             'at runCallback <hidden>/timers.js:789:20',
             'at tryOnImmediate <hidden>/timers.js:751:5',
-            'at processImmediate [as _immediateCallback] <hidden>/timers.js:722:5'].join('\n\t'));
+            'at processImmediate [as _immediateCallback] <hidden>/timers.js:722:5'].join('\n\t');
 
         expect(stackTrace).to.be.equal(expectedStack);
     });
     test('Ensure non extension file paths are stripped from stack trace', () => {
         rewiremock.enable();
         const error = new Error('Boo');
-        error.stack = correctPathForOsType(['Error: Boo',
+        error.stack = ['Error: Boo',
             `at Context.test (${EXTENSION_ROOT_DIR}/src/test/telemetry/index.unit.test.ts:50:23)`,
             'at callFn (c:/one/two/user/node_modules/mocha/lib/runnable.js:372:21)',
             'at Test.Runnable.run (/usr/Paul/Homer/desktop/node_modules/mocha/lib/runnable.js:364:7)',
             'at Runner.runTest (\\wow\wee/node_modules/mocha/lib/runner.js:455:10)',
-            `at Immediate.<anonymous> (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runner.js:347:5)`].join('\n\t'));
+            `at Immediate.<anonymous> (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runner.js:347:5)`].join('\n\t');
         rewiremock('vscode-extension-telemetry').with({ default: Reporter });
 
         const eventName = 'Testing';
@@ -220,23 +219,23 @@ suite('Telemetry', () => {
         expect(Reporter.properties).to.deep.equal([expectedErrorProperties, properties]);
         expect(stackTrace).to.be.length.greaterThan(1);
 
-        const expectedStack = correctPathForOsType(['at Context.test <pvsc>/src/test/telemetry/index.unit.test.ts:50:23',
+        const expectedStack = ['at Context.test <pvsc>/src/test/telemetry/index.unit.test.ts:50:23',
             'at callFn <hidden>/runnable.js:372:21',
             'at Test.Runnable.run <hidden>/runnable.js:364:7',
             'at Runner.runTest <hidden>/runner.js:455:10',
-            'at Immediate <pvsc>/node_modules/mocha/lib/runner.js:347:5'].join('\n\t'));
+            'at Immediate <pvsc>/node_modules/mocha/lib/runner.js:347:5'].join('\n\t');
 
         expect(stackTrace).to.be.equal(expectedStack);
     });
     test('Ensure non function names containing file names (unlikely, but for sake of completeness) are stripped from stack trace', () => {
         rewiremock.enable();
         const error = new Error('Boo');
-        error.stack = correctPathForOsType(['Error: Boo',
+        error.stack = ['Error: Boo',
             `at Context.test (${EXTENSION_ROOT_DIR}/src/test/telemetry/index.unit.test.ts:50:23)`,
             'at callFn (c:/one/two/user/node_modules/mocha/lib/runnable.js:372:21)',
             'at Test./usr/Paul/Homer/desktop/node_modules/mocha/lib/runnable.run (/usr/Paul/Homer/desktop/node_modules/mocha/lib/runnable.js:364:7)',
             'at Runner.runTest (\\wow\wee/node_modules/mocha/lib/runner.js:455:10)',
-            `at Immediate.<anonymous> (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runner.js:347:5)`].join('\n\t'));
+            `at Immediate.<anonymous> (${EXTENSION_ROOT_DIR}/node_modules/mocha/lib/runner.js:347:5)`].join('\n\t');
         rewiremock('vscode-extension-telemetry').with({ default: Reporter });
 
         const eventName = 'Testing';
@@ -258,11 +257,11 @@ suite('Telemetry', () => {
         expect(Reporter.properties).to.deep.equal([expectedErrorProperties, properties]);
         expect(stackTrace).to.be.length.greaterThan(1);
 
-        const expectedStack = correctPathForOsType(['at Context.test <pvsc>/src/test/telemetry/index.unit.test.ts:50:23',
+        const expectedStack = ['at Context.test <pvsc>/src/test/telemetry/index.unit.test.ts:50:23',
             'at callFn <hidden>/runnable.js:372:21',
             'at <hidden>.run <hidden>/runnable.js:364:7',
             'at Runner.runTest <hidden>/runner.js:455:10',
-            'at Immediate <pvsc>/node_modules/mocha/lib/runner.js:347:5'].join('\n\t'));
+            'at Immediate <pvsc>/node_modules/mocha/lib/runner.js:347:5'].join('\n\t');
 
         expect(stackTrace).to.be.equal(expectedStack);
     });


### PR DESCRIPTION
For #6460

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
