### PR TITLE
Attempt to use uri of active text editor document to determine virtual env to use with terminal

### DIFF
--- a/news/2 Fixes/6282.md
+++ b/news/2 Fixes/6282.md
@@ -1,0 +1,1 @@
+determine python path from workspace of active text editor

--- a/news/2 Fixes/6282.md
+++ b/news/2 Fixes/6282.md
@@ -1,1 +1,1 @@
-[Eric Bajumpaa (@SteelPhase)](https://github.com/Steelphase): Fix loging for determining python path from workspace of active text editor
+Fix loging for determining python path from workspace of active text editor (thanks [Eric Bajumpaa (@SteelPhase)](https://github.com/SteelPhase))

--- a/news/2 Fixes/6282.md
+++ b/news/2 Fixes/6282.md
@@ -1,1 +1,1 @@
-determine python path from workspace of active text editor
+[Eric Bajumpaa (@SteelPhase)](https://github.com/Steelphase): Fix loging for determining python path from workspace of active text editor

--- a/src/client/terminals/activation.ts
+++ b/src/client/terminals/activation.ts
@@ -4,10 +4,10 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { Terminal } from 'vscode';
+import { Terminal, Uri } from 'vscode';
 import { IExtensionSingleActivationService } from '../activation/types';
 import {
-    ICommandManager, ITerminalManager, IWorkspaceService
+    ICommandManager, IDocumentManager, ITerminalManager, IWorkspaceService
 } from '../common/application/types';
 import { ShowPlayIcon } from '../common/experimentGroups';
 import { ITerminalActivator } from '../common/terminal/types';
@@ -48,6 +48,7 @@ export class TerminalAutoActivation implements ITerminalAutoActivation {
     constructor(
         @inject(ITerminalManager) private readonly terminalManager: ITerminalManager,
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+        @inject(IDocumentManager) private readonly documentManager: IDocumentManager,
         @inject(ITerminalActivator) private readonly activator: ITerminalActivator,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
     ) {
@@ -68,10 +69,14 @@ export class TerminalAutoActivation implements ITerminalAutoActivation {
     private async activateTerminal(terminal: Terminal): Promise<void> {
         // If we have just one workspace, then pass that as the resource.
         // Until upstream VSC issue is resolved https://github.com/Microsoft/vscode/issues/63052.
-        const workspaceFolder =
-            this.workspaceService.hasWorkspaceFolders && this.workspaceService.workspaceFolders!.length > 0
-                ? this.workspaceService.workspaceFolders![0].uri
-                : undefined;
-        await this.activator.activateEnvironmentInTerminal(terminal, workspaceFolder);
+        await this.activator.activateEnvironmentInTerminal(terminal, this.getActiveResource());
+    }
+
+    private getActiveResource(): Uri | undefined {
+        if (this.documentManager.activeTextEditor && !this.documentManager.activeTextEditor.document.isUntitled) {
+            return this.documentManager.activeTextEditor.document.uri;
+        }
+
+        return Array.isArray(this.workspaceService.workspaceFolders) && this.workspaceService.workspaceFolders.length > 0 ? this.workspaceService.workspaceFolders[0].uri : undefined;
     }
 }

--- a/src/test/common/terminals/activation.unit.test.ts
+++ b/src/test/common/terminals/activation.unit.test.ts
@@ -6,8 +6,9 @@ import { expect } from 'chai';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import { Terminal, Uri } from 'vscode';
+import { DocumentManager } from '../../../client/common/application/documentManager';
 import { TerminalManager } from '../../../client/common/application/terminalManager';
-import { ITerminalManager, IWorkspaceService } from '../../../client/common/application/types';
+import { IDocumentManager, ITerminalManager, IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
 import { TerminalActivator } from '../../../client/common/terminal/activator';
 import { ITerminalActivator } from '../../../client/common/terminal/types';
@@ -17,18 +18,21 @@ import { ITerminalAutoActivation } from '../../../client/terminals/types';
 
 suite('Terminal Auto Activation', () => {
     let activator: ITerminalActivator;
+    let documentManager: IDocumentManager;
     let terminalManager: ITerminalManager;
     let terminalAutoActivation: ITerminalAutoActivation;
     let workspaceService: IWorkspaceService;
 
     setup(() => {
         terminalManager = mock(TerminalManager);
+        documentManager = mock(DocumentManager);
         activator = mock(TerminalActivator);
         workspaceService = mock(WorkspaceService);
 
         terminalAutoActivation = new TerminalAutoActivation(
             instance(terminalManager),
             [],
+            instance(documentManager),
             instance(activator),
             instance(workspaceService)
         );


### PR DESCRIPTION
For #6282

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [X] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [ ] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] ~The wiki is updated with any design decisions/details.~
