### PR TITLE
Add DA and ptvsd experiments support to remote debugging API

### DIFF
--- a/news/1 Enhancements/7549.md
+++ b/news/1 Enhancements/7549.md
@@ -1,0 +1,1 @@
+Add support for ptvsd and debug adapter experiments in remote debugging API.

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -3,8 +3,11 @@
 
 'use strict';
 
+import { DebugAdapterDescriptorFactory as DebugAdapterExperiment } from './common/experimentGroups';
 import { traceError } from './common/logger';
+import { IConfigurationService, IExperimentsManager } from './common/types';
 import { RemoteDebuggerExternalLauncherScriptProvider } from './debugger/debugAdapter/DebugClients/launcherProvider';
+import { IDebugAdapterDescriptorFactory } from './debugger/extension/types';
 
 /*
  * Do not introduce any breaking changes to this API.
@@ -33,7 +36,7 @@ export interface IExtensionApi {
 }
 
 // tslint:disable-next-line:no-any
-export function buildApi(ready: Promise<any>) {
+export function buildApi(ready: Promise<any>, experimentsManager: IExperimentsManager, debugFactory: IDebugAdapterDescriptorFactory, configuration: IConfigurationService) {
     return {
         // 'ready' will propogate the exception, but we must log it here first.
         ready: ready.catch((ex) => {
@@ -44,8 +47,15 @@ export function buildApi(ready: Promise<any>) {
             // tslint:disable-next-line:no-suspicious-comment
             // TODO: Add support for ptvsd wheels experiment, see https://github.com/microsoft/vscode-python/issues/7549
             async getRemoteLauncherCommand(host: string, port: number, waitUntilDebuggerAttaches: boolean = true): Promise<string[]> {
+                const pythonSettings = configuration.getSettings();
+
+                if (experimentsManager.inExperiment(DebugAdapterExperiment.experiment) && (await debugFactory.useNewPtvsd(pythonSettings.pythonPath))) {
+                    const waitArgs = waitUntilDebuggerAttaches ? ['--wait'] : [];
+                    return [await debugFactory.getPtvsdPath(pythonSettings.pythonPath), '--default', '--host', host, '--port', port.toString(), ...waitArgs];
+                } else {
                 return new RemoteDebuggerExternalLauncherScriptProvider().getLauncherArgs({ host, port, waitUntilDebuggerAttaches });
             }
+        }
         }
     };
 }

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -44,12 +44,11 @@ export function buildApi(ready: Promise<any>, experimentsManager: IExperimentsMa
             return Promise.reject(ex);
         }),
         debug: {
-            // tslint:disable-next-line:no-suspicious-comment
-            // TODO: Add support for ptvsd wheels experiment, see https://github.com/microsoft/vscode-python/issues/7549
             async getRemoteLauncherCommand(host: string, port: number, waitUntilDebuggerAttaches: boolean = true): Promise<string[]> {
                 const pythonSettings = configuration.getSettings();
 
                 if (experimentsManager.inExperiment(DebugAdapterExperiment.experiment) && (await debugFactory.useNewPtvsd(pythonSettings.pythonPath))) {
+                    // Same logic as in RemoteDebuggerExternalLauncherScriptProvider, but eventually launcherProvider.ts will be deleted.
                     const waitArgs = waitUntilDebuggerAttaches ? ['--wait'] : [];
                     return [await debugFactory.getPtvsdPath(pythonSettings.pythonPath), '--default', '--host', host, '--port', port.toString(), ...waitArgs];
                 } else {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -45,7 +45,7 @@ export function buildApi(ready: Promise<any>, experimentsManager: IExperimentsMa
         }),
         debug: {
             async getRemoteLauncherCommand(host: string, port: number, waitUntilDebuggerAttaches: boolean = true): Promise<string[]> {
-                const pythonSettings = configuration.getSettings();
+                const pythonSettings = configuration.getSettings(undefined);
 
                 if (experimentsManager.inExperiment(DebugAdapterExperiment.experiment) && (await debugFactory.useNewPtvsd(pythonSettings.pythonPath))) {
                     // Same logic as in RemoteDebuggerExternalLauncherScriptProvider, but eventually launcherProvider.ts will be deleted.

--- a/src/client/debugger/extension/types.ts
+++ b/src/client/debugger/extension/types.ts
@@ -5,6 +5,7 @@
 
 import { CancellationToken, DebugAdapterDescriptorFactory, DebugConfigurationProvider, WorkspaceFolder } from 'vscode';
 import { InputStep, MultiStepInput } from '../../common/utils/multiStepInput';
+import { RemoteDebugOptions } from '../debugAdapter/types';
 import { DebugConfigurationArguments } from '../types';
 
 export const IDebugConfigurationService = Symbol('IDebugConfigurationService');
@@ -39,6 +40,7 @@ export const IDebugAdapterDescriptorFactory = Symbol('IDebugAdapterDescriptorFac
 export interface IDebugAdapterDescriptorFactory extends DebugAdapterDescriptorFactory {
     useNewPtvsd(pythonPath: string): Promise<boolean>;
     getPtvsdPath(pythonPath: string): Promise<string>;
+    getRemotePtvsdArgs(remoteDebugOptions: RemoteDebugOptions): string[];
 }
 
 export type DebugAdapterPtvsdPathInfo = { extensionVersion: string; ptvsdPath: string };

--- a/src/client/debugger/extension/types.ts
+++ b/src/client/debugger/extension/types.ts
@@ -36,6 +36,9 @@ export enum PythonPathSource {
 }
 
 export const IDebugAdapterDescriptorFactory = Symbol('IDebugAdapterDescriptorFactory');
-export interface IDebugAdapterDescriptorFactory extends DebugAdapterDescriptorFactory {}
+export interface IDebugAdapterDescriptorFactory extends DebugAdapterDescriptorFactory {
+    useNewPtvsd(pythonPath: string): Promise<boolean>;
+    getPtvsdPath(pythonPath: string): Promise<string>;
+}
 
 export type DebugAdapterPtvsdPathInfo = { extensionVersion: string; ptvsdPath: string };

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -69,7 +69,7 @@ import { DebuggerTypeName } from './debugger/constants';
 import { DebugSessionEventDispatcher } from './debugger/extension/hooks/eventHandlerDispatcher';
 import { IDebugSessionEventHandlers } from './debugger/extension/hooks/types';
 import { registerTypes as debugConfigurationRegisterTypes } from './debugger/extension/serviceRegistry';
-import { IDebugConfigurationService, IDebuggerBanner } from './debugger/extension/types';
+import { IDebugAdapterDescriptorFactory, IDebugConfigurationService, IDebuggerBanner } from './debugger/extension/types';
 import { registerTypes as formattersRegisterTypes } from './formatters/serviceRegistry';
 import { AutoSelectionRule, IInterpreterAutoSelectionRule, IInterpreterAutoSelectionService } from './interpreter/autoSelection/types';
 import { IInterpreterSelector } from './interpreter/configuration/types';
@@ -194,7 +194,12 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
     durations.endActivateTime = stopWatch.elapsedTime;
     activationDeferred.resolve();
 
-    const api = buildApi(Promise.all([activationDeferred.promise, activationPromise]));
+    const api = buildApi(
+        Promise.all([activationDeferred.promise, activationPromise]),
+        serviceContainer.get<IExperimentsManager>(IExperimentsManager),
+        serviceContainer.get<IDebugAdapterDescriptorFactory>(IDebugAdapterDescriptorFactory),
+        configuration
+    );
     // In test environment return the DI Container.
     if (isTestExecution()) {
         // tslint:disable:no-any

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -6,22 +6,93 @@
 // tslint:disable:no-any
 
 import { expect } from 'chai';
+import * as path from 'path';
+import { anyString, instance, mock, when } from 'ts-mockito';
 import { buildApi } from '../client/api';
 import { ApplicationEnvironment } from '../client/common/application/applicationEnvironment';
 import { IApplicationEnvironment } from '../client/common/application/types';
+import { ConfigurationService } from '../client/common/configuration/service';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
-
-const expectedPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
+import { ExperimentsManager } from '../client/common/experiments';
+import { IConfigurationService, IExperimentsManager, IPythonSettings } from '../client/common/types';
+import { DebugAdapterDescriptorFactory } from '../client/debugger/extension/adapter/factory';
+import { IDebugAdapterDescriptorFactory } from '../client/debugger/extension/types';
 
 suite('Extension API Debugger', () => {
-    test('Test debug launcher args (no-wait)', async () => {
-        const args = await buildApi(Promise.resolve()).debug.getRemoteLauncherCommand('something', 1234, false);
-        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234'];
+    const expectedLauncherPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
+    const ptvsdPath = path.join('path', 'to', 'ptvsd');
+
+    let experimentsManager: IExperimentsManager;
+    let debugAdapterFactory: IDebugAdapterDescriptorFactory;
+    let configurationService: IConfigurationService;
+
+    setup(() => {
+        experimentsManager = mock(ExperimentsManager);
+        debugAdapterFactory = mock(DebugAdapterDescriptorFactory);
+        configurationService = mock(ConfigurationService);
+    });
+
+    function mockInExperiment() {
+        when(experimentsManager.inExperiment(anyString())).thenReturn(true);
+        when(debugAdapterFactory.useNewPtvsd(anyString())).thenResolve(true);
+        when(debugAdapterFactory.getPtvsdPath(anyString())).thenResolve(ptvsdPath);
+        when(configurationService.getSettings()).thenReturn(({ pythonPath: 'python' } as any) as IPythonSettings);
+    }
+
+    function mockNotInExperiment() {
+        when(experimentsManager.inExperiment(anyString())).thenReturn(false);
+        when(debugAdapterFactory.useNewPtvsd(anyString())).thenResolve(false);
+    }
+
+    test('Test debug launcher args (no-wait and not in experiment)', async () => {
+        mockNotInExperiment();
+
+        const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
+            'something',
+            1234,
+            false
+        );
+        const expectedArgs = [expectedLauncherPath, '--default', '--host', 'something', '--port', '1234'];
+
         expect(args).to.be.deep.equal(expectedArgs);
     });
-    test('Test debug launcher args (wait)', async () => {
-        const args = await buildApi(Promise.resolve()).debug.getRemoteLauncherCommand('something', 1234, true);
-        const expectedArgs = [expectedPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
+
+    test('Test debug launcher args (no-wait and in experiment)', async () => {
+        mockInExperiment();
+
+        const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
+            'something',
+            1234,
+            false
+        );
+        const expectedArgs = [ptvsdPath, '--default', '--host', 'something', '--port', '1234'];
+
+        expect(args).to.be.deep.equal(expectedArgs);
+    });
+
+    test('Test debug launcher args (wait and not in experiment)', async () => {
+        mockNotInExperiment();
+
+        const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
+            'something',
+            1234,
+            true
+        );
+        const expectedArgs = [expectedLauncherPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
+
+        expect(args).to.be.deep.equal(expectedArgs);
+    });
+
+    test('Test debug launcher args (wait and in experiment)', async () => {
+        mockInExperiment();
+
+        const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
+            'something',
+            1234,
+            true
+        );
+        const expectedArgs = [ptvsdPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
+
         expect(args).to.be.deep.equal(expectedArgs);
     });
 });

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -7,7 +7,7 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
-import { anyString, instance, mock, when } from 'ts-mockito';
+import { anyString, anything, instance, mock, when } from 'ts-mockito';
 import { buildApi } from '../client/api';
 import { ApplicationEnvironment } from '../client/common/application/applicationEnvironment';
 import { IApplicationEnvironment } from '../client/common/application/types';
@@ -59,6 +59,7 @@ suite('Extension API Debugger', () => {
 
     test('Test debug launcher args (no-wait and in experiment)', async () => {
         mockInExperiment();
+        when(debugAdapterFactory.getRemotePtvsdArgs(anything())).thenReturn(['--default', '--host', 'something', '--port', '1234']);
 
         const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
             'something',
@@ -85,6 +86,7 @@ suite('Extension API Debugger', () => {
 
     test('Test debug launcher args (wait and in experiment)', async () => {
         mockInExperiment();
+        when(debugAdapterFactory.getRemotePtvsdArgs(anything())).thenReturn(['--default', '--host', 'something', '--port', '1234', '--wait']);
 
         const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
             'something',

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -36,7 +36,7 @@ suite('Extension API Debugger', () => {
         when(experimentsManager.inExperiment(anyString())).thenReturn(true);
         when(debugAdapterFactory.useNewPtvsd(anyString())).thenResolve(true);
         when(debugAdapterFactory.getPtvsdPath(anyString())).thenResolve(ptvsdPath);
-        when(configurationService.getSettings()).thenReturn(({ pythonPath: 'python' } as any) as IPythonSettings);
+        when(configurationService.getSettings(undefined)).thenReturn(({ pythonPath: 'python' } as any) as IPythonSettings);
     }
 
     function mockNotInExperiment() {


### PR DESCRIPTION
For #7549 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
