### PR TITLE
Put back the runMagicCommands but deprecate it

### DIFF
--- a/news/2 Fixes/7294.md
+++ b/news/2 Fixes/7294.md
@@ -1,0 +1,1 @@
+Deprecate the 'runMagicCommands' datascience setting.

--- a/news/2 Fixes/7370.md
+++ b/news/2 Fixes/7370.md
@@ -1,0 +1,1 @@
+Runtime errors cause the run button to disappear.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4725,8 +4725,7 @@
                             "version": "2.1.1",
                             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -5178,8 +5177,7 @@
                             "version": "5.1.2",
                             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -5242,7 +5240,6 @@
                             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -5291,15 +5288,13 @@
                             "version": "1.0.2",
                             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
                             "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         }
                     }
                 },
@@ -9224,8 +9219,7 @@
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -9683,7 +9677,6 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -9740,8 +9733,7 @@
                             "version": "5.1.2",
                             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         }
                     }
                 },
@@ -9764,8 +9756,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                    "dev": true,
-                    "optional": true
+                    "dev": true
                 },
                 "yallist": {
                     "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -2432,10 +2432,17 @@
                     "description": "Uncomment shell assignments (#!), line magic (#!%) and cell magic (#!%%) when parsing code cells.",
                     "scope": "resource"
                 },
+                "python.dataScience.runMagicCommands": {
+                    "type": "string",
+                    "default": "",
+                    "deprecationMessage": "This setting has been deprecated in favor of 'runStartupCommands'.",
+                    "description": "A series of Python instructions or iPython magic commands separated by '\\n' that will be executed when the interactive window loads.",
+                    "scope": "resource"
+                },
                 "python.dataScience.runStartupCommands": {
                     "type": "string",
                     "default": "",
-                    "description": "A series of Python instructions or iPython magic commands separated by '\n' that will be executed when the interactive window loads. For instance, set this to '%load_ext autoreload\n%autoreload 2' to automatically reload changes made to imported files without having to restart the interactive session.",
+                    "description": "A series of Python instructions or iPython magic commands separated by '\\n' that will be executed when the interactive window loads. For instance, set this to '%load_ext autoreload\\n%autoreload 2' to automatically reload changes made to imported files without having to restart the interactive session.",
                     "scope": "resource"
                 },
                 "python.dataScience.debugJustMyCode": {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -341,6 +341,7 @@ export interface IDataScienceSettings {
     colorizeInputBox?: boolean;
     addGotoCodeLenses?: boolean;
     useNotebookEditor?: boolean;
+    runMagicCommands?: string;
     runStartupCommands: string;
     debugJustMyCode: boolean;
 }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -390,7 +390,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         // it's been activated. However if there's no active text editor and we're active, we
         // can safely attempt to give ourselves focus. This won't actually give us focus if we aren't
         // allowed to have it.
-        if (visible && active && !this.documentManager.activeTextEditor) {
+        if (visible && active && (!this.viewState.active || !this.viewState.visible) && !this.documentManager.activeTextEditor) {
             // Force the webpanel to reveal and take focus.
             await super.show(false);
 

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -197,10 +197,13 @@ export class JupyterNotebookBase implements INotebook {
                 cancelToken
             );
 
-            // Run any startup commands that we specified
-            if (settings.runStartupCommands) {
-                await this.executeSilently(settings.runStartupCommands, cancelToken);
-                traceInfo(`Run startup code for notebook: ${settings.runStartupCommands}`);
+            // Run any startup commands that we specified. Support the old form too
+            const setting = settings.runStartupCommands || settings.runMagicCommands;
+            if (setting) {
+                // Cleanup the linefeeds. User may have typed them into the settings UI so they will have an extra \\ on the front.
+                const cleanedUp = setting.replace(/\\n/g, '\n');
+                await this.executeSilently(cleanedUp, cancelToken);
+                traceInfo(`Run startup code for notebook: ${cleanedUp}`);
             }
 
             traceInfo(`Initial setup complete for ${this.resource.toString()}`);

--- a/src/datascience-ui/native-editor/nativeEditor.less
+++ b/src/datascience-ui/native-editor/nativeEditor.less
@@ -52,12 +52,12 @@
 .cell-output {
     margin-top: 5px;
     background: transparent;
-    width: calc(95vw - 95px);
+    width: calc(100vw - 95px);
     overflow-x: scroll;
 }
 
 .markdown-cell-output {
-    width: calc(95vw - 95px);
+    width: calc(100vw - 95px);
     overflow-x: scroll;
 }
 

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -651,7 +651,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 this.stateController.sendCommand(NativeCommandType.RunBelow, 'mouse');
             };
             const canRunAbove = this.stateController.canRunAbove(cellId);
-            const canRunBelow = cell.cell.state === CellState.finished;
+            const canRunBelow = cell.cell.state === CellState.finished || cell.cell.state === CellState.error;
             const insertAbove = () => {
                 this.stateController.insertAbove(cellId, true);
                 this.stateController.sendCommand(NativeCommandType.InsertAbove, 'mouse');
@@ -660,7 +660,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 this.stateController.insertBelow(cellId, true);
                 this.stateController.sendCommand(NativeCommandType.InsertBelow, 'mouse');
             };
-            const runCellHidden = cell.cell.state !== CellState.finished;
+            const runCellHidden = !canRunBelow;
             const flyoutClass = cell.cell.id === this.state.focusedCell ? 'native-editor-cellflyout native-editor-cellflyout-focused'
                 : 'native-editor-cellflyout native-editor-cellflyout-selected';
             const switchTooltip = cell.cell.data.cell_type === 'code' ? getLocString('DataScience.switchToMarkdown', 'Change to markdown') :


### PR DESCRIPTION
For #7294

Support old runMagicCommands and deprecate the setting

Fix #7370 - Errors make the run button go away

Also fix a number of issues found while testing
- Text output has a weird border on the right after the change for no horizontal scrolling
- Native editors can flash weirdly
