### PR TITLE
Allow code like ABC123 for flake8 v3 plugin

### DIFF
--- a/news/2 Fixes/4074.md
+++ b/news/2 Fixes/4074.md
@@ -1,0 +1,1 @@
+Supports error codes like ABC123 as used in plugins.

--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -19,7 +19,8 @@ import {
 // tslint:disable-next-line:no-require-imports no-var-requires no-any
 const namedRegexp = require('named-js-regexp');
 // Allow negative column numbers (https://github.com/PyCQA/pylint/issues/1822)
-const REGEX = '(?<line>\\d+),(?<column>-?\\d+),(?<type>\\w+),(?<code>\\w\\d+):(?<message>.*)\\r?(\\n|$)';
+// Allow codes with more than one letter (i.e. ABC123)
+const REGEX = '(?<line>\\d+),(?<column>-?\\d+),(?<type>\\w+),(?<code>\\w+\\d+):(?<message>.*)\\r?(\\n|$)';
 
 export interface IRegexGroup {
     line: number;


### PR DESCRIPTION
For #4074

This PR change the regular expression for linter.
It is able to show flake8-plugin's output in `PROBLEMS` panel.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.

Special thanks for @jraygauthier and @peterjc(#4443).
