### PR TITLE
Capture vscode logs with failed tests results

### DIFF
--- a/uitests/src/setup/setup.ts
+++ b/uitests/src/setup/setup.ts
@@ -79,7 +79,10 @@ export class TestOptions implements ITestOptions {
             fs.ensureDir(this._workspacePathOrFolder),
             fs.ensureDir(this.screenshotsPath),
             fs.ensureDir(this.rootReportsPath),
-            fs.ensureDir(this.reportsPath)
+            fs.ensureDir(this.reportsPath),
+            // If possible delete the vscode user logs directory (this is where VS Code stores logs).
+            // Clear for every test so we have a fresh set of data (this way when tests fail, we have logs specific to that test run).
+            fs.remove(path.join(this.userDataPath, 'logs'))
         ]);
         // Set variables for logging to be enabled within extension.
         process.env.TF_BUILD = 'true';

--- a/uitests/src/steps/main.ts
+++ b/uitests/src/steps/main.ts
@@ -136,6 +136,7 @@ After(async function(scenario: HookScenarioResult) {
             // State of the workspace folder, logs, screenshots, everything.
             // Rememeber, screenshots are specific to each test (hence they are preserved as long as we don't delete them).
             await fs.copy(options.workspacePathOrFolder, path.join(options.reportsPath, 'workspace folder'));
+            await fs.copy(path.join(options.userDataPath, 'logs'), path.join(options.reportsPath, 'user logs')).catch(noop);
             await fs.copyFile(options.userSettingsFilePath, path.join(options.reportsPath, 'user_settings.json'));
             await Promise.all([
                 new Promise(resolve => rimraf(options.workspacePathOrFolder, resolve)).catch(noop),


### PR DESCRIPTION
When a test fails, ensure we capture and store the vs code logs along with the test results. 
This way we have vscode logs that are specific to that test.