### PR TITLE
Open browser after launching a Django or flask app

### DIFF
--- a/news/1 Enhancements/1058.md
+++ b/news/1 Enhancements/1058.md
@@ -1,0 +1,1 @@
+Automatically open browser once a Django or Flask app has been started

--- a/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
@@ -39,7 +39,12 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
                 'runserver',
                 '--noreload'
             ],
-            django: true
+            django: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
         if (!program) {
             const selectedProgram = await input.showInputBox({

--- a/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
@@ -39,7 +39,12 @@ export class FlaskLaunchDebugConfigurationProvider implements IDebugConfiguratio
                 '--no-debugger',
                 '--no-reload'
             ],
-            jinja: true
+            jinja: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         if (!application) {

--- a/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
@@ -139,7 +139,12 @@ suite('Debugging - Configuration Provider Django', () => {
                 'runserver',
                 '--noreload'
             ],
-            django: true
+            django: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -162,7 +167,12 @@ suite('Debugging - Configuration Provider Django', () => {
                 'runserver',
                 '--noreload'
             ],
-            django: true
+            django: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -188,7 +198,12 @@ suite('Debugging - Configuration Provider Django', () => {
                 'runserver',
                 '--noreload'
             ],
-            django: true
+            django: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         expect(state.config).to.be.deep.equal(config);

--- a/src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
@@ -74,7 +74,12 @@ suite('Debugging - Configuration Provider Flask', () => {
                 '--no-debugger',
                 '--no-reload'
             ],
-            jinja: true
+            jinja: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -103,7 +108,12 @@ suite('Debugging - Configuration Provider Flask', () => {
                 '--no-debugger',
                 '--no-reload'
             ],
-            jinja: true
+            jinja: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         expect(state.config).to.be.deep.equal(config);
@@ -132,7 +142,12 @@ suite('Debugging - Configuration Provider Flask', () => {
                 '--no-debugger',
                 '--no-reload'
             ],
-            jinja: true
+            jinja: true,
+            serverReadyAction: {
+                pattern: '(https?:\\/\\/\\S+:[0-9]+\\/?)',
+                uriFormat: '%s',
+                action: 'openExternally'
+            }
         };
 
         expect(state.config).to.be.deep.equal(config);


### PR DESCRIPTION
For #1058

Just removed starting & trailing `.*` from the pattern you suggested @karthiknadig 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
