### PR TITLE
Run fish activation scripts with `source` instead of `.

### DIFF
--- a/news/2 Fixes/7343.md
+++ b/news/2 Fixes/7343.md
@@ -1,1 +1,0 @@
-Use `. xyz.fish` instead of `source xyz.fish` to source fish scripts in the terminal.

--- a/news/2 Fixes/7343.md
+++ b/news/2 Fixes/7343.md
@@ -1,1 +1,0 @@
-Run fish activation scripts with `source` instead of `.` (Revert PR [#7387](https://github.com/microsoft/vscode-python/pull/7387)).

--- a/news/2 Fixes/7343.md
+++ b/news/2 Fixes/7343.md
@@ -1,0 +1,1 @@
+Run fish activation scripts with `source` instead of `.` (Revert PR [#7387](https://github.com/microsoft/vscode-python/pull/7387)).

--- a/src/client/common/terminal/environmentActivationProviders/bash.ts
+++ b/src/client/common/terminal/environmentActivationProviders/bash.ts
@@ -27,11 +27,7 @@ export class Bash extends BaseActivationCommandProvider {
         if (!scriptFile) {
             return;
         }
-        if (targetShell === TerminalShellType.fish) {
-            return [`. ${scriptFile.fileToCommandArgument()}`];
-        } else {
-            return [`source ${scriptFile.fileToCommandArgument()}`];
-        }
+        return [`source ${scriptFile.fileToCommandArgument()}`];
     }
 
     private getScriptsInOrderOfPreference(targetShell: TerminalShellType): string[] {

--- a/src/test/common/terminals/activation.bash.unit.test.ts
+++ b/src/test/common/terminals/activation.bash.unit.test.ts
@@ -89,13 +89,12 @@ suite('Terminal Environment Activation (bash)', () => {
                             const command = await bash.getActivationCommands(undefined, shellType.value);
 
                             if (isScriptFileSupported) {
-                                const sourceCmd = shellType.value === TerminalShellType.fish ? '.' : 'source';
                                 // Ensure the script file is of the following form:
                                 // source "<path to script file>" <environment name>
                                 // Ensure the path is quoted if it contains any spaces.
                                 // Ensure it contains the name of the environment as an argument to the script file.
 
-                                expect(command).to.be.deep.equal([`${sourceCmd} ${pathToScriptFile.fileToCommandArgument()}`.trim()], 'Invalid command');
+                                expect(command).to.be.deep.equal([`source ${pathToScriptFile.fileToCommandArgument()}`.trim()], 'Invalid command');
                             } else {
                                 expect(command).to.be.equal(undefined, 'Command should be undefined');
                             }


### PR DESCRIPTION
For #7343