### PR TITLE
#7010: Replaced 'python.enableJedi' setting with 'python.languageServ…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,7 +35,7 @@
     "prettier.tslintIntegration": true,
     "prettier.printWidth": 180,
     "prettier.singleQuote": true,
-    "python.jediEnabled": false,
+    "python.languageServer": "microsoft",
     "python.analysis.logLevel": "Trace",
     "python.analysis.downloadChannel": "beta",
    "python.linting.pylintEnabled": false,

--- a/news/.vscode/settings.json
+++ b/news/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.jediEnabled": false,
+    "python.languageServer": "microsoft",
     "python.formatting.provider": "black",
     "editor.formatOnSave": true,
     "python.testing.pytestArgs": [

--- a/news/1 Enhancements/7010.md
+++ b/news/1 Enhancements/7010.md
@@ -1,0 +1,1 @@
+Replaced "python.enableJedi" setting with "python.languageServer". The new setting supports three string-based values: 'jedi', 'microsoft', and 'none'. If it's set to 'none', no language server is loaded, allowing for other Python language servers to be installed by the user.

--- a/package.json
+++ b/package.json
@@ -1644,10 +1644,15 @@
                     "description": "Whether to install Python modules globally when not using an environment.",
                     "scope": "resource"
                 },
-                "python.jediEnabled": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Enables Jedi as IntelliSense engine instead of Microsoft Python Analysis Engine.",
+                "python.languageServer": {
+                    "type": "string",
+                    "enum": [
+                        "jedi",
+                        "microsoft",
+                        "none"
+                    ],
+                    "default": "jedi",
+                    "description": "Specifies which language server to use for IntelliSense engine.",
                     "scope": "resource"
                 },
                 "python.jediMemoryLimit": {

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -12,14 +12,17 @@ import { STANDARD_OUTPUT_CHANNEL } from '../common/constants';
 import { LSControl, LSEnabled } from '../common/experimentGroups';
 import '../common/extensions';
 import { traceError } from '../common/logger';
-import { IConfigurationService, IDisposableRegistry, IExperimentsManager, IOutputChannel, IPersistentStateFactory, IPythonSettings, Resource } from '../common/types';
+import {
+    IConfigurationService, IDisposableRegistry, IExperimentsManager, IOutputChannel,
+    IPersistentStateFactory, IPythonSettings, LanguageServerType, Resource
+} from '../common/types';
 import { swallowExceptions } from '../common/utils/decorators';
 import { IServiceContainer } from '../ioc/types';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { IExtensionActivationService, ILanguageServerActivator, LanguageServerActivator } from './types';
 
-const jediEnabledSetting: keyof IPythonSettings = 'jediEnabled';
+const languageServerSetting: keyof IPythonSettings = 'languageServer';
 const workspacePathNameForGlobalWorkspaces = '';
 type ActivatorInfo = { jedi: boolean; activator: ILanguageServerActivator };
 
@@ -51,8 +54,8 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
     }
 
     public async activate(resource: Resource): Promise<void> {
-        let jedi = this.useJedi();
-        if (!jedi) {
+        let lsSettingValue = this.getLanguageServerSetting();
+        if (lsSettingValue === 'microsoft') {
             if (this.lsActivatedWorkspaces.has(this.getWorkspacePathKey(resource))) {
                 return;
             }
@@ -60,7 +63,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
             this.lsNotSupportedDiagnosticService.handle(diagnostic).ignoreErrors();
             if (diagnostic.length) {
                 sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_PLATFORM_SUPPORTED, undefined, { supported: false });
-                jedi = true;
+                lsSettingValue = 'jedi';
             }
         } else {
             if (this.jediActivatedOnce) {
@@ -70,18 +73,22 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         }
 
         this.resource = resource;
-        await this.logStartup(jedi);
-        let activatorName = jedi ? LanguageServerActivator.Jedi : LanguageServerActivator.DotNet;
+        await this.logStartup(lsSettingValue);
+        if (lsSettingValue === 'none') {
+            this.currentActivator = undefined;
+            return;
+        }
+        let activatorName = lsSettingValue === 'jedi' ? LanguageServerActivator.Jedi : LanguageServerActivator.DotNet;
         let activator = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, activatorName);
-        this.currentActivator = { jedi, activator };
+        this.currentActivator = { jedi: lsSettingValue === 'jedi', activator };
 
         try {
             await activator.activate(resource);
-            if (!jedi) {
+            if (lsSettingValue === 'microsoft') {
                 this.lsActivatedWorkspaces.set(this.getWorkspacePathKey(resource), activator);
             }
         } catch (ex) {
-            if (jedi) {
+            if (lsSettingValue === 'jedi') {
                 return;
             }
             //Language server fails, reverting to jedi
@@ -89,11 +96,11 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
                 return;
             }
             this.jediActivatedOnce = true;
-            jedi = true;
-            await this.logStartup(jedi);
+            lsSettingValue = 'jedi';
+            await this.logStartup(lsSettingValue);
             activatorName = LanguageServerActivator.Jedi;
             activator = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, activatorName);
-            this.currentActivator = { jedi, activator };
+            this.currentActivator = { jedi: lsSettingValue === 'jedi', activator };
             await activator.activate(resource);
         }
     }
@@ -103,29 +110,30 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
             this.currentActivator.activator.dispose();
         }
     }
+
     @swallowExceptions('Switch Language Server')
-    public async trackLangaugeServerSwitch(jediEnabled: boolean): Promise<void> {
-        const state = this.stateFactory.createGlobalPersistentState<boolean | undefined>('SWITCH_LS', undefined);
-        if (typeof state.value !== 'boolean') {
-            await state.updateValue(jediEnabled);
+    public async trackLangaugeServerSwitch(newValue: LanguageServerType): Promise<void> {
+        const state = this.stateFactory.createGlobalPersistentState<LanguageServerType | undefined>('SWITCH_LS', undefined);
+        if (typeof state.value !== 'string') {
+            await state.updateValue(newValue);
             return;
         }
-        if (state.value !== jediEnabled) {
-            await state.updateValue(jediEnabled);
-            const message = jediEnabled ? 'Switch to Jedi from LS' : 'Switch to LS from Jedi';
-            sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_SWITCHED, undefined, { change: message });
+        const oldValue = state.value;
+        if (oldValue !== newValue) {
+            await state.updateValue(newValue);
+            sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_SWITCHED, undefined, { oldValue, newValue });
         }
     }
 
     /**
-     * Checks if user has not manually set `jediEnabled` setting
+     * Checks if user has not manually set `languageServer` setting
      * @param resource
-     * @returns `true` if user has NOT manually added the setting and is using default configuration, `false` if user has `jediEnabled` setting added
+     * @returns `true` if user has NOT manually added the setting and is using default configuration, `false` if user has `languageServer` setting added
      */
-    public isJediUsingDefaultConfiguration(resource?: Uri): boolean {
-        const settings = this.workspaceService.getConfiguration('python', resource).inspect<boolean>('jediEnabled');
+    public isLanguageServerUsingDefaultConfiguration(resource?: Uri): boolean {
+        const settings = this.workspaceService.getConfiguration('python', resource).inspect<LanguageServerType>('languageServer');
         if (!settings) {
-            traceError('WorkspaceConfiguration.inspect returns `undefined` for setting `python.jediEnabled`');
+            traceError('WorkspaceConfiguration.inspect returns `undefined` for setting `python.languageServer`');
             return false;
         }
         return (settings.globalValue === undefined && settings.workspaceValue === undefined && settings.workspaceFolderValue === undefined);
@@ -133,20 +141,34 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
 
     /**
      * Checks if user is using Jedi as intellisense
-     * @returns `true` if user is using jedi, `false` if user is using language server
+     * @returns `jedi` if user is using jedi, `microsoft` if user is using language server
+     * or `none` if using neither.
      */
-    public useJedi(): boolean {
-        if (this.isJediUsingDefaultConfiguration()) {
+    public getLanguageServerSetting(): LanguageServerType {
+        if (this.isLanguageServerUsingDefaultConfiguration()) {
             if (this.abExperiments.inExperiment(LSEnabled)) {
-                return false;
+                return 'microsoft';
             }
             // Send telemetry if user is in control group
             this.abExperiments.sendTelemetryIfInExperiment(LSControl);
         }
         const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
-        const enabled = configurationService.getSettings(this.resource).jediEnabled;
-        this.trackLangaugeServerSwitch(enabled).ignoreErrors();
-        return enabled;
+        const languageServerValue = configurationService.getSettings(this.resource).languageServer.toLowerCase();
+        let languageServerType: LanguageServerType;
+
+        // Make sure the value is one of the allowed values.
+        if (languageServerValue === 'microsoft') {
+            languageServerType = 'microsoft';
+        } else if (languageServerValue === 'none') {
+            languageServerType = 'none';
+        } else {
+            // Map everything else to the default value.
+            languageServerType = 'jedi';
+        }
+
+        this.trackLangaugeServerSwitch(languageServerType).ignoreErrors();
+
+        return languageServerType;
     }
 
     protected onWorkspaceFoldersChanged() {
@@ -162,10 +184,15 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         }
     }
 
-    private async logStartup(isJedi: boolean): Promise<void> {
-        const outputLine = isJedi
-            ? 'Starting Jedi Python language engine.'
-            : 'Starting Microsoft Python language server.';
+    private async logStartup(lsSettingValue: LanguageServerType): Promise<void> {
+        let outputLine: string;
+        if (lsSettingValue === 'jedi') {
+            outputLine = 'Starting Jedi Python language engine.';
+        } else if (lsSettingValue === 'none') {
+            outputLine = 'No language server started.';
+        } else {
+            outputLine = 'Starting Microsoft Python language server.';
+        }
         this.output.appendLine(outputLine);
     }
 
@@ -173,12 +200,20 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
         const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders
             ? this.workspaceService.workspaceFolders!.map(workspace => workspace.uri)
             : [undefined];
-        if (workspacesUris.findIndex(uri => event.affectsConfiguration(`python.${jediEnabledSetting}`, uri)) === -1) {
+        if (workspacesUris.findIndex(uri => event.affectsConfiguration(`python.${languageServerSetting}`, uri)) === -1) {
             return;
         }
-        const jedi = this.useJedi();
-        if (this.currentActivator && this.currentActivator.jedi === jedi) {
-            return;
+        const newSettingValue = this.getLanguageServerSetting();
+
+        // If the setting value doesn't require a change in activators, return without doing anything.
+        if (newSettingValue === 'none') {
+            if (this.currentActivator === undefined) {
+                return;
+            }
+        } else {
+            if (this.currentActivator && this.currentActivator.jedi === (newSettingValue === 'jedi')) {
+                return;
+            }
         }
 
         const item = await this.appShell.showInformationMessage(

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -112,7 +112,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
     }
 
     @swallowExceptions('Switch Language Server')
-    public async trackLangaugeServerSwitch(newValue: LanguageServerType): Promise<void> {
+    public async trackLanguageServerSwitch(newValue: LanguageServerType): Promise<void> {
         const state = this.stateFactory.createGlobalPersistentState<LanguageServerType | undefined>('SWITCH_LS', undefined);
         if (typeof state.value !== 'string') {
             await state.updateValue(newValue);
@@ -166,7 +166,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
             languageServerType = 'jedi';
         }
 
-        this.trackLangaugeServerSwitch(languageServerType).ignoreErrors();
+        this.trackLanguageServerSwitch(languageServerType).ignoreErrors();
 
         return languageServerType;
     }

--- a/src/client/activation/languageServer/languageClientFactory.ts
+++ b/src/client/activation/languageServer/languageClientFactory.ts
@@ -41,7 +41,7 @@ export class BaseLanguageClientFactory implements ILanguageClientFactory {
 }
 
 /**
- * Creates a langauge client for use by users of the extension.
+ * Creates a language client for use by users of the extension.
  *
  * @export
  * @class DownloadedLanguageClientFactory

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -23,6 +23,7 @@ import {
     ITerminalSettings,
     ITestingSettings,
     IWorkspaceSymbolSettings,
+    LanguageServerType,
     Resource
 } from './types';
 import { debounceSync } from './utils/decorators';
@@ -35,7 +36,7 @@ const untildify = require('untildify');
 export class PythonSettings implements IPythonSettings {
     private static pythonSettings: Map<string, PythonSettings> = new Map<string, PythonSettings>();
     public downloadLanguageServer = true;
-    public jediEnabled = true;
+    public languageServer: LanguageServerType = 'jedi';
     public jediPath = '';
     public jediMemoryLimit = 1024;
     public envFile = '';
@@ -153,9 +154,9 @@ export class PythonSettings implements IPythonSettings {
         this.poetryPath = poetryPath && poetryPath.length > 0 ? getAbsolutePath(poetryPath, workspaceRoot) : poetryPath;
 
         this.downloadLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('downloadLanguageServer', true))!;
-        this.jediEnabled = systemVariables.resolveAny(pythonSettings.get<boolean>('jediEnabled', true))!;
+        this.languageServer = systemVariables.resolveAny(pythonSettings.get<LanguageServerType>('languageServer'))!;
         this.autoUpdateLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('autoUpdateLanguageServer', true))!;
-        if (this.jediEnabled) {
+        if (this.languageServer === 'jedi') {
             // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
             this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!;
             if (typeof this.jediPath === 'string' && this.jediPath.length > 0) {

--- a/src/client/common/featureDeprecationManager.ts
+++ b/src/client/common/featureDeprecationManager.ts
@@ -27,7 +27,7 @@ const deprecatedFeatures: DeprecatedFeatureInfo[] = [
     },
     {
         doNotDisplayPromptStateKey: 'SHOW_DEPRECATED_FEATURE_PROMPT_FOR_AUTO_COMPLETE_PRELOAD_MODULES',
-        message: 'The setting \'python.autoComplete.preloadModules\' is deprecated, please consider using the new Language Server (\'python.jediEnabled = false\').',
+        message: 'The setting \'python.autoComplete.preloadModules\' is deprecated, please consider using the new Language Server (\'python.languageServer = "microsoft"\').',
         moreInfoUrl: 'https://github.com/Microsoft/vscode-python/issues/1704',
         setting: { setting: 'autoComplete.preloadModules' }
     }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -145,6 +145,7 @@ export interface ICurrentProcess {
     on(event: string | symbol, listener: Function): this;
 }
 
+export type LanguageServerType = 'jedi' | 'microsoft' | 'none';
 export interface IPythonSettings {
     readonly pythonPath: string;
     readonly venvPath: string;
@@ -154,7 +155,7 @@ export interface IPythonSettings {
     readonly poetryPath: string;
     readonly insidersChannel: ExtensionChannels;
     readonly downloadLanguageServer: boolean;
-    readonly jediEnabled: boolean;
+    readonly languageServer: LanguageServerType;
     readonly jediPath: string;
     readonly jediMemoryLimit: number;
     readonly devOptions: string[];

--- a/src/client/datascience/interactive-window/intellisense/dotNetIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-window/intellisense/dotNetIntellisenseProvider.ts
@@ -40,11 +40,15 @@ export class DotNetIntellisenseProvider extends BaseIntellisenseProvider impleme
 
         // Make sure we're active. We still listen to messages for adding and editing cells,
         // but we don't actually return any data.
-        this.active = !this.configService.getSettings().jediEnabled;
+        const isLsActive = () => {
+            const lsSetting = this.configService.getSettings().languageServer;
+            return lsSetting === 'microsoft';
+        };
+        this.active = isLsActive();
 
         // Listen for updates to settings to change this flag. Don't bother disposing the config watcher. It lives
         // till the extension dies anyway.
-        this.configService.getSettings().onDidChange(() => this.active = !this.configService.getSettings().jediEnabled);
+        this.configService.getSettings().onDidChange(() => this.active = isLsActive());
     }
 
     protected get isActive(): boolean {

--- a/src/client/datascience/interactive-window/intellisense/jediIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-window/intellisense/jediIntellisenseProvider.ts
@@ -48,10 +48,14 @@ export class JediIntellisenseProvider extends BaseIntellisenseProvider implement
 
         // Make sure we're active. We still listen to messages for adding and editing cells,
         // but we don't actually return any data.
-        this.active = this.configService.getSettings().jediEnabled;
+        const isJediActive = () => {
+            const lsSetting = this.configService.getSettings().languageServer;
+            return lsSetting === 'jedi';
+        };
+        this.active = isJediActive();
 
         // Listen for updates to settings to change this flag
-        disposables.push(this.configService.getSettings().onDidChange(() => this.active = this.configService.getSettings().jediEnabled));
+        disposables.push(this.configService.getSettings().onDidChange(() => this.active = isJediActive()));
 
         // Create our jedi wrappers if necessary
         if (this.active) {

--- a/src/client/languageServices/proposeLanguageServerBanner.ts
+++ b/src/client/languageServices/proposeLanguageServerBanner.ts
@@ -110,6 +110,6 @@ export class ProposeLanguageServerBanner implements IPythonExtensionBanner {
     }
 
     public async enableNewLanguageServer(): Promise<void> {
-        await this.configuration.updateSetting('jediEnabled', false, undefined, ConfigurationTarget.Global);
+        await this.configuration.updateSetting('languageServer', 'microsoft', undefined, ConfigurationTarget.Global);
     }
 }

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -126,11 +126,11 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      *
      * This is a feature of the vscode-python extension that will become enabled once the
      * Python Language Server becomes the default, replacing Jedi as the default. Testing
-     * the global default setting for `"python.jediEnabled": false` enables it.
+     * the global default setting for `"python.languageServer": "microsoft"` enables it.
      *
-     * @returns true if the global default for python.jediEnabled is false.
+     * @returns true if the global default for python.languageServer is "microsoft".
      */
     public get isFeatureEnabled(): boolean {
-        return !this.configService.getSettings().jediEnabled;
+        return this.configService.getSettings().languageServer === 'microsoft';
     }
 }

--- a/src/client/linters/linterInfo.ts
+++ b/src/client/linters/linterInfo.ts
@@ -77,7 +77,7 @@ export class PylintLinterInfo extends LinterInfo {
     }
     public isEnabled(resource?: Uri): boolean {
         const enabled = super.isEnabled(resource);
-        if (!enabled || this.configService.getSettings(resource).jediEnabled) {
+        if (!enabled || this.configService.getSettings(resource).languageServer === 'jedi') {
             return enabled;
         }
         // If we're using new LS, then by default Pylint is disabled (unless the user provides a value).

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -871,7 +871,16 @@ export interface IEventNamePropertyMapping {
     /**
      * Telemetry tracking switching between LS and Jedi
      */
-    [EventName.PYTHON_LANGUAGE_SERVER_SWITCHED]: { change: 'Switch to Jedi from LS' | 'Switch to LS from Jedi' };
+    [EventName.PYTHON_LANGUAGE_SERVER_SWITCHED]: {
+        /**
+         * Value of LS setting prior to switch.
+         */
+        oldValue: string;
+        /**
+         * Value of LS setting after switch.
+         */
+        newValue: string;
+    };
     /**
      * Telemetry event sent with details after attempting to download LS
      */

--- a/src/client/testing/common/updateTestSettings.ts
+++ b/src/client/testing/common/updateTestSettings.ts
@@ -53,17 +53,22 @@ export class UpdateTestSettingService implements IExtensionActivationService {
         const setting_pytest_enabled = new RegExp('.pyTestEnabled"', 'g');
         const setting_pytest_args = new RegExp('.pyTestArgs"', 'g');
         const setting_pytest_path = new RegExp('.pyTestPath"', 'g');
+        const setting_jedi_disabled = new RegExp('.jediEnabled": false', 'g');
+        const setting_jedi_enabled = new RegExp('.jediEnabled": true', 'g');
 
         fileContents = fileContents.replace(setting, '"python.testing');
         fileContents = fileContents.replace(setting_pytest_enabled, '.pytestEnabled"');
         fileContents = fileContents.replace(setting_pytest_args, '.pytestArgs"');
         fileContents = fileContents.replace(setting_pytest_path, '.pytestPath"');
+        fileContents = fileContents.replace(setting_jedi_disabled, '.languageServer": "microsoft"');
+        fileContents = fileContents.replace(setting_jedi_enabled, '.languageServer": "jedi"');
         await this.fs.writeFile(filePath, fileContents);
     }
     public async doesFileNeedToBeFixed(filePath: string) {
         try {
             const contents = await this.fs.readFile(filePath);
-            return contents.indexOf('python.unitTest.') > 0 || contents.indexOf('.pyTest') > 0;
+            return contents.indexOf('python.unitTest.') > 0 || contents.indexOf('.pyTest') > 0 ||
+                contents.indexOf('python.jediEnabled') > 0;
         } catch (ex) {
             traceError('Failed to check if file needs to be fixed', ex);
             return false;

--- a/src/client/testing/common/updateTestSettings.ts
+++ b/src/client/testing/common/updateTestSettings.ts
@@ -49,12 +49,12 @@ export class UpdateTestSettingService implements IExtensionActivationService {
     @swallowExceptions('Failed to update settings.json')
     public async fixSettingInFile(filePath: string) {
         let fileContents = await this.fs.readFile(filePath);
-        const setting = new RegExp('"python.unitTest', 'g');
-        const setting_pytest_enabled = new RegExp('.pyTestEnabled"', 'g');
-        const setting_pytest_args = new RegExp('.pyTestArgs"', 'g');
-        const setting_pytest_path = new RegExp('.pyTestPath"', 'g');
-        const setting_jedi_disabled = new RegExp('.jediEnabled": false', 'g');
-        const setting_jedi_enabled = new RegExp('.jediEnabled": true', 'g');
+        const setting = new RegExp('"python\\.unitTest', 'g');
+        const setting_pytest_enabled = new RegExp('\\.pyTestEnabled"', 'g');
+        const setting_pytest_args = new RegExp('\\.pyTestArgs"', 'g');
+        const setting_pytest_path = new RegExp('\\.pyTestPath"', 'g');
+        const setting_jedi_disabled = new RegExp('\\.jediEnabled": *false', 'g');
+        const setting_jedi_enabled = new RegExp('\\.jediEnabled": *true', 'g');
 
         fileContents = fileContents.replace(setting, '"python.testing');
         fileContents = fileContents.replace(setting_pytest_enabled, '.pytestEnabled"');

--- a/src/test/.vscode/settings.json
+++ b/src/test/.vscode/settings.json
@@ -19,8 +19,8 @@
     "python.linting.banditEnabled": false,
     "python.formatting.provider": "yapf",
     "python.linting.pylintUseMinimalCheckers": false
-    // Do not set this to true/false even when LS is the default, else
+    // Do not set this value even when LS is the default, else
     // it will result in LS being downloaded on CI and slow down tests significantly.
     // We have other tests on CI for testing downloading of CI with this setting enabled.
-    // "python.jediEnabled": true
+    // "python.languageServer": "jedi"
 }

--- a/src/test/activation/activationService.unit.test.ts
+++ b/src/test/activation/activationService.unit.test.ts
@@ -22,14 +22,18 @@ import { IDiagnostic, IDiagnosticsService } from '../../client/application/diagn
 import { IApplicationShell, ICommandManager, IWorkspaceService } from '../../client/common/application/types';
 import { LSControl, LSEnabled } from '../../client/common/experimentGroups';
 import { IPlatformService } from '../../client/common/platform/types';
-import { IConfigurationService, IDisposable, IDisposableRegistry, IExperimentsManager, IOutputChannel, IPersistentState, IPersistentStateFactory, IPythonSettings, Resource } from '../../client/common/types';
+import {
+    IConfigurationService, IDisposable, IDisposableRegistry, IExperimentsManager, IOutputChannel,
+    IPersistentState, IPersistentStateFactory, IPythonSettings, LanguageServerType, Resource
+} from '../../client/common/types';
 import { IServiceContainer } from '../../client/ioc/types';
 
 // tslint:disable:no-any
 
 suite('Activation - ActivationService', () => {
-    [true, false].forEach(jediIsEnabled => {
-        suite(`Test activation - ${jediIsEnabled ? 'Jedi is enabled' : 'Jedi is disabled'}`, () => {
+    const languageServiceValues: LanguageServerType[] = ['jedi', 'microsoft', 'none'];
+    languageServiceValues.forEach(languageServerValue => {
+        suite(`Test activation - Language Server is ${languageServerValue}`, () => {
             let serviceContainer: TypeMoq.IMock<IServiceContainer>;
             let pythonSettings: TypeMoq.IMock<IPythonSettings>;
             let appShell: TypeMoq.IMock<IApplicationShell>;
@@ -68,10 +72,10 @@ suite('Activation - ActivationService', () => {
                     .returns(() => state.object);
                 state.setup(s => s.value).returns(() => undefined);
                 state.setup(s => s.updateValue(TypeMoq.It.isAny())).returns(() => Promise.resolve());
-                const setting = { workspaceFolderValue: jediIsEnabled };
+                const setting = { workspaceFolderValue: languageServerValue };
                 workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
                 workspaceService.setup(ws => ws.getConfiguration('python', TypeMoq.It.isAny())).returns(() => workspaceConfig.object);
-                workspaceConfig.setup(c => c.inspect<boolean>('jediEnabled'))
+                workspaceConfig.setup(c => c.inspect<string>('languageServer'))
                     .returns(() => setting as any);
                 const output = TypeMoq.Mock.ofType<IOutputChannel>();
                 serviceContainer
@@ -114,13 +118,14 @@ suite('Activation - ActivationService', () => {
                 activator
                     .setup(a => a.activate(undefined))
                     .returns(() => Promise.resolve())
-                    .verifiable(TypeMoq.Times.once());
+                    .verifiable(languageServerValue === 'none' ?
+                        TypeMoq.Times.never() : TypeMoq.Times.once());
                 let activatorName = LanguageServerActivator.Jedi;
-                if (lsSupported && !jediIsEnabled) {
+                if (lsSupported && languageServerValue === 'microsoft') {
                     activatorName = LanguageServerActivator.DotNet;
                 }
                 let diagnostics: IDiagnostic[];
-                if (!lsSupported && !jediIsEnabled) {
+                if (!lsSupported && languageServerValue === 'microsoft') {
                     diagnostics = [TypeMoq.It.isAny()];
                 } else {
                     diagnostics = [];
@@ -134,7 +139,8 @@ suite('Activation - ActivationService', () => {
                 serviceContainer
                     .setup(c => c.get(TypeMoq.It.isValue(ILanguageServerActivator), TypeMoq.It.isValue(activatorName)))
                     .returns(() => activator.object)
-                    .verifiable(TypeMoq.Times.once());
+                    .verifiable(languageServerValue === 'none' ?
+                        TypeMoq.Times.never() : TypeMoq.Times.once());
 
                 experiments
                     .setup(ex => ex.inExperiment(TypeMoq.It.isAny()))
@@ -149,14 +155,14 @@ suite('Activation - ActivationService', () => {
             }
 
             test('LS is supported', async () => {
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
                 await testActivation(activationService, activator, true);
             });
             test('LS is not supported', async () => {
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
@@ -164,14 +170,14 @@ suite('Activation - ActivationService', () => {
             });
 
             test('Activatory must be activated', async () => {
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
                 await testActivation(activationService, activator);
             });
             test('Activatory must be deactivated', async () => {
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
@@ -179,21 +185,22 @@ suite('Activation - ActivationService', () => {
 
                 activator
                     .setup(a => a.dispose())
-                    .verifiable(TypeMoq.Times.once());
+                    .verifiable(languageServerValue === 'none' ?
+                        TypeMoq.Times.never() : TypeMoq.Times.once());
 
                 activationService.dispose();
                 activator.verifyAll();
             });
             test('Prompt user to reload VS Code and reload, when setting is toggled', async () => {
                 let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
-                let jediIsEnabledValueInSetting = jediIsEnabled;
+                let lsValueInSetting = languageServerValue;
                 workspaceService
                     .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                     .callback(cb => (callbackHandler = cb))
                     .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
                     .verifiable(TypeMoq.Times.once());
 
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabledValueInSetting);
+                pythonSettings.setup(p => p.languageServer).returns(() => lsValueInSetting);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
@@ -202,7 +209,7 @@ suite('Activation - ActivationService', () => {
 
                 const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
                 event
-                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.languageServer'), TypeMoq.It.isAny()))
                     .returns(() => true)
                     .verifiable(TypeMoq.Times.atLeastOnce());
                 appShell
@@ -214,7 +221,7 @@ suite('Activation - ActivationService', () => {
                     .verifiable(TypeMoq.Times.once());
 
                 // Toggle the value in the setting and invoke the callback.
-                jediIsEnabledValueInSetting = !jediIsEnabledValueInSetting;
+                lsValueInSetting = lsValueInSetting === 'none' ? 'jedi' : 'none';
                 await callbackHandler(event.object);
 
                 event.verifyAll();
@@ -223,14 +230,14 @@ suite('Activation - ActivationService', () => {
             });
             test('Prompt user to reload VS Code and do not reload, when setting is toggled', async () => {
                 let callbackHandler!: (e: ConfigurationChangeEvent) => Promise<void>;
-                let jediIsEnabledValueInSetting = jediIsEnabled;
+                let lsValueInSetting = languageServerValue;
                 workspaceService
                     .setup(w => w.onDidChangeConfiguration(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                     .callback(cb => (callbackHandler = cb))
                     .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
                     .verifiable(TypeMoq.Times.once());
 
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabledValueInSetting);
+                pythonSettings.setup(p => p.languageServer).returns(() => lsValueInSetting);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
@@ -239,7 +246,7 @@ suite('Activation - ActivationService', () => {
 
                 const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
                 event
-                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.languageServer'), TypeMoq.It.isAny()))
                     .returns(() => true)
                     .verifiable(TypeMoq.Times.atLeastOnce());
                 appShell
@@ -251,7 +258,7 @@ suite('Activation - ActivationService', () => {
                     .verifiable(TypeMoq.Times.never());
 
                 // Toggle the value in the setting and invoke the callback.
-                jediIsEnabledValueInSetting = !jediIsEnabledValueInSetting;
+                lsValueInSetting = lsValueInSetting === 'none' ? 'jedi' : 'none';
                 await callbackHandler(event.object);
 
                 event.verifyAll();
@@ -266,7 +273,7 @@ suite('Activation - ActivationService', () => {
                     .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
                     .verifiable(TypeMoq.Times.once());
 
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
@@ -275,7 +282,7 @@ suite('Activation - ActivationService', () => {
 
                 const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
                 event
-                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.languageServer'), TypeMoq.It.isAny()))
                     .returns(() => true)
                     .verifiable(TypeMoq.Times.atLeastOnce());
                 appShell
@@ -301,7 +308,7 @@ suite('Activation - ActivationService', () => {
                     .returns(() => TypeMoq.Mock.ofType<Disposable>().object)
                     .verifiable(TypeMoq.Times.once());
 
-                pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                 const activator = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                 const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
 
@@ -310,7 +317,7 @@ suite('Activation - ActivationService', () => {
 
                 const event = TypeMoq.Mock.ofType<ConfigurationChangeEvent>();
                 event
-                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.jediEnabled'), TypeMoq.It.isAny()))
+                    .setup(e => e.affectsConfiguration(TypeMoq.It.isValue('python.languageServer'), TypeMoq.It.isAny()))
                     .returns(() => false)
                     .verifiable(TypeMoq.Times.atLeastOnce());
                 appShell
@@ -328,9 +335,9 @@ suite('Activation - ActivationService', () => {
                 appShell.verifyAll();
                 cmdManager.verifyAll();
             });
-            if (!jediIsEnabled) {
+            if (languageServerValue === 'microsoft') {
                 test('Revert to jedi when LS activation fails', async () => {
-                    pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                    pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                     const activatorDotNet = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                     const activatorJedi = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                     const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
@@ -410,7 +417,7 @@ suite('Activation - ActivationService', () => {
                     experiments.verifyAll();
                 }
                 test('Activator is disposed if activated workspace is removed', async () => {
-                    pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                    pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                     let workspaceFoldersChangedHandler!: Function;
                     workspaceService
                         .setup(w => w.onDidChangeWorkspaceFolders(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
@@ -455,9 +462,9 @@ suite('Activation - ActivationService', () => {
                     workspaceService.verifyAll();
                     activator3.verifyAll();
                 });
-            } else {
+            } else if (languageServerValue === 'jedi') {
                 test('Jedi is only activated once', async () => {
-                    pythonSettings.setup(p => p.jediEnabled).returns(() => jediIsEnabled);
+                    pythonSettings.setup(p => p.languageServer).returns(() => languageServerValue);
                     const activator1 = TypeMoq.Mock.ofType<ILanguageServerActivator>();
                     const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
                     const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
@@ -511,7 +518,7 @@ suite('Activation - ActivationService', () => {
         let platformService: TypeMoq.IMock<IPlatformService>;
         let lsNotSupportedDiagnosticService: TypeMoq.IMock<IDiagnosticsService>;
         let stateFactory: TypeMoq.IMock<IPersistentStateFactory>;
-        let state: TypeMoq.IMock<IPersistentState<boolean | undefined>>;
+        let state: TypeMoq.IMock<IPersistentState<LanguageServerType | undefined>>;
         let experiments: TypeMoq.IMock<IExperimentsManager>;
         let workspaceConfig: TypeMoq.IMock<WorkspaceConfiguration>;
         setup(() => {
@@ -521,7 +528,7 @@ suite('Activation - ActivationService', () => {
             cmdManager = TypeMoq.Mock.ofType<ICommandManager>();
             platformService = TypeMoq.Mock.ofType<IPlatformService>();
             stateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
-            state = TypeMoq.Mock.ofType<IPersistentState<boolean | undefined>>();
+            state = TypeMoq.Mock.ofType<IPersistentState<LanguageServerType | undefined>>();
             const configService = TypeMoq.Mock.ofType<IConfigurationService>();
             pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
             experiments = TypeMoq.Mock.ofType<IExperimentsManager>();
@@ -579,32 +586,45 @@ suite('Activation - ActivationService', () => {
         test('Track current LS usage for first usage', async () => {
             state.reset();
             state.setup(s => s.value).returns(() => undefined).verifiable(TypeMoq.Times.once());
-            state.setup(s => s.updateValue(TypeMoq.It.isValue(true))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
+            state.setup(s => s.updateValue(TypeMoq.It.isValue('jedi'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch(true);
+            await activationService.trackLangaugeServerSwitch('jedi');
 
             state.verifyAll();
         });
+
         test('Track switch to LS', async () => {
             state.reset();
-            state.setup(s => s.value).returns(() => true).verifiable(TypeMoq.Times.once());
-            state.setup(s => s.updateValue(TypeMoq.It.isValue(false))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
+            state.setup(s => s.value).returns(() => 'jedi').verifiable(TypeMoq.Times.once());
+            state.setup(s => s.updateValue(TypeMoq.It.isValue('microsoft'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch(false);
+            await activationService.trackLangaugeServerSwitch('microsoft');
 
-            state.verify(s => s.updateValue(TypeMoq.It.isValue(false)), TypeMoq.Times.once());
+            state.verify(s => s.updateValue(TypeMoq.It.isValue('microsoft')), TypeMoq.Times.once());
         });
+
         test('Track switch to Jedi', async () => {
             state.reset();
-            state.setup(s => s.value).returns(() => false).verifiable(TypeMoq.Times.once());
-            state.setup(s => s.updateValue(TypeMoq.It.isValue(true))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
+            state.setup(s => s.value).returns(() => 'microsoft').verifiable(TypeMoq.Times.once());
+            state.setup(s => s.updateValue(TypeMoq.It.isValue('jedi'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch(true);
+            await activationService.trackLangaugeServerSwitch('jedi');
 
-            state.verify(s => s.updateValue(TypeMoq.It.isValue(true)), TypeMoq.Times.once());
+            state.verify(s => s.updateValue(TypeMoq.It.isValue('jedi')), TypeMoq.Times.once());
+        });
+
+        test('Track switch to None', async () => {
+            state.reset();
+            state.setup(s => s.value).returns(() => 'microsoft').verifiable(TypeMoq.Times.once());
+            state.setup(s => s.updateValue(TypeMoq.It.isValue('none'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
+
+            const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
+            await activationService.trackLangaugeServerSwitch('none');
+
+            state.verify(s => s.updateValue(TypeMoq.It.isValue('none')), TypeMoq.Times.once());
         });
     });
 
@@ -692,13 +712,13 @@ suite('Activation - ActivationService', () => {
                 .setup(ex => ex.sendTelemetryIfInExperiment(TypeMoq.It.isAny()))
                 .returns(() => undefined)
                 .verifiable(TypeMoq.Times.never());
-            workspaceConfig.setup(c => c.inspect<boolean>('jediEnabled'))
+            workspaceConfig.setup(c => c.inspect<string>('languageServer'))
                 .returns(() => settings as any)
                 .verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            const result = activationService.useJedi();
-            expect(result).to.equal(false, 'LS should be enabled');
+            const result = activationService.getLanguageServerSetting();
+            expect(result).to.equal('microsoft', 'LS should be enabled');
 
             workspaceService.verifyAll();
             workspaceConfig.verifyAll();
@@ -715,17 +735,17 @@ suite('Activation - ActivationService', () => {
                 .setup(ex => ex.sendTelemetryIfInExperiment(LSControl))
                 .returns(() => undefined)
                 .verifiable(TypeMoq.Times.once());
-            workspaceConfig.setup(c => c.inspect<boolean>('jediEnabled'))
+            workspaceConfig.setup(c => c.inspect<string>('languageServer'))
                 .returns(() => settings as any)
                 .verifiable(TypeMoq.Times.once());
             pythonSettings
-                .setup(p => p.jediEnabled)
-                .returns(() => true)
+                .setup(p => p.languageServer)
+                .returns(() => 'jedi')
                 .verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            const result = activationService.useJedi();
-            expect(result).to.equal(true, 'Return value should be true');
+            const result = activationService.getLanguageServerSetting();
+            expect(result).to.equal('jedi', 'Return value should be "jedi"');
 
             pythonSettings.verifyAll();
             experiments.verifyAll();
@@ -736,14 +756,19 @@ suite('Activation - ActivationService', () => {
         suite('If default value of jedi is not being used, then no experiments are used, and python settings value is returned', async () => {
             [
                 {
-                    testName: 'Returns false when python settings value is false',
-                    pythonSettingsValue: false,
-                    expectedResult: false
+                    testName: 'Returns "microsoft" when python settings value is "microsoft',
+                    pythonSettingsValue: 'microsoft' as LanguageServerType,
+                    expectedResult: 'microsoft' as LanguageServerType
                 },
                 {
-                    testName: 'Returns true when python settings value is true',
-                    pythonSettingsValue: true,
-                    expectedResult: true
+                    testName: 'Returns "jedi" when python settings value is "jedi"',
+                    pythonSettingsValue: 'jedi' as LanguageServerType,
+                    expectedResult: 'jedi' as LanguageServerType
+                },
+                {
+                    testName: 'Returns "none" when python settings value is "none"',
+                    pythonSettingsValue: 'none' as LanguageServerType,
+                    expectedResult: 'none' as LanguageServerType
                 }
             ].forEach(testParams => {
                 test(testParams.testName, async () => {
@@ -756,16 +781,16 @@ suite('Activation - ActivationService', () => {
                         .setup(ex => ex.sendTelemetryIfInExperiment(LSControl))
                         .returns(() => undefined)
                         .verifiable(TypeMoq.Times.never());
-                    workspaceConfig.setup(c => c.inspect<boolean>('jediEnabled'))
+                    workspaceConfig.setup(c => c.inspect<string>('languageServer'))
                         .returns(() => settings as any)
                         .verifiable(TypeMoq.Times.once());
                     pythonSettings
-                        .setup(p => p.jediEnabled)
+                        .setup(p => p.languageServer)
                         .returns(() => testParams.pythonSettingsValue)
                         .verifiable(TypeMoq.Times.once());
 
                     const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-                    const result = activationService.useJedi();
+                    const result = activationService.getLanguageServerSetting();
                     expect(result).to.equal(testParams.pythonSettingsValue, `Return value should be ${testParams.pythonSettingsValue}`);
 
                     pythonSettings.verifyAll();
@@ -865,12 +890,12 @@ suite('Activation - ActivationService', () => {
                     const testName = `Returns ${expectedResult} for setting = ${JSON.stringify(settings)}`;
                     test(testName, async () => {
                         workspaceConfig.reset();
-                        workspaceConfig.setup(c => c.inspect<boolean>('jediEnabled'))
+                        workspaceConfig.setup(c => c.inspect<string>('languageServer'))
                             .returns(() => settings as any)
                             .verifiable(TypeMoq.Times.once());
 
                         const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-                        const result = activationService.isJediUsingDefaultConfiguration(Uri.parse('a'));
+                        const result = activationService.isLanguageServerUsingDefaultConfiguration(Uri.parse('a'));
                         expect(result).to.equal(expectedResult);
 
                         workspaceService.verifyAll();
@@ -881,12 +906,12 @@ suite('Activation - ActivationService', () => {
         }
         test('Returns false for settings = undefined', async () => {
             workspaceConfig.reset();
-            workspaceConfig.setup(c => c.inspect<boolean>('jediEnabled'))
+            workspaceConfig.setup(c => c.inspect<string>('languageServer'))
                 .returns(() => undefined as any)
                 .verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            const result = activationService.isJediUsingDefaultConfiguration(Uri.parse('a'));
+            const result = activationService.isLanguageServerUsingDefaultConfiguration(Uri.parse('a'));
             expect(result).to.equal(false, 'Return value should be false');
 
             workspaceService.verifyAll();

--- a/src/test/activation/activationService.unit.test.ts
+++ b/src/test/activation/activationService.unit.test.ts
@@ -509,7 +509,7 @@ suite('Activation - ActivationService', () => {
         });
     });
 
-    suite('Test trackLangaugeServerSwitch()', () => {
+    suite('Test trackLanguageServerSwitch()', () => {
         let serviceContainer: TypeMoq.IMock<IServiceContainer>;
         let pythonSettings: TypeMoq.IMock<IPythonSettings>;
         let appShell: TypeMoq.IMock<IApplicationShell>;
@@ -589,7 +589,7 @@ suite('Activation - ActivationService', () => {
             state.setup(s => s.updateValue(TypeMoq.It.isValue('jedi'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch('jedi');
+            await activationService.trackLanguageServerSwitch('jedi');
 
             state.verifyAll();
         });
@@ -600,7 +600,7 @@ suite('Activation - ActivationService', () => {
             state.setup(s => s.updateValue(TypeMoq.It.isValue('microsoft'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch('microsoft');
+            await activationService.trackLanguageServerSwitch('microsoft');
 
             state.verify(s => s.updateValue(TypeMoq.It.isValue('microsoft')), TypeMoq.Times.once());
         });
@@ -611,7 +611,7 @@ suite('Activation - ActivationService', () => {
             state.setup(s => s.updateValue(TypeMoq.It.isValue('jedi'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch('jedi');
+            await activationService.trackLanguageServerSwitch('jedi');
 
             state.verify(s => s.updateValue(TypeMoq.It.isValue('jedi')), TypeMoq.Times.once());
         });
@@ -622,7 +622,7 @@ suite('Activation - ActivationService', () => {
             state.setup(s => s.updateValue(TypeMoq.It.isValue('none'))).returns(() => Promise.resolve()).verifiable(TypeMoq.Times.once());
 
             const activationService = new LanguageServerExtensionActivationService(serviceContainer.object, stateFactory.object, experiments.object);
-            await activationService.trackLangaugeServerSwitch('none');
+            await activationService.trackLanguageServerSwitch('none');
 
             state.verify(s => s.updateValue(TypeMoq.It.isValue('none')), TypeMoq.Times.once());
         });

--- a/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
+++ b/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
@@ -184,6 +184,16 @@ suite('Application Diagnostics - Check Test Settings', () => {
             expectedContents: '{"python.pythonPath":"1234", "python.testing.pytestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestPath":[]}'
         },
         {
+            testTitle: 'Should replace python.jediEnabled.',
+            contents: '{"python.jediEnabled":false}',
+            expectedContents: '{"python.languageServer": "microsoft"}'
+        },
+        {
+            testTitle: 'Should replace python.jediEnabled.',
+            contents: '{"python.jediEnabled": true}',
+            expectedContents: '{"python.languageServer": "jedi"}'
+        },
+        {
             testTitle: 'Should not make any changes to the file',
             contents: '{"python.pythonPath":"1234", "python.unittest.unitTestArgs":[], "python.unitTest.pytestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestPath":[]}',
             expectedContents: '{"python.pythonPath":"1234", "python.unittest.unitTestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestPath":[]}'

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -49,7 +49,7 @@ export type PythonSettingKeys = 'workspaceSymbols.enabled' | 'pythonPath' |
     'testing.nosetestArgs' | 'testing.pytestArgs' | 'testing.unittestArgs' |
     'formatting.provider' | 'sortImports.args' |
     'testing.nosetestsEnabled' | 'testing.pytestEnabled' | 'testing.unittestEnabled' |
-    'envFile' | 'jediEnabled' | 'linting.ignorePatterns' | 'terminal.activateEnvironment';
+    'envFile' | 'languageServer' | 'linting.ignorePatterns' | 'terminal.activateEnvironment';
 
 async function disposePythonSettings() {
     if (!IS_SMOKE_TEST) {

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -48,12 +48,12 @@ suite('Python Settings', async () => {
 
     function initializeConfig(sourceSettings: PythonSettings) {
         // string settings
-        for (const name of ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel']) {
+        for (const name of ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel', 'languageServer']) {
             config.setup(c => c.get<string>(name))
                 // tslint:disable-next-line:no-any
                 .returns(() => (sourceSettings as any)[name]);
         }
-        if (sourceSettings.jediEnabled) {
+        if (sourceSettings.languageServer === 'jedi') {
             config.setup(c => c.get<string>('jediPath'))
                 .returns(() => sourceSettings.jediPath);
         }
@@ -64,7 +64,7 @@ suite('Python Settings', async () => {
         }
 
         // boolean settings
-        for (const name of ['downloadLanguageServer', 'jediEnabled', 'autoUpdateLanguageServer']) {
+        for (const name of ['downloadLanguageServer', 'autoUpdateLanguageServer']) {
             config.setup(c => c.get<boolean>(name, true))
                 // tslint:disable-next-line:no-any
                 .returns(() => (sourceSettings as any)[name]);
@@ -76,7 +76,7 @@ suite('Python Settings', async () => {
         }
 
         // number settings
-        if (sourceSettings.jediEnabled) {
+        if (sourceSettings.languageServer === 'jedi') {
             config.setup(c => c.get<number>('jediMemoryLimit'))
                 .returns(() => sourceSettings.jediMemoryLimit);
         }
@@ -121,13 +121,13 @@ suite('Python Settings', async () => {
     }
 
     suite('String settings', async () => {
-        ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel'].forEach(async settingName => {
+        ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel', 'languageServer'].forEach(async settingName => {
             testIfValueIsUpdated(settingName, 'stringValue');
         });
     });
 
     suite('Boolean settings', async () => {
-        ['downloadLanguageServer', 'jediEnabled', 'autoUpdateLanguageServer', 'globalModuleInstallation'].forEach(async settingName => {
+        ['downloadLanguageServer', 'autoUpdateLanguageServer', 'globalModuleInstallation'].forEach(async settingName => {
             testIfValueIsUpdated(settingName, true);
         });
     });

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -86,7 +86,8 @@ import {
     ILogger,
     IPathUtils,
     IPersistentStateFactory,
-    IsWindows
+    IsWindows,
+    LanguageServerType
 } from '../../client/common/types';
 import { Deferred, sleep } from '../../client/common/utils/async';
 import { noop } from '../../client/common/utils/misc';
@@ -669,8 +670,8 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.extraListeners.push(callback);
     }
 
-    public changeJediEnabled(enabled: boolean) {
-        this.pythonSettings.jediEnabled = enabled;
+    public changeLanguageServer(languageServerValue: LanguageServerType) {
+        this.pythonSettings.languageServer = languageServerValue;
     }
 
     private findPythonPath(): string {

--- a/src/test/datascience/intellisense.functional.test.tsx
+++ b/src/test/datascience/intellisense.functional.test.tsx
@@ -23,7 +23,7 @@ suite('DataScience Intellisense tests', () => {
     setup(() => {
         ioc = new DataScienceIocContainer();
         // For this test, jedi is turned off so we use our mock language server
-        ioc.changeJediEnabled(false);
+        ioc.changeLanguageServer('microsoft');
         ioc.registerDataScienceTypes();
     });
 

--- a/src/test/datascience/intellisense.unit.test.ts
+++ b/src/test/datascience/intellisense.unit.test.ts
@@ -47,7 +47,7 @@ suite('DataScience Intellisense Unit Tests', () => {
         jupyterExecution = TypeMoq.Mock.ofType<IJupyterExecution>();
         interactiveWindowProvider = TypeMoq.Mock.ofType<IInteractiveWindowProvider>();
 
-        pythonSettings.jediEnabled = false;
+        pythonSettings.languageServer = 'microsoft';
         languageServer.setup(l => l.start(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve());
         analysisOptions.setup(a => a.getAnalysisOptions()).returns(() => Promise.resolve({}));
         languageServer.setup(l => l.languageClient).returns(() => languageClient);

--- a/src/test/linters/common.ts
+++ b/src/test/linters/common.ts
@@ -344,8 +344,8 @@ export class BaseTestFixture {
             })
             .returns(() => Promise.resolve(undefined));
 
-        this.pythonSettings.setup(s => s.jediEnabled)
-            .returns(() => true);
+        this.pythonSettings.setup(s => s.languageServer)
+            .returns(() => 'jedi');
     }
 
     private initData(): void {

--- a/src/test/linters/linter.availability.unit.test.ts
+++ b/src/test/linters/linter.availability.unit.test.ts
@@ -15,7 +15,7 @@ import { ConfigurationService } from '../../client/common/configuration/service'
 import { PersistentStateFactory } from '../../client/common/persistentState';
 import { FileSystem } from '../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../client/common/platform/types';
-import { IConfigurationService, IPersistentState, IPersistentStateFactory, IPythonSettings, Product } from '../../client/common/types';
+import { IConfigurationService, IPersistentState, IPersistentStateFactory, IPythonSettings, Product, LanguageServerType } from '../../client/common/types';
 import { Common, Linters } from '../../client/common/utils/localize';
 import { AvailableLinterActivator } from '../../client/linters/linterAvailability';
 import { LinterInfo } from '../../client/linters/linterInfo';
@@ -23,35 +23,35 @@ import { IAvailableLinterActivator, ILinterInfo } from '../../client/linters/typ
 
 // tslint:disable:max-func-body-length no-any
 suite('Linter Availability Provider tests', () => {
-    test('Availability feature is disabled when global default for jediEnabled=true.', async () => {
+    test('Availability feature is disabled when global default for languageServer="jedi".', async () => {
         // set expectations
-        const jediEnabledValue = true;
+        const languageServerValue: LanguageServerType = 'jedi';
         const expectedResult = false;
 
         // arrange
         const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, factoryMock] = getDependenciesForAvailabilityTests();
-        setupConfigurationServiceForJediSettingsTest(jediEnabledValue, configServiceMock);
+        setupConfigurationServiceForJediSettingsTest(languageServerValue, configServiceMock);
 
         // call
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object, factoryMock.object);
 
         // check expectaions
-        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be disabled when python.jediEnabled is true');
+        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be disabled when python.languageServer is "jedi"');
         workspaceServiceMock.verifyAll();
     });
 
-    test('Availability feature is enabled when global default for jediEnabled=false.', async () => {
+    test('Availability feature is enabled when global default for languageServer="microsoft".', async () => {
         // set expectations
-        const jediEnabledValue = false;
+        const languageServerValue: LanguageServerType = 'microsoft';
         const expectedResult = true;
 
         // arrange
         const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, factoryMock] = getDependenciesForAvailabilityTests();
-        setupConfigurationServiceForJediSettingsTest(jediEnabledValue, configServiceMock);
+        setupConfigurationServiceForJediSettingsTest(languageServerValue, configServiceMock);
 
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object, factoryMock.object);
 
-        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be enabled when python.jediEnabled defaults to false');
+        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be enabled when python.languageServer defaults to "microsoft');
         workspaceServiceMock.verifyAll();
     });
 
@@ -249,7 +249,7 @@ suite('Linter Availability Provider tests', () => {
     // Options to test the implementation of the IAvailableLinterActivator.
     // All options default to values that would otherwise allow the prompt to appear.
     class AvailablityTestOverallOptions {
-        public jediEnabledValue: boolean = false;
+        public languageServerValue: LanguageServerType = 'microsoft';
         public pylintUserEnabled?: boolean;
         public pylintWorkspaceEnabled?: boolean;
         public pylintWorkspaceFolderEnabled?: boolean;
@@ -288,7 +288,7 @@ suite('Linter Availability Provider tests', () => {
             .returns(async () => options.linterIsInstalled)
             .verifiable(TypeMoq.Times.atLeastOnce());
 
-        setupConfigurationServiceForJediSettingsTest(options.jediEnabledValue, configServiceMock);
+        setupConfigurationServiceForJediSettingsTest(options.languageServerValue, configServiceMock);
         setupWorkspaceMockForLinterConfiguredTests(
             options.pylintUserEnabled,
             options.pylintWorkspaceEnabled,
@@ -309,14 +309,14 @@ suite('Linter Availability Provider tests', () => {
     test('Overall implementation does not change configuration when feature disabled', async () => {
         // set expectations
         const testOpts = new AvailablityTestOverallOptions();
-        testOpts.jediEnabledValue = true;
+        testOpts.languageServerValue = 'jedi';
         const expectedResult = false;
 
         // arrange
         const result = await performTestOfOverallImplementation(testOpts);
 
         // perform test
-        expect(expectedResult).to.equal(result, 'promptIfLinterAvailable should not change any configuration when python.jediEnabled is true.');
+        expect(expectedResult).to.equal(result, 'promptIfLinterAvailable should not change any configuration when python.languageServer is "jedi".');
     });
 
     test('Overall implementation does not change configuration when linter is configured (enabled)', async () => {
@@ -584,7 +584,7 @@ function setupWorkspaceMockForLinterConfiguredTests(
 }
 
 function setupConfigurationServiceForJediSettingsTest(
-    jediEnabledValue: boolean,
+    languageServerValue: LanguageServerType,
     configServiceMock: TypeMoq.IMock<IConfigurationService>
 ): [
         TypeMoq.IMock<IConfigurationService>,
@@ -595,7 +595,7 @@ function setupConfigurationServiceForJediSettingsTest(
         configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
     }
     const pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
-    pythonSettings.setup(ps => ps.jediEnabled).returns(() => jediEnabledValue);
+    pythonSettings.setup(ps => ps.languageServer).returns(() => languageServerValue);
 
     configServiceMock.setup(cs => cs.getSettings()).returns(() => pythonSettings.object);
     return [configServiceMock, pythonSettings];

--- a/src/test/linters/linter.availability.unit.test.ts
+++ b/src/test/linters/linter.availability.unit.test.ts
@@ -15,7 +15,7 @@ import { ConfigurationService } from '../../client/common/configuration/service'
 import { PersistentStateFactory } from '../../client/common/persistentState';
 import { FileSystem } from '../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../client/common/platform/types';
-import { IConfigurationService, IPersistentState, IPersistentStateFactory, IPythonSettings, Product, LanguageServerType } from '../../client/common/types';
+import { IConfigurationService, IPersistentState, IPersistentStateFactory, IPythonSettings, LanguageServerType, Product } from '../../client/common/types';
 import { Common, Linters } from '../../client/common/utils/localize';
 import { AvailableLinterActivator } from '../../client/linters/linterAvailability';
 import { LinterInfo } from '../../client/linters/linterInfo';

--- a/src/test/linters/linterinfo.unit.test.ts
+++ b/src/test/linters/linterinfo.unit.test.ts
@@ -26,7 +26,7 @@ suite('Linter Info - Pylint', () => {
         const workspaceService = mock(WorkspaceService);
         const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
 
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: false }, jediEnabled: true } as any);
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: false }, languageServer: 'jedi' } as any);
 
         expect(linterInfo.isEnabled()).to.be.false;
     });
@@ -35,7 +35,7 @@ suite('Linter Info - Pylint', () => {
         const workspaceService = mock(WorkspaceService);
         const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
 
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: true } as any);
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, languageServer: 'jedi' } as any);
 
         expect(linterInfo.isEnabled()).to.be.true;
     });
@@ -48,7 +48,7 @@ suite('Linter Info - Pylint', () => {
         const pythonConfig = {
             inspect: () => inspection
         };
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, languageServer: 'microsoft' } as any);
         when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
 
         expect(linterInfo.isEnabled()).to.be.false;
@@ -79,7 +79,7 @@ suite('Linter Info - Pylint', () => {
                 const pythonConfig = {
                     inspect: () => testParams.inspection
                 };
-                when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
+                when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, languageServer: 'microsoft' } as any);
                 when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
 
                 expect(linterInfo.isEnabled()).to.be.true;

--- a/src/test/performance/settings.json
+++ b/src/test/performance/settings.json
@@ -1,1 +1,1 @@
-{ "python.jediEnabled": true }
+{ "python.languageServer": "jedi" }

--- a/src/test/performanceTest.ts
+++ b/src/test/performanceTest.ts
@@ -71,7 +71,7 @@ class TestRunner {
         await this.runPerfTest(devLogFiles, releaseLogFiles, languageServerLogFiles);
     }
     private async enableLanguageServer(enable: boolean) {
-        const settings = `{ "python.jediEnabled": ${!enable} }`;
+        const settings = `{ "python.languageServer": ${enable ? 'microsoft' : 'jedi'} }`;
         await fs.writeFile(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'performance', 'settings.json'), settings);
     }
 

--- a/src/test/performanceTest.ts
+++ b/src/test/performanceTest.ts
@@ -71,7 +71,7 @@ class TestRunner {
         await this.runPerfTest(devLogFiles, releaseLogFiles, languageServerLogFiles);
     }
     private async enableLanguageServer(enable: boolean) {
-        const settings = `{ "python.languageServer": ${enable ? 'microsoft' : 'jedi'} }`;
+        const settings = `{ "python.languageServer": ${enable ? '"microsoft"' : '"jedi"'} }`;
         await fs.writeFile(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'performance', 'settings.json'), settings);
     }
 

--- a/src/test/smoke/common.ts
+++ b/src/test/smoke/common.ts
@@ -10,6 +10,7 @@ import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { LanguageServerType } from '../../client/common/types';
 import { SMOKE_TEST_EXTENSIONS_DIR } from '../constants';
 import { noop, sleep } from '../core';
 
@@ -30,16 +31,16 @@ async function getLanaguageServerFolders(): Promise<string[]> {
         });
     });
 }
-export function isJediEnabled() {
+export function getLanguageServerSetting() {
     const resource = vscode.workspace.workspaceFolders![0].uri;
     const settings = vscode.workspace.getConfiguration('python', resource);
-    return settings.get<boolean>('jediEnabled') === true;
+    return settings.get<string>('languageServer');
 }
-export async function enableJedi(enable: boolean | undefined) {
-    if (isJediEnabled() === enable) {
+export async function setLanguageServerSetting(lsSetting: LanguageServerType) {
+    if (getLanguageServerSetting() === lsSetting) {
         return;
     }
-    await updateSetting('jediEnabled', enable);
+    await updateSetting('languageServer', lsSetting);
 }
 export async function openFileAndWaitForLS(file: string): Promise<vscode.TextDocument> {
     const textDocument = await vscode.workspace.openTextDocument(file);

--- a/src/test/smokeTest.ts
+++ b/src/test/smokeTest.ts
@@ -31,7 +31,7 @@ class TestRunner {
         await this.launchTest(env);
     }
     private async enableLanguageServer(enable: boolean) {
-        const settings = `{ "python.jediEnabled": ${!enable} }`;
+        const settings = `{ "python.languageServer": ${enable ? 'microsoft' : 'jedi'} }`;
         await fs.ensureDir(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'smokeTests', '.vscode'));
         await fs.writeFile(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'smokeTests', '.vscode', 'settings.json'), settings);
     }

--- a/src/test/smokeTest.ts
+++ b/src/test/smokeTest.ts
@@ -31,7 +31,7 @@ class TestRunner {
         await this.launchTest(env);
     }
     private async enableLanguageServer(enable: boolean) {
-        const settings = `{ "python.languageServer": ${enable ? 'microsoft' : 'jedi'} }`;
+        const settings = `{ "python.languageServer": ${enable ? '"microsoft"' : '"jedi"'} }`;
         await fs.ensureDir(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'smokeTests', '.vscode'));
         await fs.writeFile(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'smokeTests', '.vscode', 'settings.json'), settings);
     }


### PR DESCRIPTION
For #7010

* Updated unit tests accordingly
* Updated telemetry event that records switches between language servers
* Added code to automatically update existing "python.enableJedi" setting to new setting

- [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [X] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [X] Appropriate comments and documentation strings in the code
- [X] Has sufficient logging.
- [X] Has telemetry for enhancements.
- [X] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.