### PR TITLE
Opt insiders users into beta language server by default

### DIFF
--- a/news/1 Enhancements/7108.md
+++ b/news/1 Enhancements/7108.md
@@ -1,0 +1,1 @@
+Opt insiders users into beta language server by default

--- a/src/client/activation/languageServer/languageServerPackageService.ts
+++ b/src/client/activation/languageServer/languageServerPackageService.ts
@@ -65,8 +65,18 @@ export class LanguageServerPackageService implements ILanguageServerPackageServi
             return settings.analysis.downloadChannel;
         }
 
+        if (settings.insidersChannel === 'daily' || settings.insidersChannel === 'weekly') {
+            return 'beta';
+        }
         const isAlphaVersion = this.isAlphaVersionOfExtension();
         return isAlphaVersion ? 'beta' : 'stable';
+    }
+
+    public isAlphaVersionOfExtension() {
+        const extensions = this.serviceContainer.get<IExtensions>(IExtensions);
+        const extension = extensions.getExtension(PVSC_EXTENSION_ID)!;
+        const version = parse(extension.packageJSON.version)!;
+        return version.prerelease.length > 0 && version.prerelease[0] === 'alpha';
     }
     protected getValidPackage(packages: NugetPackage[]): NugetPackage {
         const nugetService = this.serviceContainer.get<INugetService>(INugetService);
@@ -88,12 +98,5 @@ export class LanguageServerPackageService implements ILanguageServerPackageServi
             package: LanguageServerPackageStorageContainers.stable,
             uri: `${azureCDNBlobStorageAccount}/${LanguageServerPackageStorageContainers.stable}/${this.getNugetPackageName()}.${minimumVersion}.nupkg`
         };
-    }
-
-    private isAlphaVersionOfExtension() {
-        const extensions = this.serviceContainer.get<IExtensions>(IExtensions);
-        const extension = extensions.getExtension(PVSC_EXTENSION_ID)!;
-        const version = parse(extension.packageJSON.version)!;
-        return version.prerelease.length > 0 && version.prerelease[0] === 'alpha';
     }
 }

--- a/src/test/activation/languageServer/languageServerPackageService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.unit.test.ts
@@ -169,6 +169,9 @@ suite('Language Server Package Service - getLanguageServerDownloadChannel()', ()
         platform = typeMoq.Mock.ofType<IPlatformService>();
         appVersion = typeMoq.Mock.ofType<IApplicationEnvironment>();
         configService = typeMoq.Mock.ofType<IConfigurationService>();
+        serviceContainer
+            .setup(s => s.get(IConfigurationService))
+            .returns(() => configService.object);
         lsPackageService = new LanguageServerPackageService(serviceContainer.object, appVersion.object, platform.object);
         lsPackageService.isAlphaVersionOfExtension = () => true;
     });
@@ -178,9 +181,6 @@ suite('Language Server Package Service - getLanguageServerDownloadChannel()', ()
                 downloadChannel: 'someValue'
             }
         };
-        serviceContainer
-            .setup(s => s.get(IConfigurationService))
-            .returns(() => configService.object);
         configService.setup(c => c.getSettings())
             .returns(() => settings as any);
 
@@ -195,9 +195,6 @@ suite('Language Server Package Service - getLanguageServerDownloadChannel()', ()
             analysis: {},
             insidersChannel: 'weekly'
         };
-        serviceContainer
-            .setup(s => s.get(IConfigurationService))
-            .returns(() => configService.object);
         configService.setup(c => c.getSettings())
             .returns(() => settings as any);
 
@@ -212,9 +209,6 @@ suite('Language Server Package Service - getLanguageServerDownloadChannel()', ()
             analysis: {},
             insidersChannel: 'daily'
         };
-        serviceContainer
-            .setup(s => s.get(IConfigurationService))
-            .returns(() => configService.object);
         configService.setup(c => c.getSettings())
             .returns(() => settings as any);
 
@@ -229,9 +223,6 @@ suite('Language Server Package Service - getLanguageServerDownloadChannel()', ()
             analysis: {},
             insidersChannel: 'off'
         };
-        serviceContainer
-            .setup(s => s.get(IConfigurationService))
-            .returns(() => configService.object);
         configService.setup(c => c.getSettings())
             .returns(() => settings as any);
 
@@ -246,9 +237,6 @@ suite('Language Server Package Service - getLanguageServerDownloadChannel()', ()
             analysis: {},
             insidersChannel: 'off'
         };
-        serviceContainer
-            .setup(s => s.get(IConfigurationService))
-            .returns(() => configService.object);
         configService.setup(c => c.getSettings())
             .returns(() => settings as any);
 

--- a/src/test/activation/languageServer/languageServerPackageService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerPackageService.unit.test.ts
@@ -15,6 +15,7 @@ import { IApplicationEnvironment } from '../../../client/common/application/type
 import { NugetService } from '../../../client/common/nuget/nugetService';
 import { INugetRepository, INugetService, NugetPackage } from '../../../client/common/nuget/types';
 import { IPlatformService } from '../../../client/common/platform/types';
+import { IConfigurationService } from '../../../client/common/types';
 import { OSType } from '../../../client/common/utils/platform';
 import { IServiceContainer } from '../../../client/ioc/types';
 
@@ -155,5 +156,105 @@ suite('Language', () => {
             uri: `${azureCDNBlobStorageAccount}/${LanguageServerPackageStorageContainers.stable}/${packageName}.${minimumVersion}.nupkg`
         };
         expect(info).to.deep.equal(expectedPackage);
+    });
+});
+suite('Language Server Package Service - getLanguageServerDownloadChannel()', () => {
+    let serviceContainer: typeMoq.IMock<IServiceContainer>;
+    let platform: typeMoq.IMock<IPlatformService>;
+    let lsPackageService: LanguageServerPackageService;
+    let appVersion: typeMoq.IMock<IApplicationEnvironment>;
+    let configService: typeMoq.IMock<IConfigurationService>;
+    setup(() => {
+        serviceContainer = typeMoq.Mock.ofType<IServiceContainer>();
+        platform = typeMoq.Mock.ofType<IPlatformService>();
+        appVersion = typeMoq.Mock.ofType<IApplicationEnvironment>();
+        configService = typeMoq.Mock.ofType<IConfigurationService>();
+        lsPackageService = new LanguageServerPackageService(serviceContainer.object, appVersion.object, platform.object);
+        lsPackageService.isAlphaVersionOfExtension = () => true;
+    });
+    test('If \'python.analysis.downloadChannel\' setting is specified, return the value of the setting', async () => {
+        const settings = {
+            analysis: {
+                downloadChannel: 'someValue'
+            }
+        };
+        serviceContainer
+            .setup(s => s.get(IConfigurationService))
+            .returns(() => configService.object);
+        configService.setup(c => c.getSettings())
+            .returns(() => settings as any);
+
+        lsPackageService.isAlphaVersionOfExtension = () => { throw new Error('Should not be here'); };
+        const downloadChannel = lsPackageService.getLanguageServerDownloadChannel();
+
+        expect(downloadChannel).to.be.equal('someValue');
+    });
+
+    test('If \'python.analysis.downloadChannel\' setting is not specified and insiders channel is \'weekly\', return \'beta\'', async () => {
+        const settings = {
+            analysis: {},
+            insidersChannel: 'weekly'
+        };
+        serviceContainer
+            .setup(s => s.get(IConfigurationService))
+            .returns(() => configService.object);
+        configService.setup(c => c.getSettings())
+            .returns(() => settings as any);
+
+        lsPackageService.isAlphaVersionOfExtension = () => { throw new Error('Should not be here'); };
+        const downloadChannel = lsPackageService.getLanguageServerDownloadChannel();
+
+        expect(downloadChannel).to.be.equal('beta');
+    });
+
+    test('If \'python.analysis.downloadChannel\' setting is not specified and insiders channel is \'daily\', return \'beta\'', async () => {
+        const settings = {
+            analysis: {},
+            insidersChannel: 'daily'
+        };
+        serviceContainer
+            .setup(s => s.get(IConfigurationService))
+            .returns(() => configService.object);
+        configService.setup(c => c.getSettings())
+            .returns(() => settings as any);
+
+        lsPackageService.isAlphaVersionOfExtension = () => { throw new Error('Should not be here'); };
+        const downloadChannel = lsPackageService.getLanguageServerDownloadChannel();
+
+        expect(downloadChannel).to.be.equal('beta');
+    });
+
+    test('If \'python.analysis.downloadChannel\' setting is not specified, user is not using insiders, and extension has Alpha version, return \'beta\'', async () => {
+        const settings = {
+            analysis: {},
+            insidersChannel: 'off'
+        };
+        serviceContainer
+            .setup(s => s.get(IConfigurationService))
+            .returns(() => configService.object);
+        configService.setup(c => c.getSettings())
+            .returns(() => settings as any);
+
+        lsPackageService.isAlphaVersionOfExtension = () => true;
+        const downloadChannel = lsPackageService.getLanguageServerDownloadChannel();
+
+        expect(downloadChannel).to.be.equal('beta');
+    });
+
+    test('If \'python.analysis.downloadChannel\' setting is not specified, user is not using insiders, and extension does not have Alpha version, return \'stable\'', async () => {
+        const settings = {
+            analysis: {},
+            insidersChannel: 'off'
+        };
+        serviceContainer
+            .setup(s => s.get(IConfigurationService))
+            .returns(() => configService.object);
+        configService.setup(c => c.getSettings())
+            .returns(() => settings as any);
+
+        lsPackageService.isAlphaVersionOfExtension = () => false;
+        const downloadChannel = lsPackageService.getLanguageServerDownloadChannel();
+
+        expect(downloadChannel).to.be.equal('stable');
     });
 });


### PR DESCRIPTION
For #7108 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
