### PR TITLE
Guarantee that master branch has "-dev" tag in version

### DIFF
--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -6,3 +6,4 @@ variables:
   MOCHA_REPORTER_JUNIT: true # Use the mocha-multi-reporters and send output to both console (spec) and JUnit (mocha-junit-reporter).
   VSC_PYTHON_FORCE_LOGGING: true # Enable this to turn on console output for the logger
   VSC_PYTHON_LOG_FILE: '$(Build.ArtifactStagingDirectory)/pvsc.log'
+  CI_BRANCH_NAME: ${Build.SourceBranchName}

--- a/news/3 Code Health/7471.md
+++ b/news/3 Code Health/7471.md
@@ -1,0 +1,1 @@
+Add unit tests to guarantee that the extension version in the master branch has the '-dev' suffix.

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -8,6 +8,8 @@
 import { expect } from 'chai';
 import { parse } from 'semver';
 import { buildApi } from '../client/api';
+import { ApplicationEnvironment } from '../client/common/application/applicationEnvironment';
+import { IApplicationEnvironment } from '../client/common/application/types';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 
 const expectedPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
@@ -28,6 +30,7 @@ suite('Extension API Debugger', () => {
 suite('Extension version tests', () => {
     let version: string;
     let branchName: string;
+    let applicationEnvironment: IApplicationEnvironment;
 
     suiteSetup(async function() {
         // Skip the entire suite if running locally
@@ -39,9 +42,8 @@ suite('Extension version tests', () => {
     });
 
     setup(() => {
-        // tslint:disable-next-line: no-require-imports
-        const extension = require('../../package.json');
-        version = parse(extension.version)!.raw;
+        applicationEnvironment = new ApplicationEnvironment(undefined as any, undefined as any, undefined as any);
+        version = parse(applicationEnvironment.packageJson.version)!.raw;
     });
 
     test('If we are running a pipeline in the master branch, the extension version in `package.json` should have the "-dev" suffix', async function() {

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -7,9 +7,8 @@
 
 import { expect } from 'chai';
 import { parse } from 'semver';
-import { extensions } from 'vscode';
 import { buildApi } from '../client/api';
-import { EXTENSION_ROOT_DIR, PVSC_EXTENSION_ID } from '../client/common/constants';
+import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 
 const expectedPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
 
@@ -39,7 +38,8 @@ suite('Extension version tests', () => {
     });
 
     setup(() => {
-        const extension = extensions.getExtension(PVSC_EXTENSION_ID)!;
+        // tslint:disable-next-line: no-require-imports
+        const extension = require('../../package.json');
         version = parse(extension.packageJSON.version)!.raw;
     });
 

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -40,7 +40,7 @@ suite('Extension version tests', () => {
     setup(() => {
         // tslint:disable-next-line: no-require-imports
         const extension = require('../../package.json');
-        version = parse(extension.packageJSON.version)!.raw;
+        version = parse(extension.version)!.raw;
     });
 
     test('If we are running a pipeline in the master branch, the extension version in `package.json` should have the "-dev" suffix', async function() {

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -30,6 +30,7 @@ suite('Extension version tests', () => {
     let branchName: string;
 
     suiteSetup(async function() {
+        // Skip the entire suite if running locally
         if (!process.env.CI_BRANCH_NAME) {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
@@ -53,7 +54,7 @@ suite('Extension version tests', () => {
     });
 
     test('If we are running a pipeline in the release branch, the extension version in `package.json` should not have the "-dev" suffix', async function() {
-        if (!branchName.startsWith('release')) {
+        if (branchName !== 'release') {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
         }

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -6,7 +6,6 @@
 // tslint:disable:no-any
 
 import { expect } from 'chai';
-import { parse } from 'semver';
 import { buildApi } from '../client/api';
 import { ApplicationEnvironment } from '../client/common/application/applicationEnvironment';
 import { IApplicationEnvironment } from '../client/common/application/types';
@@ -29,21 +28,20 @@ suite('Extension API Debugger', () => {
 
 suite('Extension version tests', () => {
     let version: string;
-    let branchName: string;
     let applicationEnvironment: IApplicationEnvironment;
+    const branchName = process.env.CI_BRANCH_NAME;
 
     suiteSetup(async function() {
         // Skip the entire suite if running locally
-        if (!process.env.CI_BRANCH_NAME) {
+        if (!branchName) {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
         }
-        branchName = process.env.CI_BRANCH_NAME;
     });
 
     setup(() => {
         applicationEnvironment = new ApplicationEnvironment(undefined as any, undefined as any, undefined as any);
-        version = parse(applicationEnvironment.packageJson.version)!.raw;
+        version = applicationEnvironment.packageJson.version;
     });
 
     test('If we are running a pipeline in the master branch, the extension version in `package.json` should have the "-dev" suffix', async function() {
@@ -56,7 +54,7 @@ suite('Extension version tests', () => {
     });
 
     test('If we are running a pipeline in the release branch, the extension version in `package.json` should not have the "-dev" suffix', async function() {
-        if (branchName !== 'release') {
+        if (!branchName!.startsWith('release')) {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
         }

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -6,8 +6,10 @@
 // tslint:disable:no-any
 
 import { expect } from 'chai';
+import { parse } from 'semver';
+import { extensions } from 'vscode';
 import { buildApi } from '../client/api';
-import { EXTENSION_ROOT_DIR } from '../client/common/constants';
+import { EXTENSION_ROOT_DIR, PVSC_EXTENSION_ID } from '../client/common/constants';
 
 const expectedPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
 
@@ -21,5 +23,32 @@ suite('Extension API Debugger', () => {
         const args = await buildApi(Promise.resolve()).debug.getRemoteLauncherCommand('something', 1234, true);
         const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
         expect(args).to.be.deep.equal(expectedArgs);
+    });
+});
+
+suite('Extension version tests', () => {
+    let version: string;
+
+    setup(() => {
+        const extension = extensions.getExtension(PVSC_EXTENSION_ID)!;
+        version = parse(extension.packageJSON.version)!.raw;
+    });
+
+    test('If we are running a pipeline in the master branch, the extension version in `package.json` should have the "-dev" suffix', async function() {
+        if (process.env.CI_BRANCH_NAME !== 'master') {
+            // tslint:disable-next-line: no-invalid-this
+            return this.skip();
+        }
+
+        return expect(version.endsWith('-dev'), 'When running a pipeline in the master branch, the extension version in package.json should have the -dev suffix').to.be.true;
+    });
+
+    test('If we are running a pipeline in the release branch, the extension version in `package.json` should not have the "-dev" suffix', async function() {
+        if (process.env.CI_BRANCH_NAME !== 'release') {
+            // tslint:disable-next-line: no-invalid-this
+            return this.skip();
+        }
+
+        return expect(version.endsWith('-dev'), 'When running a pipeline in the release branch, the extension version in package.json should not have the -dev suffix').to.be.false;
     });
 });

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -28,6 +28,15 @@ suite('Extension API Debugger', () => {
 
 suite('Extension version tests', () => {
     let version: string;
+    let branchName: string;
+
+    suiteSetup(async function() {
+        if (!process.env.CI_BRANCH_NAME) {
+            // tslint:disable-next-line: no-invalid-this
+            return this.skip();
+        }
+        branchName = process.env.CI_BRANCH_NAME;
+    });
 
     setup(() => {
         const extension = extensions.getExtension(PVSC_EXTENSION_ID)!;
@@ -35,7 +44,7 @@ suite('Extension version tests', () => {
     });
 
     test('If we are running a pipeline in the master branch, the extension version in `package.json` should have the "-dev" suffix', async function() {
-        if (process.env.CI_BRANCH_NAME !== 'master') {
+        if (branchName !== 'master') {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
         }
@@ -44,7 +53,7 @@ suite('Extension version tests', () => {
     });
 
     test('If we are running a pipeline in the release branch, the extension version in `package.json` should not have the "-dev" suffix', async function() {
-        if (process.env.CI_BRANCH_NAME !== 'release') {
+        if (branchName !== 'release') {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
         }

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -53,7 +53,7 @@ suite('Extension version tests', () => {
     });
 
     test('If we are running a pipeline in the release branch, the extension version in `package.json` should not have the "-dev" suffix', async function() {
-        if (branchName !== 'release') {
+        if (!branchName.startsWith('release')) {
             // tslint:disable-next-line: no-invalid-this
             return this.skip();
         }


### PR DESCRIPTION
For #7471 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
