### PR TITLE
Fix monacoEditor perf and intellisense in the interactive window

### DIFF
--- a/news/2 Fixes/7241.md
+++ b/news/2 Fixes/7241.md
@@ -1,0 +1,1 @@
+Fix monaco editor layout perf.

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -342,7 +342,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         showWatermark={cellVM.cell.id === Identifiers.EditCellId}
                         editExecutionCount={this.getInputExecutionCount().toString()}
                         onCodeChange={this.stateController.codeChange}
-                        onCodeCreated={this.stateController.editableCodeCreated}
+                        onCodeCreated={this.stateController.readOnlyCodeCreated}
                         monacoTheme={this.state.monacoTheme}
                         openLink={this.stateController.openLink}
                         expandImage={this.stateController.showPlot}

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -182,7 +182,7 @@ function generateVMs(inputBlockToggled: (id: string) => void, filePath: string, 
     const cells = generateCells(filePath);
     return cells.map((cell: ICell) => {
         const vm = createCellVM(cell, undefined, inputBlockToggled, editable);
-        vm.useQuickEdit = true;
+        vm.useQuickEdit = false;
         return vm;
     });
 }

--- a/src/datascience-ui/native-editor/nativeEditorStateController.ts
+++ b/src/datascience-ui/native-editor/nativeEditorStateController.ts
@@ -190,11 +190,6 @@ export class NativeEditorStateController extends MainStateController {
         cellVM.inputBlockOpen = true;
         cellVM.inputBlockText = newText;
 
-        // Turn on quick edit (use a textArea) for any cell that's just been created.
-        if (cellVM.useQuickEdit === undefined) {
-            cellVM.useQuickEdit = true;
-        }
-
         return cellVM;
     }
 


### PR DESCRIPTION
For #7241

Change monacoEditor to be attached to a dom node that isn't in the tree during creation.

Reattach this dom node later. This prevents the initial layout from taking too long.