### PR TITLE
Temporarily enable old smoke tests

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -532,6 +532,28 @@ steps:
     env:
       DISPLAY: :10
 
+  # Run the smoke tests.
+  #
+  # This task only runs if the string 'testSmoke' exists in variable `TestsToRun`.
+  #
+  # Example command line (windows pwsh):
+  # > npm run clean
+  # > npm run updateBuildNumber -- --buildNumber 0.0.0-local
+  # > npm run package
+  # > npx gulp clean:cleanExceptTests
+  # > npm run testSmoke
+  - bash: |
+      npm install -g vsce
+      npm run clean
+      npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
+      npm run package
+      npx gulp clean:cleanExceptTests
+      npm run testSmoke
+    displayName: 'Run Smoke Tests'
+    condition: and(succeeded(), contains(variables['TestsToRun'], 'testSmoke'))
+    env:
+      DISPLAY: :10
+
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: $(Build.ArtifactStagingDirectory)

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -544,7 +544,8 @@ steps:
   # > npm run testSmoke
   - bash: |
       npm install -g vsce
-      npm run clean
+      npx tsc -p ./
+      npx gulp clean:cleanExceptTests
       npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
       npm run package
       npx gulp clean:cleanExceptTests

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -544,11 +544,15 @@ steps:
   # > npm run testSmoke
   - bash: |
       npm install -g vsce
+      npm run clean
       npx tsc -p ./
       npx gulp clean:cleanExceptTests
+      mkdir -p ./tmp
+      cp -r ./out/test ./tmp/test
       npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
       npm run package
       npx gulp clean:cleanExceptTests
+      cp -r ./tmp/test ./out/test
       npm run testSmoke
     displayName: 'Run Smoke Tests'
     condition: and(succeeded(), contains(variables['TestsToRun'], 'testSmoke'))

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -68,6 +68,16 @@ jobs:
         VMImageName: 'macos-10.13'
         TestsToRun: 'testSingleWorkspace'
         NeedsPythonTestReqs: true
+      'Mac-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'macos-10.13'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+      'Linux-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'ubuntu-16.04'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
       'Mac-Py2.7 Unit+Single':
         PythonVersion: '2.7'
         VMImageName: 'macos-10.13'

--- a/package.json
+++ b/package.json
@@ -2445,6 +2445,7 @@
         "testSingleWorkspace": "node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "testMultiWorkspace": "node ./out/test/testBootstrap.js ./out/test/multiRootTest.js",
         "testPerformance": "node ./out/test/testBootstrap.js ./out/test/performanceTest.js",
+        "testSmoke": "node ./out/test/smokeTest.js",
         "lint-staged": "node gulpfile.js",
         "lint": "tslint src/**/*.ts -t verbose",
         "clean": "gulp clean",


### PR DESCRIPTION
For #6863

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
