### PR TITLE
Turn on the native editor by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1608,7 +1608,7 @@
                 },
                 "python.dataScience.useNotebookEditor": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Automatically open .ipynb files in the Notebook Editor.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
We should have done this a while ago, but this setting enables the notebook editor for everyone by default.