### PR TITLE
Drop dedent-on-enter for "return" statements.

### DIFF
--- a/news/2 Fixes/6813.md
+++ b/news/2 Fixes/6813.md
@@ -1,0 +1,2 @@
+Drop dedent-on-enter for "return" statements.  It will be addressed in:
+  https://github.com/microsoft/vscode-python/issues/6564

--- a/src/client/common/utils/regexp.ts
+++ b/src/client/common/utils/regexp.ts
@@ -3,6 +3,19 @@
 
 'use strict';
 
+/* Generate a RegExp from a "verbose" pattern.
+ *
+ * All whitespace in the pattern is removed, including newlines.  This
+ * allows the pattern to be much more readable by allowing it to span
+ * multiple lines and to separate tokens with insignificant whitespace.
+ * The functionality is similar to the VERBOSE ("x") flag in Python's
+ * regular expressions.
+ *
+ * Note that significant whitespace in the pattern must be explicitly
+ * indicated by "\s".  Also, unlike with regular expression literals,
+ * backslashes must be escaped.  Conversely, forward slashes do not
+ * need to be escaped.
+ */
 export function verboseRegExp(pattern: string): RegExp {
     pattern = pattern.replace(/\s+?/g, '');
     return RegExp(pattern);

--- a/src/client/common/utils/regexp.ts
+++ b/src/client/common/utils/regexp.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+export function verboseRegExp(pattern: string): RegExp {
+    pattern = pattern.replace(/\s+?/g, '');
+    return RegExp(pattern);
+}

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -40,7 +40,7 @@ import { registerTypes as appRegisterTypes } from './application/serviceRegistry
 import { IApplicationDiagnostics } from './application/types';
 import { DebugService } from './common/application/debugService';
 import { IApplicationShell, ICommandManager, IWorkspaceService } from './common/application/types';
-import { Commands, isTestExecution, PYTHON, STANDARD_OUTPUT_CHANNEL } from './common/constants';
+import { Commands, isTestExecution, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as registerDotNetTypes } from './common/dotnet/serviceRegistry';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
 import { traceError } from './common/logger';
@@ -85,7 +85,7 @@ import { registerTypes as interpretersRegisterTypes } from './interpreter/servic
 import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
-import { setLanguageConfiguration } from './language/languageConfiguration';
+import { getLanguageConfiguration } from './language/languageConfiguration';
 import { LinterCommands } from './linters/linterCommands';
 import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
 import { ILintingEngine } from './linters/types';
@@ -176,7 +176,7 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
     const linterProvider = new LinterProvider(context, serviceManager);
     context.subscriptions.push(linterProvider);
 
-    setLanguageConfiguration();
+    languages.setLanguageConfiguration(PYTHON_LANGUAGE, getLanguageConfiguration());
 
     if (pythonSettings && pythonSettings.formatting && pythonSettings.formatting.provider !== 'internalConsole') {
         const formatProvider = new PythonFormattingEditProvider(context, serviceContainer);

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -2,19 +2,24 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { IndentAction, languages } from 'vscode';
-import { PYTHON_LANGUAGE } from '../common/constants';
+import { IndentAction } from 'vscode';
 
 export const MULTILINE_SEPARATOR_INDENT_REGEX = /^(?!\s+\\)[^#\n]+\\$/;
+/**
+ * This does not handle all cases. However, it does handle nearly all usage.
+ * Here's what it does not cover:
+ * - the statement is split over multiple lines (and hence the ":" is on a different line)
+ * - the code block is inlined (after the ":")
+ * - there are multiple statements on the line (separated by semicolons)
+ * Also note that `lambda` is purposefully excluded.
+ */
+export const INCREASE_INDENT_REGEX = /^\s*(?:(?:async|class|def|elif|except|for|if|while|with)\b.*|(else|finally|try))\s*:\s*(#.*)?$/;
+export const DECREASE_INDENT_REGEX = /^\s*(?:else|finally|(?:elif|except)\b.*)\s*:\s*(#.*)?$/;
+export const OUTDENT_ONENTER_REGEX = /^\s*(?:break|continue|pass|(?:raise|return)\b.*)\s*(#.*)?$/;
 
-export function setLanguageConfiguration() {
-    // Enable indentAction
-    languages.setLanguageConfiguration(PYTHON_LANGUAGE, {
+export function getLanguageConfiguration() {
+    return {
         onEnterRules: [
-            {
-                beforeText: /^\s*(?:def|class|for|if|elif|else|while|try|with|finally|except|async)\b.*:\s*/,
-                action: { indentAction: IndentAction.Indent }
-            },
             {
                 beforeText: MULTILINE_SEPARATOR_INDENT_REGEX,
                 action: { indentAction: IndentAction.Indent }
@@ -25,10 +30,13 @@ export function setLanguageConfiguration() {
                 action: { indentAction: IndentAction.None, appendText: '# ' }
             },
             {
-                beforeText: /^\s+(continue|break|return)\b.*/,
-                afterText: /\s+$/,
+                beforeText: OUTDENT_ONENTER_REGEX,
                 action: { indentAction: IndentAction.Outdent }
             }
-        ]
-    });
+        ],
+        indentationRules: {
+            increaseIndentPattern: INCREASE_INDENT_REGEX,
+            decreaseIndentPattern: DECREASE_INDENT_REGEX
+        }
+    };
 }

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -22,16 +22,23 @@ export function getLanguageConfiguration() {
         onEnterRules: [
             {
                 beforeText: MULTILINE_SEPARATOR_INDENT_REGEX,
-                action: { indentAction: IndentAction.Indent }
+                action: {
+                    indentAction: IndentAction.Indent
+                }
             },
             {
                 beforeText: /^\s*#.*/,
                 afterText: /.+$/,
-                action: { indentAction: IndentAction.None, appendText: '# ' }
+                action: {
+                    indentAction: IndentAction.None,
+                    appendText: '# '
+                }
             },
             {
                 beforeText: OUTDENT_ONENTER_REGEX,
-                action: { indentAction: IndentAction.Outdent }
+                action: {
+                    indentAction: IndentAction.Outdent
+                }
             }
         ],
         indentationRules: {

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -3,13 +3,23 @@
 'use strict';
 
 import { IndentAction } from 'vscode';
+import { verboseRegExp } from '../common/utils/regexp';
 
+// tslint:disable:no-multiline-string
+
+// tslint:disable-next-line:max-func-body-length
 export function getLanguageConfiguration() {
     return {
         onEnterRules: [
             // multi-line separator
             {
-                beforeText: /^(?!\s+\\)[^#\n]+\\$/,
+                beforeText: verboseRegExp(`
+                    ^
+                    (?! \\s+ \\\\ )
+                    [^#\n]+
+                    \\\\
+                    $
+                `),
                 action: {
                     indentAction: IndentAction.Indent
                 }
@@ -25,7 +35,20 @@ export function getLanguageConfiguration() {
             },
             // outdent on enter
             {
-                beforeText: /^\s*(?:break|continue|pass|(?:raise|return)\b.*)\s*(#.*)?$/,
+                beforeText: verboseRegExp(`
+                    ^
+                    \\s*
+                    (?:
+                        break |
+                        continue |
+                        pass |
+                        raise \\b .* |
+                        return \\b .*
+                    )
+                    \\s*
+                    ( [#] .* )?
+                    $
+                `),
                 action: {
                     indentAction: IndentAction.Outdent
                 }
@@ -40,8 +63,54 @@ export function getLanguageConfiguration() {
              * - there are multiple statements on the line (separated by semicolons)
              * Also note that `lambda` is purposefully excluded.
              */
-            increaseIndentPattern: /^\s*(?:(?:async|class|def|elif|except|for|if|while|with)\b.*|(else|finally|try))\s*:\s*(#.*)?$/,
-            decreaseIndentPattern: /^\s*(?:else|finally|(?:elif|except)\b.*)\s*:\s*(#.*)?$/
+            increaseIndentPattern: verboseRegExp(`
+                ^
+                \\s*
+                (?:
+                    (?:
+                        (?:
+                            async |
+                            class |
+                            def |
+                            elif |
+                            except |
+                            for |
+                            if |
+                            while |
+                            with
+                        )
+                        \\b .*
+                    ) |
+                    (
+                        else |
+                        finally |
+                        try
+                    )
+                )
+                \\s*
+                [:]
+                \\s*
+                ( [#] .* )?
+                $
+            `),
+            decreaseIndentPattern: verboseRegExp(`
+                ^
+                \\s*
+                (?:
+                    else |
+                    finally |
+                    (?:
+                        elif |
+                        except
+                    )
+                    \\b .*
+                )
+                \\s*
+                [:]
+                \\s*
+                ( [#] .* )?
+                $
+            `)
         }
     };
 }

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -42,12 +42,13 @@ export function getLanguageConfiguration() {
                             \\s*
                             (?:
                                 pass |
-                                raise \\b .* |
+                                raise \\s+ [^#\\s] [^#]*
                             )
                         ) |
                         (?:
                             \\s+
                             (?:
+                                raise |
                                 break |
                                 continue |
                                 return \\b .*
@@ -55,7 +56,7 @@ export function getLanguageConfiguration() {
                         )
                     )
                     \\s*
-                    ( [#] .* )?
+                    (?: [#] .* )?
                     $
                 `),
                 action: {
@@ -74,11 +75,11 @@ export function getLanguageConfiguration() {
              */
             increaseIndentPattern: verboseRegExp(`
                 ^
+                \\s*
                 (?:
-                    \\s*
                     (?:
                         (?:
-                            async |
+                            async \\s+ def |
                             class |
                             def |
                             except |
@@ -97,7 +98,7 @@ export function getLanguageConfiguration() {
                 \\s*
                 [:]
                 \\s*
-                ( [#] .* )?
+                (?: [#] .* )?
                 $
             `),
             decreaseIndentPattern: verboseRegExp(`
@@ -117,7 +118,7 @@ export function getLanguageConfiguration() {
                 \\s*
                 [:]
                 \\s*
-                ( [#] .* )?
+                (?: [#] .* )?
                 $
             `)
         }

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -51,7 +51,7 @@ export function getLanguageConfiguration() {
                                 raise |
                                 break |
                                 continue |
-                                return \\b .*
+                                return
                             )
                         )
                     )

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -37,13 +37,22 @@ export function getLanguageConfiguration() {
             {
                 beforeText: verboseRegExp(`
                     ^
-                    \\s*
                     (?:
-                        break |
-                        continue |
-                        pass |
-                        raise \\b .* |
-                        return \\b .*
+                        (?:
+                            \\s*
+                            (?:
+                                pass |
+                                raise \\b .* |
+                            )
+                        ) |
+                        (?:
+                            \\s+
+                            (?:
+                                break |
+                                continue |
+                                return \\b .*
+                            )
+                        )
                     )
                     \\s*
                     ( [#] .* )?
@@ -65,27 +74,25 @@ export function getLanguageConfiguration() {
              */
             increaseIndentPattern: verboseRegExp(`
                 ^
-                \\s*
                 (?:
+                    \\s*
                     (?:
                         (?:
                             async |
                             class |
                             def |
-                            elif |
                             except |
                             for |
                             if |
+                            elif |
                             while |
                             with
                         )
                         \\b .*
                     ) |
-                    (
-                        else |
-                        finally |
-                        try
-                    )
+                    else |
+                    try |
+                    finally
                 )
                 \\s*
                 [:]
@@ -97,13 +104,15 @@ export function getLanguageConfiguration() {
                 ^
                 \\s*
                 (?:
-                    else |
-                    finally |
                     (?:
-                        elif |
-                        except
-                    )
-                    \\b .*
+                        (?:
+                            elif |
+                            except
+                        )
+                        \\b .*
+                    ) |
+                    else |
+                    finally
                 )
                 \\s*
                 [:]

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -4,28 +4,17 @@
 
 import { IndentAction } from 'vscode';
 
-export const MULTILINE_SEPARATOR_INDENT_REGEX = /^(?!\s+\\)[^#\n]+\\$/;
-/**
- * This does not handle all cases. However, it does handle nearly all usage.
- * Here's what it does not cover:
- * - the statement is split over multiple lines (and hence the ":" is on a different line)
- * - the code block is inlined (after the ":")
- * - there are multiple statements on the line (separated by semicolons)
- * Also note that `lambda` is purposefully excluded.
- */
-export const INCREASE_INDENT_REGEX = /^\s*(?:(?:async|class|def|elif|except|for|if|while|with)\b.*|(else|finally|try))\s*:\s*(#.*)?$/;
-export const DECREASE_INDENT_REGEX = /^\s*(?:else|finally|(?:elif|except)\b.*)\s*:\s*(#.*)?$/;
-export const OUTDENT_ONENTER_REGEX = /^\s*(?:break|continue|pass|(?:raise|return)\b.*)\s*(#.*)?$/;
-
 export function getLanguageConfiguration() {
     return {
         onEnterRules: [
+            // multi-line separator
             {
-                beforeText: MULTILINE_SEPARATOR_INDENT_REGEX,
+                beforeText: /^(?!\s+\\)[^#\n]+\\$/,
                 action: {
                     indentAction: IndentAction.Indent
                 }
             },
+            // continue comments
             {
                 beforeText: /^\s*#.*/,
                 afterText: /.+$/,
@@ -34,16 +23,25 @@ export function getLanguageConfiguration() {
                     appendText: '# '
                 }
             },
+            // outdent on enter
             {
-                beforeText: OUTDENT_ONENTER_REGEX,
+                beforeText: /^\s*(?:break|continue|pass|(?:raise|return)\b.*)\s*(#.*)?$/,
                 action: {
                     indentAction: IndentAction.Outdent
                 }
             }
         ],
         indentationRules: {
-            increaseIndentPattern: INCREASE_INDENT_REGEX,
-            decreaseIndentPattern: DECREASE_INDENT_REGEX
+            /**
+             * This does not handle all cases. However, it does handle nearly all usage.
+             * Here's what it does not cover:
+             * - the statement is split over multiple lines (and hence the ":" is on a different line)
+             * - the code block is inlined (after the ":")
+             * - there are multiple statements on the line (separated by semicolons)
+             * Also note that `lambda` is purposefully excluded.
+             */
+            increaseIndentPattern: /^\s*(?:(?:async|class|def|elif|except|for|if|while|with)\b.*|(else|finally|try))\s*:\s*(#.*)?$/,
+            decreaseIndentPattern: /^\s*(?:else|finally|(?:elif|except)\b.*)\s*:\s*(#.*)?$/
         }
     };
 }

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -50,8 +50,7 @@ export function getLanguageConfiguration() {
                             (?:
                                 raise |
                                 break |
-                                continue |
-                                return
+                                continue
                             )
                         )
                     )

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { IndentAction } from 'vscode';
+import { IndentAction, LanguageConfiguration } from 'vscode';
 import { verboseRegExp } from '../common/utils/regexp';
 
 // tslint:disable:no-multiline-string
 
 // tslint:disable-next-line:max-func-body-length
-export function getLanguageConfiguration() {
+export function getLanguageConfiguration(): LanguageConfiguration {
     return {
         onEnterRules: [
             // multi-line separator
@@ -33,7 +33,49 @@ export function getLanguageConfiguration() {
                     appendText: '# '
                 }
             },
-            // outdent on enter
+            // indent on enter (block-beginning statements)
+            {
+                /**
+                 * This does not handle all cases. However, it does handle nearly all usage.
+                 * Here's what it does not cover:
+                 * - the statement is split over multiple lines (and hence the ":" is on a different line)
+                 * - the code block is inlined (after the ":")
+                 * - there are multiple statements on the line (separated by semicolons)
+                 * Also note that `lambda` is purposefully excluded.
+                 */
+                beforeText: verboseRegExp(`
+                    ^
+                    \\s*
+                    (?:
+                        (?:
+                            (?:
+                                class |
+                                def |
+                                async \\s+ def |
+                                except |
+                                for |
+                                if |
+                                elif |
+                                while |
+                                with
+                            )
+                            \\b .*
+                        ) |
+                        else |
+                        try |
+                        finally
+                    )
+                    \\s*
+                    [:]
+                    \\s*
+                    (?: [#] .* )?
+                    $
+                `),
+                action: {
+                    indentAction: IndentAction.Indent
+                }
+            },
+            // outdent on enter (block-ending statements)
             {
                 beforeText: verboseRegExp(`
                     ^
@@ -62,64 +104,9 @@ export function getLanguageConfiguration() {
                     indentAction: IndentAction.Outdent
                 }
             }
-        ],
-        indentationRules: {
-            /**
-             * This does not handle all cases. However, it does handle nearly all usage.
-             * Here's what it does not cover:
-             * - the statement is split over multiple lines (and hence the ":" is on a different line)
-             * - the code block is inlined (after the ":")
-             * - there are multiple statements on the line (separated by semicolons)
-             * Also note that `lambda` is purposefully excluded.
-             */
-            increaseIndentPattern: verboseRegExp(`
-                ^
-                \\s*
-                (?:
-                    (?:
-                        (?:
-                            async \\s+ def |
-                            class |
-                            def |
-                            except |
-                            for |
-                            if |
-                            elif |
-                            while |
-                            with
-                        )
-                        \\b .*
-                    ) |
-                    else |
-                    try |
-                    finally
-                )
-                \\s*
-                [:]
-                \\s*
-                (?: [#] .* )?
-                $
-            `),
-            decreaseIndentPattern: verboseRegExp(`
-                ^
-                \\s*
-                (?:
-                    (?:
-                        (?:
-                            elif |
-                            except
-                        )
-                        \\b .*
-                    ) |
-                    else |
-                    finally
-                )
-                \\s*
-                [:]
-                \\s*
-                (?: [#] .* )?
-                $
-            `)
-        }
+            // Note that we do not currently have an auto-dedent
+            // solution for "elif", "else", "except", and "finally".
+            // We had one but had to remove it (see issue #6886).
+        ]
     };
 }

--- a/src/test/common/utils/regexp.unit.test.ts
+++ b/src/test/common/utils/regexp.unit.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-multiline-string
+
+import { expect } from 'chai';
+
+import {
+    verboseRegExp
+} from '../../../client/common/utils/regexp';
+
+suite('Utils for regular expressions - verboseRegExp()', () => {
+    test('typical usage', () => {
+        const regex = verboseRegExp(`
+            ^
+            (?:
+                spam \\b .*
+            ) |
+            (?:
+                eggs \\b .*
+            )
+            $
+        `);
+
+        expect(regex.source).to.equal('^(?:spam\\b.*)|(?:eggs\\b.*)$', 'mismatch');
+    });
+
+    const whitespaceTests = [
+        ['spam eggs', 'spameggs'],
+        [`spam
+          eggs`, 'spameggs'],
+        // empty
+        ['  ', '(?:)'],
+        [`
+         `, '(?:)']
+    ];
+    for (const [pat, expected] of whitespaceTests) {
+        test(`whitespace removed ("${pat}")`, () => {
+            const regex = verboseRegExp(pat);
+
+            expect(regex.source).to.equal(expected, 'mismatch');
+        });
+    }
+
+    const noopPatterns = [
+        '^(?:spam\\b.*)$',
+        'spam',
+        '^spam$',
+        'spam$',
+        '^spam'
+    ];
+    for (const pat of noopPatterns) {
+        test(`pattern not changed ("${pat}")`, () => {
+            const regex = verboseRegExp(pat);
+
+            expect(regex.source).to.equal(pat, 'mismatch');
+        });
+    }
+
+    const emptyPatterns = [
+        '',
+        `
+        `,
+        '  '
+    ];
+    for (const pat of emptyPatterns) {
+        test(`no pattern ("${pat}")`, () => {
+            const regex = verboseRegExp(pat);
+
+            expect(regex.source).to.equal('(?:)', 'mismatch');
+        });
+    }
+});

--- a/src/test/common/utils/regexp.unit.test.ts
+++ b/src/test/common/utils/regexp.unit.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../client/common/utils/regexp';
 
 suite('Utils for regular expressions - verboseRegExp()', () => {
-    test('typical usage', () => {
+    test('whitespace removed in multiline pattern (example of typical usage)', () => {
         const regex = verboseRegExp(`
             ^
             (?:

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -5,19 +5,84 @@
 
 import { expect } from 'chai';
 
-import { MULTILINE_SEPARATOR_INDENT_REGEX } from '../../client/language/languageConfiguration';
+import { DECREASE_INDENT_REGEX, INCREASE_INDENT_REGEX, MULTILINE_SEPARATOR_INDENT_REGEX, OUTDENT_ONENTER_REGEX } from '../../client/language/languageConfiguration';
 
 suite('Language configuration regexes', () => {
     test('Multiline separator indent regex should not pick up strings with no multiline separator', async () => {
         const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = "test"');
-        expect (result).to.be.equal(false, 'Multiline separator indent regex for regular strings should not have matches');
+        expect(result).to.be.equal(false, 'Multiline separator indent regex for regular strings should not have matches');
     });
+
     test('Multiline separator indent regex should not pick up strings with escaped characters', async () => {
         const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = \'hello \\n\'');
-        expect (result).to.be.equal(false, 'Multiline separator indent regex for strings with escaped characters should not have matches');
+        expect(result).to.be.equal(false, 'Multiline separator indent regex for strings with escaped characters should not have matches');
     });
+
     test('Multiline separator indent regex should pick up strings ending with a multiline separator', async () => {
         const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = \'multiline \\');
-        expect (result).to.be.equal(true, 'Multiline separator indent regex for strings with newline separator should have matches');
+        expect(result).to.be.equal(true, 'Multiline separator indent regex for strings with newline separator should have matches');
+    });
+
+    [
+        'async def test(self):',
+        'class TestClass:',
+        'def foo(self, node, namespace=""):',
+        'for item in items:',
+        'if foo is None:',
+        'try:',
+        'while \'::\' in macaddress:',
+        'with self.test:'
+    ].forEach(example => {
+        const keyword = example.split(' ')[0];
+
+        test(`Increase indent regex should pick up lines containing the ${keyword} keyword`, async () => {
+            const result = INCREASE_INDENT_REGEX.test(example);
+            expect(result).to.be.equal(true, `Increase indent regex should pick up lines containing the ${keyword} keyword`);
+        });
+
+        test(`Decrease indent regex should not pick up lines containing the ${keyword} keyword`, async () => {
+            const result = DECREASE_INDENT_REGEX.test(example);
+            expect(result).to.be.equal(false, `Decrease indent regex should not pick up lines containing the ${keyword} keyword`);
+        });
+    });
+
+    ['elif x < 5:', 'else:', 'except TestError:', 'finally:'].forEach(example => {
+        const keyword = example.split(' ')[0];
+
+        test(`Increase indent regex should pick up lines containing the ${keyword} keyword`, async () => {
+            const result = INCREASE_INDENT_REGEX.test(example);
+            expect(result).to.be.equal(true, `Increase indent regex should pick up lines containing the ${keyword} keyword`);
+        });
+
+        test(`Decrease indent regex should pick up lines containing the ${keyword} keyword`, async () => {
+            const result = DECREASE_INDENT_REGEX.test(example);
+            expect(result).to.be.equal(true, `Decrease indent regex should pick up lines containing the ${keyword} keyword`);
+        });
+    });
+
+    test('Increase indent regex should not pick up lines without keywords', async () => {
+        const result = INCREASE_INDENT_REGEX.test('a = \'hello \\n \'');
+        expect(result).to.be.equal(false, 'Increase indent regex should not pick up lines without keywords');
+    });
+
+    test('Decrease indent regex should not pick up lines without keywords', async () => {
+        const result = DECREASE_INDENT_REGEX.test('a = \'hello \\n \'');
+        expect(result).to.be.equal(false, 'Decrease indent regex should not pick up lines without keywords');
+    });
+
+    ['    break', '\t\t continue', ' pass', 'raise Exception(\'Unknown Exception\'', '    return [ True, False, False ]'].forEach(example => {
+        const keyword = example.trim().split(' ')[0];
+
+        const testWithoutComments = `Outdent regex for on enter rule should pick up lines containing the ${keyword} keyword`;
+        test(testWithoutComments, () => {
+            const result = OUTDENT_ONENTER_REGEX.test(example);
+            expect(result).to.be.equal(true, testWithoutComments);
+        });
+
+        const testWithComments = `Outdent regex on enter should pick up lines containing the ${keyword} keyword and ending with comments`;
+        test(testWithComments, () => {
+            const result = OUTDENT_ONENTER_REGEX.test(`${example} # test comment`);
+            expect(result).to.be.equal(true, testWithComments);
+        });
     });
 });

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -3,18 +3,67 @@
 
 'use strict';
 
+// tslint:disable:max-func-body-length
+
 import { expect } from 'chai';
 
 import {
     getLanguageConfiguration
 } from '../../client/language/languageConfiguration';
 
+const NEEDS_INDENT = [
+    /^break$/,
+    /^continue$/,
+    /^raise$/,  // only re-raise
+    /^return\b/
+];
+const INDENT_ON_MATCH = [
+    /^async\s+def\b/,
+    /^class\b/,
+    /^def\b/,
+    /^with\b/,
+    /^try\b/,
+    /^except\b/,
+    /^finally\b/,
+    /^while\b/,
+    /^for\b/,
+    /^if\b/,
+    /^elif\b/,
+    /^else\b/
+];
+const DEDENT_ON_MATCH = [
+    /^elif\b/,
+    /^else\b/,
+    /^except\b/,
+    /^finally\b/
+];
+const DEDENT_ON_ENTER = [
+    /^break$/,
+    /^continue$/,
+    /^raise\b/,
+    /^return\b/,
+    /^pass\b/
+];
+
+function isMember(line: string, regexes: RegExp[]): boolean {
+    for (const regex of regexes) {
+        if (regex.test(line)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 suite('Language configuration regexes', () => {
     const cfg = getLanguageConfiguration();
+    const MULTILINE_SEPARATOR_INDENT_REGEX = cfg.onEnterRules[0].beforeText;
     const DECREASE_INDENT_REGEX = cfg.indentationRules.decreaseIndentPattern;
     const INCREASE_INDENT_REGEX = cfg.indentationRules.increaseIndentPattern;
-    const MULTILINE_SEPARATOR_INDENT_REGEX = cfg.onEnterRules[0].beforeText;
     const OUTDENT_ONENTER_REGEX = cfg.onEnterRules[2].beforeText;
+    // To see the actual (non-verbose) regex patterns, un-comment here:
+    //console.log(DECREASE_INDENT_REGEX.source);
+    //console.log(INCREASE_INDENT_REGEX.source);
+    //console.log(OUTDENT_ONENTER_REGEX.source);
 
     test('Multiline separator indent regex should not pick up strings with no multiline separator', async () => {
         const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = "test"');
@@ -32,77 +81,151 @@ suite('Language configuration regexes', () => {
     });
 
     [
+        // compound statements
         'async def test(self):',
-        'class TestClass:',
-        'def foo(self, node, namespace=""):',
+        'async def :',
+        'async :',
+        'class Test:',
+        'class Test(object):',
+        'class :',
+        'def spam():',
+        'def spam(self, node, namespace=""):',
+        'def :',
         'for item in items:',
+        'for item in :',
+        'for :',
         'if foo is None:',
+        'if :',
         'try:',
         'while \'::\' in macaddress:',
-        'with self.test:'
-    ].forEach(example => {
-        const keyword = example.split(' ')[0];
-
-        test(`Increase indent regex should pick up lines containing the ${keyword} keyword`, async () => {
-            const result = INCREASE_INDENT_REGEX.test(example);
-            expect(result).to.be.equal(true, `Increase indent regex should pick up lines containing the ${keyword} keyword`);
-        });
-
-        test(`Decrease indent regex should not pick up lines containing the ${keyword} keyword`, async () => {
-            const result = DECREASE_INDENT_REGEX.test(example);
-            expect(result).to.be.equal(false, `Decrease indent regex should not pick up lines containing the ${keyword} keyword`);
-        });
-    });
-
-    [
+        'while :',
+        'with self.test:',
+        'with :',
         'elif x < 5:',
+        'elif :',
         'else:',
+        //'else if x < 5:',
         'except TestError:',
-        'finally:'
-    ].forEach(example => {
-        const keyword = example.split(' ')[0];
+        'except :',
+        'finally:',
+        // simple statemenhts
+        'pass',
+        'raise Exception(msg)',
+        'raise Exception',
+        'raise',  // re-raise
+        'break',
+        'continue',
+        'return True',
+        'return (True, False, False)',
+        'return [True, False, False]',
+        'return {True, False, False}',
+        'return (',
+        'return [',
+        'return {',
+        'return',
+        // bogus
+        '',
+        ' ',
+        '  '
+    ].forEach(base => {
+        [
+            ['', '', '', ''],
+            // leading
+            ['    ', '', '', ''],
+            ['   ', '', '', ''],  // unusual indent
+            ['\t\t', '', '', ''],
+            // pre-keyword
+            ['x', '', '', ''],
+            // post-keyword
+            ['', 'x', '', ''],
+            // pre-colon
+            ['', '', ' ', ''],
+            // trailing
+            ['', '', '', ' '],
+            ['', '', '', '# a comment'],
+            ['', '', '', ' # ...']
+        ].forEach(whitespace => {
+            const [leading, postKeyword, preColon, trailing] = whitespace;
+            let invalid: string | undefined;
+            if (base.trim() === '') {
+                invalid = 'blank line';
+            } else if (leading === '' && isMember(base, NEEDS_INDENT)) {
+                invalid = 'expected indent';
+            } else if (leading.trim() !== '') {
+                invalid = 'look-alike - pre-keyword';
+            } else if (postKeyword.trim() !== '') {
+                invalid = 'look-alike - post-keyword';
+            }
 
-        test(`Increase indent regex should pick up lines containing the ${keyword} keyword`, async () => {
-            const result = INCREASE_INDENT_REGEX.test(example);
-            expect(result).to.be.equal(true, `Increase indent regex should pick up lines containing the ${keyword} keyword`);
-        });
+            let resolvedBase = base;
+            if (postKeyword !== '') {
+                if (resolvedBase.includes(' ')) {
+                    const kw = resolvedBase.split(' ', 1)[0];
+                    const remainder = resolvedBase.substring(kw.length);
+                    resolvedBase = `${kw}${postKeyword} ${remainder}`;
+                } else {
+                    if (resolvedBase.endsWith(':')) {
+                        resolvedBase = `${resolvedBase.substring(0, resolvedBase.length - 1)}${postKeyword}:`;
+                    } else {
+                        resolvedBase = `${resolvedBase}${postKeyword}`;
+                    }
+                }
+            }
+            if (preColon !== '') {
+                if (resolvedBase.endsWith(':')) {
+                    resolvedBase = `${resolvedBase.substring(0, resolvedBase.length - 1)}${preColon}:`;
+                } else {
+                    return;
+                }
+            }
+            const example = `${leading}${resolvedBase}${trailing}`;
 
-        test(`Decrease indent regex should pick up lines containing the ${keyword} keyword`, async () => {
-            const result = DECREASE_INDENT_REGEX.test(example);
-            expect(result).to.be.equal(true, `Decrease indent regex should pick up lines containing the ${keyword} keyword`);
-        });
-    });
+            if (invalid) {
+                test(`Line "${example}" ignored (${invalid})`, () => {
+                    let result = INCREASE_INDENT_REGEX.test(example);
+                    expect(result).to.be.equal(false, 'unexpected match');
 
-    test('Increase indent regex should not pick up lines without keywords', async () => {
-        const result = INCREASE_INDENT_REGEX.test('a = \'hello \\n \'');
-        expect(result).to.be.equal(false, 'Increase indent regex should not pick up lines without keywords');
-    });
+                    result = DECREASE_INDENT_REGEX.test(example);
+                    expect(result).to.be.equal(false, 'unexpected match');
 
-    test('Decrease indent regex should not pick up lines without keywords', async () => {
-        const result = DECREASE_INDENT_REGEX.test('a = \'hello \\n \'');
-        expect(result).to.be.equal(false, 'Decrease indent regex should not pick up lines without keywords');
-    });
+                    result = OUTDENT_ONENTER_REGEX.test(example);
+                    expect(result).to.be.equal(false, 'unexpected match');
+                });
+                return;
+            }
 
-    [
-        '    break',
-        '\t\t continue',
-        ' pass',
-        'raise Exception(\'Unknown Exception\'',
-        '    return',
-        '    return [ True, False, False ]'
-    ].forEach(example => {
-        const keyword = example.trim().split(' ')[0];
+            test(`Check indent-on-match for line "${example}"`, () => {
+                let expected = false;
+                if (isMember(base, INDENT_ON_MATCH)) {
+                    expected = true;
+                }
 
-        const testWithoutComments = `Outdent regex for on enter rule should pick up lines containing the ${keyword} keyword`;
-        test(testWithoutComments, () => {
-            const result = OUTDENT_ONENTER_REGEX.test(example);
-            expect(result).to.be.equal(true, testWithoutComments);
-        });
+                const result = INCREASE_INDENT_REGEX.test(example);
 
-        const testWithComments = `Outdent regex on enter should pick up lines containing the ${keyword} keyword and ending with comments`;
-        test(testWithComments, () => {
-            const result = OUTDENT_ONENTER_REGEX.test(`${example} # test comment`);
-            expect(result).to.be.equal(true, testWithComments);
+                expect(result).to.be.equal(expected, 'unexpected result');
+            });
+
+            test(`Check dedent-on-match for line "${example}"`, () => {
+                let expected = false;
+                if (isMember(base, DEDENT_ON_MATCH)) {
+                    expected = true;
+                }
+
+                const result = DECREASE_INDENT_REGEX.test(example);
+
+                expect(result).to.be.equal(expected, 'unexpected result');
+            });
+
+            test(`Check dedent-on-enter for line "${example}"`, () => {
+                let expected = false;
+                if (isMember(base, DEDENT_ON_ENTER)) {
+                    expected = true;
+                }
+
+                const result = OUTDENT_ONENTER_REGEX.test(example);
+
+                expect(result).to.be.equal(expected, 'unexpected result');
+            });
         });
     });
 });

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -92,162 +92,164 @@ function resolveExample(
     return [example, invalid, false];
 }
 
-const cfg = getLanguageConfiguration();
+suite('Language Configuration', () => {
+    const cfg = getLanguageConfiguration();
 
-suite('Language configuration - brackets', () => {
-    test('brackets is not defined', () => {
-        expect(cfg.brackets).to.be.equal(undefined, 'missing tests');
-    });
-});
-
-suite('Language configuration - comments', () => {
-    test('comments is not defined', () => {
-        expect(cfg.comments).to.be.equal(undefined, 'missing tests');
-    });
-});
-
-suite('Language configuration - indentationRules', () => {
-    test('indentationRules is not defined', () => {
-        expect(cfg.indentationRules).to.be.equal(undefined, 'missing tests');
-    });
-});
-
-suite('Language configuration - onEnterRules', () => {
-    const MULTILINE_SEPARATOR_INDENT_REGEX = cfg.onEnterRules![0].beforeText;
-    const INDENT_ONENTER_REGEX = cfg.onEnterRules![2].beforeText;
-    const OUTDENT_ONENTER_REGEX = cfg.onEnterRules![3].beforeText;
-    // To see the actual (non-verbose) regex patterns, un-comment
-    // the following lines:
-    //console.log(INDENT_ONENTER_REGEX.source);
-    //console.log(OUTDENT_ONENTER_REGEX.source);
-
-    test('Multiline separator indent regex should not pick up strings with no multiline separator', async () => {
-        const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = "test"');
-        expect(result).to.be.equal(false, 'Multiline separator indent regex for regular strings should not have matches');
+    suite('"brackets"', () => {
+        test('brackets is not defined', () => {
+            expect(cfg.brackets).to.be.equal(undefined, 'missing tests');
+        });
     });
 
-    test('Multiline separator indent regex should not pick up strings with escaped characters', async () => {
-        const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = \'hello \\n\'');
-        expect(result).to.be.equal(false, 'Multiline separator indent regex for strings with escaped characters should not have matches');
+    suite('"comments"', () => {
+        test('comments is not defined', () => {
+            expect(cfg.comments).to.be.equal(undefined, 'missing tests');
+        });
     });
 
-    test('Multiline separator indent regex should pick up strings ending with a multiline separator', async () => {
-        const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = \'multiline \\');
-        expect(result).to.be.equal(true, 'Multiline separator indent regex for strings with newline separator should have matches');
+    suite('"indentationRules"', () => {
+        test('indentationRules is not defined', () => {
+            expect(cfg.indentationRules).to.be.equal(undefined, 'missing tests');
+        });
     });
 
-    [
-        // compound statements
-        'async def test(self):',
-        'async def :',
-        'async :',
-        'class Test:',
-        'class Test(object):',
-        'class :',
-        'def spam():',
-        'def spam(self, node, namespace=""):',
-        'def :',
-        'for item in items:',
-        'for item in :',
-        'for :',
-        'if foo is None:',
-        'if :',
-        'try:',
-        'while \'::\' in macaddress:',
-        'while :',
-        'with self.test:',
-        'with :',
-        'elif x < 5:',
-        'elif :',
-        'else:',
-        'except TestError:',
-        'except :',
-        'finally:',
-        // simple statemenhts
-        'pass',
-        'raise Exception(msg)',
-        'raise Exception',
-        'raise',  // re-raise
-        'break',
-        'continue',
-        'return',
-        'return True',
-        'return (True, False, False)',
-        'return [True, False, False]',
-        'return {True, False, False}',
-        'return (',
-        'return [',
-        'return {',
-        'return',
-        // bogus
-        '',
-        ' ',
-        '  '
-    ].forEach(base => {
+    suite('"onEnterRules"', () => {
+        const MULTILINE_SEPARATOR_INDENT_REGEX = cfg.onEnterRules![0].beforeText;
+        const INDENT_ONENTER_REGEX = cfg.onEnterRules![2].beforeText;
+        const OUTDENT_ONENTER_REGEX = cfg.onEnterRules![3].beforeText;
+        // To see the actual (non-verbose) regex patterns, un-comment
+        // the following lines:
+        //console.log(INDENT_ONENTER_REGEX.source);
+        //console.log(OUTDENT_ONENTER_REGEX.source);
+
+        test('Multiline separator indent regex should not pick up strings with no multiline separator', async () => {
+            const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = "test"');
+            expect(result).to.be.equal(false, 'Multiline separator indent regex for regular strings should not have matches');
+        });
+
+        test('Multiline separator indent regex should not pick up strings with escaped characters', async () => {
+            const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = \'hello \\n\'');
+            expect(result).to.be.equal(false, 'Multiline separator indent regex for strings with escaped characters should not have matches');
+        });
+
+        test('Multiline separator indent regex should pick up strings ending with a multiline separator', async () => {
+            const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = \'multiline \\');
+            expect(result).to.be.equal(true, 'Multiline separator indent regex for strings with newline separator should have matches');
+        });
+
         [
-            ['', '', '', ''],
-            // leading
-            ['    ', '', '', ''],
-            ['   ', '', '', ''],  // unusual indent
-            ['\t\t', '', '', ''],
-            // pre-keyword
-            ['x', '', '', ''],
-            // post-keyword
-            ['', 'x', '', ''],
-            // pre-colon
-            ['', '', ' ', ''],
-            // trailing
-            ['', '', '', ' '],
-            ['', '', '', '# a comment'],
-            ['', '', '', ' # ...']
-        ].forEach(whitespace => {
-            const [leading, postKeyword, preColon, trailing] = whitespace;
-            const [_example, invalid, ignored] = resolveExample(base, leading, postKeyword, preColon, trailing);
-            if (ignored) {
-                return;
-            }
-            const example = _example!;
+            // compound statements
+            'async def test(self):',
+            'async def :',
+            'async :',
+            'class Test:',
+            'class Test(object):',
+            'class :',
+            'def spam():',
+            'def spam(self, node, namespace=""):',
+            'def :',
+            'for item in items:',
+            'for item in :',
+            'for :',
+            'if foo is None:',
+            'if :',
+            'try:',
+            'while \'::\' in macaddress:',
+            'while :',
+            'with self.test:',
+            'with :',
+            'elif x < 5:',
+            'elif :',
+            'else:',
+            'except TestError:',
+            'except :',
+            'finally:',
+            // simple statemenhts
+            'pass',
+            'raise Exception(msg)',
+            'raise Exception',
+            'raise',  // re-raise
+            'break',
+            'continue',
+            'return',
+            'return True',
+            'return (True, False, False)',
+            'return [True, False, False]',
+            'return {True, False, False}',
+            'return (',
+            'return [',
+            'return {',
+            'return',
+            // bogus
+            '',
+            ' ',
+            '  '
+        ].forEach(base => {
+            [
+                ['', '', '', ''],
+                // leading
+                ['    ', '', '', ''],
+                ['   ', '', '', ''],  // unusual indent
+                ['\t\t', '', '', ''],
+                // pre-keyword
+                ['x', '', '', ''],
+                // post-keyword
+                ['', 'x', '', ''],
+                // pre-colon
+                ['', '', ' ', ''],
+                // trailing
+                ['', '', '', ' '],
+                ['', '', '', '# a comment'],
+                ['', '', '', ' # ...']
+            ].forEach(whitespace => {
+                const [leading, postKeyword, preColon, trailing] = whitespace;
+                const [_example, invalid, ignored] = resolveExample(base, leading, postKeyword, preColon, trailing);
+                if (ignored) {
+                    return;
+                }
+                const example = _example!;
 
-            if (invalid) {
-                test(`Line "${example}" ignored (${invalid})`, () => {
-                    let result: boolean;
+                if (invalid) {
+                    test(`Line "${example}" ignored (${invalid})`, () => {
+                        let result: boolean;
 
-                    result = INDENT_ONENTER_REGEX.test(example);
-                    expect(result).to.be.equal(false, 'unexpected match');
+                        result = INDENT_ONENTER_REGEX.test(example);
+                        expect(result).to.be.equal(false, 'unexpected match');
 
-                    result = OUTDENT_ONENTER_REGEX.test(example);
-                    expect(result).to.be.equal(false, 'unexpected match');
+                        result = OUTDENT_ONENTER_REGEX.test(example);
+                        expect(result).to.be.equal(false, 'unexpected match');
+                    });
+                    return;
+                }
+
+                test(`Check indent-on-enter for line "${example}"`, () => {
+                    let expected = false;
+                    if (isMember(base, INDENT_ON_ENTER)) {
+                        expected = true;
+                    }
+
+                    const result = INDENT_ONENTER_REGEX.test(example);
+
+                    expect(result).to.be.equal(expected, 'unexpected result');
                 });
-                return;
-            }
 
-            test(`Check indent-on-enter for line "${example}"`, () => {
-                let expected = false;
-                if (isMember(base, INDENT_ON_ENTER)) {
-                    expected = true;
-                }
+                test(`Check dedent-on-enter for line "${example}"`, () => {
+                    let expected = false;
+                    if (isMember(base, DEDENT_ON_ENTER)) {
+                        expected = true;
+                    }
 
-                const result = INDENT_ONENTER_REGEX.test(example);
+                    const result = OUTDENT_ONENTER_REGEX.test(example);
 
-                expect(result).to.be.equal(expected, 'unexpected result');
-            });
-
-            test(`Check dedent-on-enter for line "${example}"`, () => {
-                let expected = false;
-                if (isMember(base, DEDENT_ON_ENTER)) {
-                    expected = true;
-                }
-
-                const result = OUTDENT_ONENTER_REGEX.test(example);
-
-                expect(result).to.be.equal(expected, 'unexpected result');
+                    expect(result).to.be.equal(expected, 'unexpected result');
+                });
             });
         });
     });
-});
 
-suite('Language configuration - wordPattern', () => {
-    test('wordPattern is not defined', () => {
-        expect(cfg.wordPattern).to.be.equal(undefined, 'missing tests');
+    suite('"wordPattern"', () => {
+        test('wordPattern is not defined', () => {
+            expect(cfg.wordPattern).to.be.equal(undefined, 'missing tests');
+        });
     });
 });

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -54,7 +54,12 @@ suite('Language configuration regexes', () => {
         });
     });
 
-    ['elif x < 5:', 'else:', 'except TestError:', 'finally:'].forEach(example => {
+    [
+        'elif x < 5:',
+        'else:',
+        'except TestError:',
+        'finally:'
+    ].forEach(example => {
         const keyword = example.split(' ')[0];
 
         test(`Increase indent regex should pick up lines containing the ${keyword} keyword`, async () => {
@@ -78,7 +83,13 @@ suite('Language configuration regexes', () => {
         expect(result).to.be.equal(false, 'Decrease indent regex should not pick up lines without keywords');
     });
 
-    ['    break', '\t\t continue', ' pass', 'raise Exception(\'Unknown Exception\'', '    return [ True, False, False ]'].forEach(example => {
+    [
+        '    break',
+        '\t\t continue',
+        ' pass',
+        'raise Exception(\'Unknown Exception\'',
+        '    return [ True, False, False ]'
+    ].forEach(example => {
         const keyword = example.trim().split(' ')[0];
 
         const testWithoutComments = `Outdent regex for on enter rule should pick up lines containing the ${keyword} keyword`;

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -88,6 +88,7 @@ suite('Language configuration regexes', () => {
         '\t\t continue',
         ' pass',
         'raise Exception(\'Unknown Exception\'',
+        '    return',
         '    return [ True, False, False ]'
     ].forEach(example => {
         const keyword = example.trim().split(' ')[0];

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -41,7 +41,7 @@ const DEDENT_ON_ENTER = [
     /^break$/,
     /^continue$/,
     /^raise\b/,
-    /^return\b/,
+    /^return$/,
     /^pass\b/
 ];
 
@@ -115,6 +115,7 @@ suite('Language configuration regexes', () => {
         'raise',  // re-raise
         'break',
         'continue',
+        'return',
         'return True',
         'return (True, False, False)',
         'return [True, False, False]',

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -105,7 +105,6 @@ suite('Language configuration regexes', () => {
         'elif x < 5:',
         'elif :',
         'else:',
-        //'else if x < 5:',
         'except TestError:',
         'except :',
         'finally:',

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -41,7 +41,8 @@ const DEDENT_ON_ENTER = [
     /^break$/,
     /^continue$/,
     /^raise\b/,
-    /^return$/,
+    // For now we are ignoring "return" completely.  See gh-6564.
+    ///^return\b/,
     /^pass\b/
 ];
 

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -32,11 +32,11 @@ const INDENT_ON_ENTER = [  // block-beginning statements
     /^else\b/
 ];
 const DEDENT_ON_ENTER = [  // block-ending statements
+    // For now we are ignoring "return" completely.  See gh-6564.
+    ///^return\b/,
     /^break$/,
     /^continue$/,
     /^raise\b/,
-    // For now we are ignoring "return" completely.  See gh-6564.
-    ///^return\b/,
     /^pass\b/
 ];
 

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -5,9 +5,17 @@
 
 import { expect } from 'chai';
 
-import { DECREASE_INDENT_REGEX, INCREASE_INDENT_REGEX, MULTILINE_SEPARATOR_INDENT_REGEX, OUTDENT_ONENTER_REGEX } from '../../client/language/languageConfiguration';
+import {
+    getLanguageConfiguration
+} from '../../client/language/languageConfiguration';
 
 suite('Language configuration regexes', () => {
+    const cfg = getLanguageConfiguration();
+    const DECREASE_INDENT_REGEX = cfg.indentationRules.decreaseIndentPattern;
+    const INCREASE_INDENT_REGEX = cfg.indentationRules.increaseIndentPattern;
+    const MULTILINE_SEPARATOR_INDENT_REGEX = cfg.onEnterRules[0].beforeText;
+    const OUTDENT_ONENTER_REGEX = cfg.onEnterRules[2].beforeText;
+
     test('Multiline separator indent regex should not pick up strings with no multiline separator', async () => {
         const result = MULTILINE_SEPARATOR_INDENT_REGEX.test('a = "test"');
         expect(result).to.be.equal(false, 'Multiline separator indent regex for regular strings should not have matches');

--- a/src/test/mocks/vsc/index.ts
+++ b/src/test/mocks/vsc/index.ts
@@ -172,6 +172,12 @@ export namespace vscMock {
         Operator = 24,
         TypeParameter = 25
     }
+    export enum IndentAction {
+        None = 0,
+        Indent = 1,
+        IndentOutdent = 2,
+        Outdent = 3
+    }
 
     export class CodeActionKind {
         public static readonly Empty: CodeActionKind = new CodeActionKind('empty');

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -54,6 +54,7 @@ mockedVSCode.EventEmitter = vscodeMocks.vscMock.EventEmitter;
 mockedVSCode.CancellationTokenSource = vscodeMocks.vscMock.CancellationTokenSource;
 mockedVSCode.CompletionItemKind = vscodeMocks.vscMock.CompletionItemKind;
 mockedVSCode.SymbolKind = vscodeMocks.vscMock.SymbolKind;
+mockedVSCode.IndentAction = vscodeMocks.vscMock.IndentAction;
 mockedVSCode.Uri = vscodeMocks.vscMock.Uri as any;
 mockedVSCode.Range = vscodeMocks.vscMockExtHostedTypes.Range;
 mockedVSCode.Position = vscodeMocks.vscMockExtHostedTypes.Position;


### PR DESCRIPTION
(for #6813)

We'll work on adding support back in #6564.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
