### PR TITLE
Make sure we only prompt once for re-enrolling insiders.

### DIFF
--- a/news/2 Fixes/7606.md
+++ b/news/2 Fixes/7606.md
@@ -1,0 +1,1 @@
+Ensure the insiders prompt only shows once.

--- a/src/client/common/insidersBuild/insidersExtensionService.ts
+++ b/src/client/common/insidersBuild/insidersExtensionService.ts
@@ -99,6 +99,9 @@ export class InsidersExtensionService implements IExtensionSingleActivationServi
         if (installChannel !== 'off') {
             return false;
         }
+        if (this.insidersPrompt.hasUserBeenAskedToOptInAgain.value) {
+            return false;
+        }
         if (this.extensionChannelService.isChannelUsingDefaultConfiguration) {
             return false;
         }

--- a/src/client/common/insidersBuild/types.ts
+++ b/src/client/common/insidersBuild/types.ts
@@ -25,6 +25,7 @@ export interface IInsiderExtensionPrompt {
      * Gets updated to `true` once user has been prompted to install insiders.
      */
     readonly hasUserBeenNotified: IPersistentState<boolean>;
+    readonly hasUserBeenAskedToOptInAgain: IPersistentState<boolean>;
     promptToInstallInsiders(): Promise<void>;
     promptToEnrollBackToInsiders(): Promise<void>;
     promptToReload(): Promise<void>;

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -183,6 +183,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     let cmdManager: TypeMoq.IMock<ICommandManager>;
     let insidersPrompt: TypeMoq.IMock<IInsiderExtensionPrompt>;
     let hasUserBeenNotifiedState: IPersistentState<boolean>;
+    let hasUserBeenAskedToOptInAgainState: IPersistentState<boolean>;
     let insidersInstaller: TypeMoq.IMock<IExtensionBuildInstaller>;
 
     let insidersExtensionService: InsidersExtensionService;
@@ -195,6 +196,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>(undefined, TypeMoq.MockBehavior.Strict);
         insidersPrompt = TypeMoq.Mock.ofType<IInsiderExtensionPrompt>(undefined, TypeMoq.MockBehavior.Strict);
         hasUserBeenNotifiedState = mock(PersistentState);
+        hasUserBeenAskedToOptInAgainState = mock(PersistentState);
 
         insidersExtensionService = new InsidersExtensionService(
             extensionChannelService.object,
@@ -209,6 +211,10 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
         insidersPrompt
             .setup(p => p.hasUserBeenNotified)
             .returns(() => instance(hasUserBeenNotifiedState))
+            .verifiable(TypeMoq.Times.atLeast(0));
+        insidersPrompt
+            .setup(p => p.hasUserBeenAskedToOptInAgain)
+            .returns(() => instance(hasUserBeenAskedToOptInAgainState))
             .verifiable(TypeMoq.Times.atLeast(0));
     }
 
@@ -227,6 +233,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
         installChannel?: ExtensionChannels;
         isChannelUsingDefaultConfiguration?: boolean | number;
         hasUserBeenNotified?: boolean;
+        hasUserBeenAskedToOptInAgain?: boolean;
     };
 
     function setState(
@@ -262,10 +269,13 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
                 .setup(ec => ec.updateChannel('off'))
                 .returns(() => Promise.resolve());
         }
-
         if (info.hasUserBeenNotified !== undefined) {
             when(hasUserBeenNotifiedState.value)
                 .thenReturn(info.hasUserBeenNotified!);
+        }
+        if (info.hasUserBeenAskedToOptInAgain !== undefined) {
+            when(hasUserBeenAskedToOptInAgainState.value)
+                .thenReturn(info.hasUserBeenAskedToOptInAgain!);
         }
 
         if (checkPromptEnroll) {
@@ -284,7 +294,8 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
         const testsForHandleEdgeCaseI: TestInfo[] = [
             {
                 installChannel: 'off',
-                isChannelUsingDefaultConfiguration: false
+                isChannelUsingDefaultConfiguration: false,
+                hasUserBeenAskedToOptInAgain: false
             }
         ];
 
@@ -315,6 +326,14 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             },
             {
                 installChannel: 'off',
+                hasUserBeenAskedToOptInAgain: true,
+                vscodeChannel: 'insiders',
+                hasUserBeenNotified: false,
+                isChannelUsingDefaultConfiguration: true
+            },
+            {
+                installChannel: 'off',
+                hasUserBeenAskedToOptInAgain: false,
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: false,
                 isChannelUsingDefaultConfiguration: 2
@@ -397,6 +416,15 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             },
             {
                 installChannel: 'off',
+                hasUserBeenAskedToOptInAgain: true,
+                //
+                vscodeChannel: 'insiders',
+                hasUserBeenNotified: true
+                //
+            },
+            {
+                installChannel: 'off',
+                hasUserBeenAskedToOptInAgain: false,
                 isChannelUsingDefaultConfiguration: true,
                 //
                 vscodeChannel: 'insiders',
@@ -405,6 +433,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             },
             {
                 installChannel: 'off',
+                hasUserBeenAskedToOptInAgain: false,
                 isChannelUsingDefaultConfiguration: true,
                 //
                 vscodeChannel: 'stable'
@@ -412,6 +441,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             },
             {
                 installChannel: 'off',
+                hasUserBeenAskedToOptInAgain: false,
                 isChannelUsingDefaultConfiguration: true,
                 //
                 vscodeChannel: 'stable'
@@ -435,6 +465,11 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
                     verify(hasUserBeenNotifiedState.value).never();
                 } else {
                     verify(hasUserBeenNotifiedState.value).once();
+                }
+                if (testParams.hasUserBeenAskedToOptInAgain === undefined) {
+                    verify(hasUserBeenAskedToOptInAgainState.value).never();
+                } else {
+                    verify(hasUserBeenAskedToOptInAgainState.value).once();
                 }
             });
         });

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -295,6 +295,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     suite('Case I - Verify enroll into the program again prompt is displayed when conditions are met', async () => {
         const testsForHandleEdgeCaseI: TestInfo[] = [
             {
+                // prompt to re-enroll
                 installChannel: 'off',
                 isChannelUsingDefaultConfiguration: false,
                 hasUserBeenAskedToOptInAgain: false
@@ -321,21 +322,27 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     suite('Case II - Verify Insiders Install Prompt is displayed when conditions are met', async () => {
         const testsForHandleEdgeCaseII: TestInfo[] = [
             {
+                // skip re-enroll
                 installChannel: 'daily',
+                // prompt to enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: false,
                 isChannelUsingDefaultConfiguration: true
             },
             {
+                // skip re-enroll
                 installChannel: 'off',
                 hasUserBeenAskedToOptInAgain: true,
+                // prompt to enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: false,
                 isChannelUsingDefaultConfiguration: true
             },
             {
+                // skip re-enroll
                 installChannel: 'off',
                 hasUserBeenAskedToOptInAgain: false,
+                // prompt to enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: false,
                 isChannelUsingDefaultConfiguration: 2
@@ -362,14 +369,22 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     suite('Case III - Verify Insiders channel is set to off when conditions are met', async () => {
         const testsForHandleEdgeCaseIII: TestInfo[] = [
             {
+                // skip re-enroll
+                installChannel: 'daily',
+                // skip enroll
                 vscodeChannel: 'stable',
-                extensionChannel: 'stable',
-                installChannel: 'daily'
+                // disable
+                // with installChannel from above
+                extensionChannel: 'stable'
             },
             {
+                // skip re-enroll
+                installChannel: 'weekly',
+                // skip enroll
                 vscodeChannel: 'stable',
-                extensionChannel: 'stable',
-                installChannel: 'weekly'
+                // disable
+                // with installChannel from above
+                extensionChannel: 'stable'
             }
         ];
 
@@ -393,61 +408,68 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     suite('Case IV - Verify no operation is performed if none of the case conditions are met', async () => {
         const testsForHandleEdgeCaseIV: TestInfo[] = [
             {
+                // skip re-enroll
                 installChannel: 'daily',
-                //
+                // skip enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: true,
-                //
+                // skip disable
                 extensionChannel: 'insiders'
             },
             {
+                // skip re-enroll
                 installChannel: 'daily',
-                //
+                // skip enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: false,
                 isChannelUsingDefaultConfiguration: false,
-                //
+                // skip disable
                 extensionChannel: 'insiders'
             },
             {
+                // skip re-enroll
                 installChannel: 'daily',
-                //
+                // skip enroll
                 vscodeChannel: 'stable',
-                //
+                // skip disable
                 extensionChannel: 'insiders'
             },
             {
+                // skip re-enroll
                 installChannel: 'off',
                 hasUserBeenAskedToOptInAgain: true,
-                //
+                // skip enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: true
-                //
+                // disable skipped due to installChannel
             },
             {
+                // skip re-enroll
                 installChannel: 'off',
                 hasUserBeenAskedToOptInAgain: false,
                 isChannelUsingDefaultConfiguration: true,
-                //
+                // skip enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: true
-                //
+                // disable skipped due to installChannel
             },
             {
+                // skip re-enroll
                 installChannel: 'off',
                 hasUserBeenAskedToOptInAgain: false,
                 isChannelUsingDefaultConfiguration: true,
-                //
+                // skip enroll
                 vscodeChannel: 'stable'
-                //
+                // disable skipped due to installChannel
             },
             {
+                // skip re-enroll
                 installChannel: 'off',
                 hasUserBeenAskedToOptInAgain: false,
                 isChannelUsingDefaultConfiguration: true,
-                //
+                // skip enroll
                 vscodeChannel: 'stable'
-                //
+                // disable skipped due to installChannel
             }
         ];
 

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -221,12 +221,14 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     }
 
     function verifyAll() {
-        appEnvironment.verifyAll();
-        serviceContainer.verifyAll();
-        extensionChannelService.verifyAll();
-        cmdManager.verifyAll();
+        // the most important ones:
         insidersPrompt.verifyAll();
         insidersInstaller.verifyAll();
+        extensionChannelService.verifyAll();
+        // the other used interfaces:
+        appEnvironment.verifyAll();
+        serviceContainer.verifyAll();
+        cmdManager.verifyAll();
     }
 
     type TestInfo = {

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -211,10 +211,12 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
         insidersPrompt
             .setup(p => p.hasUserBeenNotified)
             .returns(() => instance(hasUserBeenNotifiedState))
+            // Basically means "we don't care" (necessary for strict mocks).
             .verifiable(TypeMoq.Times.atLeast(0));
         insidersPrompt
             .setup(p => p.hasUserBeenAskedToOptInAgain)
             .returns(() => instance(hasUserBeenAskedToOptInAgainState))
+            // Basically means "we don't care" (necessary for strict mocks).
             .verifiable(TypeMoq.Times.atLeast(0));
     }
 

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -234,8 +234,8 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
     type TestInfo = {
         vscodeChannel?: Channel;
         extensionChannel?: Channel;
-        installChannel?: ExtensionChannels;
-        isChannelUsingDefaultConfiguration?: boolean | number;
+        installChannel: ExtensionChannels;
+        isChannelUsingDefaultConfiguration?: boolean;
         hasUserBeenNotified?: boolean;
         hasUserBeenAskedToOptInAgain?: boolean;
     };
@@ -257,17 +257,6 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
                 .returns(() => info.extensionChannel!);
         }
 
-        if (info.isChannelUsingDefaultConfiguration !== undefined) {
-            const inst = extensionChannelService
-                .setup(ec => ec.isChannelUsingDefaultConfiguration);
-            if (info.isChannelUsingDefaultConfiguration === 2) {
-                inst
-                    .returns(() => true)
-                    .verifiable(TypeMoq.Times.exactly(2));
-            } else {
-                inst.returns(() => info.isChannelUsingDefaultConfiguration as boolean);
-            }
-        }
         if (checkDisable) {
             extensionChannelService
                 .setup(ec => ec.updateChannel('off'))
@@ -313,7 +302,10 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             test(testName, async () => {
                 setState(testParams, false, true, false);
 
-                await insidersExtensionService.handleEdgeCases(testParams.installChannel!);
+                await insidersExtensionService.handleEdgeCases(
+                    testParams.installChannel,
+                    testParams.isChannelUsingDefaultConfiguration!
+                );
 
                 verifyAll();
                 verify(hasUserBeenNotifiedState.value).never();
@@ -347,7 +339,7 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
                 // prompt to enroll
                 vscodeChannel: 'insiders',
                 hasUserBeenNotified: false,
-                isChannelUsingDefaultConfiguration: 2
+                isChannelUsingDefaultConfiguration: true
             }
         ];
 
@@ -360,7 +352,10 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             test(testName, async () => {
                 setState(testParams, true, false, false);
 
-                await insidersExtensionService.handleEdgeCases(testParams.installChannel!);
+                await insidersExtensionService.handleEdgeCases(
+                    testParams.installChannel,
+                    testParams.isChannelUsingDefaultConfiguration!
+                );
 
                 verifyAll();
                 verify(hasUserBeenNotifiedState.value).once();
@@ -399,7 +394,10 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             test(testName, async () => {
                 setState(testParams, false, false, true);
 
-                await insidersExtensionService.handleEdgeCases(testParams.installChannel || 'off');
+                await insidersExtensionService.handleEdgeCases(
+                    testParams.installChannel,
+                    false  // isDefault
+                );
 
                 verifyAll();
                 verify(hasUserBeenNotifiedState.value).never();
@@ -484,7 +482,10 @@ suite('Insiders Extension Service - Function handleEdgeCases()', () => {
             test(testName, async () => {
                 setState(testParams, false, false, false);
 
-                await insidersExtensionService.handleEdgeCases(testParams.installChannel || 'off');
+                await insidersExtensionService.handleEdgeCases(
+                    testParams.installChannel,
+                    testParams.isChannelUsingDefaultConfiguration || testParams.installChannel === 'off'
+                );
 
                 verifyAll();
                 if (testParams.hasUserBeenNotified === undefined) {

--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -125,12 +125,15 @@ suite('Insiders Extension Service - Activation', () => {
         handleEdgeCases.callsFake(() => Promise.resolve(true));
         insidersExtensionService = new InsidersExtensionService(instance(extensionChannelService), instance(insidersPrompt), instance(appEnvironment), instance(cmdManager), instance(serviceContainer), instance(insidersInstaller), []);
         when(extensionChannelService.getChannel()).thenReturn('daily');
+        when(extensionChannelService.isChannelUsingDefaultConfiguration).thenReturn(false);
 
         await insidersExtensionService.activate();
 
         verify(extensionChannelService.getChannel()).once();
+        verify(extensionChannelService.isChannelUsingDefaultConfiguration).once();
         assert.ok(registerCommandsAndHandlers.calledOnce);
         assert.ok(handleEdgeCases.calledOnce);
+        assert.ok(handleEdgeCases.calledWith('daily', false));
         assert.ok(handleChannel.notCalled);
     });
 
@@ -140,14 +143,16 @@ suite('Insiders Extension Service - Activation', () => {
         handleEdgeCases.callsFake(() => Promise.resolve(false));
         insidersExtensionService = new InsidersExtensionService(instance(extensionChannelService), instance(insidersPrompt), instance(appEnvironment), instance(cmdManager), instance(serviceContainer), instance(insidersInstaller), []);
         when(extensionChannelService.getChannel()).thenReturn('daily');
+        when(extensionChannelService.isChannelUsingDefaultConfiguration).thenReturn(false);
 
         await insidersExtensionService.activate();
 
         verify(extensionChannelService.getChannel()).once();
+        verify(extensionChannelService.isChannelUsingDefaultConfiguration).once();
         assert.ok(registerCommandsAndHandlers.calledOnce);
         assert.ok(handleEdgeCases.calledOnce);
+        assert.ok(handleEdgeCases.calledWith('daily', false));
         assert.ok(handleChannel.calledOnce);
-        expect(handleChannel.args[0][0]).to.equal('daily');
     });
 
     test('Ensure channels are reliably handled in the background', async () => {
@@ -157,6 +162,7 @@ suite('Insiders Extension Service - Activation', () => {
         handleEdgeCases.callsFake(() => Promise.resolve(false));
         insidersExtensionService = new InsidersExtensionService(instance(extensionChannelService), instance(insidersPrompt), instance(appEnvironment), instance(cmdManager), instance(serviceContainer), instance(insidersInstaller), []);
         when(extensionChannelService.getChannel()).thenReturn('daily');
+        when(extensionChannelService.isChannelUsingDefaultConfiguration).thenReturn(false);
 
         const promise = insidersExtensionService.activate();
         const deferred = createDeferredFromPromise(promise);
@@ -171,7 +177,7 @@ suite('Insiders Extension Service - Activation', () => {
         assert.ok(registerCommandsAndHandlers.calledOnce);
         assert.ok(handleEdgeCases.calledOnce);
         assert.ok(handleChannel.calledOnce);
-        expect(handleChannel.args[0][0]).to.equal('daily');
+        assert.ok(handleEdgeCases.calledWith('daily', false));
     });
 });
 


### PR DESCRIPTION
(for #7606)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- [x] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
