### PR TITLE
Fast CI/PR pipeline. Tests need not wait for build

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -26,8 +26,7 @@ stages:
   - template: templates/jobs/build_uitests.yml
 
 - stage: Tests
-  dependsOn:
-  - Build
+  dependsOn: []
   jobs:
   - job: 'Test'
     dependsOn: []

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -28,8 +28,7 @@ stages:
   - template: templates/jobs/build_uitests.yml
 
 - stage: Tests
-  dependsOn:
-  - Build
+  dependsOn: []
   jobs:
   - job: 'Test'
     dependsOn: []


### PR DESCRIPTION
Currently the tests run only after the Build stage.
There's no need for this, tests can run along with the build stage.

<img width="791" alt="Screen Shot 2019-10-01 at 17 07 11" src="https://user-images.githubusercontent.com/1948812/66009109-ef5e1780-e46d-11e9-92a2-0cdad10d1e39.png">
