### PR TITLE
Extend description of dataScience.runStartupCommands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1936,7 +1936,6 @@
                     "description": "Path to mypy, you can use a custom version of mypy by modifying this setting to include the full path.",
                     "scope": "resource"
                 },
-
                 "python.linting.pycodestyleArgs": {
                     "type": "array",
                     "description": "Arguments passed in. Each argument is a separate item in the array.",
@@ -2341,7 +2340,7 @@
                 "python.dataScience.runStartupCommands": {
                     "type": "string",
                     "default": "",
-                    "description": "A series of Python instructions that will be executed when the interactive window loads.",
+                    "description": "A series of Python instructions or iPython magic commands separated by '\n' that will be executed when the interactive window loads. For instance, set this to '%load_ext autoreload\n%autoreload 2' to automatically reload changes made to imported files without having to restart the interactive session.",
                     "scope": "resource"
                 },
                 "python.dataScience.debugJustMyCode": {


### PR DESCRIPTION
For #6842 (following #7163) (needs further discussion)

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.

`python.dataScience.runStartupCommands` is only triggered when launching a fresh interactive window. It should, in my opinion, also trigger when restarting the kernel. Users will expect that restarting the kernel results in a clean but identical state to when they first launched the interactive window. Currently, this is not the case. If maintainers agree, I'm happy to add a fix to this PR.