### PR TITLE
Support the new JUnit XML format.

### DIFF
--- a/news/2 Fixes/6990.md
+++ b/news/2 Fixes/6990.md
@@ -1,0 +1,1 @@
+Add support for the new JUnit XML format used by pytest 5.1+.

--- a/src/client/testing/common/xUnitParser.ts
+++ b/src/client/testing/common/xUnitParser.ts
@@ -59,8 +59,25 @@ export class XUnitParser implements IXUnitParser {
     ) {
         const data = await this.fs.readFile(outputXmlFile);
 
-        const parserResult = await parseXML(data) as { testsuite: TestSuiteResult };
-        updateTests(tests, parserResult.testsuite);
+        const parserResult = await parseXML(data);
+        let junitResults: TestSuiteResult;
+        const fullResults = parserResult as { testsuites: { testsuite: TestSuiteResult[] }};
+        if (fullResults.testsuites) {
+            const junitSuites = fullResults.testsuites.testsuite;
+            if (!Array.isArray(junitSuites)) {
+                throw Error('bad JUnit XML data');
+            }
+            if (junitSuites.length === 0) {
+                return;
+            }
+            if (junitSuites.length > 1) {
+                throw Error('got multiple XML results');
+            }
+            junitResults = junitSuites[0];
+        } else {
+            junitResults = (parserResult as { testsuite: TestSuiteResult }).testsuite;
+        }
+        updateTests(tests, junitResults);
     }
 }
 

--- a/src/client/testing/common/xUnitParser.ts
+++ b/src/client/testing/common/xUnitParser.ts
@@ -60,24 +60,10 @@ export class XUnitParser implements IXUnitParser {
         const data = await this.fs.readFile(outputXmlFile);
 
         const parserResult = await parseXML(data);
-        let junitResults: TestSuiteResult;
-        const fullResults = parserResult as { testsuites: { testsuite: TestSuiteResult[] }};
-        if (fullResults.testsuites) {
-            const junitSuites = fullResults.testsuites.testsuite;
-            if (!Array.isArray(junitSuites)) {
-                throw Error('bad JUnit XML data');
-            }
-            if (junitSuites.length === 0) {
-                return;
-            }
-            if (junitSuites.length > 1) {
-                throw Error('got multiple XML results');
-            }
-            junitResults = junitSuites[0];
-        } else {
-            junitResults = (parserResult as { testsuite: TestSuiteResult }).testsuite;
+        const junitResults = getJunitResults(parserResult);
+        if (junitResults) {
+            updateTests(tests, junitResults);
         }
-        updateTests(tests, junitResults);
     }
 }
 
@@ -95,6 +81,28 @@ async function parseXML(data: string): Promise<any> {
             return resolve(result);
         });
     });
+}
+
+// Return the actual test results from the given data.
+// tslint:disable-next-line:no-any
+function getJunitResults(parserResult: any): TestSuiteResult | undefined {
+    // This is the newer JUnit XML format (e.g. pytest 5.1 and later).
+    const fullResults = parserResult as { testsuites: { testsuite: TestSuiteResult[] }};
+    if (!fullResults.testsuites) {
+        return (parserResult as { testsuite: TestSuiteResult }).testsuite;
+    }
+
+    const junitSuites = fullResults.testsuites.testsuite;
+    if (!Array.isArray(junitSuites)) {
+        throw Error('bad JUnit XML data');
+    }
+    if (junitSuites.length === 0) {
+        return;
+    }
+    if (junitSuites.length > 1) {
+        throw Error('got multiple XML results');
+    }
+    return junitSuites[0];
 }
 
 // Update "tests" with the given results.


### PR DESCRIPTION
(for #6990)

The JUnit XML format used by pytest was updated in version 5.1.0.  This PR adds support for that format, and falls back to the old one.

This branch builds on PR #7263 and includes the actual fix for #6990.  Please review commits *after* e58922a.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
