### PR TITLE
Fix slowdown when jedi is used for intellisense in the notebook editor

### DIFF
--- a/news/2 Fixes/7497.md
+++ b/news/2 Fixes/7497.md
@@ -1,0 +1,1 @@
+Fix jedi intellisense in the notebook editor to be performant.

--- a/src/client/datascience/interactive-common/intellisense/conversion.ts
+++ b/src/client/datascience/interactive-common/intellisense/conversion.ts
@@ -161,6 +161,13 @@ function convertToMonacoCompletionItem(item: vscodeLanguageClient.CompletionItem
         result.insertText = result.label;
     }
 
+    // Make sure we don't have _documentPosition. It holds onto a huge tree of information
+    // tslint:disable-next-line: no-any
+    const resultAny = result as any;
+    if (resultAny._documentPosition) {
+        delete resultAny._documentPosition;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
For #7497 
Root cause was the completion items coming back with an extra hidden field that referenced a whole bunch of unnecessary stuff. We were then translating that to JSON and sending it to the webview. Since each element referenced the same stuff, this created a huge amount of JSON. One of the things referenced was the entire document.
