### PR TITLE
Added button to get more info related to inheritEnv setting when prompt is dispalyed

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -125,6 +125,7 @@
     "Logging.CurrentWorkingDirectory": "cwd:",
     "Common.doNotShowAgain": "Do not show again",
     "Common.reload": "Reload",
+    "Common.moreInfo": "More Info",
     "OutputChannelNames.languageServer": "Python Language Server",
     "OutputChannelNames.python": "Python",
     "OutputChannelNames.pythonTest": "Python Test Log",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -33,6 +33,7 @@ export namespace Common {
     export const notNow = localize('Common.notNow', 'Not now');
     export const doNotShowAgain = localize('Common.doNotShowAgain', 'Do not show again');
     export const reload = localize('Common.reload', 'Reload');
+    export const moreInfo = localize('Common.moreInfo', 'More Info');
 }
 
 export namespace LanguageService {

--- a/src/client/interpreter/virtualEnvs/condaInheritEnvPrompt.ts
+++ b/src/client/interpreter/virtualEnvs/condaInheritEnvPrompt.ts
@@ -6,8 +6,8 @@ import { ConfigurationTarget, Uri } from 'vscode';
 import { IExtensionActivationService } from '../../activation/types';
 import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
 import { traceDecorators, traceError } from '../../common/logger';
-import { IPersistentStateFactory } from '../../common/types';
-import { InteractiveShiftEnterBanner, Interpreters } from '../../common/utils/localize';
+import { IBrowserService, IPersistentStateFactory } from '../../common/types';
+import { Common, InteractiveShiftEnterBanner, Interpreters } from '../../common/utils/localize';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { IInterpreterService, InterpreterType } from '../contracts';
@@ -19,6 +19,7 @@ export class CondaInheritEnvPrompt implements IExtensionActivationService {
     constructor(
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
+        @inject(IBrowserService) private browserService: IBrowserService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
         @optional() public hasPromptBeenShownInCurrentSession: boolean = false
@@ -43,8 +44,8 @@ export class CondaInheritEnvPrompt implements IExtensionActivationService {
         if (!notificationPromptEnabled.value) {
             return;
         }
-        const prompts = [InteractiveShiftEnterBanner.bannerLabelYes(), InteractiveShiftEnterBanner.bannerLabelNo()];
-        const telemetrySelections: ['Yes', 'No'] = ['Yes', 'No'];
+        const prompts = [InteractiveShiftEnterBanner.bannerLabelYes(), InteractiveShiftEnterBanner.bannerLabelNo(), Common.moreInfo()];
+        const telemetrySelections: ['Yes', 'No', 'More Info'] = ['Yes', 'No', 'More Info'];
         const selection = await this.appShell.showInformationMessage(Interpreters.condaInheritEnvMessage(), ...prompts);
         sendTelemetryEvent(EventName.CONDA_INHERIT_ENV_PROMPT, undefined, { selection: selection ? telemetrySelections[prompts.indexOf(selection)] : undefined });
         if (!selection) {
@@ -54,6 +55,8 @@ export class CondaInheritEnvPrompt implements IExtensionActivationService {
             await this.workspaceService.getConfiguration('terminal').update('integrated.inheritEnv', false, ConfigurationTarget.Global);
         } else if (selection === prompts[1]) {
             await notificationPromptEnabled.updateValue(false);
+        } else if (selection === prompts[2]) {
+            this.browserService.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments');
         }
     }
 

--- a/src/client/interpreter/virtualEnvs/condaInheritEnvPrompt.ts
+++ b/src/client/interpreter/virtualEnvs/condaInheritEnvPrompt.ts
@@ -56,7 +56,7 @@ export class CondaInheritEnvPrompt implements IExtensionActivationService {
         } else if (selection === prompts[1]) {
             await notificationPromptEnabled.updateValue(false);
         } else if (selection === prompts[2]) {
-            this.browserService.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments');
+            this.browserService.launch('https://aka.ms/AA66i8f');
         }
     }
 

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -939,8 +939,9 @@ export interface IEventNamePropertyMapping {
         /**
          * `Yes` When 'Yes' option is selected
          * `No` When 'No' option is selected
+         * `More info` When 'More Info' option is selected
          */
-        selection: 'Yes' | 'No' | undefined;
+        selection: 'Yes' | 'No' | 'More Info' | undefined;
     };
     /**
      * Telemetry event sent with details when user clicks a button in the virtual environment prompt.

--- a/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
@@ -10,9 +10,9 @@ import * as TypeMoq from 'typemoq';
 import { ConfigurationTarget, Uri, WorkspaceConfiguration } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { PersistentStateFactory } from '../../../client/common/persistentState';
-import { IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
+import { IBrowserService, IPersistentState, IPersistentStateFactory } from '../../../client/common/types';
 import { createDeferred, createDeferredFromPromise, sleep } from '../../../client/common/utils/async';
-import { InteractiveShiftEnterBanner, Interpreters } from '../../../client/common/utils/localize';
+import { Common, InteractiveShiftEnterBanner, Interpreters } from '../../../client/common/utils/localize';
 import { IInterpreterService, InterpreterType } from '../../../client/interpreter/contracts';
 import { CondaInheritEnvPrompt, condaInheritEnvPromptKey } from '../../../client/interpreter/virtualEnvs/condaInheritEnvPrompt';
 
@@ -24,6 +24,7 @@ suite('Conda Inherit Env Prompt', async () => {
     let workspaceService: TypeMoq.IMock<IWorkspaceService>;
     let appShell: TypeMoq.IMock<IApplicationShell>;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let browserService: TypeMoq.IMock<IBrowserService>;
     let persistentStateFactory: IPersistentStateFactory;
     let notificationPromptEnabled: TypeMoq.IMock<IPersistentState<any>>;
     let condaInheritEnvPrompt: CondaInheritEnvPrompt;
@@ -37,12 +38,13 @@ suite('Conda Inherit Env Prompt', async () => {
         setup(() => {
             workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
             appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+            browserService = TypeMoq.Mock.ofType<IBrowserService>();
             interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
             persistentStateFactory = mock(PersistentStateFactory);
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory));
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory));
         });
         test('Returns false if prompt has already been shown in the current session', async () => {
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory), true);
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory), true);
             const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
             interpreterService
                 .setup(is => is.getActiveInterpreter(resource))
@@ -191,6 +193,7 @@ suite('Conda Inherit Env Prompt', async () => {
         setup(() => {
             workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
             appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+            browserService = TypeMoq.Mock.ofType<IBrowserService>();
             interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
             persistentStateFactory = mock(PersistentStateFactory);
         });
@@ -203,7 +206,7 @@ suite('Conda Inherit Env Prompt', async () => {
             const initializeInBackgroundDeferred = createDeferred<void>();
             initializeInBackground = sinon.stub(CondaInheritEnvPrompt.prototype, 'initializeInBackground');
             initializeInBackground.callsFake(() => initializeInBackgroundDeferred.promise);
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory));
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory));
 
             const promise = condaInheritEnvPrompt.activate(resource);
             const deferred = createDeferredFromPromise(promise);
@@ -220,7 +223,7 @@ suite('Conda Inherit Env Prompt', async () => {
         test('Ignores errors raised by initializeInBackground()', async () => {
             initializeInBackground = sinon.stub(CondaInheritEnvPrompt.prototype, 'initializeInBackground');
             initializeInBackground.rejects(new Error('Kaboom'));
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory));
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory));
             await condaInheritEnvPrompt.activate(resource);
             assert.ok(initializeInBackground.calledOnce);
         });
@@ -232,6 +235,7 @@ suite('Conda Inherit Env Prompt', async () => {
         setup(() => {
             workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
             appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+            browserService = TypeMoq.Mock.ofType<IBrowserService>();
             interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
             persistentStateFactory = mock(PersistentStateFactory);
         });
@@ -245,7 +249,7 @@ suite('Conda Inherit Env Prompt', async () => {
             shouldShowPrompt.callsFake(() => Promise.resolve(true));
             promptAndUpdate = sinon.stub(CondaInheritEnvPrompt.prototype, 'promptAndUpdate');
             promptAndUpdate.callsFake(() => Promise.resolve(undefined));
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory));
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory));
             await condaInheritEnvPrompt.initializeInBackground(resource);
             assert.ok(shouldShowPrompt.calledOnce);
             assert.ok(promptAndUpdate.calledOnce);
@@ -256,7 +260,7 @@ suite('Conda Inherit Env Prompt', async () => {
             shouldShowPrompt.callsFake(() => Promise.resolve(false));
             promptAndUpdate = sinon.stub(CondaInheritEnvPrompt.prototype, 'promptAndUpdate');
             promptAndUpdate.callsFake(() => Promise.resolve(undefined));
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory));
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory));
             await condaInheritEnvPrompt.initializeInBackground(resource);
             assert.ok(shouldShowPrompt.calledOnce);
             assert.ok(promptAndUpdate.notCalled);
@@ -264,15 +268,16 @@ suite('Conda Inherit Env Prompt', async () => {
     });
 
     suite('Method promptAndUpdate()', () => {
-        const prompts = [InteractiveShiftEnterBanner.bannerLabelYes(), InteractiveShiftEnterBanner.bannerLabelNo()];
+        const prompts = [InteractiveShiftEnterBanner.bannerLabelYes(), InteractiveShiftEnterBanner.bannerLabelNo(), Common.moreInfo()];
         setup(() => {
             workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
             appShell = TypeMoq.Mock.ofType<IApplicationShell>();
             interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
             persistentStateFactory = mock(PersistentStateFactory);
+            browserService = TypeMoq.Mock.ofType<IBrowserService>();
             notificationPromptEnabled = TypeMoq.Mock.ofType<IPersistentState<any>>();
             when(persistentStateFactory.createGlobalPersistentState(condaInheritEnvPromptKey, true)).thenReturn(notificationPromptEnabled.object);
-            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, appShell.object, instance(persistentStateFactory));
+            condaInheritEnvPrompt = new CondaInheritEnvPrompt(interpreterService.object, workspaceService.object, browserService.object, appShell.object, instance(persistentStateFactory));
         });
 
         test('Does not display prompt if it is disabled', async () => {
@@ -311,11 +316,16 @@ suite('Conda Inherit Env Prompt', async () => {
                 .setup(n => n.updateValue(false))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.never());
+            browserService
+                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .returns(() => undefined)
+                .verifiable(TypeMoq.Times.never());
             await condaInheritEnvPrompt.promptAndUpdate();
             verify(persistentStateFactory.createGlobalPersistentState(condaInheritEnvPromptKey, true)).once();
             verifyAll();
             workspaceConfig.verifyAll();
             notificationPromptEnabled.verifyAll();
+            browserService.verifyAll();
         });
         test('Update terminal settings if `Yes` is selected', async () => {
             const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
@@ -339,11 +349,16 @@ suite('Conda Inherit Env Prompt', async () => {
                 .setup(n => n.updateValue(false))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.never());
+            browserService
+                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .returns(() => undefined)
+                .verifiable(TypeMoq.Times.never());
             await condaInheritEnvPrompt.promptAndUpdate();
             verify(persistentStateFactory.createGlobalPersistentState(condaInheritEnvPromptKey, true)).once();
             verifyAll();
             workspaceConfig.verifyAll();
             notificationPromptEnabled.verifyAll();
+            browserService.verifyAll();
         });
         test('Disable notification prompt if `No` is selected', async () => {
             const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
@@ -367,11 +382,49 @@ suite('Conda Inherit Env Prompt', async () => {
                 .setup(n => n.updateValue(false))
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.once());
+            browserService
+                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .returns(() => undefined)
+                .verifiable(TypeMoq.Times.never());
             await condaInheritEnvPrompt.promptAndUpdate();
             verify(persistentStateFactory.createGlobalPersistentState(condaInheritEnvPromptKey, true)).once();
             verifyAll();
             workspaceConfig.verifyAll();
             notificationPromptEnabled.verifyAll();
+            browserService.verifyAll();
+        });
+        test('Launch browser if `More info` option is selected', async () => {
+            const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
+            notificationPromptEnabled
+                .setup(n => n.value)
+                .returns(() => true)
+                .verifiable(TypeMoq.Times.once());
+            appShell
+                .setup(a => a.showInformationMessage(Interpreters.condaInheritEnvMessage(), ...prompts))
+                .returns(() => Promise.resolve(Common.moreInfo()))
+                .verifiable(TypeMoq.Times.once());
+            workspaceService
+                .setup(ws => ws.getConfiguration('terminal'))
+                .returns(() => workspaceConfig.object)
+                .verifiable(TypeMoq.Times.never());
+            workspaceConfig
+                .setup(wc => wc.update('integrated.inheritEnv', false, ConfigurationTarget.Global))
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.never());
+            notificationPromptEnabled
+                .setup(n => n.updateValue(false))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable(TypeMoq.Times.never());
+            browserService
+                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .returns(() => undefined)
+                .verifiable(TypeMoq.Times.once());
+            await condaInheritEnvPrompt.promptAndUpdate();
+            verify(persistentStateFactory.createGlobalPersistentState(condaInheritEnvPromptKey, true)).once();
+            verifyAll();
+            workspaceConfig.verifyAll();
+            notificationPromptEnabled.verifyAll();
+            browserService.verifyAll();
         });
     });
 });

--- a/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
@@ -317,7 +317,7 @@ suite('Conda Inherit Env Prompt', async () => {
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.never());
             browserService
-                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .setup(b => b.launch('https://aka.ms/AA66i8f'))
                 .returns(() => undefined)
                 .verifiable(TypeMoq.Times.never());
             await condaInheritEnvPrompt.promptAndUpdate();
@@ -350,7 +350,7 @@ suite('Conda Inherit Env Prompt', async () => {
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.never());
             browserService
-                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .setup(b => b.launch('https://aka.ms/AA66i8f'))
                 .returns(() => undefined)
                 .verifiable(TypeMoq.Times.never());
             await condaInheritEnvPrompt.promptAndUpdate();
@@ -383,7 +383,7 @@ suite('Conda Inherit Env Prompt', async () => {
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.once());
             browserService
-                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .setup(b => b.launch('https://aka.ms/AA66i8f'))
                 .returns(() => undefined)
                 .verifiable(TypeMoq.Times.never());
             await condaInheritEnvPrompt.promptAndUpdate();
@@ -416,7 +416,7 @@ suite('Conda Inherit Env Prompt', async () => {
                 .returns(() => Promise.resolve(undefined))
                 .verifiable(TypeMoq.Times.never());
             browserService
-                .setup(b => b.launch('https://code.visualstudio.com/updates/v1_36#_launch-terminals-with-clean-environments'))
+                .setup(b => b.launch('https://aka.ms/AA66i8f'))
                 .returns(() => undefined)
                 .verifiable(TypeMoq.Times.once());
             await condaInheritEnvPrompt.promptAndUpdate();


### PR DESCRIPTION
For #7733

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
