### PR TITLE
Fixes to CSS selectors of test explorer

### DIFF
--- a/uitests/src/selectors.ts
+++ b/uitests/src/selectors.ts
@@ -192,6 +192,9 @@ const selectors: Record<Selector, { stable: string } & { insider?: string }> = {
     [Selector.PythonExtensionStatusBar]: {
         stable: ".statusbar-item[id='ms-python.python']"
     },
+    [Selector.StatusBarItem]: {
+        stable: '.statusbar-item'
+    },
     [Selector.PyBootstrapStatusBar]: {
         stable: `.part.statusbar *[title='${pyBootstrapTooltip}'] a`
     },
@@ -291,19 +294,19 @@ const selectors: Record<Selector, { stable: string } & { insider?: string }> = {
         stable: "div[id='workbench.parts.sidebar']"
     },
     [Selector.NthTestExplorerNodeLabel]: {
-        stable: 'div[id="workbench.view.extension.test"] div.monaco-tree-row:nth-child({0}) a.label-name'
+        stable: 'div[id="workbench.view.extension.test"] .tree-explorer-viewlet-tree-view div[role="treeitem"]:nth-child({0}) a.label-name'
     },
     [Selector.NthTestExplorerNodeIcon]: {
-        stable: 'div[id="workbench.view.extension.test"] div.monaco-tree-row:nth-child({0}) .custom-view-tree-node-item-icon'
+        stable: 'div[id="workbench.view.extension.test"] .tree-explorer-viewlet-tree-view div[role="treeitem"]:nth-child({0}) .custom-view-tree-node-item-icon'
     },
     [Selector.NthTestExplorerNode]: {
-        stable: 'div[id="workbench.view.extension.test"] div.monaco-tree-row:nth-child({0})'
+        stable: 'div[id="workbench.view.extension.test"] .tree-explorer-viewlet-tree-view div[role="treeitem"]:nth-child({0})'
     },
     [Selector.TestExplorerNode]: {
-        stable: 'div[id="workbench.view.extension.test"] .tree-explorer-viewlet-tree-view div.monaco-tree-row'
+        stable: 'div[id="workbench.view.extension.test"] .tree-explorer-viewlet-tree-view div[role="treeitem"]'
     },
     [Selector.TestExplorerTreeViewContainer]: {
-        stable: "div[id='workbench.view.extension.test'] .monaco-tree"
+        stable: "div[id='workbench.view.extension.test'] [role='tree']"
     },
     [Selector.QuickOpenHidden]: {
         stable: QuickOpen.QUICK_OPEN_HIDDEN

--- a/uitests/src/selectors.ts
+++ b/uitests/src/selectors.ts
@@ -192,9 +192,6 @@ const selectors: Record<Selector, { stable: string } & { insider?: string }> = {
     [Selector.PythonExtensionStatusBar]: {
         stable: ".statusbar-item[id='ms-python.python']"
     },
-    [Selector.StatusBarItem]: {
-        stable: '.statusbar-item'
-    },
     [Selector.PyBootstrapStatusBar]: {
         stable: `.part.statusbar *[title='${pyBootstrapTooltip}'] a`
     },

--- a/uitests/src/vscode/testExplorer.ts
+++ b/uitests/src/vscode/testExplorer.ts
@@ -258,10 +258,11 @@ export class TestExplorer implements ITestExplorer {
         const iconSelector = this.app.getCSSSelector(Selector.NthTestExplorerNodeIcon).format(nodeNumber.toString());
         const selector = this.app.getCSSSelector(Selector.NthTestExplorerNode).format(nodeNumber.toString());
 
-        const [bgIcon, nodeLabel, className] = await Promise.all([
+        const [bgIcon, nodeLabel, className, ariaExpandedAttrValue] = await Promise.all([
             this.app.driver.$eval(iconSelector, element => getComputedStyle(element).backgroundImage || ''),
             label ? Promise.resolve(label) : this.getNodeLabel(nodeNumber),
-            this.app.driver.$eval(selector, element => element.className)
+            this.app.driver.$eval(selector, element => element.className),
+            this.app.driver.$eval(selector, element => element.getAttribute('aria-expanded') || '')
         ]);
 
         const status = Array.from(statusToIconMapping.entries()).reduce<TestExplorerNodeStatus>((currentStatus, item) => {
@@ -272,9 +273,9 @@ export class TestExplorer implements ITestExplorer {
         }, 'Unknown');
 
         return {
-            expanded: className.indexOf('expanded') >= 0,
+            expanded: ariaExpandedAttrValue === 'true',
             focused: className.indexOf('focused') >= 0,
-            hasChildren: className.indexOf('has-children') >= 0,
+            hasChildren: ariaExpandedAttrValue !== '',
             status,
             index: nodeNumber - 1,
             label: nodeLabel


### PR DESCRIPTION
The CSS Selectors for the treeview items have changed, due to a massive re-write of tree implementation in VS Code.