### PR TITLE
Hash providers for Python Interpreters

### DIFF
--- a/package.json
+++ b/package.json
@@ -2436,7 +2436,7 @@
         "compile-webviews-verbose": "npx webpack --config webpack.datascience-ui.config.js",
         "postinstall": "node ./build/ci/postInstall.js",
         "test": "node ./out/test/standardTest.js && node ./out/test/multiRootTest.js",
-        "test:unittests": "mocha --opts ./build/.mocha.unittests.js.opts --grep='Interpretersx'",
+        "test:unittests": "mocha --opts ./build/.mocha.unittests.js.opts",
         "test:unittests:cover": "nyc --silent --no-clean --nycrc-path build/.nycrc mocha --opts ./build/.mocha.unittests.ts.opts",
         "test:functional": "mocha --require source-map-support/register --opts ./build/.mocha.functional.opts",
         "test:functional:cover": "npm run test:functional",

--- a/package.json
+++ b/package.json
@@ -2436,7 +2436,7 @@
         "compile-webviews-verbose": "npx webpack --config webpack.datascience-ui.config.js",
         "postinstall": "node ./build/ci/postInstall.js",
         "test": "node ./out/test/standardTest.js && node ./out/test/multiRootTest.js",
-        "test:unittests": "mocha --opts ./build/.mocha.unittests.js.opts",
+        "test:unittests": "mocha --opts ./build/.mocha.unittests.js.opts --grep='Interpretersx'",
         "test:unittests:cover": "nyc --silent --no-clean --nycrc-path build/.nycrc mocha --opts ./build/.mocha.unittests.ts.opts",
         "test:functional": "mocha --require source-map-support/register --opts ./build/.mocha.functional.opts",
         "test:functional:cover": "npm run test:functional",

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -38,7 +38,7 @@ export type CondaInfo = {
     envs?: string[];
     'sys.version'?: string;
     'sys.prefix'?: string;
-    'python_version'?: string;
+    python_version?: string;
     default_prefix?: string;
     conda_version?: string;
 };
@@ -64,7 +64,8 @@ export enum InterpreterType {
     VirtualEnv = 'VirtualEnv',
     Pipenv = 'PipEnv',
     Pyenv = 'Pyenv',
-    Venv = 'Venv'
+    Venv = 'Venv',
+    WindowsStore = 'WindowsStore'
 }
 export type PythonInterpreter = InterpreterInfomation & {
     companyDisplayName?: string;

--- a/src/client/interpreter/locators/services/hashProvider.ts
+++ b/src/client/interpreter/locators/services/hashProvider.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { IFileSystem } from '../../../common/platform/types';
+import { IInterpreterHashProvider } from '../types';
+
+@injectable()
+export class InterpreterHashProvider implements IInterpreterHashProvider {
+    constructor(@inject(IFileSystem) private readonly fs: IFileSystem) {}
+    public async getInterpreterHash(pythonPath: string): Promise<string> {
+        return this.fs.getFileHash(pythonPath);
+    }
+}

--- a/src/client/interpreter/locators/services/hashProviderFactory.ts
+++ b/src/client/interpreter/locators/services/hashProviderFactory.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { IConfigurationService } from '../../../common/types';
+import { IInterpreterHashProvider, IInterpreterHashProviderFactory, IWindowsStoreInterpreter } from '../types';
+import { InterpreterHashProvider } from './hashProvider';
+import { WindowsStoreInterpreter } from './windowsStoreInterpreter';
+
+@injectable()
+export class InterpeterHashProviderFactory implements IInterpreterHashProviderFactory {
+    constructor(
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(WindowsStoreInterpreter) private readonly windowsStoreInterpreter: IWindowsStoreInterpreter,
+        @inject(WindowsStoreInterpreter) private readonly windowsStoreHashProvider: IInterpreterHashProvider,
+        @inject(InterpreterHashProvider) private readonly hashProvider: IInterpreterHashProvider
+    ) {}
+
+    public async create(options: { pythonPath: string } | { resource: Uri }): Promise<IInterpreterHashProvider> {
+        const pythonPath = 'pythonPath' in options ? options.pythonPath : this.configService.getSettings(options.resource).pythonPath;
+        return this.windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath) ? this.windowsStoreHashProvider : this.hashProvider;
+    }
+}

--- a/src/client/interpreter/locators/services/windowsRegistryService.ts
+++ b/src/client/interpreter/locators/services/windowsRegistryService.ts
@@ -3,14 +3,17 @@ import * as fs from 'fs-extra';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
+import { traceError } from '../../../common/logger';
 import { IPlatformService, IRegistry, RegistryHive } from '../../../common/platform/types';
 import { IPathUtils } from '../../../common/types';
 import { Architecture } from '../../../common/utils/platform';
 import { parsePythonVersion } from '../../../common/utils/version';
 import { IServiceContainer } from '../../../ioc/types';
 import { IInterpreterHelper, InterpreterType, PythonInterpreter } from '../../contracts';
+import { IWindowsStoreInterpreter } from '../types';
 import { CacheableLocatorService } from './cacheableLocatorService';
 import { AnacondaCompanyName, AnacondaCompanyNames } from './conda';
+import { WindowsStoreInterpreter } from './windowsStoreInterpreter';
 const flatten = require('lodash/flatten') as typeof import('lodash/flatten');
 
 // tslint:disable-next-line:variable-name
@@ -31,54 +34,59 @@ type CompanyInterpreter = {
 @injectable()
 export class WindowsRegistryService extends CacheableLocatorService {
     private readonly pathUtils: IPathUtils;
-    constructor(@inject(IRegistry) private registry: IRegistry,
+    constructor(
+        @inject(IRegistry) private registry: IRegistry,
         @inject(IPlatformService) private readonly platform: IPlatformService,
-        @inject(IServiceContainer) serviceContainer: IServiceContainer) {
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(WindowsStoreInterpreter) private readonly windowsStoreInterpreter: IWindowsStoreInterpreter
+    ) {
         super('WindowsRegistryService', serviceContainer);
         this.pathUtils = serviceContainer.get<IPathUtils>(IPathUtils);
     }
     // tslint:disable-next-line:no-empty
-    public dispose() { }
+    public dispose() {}
     protected async getInterpretersImplementation(_resource?: Uri): Promise<PythonInterpreter[]> {
         return this.platform.isWindows ? this.getInterpretersFromRegistry() : [];
     }
     private async getInterpretersFromRegistry() {
         // https://github.com/python/peps/blob/master/pep-0514.txt#L357
         const hkcuArch = this.platform.is64bit ? undefined : Architecture.x86;
-        const promises: Promise<CompanyInterpreter[]>[] = [
-            this.getCompanies(RegistryHive.HKCU, hkcuArch),
-            this.getCompanies(RegistryHive.HKLM, Architecture.x86)
-        ];
+        const promises: Promise<CompanyInterpreter[]>[] = [this.getCompanies(RegistryHive.HKCU, hkcuArch), this.getCompanies(RegistryHive.HKLM, Architecture.x86)];
         // https://github.com/Microsoft/PTVS/blob/ebfc4ca8bab234d453f15ee426af3b208f3c143c/Python/Product/Cookiecutter/Shared/Interpreters/PythonRegistrySearch.cs#L44
         if (this.platform.is64bit) {
             promises.push(this.getCompanies(RegistryHive.HKLM, Architecture.x64));
         }
 
         const companies = await Promise.all<CompanyInterpreter[]>(promises);
-        const companyInterpreters = await Promise.all(flatten(companies)
-            .filter(item => item !== undefined && item !== null)
-            .map(company => {
-                return this.getInterpretersForCompany(company.companyKey, company.hive, company.arch);
-            }));
+        const companyInterpreters = await Promise.all(
+            flatten(companies)
+                .filter(item => item !== undefined && item !== null)
+                .map(company => {
+                    return this.getInterpretersForCompany(company.companyKey, company.hive, company.arch);
+                })
+        );
 
-        return flatten(companyInterpreters)
-            .filter(item => item !== undefined && item !== null)
-            // tslint:disable-next-line:no-non-null-assertion
-            .map(item => item!)
-            .reduce<PythonInterpreter[]>((prev, current) => {
-                if (prev.findIndex(item => item.path.toUpperCase() === current.path.toUpperCase()) === -1) {
-                    prev.push(current);
-                }
-                return prev;
-            }, []);
+        return (
+            flatten(companyInterpreters)
+                .filter(item => item !== undefined && item !== null)
+                // tslint:disable-next-line:no-non-null-assertion
+                .map(item => item!)
+                .reduce<PythonInterpreter[]>((prev, current) => {
+                    if (prev.findIndex(item => item.path.toUpperCase() === current.path.toUpperCase()) === -1) {
+                        prev.push(current);
+                    }
+                    return prev;
+                }, [])
+        );
     }
     private async getCompanies(hive: RegistryHive, arch?: Architecture): Promise<CompanyInterpreter[]> {
-        return this.registry.getKeys('\\Software\\Python', hive, arch)
-            .then(companyKeys => companyKeys
+        return this.registry.getKeys('\\Software\\Python', hive, arch).then(companyKeys =>
+            companyKeys
                 .filter(companyKey => CompaniesToIgnore.indexOf(this.pathUtils.basename(companyKey).toUpperCase()) === -1)
                 .map(companyKey => {
                     return { companyKey, hive, arch };
-                }));
+                })
+        );
     }
     private async getInterpretersForCompany(companyKey: string, hive: RegistryHive, arch?: Architecture) {
         const tagKeys = await this.registry.getKeys(companyKey, hive, arch);
@@ -86,14 +94,18 @@ export class WindowsRegistryService extends CacheableLocatorService {
     }
     private getInreterpreterDetailsForCompany(tagKey: string, companyKey: string, hive: RegistryHive, arch?: Architecture): Promise<PythonInterpreter | undefined | null> {
         const key = `${tagKey}\\InstallPath`;
-        type InterpreterInformation = null | undefined | {
-            installPath: string;
-            executablePath?: string;
-            displayName?: string;
-            version?: string;
-            companyDisplayName?: string;
-        };
-        return this.registry.getValue(key, hive, arch)
+        type InterpreterInformation =
+            | null
+            | undefined
+            | {
+                  installPath: string;
+                  executablePath?: string;
+                  displayName?: string;
+                  version?: string;
+                  companyDisplayName?: string;
+              };
+        return this.registry
+            .getValue(key, hive, arch)
             .then(installPath => {
                 // Install path is mandatory.
                 if (!installPath) {
@@ -107,19 +119,25 @@ export class WindowsRegistryService extends CacheableLocatorService {
                     this.registry.getValue(key, hive, arch, 'ExecutablePath'),
                     this.registry.getValue(tagKey, hive, arch, 'SysVersion'),
                     this.getCompanyDisplayName(companyKey, hive, arch)
-                ])
-                    .then(([installedPath, executablePath, version, companyDisplayName]) => {
-                        companyDisplayName = AnacondaCompanyNames.indexOf(companyDisplayName) === -1 ? companyDisplayName : AnacondaCompanyName;
-                        // tslint:disable-next-line:prefer-type-cast no-object-literal-type-assertion
-                        return { installPath: installedPath, executablePath, version, companyDisplayName } as InterpreterInformation;
-                    });
+                ]).then(([installedPath, executablePath, version, companyDisplayName]) => {
+                    companyDisplayName = AnacondaCompanyNames.indexOf(companyDisplayName) === -1 ? companyDisplayName : AnacondaCompanyName;
+                    // tslint:disable-next-line:prefer-type-cast no-object-literal-type-assertion
+                    return { installPath: installedPath, executablePath, version, companyDisplayName } as InterpreterInformation;
+                });
             })
             .then(async (interpreterInfo?: InterpreterInformation) => {
                 if (!interpreterInfo) {
                     return;
                 }
 
-                const executablePath = interpreterInfo.executablePath && interpreterInfo.executablePath.length > 0 ? interpreterInfo.executablePath : path.join(interpreterInfo.installPath, DefaultPythonExecutable);
+                const executablePath =
+                    interpreterInfo.executablePath && interpreterInfo.executablePath.length > 0
+                        ? interpreterInfo.executablePath
+                        : path.join(interpreterInfo.installPath, DefaultPythonExecutable);
+
+                if (this.windowsStoreInterpreter.isInternalInterpreter(executablePath)) {
+                    return;
+                }
                 const helper = this.serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
                 const details = await helper.getInterpreterInformation(executablePath);
                 if (!details) {
@@ -135,17 +153,23 @@ export class WindowsRegistryService extends CacheableLocatorService {
                     // Give preference to what we have retrieved from getInterpreterInformation.
                     version: details.version || parsePythonVersion(version),
                     companyDisplayName: interpreterInfo.companyDisplayName,
-                    type: InterpreterType.Unknown
+                    type: this.windowsStoreInterpreter.isWindowsStoreInterpreter(executablePath) ? InterpreterType.WindowsStore : InterpreterType.Unknown
                 } as PythonInterpreter;
             })
-            .then(interpreter => interpreter ? fs.pathExists(interpreter.path).catch(() => false).then(exists => exists ? interpreter : null) : null)
+            .then(interpreter =>
+                interpreter
+                    ? fs
+                          .pathExists(interpreter.path)
+                          .catch(() => false)
+                          .then(exists => (exists ? interpreter : null))
+                    : null
+            )
             .catch(error => {
-                console.error(`Failed to retrieve interpreter details for company ${companyKey},tag: ${tagKey}, hive: ${hive}, arch: ${arch}`);
-                console.error(error);
+                traceError(`Failed to retrieve interpreter details for company ${companyKey},tag: ${tagKey}, hive: ${hive}, arch: ${arch}`, error);
                 return null;
             });
     }
-    private async  getCompanyDisplayName(companyKey: string, hive: RegistryHive, arch?: Architecture) {
+    private async getCompanyDisplayName(companyKey: string, hive: RegistryHive, arch?: Architecture) {
         const displayName = await this.registry.getValue(companyKey, hive, arch, 'DisplayName');
         if (displayName && displayName.length > 0) {
             return displayName;

--- a/src/client/interpreter/locators/services/windowsRegistryService.ts
+++ b/src/client/interpreter/locators/services/windowsRegistryService.ts
@@ -135,7 +135,7 @@ export class WindowsRegistryService extends CacheableLocatorService {
                         ? interpreterInfo.executablePath
                         : path.join(interpreterInfo.installPath, DefaultPythonExecutable);
 
-                if (this.windowsStoreInterpreter.isInternalInterpreter(executablePath)) {
+                if (this.windowsStoreInterpreter.isHiddenInterpreter(executablePath)) {
                     return;
                 }
                 const helper = this.serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);

--- a/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
+++ b/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
@@ -10,6 +10,29 @@ import { IPythonExecutionFactory } from '../../../common/process/types';
 import { IPersistentStateFactory } from '../../../common/types';
 import { IInterpreterHashProvider, IWindowsStoreInterpreter } from '../types';
 
+/**
+ * The default location of Windows apps are `%ProgramFiles%\WindowsApps`.
+ * (https://www.samlogic.net/articles/windows-8-windowsapps-folder.htm)
+ * When users access Python interpreter it is installed in `<users local folder>\Microsoft\WindowsApps`
+ * Based on our testing this is where Python interpreters installed from Windows Store is always installed.
+ * (unforutnately couldn't find any documentation on this).
+ * What we've identified is the fact that:
+ * - The Python interpreter in Microsoft\WIndowsApps\python.exe is a symbolic link to files located in:
+ *  - Program Files\WindowsApps\ & Microsoft\WindowsApps\PythonSoftwareFoundation
+ * - I.e. they all point to the same place.
+ * However when the user lauches the executabale, its located in `Microsoft\WindowsAapps\python.exe`
+ * Hence for all intensive purposes that's the main executable, that's what the user uses.
+ * As a result:
+ * - We'll only display what the user has access to, that being `Microsoft\WindowsAapps\python.exe`
+ * - Others are hidden.
+ *
+ * Details can be found here (original issue https://github.com/microsoft/vscode-python/issues/5926).
+ *
+ * @export
+ * @class WindowsStoreInterpreter
+ * @implements {IWindowsStoreInterpreter}
+ * @implements {IInterpreterHashProvider}
+ */
 @injectable()
 export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInterpreterHashProvider {
     constructor(
@@ -40,7 +63,7 @@ export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInter
      * @returns {Promise<boolean>}
      * @memberof IInterpreterHelper
      */
-    public isInternalInterpreter(pythonPath: string): boolean {
+    public isHiddenInterpreter(pythonPath: string): boolean {
         const pythonPathToCompare = pythonPath.toUpperCase().replace(/\//g, '\\');
         return (
             pythonPathToCompare.includes('\\Program Files\\WindowsApps\\'.toUpperCase()) ||
@@ -55,7 +78,10 @@ export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInter
      * Using fs.lstat or similar nodejs functions do not work, as these are some weird form of symbolic linked files.
      *
      * Note: Store the hash in a temporary state store (as we're spawning processes here).
-     * That's expensive.
+     * Spawning processes to get a hash of a terminal is expensive.
+     * Hence to minimize resource usage (just to get a file hash), we will cache the generated hash for 1hr.
+     * (why 1hr, simple, why 2hrs, or 3hrs.)
+     * If user installs/updates/uninstalls Windows Store Python apps, 1hr is enough time to get things rolling again.
      *
      * @param {string} pythonPath
      * @returns {Promise<string>}

--- a/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
+++ b/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
@@ -25,10 +25,10 @@ export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInter
      * @memberof WindowsStoreInterpreter
      */
     public isWindowsStoreInterpreter(pythonPath: string): boolean {
-        const pythonPathToCompare = pythonPath.toUpperCase();
+        const pythonPathToCompare = pythonPath.toUpperCase().replace(/\//g, '\\');
         return (
             pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\'.toUpperCase()) ||
-            pythonPathToCompare.includes('Program Files\\WindowsApps'.toUpperCase()) ||
+            pythonPathToCompare.includes('\\Program Files\\WindowsApps\\'.toUpperCase()) ||
             pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\PythonSoftwareFoundation'.toUpperCase())
         );
     }
@@ -41,9 +41,9 @@ export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInter
      * @memberof IInterpreterHelper
      */
     public isInternalInterpreter(pythonPath: string): boolean {
-        const pythonPathToCompare = pythonPath.toUpperCase();
+        const pythonPathToCompare = pythonPath.toUpperCase().replace(/\//g, '\\');
         return (
-            pythonPathToCompare.includes('Program Files\\WindowsApps'.toUpperCase()) ||
+            pythonPathToCompare.includes('\\Program Files\\WindowsApps\\'.toUpperCase()) ||
             pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\PythonSoftwareFoundation'.toUpperCase())
         );
     }

--- a/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
+++ b/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { traceDecorators } from '../../../common/logger';
+import { IFileSystem } from '../../../common/platform/types';
+import { IPythonExecutionFactory } from '../../../common/process/types';
+import { IPersistentStateFactory } from '../../../common/types';
+import { IInterpreterHashProvider, IWindowsStoreInterpreter } from '../types';
+
+@injectable()
+export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInterpreterHashProvider {
+    constructor(
+        @inject(IPythonExecutionFactory) private readonly executionFactory: IPythonExecutionFactory,
+        @inject(IPersistentStateFactory) private readonly persistentFactory: IPersistentStateFactory,
+        @inject(IFileSystem) private readonly fs: IFileSystem
+    ) {}
+    /**
+     * Whether this is a Windows Store/App Interpreter.
+     *
+     * @param {string} pythonPath
+     * @returns {boolean}
+     * @memberof WindowsStoreInterpreter
+     */
+    public isWindowsStoreInterpreter(pythonPath: string): boolean {
+        const pythonPathToCompare = pythonPath.toUpperCase();
+        return (
+            pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\'.toUpperCase()) ||
+            pythonPathToCompare.includes('Program Files\\WindowsApps'.toUpperCase()) ||
+            pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\PythonSoftwareFoundation'.toUpperCase())
+        );
+    }
+    /**
+     * Whether this is a python executable in a windows app store folder that is internal and can be hidden from users.
+     * Interpreters that fall into this category will not be displayed to the users.
+     *
+     * @param {string} pythonPath
+     * @returns {Promise<boolean>}
+     * @memberof IInterpreterHelper
+     */
+    public async isInternalInterpreter(pythonPath: string): Promise<boolean> {
+        const pythonPathToCompare = pythonPath.toUpperCase();
+        return (
+            pythonPathToCompare.includes('Program Files\\WindowsApps'.toUpperCase()) ||
+            pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\PythonSoftwareFoundation'.toUpperCase())
+        );
+    }
+    /**
+     * Gets the hash of the Python interpreter (installed from the windows store).
+     * We need to use a special way to get the hash for these, by first resolving the
+     * path to the actual executable and then calculating the hash on that file.
+     *
+     * Using fs.lstat or similar nodejs functions do not work, as these are some weird form of symbolic linked files.
+     *
+     * Note: Store the hash in a temporary state store (as we're spawning processes here).
+     * That's expensive.
+     *
+     * @param {string} pythonPath
+     * @returns {Promise<string>}
+     * @memberof InterpreterHelper
+     */
+    @traceDecorators.error('Get Windows Store Interpreter Hash')
+    public async getInterpreterHash(pythonPath: string): Promise<string> {
+        const key = `WINDOWS_STORE_INTERPRETER_HASH_${pythonPath}`;
+        const stateStore = this.persistentFactory.createGlobalPersistentState<string | undefined>(key, undefined, 60 * 60 * 1000);
+
+        if (stateStore.value) {
+            return stateStore.value;
+        }
+        const pythonService = await this.executionFactory.create({ pythonPath });
+        const executablePath = await pythonService.getExecutablePath();
+        const hash = await this.fs.getFileHash(executablePath);
+        await stateStore.updateValue(hash);
+
+        return hash;
+    }
+}

--- a/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
+++ b/src/client/interpreter/locators/services/windowsStoreInterpreter.ts
@@ -40,7 +40,7 @@ export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInter
      * @returns {Promise<boolean>}
      * @memberof IInterpreterHelper
      */
-    public async isInternalInterpreter(pythonPath: string): Promise<boolean> {
+    public isInternalInterpreter(pythonPath: string): boolean {
         const pythonPathToCompare = pythonPath.toUpperCase();
         return (
             pythonPathToCompare.includes('Program Files\\WindowsApps'.toUpperCase()) ||

--- a/src/client/interpreter/locators/types.ts
+++ b/src/client/interpreter/locators/types.ts
@@ -60,5 +60,5 @@ export interface IWindowsStoreInterpreter {
      * @returns {boolean}
      * @memberof IInterpreterHelper
      */
-    isInternalInterpreter(pythonPath: string): boolean;
+    isHiddenInterpreter(pythonPath: string): boolean;
 }

--- a/src/client/interpreter/locators/types.ts
+++ b/src/client/interpreter/locators/types.ts
@@ -11,6 +11,54 @@ export interface IPythonInPathCommandProvider {
 }
 export const IPipEnvServiceHelper = Symbol('IPipEnvServiceHelper');
 export interface IPipEnvServiceHelper {
-    getPipEnvInfo(pythonPath: string): Promise<{ workspaceFolder: Uri; envName: string} | undefined>;
+    getPipEnvInfo(pythonPath: string): Promise<{ workspaceFolder: Uri; envName: string } | undefined>;
     trackWorkspaceFolder(pythonPath: string, workspaceFolder: Uri): Promise<void>;
+}
+
+/**
+ * Factory to create a hash provider.
+ * Getting the hash of an interpreter can vary based on the type of the interpreter.
+ *
+ * @export
+ * @interface IInterpreterHashProviderFactory
+ */
+export interface IInterpreterHashProviderFactory {
+    create(options: { pythonPath: string } | { resource: Uri }): Promise<IInterpreterHashProvider>;
+}
+
+/**
+ * Provides the ability to get the has of a given interpreter.
+ *
+ * @export
+ * @interface IInterpreterHashProvider
+ */
+export interface IInterpreterHashProvider {
+    /**
+     * Gets the hash of a given Python Interpreter.
+     * (hash is calculated based on last modified timestamp of executable)
+     *
+     * @param {string} pythonPath
+     * @returns {Promise<string>}
+     * @memberof IInterpreterHashProvider
+     */
+    getInterpreterHash(pythonPath: string): Promise<string>;
+}
+
+export interface IWindowsStoreInterpreter {
+    /**
+     * Whether this is a Windows Store/App Interpreter.
+     *
+     * @param {string} pythonPath
+     * @returns {boolean}
+     * @memberof WindowsStoreInterpreter
+     */
+    isWindowsStoreInterpreter(pythonPath: string): boolean;
+    /**
+     * Whether this is a python executable in a windows app store folder that is internal and can be hidden from users.
+     *
+     * @param {string} pythonPath
+     * @returns {Promise<boolean>}
+     * @memberof IInterpreterHelper
+     */
+    isInternalInterpreter(pythonPath: string): Promise<boolean>;
 }

--- a/src/client/interpreter/locators/types.ts
+++ b/src/client/interpreter/locators/types.ts
@@ -57,8 +57,8 @@ export interface IWindowsStoreInterpreter {
      * Whether this is a python executable in a windows app store folder that is internal and can be hidden from users.
      *
      * @param {string} pythonPath
-     * @returns {Promise<boolean>}
+     * @returns {boolean}
      * @memberof IInterpreterHelper
      */
-    isInternalInterpreter(pythonPath: string): Promise<boolean>;
+    isInternalInterpreter(pythonPath: string): boolean;
 }

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+'use strict';
+
 import { IExtensionActivationService, IExtensionSingleActivationService } from '../activation/types';
 import { IServiceManager } from '../ioc/types';
 import { EnvironmentActivationService } from './activation/service';
@@ -60,11 +62,14 @@ import { CondaEnvService } from './locators/services/condaEnvService';
 import { CondaService } from './locators/services/condaService';
 import { CurrentPathService, PythonInPathCommandProvider } from './locators/services/currentPathService';
 import { GlobalVirtualEnvironmentsSearchPathProvider, GlobalVirtualEnvService } from './locators/services/globalVirtualEnvService';
+import { InterpreterHashProvider } from './locators/services/hashProvider';
+import { InterpeterHashProviderFactory } from './locators/services/hashProviderFactory';
 import { InterpreterWatcherBuilder } from './locators/services/interpreterWatcherBuilder';
 import { KnownPathsService, KnownSearchPathsForInterpreters } from './locators/services/KnownPathsService';
 import { PipEnvService } from './locators/services/pipEnvService';
 import { PipEnvServiceHelper } from './locators/services/pipEnvServiceHelper';
 import { WindowsRegistryService } from './locators/services/windowsRegistryService';
+import { WindowsStoreInterpreter } from './locators/services/windowsStoreInterpreter';
 import { WorkspaceVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvService } from './locators/services/workspaceVirtualEnvService';
 import { WorkspaceVirtualEnvWatcherService } from './locators/services/workspaceVirtualEnvWatcherService';
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from './locators/types';
@@ -117,11 +122,19 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, CurrentPathInterpretersAutoSelectionRule, AutoSelectionRule.currentPath);
     serviceManager.addSingleton<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, SystemWideInterpretersAutoSelectionRule, AutoSelectionRule.systemWide);
     serviceManager.addSingleton<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, WindowsRegistryInterpretersAutoSelectionRule, AutoSelectionRule.windowsRegistry);
-    serviceManager.addSingleton<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, WorkspaceVirtualEnvInterpretersAutoSelectionRule, AutoSelectionRule.workspaceVirtualEnvs);
+    serviceManager.addSingleton<IInterpreterAutoSelectionRule>(
+        IInterpreterAutoSelectionRule,
+        WorkspaceVirtualEnvInterpretersAutoSelectionRule,
+        AutoSelectionRule.workspaceVirtualEnvs
+    );
     serviceManager.addSingleton<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, CachedInterpretersAutoSelectionRule, AutoSelectionRule.cachedInterpreters);
     serviceManager.addSingleton<IInterpreterAutoSelectionRule>(IInterpreterAutoSelectionRule, SettingsInterpretersAutoSelectionRule, AutoSelectionRule.settings);
     serviceManager.addSingleton<IInterpreterAutoSeletionProxyService>(IInterpreterAutoSeletionProxyService, InterpreterAutoSeletionProxyService);
     serviceManager.addSingleton<IInterpreterAutoSelectionService>(IInterpreterAutoSelectionService, InterpreterAutoSelectionService);
 
     serviceManager.addSingleton<IEnvironmentActivationService>(IEnvironmentActivationService, EnvironmentActivationService);
+
+    serviceManager.addSingleton<WindowsStoreInterpreter>(WindowsStoreInterpreter, WindowsStoreInterpreter);
+    serviceManager.addSingleton<InterpreterHashProvider>(InterpreterHashProvider, InterpreterHashProvider);
+    serviceManager.addSingleton<InterpeterHashProviderFactory>(InterpeterHashProviderFactory, InterpeterHashProviderFactory);
 }

--- a/src/test/interpreters/locators/hasProviderFactory.unit.test.ts
+++ b/src/test/interpreters/locators/hasProviderFactory.unit.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { instance, mock, verify, when } from 'ts-mockito';
+import { Uri } from 'vscode';
+import { ConfigurationService } from '../../../client/common/configuration/service';
+import { IConfigurationService } from '../../../client/common/types';
+import { InterpreterHashProvider } from '../../../client/interpreter/locators/services/hashProvider';
+import { InterpeterHashProviderFactory } from '../../../client/interpreter/locators/services/hashProviderFactory';
+import { WindowsStoreInterpreter } from '../../../client/interpreter/locators/services/windowsStoreInterpreter';
+import { IInterpreterHashProvider } from '../../../client/interpreter/locators/types';
+
+use(chaiAsPromised);
+
+suite('Interpretersx - Interpreter Hash Provider Factory', () => {
+    let configService: IConfigurationService;
+    let windowsStoreInterpreter: WindowsStoreInterpreter;
+    let standardHashProvider: IInterpreterHashProvider;
+    let factory: InterpeterHashProviderFactory;
+    setup(() => {
+        configService = mock(ConfigurationService);
+        windowsStoreInterpreter = mock(WindowsStoreInterpreter);
+        standardHashProvider = mock(InterpreterHashProvider);
+        const windowsStoreInstance = instance(windowsStoreInterpreter);
+        (windowsStoreInstance as any).then = undefined;
+        factory = new InterpeterHashProviderFactory(instance(configService), windowsStoreInstance, windowsStoreInstance, instance(standardHashProvider));
+    });
+    test('When provided python path is not a window store interpreter return standard hash provider', async () => {
+        const pythonPath = 'NonWindowsInterpreterPath';
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(false);
+
+        const provider = await factory.create({ pythonPath });
+
+        expect(provider).to.deep.equal(instance(standardHashProvider));
+        verify(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).once();
+    });
+    test('When provided python path is a windows store interpreter return windows store hash provider', async () => {
+        const pythonPath = 'NonWindowsInterpreterPath';
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(true);
+
+        const provider = await factory.create({ pythonPath });
+
+        expect(provider).to.deep.equal(instance(windowsStoreInterpreter));
+        verify(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).once();
+    });
+    test('When provided resource resolves to a python path that is not a window store interpreter return standard hash provider', async () => {
+        const pythonPath = 'NonWindowsInterpreterPath';
+        const resource = Uri.file('1');
+        when(configService.getSettings(resource)).thenReturn({ pythonPath } as any);
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(false);
+
+        const provider = await factory.create({ resource });
+
+        expect(provider).to.deep.equal(instance(standardHashProvider));
+        verify(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).once();
+    });
+    test('When provided resource resolves to a python path that is a windows store interpreter return windows store hash provider', async () => {
+        const pythonPath = 'NonWindowsInterpreterPath';
+        const resource = Uri.file('1');
+        when(configService.getSettings(resource)).thenReturn({ pythonPath } as any);
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(true);
+
+        const provider = await factory.create({ resource });
+
+        expect(provider).to.deep.equal(instance(windowsStoreInterpreter));
+        verify(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).once();
+    });
+});

--- a/src/test/interpreters/locators/hashProvider.unit.test.ts
+++ b/src/test/interpreters/locators/hashProvider.unit.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { instance, mock, verify, when } from 'ts-mockito';
+import { FileSystem } from '../../../client/common/platform/fileSystem';
+import { IFileSystem } from '../../../client/common/platform/types';
+import { InterpreterHashProvider } from '../../../client/interpreter/locators/services/hashProvider';
+
+use(chaiAsPromised);
+
+suite('Interpreters - Interpreter Hash Provider', () => {
+    let hashProvider: InterpreterHashProvider;
+    let fs: IFileSystem;
+    setup(() => {
+        fs = mock(FileSystem);
+        hashProvider = new InterpreterHashProvider(instance(fs));
+    });
+    test('Get hash from fs', async () => {
+        const pythonPath = 'WindowsInterpreterPath';
+        when(fs.getFileHash(pythonPath)).thenResolve('hash');
+
+        const hash = await hashProvider.getInterpreterHash(pythonPath);
+
+        expect(hash).to.equal('hash');
+        verify(fs.getFileHash(pythonPath)).once();
+    });
+    test('Exceptios from fs.getFilehash will be bubbled up', async () => {
+        const pythonPath = 'WindowsInterpreterPath';
+        when(fs.getFileHash(pythonPath)).thenReject(new Error('Kaboom'));
+
+        const promise = hashProvider.getInterpreterHash(pythonPath);
+
+        verify(fs.getFileHash(pythonPath)).once();
+        await expect(promise).to.eventually.be.rejectedWith('Kaboom');
+    });
+});

--- a/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
+++ b/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
@@ -28,150 +28,78 @@ suite('Interpreters - Windows Store Interpreter', () => {
         windowsStoreInterpreter = new WindowsStoreInterpreter(instance(executionFactory), instance(persistanceStateFactory), instance(fs));
     });
     const windowsStoreInterpreters = [
+        '\\\\Program Files\\WindowsApps\\Something\\Python.exe',
+        '..\\Program Files\\WindowsApps\\Something\\Python.exe',
+        '..\\one\\Program Files\\WindowsApps\\Something\\Python.exe',
         'C:\\Program Files\\WindowsApps\\Something\\Python.exe',
         'C:\\Program Files\\WindowsApps\\Python.exe',
-        'C:\\Program Files\\python\\Python.exe',
-        'D:\\program files\\WindowsApps\\Something\\Python.exe',
-        'D:\\program files\\WindowsApps\\Python.exe',
-        'D:\\program files\\python\\Python.exe',
-        'C:\\Program Files\\python\\Python.exe',
         'C:\\Microsoft\\WindowsApps\\Something\\Python.exe',
         'C:\\Microsoft\\WindowsApps\\Python.exe',
-        'C:\\Microsoft\\python\\Python.exe',
-        'D:\\microsoft\\WindowsApps\\Something\\Python.exe',
-        'D:\\microsoft\\WindowsApps\\Python.exe',
-        'D:\\microsoft\\python\\Python.exe',
-        'C:\\Microsoft\\python\\Python.exe',
         'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-        'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe',
-        'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-        'D:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python\\Python.exe',
-        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe'
+        'C:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe'
     ];
     for (const interpreter of windowsStoreInterpreters) {
         test(`${interpreter} must be identified as a windows store interpter`, () => {
-            const isWindowsStoreInterpreter = windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter);
-            expect(isWindowsStoreInterpreter).to.equal(true, 'Must be true');
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter)).to.equal(true, 'Must be true');
+        });
+        test(`${interpreter.toLowerCase()} must be identified as a windows store interpter (ignoring case)`, () => {
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toLowerCase())).to.equal(true, 'Must be true');
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toUpperCase())).to.equal(true, 'Must be true');
+        });
+        test(`D${interpreter.substring(1)} must be identified as a windows store interpter (ignoring driver letter)`, () => {
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(`D${interpreter.substring(1)}`)).to.equal(true, 'Must be true');
+        });
+        test(`${interpreter.replace(/\\/g, '/')} must be identified as a windows store interpter (ignoring path separator)`, () => {
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(true, 'Must be true');
         });
     }
-
-    const interpreters = [
-        {
-            path: 'C:\\Program Files\\WindowsApps\\Something\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'C:\\Program Files\\WindowsApps\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'C:\\Program Files\\python\\Python.exe',
-            isWindowsStoreInterpreter: false,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'D:\\program files\\WindowsApps\\Something\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'D:\\program files\\WindowsApps\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'D:\\program files\\python\\Python.exe',
-            isWindowsStoreInterpreter: false,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'C:\\Program Files\\python\\Python.exe',
-            isWindowsStoreInterpreter: false,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'C:\\Microsoft\\WindowsApps\\Something\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'C:\\Microsoft\\WindowsApps\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'C:\\Microsoft\\python\\Python.exe',
-            isWindowsStoreInterpreter: false,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'D:\\microsoft\\WindowsApps\\Something\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'D:\\microsoft\\WindowsApps\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'D:\\microsoft\\python\\Python.exe',
-            isWindowsStoreInterpreter: false,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'C:\\Microsoft\\python\\Python.exe',
-            isWindowsStoreInterpreter: false,
-            isInternalInterpreter: false
-        },
-        {
-            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'D:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        },
-        {
-            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
-            isWindowsStoreInterpreter: true,
-            isInternalInterpreter: true
-        }
+    const nonWindowsStoreInterpreters = [
+        '..\\Program Filess\\WindowsApps\\Something\\Python.exe',
+        'C:\\Program Filess\\WindowsApps\\Something\\Python.exe',
+        'C:\\Program Files\\WindowsAppss\\Python.exe',
+        'C:\\Microsofts\\WindowsApps\\Something\\Python.exe',
+        'C:\\Microsoft\\WindowsAppss\\Python.exe',
+        'C:\\Microsofts\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+        'C:\\microsoft\\WindowsAppss\\PythonSoftwareFoundation\\Something\\Python.exe',
+        'C:\\Python\\python.exe',
+        'C:\\Program Files\\Python\\python.exe',
+        'C:\\Program Files\\Microsoft\\Python\\python.exe',
+        '..\\apps\\Python.exe',
+        'C:\\Apps\\Python.exe'
     ];
-    for (const interpreter of interpreters) {
-        test(`${interpreter.path} must ${interpreter.isWindowsStoreInterpreter ? 'be' : 'not be'} identified as a windows store interpter`, () => {
-            const isWindowsStoreInterpreter = windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.path);
-            expect(isWindowsStoreInterpreter).to.equal(interpreter.isWindowsStoreInterpreter);
+    for (const interpreter of nonWindowsStoreInterpreters) {
+        test(`${interpreter} must not be identified as a windows store interpter`, () => {
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter)).to.equal(false, 'Must be false');
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(false, 'Must be false');
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter)).to.equal(false, 'Must be false');
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(false, 'Must be false');
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter.toLowerCase())).to.equal(false, 'Must be false');
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toUpperCase())).to.equal(false, 'Must be false');
+            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(`D${interpreter.substring(1)}`)).to.equal(false, 'Must be false');
         });
-        test(`${interpreter.path} must ${interpreter.isInternalInterpreter ? 'be' : 'not be'} identified as an internal windows store interpter`, () => {
-            const isWindowsStoreInterpreter = windowsStoreInterpreter.isInternalInterpreter(interpreter.path);
-            expect(isWindowsStoreInterpreter).to.equal(interpreter.isInternalInterpreter);
+    }
+    const windowsStoreHiddenInterpreters = [
+        'C:\\Program Files\\WindowsApps\\Something\\Python.exe',
+        'C:\\Program Files\\WindowsApps\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+        'C:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe'
+    ];
+    for (const interpreter of windowsStoreHiddenInterpreters) {
+        test(`${interpreter} must be identified as a windows store (hidden) interpter`, () => {
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter)).to.equal(true, 'Must be true');
+        });
+        test(`${interpreter.toLowerCase()} must be identified as a windows store (hidden) interpter (ignoring case)`, () => {
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter.toLowerCase())).to.equal(true, 'Must be true');
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter.toUpperCase())).to.equal(true, 'Must be true');
+        });
+        test(`${interpreter} must be identified as a windows store (hidden) interpter (ignoring driver letter)`, () => {
+            expect(windowsStoreInterpreter.isHiddenInterpreter(`D${interpreter.substring(1)}`)).to.equal(true, 'Must be true');
+        });
+    }
+    const nonWindowsStoreHiddenInterpreters = ['C:\\Microsofts\\WindowsApps\\Something\\Python.exe', 'C:\\Microsoft\\WindowsAppss\\Python.exe'];
+    for (const interpreter of nonWindowsStoreHiddenInterpreters) {
+        test(`${interpreter} must not be identified as a windows store (hidden) interpter`, () => {
+            expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter)).to.equal(false, 'Must be true');
         });
     }
 

--- a/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
+++ b/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:no-any max-classes-per-file max-func-body-length
+
+import { expect } from 'chai';
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { PersistentState, PersistentStateFactory } from '../../../client/common/persistentState';
+import { FileSystem } from '../../../client/common/platform/fileSystem';
+import { IFileSystem } from '../../../client/common/platform/types';
+import { PythonExecutionFactory } from '../../../client/common/process/pythonExecutionFactory';
+import { PythonExecutionService } from '../../../client/common/process/pythonProcess';
+import { IPythonExecutionFactory } from '../../../client/common/process/types';
+import { IPersistentStateFactory } from '../../../client/common/types';
+import { WindowsStoreInterpreter } from '../../../client/interpreter/locators/services/windowsStoreInterpreter';
+
+suite('Interpreters - Windows Store Interpreter', () => {
+    let windowsStoreInterpreter: WindowsStoreInterpreter;
+    let fs: IFileSystem;
+    let persistanceStateFactory: IPersistentStateFactory;
+    let executionFactory: IPythonExecutionFactory;
+    setup(() => {
+        fs = mock(FileSystem);
+        persistanceStateFactory = mock(PersistentStateFactory);
+        executionFactory = mock(PythonExecutionFactory);
+        windowsStoreInterpreter = new WindowsStoreInterpreter(instance(executionFactory), instance(persistanceStateFactory), instance(fs));
+    });
+    const interpreters = [
+        {
+            path: 'C:\\Program Files\\WindowsApps\\Something\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'C:\\Program Files\\WindowsApps\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'C:\\Program Files\\python\\Python.exe',
+            isWindowsStoreInterpreter: false,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'D:\\program files\\WindowsApps\\Something\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'D:\\program files\\WindowsApps\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'D:\\program files\\python\\Python.exe',
+            isWindowsStoreInterpreter: false,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'C:\\Program Files\\python\\Python.exe',
+            isWindowsStoreInterpreter: false,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'C:\\Microsoft\\WindowsApps\\Something\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'C:\\Microsoft\\WindowsApps\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'C:\\Microsoft\\python\\Python.exe',
+            isWindowsStoreInterpreter: false,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'D:\\microsoft\\WindowsApps\\Something\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'D:\\microsoft\\WindowsApps\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'D:\\microsoft\\python\\Python.exe',
+            isWindowsStoreInterpreter: false,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'C:\\Microsoft\\python\\Python.exe',
+            isWindowsStoreInterpreter: false,
+            isInternalInterpreter: false
+        },
+        {
+            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'D:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        },
+        {
+            path: 'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+            isWindowsStoreInterpreter: true,
+            isInternalInterpreter: true
+        }
+    ];
+    for (const interpreter of interpreters) {
+        test(`${interpreter.path} must ${interpreter.isWindowsStoreInterpreter ? 'be' : 'not be'} identified as a windows store interpter`, async () => {
+            const isWindowsStoreInterpreter = windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.path);
+            expect(isWindowsStoreInterpreter).to.equal(interpreter.isWindowsStoreInterpreter);
+        });
+        test(`${interpreter.path} must ${interpreter.isInternalInterpreter ? 'be' : 'not be'} identified as an internal windows store interpter`, async () => {
+            const isWindowsStoreInterpreter = await windowsStoreInterpreter.isInternalInterpreter(interpreter.path);
+            expect(isWindowsStoreInterpreter).to.equal(interpreter.isInternalInterpreter);
+        });
+    }
+
+    test('Getting hash should get hash of python executable', async () => {
+        const pythonPath = 'WindowsInterpreterPath';
+
+        const stateStore = mock<PersistentState<string | undefined>>(PersistentState);
+        const key = `WINDOWS_STORE_INTERPRETER_HASH_${pythonPath}`;
+        const pythonService = mock(PythonExecutionService);
+        const pythonServiceInstance = instance(pythonService);
+        (pythonServiceInstance as any).then = undefined;
+        const oneHour = 60 * 60 * 1000;
+
+        when(persistanceStateFactory.createGlobalPersistentState<string | undefined>(key, undefined, oneHour)).thenReturn(instance(stateStore));
+        when(stateStore.value).thenReturn();
+        when(executionFactory.create(deepEqual({ pythonPath }))).thenResolve(pythonServiceInstance);
+        when(pythonService.getExecutablePath()).thenResolve('FullyQualifiedPathToPythonExec');
+        when(fs.getFileHash('FullyQualifiedPathToPythonExec')).thenResolve('hash');
+        when(stateStore.updateValue('hash')).thenResolve();
+
+        const hash = await windowsStoreInterpreter.getInterpreterHash(pythonPath);
+
+        verify(persistanceStateFactory.createGlobalPersistentState(key, undefined, oneHour)).once();
+        verify(stateStore.value).once();
+        verify(executionFactory.create(deepEqual({ pythonPath }))).once();
+        verify(pythonService.getExecutablePath()).once();
+        verify(fs.getFileHash('FullyQualifiedPathToPythonExec')).once();
+        verify(stateStore.updateValue('hash')).once();
+        expect(hash).to.equal('hash');
+    });
+
+    test('Getting hash from cache', async () => {
+        const pythonPath = 'WindowsInterpreterPath';
+
+        const stateStore = mock<PersistentState<string | undefined>>(PersistentState);
+        const key = `WINDOWS_STORE_INTERPRETER_HASH_${pythonPath}`;
+        const oneHour = 60 * 60 * 1000;
+
+        when(persistanceStateFactory.createGlobalPersistentState<string | undefined>(key, undefined, oneHour)).thenReturn(instance(stateStore));
+        when(stateStore.value).thenReturn('fileHash');
+        const hash = await windowsStoreInterpreter.getInterpreterHash(pythonPath);
+
+        verify(persistanceStateFactory.createGlobalPersistentState(key, undefined, oneHour)).once();
+        verify(stateStore.value).atLeast(1);
+        verify(executionFactory.create(anything())).never();
+        verify(fs.getFileHash(anything())).never();
+        verify(stateStore.updateValue(anything())).never();
+        expect(hash).to.equal('fileHash');
+    });
+});

--- a/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
+++ b/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
@@ -27,6 +27,36 @@ suite('Interpreters - Windows Store Interpreter', () => {
         executionFactory = mock(PythonExecutionFactory);
         windowsStoreInterpreter = new WindowsStoreInterpreter(instance(executionFactory), instance(persistanceStateFactory), instance(fs));
     });
+    const windowsStoreInterpreters = [
+        'C:\\Program Files\\WindowsApps\\Something\\Python.exe',
+        'C:\\Program Files\\WindowsApps\\Python.exe',
+        'C:\\Program Files\\python\\Python.exe',
+        'D:\\program files\\WindowsApps\\Something\\Python.exe',
+        'D:\\program files\\WindowsApps\\Python.exe',
+        'D:\\program files\\python\\Python.exe',
+        'C:\\Program Files\\python\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\Something\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\Python.exe',
+        'C:\\Microsoft\\python\\Python.exe',
+        'D:\\microsoft\\WindowsApps\\Something\\Python.exe',
+        'D:\\microsoft\\WindowsApps\\Python.exe',
+        'D:\\microsoft\\python\\Python.exe',
+        'C:\\Microsoft\\python\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+        'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe',
+        'D:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe',
+        'D:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python\\Python.exe',
+        'C:\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\Python.exe'
+    ];
+    for (const interpreter of windowsStoreInterpreters) {
+        test(`${interpreter} must be identified as a windows store interpter`, () => {
+            const isWindowsStoreInterpreter = windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter);
+            expect(isWindowsStoreInterpreter).to.equal(true, 'Must be true');
+        });
+    }
+
     const interpreters = [
         {
             path: 'C:\\Program Files\\WindowsApps\\Something\\Python.exe',

--- a/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
+++ b/src/test/interpreters/locators/windowsStoreInterpreter.unit.test.ts
@@ -135,12 +135,12 @@ suite('Interpreters - Windows Store Interpreter', () => {
         }
     ];
     for (const interpreter of interpreters) {
-        test(`${interpreter.path} must ${interpreter.isWindowsStoreInterpreter ? 'be' : 'not be'} identified as a windows store interpter`, async () => {
+        test(`${interpreter.path} must ${interpreter.isWindowsStoreInterpreter ? 'be' : 'not be'} identified as a windows store interpter`, () => {
             const isWindowsStoreInterpreter = windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.path);
             expect(isWindowsStoreInterpreter).to.equal(interpreter.isWindowsStoreInterpreter);
         });
-        test(`${interpreter.path} must ${interpreter.isInternalInterpreter ? 'be' : 'not be'} identified as an internal windows store interpter`, async () => {
-            const isWindowsStoreInterpreter = await windowsStoreInterpreter.isInternalInterpreter(interpreter.path);
+        test(`${interpreter.path} must ${interpreter.isInternalInterpreter ? 'be' : 'not be'} identified as an internal windows store interpter`, () => {
+            const isWindowsStoreInterpreter = windowsStoreInterpreter.isInternalInterpreter(interpreter.path);
             expect(isWindowsStoreInterpreter).to.equal(interpreter.isInternalInterpreter);
         });
     }

--- a/src/test/interpreters/serviceRegistry.unit.test.ts
+++ b/src/test/interpreters/serviceRegistry.unit.test.ts
@@ -5,9 +5,7 @@
 
 // tslint:disable: no-any
 
-import { expect } from 'chai';
 import { instance, mock, verify } from 'ts-mockito';
-import * as typemoq from 'typemoq';
 import { IExtensionActivationService, IExtensionSingleActivationService } from '../../client/activation/types';
 import { EnvironmentActivationService } from '../../client/interpreter/activation/service';
 import { IEnvironmentActivationService } from '../../client/interpreter/activation/types';

--- a/src/test/interpreters/serviceRegistry.unit.test.ts
+++ b/src/test/interpreters/serviceRegistry.unit.test.ts
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable: no-any
+
+import { expect } from 'chai';
+import { instance, mock, verify } from 'ts-mockito';
+import * as typemoq from 'typemoq';
+import { IExtensionActivationService, IExtensionSingleActivationService } from '../../client/activation/types';
+import { EnvironmentActivationService } from '../../client/interpreter/activation/service';
+import { IEnvironmentActivationService } from '../../client/interpreter/activation/types';
+import { InterpreterAutoSelectionService } from '../../client/interpreter/autoSelection';
+import { InterpreterAutoSeletionProxyService } from '../../client/interpreter/autoSelection/proxy';
+import { CachedInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/cached';
+import { CurrentPathInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/currentPath';
+import { SettingsInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/settings';
+import { SystemWideInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/system';
+import { WindowsRegistryInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/winRegistry';
+import { WorkspaceVirtualEnvInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/workspaceEnv';
+import {
+    AutoSelectionRule,
+    IInterpreterAutoSelectionRule,
+    IInterpreterAutoSelectionService,
+    IInterpreterAutoSeletionProxyService
+} from '../../client/interpreter/autoSelection/types';
+import { InterpreterComparer } from '../../client/interpreter/configuration/interpreterComparer';
+import { InterpreterSelector } from '../../client/interpreter/configuration/interpreterSelector';
+import { PythonPathUpdaterService } from '../../client/interpreter/configuration/pythonPathUpdaterService';
+import { PythonPathUpdaterServiceFactory } from '../../client/interpreter/configuration/pythonPathUpdaterServiceFactory';
+import { IInterpreterComparer, IInterpreterSelector, IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from '../../client/interpreter/configuration/types';
+import {
+    CONDA_ENV_FILE_SERVICE,
+    CONDA_ENV_SERVICE,
+    CURRENT_PATH_SERVICE,
+    GLOBAL_VIRTUAL_ENV_SERVICE,
+    ICondaService,
+    IInterpreterDisplay,
+    IInterpreterHelper,
+    IInterpreterLocatorHelper,
+    IInterpreterLocatorProgressService,
+    IInterpreterLocatorService,
+    IInterpreterService,
+    IInterpreterVersionService,
+    IInterpreterWatcher,
+    IInterpreterWatcherBuilder,
+    IKnownSearchPathsForInterpreters,
+    INTERPRETER_LOCATOR_SERVICE,
+    InterpreterLocatorProgressHandler,
+    IPipEnvService,
+    IShebangCodeLensProvider,
+    IVirtualEnvironmentsSearchPathProvider,
+    KNOWN_PATH_SERVICE,
+    PIPENV_SERVICE,
+    WINDOWS_REGISTRY_SERVICE,
+    WORKSPACE_VIRTUAL_ENV_SERVICE
+} from '../../client/interpreter/contracts';
+import { InterpreterDisplay } from '../../client/interpreter/display';
+import { InterpreterSelectionTip } from '../../client/interpreter/display/interpreterSelectionTip';
+import { InterpreterLocatorProgressStatubarHandler } from '../../client/interpreter/display/progressDisplay';
+import { ShebangCodeLensProvider } from '../../client/interpreter/display/shebangCodeLensProvider';
+import { InterpreterHelper } from '../../client/interpreter/helpers';
+import { InterpreterService } from '../../client/interpreter/interpreterService';
+import { InterpreterVersionService } from '../../client/interpreter/interpreterVersion';
+import { PythonInterpreterLocatorService } from '../../client/interpreter/locators';
+import { InterpreterLocatorHelper } from '../../client/interpreter/locators/helpers';
+import { InterpreterLocatorProgressService } from '../../client/interpreter/locators/progressService';
+import { CondaEnvFileService } from '../../client/interpreter/locators/services/condaEnvFileService';
+import { CondaEnvService } from '../../client/interpreter/locators/services/condaEnvService';
+import { CondaService } from '../../client/interpreter/locators/services/condaService';
+import { CurrentPathService, PythonInPathCommandProvider } from '../../client/interpreter/locators/services/currentPathService';
+import { GlobalVirtualEnvironmentsSearchPathProvider, GlobalVirtualEnvService } from '../../client/interpreter/locators/services/globalVirtualEnvService';
+import { InterpreterHashProvider } from '../../client/interpreter/locators/services/hashProvider';
+import { InterpeterHashProviderFactory } from '../../client/interpreter/locators/services/hashProviderFactory';
+import { InterpreterWatcherBuilder } from '../../client/interpreter/locators/services/interpreterWatcherBuilder';
+import { KnownPathsService, KnownSearchPathsForInterpreters } from '../../client/interpreter/locators/services/KnownPathsService';
+import { PipEnvService } from '../../client/interpreter/locators/services/pipEnvService';
+import { PipEnvServiceHelper } from '../../client/interpreter/locators/services/pipEnvServiceHelper';
+import { WindowsRegistryService } from '../../client/interpreter/locators/services/windowsRegistryService';
+import { WindowsStoreInterpreter } from '../../client/interpreter/locators/services/windowsStoreInterpreter';
+import { WorkspaceVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvService } from '../../client/interpreter/locators/services/workspaceVirtualEnvService';
+import { WorkspaceVirtualEnvWatcherService } from '../../client/interpreter/locators/services/workspaceVirtualEnvWatcherService';
+import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../../client/interpreter/locators/types';
+import { registerTypes } from '../../client/interpreter/serviceRegistry';
+import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
+import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
+import { VirtualEnvironmentPrompt } from '../../client/interpreter/virtualEnvs/virtualEnvPrompt';
+import { ServiceManager } from '../../client/ioc/serviceManager';
+
+suite('Interpreters - Service Registry', () => {
+    test('Registrations', () => {
+        const serviceManager = mock(ServiceManager);
+        registerTypes(instance(serviceManager));
+
+        [
+            [IKnownSearchPathsForInterpreters, KnownSearchPathsForInterpreters],
+            [IVirtualEnvironmentsSearchPathProvider, GlobalVirtualEnvironmentsSearchPathProvider, 'global'],
+            [IVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvironmentsSearchPathProvider, 'workspace'],
+
+            [ICondaService, CondaService],
+            [IPipEnvServiceHelper, PipEnvServiceHelper],
+            [IVirtualEnvironmentManager, VirtualEnvironmentManager],
+            [IExtensionActivationService, VirtualEnvironmentPrompt],
+            [IExtensionSingleActivationService, InterpreterSelectionTip],
+            [IPythonInPathCommandProvider, PythonInPathCommandProvider],
+
+            [IInterpreterWatcherBuilder, InterpreterWatcherBuilder],
+
+            [IInterpreterVersionService, InterpreterVersionService],
+            [IInterpreterLocatorService, PythonInterpreterLocatorService, INTERPRETER_LOCATOR_SERVICE],
+            [IInterpreterLocatorService, CondaEnvFileService, CONDA_ENV_FILE_SERVICE],
+            [IInterpreterLocatorService, CondaEnvService, CONDA_ENV_SERVICE],
+            [IInterpreterLocatorService, CurrentPathService, CURRENT_PATH_SERVICE],
+            [IInterpreterLocatorService, GlobalVirtualEnvService, GLOBAL_VIRTUAL_ENV_SERVICE],
+            [IInterpreterLocatorService, WorkspaceVirtualEnvService, WORKSPACE_VIRTUAL_ENV_SERVICE],
+            [IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE],
+            [IPipEnvService, PipEnvService],
+
+            [IInterpreterLocatorService, WindowsRegistryService, WINDOWS_REGISTRY_SERVICE],
+            [IInterpreterLocatorService, KnownPathsService, KNOWN_PATH_SERVICE],
+            [IInterpreterService, InterpreterService],
+            [IInterpreterDisplay, InterpreterDisplay],
+
+            [IPythonPathUpdaterServiceFactory, PythonPathUpdaterServiceFactory],
+            [IPythonPathUpdaterServiceManager, PythonPathUpdaterService],
+
+            [IInterpreterSelector, InterpreterSelector],
+            [IShebangCodeLensProvider, ShebangCodeLensProvider],
+            [IInterpreterHelper, InterpreterHelper],
+            [IInterpreterLocatorHelper, InterpreterLocatorHelper],
+            [IInterpreterComparer, InterpreterComparer],
+
+            [InterpreterLocatorProgressHandler, InterpreterLocatorProgressStatubarHandler],
+            [IInterpreterLocatorProgressService, InterpreterLocatorProgressService],
+
+            [IInterpreterAutoSelectionRule, CurrentPathInterpretersAutoSelectionRule, AutoSelectionRule.currentPath],
+            [IInterpreterAutoSelectionRule, SystemWideInterpretersAutoSelectionRule, AutoSelectionRule.systemWide],
+            [IInterpreterAutoSelectionRule, WindowsRegistryInterpretersAutoSelectionRule, AutoSelectionRule.windowsRegistry],
+            [IInterpreterAutoSelectionRule, WorkspaceVirtualEnvInterpretersAutoSelectionRule, AutoSelectionRule.workspaceVirtualEnvs],
+            [IInterpreterAutoSelectionRule, CachedInterpretersAutoSelectionRule, AutoSelectionRule.cachedInterpreters],
+            [IInterpreterAutoSelectionRule, SettingsInterpretersAutoSelectionRule, AutoSelectionRule.settings],
+            [IInterpreterAutoSeletionProxyService, InterpreterAutoSeletionProxyService],
+            [IInterpreterAutoSelectionService, InterpreterAutoSelectionService],
+
+            [IEnvironmentActivationService, EnvironmentActivationService],
+
+            [WindowsStoreInterpreter, WindowsStoreInterpreter],
+            [InterpreterHashProvider, InterpreterHashProvider],
+            [InterpeterHashProviderFactory, InterpeterHashProviderFactory]
+        ].forEach(mapping => {
+            verify(serviceManager.addSingleton.apply(serviceManager, mapping as any)).once();
+        });
+        verify(serviceManager.add<IInterpreterWatcher>(IInterpreterWatcher, WorkspaceVirtualEnvWatcherService, WORKSPACE_VIRTUAL_ENV_SERVICE)).once();
+    });
+});

--- a/src/test/interpreters/windowsRegistryService.unit.test.ts
+++ b/src/test/interpreters/windowsRegistryService.unit.test.ts
@@ -4,8 +4,9 @@ import * as TypeMoq from 'typemoq';
 import { IPlatformService, RegistryHive } from '../../client/common/platform/types';
 import { IPathUtils, IPersistentStateFactory } from '../../client/common/types';
 import { Architecture } from '../../client/common/utils/platform';
-import { IInterpreterHelper } from '../../client/interpreter/contracts';
+import { IInterpreterHelper, InterpreterType } from '../../client/interpreter/contracts';
 import { WindowsRegistryService } from '../../client/interpreter/locators/services/windowsRegistryService';
+import { IWindowsStoreInterpreter } from '../../client/interpreter/locators/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { MockRegistry, MockState } from './mocks';
 
@@ -13,16 +14,20 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 
 // tslint:disable:max-func-body-length no-octal-literal
 
-suite('Interpreters from Windows Registry (unit)', () => {
+suite('Interpretersx from Windows Registry (unit)', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     let platformService: TypeMoq.IMock<IPlatformService>;
+    let windowsStoreInterpreter: TypeMoq.IMock<IWindowsStoreInterpreter>;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         const stateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
         interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         const pathUtils = TypeMoq.Mock.ofType<IPathUtils>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
+        windowsStoreInterpreter = TypeMoq.Mock.ofType<IWindowsStoreInterpreter>();
+        windowsStoreInterpreter.setup(w => w.isInternalInterpreter(TypeMoq.It.isAny())).returns(() => false);
+        windowsStoreInterpreter.setup(w => w.isWindowsStoreInterpreter(TypeMoq.It.isAny())).returns(() => false);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPersistentStateFactory))).returns(() => stateFactory.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterHelper))).returns(() => interpreterHelper.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPathUtils))).returns(() => pathUtils.object);
@@ -38,14 +43,14 @@ suite('Interpreters from Windows Registry (unit)', () => {
     }
     test('Must return an empty list (x86)', async () => {
         const registry = new MockRegistry([], []);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
 
         const interpreters = await winRegistry.getInterpreters();
         assert.equal(interpreters.length, 0, 'Incorrect number of entries');
     });
     test('Must return an empty list (x64)', async () => {
         const registry = new MockRegistry([], []);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(true), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(true), serviceContainer.object, windowsStoreInterpreter.object);
 
         const interpreters = await winRegistry.getInterpreters();
         assert.equal(interpreters.length, 0, 'Incorrect number of entries');
@@ -63,7 +68,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\Company One\\Tag1', hive: RegistryHive.HKCU, arch: Architecture.x86, value: 'DisplayName.Tag1', name: 'DisplayName' }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
 
         interpreterHelper.reset();
         interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
@@ -85,7 +90,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\PythonCore\\9.9.9-final\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'path1') }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
 
         interpreterHelper.reset();
         interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
@@ -107,7 +112,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\PyLauncher\\Tag1\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: 'c:/temp/Install Path Tag1' }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
 
         const interpreters = await winRegistry.getInterpreters();
 
@@ -122,7 +127,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\Company One\\9.9.9-final\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'path1') }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
         interpreterHelper.reset();
         interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
@@ -133,6 +138,26 @@ suite('Interpreters from Windows Registry (unit)', () => {
         assert.equal(interpreters[0].companyDisplayName, 'Company One', 'Incorrect company name');
         assert.equal(interpreters[0].path, path.join(environmentsPath, 'path1', 'python.exe'), 'Incorrect path');
         assert.equal(interpreters[0].version!.raw, '9.9.9-final', 'Incorrect version');
+        assert.equal(interpreters[0].type, InterpreterType.Unknown, 'Incorrect type');
+    });
+    test('Must return a single entry with a type of WindowsStore', async () => {
+        const registryKeys = [
+            { key: '\\Software\\Python', hive: RegistryHive.HKCU, arch: Architecture.x86, values: ['\\Software\\Python\\Company One'] },
+            { key: '\\Software\\Python\\Company One', hive: RegistryHive.HKCU, arch: Architecture.x86, values: ['\\Software\\Python\\Company One\\9.9.9-final'] }
+        ];
+        const registryValues = [
+            { key: '\\Software\\Python\\Company One\\9.9.9-final\\InstallPath', hive: RegistryHive.HKCU, arch: Architecture.x86, value: path.join(environmentsPath, 'path1') }
+        ];
+        const registry = new MockRegistry(registryKeys, registryValues);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
+        interpreterHelper.reset();
+        interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
+
+        const interpreters = await winRegistry.getInterpreters();
+
+        assert.equal(interpreters.length, 1, 'Incorrect number of entries');
+        console.log(interpreters[0].path);
+        assert.equal(interpreters[0].type, InterpreterType.WindowsStore, 'Incorrect type');
     });
     test('Must return multiple entries', async () => {
         const registryKeys = [
@@ -166,7 +191,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\Company A\\8.0.0\\InstallPath', hive: RegistryHive.HKLM, arch: Architecture.x86, value: path.join(environmentsPath, 'conda', 'envs', 'scipy', 'python.exe') }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
         interpreterHelper.reset();
         interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
@@ -230,7 +255,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\Company A\\10.0.0\\InstallPath', hive: RegistryHive.HKLM, arch: Architecture.x86, value: path.join(environmentsPath, 'conda', 'envs', 'numpy') }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
         interpreterHelper.reset();
         interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 
@@ -294,7 +319,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             { key: '\\Software\\Python\\Company A\\Another Tag\\InstallPath', hive: RegistryHive.HKLM, arch: Architecture.x86, value: path.join(environmentsPath, 'non-existent-path', 'envs', 'numpy') }
         ];
         const registry = new MockRegistry(registryKeys, registryValues);
-        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object);
+        const winRegistry = new WindowsRegistryService(registry, setup64Bit(false), serviceContainer.object, windowsStoreInterpreter.object);
         interpreterHelper.reset();
         interpreterHelper.setup(h => h.getInterpreterInformation(TypeMoq.It.isAny())).returns(() => Promise.resolve({ architecture: Architecture.x86 }));
 

--- a/src/test/interpreters/windowsRegistryService.unit.test.ts
+++ b/src/test/interpreters/windowsRegistryService.unit.test.ts
@@ -14,7 +14,7 @@ const environmentsPath = path.join(__dirname, '..', '..', '..', 'src', 'test', '
 
 // tslint:disable:max-func-body-length no-octal-literal
 
-suite('Interpretersx from Windows Registry (unit)', () => {
+suite('Interpreters from Windows Registry (unit)', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     let platformService: TypeMoq.IMock<IPlatformService>;

--- a/src/test/interpreters/windowsRegistryService.unit.test.ts
+++ b/src/test/interpreters/windowsRegistryService.unit.test.ts
@@ -26,7 +26,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
         const pathUtils = TypeMoq.Mock.ofType<IPathUtils>();
         platformService = TypeMoq.Mock.ofType<IPlatformService>();
         windowsStoreInterpreter = TypeMoq.Mock.ofType<IWindowsStoreInterpreter>();
-        windowsStoreInterpreter.setup(w => w.isInternalInterpreter(TypeMoq.It.isAny())).returns(() => false);
+        windowsStoreInterpreter.setup(w => w.isHiddenInterpreter(TypeMoq.It.isAny())).returns(() => false);
         windowsStoreInterpreter.setup(w => w.isWindowsStoreInterpreter(TypeMoq.It.isAny())).returns(() => false);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IPersistentStateFactory))).returns(() => stateFactory.object);
         serviceContainer.setup(c => c.get(TypeMoq.It.isValue(IInterpreterHelper))).returns(() => interpreterHelper.object);
@@ -155,7 +155,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
         windowsStoreInterpreter.reset();
         const expectedPythonPath = path.join(environmentsPath, 'path1', 'python.exe');
         windowsStoreInterpreter
-            .setup(w => w.isInternalInterpreter(TypeMoq.It.isValue(expectedPythonPath)))
+            .setup(w => w.isHiddenInterpreter(TypeMoq.It.isValue(expectedPythonPath)))
             .returns(() => false)
             .verifiable(TypeMoq.Times.atLeastOnce());
         windowsStoreInterpreter
@@ -184,7 +184,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
         windowsStoreInterpreter.reset();
         const expectedPythonPath = path.join(environmentsPath, 'path1', 'python.exe');
         windowsStoreInterpreter
-            .setup(w => w.isInternalInterpreter(TypeMoq.It.isValue(expectedPythonPath)))
+            .setup(w => w.isHiddenInterpreter(TypeMoq.It.isValue(expectedPythonPath)))
             .returns(() => true)
             .verifiable(TypeMoq.Times.atLeastOnce());
 


### PR DESCRIPTION
For #5926 
For #6113 (added tests)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
