### PR TITLE
Change skipped test symbol for codelens

### DIFF
--- a/news/2 Fixes/7705.md
+++ b/news/2 Fixes/7705.md
@@ -1,0 +1,1 @@
+Unicode symbol used to mark skipped tests was almost not visible on Linux and Windows

--- a/src/client/testing/codeLenses/testFiles.ts
+++ b/src/client/testing/codeLenses/testFiles.ts
@@ -151,7 +151,7 @@ function getTestStatusIcon(status?: TestStatus): string {
             return '✘ ';
         }
         case TestStatus.Skipped: {
-            return '⃠ ';
+            return '⊘ ';
         }
         default: {
             return '';
@@ -171,7 +171,7 @@ function getTestStatusIcons(fns: TestFunction[]): string {
     }
     count = fns.filter(fn => fn.status === TestStatus.Skipped).length;
     if (count > 0) {
-        statuses.push(`⃠ ${count}`);
+        statuses.push(`⊘ ${count}`);
     }
 
     return statuses.join(' ');


### PR DESCRIPTION
For #7705

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
