### PR TITLE
Revert "#7010: Replaced 'python.enableJedi' setting with 'python.languageServ…"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,7 +35,7 @@
     "prettier.tslintIntegration": true,
     "prettier.printWidth": 180,
     "prettier.singleQuote": true,
-    "python.languageServer": "microsoft",
+    "python.jediEnabled": false,
     "python.analysis.logLevel": "Trace",
     "python.analysis.downloadChannel": "beta",
    "python.linting.pylintEnabled": false,

--- a/news/.vscode/settings.json
+++ b/news/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.languageServer": "microsoft",
+    "python.jediEnabled": false,
     "python.formatting.provider": "black",
     "editor.formatOnSave": true,
     "python.testing.pytestArgs": [

--- a/news/1 Enhancements/7010.md
+++ b/news/1 Enhancements/7010.md
@@ -1,1 +1,0 @@
-Replaced "python.enableJedi" setting with "python.languageServer". The new setting supports three string-based values: 'jedi', 'microsoft', and 'none'. If it's set to 'none', no language server is loaded, allowing for other Python language servers to be installed by the user.

--- a/package.json
+++ b/package.json
@@ -1644,15 +1644,10 @@
                     "description": "Whether to install Python modules globally when not using an environment.",
                     "scope": "resource"
                 },
-                "python.languageServer": {
-                    "type": "string",
-                    "enum": [
-                        "jedi",
-                        "microsoft",
-                        "none"
-                    ],
-                    "default": "jedi",
-                    "description": "Specifies which language server to use for IntelliSense engine.",
+                "python.jediEnabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enables Jedi as IntelliSense engine instead of Microsoft Python Analysis Engine.",
                     "scope": "resource"
                 },
                 "python.jediMemoryLimit": {

--- a/src/client/activation/languageServer/languageClientFactory.ts
+++ b/src/client/activation/languageServer/languageClientFactory.ts
@@ -41,7 +41,7 @@ export class BaseLanguageClientFactory implements ILanguageClientFactory {
 }
 
 /**
- * Creates a language client for use by users of the extension.
+ * Creates a langauge client for use by users of the extension.
  *
  * @export
  * @class DownloadedLanguageClientFactory

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -23,7 +23,6 @@ import {
     ITerminalSettings,
     ITestingSettings,
     IWorkspaceSymbolSettings,
-    LanguageServerType,
     Resource
 } from './types';
 import { debounceSync } from './utils/decorators';
@@ -36,7 +35,7 @@ const untildify = require('untildify');
 export class PythonSettings implements IPythonSettings {
     private static pythonSettings: Map<string, PythonSettings> = new Map<string, PythonSettings>();
     public downloadLanguageServer = true;
-    public languageServer: LanguageServerType = 'jedi';
+    public jediEnabled = true;
     public jediPath = '';
     public jediMemoryLimit = 1024;
     public envFile = '';
@@ -154,9 +153,9 @@ export class PythonSettings implements IPythonSettings {
         this.poetryPath = poetryPath && poetryPath.length > 0 ? getAbsolutePath(poetryPath, workspaceRoot) : poetryPath;
 
         this.downloadLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('downloadLanguageServer', true))!;
-        this.languageServer = systemVariables.resolveAny(pythonSettings.get<LanguageServerType>('languageServer'))!;
+        this.jediEnabled = systemVariables.resolveAny(pythonSettings.get<boolean>('jediEnabled', true))!;
         this.autoUpdateLanguageServer = systemVariables.resolveAny(pythonSettings.get<boolean>('autoUpdateLanguageServer', true))!;
-        if (this.languageServer === 'jedi') {
+        if (this.jediEnabled) {
             // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
             this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!;
             if (typeof this.jediPath === 'string' && this.jediPath.length > 0) {

--- a/src/client/common/featureDeprecationManager.ts
+++ b/src/client/common/featureDeprecationManager.ts
@@ -27,7 +27,7 @@ const deprecatedFeatures: DeprecatedFeatureInfo[] = [
     },
     {
         doNotDisplayPromptStateKey: 'SHOW_DEPRECATED_FEATURE_PROMPT_FOR_AUTO_COMPLETE_PRELOAD_MODULES',
-        message: 'The setting \'python.autoComplete.preloadModules\' is deprecated, please consider using the new Language Server (\'python.languageServer = "microsoft"\').',
+        message: 'The setting \'python.autoComplete.preloadModules\' is deprecated, please consider using the new Language Server (\'python.jediEnabled = false\').',
         moreInfoUrl: 'https://github.com/Microsoft/vscode-python/issues/1704',
         setting: { setting: 'autoComplete.preloadModules' }
     }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -145,7 +145,6 @@ export interface ICurrentProcess {
     on(event: string | symbol, listener: Function): this;
 }
 
-export type LanguageServerType = 'jedi' | 'microsoft' | 'none';
 export interface IPythonSettings {
     readonly pythonPath: string;
     readonly venvPath: string;
@@ -155,7 +154,7 @@ export interface IPythonSettings {
     readonly poetryPath: string;
     readonly insidersChannel: ExtensionChannels;
     readonly downloadLanguageServer: boolean;
-    readonly languageServer: LanguageServerType;
+    readonly jediEnabled: boolean;
     readonly jediPath: string;
     readonly jediMemoryLimit: number;
     readonly devOptions: string[];

--- a/src/client/datascience/interactive-window/intellisense/dotNetIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-window/intellisense/dotNetIntellisenseProvider.ts
@@ -40,15 +40,11 @@ export class DotNetIntellisenseProvider extends BaseIntellisenseProvider impleme
 
         // Make sure we're active. We still listen to messages for adding and editing cells,
         // but we don't actually return any data.
-        const isLsActive = () => {
-            const lsSetting = this.configService.getSettings().languageServer;
-            return lsSetting === 'microsoft';
-        };
-        this.active = isLsActive();
+        this.active = !this.configService.getSettings().jediEnabled;
 
         // Listen for updates to settings to change this flag. Don't bother disposing the config watcher. It lives
         // till the extension dies anyway.
-        this.configService.getSettings().onDidChange(() => this.active = isLsActive());
+        this.configService.getSettings().onDidChange(() => this.active = !this.configService.getSettings().jediEnabled);
     }
 
     protected get isActive(): boolean {

--- a/src/client/datascience/interactive-window/intellisense/jediIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-window/intellisense/jediIntellisenseProvider.ts
@@ -48,14 +48,10 @@ export class JediIntellisenseProvider extends BaseIntellisenseProvider implement
 
         // Make sure we're active. We still listen to messages for adding and editing cells,
         // but we don't actually return any data.
-        const isJediActive = () => {
-            const lsSetting = this.configService.getSettings().languageServer;
-            return lsSetting === 'jedi';
-        };
-        this.active = isJediActive();
+        this.active = this.configService.getSettings().jediEnabled;
 
         // Listen for updates to settings to change this flag
-        disposables.push(this.configService.getSettings().onDidChange(() => this.active = isJediActive()));
+        disposables.push(this.configService.getSettings().onDidChange(() => this.active = this.configService.getSettings().jediEnabled));
 
         // Create our jedi wrappers if necessary
         if (this.active) {

--- a/src/client/languageServices/proposeLanguageServerBanner.ts
+++ b/src/client/languageServices/proposeLanguageServerBanner.ts
@@ -110,6 +110,6 @@ export class ProposeLanguageServerBanner implements IPythonExtensionBanner {
     }
 
     public async enableNewLanguageServer(): Promise<void> {
-        await this.configuration.updateSetting('languageServer', 'microsoft', undefined, ConfigurationTarget.Global);
+        await this.configuration.updateSetting('jediEnabled', false, undefined, ConfigurationTarget.Global);
     }
 }

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -126,11 +126,11 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      *
      * This is a feature of the vscode-python extension that will become enabled once the
      * Python Language Server becomes the default, replacing Jedi as the default. Testing
-     * the global default setting for `"python.languageServer": "microsoft"` enables it.
+     * the global default setting for `"python.jediEnabled": false` enables it.
      *
-     * @returns true if the global default for python.languageServer is "microsoft".
+     * @returns true if the global default for python.jediEnabled is false.
      */
     public get isFeatureEnabled(): boolean {
-        return this.configService.getSettings().languageServer === 'microsoft';
+        return !this.configService.getSettings().jediEnabled;
     }
 }

--- a/src/client/linters/linterInfo.ts
+++ b/src/client/linters/linterInfo.ts
@@ -77,7 +77,7 @@ export class PylintLinterInfo extends LinterInfo {
     }
     public isEnabled(resource?: Uri): boolean {
         const enabled = super.isEnabled(resource);
-        if (!enabled || this.configService.getSettings(resource).languageServer === 'jedi') {
+        if (!enabled || this.configService.getSettings(resource).jediEnabled) {
             return enabled;
         }
         // If we're using new LS, then by default Pylint is disabled (unless the user provides a value).

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -877,16 +877,7 @@ export interface IEventNamePropertyMapping {
     /**
      * Telemetry tracking switching between LS and Jedi
      */
-    [EventName.PYTHON_LANGUAGE_SERVER_SWITCHED]: {
-        /**
-         * Value of LS setting prior to switch.
-         */
-        oldValue: string;
-        /**
-         * Value of LS setting after switch.
-         */
-        newValue: string;
-    };
+    [EventName.PYTHON_LANGUAGE_SERVER_SWITCHED]: { change: 'Switch to Jedi from LS' | 'Switch to LS from Jedi' };
     /**
      * Telemetry event sent with details after attempting to download LS
      */

--- a/src/client/testing/common/updateTestSettings.ts
+++ b/src/client/testing/common/updateTestSettings.ts
@@ -49,26 +49,21 @@ export class UpdateTestSettingService implements IExtensionActivationService {
     @swallowExceptions('Failed to update settings.json')
     public async fixSettingInFile(filePath: string) {
         let fileContents = await this.fs.readFile(filePath);
-        const setting = new RegExp('"python\\.unitTest', 'g');
-        const setting_pytest_enabled = new RegExp('\\.pyTestEnabled"', 'g');
-        const setting_pytest_args = new RegExp('\\.pyTestArgs"', 'g');
-        const setting_pytest_path = new RegExp('\\.pyTestPath"', 'g');
-        const setting_jedi_disabled = new RegExp('\\.jediEnabled": *false', 'g');
-        const setting_jedi_enabled = new RegExp('\\.jediEnabled": *true', 'g');
+        const setting = new RegExp('"python.unitTest', 'g');
+        const setting_pytest_enabled = new RegExp('.pyTestEnabled"', 'g');
+        const setting_pytest_args = new RegExp('.pyTestArgs"', 'g');
+        const setting_pytest_path = new RegExp('.pyTestPath"', 'g');
 
         fileContents = fileContents.replace(setting, '"python.testing');
         fileContents = fileContents.replace(setting_pytest_enabled, '.pytestEnabled"');
         fileContents = fileContents.replace(setting_pytest_args, '.pytestArgs"');
         fileContents = fileContents.replace(setting_pytest_path, '.pytestPath"');
-        fileContents = fileContents.replace(setting_jedi_disabled, '.languageServer": "microsoft"');
-        fileContents = fileContents.replace(setting_jedi_enabled, '.languageServer": "jedi"');
         await this.fs.writeFile(filePath, fileContents);
     }
     public async doesFileNeedToBeFixed(filePath: string) {
         try {
             const contents = await this.fs.readFile(filePath);
-            return contents.indexOf('python.unitTest.') > 0 || contents.indexOf('.pyTest') > 0 ||
-                contents.indexOf('python.jediEnabled') > 0;
+            return contents.indexOf('python.unitTest.') > 0 || contents.indexOf('.pyTest') > 0;
         } catch (ex) {
             traceError('Failed to check if file needs to be fixed', ex);
             return false;

--- a/src/test/.vscode/settings.json
+++ b/src/test/.vscode/settings.json
@@ -19,8 +19,8 @@
     "python.linting.banditEnabled": false,
     "python.formatting.provider": "yapf",
     "python.linting.pylintUseMinimalCheckers": false
-    // Do not set this value even when LS is the default, else
+    // Do not set this to true/false even when LS is the default, else
     // it will result in LS being downloaded on CI and slow down tests significantly.
     // We have other tests on CI for testing downloading of CI with this setting enabled.
-    // "python.languageServer": "jedi"
+    // "python.jediEnabled": true
 }

--- a/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
+++ b/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
@@ -184,16 +184,6 @@ suite('Application Diagnostics - Check Test Settings', () => {
             expectedContents: '{"python.pythonPath":"1234", "python.testing.pytestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestPath":[]}'
         },
         {
-            testTitle: 'Should replace python.jediEnabled.',
-            contents: '{"python.jediEnabled":false}',
-            expectedContents: '{"python.languageServer": "microsoft"}'
-        },
-        {
-            testTitle: 'Should replace python.jediEnabled.',
-            contents: '{"python.jediEnabled": true}',
-            expectedContents: '{"python.languageServer": "jedi"}'
-        },
-        {
             testTitle: 'Should not make any changes to the file',
             contents: '{"python.pythonPath":"1234", "python.unittest.unitTestArgs":[], "python.unitTest.pytestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestPath":[]}',
             expectedContents: '{"python.pythonPath":"1234", "python.unittest.unitTestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestArgs":[], "python.testing.pytestPath":[]}'

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -49,7 +49,7 @@ export type PythonSettingKeys = 'workspaceSymbols.enabled' | 'pythonPath' |
     'testing.nosetestArgs' | 'testing.pytestArgs' | 'testing.unittestArgs' |
     'formatting.provider' | 'sortImports.args' |
     'testing.nosetestsEnabled' | 'testing.pytestEnabled' | 'testing.unittestEnabled' |
-    'envFile' | 'languageServer' | 'linting.ignorePatterns' | 'terminal.activateEnvironment';
+    'envFile' | 'jediEnabled' | 'linting.ignorePatterns' | 'terminal.activateEnvironment';
 
 async function disposePythonSettings() {
     if (!IS_SMOKE_TEST) {

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -48,12 +48,12 @@ suite('Python Settings', async () => {
 
     function initializeConfig(sourceSettings: PythonSettings) {
         // string settings
-        for (const name of ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel', 'languageServer']) {
+        for (const name of ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel']) {
             config.setup(c => c.get<string>(name))
                 // tslint:disable-next-line:no-any
                 .returns(() => (sourceSettings as any)[name]);
         }
-        if (sourceSettings.languageServer === 'jedi') {
+        if (sourceSettings.jediEnabled) {
             config.setup(c => c.get<string>('jediPath'))
                 .returns(() => sourceSettings.jediPath);
         }
@@ -64,7 +64,7 @@ suite('Python Settings', async () => {
         }
 
         // boolean settings
-        for (const name of ['downloadLanguageServer', 'autoUpdateLanguageServer']) {
+        for (const name of ['downloadLanguageServer', 'jediEnabled', 'autoUpdateLanguageServer']) {
             config.setup(c => c.get<boolean>(name, true))
                 // tslint:disable-next-line:no-any
                 .returns(() => (sourceSettings as any)[name]);
@@ -76,7 +76,7 @@ suite('Python Settings', async () => {
         }
 
         // number settings
-        if (sourceSettings.languageServer === 'jedi') {
+        if (sourceSettings.jediEnabled) {
             config.setup(c => c.get<number>('jediMemoryLimit'))
                 .returns(() => sourceSettings.jediMemoryLimit);
         }
@@ -121,13 +121,13 @@ suite('Python Settings', async () => {
     }
 
     suite('String settings', async () => {
-        ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel', 'languageServer'].forEach(async settingName => {
+        ['pythonPath', 'venvPath', 'condaPath', 'pipenvPath', 'envFile', 'poetryPath', 'insidersChannel'].forEach(async settingName => {
             testIfValueIsUpdated(settingName, 'stringValue');
         });
     });
 
     suite('Boolean settings', async () => {
-        ['downloadLanguageServer', 'autoUpdateLanguageServer', 'globalModuleInstallation'].forEach(async settingName => {
+        ['downloadLanguageServer', 'jediEnabled', 'autoUpdateLanguageServer', 'globalModuleInstallation'].forEach(async settingName => {
             testIfValueIsUpdated(settingName, true);
         });
     });

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -86,8 +86,7 @@ import {
     ILogger,
     IPathUtils,
     IPersistentStateFactory,
-    IsWindows,
-    LanguageServerType
+    IsWindows
 } from '../../client/common/types';
 import { Deferred, sleep } from '../../client/common/utils/async';
 import { noop } from '../../client/common/utils/misc';
@@ -671,8 +670,8 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.extraListeners.push(callback);
     }
 
-    public changeLanguageServer(languageServerValue: LanguageServerType) {
-        this.pythonSettings.languageServer = languageServerValue;
+    public changeJediEnabled(enabled: boolean) {
+        this.pythonSettings.jediEnabled = enabled;
     }
 
     private findPythonPath(): string {

--- a/src/test/datascience/intellisense.functional.test.tsx
+++ b/src/test/datascience/intellisense.functional.test.tsx
@@ -23,7 +23,7 @@ suite('DataScience Intellisense tests', () => {
     setup(() => {
         ioc = new DataScienceIocContainer();
         // For this test, jedi is turned off so we use our mock language server
-        ioc.changeLanguageServer('microsoft');
+        ioc.changeJediEnabled(false);
         ioc.registerDataScienceTypes();
     });
 

--- a/src/test/datascience/intellisense.unit.test.ts
+++ b/src/test/datascience/intellisense.unit.test.ts
@@ -47,7 +47,7 @@ suite('DataScience Intellisense Unit Tests', () => {
         jupyterExecution = TypeMoq.Mock.ofType<IJupyterExecution>();
         interactiveWindowProvider = TypeMoq.Mock.ofType<IInteractiveWindowProvider>();
 
-        pythonSettings.languageServer = 'microsoft';
+        pythonSettings.jediEnabled = false;
         languageServer.setup(l => l.start(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve());
         analysisOptions.setup(a => a.getAnalysisOptions()).returns(() => Promise.resolve({}));
         languageServer.setup(l => l.languageClient).returns(() => languageClient);

--- a/src/test/linters/common.ts
+++ b/src/test/linters/common.ts
@@ -344,8 +344,8 @@ export class BaseTestFixture {
             })
             .returns(() => Promise.resolve(undefined));
 
-        this.pythonSettings.setup(s => s.languageServer)
-            .returns(() => 'jedi');
+        this.pythonSettings.setup(s => s.jediEnabled)
+            .returns(() => true);
     }
 
     private initData(): void {

--- a/src/test/linters/linter.availability.unit.test.ts
+++ b/src/test/linters/linter.availability.unit.test.ts
@@ -15,7 +15,7 @@ import { ConfigurationService } from '../../client/common/configuration/service'
 import { PersistentStateFactory } from '../../client/common/persistentState';
 import { FileSystem } from '../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../client/common/platform/types';
-import { IConfigurationService, IPersistentState, IPersistentStateFactory, IPythonSettings, LanguageServerType, Product } from '../../client/common/types';
+import { IConfigurationService, IPersistentState, IPersistentStateFactory, IPythonSettings, Product } from '../../client/common/types';
 import { Common, Linters } from '../../client/common/utils/localize';
 import { AvailableLinterActivator } from '../../client/linters/linterAvailability';
 import { LinterInfo } from '../../client/linters/linterInfo';
@@ -23,35 +23,35 @@ import { IAvailableLinterActivator, ILinterInfo } from '../../client/linters/typ
 
 // tslint:disable:max-func-body-length no-any
 suite('Linter Availability Provider tests', () => {
-    test('Availability feature is disabled when global default for languageServer="jedi".', async () => {
+    test('Availability feature is disabled when global default for jediEnabled=true.', async () => {
         // set expectations
-        const languageServerValue: LanguageServerType = 'jedi';
+        const jediEnabledValue = true;
         const expectedResult = false;
 
         // arrange
         const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, factoryMock] = getDependenciesForAvailabilityTests();
-        setupConfigurationServiceForJediSettingsTest(languageServerValue, configServiceMock);
+        setupConfigurationServiceForJediSettingsTest(jediEnabledValue, configServiceMock);
 
         // call
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object, factoryMock.object);
 
         // check expectaions
-        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be disabled when python.languageServer is "jedi"');
+        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be disabled when python.jediEnabled is true');
         workspaceServiceMock.verifyAll();
     });
 
-    test('Availability feature is enabled when global default for languageServer="microsoft".', async () => {
+    test('Availability feature is enabled when global default for jediEnabled=false.', async () => {
         // set expectations
-        const languageServerValue: LanguageServerType = 'microsoft';
+        const jediEnabledValue = false;
         const expectedResult = true;
 
         // arrange
         const [appShellMock, fsMock, workspaceServiceMock, configServiceMock, factoryMock] = getDependenciesForAvailabilityTests();
-        setupConfigurationServiceForJediSettingsTest(languageServerValue, configServiceMock);
+        setupConfigurationServiceForJediSettingsTest(jediEnabledValue, configServiceMock);
 
         const availabilityProvider = new AvailableLinterActivator(appShellMock.object, fsMock.object, workspaceServiceMock.object, configServiceMock.object, factoryMock.object);
 
-        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be enabled when python.languageServer defaults to "microsoft');
+        expect(availabilityProvider.isFeatureEnabled).is.equal(expectedResult, 'Avaialability feature should be enabled when python.jediEnabled defaults to false');
         workspaceServiceMock.verifyAll();
     });
 
@@ -249,7 +249,7 @@ suite('Linter Availability Provider tests', () => {
     // Options to test the implementation of the IAvailableLinterActivator.
     // All options default to values that would otherwise allow the prompt to appear.
     class AvailablityTestOverallOptions {
-        public languageServerValue: LanguageServerType = 'microsoft';
+        public jediEnabledValue: boolean = false;
         public pylintUserEnabled?: boolean;
         public pylintWorkspaceEnabled?: boolean;
         public pylintWorkspaceFolderEnabled?: boolean;
@@ -288,7 +288,7 @@ suite('Linter Availability Provider tests', () => {
             .returns(async () => options.linterIsInstalled)
             .verifiable(TypeMoq.Times.atLeastOnce());
 
-        setupConfigurationServiceForJediSettingsTest(options.languageServerValue, configServiceMock);
+        setupConfigurationServiceForJediSettingsTest(options.jediEnabledValue, configServiceMock);
         setupWorkspaceMockForLinterConfiguredTests(
             options.pylintUserEnabled,
             options.pylintWorkspaceEnabled,
@@ -309,14 +309,14 @@ suite('Linter Availability Provider tests', () => {
     test('Overall implementation does not change configuration when feature disabled', async () => {
         // set expectations
         const testOpts = new AvailablityTestOverallOptions();
-        testOpts.languageServerValue = 'jedi';
+        testOpts.jediEnabledValue = true;
         const expectedResult = false;
 
         // arrange
         const result = await performTestOfOverallImplementation(testOpts);
 
         // perform test
-        expect(expectedResult).to.equal(result, 'promptIfLinterAvailable should not change any configuration when python.languageServer is "jedi".');
+        expect(expectedResult).to.equal(result, 'promptIfLinterAvailable should not change any configuration when python.jediEnabled is true.');
     });
 
     test('Overall implementation does not change configuration when linter is configured (enabled)', async () => {
@@ -584,7 +584,7 @@ function setupWorkspaceMockForLinterConfiguredTests(
 }
 
 function setupConfigurationServiceForJediSettingsTest(
-    languageServerValue: LanguageServerType,
+    jediEnabledValue: boolean,
     configServiceMock: TypeMoq.IMock<IConfigurationService>
 ): [
         TypeMoq.IMock<IConfigurationService>,
@@ -595,7 +595,7 @@ function setupConfigurationServiceForJediSettingsTest(
         configServiceMock = TypeMoq.Mock.ofType<IConfigurationService>();
     }
     const pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
-    pythonSettings.setup(ps => ps.languageServer).returns(() => languageServerValue);
+    pythonSettings.setup(ps => ps.jediEnabled).returns(() => jediEnabledValue);
 
     configServiceMock.setup(cs => cs.getSettings()).returns(() => pythonSettings.object);
     return [configServiceMock, pythonSettings];

--- a/src/test/linters/linterinfo.unit.test.ts
+++ b/src/test/linters/linterinfo.unit.test.ts
@@ -26,7 +26,7 @@ suite('Linter Info - Pylint', () => {
         const workspaceService = mock(WorkspaceService);
         const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
 
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: false }, languageServer: 'jedi' } as any);
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: false }, jediEnabled: true } as any);
 
         expect(linterInfo.isEnabled()).to.be.false;
     });
@@ -35,7 +35,7 @@ suite('Linter Info - Pylint', () => {
         const workspaceService = mock(WorkspaceService);
         const linterInfo = new PylintLinterInfo(instance(config), instance(workspaceService), []);
 
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, languageServer: 'jedi' } as any);
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: true } as any);
 
         expect(linterInfo.isEnabled()).to.be.true;
     });
@@ -48,7 +48,7 @@ suite('Linter Info - Pylint', () => {
         const pythonConfig = {
             inspect: () => inspection
         };
-        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, languageServer: 'microsoft' } as any);
+        when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
         when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
 
         expect(linterInfo.isEnabled()).to.be.false;
@@ -79,7 +79,7 @@ suite('Linter Info - Pylint', () => {
                 const pythonConfig = {
                     inspect: () => testParams.inspection
                 };
-                when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, languageServer: 'microsoft' } as any);
+                when(config.getSettings(anything())).thenReturn({ linting: { pylintEnabled: true }, jediEnabled: false } as any);
                 when(workspaceService.getConfiguration('python', anything())).thenReturn(pythonConfig as any);
 
                 expect(linterInfo.isEnabled()).to.be.true;

--- a/src/test/performance/settings.json
+++ b/src/test/performance/settings.json
@@ -1,1 +1,1 @@
-{ "python.languageServer": "jedi" }
+{ "python.jediEnabled": true }

--- a/src/test/performanceTest.ts
+++ b/src/test/performanceTest.ts
@@ -71,7 +71,7 @@ class TestRunner {
         await this.runPerfTest(devLogFiles, releaseLogFiles, languageServerLogFiles);
     }
     private async enableLanguageServer(enable: boolean) {
-        const settings = `{ "python.languageServer": ${enable ? '"microsoft"' : '"jedi"'} }`;
+        const settings = `{ "python.jediEnabled": ${!enable} }`;
         await fs.writeFile(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'performance', 'settings.json'), settings);
     }
 

--- a/src/test/smoke/common.ts
+++ b/src/test/smoke/common.ts
@@ -10,7 +10,6 @@ import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { LanguageServerType } from '../../client/common/types';
 import { SMOKE_TEST_EXTENSIONS_DIR } from '../constants';
 import { noop, sleep } from '../core';
 
@@ -31,16 +30,16 @@ async function getLanaguageServerFolders(): Promise<string[]> {
         });
     });
 }
-export function getLanguageServerSetting() {
+export function isJediEnabled() {
     const resource = vscode.workspace.workspaceFolders![0].uri;
     const settings = vscode.workspace.getConfiguration('python', resource);
-    return settings.get<string>('languageServer');
+    return settings.get<boolean>('jediEnabled') === true;
 }
-export async function setLanguageServerSetting(lsSetting: LanguageServerType) {
-    if (getLanguageServerSetting() === lsSetting) {
+export async function enableJedi(enable: boolean | undefined) {
+    if (isJediEnabled() === enable) {
         return;
     }
-    await updateSetting('languageServer', lsSetting);
+    await updateSetting('jediEnabled', enable);
 }
 export async function openFileAndWaitForLS(file: string): Promise<vscode.TextDocument> {
     const textDocument = await vscode.workspace.openTextDocument(file);

--- a/src/test/smokeTest.ts
+++ b/src/test/smokeTest.ts
@@ -31,7 +31,7 @@ class TestRunner {
         await this.launchTest(env);
     }
     private async enableLanguageServer(enable: boolean) {
-        const settings = `{ "python.languageServer": ${enable ? '"microsoft"' : '"jedi"'} }`;
+        const settings = `{ "python.jediEnabled": ${!enable} }`;
         await fs.ensureDir(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'smokeTests', '.vscode'));
         await fs.writeFile(path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'testMultiRootWkspc', 'smokeTests', '.vscode', 'settings.json'), settings);
     }


### PR DESCRIPTION
@erictraut File `pylint.test.ts` has failing tests, reverting the PR for now.