### PR TITLE
Make interactive window and native editor take their fontSize and fontFamily from the settings in VS Code.

### DIFF
--- a/news/2 Fixes/7624.md
+++ b/news/2 Fixes/7624.md
@@ -1,0 +1,1 @@
+Make interactive window and native take their fontSize and fontFamily from the settings in VS Code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13770,7 +13770,7 @@
             "dependencies": {
                 "buffer": {
                     "version": "4.9.1",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+                    "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
@@ -13793,7 +13793,7 @@
                 },
                 "readable-stream": {
                     "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
@@ -18754,7 +18754,7 @@
             "dependencies": {
                 "json5": {
                     "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -394,6 +394,8 @@ export interface IDataScienceExtraSettings extends IDataScienceSettings {
     extraSettings: {
         editorCursor: string;
         editorCursorBlink: string;
+        fontSize: number;
+        fontFamily: string;
         theme: string;
     };
     intellisenseOptions: {

--- a/src/client/datascience/webViewHost.ts
+++ b/src/client/datascience/webViewHost.ts
@@ -170,6 +170,8 @@ export class WebViewHost<IMapping> implements IDisposable {
             extraSettings: {
                 editorCursor: this.getValue(editor, 'cursorStyle', 'line'),
                 editorCursorBlink: this.getValue(editor, 'cursorBlinking', 'blink'),
+                fontSize: this.getValue(editor, 'fontSize', 14),
+                fontFamily: this.getValue(editor, 'fontFamily', 'Consolas, \'Courier New\', monospace'),
                 theme: theme
             },
             intellisenseOptions: {
@@ -240,6 +242,8 @@ export class WebViewHost<IMapping> implements IDisposable {
     // Post a message to our webpanel and update our new datascience settings
     private onPossibleSettingsChange = (event: ConfigurationChangeEvent) => {
         if (event.affectsConfiguration('workbench.colorTheme') ||
+            event.affectsConfiguration('editor.fontSize') ||
+            event.affectsConfiguration('editor.fontFamily') ||
             event.affectsConfiguration('editor.cursorStyle') ||
             event.affectsConfiguration('editor.cursorBlinking') ||
             event.affectsConfiguration('python.dataScience.enableGather')) {

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -15,7 +15,7 @@ import { CollapseButton } from '../interactive-common/collapseButton';
 import { ExecutionCount } from '../interactive-common/executionCount';
 import { InformationMessages } from '../interactive-common/informationMessages';
 import { InputHistory } from '../interactive-common/inputHistory';
-import { ICellViewModel } from '../interactive-common/mainState';
+import { ICellViewModel, IFont } from '../interactive-common/mainState';
 import { IKeyboardEvent } from '../react-common/event';
 import { getLocString } from '../react-common/locReactSide';
 import { getSettings } from '../react-common/settingsReactSide';
@@ -39,8 +39,7 @@ interface IInteractiveCellProps {
     focusedCell?: string;
     hideOutput?: boolean;
     showLineNumbers?: boolean;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     onCodeChange(changes: monacoEditor.editor.IModelContentChange[], cellId: string, modelId: string): void;
     onCodeCreated(code: string, file: string, cellId: string, modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -213,8 +212,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
                     unfocused={this.onCodeUnfocused}
                     keyDown={this.props.keyDown}
                     showLineNumbers={this.props.showLineNumbers}
-                    fontSize={this.props.fontSize}
-                    fontFamily={this.props.fontFamily}
+                    font={this.props.font}
                 />
             );
         }

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -39,6 +39,8 @@ interface IInteractiveCellProps {
     focusedCell?: string;
     hideOutput?: boolean;
     showLineNumbers?: boolean;
+    fontSize: number;
+    fontFamily: string;
     onCodeChange(changes: monacoEditor.editor.IModelContentChange[], cellId: string, modelId: string): void;
     onCodeCreated(code: string, file: string, cellId: string, modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -211,6 +213,8 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
                     unfocused={this.onCodeUnfocused}
                     keyDown={this.props.keyDown}
                     showLineNumbers={this.props.showLineNumbers}
+                    fontSize={this.props.fontSize}
+                    fontFamily={this.props.fontFamily}
                 />
             );
         }

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -69,15 +69,15 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
     public render() {
         let fontSize: number = 14;
         let fontFamily: string = 'Consolas, \'Courier New\', monospace';
-        if (this.mainPanelRef.current) {
-            fontSize = parseInt(getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-size'), 10);
-            fontFamily = getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-family');
-        }
+        if (this.state.rootCss) {
+            const fontSizeIndex = this.state.rootCss.indexOf('--code-font-size: ') + 18;
+            const fontSizeEndIndex = this.state.rootCss.indexOf('px;', fontSizeIndex);
+            fontSize = parseInt(this.state.rootCss.substring(fontSizeIndex, fontSizeEndIndex), 10);
 
-        const style: React.CSSProperties = {
-            fontSize: fontSize,
-            fontFamily: fontFamily
-        };
+            const fontFamilyIndex = this.state.rootCss.indexOf('--code-font-family: ') + 20;
+            const fontFamilyEndIndex = this.state.rootCss.indexOf(';', fontFamilyIndex);
+            fontFamily = this.state.rootCss.substring(fontFamilyIndex, fontFamilyEndIndex);
+        }
 
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
@@ -89,7 +89,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
 
         return (
-            <div id='main-panel' ref={this.mainPanelRef} role='Main' style={style}>
+            <div id='main-panel' ref={this.mainPanelRef} role='Main'>
                 <div className='styleSetter'>
                     <style>
                         {this.state.rootCss}

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -67,18 +67,6 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
     }
 
     public render() {
-        let fontSize: number = 14;
-        let fontFamily: string = 'Consolas, \'Courier New\', monospace';
-        if (this.state.rootCss) {
-            const fontSizeIndex = this.state.rootCss.indexOf('--code-font-size: ') + 18;
-            const fontSizeEndIndex = this.state.rootCss.indexOf('px;', fontSizeIndex);
-            fontSize = parseInt(this.state.rootCss.substring(fontSizeIndex, fontSizeEndIndex), 10);
-
-            const fontFamilyIndex = this.state.rootCss.indexOf('--code-font-family: ') + 20;
-            const fontFamilyEndIndex = this.state.rootCss.indexOf(';', fontFamilyIndex);
-            fontFamily = this.state.rootCss.substring(fontFamilyIndex, fontFamilyEndIndex);
-        }
-
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
         const progressBar = this.state.busy && !this.props.testMode ? <Progress /> : undefined;
@@ -103,10 +91,10 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                     {this.renderVariablePanel(this.props.baseTheme)}
                 </section>
                 <main id='main-panel-content' onScroll={this.handleScroll}>
-                    {this.renderContentPanel(this.props.baseTheme, fontSize, fontFamily)}
+                    {this.renderContentPanel(this.props.baseTheme, this.state.fontSize, this.state.fontFamily)}
                 </main>
                 <section id='main-panel-footer' aria-label={getLocString('DataScience.editSection', 'Input new cells here')}>
-                    {this.renderFooterPanel(this.props.baseTheme, fontSize, fontFamily)}
+                    {this.renderFooterPanel(this.props.baseTheme, this.state.fontSize, this.state.fontFamily)}
                 </section>
             </div>
         );

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -67,6 +67,18 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
     }
 
     public render() {
+        let fontSize: number = 14;
+        let fontFamily: string = 'Consolas, \'Courier New\', monospace';
+        if (this.mainPanelRef.current) {
+            fontSize = parseInt(getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-size'), 10);
+            fontFamily = getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-family');
+        }
+
+        const style: React.CSSProperties = {
+            fontSize: fontSize,
+            fontFamily: fontFamily
+        };
+
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
         const progressBar = this.state.busy && !this.props.testMode ? <Progress /> : undefined;
@@ -77,7 +89,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
 
         return (
-            <div id='main-panel' ref={this.mainPanelRef} role='Main'>
+            <div id='main-panel' ref={this.mainPanelRef} role='Main' style={style}>
                 <div className='styleSetter'>
                     <style>
                         {this.state.rootCss}
@@ -91,10 +103,10 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                     {this.renderVariablePanel(this.props.baseTheme)}
                 </section>
                 <main id='main-panel-content' onScroll={this.handleScroll}>
-                    {this.renderContentPanel(this.props.baseTheme)}
+                    {this.renderContentPanel(this.props.baseTheme, fontSize, fontFamily)}
                 </main>
                 <section id='main-panel-footer' aria-label={getLocString('DataScience.editSection', 'Input new cells here')}>
-                    {this.renderFooterPanel(this.props.baseTheme)}
+                    {this.renderFooterPanel(this.props.baseTheme, fontSize, fontFamily)}
                 </section>
             </div>
         );
@@ -175,7 +187,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         return null;
     }
 
-    private renderContentPanel(baseTheme: string) {
+    private renderContentPanel(baseTheme: string, fontSize: number, fontFamily: string) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded && !this.props.testMode) {
@@ -183,11 +195,11 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
 
         // Otherwise render our cells.
-        const contentProps = this.getContentProps(baseTheme);
+        const contentProps = this.getContentProps(baseTheme, fontSize, fontFamily);
         return <ContentPanel {...contentProps} ref={this.contentPanelRef} />;
     }
 
-    private renderFooterPanel(baseTheme: string) {
+    private renderFooterPanel(baseTheme: string, fontSize: number, fontFamily: string) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded || !this.state.editCellVM) {
@@ -222,6 +234,8 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         onClick={this.clickEditCell}
                         keyDown={this.editCellKeyDown}
                         renderCellToolbar={this.renderEditCellToolbar}
+                        fontSize={fontSize}
+                        fontFamily={fontFamily}
                     />
                 </ErrorBoundary>
             </div>
@@ -232,7 +246,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         return this.state.currentExecutionCount + 1;
     }
 
-    private getContentProps = (baseTheme: string): IContentPanelProps => {
+    private getContentProps = (baseTheme: string, fontSize: number, fontFamily: string): IContentPanelProps => {
         return {
             baseTheme: baseTheme,
             cellVMs: this.state.cellVMs,
@@ -244,7 +258,9 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
             editable: false,
             newCellVM: undefined,
             renderCell: this.renderCell,
-            scrollToBottom: this.scrollDiv
+            scrollToBottom: this.scrollDiv,
+            fontSize: fontSize,
+            fontFamily: fontFamily
         };
     }
     private getVariableProps = (baseTheme: string): IVariablePanelProps => {
@@ -319,7 +335,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
     }
 
-    private renderCell = (cellVM: ICellViewModel, index: number, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, index: number, fontSize: number, fontFamily: string, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
         const cellRef = React.createRef<InteractiveCell>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
         return (
@@ -346,6 +362,8 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         renderCellToolbar={this.renderCellToolbar}
                         showLineNumbers={cellVM.showLineNumbers}
                         hideOutput={cellVM.hideOutput}
+                        fontSize={fontSize}
+                        fontFamily={fontFamily}
                     />
                 </ErrorBoundary>
             </div>);

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -67,6 +67,11 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
     }
 
     public render() {
+        const dynamicFont: React.CSSProperties = {
+            fontSize: this.state.fontSize,
+            fontFamily: this.state.fontFamily
+        };
+
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
         const progressBar = this.state.busy && !this.props.testMode ? <Progress /> : undefined;
@@ -77,7 +82,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
 
         return (
-            <div id='main-panel' ref={this.mainPanelRef} role='Main'>
+            <div id='main-panel' ref={this.mainPanelRef} role='Main' style={dynamicFont}>
                 <div className='styleSetter'>
                     <style>
                         {this.state.rootCss}

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { noop } from '../../client/common/utils/misc';
 import { Identifiers } from '../../client/datascience/constants';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
-import { ICellViewModel, IMainState } from '../interactive-common/mainState';
+import { ICellViewModel, IFont, IMainState } from '../interactive-common/mainState';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
 import { ErrorBoundary } from '../react-common/errorBoundary';
 import { IKeyboardEvent } from '../react-common/event';
@@ -68,8 +68,8 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
 
     public render() {
         const dynamicFont: React.CSSProperties = {
-            fontSize: this.state.fontSize,
-            fontFamily: this.state.fontFamily
+            fontSize: this.state.font.size,
+            fontFamily: this.state.font.family
         };
 
         // Update the state controller with our new state
@@ -96,10 +96,10 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                     {this.renderVariablePanel(this.props.baseTheme)}
                 </section>
                 <main id='main-panel-content' onScroll={this.handleScroll}>
-                    {this.renderContentPanel(this.props.baseTheme, this.state.fontSize, this.state.fontFamily)}
+                    {this.renderContentPanel(this.props.baseTheme, this.state.font)}
                 </main>
                 <section id='main-panel-footer' aria-label={getLocString('DataScience.editSection', 'Input new cells here')}>
-                    {this.renderFooterPanel(this.props.baseTheme, this.state.fontSize, this.state.fontFamily)}
+                    {this.renderFooterPanel(this.props.baseTheme, this.state.font)}
                 </section>
             </div>
         );
@@ -180,7 +180,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         return null;
     }
 
-    private renderContentPanel(baseTheme: string, fontSize: number, fontFamily: string) {
+    private renderContentPanel(baseTheme: string, font: IFont) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded && !this.props.testMode) {
@@ -188,11 +188,11 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
 
         // Otherwise render our cells.
-        const contentProps = this.getContentProps(baseTheme, fontSize, fontFamily);
+        const contentProps = this.getContentProps(baseTheme, font);
         return <ContentPanel {...contentProps} ref={this.contentPanelRef} />;
     }
 
-    private renderFooterPanel(baseTheme: string, fontSize: number, fontFamily: string) {
+    private renderFooterPanel(baseTheme: string, font: IFont) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded || !this.state.editCellVM) {
@@ -227,8 +227,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         onClick={this.clickEditCell}
                         keyDown={this.editCellKeyDown}
                         renderCellToolbar={this.renderEditCellToolbar}
-                        fontSize={fontSize}
-                        fontFamily={fontFamily}
+                        font={font}
                     />
                 </ErrorBoundary>
             </div>
@@ -239,7 +238,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         return this.state.currentExecutionCount + 1;
     }
 
-    private getContentProps = (baseTheme: string, fontSize: number, fontFamily: string): IContentPanelProps => {
+    private getContentProps = (baseTheme: string, font: IFont): IContentPanelProps => {
         return {
             baseTheme: baseTheme,
             cellVMs: this.state.cellVMs,
@@ -252,8 +251,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
             newCellVM: undefined,
             renderCell: this.renderCell,
             scrollToBottom: this.scrollDiv,
-            fontSize: fontSize,
-            fontFamily: fontFamily
+            font: font
         };
     }
     private getVariableProps = (baseTheme: string): IVariablePanelProps => {
@@ -328,7 +326,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
     }
 
-    private renderCell = (cellVM: ICellViewModel, index: number, fontSize: number, fontFamily: string, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, index: number, font: IFont, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
         const cellRef = React.createRef<InteractiveCell>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
         return (
@@ -355,8 +353,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         renderCellToolbar={this.renderCellToolbar}
                         showLineNumbers={cellVM.showLineNumbers}
                         hideOutput={cellVM.hideOutput}
-                        fontSize={fontSize}
-                        fontFamily={fontFamily}
+                        font={font}
                     />
                 </ErrorBoundary>
             </div>);

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { noop } from '../../client/common/utils/misc';
 import { Identifiers } from '../../client/datascience/constants';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
-import { ICellViewModel, IFont, IMainState } from '../interactive-common/mainState';
+import { ICellViewModel, IMainState } from '../interactive-common/mainState';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
 import { ErrorBoundary } from '../react-common/errorBoundary';
 import { IKeyboardEvent } from '../react-common/event';
@@ -96,10 +96,10 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                     {this.renderVariablePanel(this.props.baseTheme)}
                 </section>
                 <main id='main-panel-content' onScroll={this.handleScroll}>
-                    {this.renderContentPanel(this.props.baseTheme, this.state.font)}
+                    {this.renderContentPanel(this.props.baseTheme)}
                 </main>
                 <section id='main-panel-footer' aria-label={getLocString('DataScience.editSection', 'Input new cells here')}>
-                    {this.renderFooterPanel(this.props.baseTheme, this.state.font)}
+                    {this.renderFooterPanel(this.props.baseTheme)}
                 </section>
             </div>
         );
@@ -180,7 +180,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         return null;
     }
 
-    private renderContentPanel(baseTheme: string, font: IFont) {
+    private renderContentPanel(baseTheme: string) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded && !this.props.testMode) {
@@ -188,11 +188,11 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
 
         // Otherwise render our cells.
-        const contentProps = this.getContentProps(baseTheme, font);
+        const contentProps = this.getContentProps(baseTheme);
         return <ContentPanel {...contentProps} ref={this.contentPanelRef} />;
     }
 
-    private renderFooterPanel(baseTheme: string, font: IFont) {
+    private renderFooterPanel(baseTheme: string) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded || !this.state.editCellVM) {
@@ -227,7 +227,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         onClick={this.clickEditCell}
                         keyDown={this.editCellKeyDown}
                         renderCellToolbar={this.renderEditCellToolbar}
-                        font={font}
+                        font={this.state.font}
                     />
                 </ErrorBoundary>
             </div>
@@ -238,7 +238,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         return this.state.currentExecutionCount + 1;
     }
 
-    private getContentProps = (baseTheme: string, font: IFont): IContentPanelProps => {
+    private getContentProps = (baseTheme: string): IContentPanelProps => {
         return {
             baseTheme: baseTheme,
             cellVMs: this.state.cellVMs,
@@ -250,8 +250,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
             editable: false,
             newCellVM: undefined,
             renderCell: this.renderCell,
-            scrollToBottom: this.scrollDiv,
-            font: font
+            scrollToBottom: this.scrollDiv
         };
     }
     private getVariableProps = (baseTheme: string): IVariablePanelProps => {
@@ -326,7 +325,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
     }
 
-    private renderCell = (cellVM: ICellViewModel, index: number, font: IFont, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, index: number, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
         const cellRef = React.createRef<InteractiveCell>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
         return (
@@ -353,7 +352,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         renderCellToolbar={this.renderCellToolbar}
                         showLineNumbers={cellVM.showLineNumbers}
                         hideOutput={cellVM.hideOutput}
-                        font={font}
+                        font={this.state.font}
                     />
                 </ErrorBoundary>
             </div>);

--- a/src/datascience-ui/interactive-common/cellInput.tsx
+++ b/src/datascience-ui/interactive-common/cellInput.tsx
@@ -12,7 +12,7 @@ import { IKeyboardEvent } from '../react-common/event';
 import { getLocString } from '../react-common/locReactSide';
 import { Code } from './code';
 import { InputHistory } from './inputHistory';
-import { ICellViewModel } from './mainState';
+import { ICellViewModel, IFont } from './mainState';
 import { Markdown } from './markdown';
 
 // tslint:disable-next-line: no-require-importss
@@ -28,8 +28,7 @@ interface ICellInputProps {
     editorMeasureClassName?: string;
     focusedCell?: string;
     showLineNumbers?: boolean;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     onCodeChange(changes: monacoEditor.editor.IModelContentChange[], cellId: string, modelId: string): void;
     onCodeCreated(code: string, file: string, cellId: string, modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -130,8 +129,7 @@ export class CellInput extends React.Component<ICellInputProps> {
                         keyDown={this.onKeyDown}
                         showLineNumbers={this.props.showLineNumbers}
                         useQuickEdit={this.props.cellVM.useQuickEdit}
-                        fontSize={this.props.fontSize}
-                        fontFamily={this.props.fontFamily}
+                        font={this.props.font}
                         />
                 </div>
             );
@@ -162,8 +160,7 @@ export class CellInput extends React.Component<ICellInputProps> {
                         keyDown={this.onKeyDown}
                         ref={this.markdownRef}
                         useQuickEdit={false}
-                        fontSize={this.props.fontSize}
-                        fontFamily={this.props.fontFamily}
+                        font={this.props.font}
                         />
                 </div>
             );

--- a/src/datascience-ui/interactive-common/cellInput.tsx
+++ b/src/datascience-ui/interactive-common/cellInput.tsx
@@ -28,6 +28,8 @@ interface ICellInputProps {
     editorMeasureClassName?: string;
     focusedCell?: string;
     showLineNumbers?: boolean;
+    fontSize: number;
+    fontFamily: string;
     onCodeChange(changes: monacoEditor.editor.IModelContentChange[], cellId: string, modelId: string): void;
     onCodeCreated(code: string, file: string, cellId: string, modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -128,6 +130,8 @@ export class CellInput extends React.Component<ICellInputProps> {
                         keyDown={this.onKeyDown}
                         showLineNumbers={this.props.showLineNumbers}
                         useQuickEdit={this.props.cellVM.useQuickEdit}
+                        fontSize={this.props.fontSize}
+                        fontFamily={this.props.fontFamily}
                         />
                 </div>
             );
@@ -158,6 +162,8 @@ export class CellInput extends React.Component<ICellInputProps> {
                         keyDown={this.onKeyDown}
                         ref={this.markdownRef}
                         useQuickEdit={false}
+                        fontSize={this.props.fontSize}
+                        fontFamily={this.props.fontFamily}
                         />
                 </div>
             );

--- a/src/datascience-ui/interactive-common/code.tsx
+++ b/src/datascience-ui/interactive-common/code.tsx
@@ -23,6 +23,8 @@ export interface ICodeProps {
     editorMeasureClassName?: string;
     showLineNumbers?: boolean;
     useQuickEdit?: boolean;
+    fontSize: number;
+    fontFamily: string;
     onCreated(code: string, modelId: string): void;
     onChange(changes: monacoEditor.editor.IModelContentChange[], modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -70,6 +72,8 @@ export class Code extends React.Component<ICodeProps, ICodeState> {
                     unfocused={this.props.unfocused}
                     showLineNumbers={this.props.showLineNumbers}
                     useQuickEdit={this.props.useQuickEdit}
+                    fontSize={this.props.fontSize}
+                    fontFamily={this.props.fontFamily}
                 />
                 <div className={waterMarkClass} role='textbox' onClick={this.clickWatermark}>{this.getWatermarkString()}</div>
             </div>

--- a/src/datascience-ui/interactive-common/code.tsx
+++ b/src/datascience-ui/interactive-common/code.tsx
@@ -8,6 +8,7 @@ import { InputHistory } from '../interactive-common/inputHistory';
 import { IKeyboardEvent } from '../react-common/event';
 import { getLocString } from '../react-common/locReactSide';
 import { Editor } from './editor';
+import { IFont } from './mainState';
 
 export interface ICodeProps {
     autoFocus: boolean;
@@ -23,8 +24,7 @@ export interface ICodeProps {
     editorMeasureClassName?: string;
     showLineNumbers?: boolean;
     useQuickEdit?: boolean;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     onCreated(code: string, modelId: string): void;
     onChange(changes: monacoEditor.editor.IModelContentChange[], modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -72,8 +72,7 @@ export class Code extends React.Component<ICodeProps, ICodeState> {
                     unfocused={this.props.unfocused}
                     showLineNumbers={this.props.showLineNumbers}
                     useQuickEdit={this.props.useQuickEdit}
-                    fontSize={this.props.fontSize}
-                    fontFamily={this.props.fontFamily}
+                    font={this.props.font}
                 />
                 <div className={waterMarkClass} role='textbox' onClick={this.clickWatermark}>{this.getWatermarkString()}</div>
             </div>

--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -148,13 +148,9 @@ body, html {
 
 .cell-output-text {
     white-space: pre-wrap;
-    font-size: var(--code-font-size);
-    font-family: var(--code-font-family);
 }
 .cell-output-text pre {
     white-space: pre-wrap;
-    font-size: var(--code-font-size);
-    font-family: var(--code-font-family);
 }
 
 .cell-output-html {

--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -23,8 +23,8 @@ body, html {
     width: 100%;
     position: absolute;
     overflow: hidden;
-    font-size: var(--code-font-size);
-    font-family: var(--code-font-family);
+    /* font-size: var(--code-font-size);
+    font-family: var(--code-font-family); */
 }
 
 #main-panel-toolbar {

--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -23,8 +23,6 @@ body, html {
     width: 100%;
     position: absolute;
     overflow: hidden;
-    /* font-size: var(--code-font-size);
-    font-family: var(--code-font-family); */
 }
 
 #main-panel-toolbar {

--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -23,6 +23,8 @@ body, html {
     width: 100%;
     position: absolute;
     overflow: hidden;
+    font-size: var(--code-font-size);
+    font-family: var(--code-font-family);
 }
 
 #main-panel-toolbar {

--- a/src/datascience-ui/interactive-common/contentPanel.tsx
+++ b/src/datascience-ui/interactive-common/contentPanel.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 
 import { InputHistory } from './inputHistory';
-import { ICellViewModel, IFont } from './mainState';
+import { ICellViewModel } from './mainState';
 
 // See the discussion here: https://github.com/Microsoft/tslint-microsoft-contrib/issues/676
 // tslint:disable: react-this-binding-issue
@@ -21,8 +21,7 @@ export interface IContentPanelProps {
     submittedText: boolean;
     skipNextScroll: boolean;
     editable: boolean;
-    font: IFont;
-    renderCell(cellVM: ICellViewModel, index: number, font: IFont): JSX.Element | null;
+    renderCell(cellVM: ICellViewModel, index: number): JSX.Element | null;
     scrollToBottom(div: HTMLDivElement): void;
 }
 
@@ -58,13 +57,13 @@ export class ContentPanel extends React.Component<IContentPanelProps> {
 
     private renderCells = () => {
         return this.props.cellVMs.map((cellVM: ICellViewModel, index: number) => {
-            return this.props.renderCell(cellVM, index, this.props.font);
+            return this.props.renderCell(cellVM, index);
         });
     }
 
     private renderEdit = () => {
         if (this.props.editable && this.props.newCellVM) {
-            return this.props.renderCell(this.props.newCellVM, 0, this.props.font);
+            return this.props.renderCell(this.props.newCellVM, 0);
         } else {
             return null;
         }

--- a/src/datascience-ui/interactive-common/contentPanel.tsx
+++ b/src/datascience-ui/interactive-common/contentPanel.tsx
@@ -21,7 +21,9 @@ export interface IContentPanelProps {
     submittedText: boolean;
     skipNextScroll: boolean;
     editable: boolean;
-    renderCell(cellVM: ICellViewModel, index: number): JSX.Element | null;
+    fontSize: number;
+    fontFamily: string;
+    renderCell(cellVM: ICellViewModel, index: number, fontSize: number, fontFamily: string): JSX.Element | null;
     scrollToBottom(div: HTMLDivElement): void;
 }
 
@@ -57,13 +59,13 @@ export class ContentPanel extends React.Component<IContentPanelProps> {
 
     private renderCells = () => {
         return this.props.cellVMs.map((cellVM: ICellViewModel, index: number) => {
-            return this.props.renderCell(cellVM, index);
+            return this.props.renderCell(cellVM, index, this.props.fontSize, this.props.fontFamily);
         });
     }
 
     private renderEdit = () => {
         if (this.props.editable && this.props.newCellVM) {
-            return this.props.renderCell(this.props.newCellVM, 0);
+            return this.props.renderCell(this.props.newCellVM, 0, this.props.fontSize, this.props.fontFamily);
         } else {
             return null;
         }

--- a/src/datascience-ui/interactive-common/contentPanel.tsx
+++ b/src/datascience-ui/interactive-common/contentPanel.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 
 import { InputHistory } from './inputHistory';
-import { ICellViewModel } from './mainState';
+import { ICellViewModel, IFont } from './mainState';
 
 // See the discussion here: https://github.com/Microsoft/tslint-microsoft-contrib/issues/676
 // tslint:disable: react-this-binding-issue
@@ -21,9 +21,8 @@ export interface IContentPanelProps {
     submittedText: boolean;
     skipNextScroll: boolean;
     editable: boolean;
-    fontSize: number;
-    fontFamily: string;
-    renderCell(cellVM: ICellViewModel, index: number, fontSize: number, fontFamily: string): JSX.Element | null;
+    font: IFont;
+    renderCell(cellVM: ICellViewModel, index: number, font: IFont): JSX.Element | null;
     scrollToBottom(div: HTMLDivElement): void;
 }
 
@@ -59,13 +58,13 @@ export class ContentPanel extends React.Component<IContentPanelProps> {
 
     private renderCells = () => {
         return this.props.cellVMs.map((cellVM: ICellViewModel, index: number) => {
-            return this.props.renderCell(cellVM, index, this.props.fontSize, this.props.fontFamily);
+            return this.props.renderCell(cellVM, index, this.props.font);
         });
     }
 
     private renderEdit = () => {
         if (this.props.editable && this.props.newCellVM) {
-            return this.props.renderCell(this.props.newCellVM, 0, this.props.fontSize, this.props.fontFamily);
+            return this.props.renderCell(this.props.newCellVM, 0, this.props.font);
         } else {
             return null;
         }

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -24,6 +24,8 @@ export interface IEditorProps {
     language: string;
     showLineNumbers?: boolean;
     useQuickEdit?: boolean;
+    fontSize: number;
+    fontFamily: string;
     onCreated(code: string, modelId: string): void;
     onChange(changes: monacoEditor.editor.IModelContentChange[], model: monacoEditor.editor.ITextModel): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -114,6 +116,8 @@ export class Editor extends React.Component<IEditorProps, IEditorState> {
             lineDecorationsWidth: 0,
             contextmenu: false,
             matchBrackets: false,
+            fontSize: this.props.fontSize,
+            fontFamily: this.props.fontFamily,
             ...this.props.editorOptions
         };
 

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -8,6 +8,7 @@ import { noop } from '../../client/common/utils/misc';
 import { IKeyboardEvent } from '../react-common/event';
 import { MonacoEditor } from '../react-common/monacoEditor';
 import { InputHistory } from './inputHistory';
+import { IFont } from './mainState';
 
 // tslint:disable-next-line: import-name
 export interface IEditorProps {
@@ -24,8 +25,7 @@ export interface IEditorProps {
     language: string;
     showLineNumbers?: boolean;
     useQuickEdit?: boolean;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     onCreated(code: string, modelId: string): void;
     onChange(changes: monacoEditor.editor.IModelContentChange[], model: monacoEditor.editor.ITextModel): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -116,8 +116,8 @@ export class Editor extends React.Component<IEditorProps, IEditorState> {
             lineDecorationsWidth: 0,
             contextmenu: false,
             matchBrackets: false,
-            fontSize: this.props.fontSize,
-            fontFamily: this.props.fontFamily,
+            fontSize: this.props.font.size,
+            fontFamily: this.props.font.family,
             ...this.props.editorOptions
         };
 

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -40,8 +40,7 @@ export interface IMainState {
     history: InputHistory;
     rootStyle?: string;
     rootCss?: string;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     theme?: string;
     forceDark?: boolean;
     monacoTheme?: string;
@@ -60,6 +59,11 @@ export interface IMainState {
     isAtBottom: boolean;
     newCell?: string;
     loadTotal?: number;
+}
+
+export interface IFont {
+    size: number;
+    family: string;
 }
 
 // tslint:disable-next-line: no-multiline-string
@@ -108,8 +112,10 @@ export function generateTestState(inputBlockToggled: (id: string) => void, fileP
         debugging: false,
         enableGather: true,
         isAtBottom: true,
-        fontSize: 14,
-        fontFamily: 'Consolas, \'Courier New\', monospace'
+        font: {
+            size: 14,
+            family: 'Consolas, \'Courier New\', monospace'
+        }
     };
 }
 

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -40,6 +40,8 @@ export interface IMainState {
     history: InputHistory;
     rootStyle?: string;
     rootCss?: string;
+    fontSize: number;
+    fontFamily: string;
     theme?: string;
     forceDark?: boolean;
     monacoTheme?: string;
@@ -105,7 +107,9 @@ export function generateTestState(inputBlockToggled: (id: string) => void, fileP
         pendingVariableCount: 0,
         debugging: false,
         enableGather: true,
-        isAtBottom: true
+        isAtBottom: true,
+        fontSize: 14,
+        fontFamily: 'Consolas, \'Courier New\', monospace'
     };
 }
 

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -905,15 +905,17 @@ export class MainStateController implements IMessageHandler {
                 this.toggleCellInputVisibility(showInputs, getSettings().collapseCellInputCodeByDefault);
             }
 
-            const fontSize = dsSettings.extraSettings.fontSize;
-            const fontFamily = dsSettings.extraSettings.fontFamily;
+            if (dsSettings.extraSettings) {
+                const fontSize = dsSettings.extraSettings.fontSize;
+                const fontFamily = dsSettings.extraSettings.fontFamily;
 
-            this.setState({
-                font: {
-                    size: fontSize,
-                    family: fontFamily
-                }
-            });
+                this.setState({
+                    font: {
+                        size: fontSize,
+                        family: fontFamily
+                    }
+                });
+            }
         }
     }
 

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -902,6 +902,14 @@ export class MainStateController implements IMessageHandler {
             if (prevShowInputs !== showInputs) {
                 this.toggleCellInputVisibility(showInputs, getSettings().collapseCellInputCodeByDefault);
             }
+
+            const fontSize = dsSettings.extraSettings.fontSize;
+            const fontFamily = dsSettings.extraSettings.fontFamily;
+
+            this.setState({
+                fontSize: fontSize,
+                fontFamily: fontFamily
+            });
         }
     }
 

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -76,7 +76,9 @@ export class MainStateController implements IMessageHandler {
             variablesVisible: false,
             editCellVM: this.props.hasEdit ? createEditableCellVM(1) : undefined,
             enableGather: this.props.enableGather,
-            isAtBottom: true
+            isAtBottom: true,
+            fontSize: 14,
+            fontFamily: 'Consolas, \'Courier New\', monospace'
         };
 
         // Add test state if necessary
@@ -1163,8 +1165,25 @@ export class MainStateController implements IMessageHandler {
                 this.darkChanged(computedKnownDark);
             }
 
+            let fontSize: number = 14;
+            let fontFamily: string = 'Consolas, \'Courier New\', monospace';
+            const fontSizeIndex = response.css.indexOf('--code-font-size: ');
+            const fontFamilyIndex = response.css.indexOf('--code-font-family: ');
+
+            if (fontSizeIndex > -1) {
+                const fontSizeEndIndex = response.css.indexOf('px;', fontSizeIndex + 18);
+                fontSize = parseInt(response.css.substring(fontSizeIndex + 18, fontSizeEndIndex), 10);
+            }
+
+            if (fontFamilyIndex > -1) {
+                const fontFamilyEndIndex = response.css.indexOf(';', fontFamilyIndex + 20);
+                fontFamily = response.css.substring(fontFamilyIndex + 20, fontFamilyEndIndex);
+            }
+
             this.setState({
                 rootCss: response.css,
+                fontSize: fontSize,
+                fontFamily: fontFamily,
                 theme: response.theme,
                 knownDark: computedKnownDark
             });

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -77,8 +77,10 @@ export class MainStateController implements IMessageHandler {
             editCellVM: this.props.hasEdit ? createEditableCellVM(1) : undefined,
             enableGather: this.props.enableGather,
             isAtBottom: true,
-            fontSize: 14,
-            fontFamily: 'Consolas, \'Courier New\', monospace'
+            font: {
+                size: 14,
+                family: 'Consolas, \'Courier New\', monospace'
+            }
         };
 
         // Add test state if necessary
@@ -907,8 +909,10 @@ export class MainStateController implements IMessageHandler {
             const fontFamily = dsSettings.extraSettings.fontFamily;
 
             this.setState({
-                fontSize: fontSize,
-                fontFamily: fontFamily
+                font: {
+                    size: fontSize,
+                    family: fontFamily
+                }
             });
         }
     }
@@ -1175,23 +1179,27 @@ export class MainStateController implements IMessageHandler {
 
             let fontSize: number = 14;
             let fontFamily: string = 'Consolas, \'Courier New\', monospace';
-            const fontSizeIndex = response.css.indexOf('--code-font-size: ');
-            const fontFamilyIndex = response.css.indexOf('--code-font-family: ');
+            const sizeSetting = '--code-font-size: ';
+            const familySetting = '--code-font-family: ';
+            const fontSizeIndex = response.css.indexOf(sizeSetting);
+            const fontFamilyIndex = response.css.indexOf(familySetting);
 
             if (fontSizeIndex > -1) {
-                const fontSizeEndIndex = response.css.indexOf('px;', fontSizeIndex + 18);
-                fontSize = parseInt(response.css.substring(fontSizeIndex + 18, fontSizeEndIndex), 10);
+                const fontSizeEndIndex = response.css.indexOf('px;', fontSizeIndex + sizeSetting.length);
+                fontSize = parseInt(response.css.substring(fontSizeIndex + sizeSetting.length, fontSizeEndIndex), 10);
             }
 
             if (fontFamilyIndex > -1) {
-                const fontFamilyEndIndex = response.css.indexOf(';', fontFamilyIndex + 20);
-                fontFamily = response.css.substring(fontFamilyIndex + 20, fontFamilyEndIndex);
+                const fontFamilyEndIndex = response.css.indexOf(';', fontFamilyIndex + familySetting.length);
+                fontFamily = response.css.substring(fontFamilyIndex + familySetting.length, fontFamilyEndIndex);
             }
 
             this.setState({
                 rootCss: response.css,
-                fontSize: fontSize,
-                fontFamily: fontFamily,
+                font: {
+                    size: fontSize,
+                    family: fontFamily
+                },
                 theme: response.theme,
                 knownDark: computedKnownDark
             });

--- a/src/datascience-ui/interactive-common/markdown.tsx
+++ b/src/datascience-ui/interactive-common/markdown.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import { IKeyboardEvent } from '../react-common/event';
 import { Editor } from './editor';
+import { IFont } from './mainState';
 
 export interface IMarkdownProps {
     autoFocus: boolean;
@@ -18,8 +19,7 @@ export interface IMarkdownProps {
     editorMeasureClassName?: string;
     showLineNumbers?: boolean;
     useQuickEdit?: boolean;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     onCreated(code: string, modelId: string): void;
     onChange(changes: monacoEditor.editor.IModelContentChange[], modelId: string): void;
     focused?(): void;
@@ -58,8 +58,7 @@ export class Markdown extends React.Component<IMarkdownProps> {
                     unfocused={this.props.unfocused}
                     showLineNumbers={this.props.showLineNumbers}
                     useQuickEdit={this.props.useQuickEdit}
-                    fontSize={this.props.fontSize}
-                    fontFamily={this.props.fontFamily}
+                    font={this.props.font}
                 />
         );
     }

--- a/src/datascience-ui/interactive-common/markdown.tsx
+++ b/src/datascience-ui/interactive-common/markdown.tsx
@@ -18,6 +18,8 @@ export interface IMarkdownProps {
     editorMeasureClassName?: string;
     showLineNumbers?: boolean;
     useQuickEdit?: boolean;
+    fontSize: number;
+    fontFamily: string;
     onCreated(code: string, modelId: string): void;
     onChange(changes: monacoEditor.editor.IModelContentChange[], modelId: string): void;
     focused?(): void;
@@ -56,6 +58,8 @@ export class Markdown extends React.Component<IMarkdownProps> {
                     unfocused={this.props.unfocused}
                     showLineNumbers={this.props.showLineNumbers}
                     useQuickEdit={this.props.useQuickEdit}
+                    fontSize={this.props.fontSize}
+                    fontFamily={this.props.fontFamily}
                 />
         );
     }

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -14,7 +14,7 @@ import { CellInput } from '../interactive-common/cellInput';
 import { CellOutput } from '../interactive-common/cellOutput';
 import { ExecutionCount } from '../interactive-common/executionCount';
 import { InformationMessages } from '../interactive-common/informationMessages';
-import { ICellViewModel } from '../interactive-common/mainState';
+import { ICellViewModel, IFont } from '../interactive-common/mainState';
 import { IKeyboardEvent } from '../react-common/event';
 import { Image, ImageName } from '../react-common/image';
 import { ImageButton } from '../react-common/imageButton';
@@ -36,8 +36,7 @@ interface INativeCellProps {
     showLineNumbers?: boolean;
     selectedCell?: string;
     focusedCell?: string;
-    fontSize: number;
-    fontFamily: string;
+    font: IFont;
     focusCell(cellId: string, focusCode: boolean): void;
     selectCell(cellId: string): void;
 }
@@ -659,8 +658,7 @@ export class NativeCell extends React.Component<INativeCellProps, INativeCellSta
                     unfocused={this.isCodeCell() ? this.onCodeUnfocused : this.onMarkdownUnfocused}
                     keyDown={this.keyDownInput}
                     showLineNumbers={this.props.showLineNumbers}
-                    fontSize={this.props.fontSize}
-                    fontFamily={this.props.fontFamily}
+                    font={this.props.font}
                 />
             );
         }

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -36,6 +36,8 @@ interface INativeCellProps {
     showLineNumbers?: boolean;
     selectedCell?: string;
     focusedCell?: string;
+    fontSize: number;
+    fontFamily: string;
     focusCell(cellId: string, focusCode: boolean): void;
     selectCell(cellId: string): void;
 }
@@ -657,6 +659,8 @@ export class NativeCell extends React.Component<INativeCellProps, INativeCellSta
                     unfocused={this.isCodeCell() ? this.onCodeUnfocused : this.onMarkdownUnfocused}
                     keyDown={this.keyDownInput}
                     showLineNumbers={this.props.showLineNumbers}
+                    fontSize={this.props.fontSize}
+                    fontFamily={this.props.fontFamily}
                 />
             );
         }

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { noop } from '../../client/common/utils/misc';
 import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
-import { ICellViewModel, IMainState } from '../interactive-common/mainState';
+import { ICellViewModel, IFont, IMainState } from '../interactive-common/mainState';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
 import { ErrorBoundary } from '../react-common/errorBoundary';
 import { Image, ImageName } from '../react-common/image';
@@ -84,8 +84,8 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
 
     public render() {
         const dynamicFont: React.CSSProperties = {
-            fontSize: this.state.fontSize,
-            fontFamily: this.state.fontFamily
+            fontSize: this.state.font.size,
+            fontFamily: this.state.font.family
         };
 
         // If in test mode, update our count. Use this to determine how many renders a normal update takes.
@@ -122,7 +122,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 </section>
                 <main id='main-panel-content' onScroll={this.onContentScroll} ref={this.contentPanelScrollRef}>
                     {addCellLine}
-                    {this.renderContentPanel(this.props.baseTheme, this.state.fontSize, this.state.fontFamily)}
+                    {this.renderContentPanel(this.props.baseTheme, this.state.font)}
                 </main>
             </div>
         );
@@ -231,7 +231,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         return null;
     }
 
-    private renderContentPanel(baseTheme: string, fontSize: number, fontFamily: string) {
+    private renderContentPanel(baseTheme: string, font: IFont) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded && !this.props.testMode) {
@@ -239,11 +239,11 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         }
 
         // Otherwise render our cells.
-        const contentProps = this.getContentProps(baseTheme, fontSize, fontFamily);
+        const contentProps = this.getContentProps(baseTheme, font);
         return <ContentPanel {...contentProps} ref={this.contentPanelRef}/>;
     }
 
-    private getContentProps = (baseTheme: string, fontSize: number, fontFamily: string): IContentPanelProps => {
+    private getContentProps = (baseTheme: string, font: IFont): IContentPanelProps => {
         return {
             baseTheme: baseTheme,
             cellVMs: this.state.cellVMs,
@@ -255,8 +255,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             editable: true,
             renderCell: this.renderCell,
             scrollToBottom: this.scrollDiv,
-            fontSize: fontSize,
-            fontFamily: fontFamily
+            font: font
         };
     }
     private getVariableProps = (baseTheme: string): IVariablePanelProps => {
@@ -363,7 +362,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     //     });
     // }
 
-    private renderCell = (cellVM: ICellViewModel, index: number, fontSize: number, fontFamily: string): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, index: number, font: IFont): JSX.Element | null => {
         const cellRef : React.RefObject<NativeCell> = React.createRef<NativeCell>();
         const containerRef = React.createRef<HTMLDivElement>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
@@ -408,8 +407,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         hideOutput={cellVM.hideOutput}
                         focusCell={this.focusCell}
                         selectCell={this.selectCell}
-                        fontSize={fontSize}
-                        fontFamily={fontFamily}
+                        font={font}
                     />
                 </ErrorBoundary>
                 {lastLine}

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { noop } from '../../client/common/utils/misc';
 import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
-import { ICellViewModel, IFont, IMainState } from '../interactive-common/mainState';
+import { ICellViewModel, IMainState } from '../interactive-common/mainState';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
 import { ErrorBoundary } from '../react-common/errorBoundary';
 import { Image, ImageName } from '../react-common/image';
@@ -122,7 +122,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 </section>
                 <main id='main-panel-content' onScroll={this.onContentScroll} ref={this.contentPanelScrollRef}>
                     {addCellLine}
-                    {this.renderContentPanel(this.props.baseTheme, this.state.font)}
+                    {this.renderContentPanel(this.props.baseTheme)}
                 </main>
             </div>
         );
@@ -231,7 +231,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         return null;
     }
 
-    private renderContentPanel(baseTheme: string, font: IFont) {
+    private renderContentPanel(baseTheme: string) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded && !this.props.testMode) {
@@ -239,11 +239,11 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         }
 
         // Otherwise render our cells.
-        const contentProps = this.getContentProps(baseTheme, font);
+        const contentProps = this.getContentProps(baseTheme);
         return <ContentPanel {...contentProps} ref={this.contentPanelRef}/>;
     }
 
-    private getContentProps = (baseTheme: string, font: IFont): IContentPanelProps => {
+    private getContentProps = (baseTheme: string): IContentPanelProps => {
         return {
             baseTheme: baseTheme,
             cellVMs: this.state.cellVMs,
@@ -254,8 +254,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             skipNextScroll: this.state.skipNextScroll ? true : false,
             editable: true,
             renderCell: this.renderCell,
-            scrollToBottom: this.scrollDiv,
-            font: font
+            scrollToBottom: this.scrollDiv
         };
     }
     private getVariableProps = (baseTheme: string): IVariablePanelProps => {
@@ -362,7 +361,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     //     });
     // }
 
-    private renderCell = (cellVM: ICellViewModel, index: number, font: IFont): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, index: number): JSX.Element | null => {
         const cellRef : React.RefObject<NativeCell> = React.createRef<NativeCell>();
         const containerRef = React.createRef<HTMLDivElement>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
@@ -407,7 +406,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         hideOutput={cellVM.hideOutput}
                         focusCell={this.focusCell}
                         selectCell={this.selectCell}
-                        font={font}
+                        font={this.state.font}
                     />
                 </ErrorBoundary>
                 {lastLine}

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -88,18 +88,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             this.renderCount = this.renderCount + 1;
         }
 
-        let fontSize: number = 14;
-        let fontFamily: string = 'Consolas, \'Courier New\', monospace';
-        if (this.state.rootCss) {
-            const fontSizeIndex = this.state.rootCss.indexOf('--code-font-size: ') + 18;
-            const fontSizeEndIndex = this.state.rootCss.indexOf('px;', fontSizeIndex);
-            fontSize = parseInt(this.state.rootCss.substring(fontSizeIndex, fontSizeEndIndex), 10);
-
-            const fontFamilyIndex = this.state.rootCss.indexOf('--code-font-family: ') + 20;
-            const fontFamilyEndIndex = this.state.rootCss.indexOf(';', fontFamilyIndex);
-            fontFamily = this.state.rootCss.substring(fontFamilyIndex, fontFamilyEndIndex);
-        }
-
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
         const progressBar = this.state.busy && !this.props.testMode ? <Progress /> : undefined;
@@ -129,7 +117,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 </section>
                 <main id='main-panel-content' onScroll={this.onContentScroll} ref={this.contentPanelScrollRef}>
                     {addCellLine}
-                    {this.renderContentPanel(this.props.baseTheme, fontSize, fontFamily)}
+                    {this.renderContentPanel(this.props.baseTheme, this.state.fontSize, this.state.fontFamily)}
                 </main>
             </div>
         );

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -90,15 +90,15 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
 
         let fontSize: number = 14;
         let fontFamily: string = 'Consolas, \'Courier New\', monospace';
-        if (this.mainPanelRef.current) {
-            fontSize = parseInt(getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-size'), 10);
-            fontFamily = getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-family');
-        }
+        if (this.state.rootCss) {
+            const fontSizeIndex = this.state.rootCss.indexOf('--code-font-size: ') + 18;
+            const fontSizeEndIndex = this.state.rootCss.indexOf('px;', fontSizeIndex);
+            fontSize = parseInt(this.state.rootCss.substring(fontSizeIndex, fontSizeEndIndex), 10);
 
-        const style: React.CSSProperties = {
-            fontSize: fontSize,
-            fontFamily: fontFamily
-        };
+            const fontFamilyIndex = this.state.rootCss.indexOf('--code-font-family: ') + 20;
+            const fontFamilyEndIndex = this.state.rootCss.indexOf(';', fontFamilyIndex);
+            fontFamily = this.state.rootCss.substring(fontFamilyIndex, fontFamilyEndIndex);
+        }
 
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
@@ -114,7 +114,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             <AddCellLine includePlus={true} className='add-cell-line-top' click={insertAboveFirst} baseTheme={this.props.baseTheme}/>;
 
         return (
-            <div id='main-panel' ref={this.mainPanelRef} role='Main' style={style}>
+            <div id='main-panel' ref={this.mainPanelRef} role='Main'>
                 <div className='styleSetter'>
                     <style>
                         {this.state.rootCss}

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -88,6 +88,18 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             this.renderCount = this.renderCount + 1;
         }
 
+        let fontSize: number = 14;
+        let fontFamily: string = 'Consolas, \'Courier New\', monospace';
+        if (this.mainPanelRef.current) {
+            fontSize = parseInt(getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-size'), 10);
+            fontFamily = getComputedStyle(this.mainPanelRef.current).getPropertyValue('--code-font-family');
+        }
+
+        const style: React.CSSProperties = {
+            fontSize: fontSize,
+            fontFamily: fontFamily
+        };
+
         // Update the state controller with our new state
         this.stateController.renderUpdate(this.state);
         const progressBar = this.state.busy && !this.props.testMode ? <Progress /> : undefined;
@@ -102,7 +114,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             <AddCellLine includePlus={true} className='add-cell-line-top' click={insertAboveFirst} baseTheme={this.props.baseTheme}/>;
 
         return (
-            <div id='main-panel' ref={this.mainPanelRef} role='Main'>
+            <div id='main-panel' ref={this.mainPanelRef} role='Main' style={style}>
                 <div className='styleSetter'>
                     <style>
                         {this.state.rootCss}
@@ -117,7 +129,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 </section>
                 <main id='main-panel-content' onScroll={this.onContentScroll} ref={this.contentPanelScrollRef}>
                     {addCellLine}
-                    {this.renderContentPanel(this.props.baseTheme)}
+                    {this.renderContentPanel(this.props.baseTheme, fontSize, fontFamily)}
                 </main>
             </div>
         );
@@ -226,7 +238,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         return null;
     }
 
-    private renderContentPanel(baseTheme: string) {
+    private renderContentPanel(baseTheme: string, fontSize: number, fontFamily: string) {
         // Skip if the tokenizer isn't finished yet. It needs
         // to finish loading so our code editors work.
         if (!this.state.tokenizerLoaded && !this.props.testMode) {
@@ -234,11 +246,11 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         }
 
         // Otherwise render our cells.
-        const contentProps = this.getContentProps(baseTheme);
+        const contentProps = this.getContentProps(baseTheme, fontSize, fontFamily);
         return <ContentPanel {...contentProps} ref={this.contentPanelRef}/>;
     }
 
-    private getContentProps = (baseTheme: string): IContentPanelProps => {
+    private getContentProps = (baseTheme: string, fontSize: number, fontFamily: string): IContentPanelProps => {
         return {
             baseTheme: baseTheme,
             cellVMs: this.state.cellVMs,
@@ -249,7 +261,9 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             skipNextScroll: this.state.skipNextScroll ? true : false,
             editable: true,
             renderCell: this.renderCell,
-            scrollToBottom: this.scrollDiv
+            scrollToBottom: this.scrollDiv,
+            fontSize: fontSize,
+            fontFamily: fontFamily
         };
     }
     private getVariableProps = (baseTheme: string): IVariablePanelProps => {
@@ -356,7 +370,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     //     });
     // }
 
-    private renderCell = (cellVM: ICellViewModel, index: number): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, index: number, fontSize: number, fontFamily: string): JSX.Element | null => {
         const cellRef : React.RefObject<NativeCell> = React.createRef<NativeCell>();
         const containerRef = React.createRef<HTMLDivElement>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
@@ -401,6 +415,8 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         hideOutput={cellVM.hideOutput}
                         focusCell={this.focusCell}
                         selectCell={this.selectCell}
+                        fontSize={fontSize}
+                        fontFamily={fontFamily}
                     />
                 </ErrorBoundary>
                 {lastLine}

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -83,6 +83,11 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     }
 
     public render() {
+        const dynamicFont: React.CSSProperties = {
+            fontSize: this.state.fontSize,
+            fontFamily: this.state.fontFamily
+        };
+
         // If in test mode, update our count. Use this to determine how many renders a normal update takes.
         if (this.props.testMode) {
             this.renderCount = this.renderCount + 1;
@@ -102,7 +107,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             <AddCellLine includePlus={true} className='add-cell-line-top' click={insertAboveFirst} baseTheme={this.props.baseTheme}/>;
 
         return (
-            <div id='main-panel' ref={this.mainPanelRef} role='Main'>
+            <div id='main-panel' ref={this.mainPanelRef} role='Main' style={dynamicFont}>
                 <div className='styleSetter'>
                     <style>
                         {this.state.rootCss}

--- a/src/datascience-ui/react-common/settingsReactSide.ts
+++ b/src/datascience-ui/react-common/settingsReactSide.ts
@@ -56,6 +56,8 @@ function load() {
             extraSettings: {
                 editorCursor: 'line',
                 editorCursorBlink: 'blink',
+                fontSize: 14,
+                fontFamily: 'Consolas, \'Courier New\', monospace',
                 theme: 'Default Dark+'
             },
             intellisenseOptions: {


### PR DESCRIPTION
We get them in nativeEditor.tsx and in interactivePanel.tsx
to apply them as styles, but we also need to send them
as props to eventually assign them in the monaco editor.

For #7624

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
