### PR TITLE
Fix jupyter server startup when xeus-cling is installed

### DIFF
--- a/news/2 Fixes/7569.md
+++ b/news/2 Fixes/7569.md
@@ -1,0 +1,1 @@
+Fix jupyter server startup when xeus-cling is installed.


### PR DESCRIPTION
For #7569 

From looking at customer logs it seems like we're attempting to start something that isn't actually python to determine if it's python or not. This can hang so making a timeout of 5 seconds to skip these 'interpreters'

