### PR TITLE
Fix jupyter server startup hang when xeus-cling is installed

### DIFF
--- a/news/2 Fixes/7569.md
+++ b/news/2 Fixes/7569.md
@@ -1,0 +1,1 @@
+Fix jupyter server startup hang when xeus-cling kernel is installed.


### PR DESCRIPTION
For #7569 

For some reason when we search for python interpreters we're finding something that isn't a python executable. Launching this executable to ask if it's a python executable can hang if the executable doesn't throw an error. Adding a five second timeout to handle this case.