### PR TITLE
Refactor how files are opened in UI Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -965,47 +965,47 @@
                 },
                 {
                     "command": "python.openTestNodeInEditor",
-                    "when": "view == python_tests && viewItem == testFunction",
+                    "when": "view == python_tests && viewItem == function",
                     "group": "inline@2"
                 },
                 {
                     "command": "python.debugTestNode",
-                    "when": "view == python_tests && viewItem == testFunction && !busyTests",
+                    "when": "view == python_tests && viewItem == function && !busyTests",
                     "group": "inline@1"
                 },
                 {
                     "command": "python.runTestNode",
-                    "when": "view == python_tests && viewItem == testFunction && !busyTests",
+                    "when": "view == python_tests && viewItem == function && !busyTests",
                     "group": "inline@0"
                 },
                 {
                     "command": "python.openTestNodeInEditor",
-                    "when": "view == python_tests && viewItem == testFile",
+                    "when": "view == python_tests && viewItem == file",
                     "group": "inline@2"
                 },
                 {
                     "command": "python.debugTestNode",
-                    "when": "view == python_tests && viewItem == testFile && !busyTests",
+                    "when": "view == python_tests && viewItem == file && !busyTests",
                     "group": "inline@1"
                 },
                 {
                     "command": "python.runTestNode",
-                    "when": "view == python_tests && viewItem == testFile && !busyTests",
+                    "when": "view == python_tests && viewItem == file && !busyTests",
                     "group": "inline@0"
                 },
                 {
                     "command": "python.openTestNodeInEditor",
-                    "when": "view == python_tests && viewItem == testSuite",
+                    "when": "view == python_tests && viewItem == suite",
                     "group": "inline@2"
                 },
                 {
                     "command": "python.debugTestNode",
-                    "when": "view == python_tests && viewItem == testSuite && !busyTests",
+                    "when": "view == python_tests && viewItem == suite && !busyTests",
                     "group": "inline@1"
                 },
                 {
                     "command": "python.runTestNode",
-                    "when": "view == python_tests && viewItem == testSuite && !busyTests",
+                    "when": "view == python_tests && viewItem == suite && !busyTests",
                     "group": "inline@0"
                 }
             ]

--- a/uitests/bootstrap/extension/extension.js
+++ b/uitests/bootstrap/extension/extension.js
@@ -116,6 +116,23 @@ function activate(context) {
         await vscode.window.activeTerminal.sendText(command, true);
         fs.unlinkSync(filePath);
     });
+    vscode.commands.registerCommand('smoketest.openFile', async () => {
+        const filePath = path.join(__dirname, '..', 'openFile.txt');
+        try {
+            fs.unlinkSync(path.join(__dirname, '..', 'openFile_error.txt'), util.format(ex));
+        } catch {}
+        try {
+            const fileToOpen = fs
+                .readFileSync(filePath)
+                .toString()
+                .trim();
+            const doc = await vscode.window.openTextDocument(fileToOpen);
+            await vscode.window.showTextDocument(doc);
+            fs.unlinkSync(filePath);
+        } catch (ex) {
+            fs.writeFileSync(path.join(__dirname, '..', 'openFile_error.txt'), util.format(ex));
+        }
+    });
     vscode.commands.registerCommand('smoketest.updateSettings', async () => {
         const filePath = path.join(__dirname, '..', 'settingsToUpdate.txt');
         try {

--- a/uitests/bootstrap/extension/extension.js
+++ b/uitests/bootstrap/extension/extension.js
@@ -126,7 +126,7 @@ function activate(context) {
                 .readFileSync(filePath)
                 .toString()
                 .trim();
-            const doc = await vscode.window.openTextDocument(fileToOpen);
+            const doc = await vscode.workspace.openTextDocument(fileToOpen);
             await vscode.window.showTextDocument(doc);
             fs.unlinkSync(filePath);
         } catch (ex) {

--- a/uitests/bootstrap/extension/package.json
+++ b/uitests/bootstrap/extension/package.json
@@ -35,6 +35,10 @@
                 "title": "Stop Debugging Python"
             },
             {
+                "command": "smoketest.openFile",
+                "title": "Smoke: Open File"
+            },
+            {
                 "command": "smoketest.runInTerminal",
                 "title": "Smoke: Run Command In Terminal"
             },

--- a/uitests/features/interpreter/terminal.feature
+++ b/uitests/features/interpreter/terminal.feature
@@ -30,7 +30,7 @@ Feature: Terminal
             open('log.log', 'w').write('Hello World')
             """
         And a file named "hello word/log.log" does not exist
-        When I open the file "run in terminal.py"
+        When I open the file "hello word/run in terminal.py"
         And I select the command "Python: Run Python File in Terminal"
         # Wait for some time, as it could take a while for terminal to get activated.
         # Slow on windows.

--- a/uitests/features/testing/explorer/debug.feature
+++ b/uitests/features/testing/explorer/debug.feature
@@ -56,12 +56,12 @@ Feature: Test Explorer (debugging)
         Then the test explorer icon will be visible
         When I select the command "View: Show Test"
         And I expand all of the nodes in the test explorer
-        When I add a breakpoint to line 33 in "test_one.py"
-        And I add a breakpoint to line 23 in "test_one.py"
+        When I add a breakpoint to line 33 in "tests/test_one.py"
+        And I add a breakpoint to line 23 in "tests/test_one.py"
         And I debug the node "test_three_first_suite" from the test explorer
         Then the debugger starts
         And the debugger pauses
-        And the current stack frame is at line 33 in "test_one.py"
+        And the current stack frame is at line 33 in "tests/test_one.py"
         When I select the command "Debug: Continue"
         Then the debugger stops
 
@@ -79,19 +79,19 @@ Feature: Test Explorer (debugging)
         Then the test explorer icon will be visible
         When I select the command "View: Show Test"
         And I expand all of the nodes in the test explorer
-        When I add a breakpoint to line 33 in "test_one.py"
-        And I add a breakpoint to line 28 in "test_one.py"
-        And I add a breakpoint to line 23 in "test_one.py"
+        When I add a breakpoint to line 33 in "tests/test_one.py"
+        And I add a breakpoint to line 28 in "tests/test_one.py"
+        And I add a breakpoint to line 23 in "tests/test_one.py"
         And I debug the node "TestFirstSuite" from the test explorer
         Then the debugger starts
         And the debugger pauses
-        And the current stack frame is at line 23 in "test_one.py"
+        And the current stack frame is at line 23 in "tests/test_one.py"
         When I select the command "Debug: Continue"
         Then the debugger pauses
-        And the current stack frame is at line 33 in "test_one.py"
+        And the current stack frame is at line 33 in "tests/test_one.py"
         When I select the command "Debug: Continue"
         Then the debugger pauses
-        And the current stack frame is at line 28 in "test_one.py"
+        And the current stack frame is at line 28 in "tests/test_one.py"
         When I select the command "Debug: Continue"
         Then the debugger stops
 
@@ -110,9 +110,9 @@ Feature: Test Explorer (debugging)
         Then the test explorer icon will be visible
         When I select the command "View: Show Test"
         And I expand all of the nodes in the test explorer
-        When I add a breakpoint to line 23 in "test_one.py"
-        And I add a breakpoint to line 38 in "test_one.py"
-        And I add a breakpoint to line 23 in "test_two.py"
+        When I add a breakpoint to line 23 in "tests/test_one.py"
+        And I add a breakpoint to line 38 in "tests/test_one.py"
+        And I add a breakpoint to line 23 in "tests/test_two.py"
         And I select the command "Python: Debug All Tests"
         Then the debugger starts
         And the debugger pauses

--- a/uitests/src/steps/documents.ts
+++ b/uitests/src/steps/documents.ts
@@ -12,13 +12,10 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 import { CucumberRetryMax10Seconds, CucumberRetryMax5Seconds } from '../constants';
 import { noop, retryWrapper, sleep } from '../helpers';
-import { warn } from '../helpers/logger';
 import { IApplication } from '../types';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
 const clipboardy = require('clipboardy');
-
-// const autoCompletionListItemSlector = '.editor-widget.suggest-widget.visible .monaco-list-row a.label-name .monaco-highlighted-label';
 
 When('I create a new file', async function() {
     await this.app.documents.createNewUntitledFile();
@@ -80,35 +77,12 @@ Then('the file {string} is opened', async function(file: string) {
     await this.app.documents.waitUntilFileOpened(file);
 });
 
-// Then('a file named {string} is created with the following content', async (fileName: string, contents: string) => {
-//     const fullFilePath = path.join(context.app.workspacePathOrFolder, fileName);
-//     await fs.mkdirp(path.dirname(fullFilePath)).catch(noop);
-//     await fs.writeFile(fullFilePath, contents);
-//     await sleep(1000);
-// });
-
 async function createFile(this: World, filename: string, contents: string) {
     const fullpath = path.join(this.app.workspacePathOrFolder, filename);
     await fs.ensureDir(path.dirname(fullpath));
     await fs.writeFile(fullpath, contents);
-    // Ensure VS Code has had time to refresh to explorer and is aware of the file.
-    // Else if we later attempt to open this file, VSC might not be aware of it and woudn't display anything in the `quick open` dropdown.
-    const openRecentlyCreatedDocument = async () => {
-        await this.app.documents.refreshExplorer();
-        // Sometimes VS Code just doesn't know about files created from outside VS Code.
-        // Not unless we expand the file explorer.
-        // Hopefully we don't have (write) tests where files are created in nested folders and not detected by VSC, but required to be opened.
-        const opened = await this.app.quickopen
-            .openFile(path.basename(filename))
-            .then(() => true)
-            .catch(ex => warn(`Failed to open the file '${filename}' in VS Code, but continuing (hopefully file will not have to be opened)`, ex));
-        if (opened === true) {
-            await this.app.quickopen.runCommand('View: Close Editor');
-        }
-    };
-
-    await retryWrapper({ timeout: 5000 }, openRecentlyCreatedDocument);
 }
+
 Given('a file named {string} is created with the following content', async function(filename: string, contents: string) {
     await createFile.call(this, filename, contents);
 });
@@ -127,12 +101,6 @@ Given('the file {string} does not exist', async function(fileName: string) {
     await fs.unlink(fullFilePath).catch(noop);
     await sleep(1000);
 });
-
-// Then('a file named {string} exists', async (fileName: string) => {
-//     const fullFilePath = path.join(context.app.workspacePathOrFolder, fileName);
-//     const exists = await fs.pathExists(fullFilePath);
-//     expect(exists).to.equal(true, `File '${fullFilePath}' should exist`);
-// });
 
 async function expectFile(app: IApplication, fileName: string, timeout = 1000) {
     const checkFile = async () => {

--- a/uitests/src/steps/statusbar.ts
+++ b/uitests/src/steps/statusbar.ts
@@ -41,7 +41,8 @@ Then('a status bar item containing the text {string} is displayed', async functi
 Then('the status bar item containing the text {string} will be hidden within {int} seconds', async function(text: string, seconds: number) {
     // First, lets wait for this status bar to appear (if it doesn't appear within 3 seconds, then give up and move on).
     await this.app.statusbar.waitUntilStatusBarItemWithText(text, 3_000).catch(noop);
-    await this.app.statusbar.waitUntilNoStatusBarItemWithText(text, seconds * 1_000).catch(ex => warn(`Status bar item with text '${text}' still visible.`, ex));
+    // await this.app.statusbar.waitUntilNoStatusBarItemWithText(text, seconds * 1_000).catch(ex => warn(`Status bar item with text '${text}' still visible.`, ex));
+    await this.app.statusbar.waitUntilNoStatusBarItemWithText(text, seconds * 1_000);
 });
 
 // Then('the python the status bar is not visible', async () => {

--- a/uitests/src/steps/statusbar.ts
+++ b/uitests/src/steps/statusbar.ts
@@ -10,7 +10,6 @@ import { Given, Then, When } from 'cucumber';
 import { CucumberRetryMax5Seconds } from '../constants';
 import { noop } from '../helpers';
 import '../helpers/extensions';
-import { warn } from '../helpers/logger';
 
 Given('the python status bar item is hidden', async function() {
     await this.app.statusbar.hidePythonStatusBarItem().catch(noop);

--- a/uitests/src/steps/testing.ts
+++ b/uitests/src/steps/testing.ts
@@ -95,7 +95,7 @@ When('I run failed tests', async function() {
 });
 
 Then('the stop icon is not visible in the toolbar', async function() {
-    await this.app.testExplorer.waitUntilToolbarIconVisible('Stop');
+    await this.app.testExplorer.waitUntilToolbarIconHidden('Stop');
 });
 When('I click the test node with the label {string}', async function(label: string) {
     await this.app.testExplorer.clickNode(label);

--- a/uitests/src/steps/testing.ts
+++ b/uitests/src/steps/testing.ts
@@ -19,14 +19,11 @@ async function waitForTestsToStopRunningOrDiscovering(this: World, type: 'runnin
     const message = type === 'running' ? 'Running Tests' : 'Discovering Tests';
 
     // Wait for tests discovery to first start.
-    await Promise.race([
-        // Wait either for 3 seconds (we know tests would have stated discoverying/running by then).
-        sleep(3_000),
-        // Or until we can see the discovering/running icon.
+    await Promise.all([
+        // Wait until we can see the discovering/running icon.
         // Note, wait for icon to be Visible only if Test Explorer is already visible.
         // Else this will result in displaying the test explorer and then checking the visibility of the icon.
-        // All of that could exceed 3 seconds (even though the Promise.race would resolve the other code would continue to run).
-        // I.e. using Promise.race should only be used when we know there are no side effects and other one can and will complete withouth any issues.
+        // All of that could exceed 3 seconds, we don't need to wait for more than 3secs.
         this.app.testExplorer
             .isOpened()
             .then(visible => (visible ? this.app.testExplorer.waitUntilToolbarIconVisible('Stop', 3_000) : Promise.resolve()))

--- a/uitests/src/steps/testing.ts
+++ b/uitests/src/steps/testing.ts
@@ -6,7 +6,7 @@
 // tslint:disable: no-invalid-this
 
 import { expect } from 'chai';
-import { Then, When } from 'cucumber';
+import { Then, When, World } from 'cucumber';
 import { CucumberRetryMax5Seconds } from '../constants';
 import { noop, sleep } from '../helpers';
 import { IApplication, TestExplorerNodeStatus } from '../types';
@@ -15,13 +15,14 @@ Then('the test explorer icon will be visible', async function() {
     await this.app.testExplorer.waitUntilIconVisible(5_000);
 });
 
-// Surely tests can't take more than 30s to get discovered.
-When('I wait for test discovery to complete', async function() {
+async function waitForTestsToStopRunningOrDiscovering(this: World, type: 'running' | 'discovering') {
+    const message = type === 'running' ? 'Running Tests' : 'Discovering Tests';
+
     // Wait for tests discovery to first start.
     await Promise.race([
-        // Wait either for 3 seconds (we know tests would have stated discoverying by then).
+        // Wait either for 3 seconds (we know tests would have stated discoverying/running by then).
         sleep(3_000),
-        // Or until we can see the discovering icon.
+        // Or until we can see the discovering/running icon.
         // Note, wait for icon to be Visible only if Test Explorer is already visible.
         // Else this will result in displaying the test explorer and then checking the visibility of the icon.
         // All of that could exceed 3 seconds (even though the Promise.race would resolve the other code would continue to run).
@@ -30,21 +31,24 @@ When('I wait for test discovery to complete', async function() {
             .isOpened()
             .then(visible => (visible ? this.app.testExplorer.waitUntilToolbarIconVisible('Stop', 3_000) : Promise.resolve()))
             .catch(noop),
-        // Or until we can see the discovering message.
-        this.app.statusbar.waitUntilStatusBarItemWithText('Discovering Tests', 3_000).catch(noop)
+        // Or until we can see the discovering/running message.
+        this.app.statusbar.waitUntilStatusBarItemWithText(message, 3_000).catch(noop)
     ]);
 
     await Promise.all([
         // Ensure the `stop` icon is not visible in the explorer toolbar.
         this.app.testExplorer.waitUntilTestsStop(30_000),
-        // Also ensure there is no statubar item with the text 'Discovering Tests'
-        this.app.statusbar.waitUntilNoStatusBarItemWithText('Discovering Tests', 30_000)
+        // Also ensure there is no statubar item with the text 'Discovering Tests' or 'Running Tests'
+        this.app.statusbar.waitUntilNoStatusBarItemWithText(message, 30_000)
     ]);
+}
+
+When('I wait for test discovery to complete', async function() {
+    await waitForTestsToStopRunningOrDiscovering.call(this, 'discovering');
 });
 
-// Surely pythonn tests (in our UI Tests) can't take more than 30s to run.
 When('I wait for tests to complete running', async function() {
-    await this.app.testExplorer.waitUntilTestsStop(30_000);
+    await waitForTestsToStopRunningOrDiscovering.call(this, 'running');
 });
 
 Then('there are {int} nodes in the test explorer', CucumberRetryMax5Seconds, async function(expectedCount: number) {

--- a/uitests/src/steps/testing.ts
+++ b/uitests/src/steps/testing.ts
@@ -8,7 +8,7 @@
 import { expect } from 'chai';
 import { Then, When, World } from 'cucumber';
 import { CucumberRetryMax5Seconds } from '../constants';
-import { noop, sleep } from '../helpers';
+import { noop } from '../helpers';
 import { IApplication, TestExplorerNodeStatus } from '../types';
 
 Then('the test explorer icon will be visible', async function() {

--- a/uitests/src/types.ts
+++ b/uitests/src/types.ts
@@ -677,7 +677,7 @@ export interface IInterpreters {
 
 export type TestExplorerToolbarIcon = 'Stop' | 'RunFailedTests';
 export type TestingAction = 'run' | 'debug' | 'open';
-export type TestExplorerNodeStatus = 'Unknown' | 'Success' | 'Progress' | 'Skip' | 'Ok' | 'Pass' | 'Fail' | 'Error';
+export type TestExplorerNodeStatus = 'Unknown' | 'Success' | 'Progress' | 'Skip' | 'Ok' | 'Pass' | 'Fail';
 export interface ITestExplorer {
     isOpened(): Promise<boolean>;
     isIconVisible(): Promise<boolean>;

--- a/uitests/src/vscode/testExplorer.ts
+++ b/uitests/src/vscode/testExplorer.ts
@@ -15,8 +15,7 @@ const statusToIconMapping: Map<TestExplorerNodeStatus, string> = new Map([
     ['Ok', 'status-ok.svg'],
     ['Pass', 'status-ok.svg'],
     ['Success', 'status-ok.svg'],
-    ['Fail', 'status-error.svg'],
-    ['Error', 'status-error.svg']
+    ['Fail', 'status-error.svg']
 ]);
 // 100ms was too low in version 1.38 of VS Code.
 const delayForUIToUpdate = 150;
@@ -109,7 +108,7 @@ export class TestExplorer implements ITestExplorer {
             }
         } finally {
             const visibleNodes = await this.getNodeCount();
-            if (visibleNodes === initialNodeCount) {
+            if (visibleNodes <= 2 && visibleNodes === initialNodeCount) {
                 // Something is wrong, try again.
                 // tslint:disable-next-line: no-unsafe-finally
                 throw new Error('Retry expanding nodes. First iteration did not reveal any new nodes!');

--- a/uitests/src/vscode/testExplorer.ts
+++ b/uitests/src/vscode/testExplorer.ts
@@ -6,6 +6,7 @@
 import { RetryMax10Seconds } from '../constants';
 import { retry, sleep } from '../helpers';
 import '../helpers/extensions';
+import { warn } from '../helpers/logger';
 import { Selector } from '../selectors';
 import { IApplication, ITestExplorer, TestExplorerNodeStatus, TestExplorerToolbarIcon, TestingAction } from '../types';
 
@@ -107,11 +108,14 @@ export class TestExplorer implements ITestExplorer {
                 }
             }
         } finally {
+            // Assumption that if there are <=2 nodes and we try to expand the nodes, and
+            // yet there's nothing new, then this could be a problem.
+            // Hence log a warning message.
             const visibleNodes = await this.getNodeCount();
             if (visibleNodes <= 2 && visibleNodes === initialNodeCount) {
                 // Something is wrong, try again.
                 // tslint:disable-next-line: no-unsafe-finally
-                throw new Error('Retry expanding nodes. First iteration did not reveal any new nodes!');
+                warn('Retry expanding nodes. First iteration did not reveal any new nodes!');
             }
         }
     }


### PR DESCRIPTION
Use the bootstrap extension to open files in VS Code.
Using VS Code is flaky. 
E.g. if a file is created outside of VS Code, then the quick pick doesn't always display these files. (this causes issues with UI Tests).