### PR TITLE
Change name of generated analysis html file

### DIFF
--- a/build/webpack/webpack.debugadapter.config.js
+++ b/build/webpack/webpack.debugadapter.config.js
@@ -45,7 +45,7 @@ const config = {
         'commonjs'
     ],
     plugins: [
-        ...common_1.getDefaultPlugins('extension')
+        ...common_1.getDefaultPlugins('debugger')
     ],
     resolve: {
         extensions: ['.ts', '.js'],

--- a/build/webpack/webpack.debugadapter.config.ts
+++ b/build/webpack/webpack.debugadapter.config.ts
@@ -49,7 +49,7 @@ const config: Configuration = {
         'commonjs'
     ],
     plugins: [
-        ...getDefaultPlugins('extension')
+        ...getDefaultPlugins('debugger')
     ],
     resolve: {
         extensions: ['.ts', '.js'],


### PR DESCRIPTION
When generating the bundle using webpack, a html file is generated with analysis information for each bundle.
Unfortunately the name of the bundle for extension and debugger code use the same name, hence overwriting the other.
