### PR TITLE
Handle situations where language client is disposed earlier than expected

### DIFF
--- a/news/3 Code Health/6865.md
+++ b/news/3 Code Health/6865.md
@@ -1,0 +1,1 @@
+Handle situations where language client is disposed earlier than expected.


### PR DESCRIPTION
Partial fix for #6865
This fix merely ensures we handle situations where language client is disposed earlier than expected (and prevent null object references).

Currently when language client gets disposed early we get `null object reference` errors. This will ensure we do not get such errors (ie gracefully handle disposing objects).