### PR TITLE
Fix goto cell in the interactive pane to scroll

### DIFF
--- a/news/2 Fixes/7639.md
+++ b/news/2 Fixes/7639.md
@@ -1,0 +1,1 @@
+Goto cell code lens was not scrolling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13770,7 +13770,7 @@
             "dependencies": {
                 "buffer": {
                     "version": "4.9.1",
-                    "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
@@ -13793,7 +13793,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -18754,7 +18754,7 @@
             "dependencies": {
                 "json5": {
                     "version": "1.0.1",
-                    "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -320,11 +320,8 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
     }
 
     private renderCell = (cellVM: ICellViewModel, index: number, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
-        let cellRef : React.RefObject<InteractiveCell> | undefined;
-        if (!this.cellRefs.has(cellVM.cell.id)) {
-            cellRef = React.createRef<InteractiveCell>();
-            this.cellRefs.set(cellVM.cell.id, cellRef);
-        }
+        const cellRef = React.createRef<InteractiveCell>();
+        this.cellRefs.set(cellVM.cell.id, cellRef);
         return (
             <div key={index} id={cellVM.cell.id} ref={containerRef}>
                 <ErrorBoundary key={index}>


### PR DESCRIPTION
For #7639 

Storing react refs in a map is a bad idea as a rerender doesn't update the object in the map.
