### PR TITLE
Refactor native cell toolbar into the nativeCell itself

### DIFF
--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -6,17 +6,12 @@ import './nativeEditor.less';
 import * as React from 'react';
 
 import { noop } from '../../client/common/utils/misc';
-import { concatMultilineString } from '../../client/datascience/common';
-import { Identifiers } from '../../client/datascience/constants';
 import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
-import { CellState, ICell } from '../../client/datascience/types';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
 import { ICellViewModel, IMainState } from '../interactive-common/mainState';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
 import { Button } from '../react-common/button';
 import { ErrorBoundary } from '../react-common/errorBoundary';
-import { IKeyboardEvent } from '../react-common/event';
-import { Flyout } from '../react-common/flyout';
 import { Image, ImageName } from '../react-common/image';
 import { ImageButton } from '../react-common/imageButton';
 import { getLocString } from '../react-common/locReactSide';
@@ -45,7 +40,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     private contentPanelRef: React.RefObject<ContentPanel> = React.createRef<ContentPanel>();
     private stateController: NativeEditorStateController;
     private debounceUpdateVisibleCells = debounce(this.updateVisibleCells.bind(this), 100);
-    private lastKeyPressed: string | undefined;
     private cellRefs: Map<string, React.RefObject<NativeCell>> = new Map<string, React.RefObject<NativeCell>>();
     private cellContainerRefs: Map<string, React.RefObject<HTMLDivElement>> = new Map<string, React.RefObject<HTMLDivElement>>();
     private initialVisibilityUpdate: boolean = false;
@@ -227,10 +221,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
        };
     }
 
-    private getNonMessageCells(): ICell[] {
-        return this.state.cellVMs.map(cvm => cvm.cell).filter(c => c.data.cell_type !== 'messages');
-    }
-
     private onContentScroll = (_event: React.UIEvent<HTMLDivElement>) => {
         if (this.contentPanelScrollRef.current) {
             this.debounceUpdateVisibleCells();
@@ -272,14 +262,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         }
     }
 
-    private findCellViewModel(cellId: string): ICellViewModel | undefined {
-        let result = this.state.cellVMs.find(c => c.cell.id === cellId);
-        if (!result) {
-            result = cellId === Identifiers.EditCellId ? this.state.editCellVM : undefined;
-        }
-        return result;
-    }
-
     private mainKeyDown = (event: KeyboardEvent) => {
         // Handler for key down presses in the main panel
         switch (event.key) {
@@ -294,283 +276,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
 
             default:
                 break;
-        }
-    }
-
-    // tslint:disable-next-line: cyclomatic-complexity max-func-body-length
-    private keyDownCell = async (cellId: string, e: IKeyboardEvent) => {
-        const isFocusedWhenNotSuggesting = this.state.focusedCell && e.editorInfo && !e.editorInfo.isSuggesting;
-        switch (e.code) {
-            case 'ArrowUp':
-            case 'k':
-                if ((isFocusedWhenNotSuggesting && e.editorInfo!.isFirstLine) || !this.state.focusedCell) {
-                    this.arrowUpFromCell(cellId, e);
-                }
-                break;
-            case 'ArrowDown':
-            case 'j':
-                if ((isFocusedWhenNotSuggesting && e.editorInfo!.isLastLine) || !this.state.focusedCell) {
-                    this.arrowDownFromCell(cellId, e);
-                }
-                break;
-            case 'Escape':
-                if (isFocusedWhenNotSuggesting) {
-                    this.escapeCell(this.state.focusedCell!, e);
-                }
-                break;
-            case 'y':
-                if (!this.state.focusedCell && this.state.selectedCell) {
-                    e.stopPropagation();
-                    this.stateController.changeCellType(this.state.selectedCell, 'code');
-                    this.stateController.sendCommand(NativeCommandType.ChangeToCode, 'keyboard');
-                }
-                break;
-            case 'm':
-                if (!this.state.focusedCell && this.state.selectedCell) {
-                    e.stopPropagation();
-                    this.stateController.changeCellType(this.state.selectedCell, 'markdown');
-                    this.stateController.sendCommand(NativeCommandType.ChangeToMarkdown, 'keyboard');
-                }
-                break;
-            case 'l':
-                if (!this.state.focusedCell && this.state.selectedCell) {
-                    e.stopPropagation();
-                    this.stateController.toggleLineNumbers(this.state.selectedCell);
-                    this.stateController.sendCommand(NativeCommandType.ToggleLineNumbers, 'keyboard');
-                }
-                break;
-            case 'o':
-                if (!this.state.focusedCell && this.state.selectedCell) {
-                    e.stopPropagation();
-                    this.stateController.toggleOutput(this.state.selectedCell);
-                    this.stateController.sendCommand(NativeCommandType.ToggleOutput, 'keyboard');
-                }
-                break;
-            case 'Enter':
-                if (e.shiftKey) {
-                    this.shiftEnterCell(cellId, e);
-                } else if (e.ctrlKey) {
-                    this.ctrlEnterCell(cellId, e);
-                } else if (e.altKey) {
-                    this.altEnterCell(cellId, e);
-                } else {
-                    this.enterCell(cellId, e);
-                }
-                break;
-            case 'd':
-                if (this.lastKeyPressed === 'd' && !this.state.focusedCell  && this.state.selectedCell) {
-                    e.stopPropagation();
-                    this.lastKeyPressed = undefined; // Reset it so we don't keep deleting
-                    const cellToSelect = this.getPrevCellId(cellId) || this.getNextCellId(cellId);
-                    this.stateController.deleteCell(cellId);
-                    if (cellToSelect) {
-                        this.moveSelection(cellToSelect);
-                    }
-                    this.stateController.sendCommand(NativeCommandType.DeleteCell, 'keyboard');
-                }
-                break;
-            case 'a':
-                if (isFocusedWhenNotSuggesting || !this.state.focusedCell) {
-                    e.stopPropagation();
-                    const cell = this.stateController.insertAbove(cellId, true);
-                    this.moveSelection(cell!);
-                    this.stateController.sendCommand(NativeCommandType.InsertAbove, 'keyboard');
-                }
-                break;
-            case 'b':
-                if (isFocusedWhenNotSuggesting || !this.state.focusedCell) {
-                    e.stopPropagation();
-                    const cell = this.stateController.insertBelow(cellId, true);
-                    this.moveSelection(cell!);
-                    this.stateController.sendCommand(NativeCommandType.InsertBelow, 'keyboard');
-                }
-                break;
-            default:
-                break;
-        }
-
-        this.lastKeyPressed = e.code;
-    }
-
-    private enterCell = (cellId: string, e: IKeyboardEvent) => {
-        // If focused, then ignore this call. It should go to the focused cell instead.
-        if (!this.state.focusedCell && !e.editorInfo && this.contentPanelRef && this.contentPanelRef.current) {
-            e.stopPropagation();
-            e.preventDefault();
-            this.focusCell(cellId, true);
-        }
-    }
-
-    private shiftEnterCell = (cellId: string, e: IKeyboardEvent) => {
-        // Prevent shift enter from add an enter
-        e.stopPropagation();
-        e.preventDefault();
-
-        // Submit and move to the next.
-        this.runAndMove(cellId, e.editorInfo ? e.editorInfo.contents : undefined);
-
-        this.stateController.sendCommand(NativeCommandType.RunAndMove, 'keyboard');
-    }
-
-    private altEnterCell = (cellId: string, e: IKeyboardEvent) => {
-        // Prevent shift enter from add an enter
-        e.stopPropagation();
-        e.preventDefault();
-
-        // Submit this cell
-        this.runAndAdd(cellId, e.editorInfo ? e.editorInfo.contents : undefined);
-
-        this.stateController.sendCommand(NativeCommandType.RunAndAdd, 'keyboard');
-    }
-
-    private runAndMove(cellId: string, possibleContents?: string) {
-        // Submit this cell
-        this.submitCell(cellId, possibleContents);
-
-        // Move to the next cell if we have one and give it focus
-        let nextCell = this.getNextCellId(cellId);
-        if (!nextCell) {
-            // At the bottom insert a cell to move to instead
-            nextCell = this.stateController.insertBelow(cellId, true);
-        }
-        if (nextCell) {
-            this.moveSelection(nextCell);
-        }
-    }
-
-    private runAndAdd(cellId: string, possibleContents?: string) {
-        // Submit this cell
-        this.submitCell(cellId, possibleContents);
-
-        // insert a cell below this one
-        const nextCell = this.stateController.insertBelow(cellId, true);
-
-        // On next update, move the new cell
-        if (nextCell) {
-            this.moveSelection(nextCell);
-        }
-    }
-
-    private ctrlEnterCell = (cellId: string, e: IKeyboardEvent) => {
-        // Prevent shift enter from add an enter
-        e.stopPropagation();
-        e.preventDefault();
-
-        // Submit this cell
-        this.submitCell(cellId, e.editorInfo ? e.editorInfo.contents : undefined);
-        this.stateController.sendCommand(NativeCommandType.Run, 'keyboard');
-    }
-
-    private moveSelectionToExisting = (cellId: string) => {
-        // Cell should already exist in the UI
-        if (this.contentPanelRef && this.contentPanelRef.current) {
-            const wasFocused = this.state.focusedCell;
-            this.stateController.selectCell(cellId, wasFocused ? cellId : undefined);
-            this.focusCell(cellId, wasFocused ? true : false);
-        }
-    }
-
-    private moveSelection = (cellId: string) => {
-        // Check to see that this cell already exists in our window (it's part of the rendered state
-        const cells = this.getNonMessageCells();
-        if (!cells || !cells.find(c => c.id === cellId)) {
-            // Force selection change right now as we don't need the cell to exist
-            // to make it selected (otherwise we'll get a flash)
-            const wasFocused = this.state.focusedCell;
-            this.stateController.selectCell(cellId, wasFocused ? cellId : undefined);
-
-            // Then wait to give it actual input focus
-            setTimeout(() => this.moveSelectionToExisting(cellId), 1);
-        } else {
-            this.moveSelectionToExisting(cellId);
-        }
-    }
-
-    private submitCell = (cellId: string, possibleContents?: string) => {
-        let content: string | undefined ;
-        const cellVM = this.findCellViewModel(cellId);
-
-        // If inside editor, submit this code
-        if (possibleContents) {
-            content = possibleContents;
-        } else if (cellVM) {
-            // Outside editor, just use the cell
-            content = concatMultilineString(cellVM.cell.data.source);
-        }
-
-        // Send to jupyter
-        if (cellVM && content) {
-            this.stateController.submitInput(content, cellVM);
-        }
-    }
-
-    private getNextCellId(cellId: string): string | undefined {
-        const cells = this.getNonMessageCells();
-
-        // Find the next cell to move to
-        const index = cells.findIndex(c => c.id === cellId);
-        let nextCellId: string | undefined;
-        if (index >= 0) {
-            if (index < cells.length - 1) {
-                nextCellId = cells[index + 1].id;
-            } else if (this.state.editCellVM) {
-                nextCellId = this.state.editCellVM.cell.id;
-            }
-        }
-
-        return nextCellId;
-    }
-
-    private getPrevCellId(cellId: string): string | undefined {
-        const cells = this.getNonMessageCells();
-        let index = cells.findIndex(c => c.id === cellId);
-        // Might also be the edit cell
-        if (this.state.editCellVM && cellId === this.state.editCellVM.cell.id) {
-            index = cells.length;
-        }
-        if (index > 0) {
-            return cells[index - 1].id;
-        }
-        return undefined;
-    }
-
-    private arrowUpFromCell = (cellId: string, e: IKeyboardEvent) => {
-        const prevCellId = this.getPrevCellId(cellId);
-        if (prevCellId && this.contentPanelRef.current) {
-            e.stopPropagation();
-            this.moveSelection(prevCellId);
-        }
-
-        this.stateController.sendCommand(NativeCommandType.ArrowUp, 'keyboard');
-    }
-
-    private arrowDownFromCell = (cellId: string, e: IKeyboardEvent) => {
-        const nextCellId = this.getNextCellId(cellId);
-
-        if (nextCellId && this.contentPanelRef.current) {
-            e.stopPropagation();
-            this.moveSelection(nextCellId);
-        }
-
-        this.stateController.sendCommand(NativeCommandType.ArrowDown, 'keyboard');
-    }
-
-    private clickCell = (cellId: string) => {
-        this.lastKeyPressed = undefined;
-        const focusedCell = cellId === this.state.focusedCell ? cellId : undefined;
-        this.stateController.selectCell(cellId, focusedCell);
-    }
-
-    private doubleClickCell = (cellId: string) => {
-        this.focusCell(cellId, true);
-    }
-
-    private escapeCell = (cellId: string, e: IKeyboardEvent) => {
-        // Unfocus the current cell by giving focus to the cell itself
-        if (this.contentPanelRef && this.contentPanelRef.current) {
-            e.stopPropagation();
-            this.focusCell(cellId, false);
-            this.stateController.sendCommand(NativeCommandType.Unfocus, 'keyboard');
         }
     }
 
@@ -606,22 +311,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     //     });
     // }
 
-    private moveCellUp = (cellId?: string) => {
-        if (this.contentPanelRef.current && cellId) {
-            const wasFocused = this.state.focusedCell;
-            this.stateController.moveCellUp(cellId);
-            setTimeout(() => this.focusCell(cellId, wasFocused ? true : false), 1);
-        }
-    }
-
-    private moveCellDown = (cellId?: string) => {
-        if (this.contentPanelRef.current && cellId) {
-            const wasFocused = this.state.focusedCell;
-            this.stateController.moveCellDown(cellId);
-            setTimeout(() => this.focusCell(cellId, wasFocused ? true : false), 1);
-        }
-    }
-
     private renderCell = (cellVM: ICellViewModel, index: number): JSX.Element | null => {
         const cellRef : React.RefObject<NativeCell> = React.createRef<NativeCell>();
         const containerRef = React.createRef<HTMLDivElement>();
@@ -640,30 +329,19 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                     <NativeCell
                         ref={cellRef}
                         role='listitem'
-                        editorOptions={this.state.editorOptions}
-                        history={undefined}
+                        stateController={this.stateController}
                         maxTextSize={getSettings().maxOutputSize}
                         autoFocus={false}
                         testMode={this.props.testMode}
                         cellVM={cellVM}
                         baseTheme={this.props.baseTheme}
                         codeTheme={this.props.codeTheme}
-                        showWatermark={false}
-                        onCodeChange={this.stateController.codeChange}
-                        onCodeCreated={this.stateController.editableCodeCreated}
                         monacoTheme={this.state.monacoTheme}
-                        openLink={this.stateController.openLink}
-                        expandImage={this.stateController.showPlot}
-                        renderCellToolbar={this.renderCellToolbar}
-                        keyDown={this.keyDownCell}
-                        onClick={this.clickCell}
-                        onDoubleClick={this.doubleClickCell}
-                        focusedCell={this.state.focusedCell}
-                        selectedCell={this.state.selectedCell}
-                        focused={this.codeGotFocus}
-                        unfocused={this.codeLostFocus}
                         showLineNumbers={cellVM.showLineNumbers}
+                        selectedCell={this.state.selectedCell}
+                        focusedCell={this.state.focusedCell}
                         hideOutput={cellVM.hideOutput}
+                        focusCell={this.focusCell}
                     />
                 </ErrorBoundary>
             </div>);
@@ -673,175 +351,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         const ref = this.cellRefs.get(cellId);
         if (ref && ref.current) {
             ref.current.giveFocus(focusCode);
-        }
-    }
-    // tslint:disable-next-line: max-func-body-length
-    private renderNormalCellToolbar(cellId: string): JSX.Element[] | null {
-        const cell = this.state.cellVMs.find(cvm => cvm.cell.id === cellId);
-        if (cell) {
-            const deleteCell = () => {
-                this.stateController.deleteCell(cellId);
-                this.stateController.sendCommand(NativeCommandType.DeleteCell, 'mouse');
-            };
-            const runCell = () => {
-                this.stateController.updateCellSource(cellId);
-                this.stateController.submitInput(concatMultilineString(cell.cell.data.source), cell);
-                this.focusCell(cellId, false);
-                this.stateController.sendCommand(NativeCommandType.Run, 'mouse');
-            };
-            const moveUp = () => {
-                this.moveCellUp(cellId);
-                this.stateController.sendCommand(NativeCommandType.MoveCellUp, 'mouse');
-            };
-            const moveDown = () => {
-                this.moveCellDown(cellId);
-                this.stateController.sendCommand(NativeCommandType.MoveCellDown, 'mouse');
-            };
-            const canMoveUp = this.stateController.canMoveUp(cellId);
-            const canMoveDown = this.stateController.canMoveDown(cellId);
-            const runAbove = () => {
-                this.stateController.runAbove(cellId);
-                this.stateController.sendCommand(NativeCommandType.RunAbove, 'mouse');
-            };
-            const runBelow = () => {
-                this.stateController.runBelow(cellId);
-                this.stateController.sendCommand(NativeCommandType.RunBelow, 'mouse');
-            };
-            const canRunAbove = this.stateController.canRunAbove(cellId);
-            const canRunBelow = cell.cell.state === CellState.finished || cell.cell.state === CellState.error;
-            const insertAbove = () => {
-                this.stateController.insertAbove(cellId, true);
-                this.stateController.sendCommand(NativeCommandType.InsertAbove, 'mouse');
-            };
-            const insertBelow = () => {
-                this.stateController.insertBelow(cellId, true);
-                this.stateController.sendCommand(NativeCommandType.InsertBelow, 'mouse');
-            };
-            const runCellHidden = !canRunBelow;
-            const flyoutClass = cell.cell.id === this.state.focusedCell ? 'native-editor-cellflyout native-editor-cellflyout-focused'
-                : 'native-editor-cellflyout native-editor-cellflyout-selected';
-            const switchTooltip = cell.cell.data.cell_type === 'code' ? getLocString('DataScience.switchToMarkdown', 'Change to markdown') :
-                getLocString('DataScience.switchToCode', 'Change to code');
-            const switchImage = cell.cell.data.cell_type === 'code' ? ImageName.SwitchToMarkdown : ImageName.SwitchToCode;
-            const switchCell = cell.cell.data.cell_type === 'code' ? () => {
-                this.stateController.changeCellType(cellId, 'markdown');
-                this.stateController.sendCommand(NativeCommandType.ChangeToMarkdown, 'mouse');
-            } : () => {
-                this.stateController.changeCellType(cellId, 'code');
-                this.stateController.sendCommand(NativeCommandType.ChangeToCode, 'mouse');
-            };
-            const outerPortion =
-                <div className='native-editor-celltoolbar-outer' key={0}>
-                    <Flyout buttonClassName='native-editor-flyout-button' buttonContent={<span className='flyout-button-content'>...</span>} flyoutContainerName={flyoutClass}>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={moveUp} disabled={!canMoveUp} tooltip={getLocString('DataScience.moveCellUp', 'Move cell up')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.Up} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={moveDown} disabled={!canMoveDown} tooltip={getLocString('DataScience.moveCellDown', 'Move cell down')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.Down} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={runAbove} disabled={!canRunAbove} tooltip={getLocString('DataScience.runAbove', 'Run cells above')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.RunAbove} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={runBelow} disabled={!canRunBelow} tooltip={getLocString('DataScience.runBelow', 'Run cell and below')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.RunBelow} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={insertAbove} tooltip={getLocString('DataScience.insertAbove', 'Insert cell above')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.InsertAbove} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={insertBelow} tooltip={getLocString('DataScience.insertBelow', 'Insert cell below')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.InsertBelow} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={switchCell} tooltip={switchTooltip}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={switchImage} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={deleteCell} tooltip={getLocString('DataScience.deleteCell', 'Delete cell')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.Delete} />
-                        </ImageButton>
-                    </Flyout>
-                </div>;
-
-            const innerPortion =
-                <div className='native-editor-celltoolbar-inner' key={1}>
-                    <ImageButton baseTheme={this.props.baseTheme} onClick={runCell} hidden={runCellHidden} tooltip={getLocString('DataScience.runCell', 'Run cell')}>
-                        <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.Run} />
-                    </ImageButton>
-                </div>;
-
-            if (cell.cell.data.cell_type === 'code') {
-                return [innerPortion, outerPortion];
-            }
-
-            return [outerPortion];
-        }
-
-        return null;
-    }
-
-    private renderEditCellToolbar() {
-        const cell = this.state.editCellVM;
-        if (cell) {
-            const runCell = () => {
-                this.stateController.submitInput(concatMultilineString(cell.cell.data.source), cell);
-                this.stateController.sendCommand(NativeCommandType.Run, 'mouse');
-            };
-            const runAbove = () => {
-                this.stateController.runAbove(Identifiers.EditCellId);
-                this.stateController.sendCommand(NativeCommandType.RunAbove, 'mouse');
-            };
-            const canRunAbove = this.stateController.canRunAbove(Identifiers.EditCellId);
-            const insertAbove = () => {
-                this.stateController.insertAbove(Identifiers.EditCellId);
-                this.stateController.sendCommand(NativeCommandType.InsertAbove, 'mouse');
-            };
-            const flyoutClass = cell.cell.id === this.state.focusedCell ? 'native-editor-cellflyout native-editor-cellflyout-focused'
-                : 'native-editor-cellflyout native-editor-cellflyout-selected';
-            const switchTooltip = cell.cell.data.cell_type === 'code' ? getLocString('DataScience.switchToMarkdown', 'Change to markdown') :
-                getLocString('DataScience.switchToCode', 'Change to code');
-            const switchImage = cell.cell.data.cell_type === 'code' ? ImageName.SwitchToMarkdown : ImageName.SwitchToCode;
-            const switchCell = cell.cell.data.cell_type === 'code' ? () => {
-                this.stateController.changeCellType(Identifiers.EditCellId, 'markdown');
-                this.stateController.sendCommand(NativeCommandType.ChangeToMarkdown, 'mouse');
-             } : () => {
-                 this.stateController.changeCellType(Identifiers.EditCellId, 'code');
-                 this.stateController.sendCommand(NativeCommandType.ChangeToCode, 'mouse');
-             };
-             const outerPortion =
-                <div className='native-editor-celltoolbar-outer' key={0}>
-                    <Flyout buttonClassName='native-editor-flyout-button' buttonContent={<span>...</span>} flyoutContainerName={flyoutClass}>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={runAbove} disabled={!canRunAbove} tooltip={getLocString('DataScience.runAbove', 'Run cells above')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.RunAbove} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={insertAbove} tooltip={getLocString('DataScience.insertAbove', 'Insert cell above')}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.InsertAbove} />
-                        </ImageButton>
-                        <ImageButton baseTheme={this.props.baseTheme} onClick={switchCell} tooltip={switchTooltip}>
-                            <Image baseTheme={this.props.baseTheme} class='image-button-image' image={switchImage} />
-                        </ImageButton>
-                    </Flyout>
-                </div>;
-
-            const innerPortion =
-                <div className='native-editor-celltoolbar-inner' key={1}>
-                    <ImageButton baseTheme={this.props.baseTheme} onClick={runCell} hidden={false} tooltip={getLocString('DataScience.runCell', 'Run cell')}>
-                        <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.Run} />
-                    </ImageButton>
-                </div>;
-
-            if (cell.cell.data.cell_type === 'code') {
-                return [innerPortion, outerPortion];
-            }
-
-            return [outerPortion];
-        }
-
-        return null;
-    }
-
-    private renderCellToolbar = (cellId: string): JSX.Element[] | null => {
-        if (cellId !== Identifiers.EditCellId) {
-            return this.renderNormalCellToolbar(cellId);
-        } else {
-            return this.renderEditCellToolbar();
         }
     }
 
@@ -856,13 +365,4 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             }, 10);
         }
     }
-
-    private codeLostFocus = (cellId: string) => {
-        this.stateController.codeLostFocus(cellId);
-    }
-
-    private codeGotFocus = (cellId: string) => {
-        this.stateController.codeGotFocus(cellId);
-    }
-
 }


### PR DESCRIPTION
Refactor our layout to put the native cell toolbar back into the NativeCell object so all rendering is next to each other.