### PR TITLE
add cron job to nightly tests (#7128)

### DIFF
--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -1,6 +1,4 @@
 # Nightly build
-# Notes: Scheduled builds don't have a trigger in YAML (as of this writing).
-#        Trigger is set through the Azure DevOps UI `Nightly Build->Edit->...->Triggers`.
 
 name: '$(Year:yyyy).$(Month).0.$(BuildID)-alpha'
 
@@ -9,6 +7,16 @@ trigger: none
 
 # Not the PR build for merges to master and release.
 pr: none
+
+schedules:
+- cron: "0 0 * * 1-5"
+  # Daily midnight build, runs Monday - Friday always
+  displayName: Nightly build
+  branches:
+    include:
+    - master
+    - release
+  always: true
 
 # Variables that are available for the entire pipeline.
 variables:


### PR DESCRIPTION
Port of this PR to release:
https://github.com/microsoft/vscode-python/pull/7128

The AzDO pipeline schedules added via the UI have been deprecated. I made a change in master to add in a cron job to do the nightly build. However since this yaml change is only in master branch it only applies to master branch so right now only master branch is getting built on schedule. Pulling in this change will get release on the schedule as well. I've just been building release manually for the last day or two to work around this. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
