### PR TITLE
Add a setting to activate environment in the current open terminal

### DIFF
--- a/news/1 Enhancements/7665.md
+++ b/news/1 Enhancements/7665.md
@@ -1,0 +1,1 @@
+Added extension option `activateEnvInCurrentTerminal` to detect if environment should be activated in the current open terminal.

--- a/package.json
+++ b/package.json
@@ -2289,6 +2289,12 @@
                     "description": "Python launch arguments to use when executing a file in the terminal.",
                     "scope": "resource"
                 },
+                "python.terminal.activateEnvInCurrentTerminal": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Activate Python Environment in the current Terminal on load of the Extension.",
+                    "scope": "resource"
+                },
                 "python.testing.cwd": {
                     "type": "string",
                     "default": null,

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -354,7 +354,8 @@ export class PythonSettings implements IPythonSettings {
         this.terminal = this.terminal ? this.terminal : {
             executeInFileDir: true,
             launchArgs: [],
-            activateEnvironment: true
+            activateEnvironment: true,
+            activateEnvInCurrentTerminal: false
         };
 
         const experiments = systemVariables.resolveAny(pythonSettings.get<IExperiments>('experiments'))!;

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -276,6 +276,7 @@ export interface ITerminalSettings {
     readonly executeInFileDir: boolean;
     readonly launchArgs: string[];
     readonly activateEnvironment: boolean;
+    readonly activateEnvInCurrentTerminal: boolean;
 }
 
 export interface IExperiments {

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -183,7 +183,10 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
     context.subscriptions.push(deprecationMgr);
 
     context.subscriptions.push(new ReplProvider(serviceContainer));
-    context.subscriptions.push(new TerminalProvider(serviceContainer));
+
+    const terminalProvider = new TerminalProvider(serviceContainer);
+    await terminalProvider.initialize(window.activeTerminal);
+    context.subscriptions.push(terminalProvider);
 
     context.subscriptions.push(languages.registerCodeActionsProvider(PYTHON, new PythonCodeActionProvider(), { providedCodeActionKinds: [CodeActionKind.SourceOrganizeImports] }));
 

--- a/src/client/providers/terminalProvider.ts
+++ b/src/client/providers/terminalProvider.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Disposable, Uri } from 'vscode';
+import { Disposable, Terminal, Uri } from 'vscode';
 import { ICommandManager, IDocumentManager, IWorkspaceService } from '../common/application/types';
 import { Commands } from '../common/constants';
-import { ITerminalServiceFactory } from '../common/terminal/types';
+import { ITerminalActivator, ITerminalServiceFactory } from '../common/terminal/types';
+import { IConfigurationService } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { captureTelemetry } from '../telemetry';
 import { EventName } from '../telemetry/constants';
@@ -13,6 +14,15 @@ export class TerminalProvider implements Disposable {
     private disposables: Disposable[] = [];
     constructor(private serviceContainer: IServiceContainer) {
         this.registerCommands();
+    }
+    public async initialize(currentTerminal: Terminal | undefined) {
+        const configuration = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const pythonSettings = configuration.getSettings();
+
+        if (pythonSettings.terminal.activateEnvInCurrentTerminal && currentTerminal) {
+            const terminalActivator = this.serviceContainer.get<ITerminalActivator>(ITerminalActivator);
+            await terminalActivator.activateEnvironmentInTerminal(currentTerminal, undefined, true);
+        }
     }
     public dispose() {
         this.disposables.forEach(disposable => disposable.dispose());

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -510,7 +510,8 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.pythonSettings.terminal = {
             executeInFileDir: false,
             launchArgs: [],
-            activateEnvironment: true
+            activateEnvironment: true,
+            activateEnvInCurrentTerminal: false
         };
 
         condaService.setup(c => c.isCondaAvailable()).returns(() => Promise.resolve(false));


### PR DESCRIPTION
For #5330

Since a generic solution for that issue is quite hard to imagine, I decided to make this functionality optional.

Thus, people who really wants to get environment activated in the current open terminal, can enable this behavior in settings, and everyone else won't be affected.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
