### PR TITLE
Modified telemetry with regards to discovery of python environments

### DIFF
--- a/news/1 Enhancements/5593.md
+++ b/news/1 Enhancements/5593.md
@@ -1,0 +1,1 @@
+Changes to telemetry with regards to discovery of python environments

--- a/src/client/interpreter/locators/services/cacheableLocatorService.ts
+++ b/src/client/interpreter/locators/services/cacheableLocatorService.ts
@@ -11,8 +11,9 @@ import '../../../common/extensions';
 import { Logger, traceDecorators, traceVerbose } from '../../../common/logger';
 import { IDisposableRegistry, IPersistentStateFactory } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
+import { StopWatch } from '../../../common/utils/stopWatch';
 import { IServiceContainer } from '../../../ioc/types';
-import { sendTelemetryWhenDone } from '../../../telemetry';
+import { sendTelemetryEvent } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
 import { IInterpreterLocatorService, IInterpreterWatcher, PythonInterpreter } from '../../contracts';
 
@@ -48,16 +49,20 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
             this.addHandlersForInterpreterWatchers(cacheKey, resource)
                 .ignoreErrors();
 
-            const promise = this.getInterpretersImplementation(resource)
+            const stopWatch = new StopWatch();
+            this.getInterpretersImplementation(resource)
                 .then(async items => {
                     await this.cacheInterpreters(items, resource);
                     traceVerbose(`Interpreters returned by ${this.name} are of count ${Array.isArray(items) ? items.length : 0}`);
                     traceVerbose(`Interpreters returned by ${this.name} are ${JSON.stringify(items)}`);
+                    sendTelemetryEvent(EventName.PYTHON_INTERPRETER_DISCOVERY, stopWatch.elapsedTime, { locator: this.name, counter: Array.isArray(items) ? items.length : 0 });
                     deferred!.resolve(items);
                 })
-                .catch(ex => deferred!.reject(ex));
+                .catch(ex => {
+                    sendTelemetryEvent(EventName.PYTHON_INTERPRETER_DISCOVERY, stopWatch.elapsedTime, { locator: this.name }, ex);
+                    deferred!.reject(ex);
+                });
 
-            sendTelemetryWhenDone(EventName.PYTHON_INTERPRETER_DISCOVERY, promise, undefined, { locator: this.name });
             this.locating.fire(deferred.promise);
         }
         deferred.promise

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -25,7 +25,6 @@ import {
     InterpreterActivation,
     InterpreterActivationEnvironmentVariables,
     InterpreterAutoSelection,
-    InterpreterDiscovery,
     LanguageServePlatformSupported,
     LanguageServerErrorTelemetry,
     LanguageServerVersionTelemetry,
@@ -451,7 +450,16 @@ export interface IEventNamePropertyMapping {
     /**
      * Sends information regarding discovered python environments (virtualenv, conda, pipenv etc.)
      */
-    [EventName.PYTHON_INTERPRETER_DISCOVERY]: InterpreterDiscovery;
+    [EventName.PYTHON_INTERPRETER_DISCOVERY]: {
+        /**
+         * Name of the locator
+         */
+        locator: string;
+        /**
+         * The number of the interpreters returned by locator
+         */
+        counter?: number;
+    };
     [EventName.PYTHON_INTERPRETER_ACTIVATE_ENVIRONMENT_PROMPT]: { selection: 'Yes' | 'No' | 'Ignore' | undefined };
     [EventName.INSIDERS_PROMPT]: {
         /**

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -448,6 +448,9 @@ export interface IEventNamePropertyMapping {
     [EventName.PYTHON_INTERPRETER_ACTIVATION_FOR_RUNNING_CODE]: InterpreterActivation;
     [EventName.PYTHON_INTERPRETER_ACTIVATION_FOR_TERMINAL]: InterpreterActivation;
     [EventName.PYTHON_INTERPRETER_AUTO_SELECTION]: InterpreterAutoSelection;
+    /**
+     * Sends information regarding discovered python environments (virtualenv, conda, pipenv etc.)
+     */
     [EventName.PYTHON_INTERPRETER_DISCOVERY]: InterpreterDiscovery;
     [EventName.PYTHON_INTERPRETER_ACTIVATE_ENVIRONMENT_PROMPT]: { selection: 'Yes' | 'No' | 'Ignore' | undefined };
     [EventName.INSIDERS_PROMPT]: {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -458,7 +458,7 @@ export interface IEventNamePropertyMapping {
         /**
          * The number of the interpreters returned by locator
          */
-        counter?: number;
+        interpreters?: number;
     };
     [EventName.PYTHON_INTERPRETER_ACTIVATE_ENVIRONMENT_PROMPT]: { selection: 'Yes' | 'No' | 'Ignore' | undefined };
     [EventName.INSIDERS_PROMPT]: {

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -156,7 +156,14 @@ export type InterpreterAutoSelection = {
     updated?: boolean;
 };
 export type InterpreterDiscovery = {
+    /**
+     * Name of the locator
+     */
     locator: string;
+    /**
+     * The number of the interpreters returned by locator
+     */
+    counter?: number;
 };
 
 export type InterpreterActivationEnvironmentVariables = {

--- a/src/client/telemetry/types.ts
+++ b/src/client/telemetry/types.ts
@@ -155,16 +155,6 @@ export type InterpreterAutoSelection = {
     identified?: boolean;
     updated?: boolean;
 };
-export type InterpreterDiscovery = {
-    /**
-     * Name of the locator
-     */
-    locator: string;
-    /**
-     * The number of the interpreters returned by locator
-     */
-    counter?: number;
-};
 
 export type InterpreterActivationEnvironmentVariables = {
     hasEnvVars?: boolean;


### PR DESCRIPTION
For #5593 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- [x] Has telemetry for enhancements.
- ~[ ] Unit tests & system/integration tests are added/updated~
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
