### PR TITLE
Run smoke tests for Windows and others on CI and Nightly

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -268,6 +268,23 @@ jobs:
         NeedsPythonTestReqs: true
         NeedsPythonFunctionalReqs: true
 
+      # Smoke Tests
+      'Mac-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'macos-10.13'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+      'Linux-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'ubuntu-16.04'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+      'Win-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'vs2017-win2016'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+
   pool:
     vmImage: $(VMImageName)
 

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -436,6 +436,23 @@ jobs:
         NeedsPythonTestReqs: true
         NeedsPythonFunctionalReqs: true
 
+      # Smoke Tests
+      'Mac-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'macos-10.13'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+      'Linux-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'ubuntu-16.04'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+      'Win-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'vs2017-win2016'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
+
   pool:
     vmImage: $(VMImageName)
 

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -78,6 +78,11 @@ jobs:
         VMImageName: 'ubuntu-16.04'
         TestsToRun: 'testSmoke'
         NeedsPythonTestReqs: true
+      'Win-Py3.7 Smoke':
+        PythonVersion: '3.7'
+        VMImageName: 'vs2017-win2016'
+        TestsToRun: 'testSmoke'
+        NeedsPythonTestReqs: true
       'Mac-Py2.7 Unit+Single':
         PythonVersion: '2.7'
         VMImageName: 'macos-10.13'


### PR DESCRIPTION
For #7433

Enable:
* Windows smoke tests in PRs (wasn't there previously)
* Smoke tests in CI (wasn't there previously)
* Smoke tests in nightly CI (wasn't there previously)

Works on PR, CI and Nightly CI.