### PR TITLE
Disable smoke tests against Python 2.7

### DIFF
--- a/build/ci/templates/jobs/smoke.yml
+++ b/build/ci/templates/jobs/smoke.yml
@@ -3,8 +3,9 @@ jobs:
   parameters:
     # In PRs, test only against stable version of VSC.
     vscodeChannels: ['stable']
-    # In PRs, run smoke tests against 3.7 and 2.7 (excluding others).
+    # In PRs, run smoke tests against 3.7 (excluding others).
+    # Azure seems to hang very often when running tests against 2.7
     jobs:
     - test: "Smoke"
       tags: "@smoke"
-      ignorePythonVersions: "3.6,3.5"
+      ignorePythonVersions: "2.7,3.6,3.5"


### PR DESCRIPTION
Smoke tests only existed on Python 3.7 and Azure seems to be very flaky when running tests again Python 2.7 on Linux (Azure hangs pretty often, even when tests have completed).