### PR TITLE
Use correct resource to retrieve settings in activationService.ts

### DIFF
--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -51,6 +51,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
     }
 
     public async activate(resource: Resource): Promise<void> {
+        this.resource = resource;
         let jedi = this.useJedi();
         if (!jedi) {
             if (this.lsActivatedWorkspaces.has(this.getWorkspacePathKey(resource))) {
@@ -69,7 +70,6 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
             this.jediActivatedOnce = true;
         }
 
-        this.resource = resource;
         await this.logStartup(jedi);
         let activatorName = jedi ? LanguageServerActivator.Jedi : LanguageServerActivator.DotNet;
         let activator = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, activatorName);
@@ -122,7 +122,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
      * @param resource
      * @returns `true` if user has NOT manually added the setting and is using default configuration, `false` if user has `jediEnabled` setting added
      */
-    public isJediUsingDefaultConfiguration(resource?: Uri): boolean {
+    public isJediUsingDefaultConfiguration(resource: Resource): boolean {
         const settings = this.workspaceService.getConfiguration('python', resource).inspect<boolean>('jediEnabled');
         if (!settings) {
             traceError('WorkspaceConfiguration.inspect returns `undefined` for setting `python.jediEnabled`');
@@ -136,7 +136,7 @@ export class LanguageServerExtensionActivationService implements IExtensionActiv
      * @returns `true` if user is using jedi, `false` if user is using language server
      */
     public useJedi(): boolean {
-        if (this.isJediUsingDefaultConfiguration()) {
+        if (this.isJediUsingDefaultConfiguration(this.resource)) {
             if (this.abExperiments.inExperiment(LSEnabled)) {
                 return false;
             }


### PR DESCRIPTION
- Method `useJedi()` uses the value of this.resource. It should be populated before calling the method.
- Also pass resource as argument when checking if jedi is using the default setting.