### PR TITLE
Update timeout value for CI builds

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -28,6 +28,7 @@ stages:
   jobs:
   - job: 'Test'
     dependsOn: []
+    timeoutInMinutes: 120
     strategy:
       matrix:
         # Each member of this list must contain these values:


### PR DESCRIPTION
CI builds are sometimes timing out. Up the timeout value.