### PR TITLE
Fix typo in method name

### DIFF
--- a/news/3 Code Health/7072.md
+++ b/news/3 Code Health/7072.md
@@ -1,0 +1,1 @@
+Corrected spelling of name for method to be `hasConfigurationFileInWorkspace`.

--- a/src/client/linters/pylint.ts
+++ b/src/client/linters/pylint.ts
@@ -38,7 +38,7 @@ export class Pylint extends BaseLinter {
         if (settings.linting.pylintUseMinimalCheckers
             && this.info.linterArgs(uri).length === 0
             // Check pylintrc next to the file or above up to and including the workspace root
-            && !await Pylint.hasConfigrationFileInWorkspace(this.fileSystem, path.dirname(uri.fsPath), workspaceRoot)
+            && !await Pylint.hasConfigurationFileInWorkspace(this.fileSystem, path.dirname(uri.fsPath), workspaceRoot)
             // Check for pylintrc at the root and above
             && !await Pylint.hasConfigurationFile(this.fileSystem, this.getWorkspaceRootPath(document), this.platformService)) {
             // Disable all checkers up front and then selectively add back in:
@@ -135,7 +135,7 @@ export class Pylint extends BaseLinter {
     }
 
     // tslint:disable-next-line:member-ordering
-    public static async hasConfigrationFileInWorkspace(fs: IFileSystem, folder: string, root: string): Promise<boolean> {
+    public static async hasConfigurationFileInWorkspace(fs: IFileSystem, folder: string, root: string): Promise<boolean> {
         // Search up from file location to the workspace root
         let current = folder;
         let above = path.dirname(current);

--- a/src/test/linters/pylint.test.ts
+++ b/src/test/linters/pylint.test.ts
@@ -133,7 +133,7 @@ suite('Linting - Pylint', () => {
             .setup(x => x.fileExists(path.join(midFolder, pylintrc)))
             .returns(() => Promise.resolve(true));
 
-        const result = await Pylint.hasConfigrationFileInWorkspace(fileSystem.object, basePath, root);
+        const result = await Pylint.hasConfigurationFileInWorkspace(fileSystem.object, basePath, root);
         expect(result).to.be.equal(true, `'${pylintrc}' not detected in the workspace tree.`);
     });
 

--- a/src/test/linters/pylint.unit.test.ts
+++ b/src/test/linters/pylint.unit.test.ts
@@ -258,7 +258,7 @@ suite('Pylint - Function hasConfigurationFileInWorkspace()', () => {
                 .verifiable(TypeMoq.Times.once());
         });
 
-        const hasConfig = await Pylint.hasConfigrationFileInWorkspace(fileSystem.object, folder, root);
+        const hasConfig = await Pylint.hasConfigurationFileInWorkspace(fileSystem.object, folder, root);
         expect(hasConfig).to.equal(false, 'Should return false');
         fileSystem.verifyAll();
     });
@@ -302,7 +302,7 @@ suite('Pylint - Function hasConfigurationFileInWorkspace()', () => {
                 .returns(() => Promise.resolve(false))
                 .verifiable(TypeMoq.Times.never());
 
-            const hasConfig = await Pylint.hasConfigrationFileInWorkspace(fileSystem.object, folder, root);
+            const hasConfig = await Pylint.hasConfigurationFileInWorkspace(fileSystem.object, folder, root);
             expect(hasConfig).to.equal(true, 'Should return true');
             fileSystem.verifyAll();
         });
@@ -349,7 +349,7 @@ suite('Pylint - Function runLinter()', () => {
         '--output-format=text',
         doc.uri.fsPath
     ];
-    const original_hasConfigrationFileInWorkspace = Pylint.hasConfigrationFileInWorkspace;
+    const original_hasConfigurationFileInWorkspace = Pylint.hasConfigurationFileInWorkspace;
     const original_hasConfigurationFile = Pylint.hasConfigurationFile;
 
     class PylintTest extends Pylint {
@@ -404,7 +404,7 @@ suite('Pylint - Function runLinter()', () => {
     });
 
     teardown(() => {
-        Pylint.hasConfigrationFileInWorkspace = original_hasConfigrationFileInWorkspace;
+        Pylint.hasConfigurationFileInWorkspace = original_hasConfigurationFileInWorkspace;
         Pylint.hasConfigurationFile = original_hasConfigurationFile;
         sinon.restore();
     });
@@ -421,7 +421,7 @@ suite('Pylint - Function runLinter()', () => {
         _info
             .setup(info => info.linterArgs(doc.uri))
             .returns(() => []);
-        Pylint.hasConfigrationFileInWorkspace = () => Promise.resolve(false);
+        Pylint.hasConfigurationFileInWorkspace = () => Promise.resolve(false);
         Pylint.hasConfigurationFile = () => Promise.resolve(false);
         run = sinon.stub(PylintTest.prototype, 'run');
         run.callsFake(() => Promise.resolve([]));
@@ -446,7 +446,7 @@ suite('Pylint - Function runLinter()', () => {
         _info
             .setup(info => info.linterArgs(doc.uri))
             .returns(() => []);
-        Pylint.hasConfigrationFileInWorkspace = () => Promise.resolve(false);
+        Pylint.hasConfigurationFileInWorkspace = () => Promise.resolve(false);
         Pylint.hasConfigurationFile = () => Promise.resolve(false);
         run = sinon.stub(PylintTest.prototype, 'run');
         run.callsFake(() => Promise.resolve([]));
@@ -471,7 +471,7 @@ suite('Pylint - Function runLinter()', () => {
         _info
             .setup(info => info.linterArgs(doc.uri))
             .returns(() => ['customArg1', 'customArg2']);
-        Pylint.hasConfigrationFileInWorkspace = () => Promise.resolve(false);
+        Pylint.hasConfigurationFileInWorkspace = () => Promise.resolve(false);
         Pylint.hasConfigurationFile = () => Promise.resolve(false);
         run = sinon.stub(PylintTest.prototype, 'run');
         run.callsFake(() => Promise.resolve([]));
@@ -484,7 +484,7 @@ suite('Pylint - Function runLinter()', () => {
         assert.ok(run.calledOnce);
     });
 
-    test('Do not use minimal checkers if there is a pylintrc file in the current working directory or when traversing the workspace up to its root (hasConfigrationFileInWorkspace() returns true)', async () => {
+    test('Do not use minimal checkers if there is a pylintrc file in the current working directory or when traversing the workspace up to its root (hasConfigurationFileInWorkspace() returns true)', async () => {
         const settings = {
             linting: {
                 pylintUseMinimalCheckers: true
@@ -496,7 +496,7 @@ suite('Pylint - Function runLinter()', () => {
         _info
             .setup(info => info.linterArgs(doc.uri))
             .returns(() => []);
-        Pylint.hasConfigrationFileInWorkspace = () => Promise.resolve(true); // This implies method hasConfigrationFileInWorkspace() returns true
+        Pylint.hasConfigurationFileInWorkspace = () => Promise.resolve(true); // This implies method hasConfigurationFileInWorkspace() returns true
         Pylint.hasConfigurationFile = () => Promise.resolve(false);
         run = sinon.stub(PylintTest.prototype, 'run');
         run.callsFake(() => Promise.resolve([]));
@@ -521,7 +521,7 @@ suite('Pylint - Function runLinter()', () => {
         _info
             .setup(info => info.linterArgs(doc.uri))
             .returns(() => []);
-        Pylint.hasConfigrationFileInWorkspace = () => Promise.resolve(false);
+        Pylint.hasConfigurationFileInWorkspace = () => Promise.resolve(false);
         Pylint.hasConfigurationFile = () => Promise.resolve(true);   // This implies method hasConfigurationFile() returns true
         run = sinon.stub(PylintTest.prototype, 'run');
         run.callsFake(() => Promise.resolve([]));
@@ -553,7 +553,7 @@ suite('Pylint - Function runLinter()', () => {
         _info
             .setup(info => info.linterArgs(doc.uri))
             .returns(() => []);
-        Pylint.hasConfigrationFileInWorkspace = () => Promise.resolve(false);
+        Pylint.hasConfigurationFileInWorkspace = () => Promise.resolve(false);
         Pylint.hasConfigurationFile = () => Promise.resolve(false);
         run = sinon.stub(PylintTest.prototype, 'run');
         run.callsFake(() => Promise.resolve(message as any));


### PR DESCRIPTION
This corrects the name of the method to be `hasConfigurationFileInWorkspace`

For #7072

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Appropriate comments and documentation strings in the code~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
