### PR TITLE
Ensure search for jupyter commands are cancelled early

### DIFF
--- a/src/client/common/cancellation.ts
+++ b/src/client/common/cancellation.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import { CancellationToken } from 'vscode-jsonrpc';
+import { CancellationToken } from 'vscode';
 
 import { createDeferred } from './utils/async';
 import * as localize from './utils/localize';
@@ -10,20 +10,46 @@ import * as localize from './utils/localize';
  * Error type thrown when canceling.
  */
 export class CancellationError extends Error {
-
     constructor() {
         super(localize.Common.canceled());
     }
 }
+/**
+ * Create a promise that will either resolve with a default value or reject when the token is cancelled.
+ *
+ * @export
+ * @template T
+ * @param {({ defaultValue: T; token: CancellationToken; cancelAction: 'reject' | 'resolve' })} options
+ * @returns {Promise<T>}
+ */
+export function createPromiseFromCancellation<T>(options: { defaultValue: T; token?: CancellationToken; cancelAction: 'reject' | 'resolve' }): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        // Never resolve.
+        if (!options.token) {
+            return;
+        }
+        const complete = () => {
+            if (options.token!.isCancellationRequested) {
+                if (options.cancelAction === 'resolve') {
+                    return resolve(options.defaultValue);
+                }
+                if (options.cancelAction === 'reject') {
+                    return reject(new CancellationError());
+                }
+            }
+        };
+
+        options.token.onCancellationRequested(complete);
+    });
+}
 
 export namespace Cancellation {
-
     /**
      * Races a promise and cancellation. Promise can take a cancellation token too in order to listen to cancellation.
      * @param work function returning a promise to race
      * @param token token used for cancellation
      */
-    export function race<T>(work : (token?: CancellationToken) => Promise<T>, token?: CancellationToken) : Promise<T> {
+    export function race<T>(work: (token?: CancellationToken) => Promise<T>, token?: CancellationToken): Promise<T> {
         if (token) {
             // Use a deferred promise. Resolves when the work finishes
             const deferred = createDeferred<T>();
@@ -43,12 +69,12 @@ export namespace Cancellation {
                 // Not canceled yet. When the work finishes
                 // either resolve our promise or cancel.
                 work(token)
-                    .then((v) => {
+                    .then(v => {
                         if (!deferred.completed) {
                             deferred.resolve(v);
                         }
                     })
-                    .catch((e) => {
+                    .catch(e => {
                         if (!deferred.completed) {
                             deferred.reject(e);
                         }
@@ -66,7 +92,7 @@ export namespace Cancellation {
      * isCanceled returns a boolean indicating if the cancel token has been canceled.
      * @param cancelToken
      */
-    export function isCanceled(cancelToken?: CancellationToken) : boolean {
+    export function isCanceled(cancelToken?: CancellationToken): boolean {
         return cancelToken ? cancelToken.isCancellationRequested : false;
     }
 
@@ -74,10 +100,9 @@ export namespace Cancellation {
      * throws a CancellationError if the token is canceled.
      * @param cancelToken
      */
-    export function throwIfCanceled(cancelToken?: CancellationToken) : void {
+    export function throwIfCanceled(cancelToken?: CancellationToken): void {
         if (isCanceled(cancelToken)) {
             throw new CancellationError();
         }
     }
-
 }


### PR DESCRIPTION
For #7262

Basically the cancellation Token isn't checked everytime. 
So even if the user were to click cancel in #7262, we'd still be doing a lot of processing.

Will implement solution for #7262 in another PR (wanted to keep this simple).