### PR TITLE
Fix ptvsd typo in descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1530,7 +1530,7 @@
                 "python.dataScience.ptvsdDistPath": {
                     "type": "string",
                     "default": "",
-                    "description": "Path to ptsvd experimental bits for debugging cells.",
+                    "description": "Path to ptvsd experimental bits for debugging cells.",
                     "scope": "resource"
                 },
                 "python.dataScience.stopOnFirstLineWhileDebugging": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -228,7 +228,7 @@
     "debug.moduleEnterModuleDefault": "enter-your-module-name",
     "debug.moduleEnterModuleInvalidNameError": "Enter a valid module name",
     "debug.remoteAttachConfigurationLabel": "Remote Attach",
-    "debug.remoteAttachConfigurationDescription": "Attach to a remote ptsvd debug server",
+    "debug.remoteAttachConfigurationDescription": "Attach to a remote ptvsd debug server",
     "debug.attachRemoteHostTitle": "Remote Debugging",
     "debug.attachRemoteHostPrompt": "Enter the host name",
     "debug.attachRemoteHostValidationError": "Enter a valid host name or IP address",


### PR DESCRIPTION
There was an annoying typo in the description of the attach configuration: `ptsvd` -> `ptvsd`.

~For #~

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] ~Appropriate comments and documentation strings in the code~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
