### PR TITLE
Refactor the debugAdapterTracker we use to handle multiple sessions

### DIFF
--- a/news/3 Code Health/7352.md
+++ b/news/3 Code Health/7352.md
@@ -1,0 +1,1 @@
+Decouple the DS location tracker from the debug session telemetry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10519,9 +10519,9 @@
             }
         },
         "handlebars": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-            "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
+            "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -13770,7 +13770,7 @@
             "dependencies": {
                 "buffer": {
                     "version": "4.9.1",
-                    "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
@@ -13793,7 +13793,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -14145,7 +14145,7 @@
                 },
                 "os-locale": {
                     "version": "3.1.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
                     "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
                     "dev": true,
                     "requires": {
@@ -14162,7 +14162,7 @@
                 },
                 "resolve-from": {
                     "version": "4.0.0",
-                    "resolved": "",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
                     "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                     "dev": true
                 },
@@ -18754,7 +18754,7 @@
             "dependencies": {
                 "json5": {
                     "version": "1.0.1",
-                    "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {

--- a/src/client/common/application/debugSessionTelemetry.ts
+++ b/src/client/common/application/debugSessionTelemetry.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable } from 'inversify';
-import { DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession, Event, EventEmitter, ProviderResult } from 'vscode';
+import { DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession, ProviderResult } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 import { IExtensionSingleActivationService } from '../../activation/types';
@@ -15,18 +15,13 @@ import { IDebugService } from './types';
 
 class TelemetryTracker implements DebugAdapterTracker {
     private timer = new StopWatch();
-    private trigger: TriggerType = 'launch';
-    private console: ConsoleType | undefined;
-    private debugLocationUpdatedEvent: EventEmitter<void> = new EventEmitter<void>();
+    private readonly trigger: TriggerType = 'launch';
+    private readonly console: ConsoleType | undefined;
 
     constructor(session: DebugSession) {
         this.trigger = session.configuration.type as TriggerType;
         const debugConfiguration = session.configuration as Partial<LaunchRequestArguments & AttachRequestArguments>;
         this.console = debugConfiguration.console;
-    }
-
-    public get debugLocationUpdated(): Event<void> {
-        return this.debugLocationUpdatedEvent.event;
     }
 
     public onWillStartSession() {
@@ -67,10 +62,10 @@ class TelemetryTracker implements DebugAdapterTracker {
 @injectable()
 export class DebugSessionTelemetry implements DebugAdapterTrackerFactory, IExtensionSingleActivationService {
     constructor(
-        @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
         @inject(IDebugService) debugService: IDebugService
     ) {
-        this.disposableRegistry.push(debugService.registerDebugAdapterTrackerFactory('python', this));
+        disposableRegistry.push(debugService.registerDebugAdapterTrackerFactory('python', this));
     }
 
     public async activate(): Promise<void> {

--- a/src/client/common/application/debugSessionTelemetry.ts
+++ b/src/client/common/application/debugSessionTelemetry.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { inject, injectable } from 'inversify';
+import { DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession, Event, EventEmitter, ProviderResult } from 'vscode';
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { AttachRequestArguments, ConsoleType, LaunchRequestArguments, TriggerType } from '../../debugger/types';
+import { sendTelemetryEvent } from '../../telemetry';
+import { EventName } from '../../telemetry/constants';
+import { IDisposableRegistry } from '../types';
+import { StopWatch } from '../utils/stopWatch';
+import { IDebugService } from './types';
+
+class TelemetryTracker implements DebugAdapterTracker {
+    private timer = new StopWatch();
+    private trigger: TriggerType = 'launch';
+    private console: ConsoleType | undefined;
+    private debugLocationUpdatedEvent: EventEmitter<void> = new EventEmitter<void>();
+
+    constructor(session: DebugSession) {
+        this.trigger = session.configuration.type as TriggerType;
+        const debugConfiguration = session.configuration as Partial<LaunchRequestArguments & AttachRequestArguments>;
+        this.console = debugConfiguration.console;
+    }
+
+    public get debugLocationUpdated(): Event<void> {
+        return this.debugLocationUpdatedEvent.event;
+    }
+
+    public onWillStartSession() {
+        this.sendTelemetry(EventName.DEBUG_SESSION_START);
+    }
+
+    // tslint:disable-next-line:no-any
+    public onDidSendMessage(message: DebugProtocol.ProtocolMessage) {
+        if (message.type === 'response') {
+            const response = message as DebugProtocol.Response;
+            if (response.command === 'configurationDone') {
+                // "configurationDone" response is sent immediately after user code starts running.
+                this.sendTelemetry(EventName.DEBUG_SESSION_USER_CODE_RUNNING);
+            }
+        }
+    }
+
+    public onWillStopSession() {
+        this.sendTelemetry(EventName.DEBUG_SESSION_STOP);
+    }
+
+    public onError?(_error: Error) {
+        this.sendTelemetry(EventName.DEBUG_SESSION_ERROR);
+    }
+
+    private sendTelemetry(eventName: EventName) {
+        if (eventName === EventName.DEBUG_SESSION_START) {
+            this.timer.reset();
+        }
+        const telemetryProps = {
+            trigger: this.trigger,
+            console: this.console
+        };
+        sendTelemetryEvent(eventName, this.timer.elapsedTime, telemetryProps);
+    }
+}
+
+@injectable()
+export class DebugSessionTelemetry implements DebugAdapterTrackerFactory, IExtensionSingleActivationService {
+    constructor(
+        @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
+        @inject(IDebugService) debugService: IDebugService
+    ) {
+        this.disposableRegistry.push(debugService.registerDebugAdapterTrackerFactory('python', this));
+    }
+
+    public async activate(): Promise<void> {
+        // We actually register in the constructor. Not necessary to do it here
+    }
+
+    public createDebugAdapterTracker(session: DebugSession): ProviderResult<DebugAdapterTracker> {
+        return new TelemetryTracker(session);
+    }
+}

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -9,6 +9,7 @@ import { ApplicationEnvironment } from './application/applicationEnvironment';
 import { ApplicationShell } from './application/applicationShell';
 import { CommandManager } from './application/commandManager';
 import { DebugService } from './application/debugService';
+import { DebugSessionTelemetry } from './application/debugSessionTelemetry';
 import { DocumentManager } from './application/documentManager';
 import { Extensions } from './application/extensions';
 import { LanguageService } from './application/languageService';
@@ -31,11 +32,20 @@ import { CryptoUtils } from './crypto';
 import { EditorUtils } from './editor';
 import { ExperimentsManager } from './experiments';
 import { FeatureDeprecationManager } from './featureDeprecationManager';
-import { ExtensionInsidersDailyChannelRule, ExtensionInsidersOffChannelRule, ExtensionInsidersWeeklyChannelRule } from './insidersBuild/downloadChannelRules';
+import {
+    ExtensionInsidersDailyChannelRule,
+    ExtensionInsidersOffChannelRule,
+    ExtensionInsidersWeeklyChannelRule
+} from './insidersBuild/downloadChannelRules';
 import { ExtensionChannelService } from './insidersBuild/downloadChannelService';
 import { InsidersExtensionPrompt } from './insidersBuild/insidersExtensionPrompt';
 import { InsidersExtensionService } from './insidersBuild/insidersExtensionService';
-import { ExtensionChannel, IExtensionChannelRule, IExtensionChannelService, IInsiderExtensionPrompt } from './insidersBuild/types';
+import {
+    ExtensionChannel,
+    IExtensionChannelRule,
+    IExtensionChannelService,
+    IInsiderExtensionPrompt
+} from './insidersBuild/types';
 import { ProductInstaller } from './installer/productInstaller';
 import { LiveShareApi } from './liveshare/liveshare';
 import { Logger } from './logger';
@@ -150,4 +160,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionChannelRule>(IExtensionChannelRule, ExtensionInsidersOffChannelRule, ExtensionChannel.off);
     serviceManager.addSingleton<IExtensionChannelRule>(IExtensionChannelRule, ExtensionInsidersDailyChannelRule, ExtensionChannel.daily);
     serviceManager.addSingleton<IExtensionChannelRule>(IExtensionChannelRule, ExtensionInsidersWeeklyChannelRule, ExtensionChannel.weekly);
+    serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, DebugSessionTelemetry);
 }

--- a/src/client/datascience/debugLocationTracker.ts
+++ b/src/client/datascience/debugLocationTracker.ts
@@ -5,10 +5,6 @@ import { injectable } from 'inversify';
 import { DebugSession, Event, EventEmitter } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
-import { StopWatch } from '../common/utils/stopWatch';
-import { AttachRequestArguments, ConsoleType, LaunchRequestArguments, TriggerType } from '../debugger/types';
-import { sendTelemetryEvent } from '../telemetry';
-import { EventName } from '../telemetry/constants';
 import { IDebugLocation, IDebugLocationTracker } from './types';
 
 // When a python debugging session is active keep track of the current debug location
@@ -17,16 +13,10 @@ export class DebugLocationTracker implements IDebugLocationTracker {
     private waitingForStackTrace: boolean = false;
     private _debugLocation: IDebugLocation | undefined;
     private debugLocationUpdatedEvent: EventEmitter<void> = new EventEmitter<void>();
-    private trigger: TriggerType = 'launch';
-    private console: ConsoleType | undefined;
-    private timer = new StopWatch();
 
-    public setDebugSession(targetSession: DebugSession) {
+    public setDebugSession(_targetSession: DebugSession) {
         this.DebugLocation = undefined;
         this.waitingForStackTrace = false;
-        this.trigger = targetSession.configuration.type as TriggerType;
-        const debugConfiguration = targetSession.configuration as Partial<LaunchRequestArguments & AttachRequestArguments>;
-        this.console = debugConfiguration.console;
     }
 
     public get debugLocationUpdated(): Event<void> {
@@ -37,20 +27,8 @@ export class DebugLocationTracker implements IDebugLocationTracker {
         return this._debugLocation;
     }
 
-    public onWillStartSession() {
-        this.sendTelemetry(EventName.DEBUG_SESSION_START);
-    }
-
     // tslint:disable-next-line:no-any
     public onDidSendMessage(message: DebugProtocol.ProtocolMessage) {
-        if (message.type === 'response') {
-            const response = message as DebugProtocol.Response;
-            if (response.command === 'configurationDone') {
-                // "configurationDone" response is sent immediately after user code starts running.
-                this.sendTelemetry(EventName.DEBUG_SESSION_USER_CODE_RUNNING);
-            }
-        }
-
         if (this.isStopEvent(message)) {
             // Some type of stop, wait to see our next stack trace to find our location
             this.waitingForStackTrace = true;
@@ -71,14 +49,6 @@ export class DebugLocationTracker implements IDebugLocationTracker {
             }
         }
 
-    }
-
-    public onWillStopSession() {
-        this.sendTelemetry(EventName.DEBUG_SESSION_STOP);
-    }
-
-    public onError?(_error: Error) {
-        this.sendTelemetry(EventName.DEBUG_SESSION_ERROR);
     }
 
     // Set our new location and fire our debug event
@@ -145,16 +115,5 @@ export class DebugLocationTracker implements IDebugLocationTracker {
         }
 
         return false;
-    }
-
-    private sendTelemetry(eventName: EventName) {
-        if (eventName === EventName.DEBUG_SESSION_START) {
-            this.timer.reset();
-        }
-        const telemetryProps = {
-            trigger: this.trigger,
-            console: this.console
-        };
-        sendTelemetryEvent(eventName, this.timer.elapsedTime, telemetryProps);
     }
 }

--- a/src/client/datascience/debugLocationTrackerFactory.ts
+++ b/src/client/datascience/debugLocationTrackerFactory.ts
@@ -2,17 +2,21 @@
 // Licensed under the MIT License.
 'use strict';
 import { inject, injectable } from 'inversify';
-import { DebugAdapterTracker, DebugSession, ProviderResult } from 'vscode';
+import { DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession, Event, EventEmitter, ProviderResult } from 'vscode';
 
 import { IDebugService } from '../common/application/types';
 import { IDisposableRegistry } from '../common/types';
-import { IDebugLocationTracker, IDebugLocationTrackerFactory } from './types';
+import { DebugLocationTracker } from './debugLocationTracker';
+import { IDebugLocationTracker } from './types';
 
 // Hook up our IDebugLocationTracker to python debugging sessions
 @injectable()
-export class DebugLocationTrackerFactory implements IDebugLocationTrackerFactory {
+export class DebugLocationTrackerFactory implements IDebugLocationTracker, DebugAdapterTrackerFactory {
+
+    private activeTrackers: Map<string, DebugLocationTracker> = new Map<string, DebugLocationTracker>();
+    private updatedEmitter: EventEmitter<void> = new EventEmitter<void>();
+
     constructor(
-        @inject(IDebugLocationTracker) private locationTracker: IDebugLocationTracker,
         @inject(IDebugService) debugService: IDebugService,
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry
     ) {
@@ -20,7 +24,30 @@ export class DebugLocationTrackerFactory implements IDebugLocationTrackerFactory
     }
 
     public createDebugAdapterTracker(session: DebugSession): ProviderResult<DebugAdapterTracker> {
-        this.locationTracker.setDebugSession(session);
-        return this.locationTracker;
+        const result = new DebugLocationTracker(session.id);
+        this.activeTrackers.set(session.id, result);
+        result.sessionEnded(this.onSessionEnd.bind(this));
+        result.debugLocationUpdated(this.onLocationUpdated.bind(this));
+        this.updatedEmitter.fire();
+        return result;
+    }
+
+    public get updated(): Event<void> {
+        return this.updatedEmitter.event;
+    }
+
+    public getLocation(session: DebugSession) {
+        const tracker = this.activeTrackers.get(session.id);
+        if (tracker) {
+            return tracker.debugLocation;
+        }
+    }
+
+    private onSessionEnd(locationTracker: DebugLocationTracker) {
+        this.activeTrackers.delete(locationTracker.sessionId);
+    }
+
+    private onLocationUpdated() {
+        this.updatedEmitter.fire();
     }
 }

--- a/src/client/datascience/debugLocationTrackerFactory.ts
+++ b/src/client/datascience/debugLocationTrackerFactory.ts
@@ -28,7 +28,7 @@ export class DebugLocationTrackerFactory implements IDebugLocationTracker, Debug
         this.activeTrackers.set(session.id, result);
         result.sessionEnded(this.onSessionEnd.bind(this));
         result.debugLocationUpdated(this.onLocationUpdated.bind(this));
-        this.updatedEmitter.fire();
+        this.onLocationUpdated();
         return result;
     }
 

--- a/src/client/datascience/editor-integration/codelensprovider.ts
+++ b/src/client/datascience/editor-integration/codelensprovider.ts
@@ -32,7 +32,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
         disposableRegistry.push(this);
         disposableRegistry.push(this.debugService.onDidChangeActiveDebugSession(this.onChangeDebugSession.bind(this)));
         disposableRegistry.push(this.documentManager.onDidCloseTextDocument(this.onDidCloseTextDocument.bind(this)));
-        disposableRegistry.push(this.debugLocationTracker.debugLocationUpdated(this.onDebugLocationUpdated.bind(this)));
+        disposableRegistry.push(this.debugLocationTracker.updated(this.onDebugLocationUpdated.bind(this)));
     }
 
     public dispose() {
@@ -104,7 +104,7 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
         const debugCellList = CodeLensCommands.DebuggerCommands;
 
         if (this.debugService.activeDebugSession) {
-            const debugLocation = this.debugLocationTracker.debugLocation;
+            const debugLocation = this.debugLocationTracker.getLocation(this.debugService.activeDebugSession);
 
             if (debugLocation && this.fileSystem.arePathsSame(debugLocation.fileName, document.uri.fsPath)) {
                 // We are in the given debug file, so only return the code lens that contains the given line

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -11,7 +11,6 @@ import { Telemetry } from './constants';
 import { DataViewer } from './data-viewing/dataViewer';
 import { DataViewerProvider } from './data-viewing/dataViewerProvider';
 import { DataScience } from './datascience';
-import { DebugLocationTracker } from './debugLocationTracker';
 import { DebugLocationTrackerFactory } from './debugLocationTrackerFactory';
 import { CellHashProvider } from './editor-integration/cellhashprovider';
 import { CodeLensFactory } from './editor-integration/codeLensFactory';
@@ -58,7 +57,6 @@ import {
     IDataViewer,
     IDataViewerProvider,
     IDebugLocationTracker,
-    IDebugLocationTrackerFactory,
     IGatherExecution,
     IInteractiveWindow,
     IInteractiveWindowListener,
@@ -140,6 +138,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, wrapType(NativeEditorCommandListener));
     serviceManager.addBinding(IGatherExecution, INotebookExecutionLogger);
     serviceManager.addBinding(ICodeLensFactory, IInteractiveWindowListener);
-    serviceManager.addSingleton<IDebugLocationTrackerFactory>(IDebugLocationTrackerFactory, wrapType(DebugLocationTrackerFactory));
-    serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, wrapType(DebugLocationTracker));
+    serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, wrapType(DebugLocationTrackerFactory));
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -5,7 +5,18 @@ import { nbformat } from '@jupyterlab/coreutils';
 import { Kernel, KernelMessage } from '@jupyterlab/services/lib/kernel';
 import { JSONObject } from '@phosphor/coreutils';
 import { Observable } from 'rxjs/Observable';
-import { CancellationToken, CodeLens, CodeLensProvider, DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession, Disposable, Event, Range, TextDocument, TextEditor, Uri } from 'vscode';
+import {
+    CancellationToken,
+    CodeLens,
+    CodeLensProvider,
+    DebugSession,
+    Disposable,
+    Event,
+    Range,
+    TextDocument,
+    TextEditor,
+    Uri
+} from 'vscode';
 
 import { ICommandManager } from '../common/application/types';
 import { ExecutionResult, ObservableExecutionResult, SpawnOptions } from '../common/process/types';
@@ -493,10 +504,6 @@ export interface ICellHashProvider {
     getHashes(): IFileHashes[];
 }
 
-export const IDebugLocationTrackerFactory = Symbol('IDebugLocationTrackerFactory');
-export interface IDebugLocationTrackerFactory extends DebugAdapterTrackerFactory {
-}
-
 export interface IDebugLocation {
     fileName: string;
     lineNumber: number;
@@ -504,8 +511,8 @@ export interface IDebugLocation {
 }
 
 export const IDebugLocationTracker = Symbol('IDebugLocationTracker');
-export interface IDebugLocationTracker extends DebugAdapterTracker {
-    debugLocationUpdated: Event<void>;
-    debugLocation: IDebugLocation | undefined;
-    setDebugSession(targetSession: DebugSession): void;
+export interface IDebugLocationTracker {
+    updated: Event<void>;
+    getLocation(debugSession: DebugSession): IDebugLocation | undefined;
+
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -64,14 +64,18 @@ import { createDeferred } from './common/utils/async';
 import { Common, OutputChannelNames } from './common/utils/localize';
 import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
 import { registerTypes as dataScienceRegisterTypes } from './datascience/serviceRegistry';
-import { IDataScience, IDebugLocationTrackerFactory } from './datascience/types';
+import { IDataScience } from './datascience/types';
 import { DebuggerTypeName } from './debugger/constants';
 import { DebugSessionEventDispatcher } from './debugger/extension/hooks/eventHandlerDispatcher';
 import { IDebugSessionEventHandlers } from './debugger/extension/hooks/types';
 import { registerTypes as debugConfigurationRegisterTypes } from './debugger/extension/serviceRegistry';
 import { IDebugAdapterDescriptorFactory, IDebugConfigurationService, IDebuggerBanner } from './debugger/extension/types';
 import { registerTypes as formattersRegisterTypes } from './formatters/serviceRegistry';
-import { AutoSelectionRule, IInterpreterAutoSelectionRule, IInterpreterAutoSelectionService } from './interpreter/autoSelection/types';
+import {
+    AutoSelectionRule,
+    IInterpreterAutoSelectionRule,
+    IInterpreterAutoSelectionService
+} from './interpreter/autoSelection/types';
 import { IInterpreterSelector } from './interpreter/configuration/types';
 import {
     ICondaService,
@@ -153,9 +157,6 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
     const interpreterManager = serviceContainer.get<IInterpreterService>(IInterpreterService);
     interpreterManager.refresh(workspaceService.hasWorkspaceFolders ? workspaceService.workspaceFolders![0].uri : undefined)
         .catch(ex => traceError('Python Extension: interpreterManager.refresh', ex));
-
-    // Activate debug location tracker
-    serviceManager.get<IDebugLocationTrackerFactory>(IDebugLocationTrackerFactory);
 
     // Activate data science features
     const dataScience = serviceManager.get<IDataScience>(IDataScience);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -97,7 +97,6 @@ import { IEnvironmentVariablesProvider, IEnvironmentVariablesService } from '../
 import { CodeCssGenerator } from '../../client/datascience/codeCssGenerator';
 import { DataViewer } from '../../client/datascience/data-viewing/dataViewer';
 import { DataViewerProvider } from '../../client/datascience/data-viewing/dataViewerProvider';
-import { DebugLocationTracker } from '../../client/datascience/debugLocationTracker';
 import { DebugLocationTrackerFactory } from '../../client/datascience/debugLocationTrackerFactory';
 import { CellHashProvider } from '../../client/datascience/editor-integration/cellhashprovider';
 import { CodeLensFactory } from '../../client/datascience/editor-integration/codeLensFactory';
@@ -141,7 +140,6 @@ import {
     IDataViewer,
     IDataViewerProvider,
     IDebugLocationTracker,
-    IDebugLocationTrackerFactory,
     IGatherExecution,
     IInteractiveWindow,
     IInteractiveWindowListener,
@@ -365,8 +363,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.add<IInstallationChannelManager>(IInstallationChannelManager, InstallationChannelManager);
         this.serviceManager.addSingleton<IJupyterVariables>(IJupyterVariables, JupyterVariables);
         this.serviceManager.addSingleton<IJupyterDebugger>(IJupyterDebugger, JupyterDebugger);
-        this.serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, DebugLocationTracker);
-        this.serviceManager.addSingleton<IDebugLocationTrackerFactory>(IDebugLocationTrackerFactory, DebugLocationTrackerFactory);
+        this.serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, DebugLocationTrackerFactory);
         this.serviceManager.addSingleton<INotebookEditorProvider>(INotebookEditorProvider, TestNativeEditorProvider);
         this.serviceManager.add<INotebookEditor>(INotebookEditor, NativeEditor);
         this.serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NativeEditorCommandListener);

--- a/src/test/datascience/debugLocationTracker.unit.test.ts
+++ b/src/test/datascience/debugLocationTracker.unit.test.ts
@@ -11,7 +11,7 @@ suite('Debug Location Tracker', () => {
     let debugTracker: DebugLocationTracker;
 
     setup(() => {
-        debugTracker = new DebugLocationTracker();
+        debugTracker = new DebugLocationTracker('1');
     });
 
     test('Check debug location', async () => {

--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -18,7 +18,7 @@ import { noop } from '../../client/common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
 import {
     IDataScienceCodeLensProvider,
-    IDebugLocationTrackerFactory,
+    IDebugLocationTracker,
     IInteractiveWindowProvider,
     IJupyterExecution
 } from '../../client/datascience/types';
@@ -126,7 +126,7 @@ suite('DataScience Debugger tests', () => {
         // This is necessary to get the appropriate live share services up and running.
         result.get<IInteractiveWindowProvider>(IInteractiveWindowProvider);
         result.get<IJupyterExecution>(IJupyterExecution);
-        result.get<IDebugLocationTrackerFactory>(IDebugLocationTrackerFactory);
+        result.get<IDebugLocationTracker>(IDebugLocationTracker);
         return result;
     }
 


### PR DESCRIPTION
For #7352 

I split the debugAdapterTracker into its two parts, the telemetry part Karthik added and the stuff we have for DS. The DS part I then modified to handle multiple sessions.

The vscode API registerDebugAdapterTrackerFactory does support more than one adapter per language so no need for a global one.

I skipped making the DS adapter being only active during DS debugging. That would really complicate creation of it and it's not that complicated, so just let it run all the time.
