### PR TITLE
Fix a number of perf issues with large notebooks

### DIFF
--- a/news/2 Fixes/7483.md
+++ b/news/2 Fixes/7483.md
@@ -1,0 +1,1 @@
+Perf improvements for opening notebooks with more than 100 cells.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14145,7 +14145,7 @@
                 },
                 "os-locale": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
                     "dev": true,
                     "requires": {
@@ -14162,7 +14162,7 @@
                 },
                 "resolve-from": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "resolved": false,
                     "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                     "dev": true
                 },

--- a/package.datascience-ui.dependencies.json
+++ b/package.datascience-ui.dependencies.json
@@ -85,6 +85,7 @@
     "escape-carriage",
     "extend",
     "fast-plist",
+    "immutable",
     "inherits",
     "is-alphabetical",
     "is-alphanumerical",

--- a/package.json
+++ b/package.json
@@ -1608,7 +1608,7 @@
                 },
                 "python.dataScience.useNotebookEditor": {
                     "type": "boolean",
-                    "default": false,
+                    "default": true,
                     "description": "Automatically open .ipynb files in the Notebook Editor.",
                     "scope": "resource"
                 },

--- a/src/client/datascience/interactive-common/intellisense/baseIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/baseIntellisenseProvider.ts
@@ -32,13 +32,13 @@ import {
     IInsertCell,
     IInteractiveWindowMapping,
     ILoadAllCells,
-    IMoveCell,
     INotebookIdentity,
     InteractiveWindowMessages,
     IProvideCompletionItemsRequest,
     IProvideHoverRequest,
     IProvideSignatureHelpRequest,
-    IRemoveCell
+    IRemoveCell,
+    ISwapCells
 } from '../interactiveWindowTypes';
 import { convertStringsToSuggestions } from './conversion';
 import { IntellisenseDocument } from './intellisenseDocument';
@@ -114,8 +114,8 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
                 this.dispatchMessage(message, payload, this.removeCell);
                 break;
 
-            case InteractiveWindowMessages.MoveCell:
-                this.dispatchMessage(message, payload, this.moveCell);
+            case InteractiveWindowMessages.SwapCells:
+                this.dispatchMessage(message, payload, this.swapCells);
                 break;
 
             case InteractiveWindowMessages.DeleteAllCells:
@@ -341,7 +341,7 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
         // Get the document and then pass onto the sub class
         const document = await this.getDocument();
         if (document) {
-            const changes = document.insertCell(request.id, request.index);
+            const changes = document.insertCell(request.id, request.code, request.codeCellAbove);
             return this.handleChanges(undefined, document, changes);
         }
     }
@@ -364,11 +364,11 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
         }
     }
 
-    private async moveCell(request: IMoveCell): Promise<void> {
+    private async swapCells(request: ISwapCells): Promise<void> {
         // First get the document
         const document = await this.getDocument();
         if (document) {
-            const changes = document.move(request.id, request.oldIndex, request.newIndex);
+            const changes = document.swap(request.firstCell, request.secondCell);
             return this.handleChanges(undefined, document, changes);
         }
     }

--- a/src/client/datascience/interactive-common/intellisense/baseIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/baseIntellisenseProvider.ts
@@ -24,19 +24,15 @@ import { IFileSystem, TemporaryFile } from '../../../common/platform/types';
 import { createDeferred, Deferred, waitForPromise } from '../../../common/utils/async';
 import { concatMultilineString } from '../../common';
 import { Identifiers, Settings } from '../../constants';
-import {
-    IInteractiveWindowInfo,
-    IInteractiveWindowListener,
-    IInteractiveWindowProvider,
-    IJupyterExecution,
-    INotebook
-} from '../../types';
+import { IInteractiveWindowListener, IInteractiveWindowProvider, IJupyterExecution, INotebook } from '../../types';
 import {
     IAddCell,
     ICancelIntellisenseRequest,
     IEditCell,
+    IInsertCell,
     IInteractiveWindowMapping,
     ILoadAllCells,
+    IMoveCell,
     INotebookIdentity,
     InteractiveWindowMessages,
     IProvideCompletionItemsRequest,
@@ -110,8 +106,16 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
                 this.dispatchMessage(message, payload, this.addCell);
                 break;
 
+            case InteractiveWindowMessages.InsertCell:
+                this.dispatchMessage(message, payload, this.insertCell);
+                break;
+
             case InteractiveWindowMessages.RemoveCell:
                 this.dispatchMessage(message, payload, this.removeCell);
+                break;
+
+            case InteractiveWindowMessages.MoveCell:
+                this.dispatchMessage(message, payload, this.moveCell);
                 break;
 
             case InteractiveWindowMessages.DeleteAllCells:
@@ -128,10 +132,6 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
 
             case InteractiveWindowMessages.LoadAllCellsComplete:
                 this.dispatchMessage(message, payload, this.loadAllCells);
-                break;
-
-            case InteractiveWindowMessages.SendInfo:
-                this.dispatchMessage(message, payload, this.handleNativeEditorChanges);
                 break;
 
             default:
@@ -337,6 +337,15 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
         }
     }
 
+    private async insertCell(request: IInsertCell): Promise<void> {
+        // Get the document and then pass onto the sub class
+        const document = await this.getDocument();
+        if (document) {
+            const changes = document.insertCell(request.id, request.index);
+            return this.handleChanges(undefined, document, changes);
+        }
+    }
+
     private async editCell(request: IEditCell): Promise<void> {
         // First get the document
         const document = await this.getDocument();
@@ -346,47 +355,45 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
         }
     }
 
-    private removeCell(_request: IRemoveCell): Promise<void> {
-        // Skip this request. The logic here being that
-        // a user can remove a cell from the UI, but it's still loaded into the Jupyter kernel.
-        return Promise.resolve();
+    private async removeCell(request: IRemoveCell): Promise<void> {
+        // First get the document
+        const document = await this.getDocument();
+        if (document) {
+            const changes = document.remove(request.id);
+            return this.handleChanges(undefined, document, changes);
+        }
     }
 
-    private removeAllCells(): Promise<void> {
-        // Skip this request. The logic here being that
-        // a user can remove a cell from the UI, but it's still loaded into the Jupyter kernel.
-        return Promise.resolve();
+    private async moveCell(request: IMoveCell): Promise<void> {
+        // First get the document
+        const document = await this.getDocument();
+        if (document) {
+            const changes = document.move(request.id, request.oldIndex, request.newIndex);
+            return this.handleChanges(undefined, document, changes);
+        }
+    }
+
+    private async removeAllCells(): Promise<void> {
+        // First get the document
+        const document = await this.getDocument();
+        if (document) {
+            const changes = document.removeAll();
+            return this.handleChanges(undefined, document, changes);
+        }
     }
 
     private async loadAllCells(payload: ILoadAllCells) {
         const document = await this.getDocument();
         if (document) {
-            document.switchToEditMode();
-            await Promise.all(payload.cells.map(async cell => {
-                if (cell.data.cell_type === 'code') {
-                    const text = concatMultilineString(cell.data.source);
-                    const addCell: IAddCell = {
-                        fullText: text,
-                        currentText: text,
-                        file: cell.file,
-                        id: cell.id
-                    };
-                    await this.addCell(addCell);
-                }
+            const changes = document.loadAllCells(payload.cells.filter(c => c.data.cell_type === 'code').map(cell => {
+                return {
+                    code: concatMultilineString(cell.data.source),
+                    id: cell.id
+                };
             }));
+
+            await this.handleChanges(Identifiers.EmptyFileName, document, changes);
         }
-    }
-
-    private async handleNativeEditorChanges(payload: IInteractiveWindowInfo) {
-        const document = await this.getDocument();
-        let changes: TextDocumentContentChangeEvent[][] = [];
-        const file = payload.visibleCells[0] ? payload.visibleCells[0].file : undefined;
-
-        if (document) {
-            changes = document.handleNativeEditorCellChanges(payload.visibleCells);
-        }
-
-        await Promise.all(changes.map(c => this.handleChanges(file, document, c)));
     }
 
     private async restartKernel(): Promise<void> {

--- a/src/client/datascience/interactive-common/intellisense/baseIntellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/baseIntellisenseProvider.ts
@@ -368,7 +368,7 @@ export abstract class BaseIntellisenseProvider implements IInteractiveWindowList
         // First get the document
         const document = await this.getDocument();
         if (document) {
-            const changes = document.swap(request.firstCell, request.secondCell);
+            const changes = document.swap(request.firstCellId, request.secondCellId);
             return this.handleChanges(undefined, document, changes);
         }
     }

--- a/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
@@ -8,9 +8,7 @@ import { EndOfLine, Position, Range, TextDocument, TextDocumentContentChangeEven
 import * as vscodeLanguageClient from 'vscode-languageclient';
 
 import { PYTHON_LANGUAGE } from '../../../common/constants';
-import { concatMultilineString } from '../../common';
 import { Identifiers } from '../../constants';
-import { ICell } from '../../types';
 import { DefaultWordPattern, ensureValidWordDefinition, getWordAtText, regExpLeadsToEndlessLoop } from './wordHelper';
 
 class IntellisenseLine implements TextLine {
@@ -118,10 +116,6 @@ export class IntellisenseDocument implements TextDocument {
         return this._lines.length;
     }
 
-    public switchToEditMode() {
-        this.inEditMode = true;
-    }
-
     public lineAt(position: Position | number): TextLine {
         if (typeof position === 'number') {
             return this._lines[position as number];
@@ -198,46 +192,54 @@ export class IntellisenseDocument implements TextDocument {
         };
     }
 
-    public handleNativeEditorCellChanges(cells: ICell[]): TextDocumentContentChangeEvent[][] {
-        const changes: TextDocumentContentChangeEvent[][] = [];
+    public loadAllCells(cells: { code: string; id: string }[]): TextDocumentContentChangeEvent[] {
+        let changes: TextDocumentContentChangeEvent[] = [];
+        if (!this.inEditMode) {
+            this.inEditMode = true;
+            this._version += 1;
 
-        if (this.inEditMode) {
-            const incomingCells = cells.filter(c => c.data.cell_type === 'code');
-            const currentCellCount = this._cellRanges.length - 1;
+            const normalized = cells.map(c => {
+                return {
+                    id: c.id,
+                    code: `${c.code.replace(/\r/g, '')}\n`
+                };
+            });
 
-            if (currentCellCount < incomingCells.length) { // Cell was added
-                incomingCells.forEach((cell, i) => {
-                    if (!this.hasCell(cell.id)) {
-                        const text = concatMultilineString(cell.data.source);
+            // Contents are easy, just load all of the code in a row
+            this._contents = normalized.map(c => c.code).reduce((p, c) => {
+                return `${p}${c}`;
+            });
 
-                        // addCell to the end of the document, or if adding in the middle,
-                        // send the id of the next cell to get its offset in the document
-                        if (i + 1 > incomingCells.length - 1) {
-                            changes.push(this.addCell(text, text, cell.id));
-                        } else {
-                            changes.push(this.addCell(text, text, cell.id, incomingCells[i + 1].id));
-                        }
-                    }
-                });
-            } else if (currentCellCount > incomingCells.length) { // Cell was deleted
-                const change = this.lookForCellToDelete(incomingCells);
+            // Cell ranges are slightly more complicated
+            let prev = 0;
+            this._cellRanges = normalized.map(c => {
+                const result = {
+                    id: c.id,
+                    start: prev,
+                    fullEnd: prev + c.code.length,
+                    currentEnd: prev + c.code.length
+                };
+                prev += c.code.length;
+                return result;
+            });
 
-                if (change.length > 0) {
-                    changes.push(change);
+            // Then create the lines.
+            this._lines = this.createLines();
+
+            // Return our changes
+            changes = [
+                {
+                    range: this.createSerializableRange(new Position(0, 0), new Position(0, 0)),
+                    rangeOffset: 0,
+                    rangeLength: 0, // Adds are always zero
+                    text: this._contents
                 }
-            } else { // Cell might have moved
-                const change = this.lookForCellMovement(incomingCells);
-
-                if (change.length > 0) {
-                    changes.push(change);
-                }
-            }
+            ];
         }
-
         return changes;
     }
 
-    public addCell(fullCode: string, currentCode: string, id: string, cellId?: string): TextDocumentContentChangeEvent[] {
+    public addCell(fullCode: string, currentCode: string, id: string): TextDocumentContentChangeEvent[] {
         // This should only happen once for each cell.
         this._version += 1;
 
@@ -251,50 +253,62 @@ export class IntellisenseDocument implements TextDocument {
         const newCode = `${normalized}\n`;
         const newCurrentCode = `${normalizedCurrent}\n`;
 
-        // We should start just before the last cell for the interactive window
-        // But return the start of the next cell for the native editor,
-        // in case we add a cell at the end in the native editor,
-        // just don't send a cellId to get an offset at the end of the document
-        const fromOffset = this.getEditCellOffset(cellId);
+        // We should start just before the last cell.
+        const fromOffset = this.getEditCellOffset();
 
         // Split our text between the edit text and the cells above
         const before = this._contents.substr(0, fromOffset);
         const after = this._contents.substr(fromOffset);
         const fromPosition = this.positionAt(fromOffset);
 
-        // for the interactive window or if the cell was added last,
-        // add cell to the end
-        let splicePosition = this._cellRanges.length - 1;
-
-        // for the native editor, find the index to add the cell to
-        if (cellId) {
-            const index = this._cellRanges.findIndex(c => c.id === cellId);
-
-            if (index > -1) {
-                splicePosition = index;
-            }
-        }
-
         // Save the range for this cell ()
-        this._cellRanges.splice(splicePosition, 0,
+        this._cellRanges.splice(this._cellRanges.length - 1, 0,
             { id, start: fromOffset, fullEnd: fromOffset + newCode.length, currentEnd: fromOffset + newCurrentCode.length });
 
         // Update our entire contents and recompute our lines
         this._contents = `${before}${newCode}${after}`;
         this._lines = this.createLines();
+        this._cellRanges[this._cellRanges.length - 1].start += newCode.length;
+        this._cellRanges[this._cellRanges.length - 1].fullEnd += newCode.length;
+        this._cellRanges[this._cellRanges.length - 1].currentEnd += newCode.length;
 
-        if (cellId) {
-            // With the native editor, we fix all the positions that changed after adding
-            for (let i = splicePosition + 1; i < this._cellRanges.length; i += 1) {
-                this._cellRanges[i].start += newCode.length;
-                this._cellRanges[i].fullEnd += newCode.length;
-                this._cellRanges[i].currentEnd += newCode.length;
+        return [
+            {
+                range: this.createSerializableRange(fromPosition, fromPosition),
+                rangeOffset: fromOffset,
+                rangeLength: 0, // Adds are always zero
+                text: newCode
             }
-        } else {
-            // with the interactive window, we just fix the positon of the last cell
-            this._cellRanges[this._cellRanges.length - 1].start += newCode.length;
-            this._cellRanges[this._cellRanges.length - 1].fullEnd += newCode.length;
-            this._cellRanges[this._cellRanges.length - 1].currentEnd += newCode.length;
+        ];
+    }
+
+    public insertCell(id: string, index: number): TextDocumentContentChangeEvent[] {
+        // This should only happen once for each cell.
+        this._version += 1;
+
+        // Make sure to put a newline between this code and the next code
+        const newCode = `\n`;
+
+        // Compute where we start from.
+        const fromOffset = index >= 0 ? index < this._cellRanges.length - 1 ? this._cellRanges[index].start : 0 : this._contents.length;
+
+        // Split our text between the text and the cells above
+        const before = this._contents.substr(0, fromOffset);
+        const after = this._contents.substr(fromOffset);
+        const fromPosition = this.positionAt(fromOffset);
+
+        // Update our entire contents and recompute our lines
+        this._contents = `${before}${newCode}${after}`;
+        this._lines = this.createLines();
+
+        // Move all the other cell ranges down
+        this._cellRanges.splice(index, 0,
+            { id, start: fromOffset, fullEnd: fromOffset + newCode.length, currentEnd: fromOffset + newCode.length });
+
+        for (let i = index + 1; i < this._cellRanges.length - 1; i += 1) {
+            this._cellRanges[i].start += newCode.length;
+            this._cellRanges[i].fullEnd += newCode.length;
+            this._cellRanges[i].fullEnd += newCode.length;
         }
 
         return [
@@ -354,12 +368,104 @@ export class IntellisenseDocument implements TextDocument {
                 return this.removeRange(normalized, from, to, cellIndex);
             } else if (cellIndex >= 0) {
                 // This is an edit of a read only cell. Just replace our currentEnd position
-                const newCode = `${normalized}\n`;
+                const newCode = `${normalized} \n`;
                 this._cellRanges[cellIndex].currentEnd = this._cellRanges[cellIndex].start + newCode.length;
             }
         }
 
         return [];
+    }
+
+    public remove(id: string): TextDocumentContentChangeEvent[] {
+        let change: TextDocumentContentChangeEvent[] = [];
+
+        const index = this._cellRanges.findIndex(c => c.id === id);
+        if (index >= 0) {
+            const found = this._cellRanges[index];
+            const from = new Position(this.getLineFromOffset(found.start), 0);
+            const to = this.positionAt(found.currentEnd);
+
+            // for some reason, start for the next cell isn't updated on removeRange,
+            // so we update it here
+            if (index < this._cellRanges.length - 1) {
+                this._cellRanges[index + 1].start = found.start;
+            }
+            this._cellRanges.splice(index, 1);
+            change = this.removeRange('', from, to, index);
+        }
+
+        return change;
+    }
+
+    public move(id: string, oldIndex: number, newIndex: number): TextDocumentContentChangeEvent[] {
+        let change: TextDocumentContentChangeEvent[] = [];
+
+        const index = this._cellRanges.findIndex(c => c.id === id);
+        if (index === oldIndex) {
+            const topIndex = oldIndex < newIndex ? oldIndex : newIndex;
+            const bottomIndex = oldIndex > newIndex ? oldIndex : newIndex;
+            const top = { ...this._cellRanges[topIndex] };
+            const bottom = { ...this._cellRanges[bottomIndex] };
+
+            const from = new Position(this.getLineFromOffset(top.start), 0);
+            const to = this.positionAt(bottom.currentEnd);
+
+            // Swap everything
+            this._cellRanges[topIndex].id = bottom.id;
+            this._cellRanges[topIndex].fullEnd = top.start + (bottom.fullEnd - bottom.start);
+            this._cellRanges[topIndex].currentEnd = top.start + (bottom.currentEnd - bottom.start);
+            this._cellRanges[bottomIndex].id = top.id;
+            this._cellRanges[bottomIndex].start = this._cellRanges[topIndex].fullEnd;
+            this._cellRanges[bottomIndex].fullEnd = this._cellRanges[topIndex].fullEnd + (top.fullEnd - top.start);
+            this._cellRanges[bottomIndex].currentEnd = this._cellRanges[topIndex].fullEnd + (top.currentEnd - top.start);
+
+            const fromOffset = this.convertToOffset(from);
+            const toOffset = this.convertToOffset(to);
+
+            // Recreate our contents, and then recompute all of our lines
+            const before = this._contents.substr(0, fromOffset);
+            const topText = this._contents.substr(top.start, top.fullEnd - top.start);
+            const bottomText = this._contents.substr(bottom.start, bottom.fullEnd - bottom.start);
+            const after = this._contents.substr(toOffset);
+            const replacement = `${bottomText}${topText}`;
+            this._contents = `${before}${replacement}${after}`;
+            this._lines = this.createLines();
+
+            // Change is a full replacement
+            change = [
+                {
+                    range: this.createSerializableRange(from, to),
+                    rangeOffset: fromOffset,
+                    rangeLength: toOffset - fromOffset,
+                    text: replacement
+                }
+            ];
+        }
+
+        return change;
+    }
+
+    public removeAll(): TextDocumentContentChangeEvent[] {
+        let change: TextDocumentContentChangeEvent[] = [];
+        if (this._lines.length > 0) {
+            const from = this._lines[0].range.start;
+            const to = this._lines[this._lines.length - 1].rangeIncludingLineBreak.end;
+            const length = this._contents.length;
+            this._cellRanges = [];
+            this._contents = '';
+            this._lines = [];
+
+            change = [
+                {
+                    range: this.createSerializableRange(from, to),
+                    rangeOffset: 0,
+                    rangeLength: length,
+                    text: ''
+                }
+            ];
+        }
+
+        return change;
     }
 
     public convertToDocumentPosition(id: string, line: number, ch: number): Position {
@@ -405,11 +511,6 @@ export class IntellisenseDocument implements TextDocument {
         return this._cellRanges[this._cellRanges.length - 1].start;
     }
 
-    private hasCell(cellId: string) {
-        const foundIt = this._cellRanges.find(c => c.id === cellId);
-        return foundIt ? true : false;
-    }
-
     private getLineFromOffset(offset: number) {
         let lineCounter = 0;
 
@@ -420,83 +521,6 @@ export class IntellisenseDocument implements TextDocument {
         }
 
         return lineCounter;
-    }
-
-    private lookForCellToDelete(incomingCells: ICell[]): TextDocumentContentChangeEvent[] {
-        let change: TextDocumentContentChangeEvent[] = [];
-
-        this._cellRanges.forEach((cell, i) => {
-            const foundIt = incomingCells.find(c => c.id === cell.id);
-
-            // if cell is not found in the document and its not the last edit cell, we remove it
-            if (!foundIt && i !== this._cellRanges.length - 1) {
-                const from = new Position(this.getLineFromOffset(cell.start), 0);
-                const to = this.positionAt(cell.currentEnd);
-
-                // for some reason, start for the next cell isn't updated on removeRange,
-                // so we update it here
-                this._cellRanges[i + 1].start = cell.start;
-                this._cellRanges.splice(i, 1);
-                change = this.removeRange('', from, to, i);
-            }
-        });
-
-        return change;
-    }
-
-    private lookForCellMovement(incomingCells: ICell[]): TextDocumentContentChangeEvent[] {
-        for (let i = 0; i < incomingCells.length && this._cellRanges.length > 1; i += 1) {
-
-            if (incomingCells[i].id !== this._cellRanges[i].id) {
-                const lineBreak = '\n';
-                const text = this._contents.substr(this._cellRanges[i].start, this._cellRanges[i].currentEnd - this._cellRanges[i].start - 1);
-                const newText = concatMultilineString(incomingCells[i].data.source) + lineBreak + text + lineBreak;
-
-                // swap contents
-                this._contents = this._contents.substring(0, this._cellRanges[i].start)
-                    + this._contents.substring(this._cellRanges[i + 1].start, this._cellRanges[i + 1].fullEnd)
-                    + this._contents.substring(this._cellRanges[i].start, this._cellRanges[i].fullEnd)
-                    + this._contents.substring(this._cellRanges[i + 1].fullEnd);
-
-                // create lines
-                this._lines = this.createLines();
-
-                // swap cell ranges
-                const temp1Id = this._cellRanges[i].id;
-                const temp1Start = this._cellRanges[i].start;
-                const temp1End = this._cellRanges[i].fullEnd;
-                const temp1Length = temp1End - temp1Start;
-
-                const temp2Id = this._cellRanges[i + 1].id;
-                const temp2Start = this._cellRanges[i + 1].start;
-                const temp2End = this._cellRanges[i + 1].fullEnd;
-                const temp2Length = temp2End - temp2Start;
-
-                this._cellRanges[i].id = temp2Id;
-                this._cellRanges[i].start = temp1Start;
-                this._cellRanges[i].currentEnd = temp1Start + temp2Length;
-                this._cellRanges[i].fullEnd = temp1Start + temp2Length;
-
-                this._cellRanges[i + 1].id = temp1Id;
-                this._cellRanges[i + 1].start = temp1Start + temp2Length;
-                this._cellRanges[i + 1].currentEnd = temp1Start + temp2Length + temp1Length;
-                this._cellRanges[i + 1].fullEnd = temp1Start + temp2Length + temp1Length;
-
-                const from = new Position(this.getLineFromOffset(temp1Start), 0);
-                const to = new Position(this.getLineFromOffset(temp2End - 1), temp2End - temp2Start);
-                const fromOffset = temp1Start;
-                const toOffset = temp2End;
-
-                return [{
-                    range: this.createSerializableRange(from, to),
-                    rangeOffset: fromOffset,
-                    rangeLength: toOffset - fromOffset,
-                    text: newText
-                }];
-            }
-        }
-
-        return [];
     }
 
     private removeRange(newText: string, from: Position, to: Position, cellIndex: number): TextDocumentContentChangeEvent[] {

--- a/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
@@ -198,6 +198,8 @@ export class IntellisenseDocument implements TextDocument {
             this.inEditMode = true;
             this._version += 1;
 
+            // Normalize all of the cells, removing \r and separating each
+            // with a newline
             const normalized = cells.map(c => {
                 return {
                     id: c.id,
@@ -599,6 +601,9 @@ export class IntellisenseDocument implements TextDocument {
     }
 
     private createSerializableRange(start: Position, end: Position): Range {
+        // This funciton is necessary so that the Range can be passed back
+        // over a remote connection without including all of the extra fields that
+        // VS code puts into a Range object.
         const result = {
             start: {
                 line: start.line,

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -51,7 +51,7 @@ export namespace InteractiveWindowMessages {
     export const AddCell = 'add_cell';
     export const EditCell = 'edit_cell';
     export const RemoveCell = 'remove_cell';
-    export const MoveCell = 'move_cell';
+    export const SwapCells = 'swap_cells';
     export const InsertCell = 'insert_cell';
     export const LoadOnigasmAssemblyRequest = 'load_onigasm_assembly_request';
     export const LoadOnigasmAssemblyResponse = 'load_onigasm_assembly_response';
@@ -212,15 +212,15 @@ export interface IRemoveCell {
     id: string;
 }
 
-export interface IMoveCell {
-    id: string;
-    oldIndex: number;
-    newIndex: number;
+export interface ISwapCells {
+    firstCell: string;
+    secondCell: string;
 }
 
 export interface IInsertCell {
     id: string;
-    index: number;
+    code: string;
+    codeCellAbove: string | undefined;
 }
 
 export interface IShowDataViewer {
@@ -297,7 +297,7 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.AddCell]: IAddCell;
     public [InteractiveWindowMessages.EditCell]: IEditCell;
     public [InteractiveWindowMessages.RemoveCell]: IRemoveCell;
-    public [InteractiveWindowMessages.MoveCell]: IMoveCell;
+    public [InteractiveWindowMessages.SwapCells]: ISwapCells;
     public [InteractiveWindowMessages.InsertCell]: IInsertCell;
     public [InteractiveWindowMessages.LoadOnigasmAssemblyRequest]: never | undefined;
     public [InteractiveWindowMessages.LoadOnigasmAssemblyResponse]: Buffer;

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -51,6 +51,8 @@ export namespace InteractiveWindowMessages {
     export const AddCell = 'add_cell';
     export const EditCell = 'edit_cell';
     export const RemoveCell = 'remove_cell';
+    export const MoveCell = 'move_cell';
+    export const InsertCell = 'insert_cell';
     export const LoadOnigasmAssemblyRequest = 'load_onigasm_assembly_request';
     export const LoadOnigasmAssemblyResponse = 'load_onigasm_assembly_response';
     export const LoadTmLanguageRequest = 'load_tmlanguage_request';
@@ -210,6 +212,17 @@ export interface IRemoveCell {
     id: string;
 }
 
+export interface IMoveCell {
+    id: string;
+    oldIndex: number;
+    newIndex: number;
+}
+
+export interface IInsertCell {
+    id: string;
+    index: number;
+}
+
 export interface IShowDataViewer {
     variableName: string;
     columnSize: number;
@@ -284,6 +297,8 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.AddCell]: IAddCell;
     public [InteractiveWindowMessages.EditCell]: IEditCell;
     public [InteractiveWindowMessages.RemoveCell]: IRemoveCell;
+    public [InteractiveWindowMessages.MoveCell]: IMoveCell;
+    public [InteractiveWindowMessages.InsertCell]: IInsertCell;
     public [InteractiveWindowMessages.LoadOnigasmAssemblyRequest]: never | undefined;
     public [InteractiveWindowMessages.LoadOnigasmAssemblyResponse]: Buffer;
     public [InteractiveWindowMessages.LoadTmLanguageRequest]: never | undefined;

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -213,8 +213,8 @@ export interface IRemoveCell {
 }
 
 export interface ISwapCells {
-    firstCell: string;
-    secondCell: string;
+    firstCellId: string;
+    secondCellId: string;
 }
 
 export interface IInsertCell {

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -4,6 +4,7 @@
 import '../../client/common/extensions';
 
 import { nbformat } from '@jupyterlab/coreutils';
+import * as fastDeepEqual from 'fast-deep-equal';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import * as React from 'react';
 
@@ -35,10 +36,6 @@ interface IInteractiveCellProps {
     editorOptions?: monacoEditor.editor.IEditorOptions;
     editExecutionCount?: string;
     editorMeasureClassName?: string;
-    selectedCell?: string;
-    focusedCell?: string;
-    hideOutput?: boolean;
-    showLineNumbers?: boolean;
     onCodeChange(changes: monacoEditor.editor.IModelContentChange[], cellId: string, modelId: string): void;
     onCodeCreated(code: string, file: string, cellId: string, modelId: string): void;
     openLink(uri: monacoEditor.Uri): void;
@@ -71,9 +68,13 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
     }
 
     public componentDidUpdate(prevProps: IInteractiveCellProps) {
-        if (this.props.selectedCell === this.props.cellVM.cell.id && prevProps.selectedCell !== this.props.selectedCell) {
-            this.giveFocus(this.props.focusedCell === this.props.cellVM.cell.id);
+        if (this.props.cellVM.selected && !prevProps.cellVM.selected) {
+            this.giveFocus(this.props.cellVM.focused);
         }
+    }
+
+    public shouldComponentUpdate(nextProps: IInteractiveCellProps): boolean {
+        return !fastDeepEqual(this.props, nextProps);
     }
 
     public scrollAndFlash() {
@@ -210,7 +211,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
                     focused={this.onCodeFocused}
                     unfocused={this.onCodeUnfocused}
                     keyDown={this.props.keyDown}
-                    showLineNumbers={this.props.showLineNumbers}
+                    showLineNumbers={this.props.cellVM.showLineNumbers}
                 />
             );
         }
@@ -238,7 +239,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
     }
 
     private shouldRenderResults(): boolean {
-        return this.isCodeCell() && this.hasOutput() && this.getCodeCell().outputs && this.getCodeCell().outputs.length > 0 && !this.props.hideOutput;
+        return this.isCodeCell() && this.hasOutput() && this.getCodeCell().outputs && this.getCodeCell().outputs.length > 0 && !this.props.cellVM.hideOutput;
     }
 
     private onCellKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -344,8 +344,6 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
                         openLink={this.stateController.openLink}
                         expandImage={this.stateController.showPlot}
                         renderCellToolbar={this.renderCellToolbar}
-                        showLineNumbers={cellVM.showLineNumbers}
-                        hideOutput={cellVM.hideOutput}
                     />
                 </ErrorBoundary>
             </div>);

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -55,11 +55,11 @@ export interface IMainState {
     pendingVariableCount: number;
     debugging: boolean;
     dirty?: boolean;
-    selectedCell?: string;
-    focusedCell?: string;
+    selectedCellId?: string;
+    focusedCellId?: string;
     enableGather: boolean;
     isAtBottom: boolean;
-    newCell?: string;
+    newCellId?: string;
     loadTotal?: number;
 }
 

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -26,6 +26,8 @@ export interface ICellViewModel {
     showLineNumbers?: boolean;
     hideOutput?: boolean;
     useQuickEdit?: boolean;
+    selected: boolean;
+    focused: boolean;
     inputBlockToggled(id: string): void;
 }
 
@@ -135,7 +137,9 @@ export function createEditableCellVM(executionCount: number): ICellViewModel {
         inputBlockShow: true,
         inputBlockText: '',
         inputBlockCollapseNeeded: false,
-        inputBlockToggled: noop
+        inputBlockToggled: noop,
+        selected: false,
+        focused: false
     };
 }
 
@@ -176,7 +180,9 @@ export function createCellVM(inputCell: ICell, settings: IDataScienceSettings | 
         inputBlockShow: true,
         inputBlockText: inputText,
         inputBlockCollapseNeeded: (inputLinesCount > 1),
-        inputBlockToggled: inputBlockToggled
+        inputBlockToggled: inputBlockToggled,
+        selected: false,
+        focused: false
     };
 }
 

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -187,7 +187,7 @@ export function createCellVM(inputCell: ICell, settings: IDataScienceSettings | 
 }
 
 function generateVMs(inputBlockToggled: (id: string) => void, filePath: string, editable: boolean): ICellViewModel[] {
-    const cells = generateCells(filePath);
+    const cells = generateCells(filePath, 10);
     return cells.map((cell: ICell) => {
         const vm = createCellVM(cell, undefined, inputBlockToggled, editable);
         vm.useQuickEdit = false;
@@ -195,10 +195,10 @@ function generateVMs(inputBlockToggled: (id: string) => void, filePath: string, 
     });
 }
 
-function generateCells(filePath: string): ICell[] {
+export function generateCells(filePath: string, repetitions: number): ICell[] {
     // Dupe a bunch times for perf reasons
     let cellData: (nbformat.ICodeCell | nbformat.IMarkdownCell | nbformat.IRawCell | IMessageCell)[] = [];
-    for (let i = 0; i < 10; i += 1) {
+    for (let i = 0; i < repetitions; i += 1) {
         cellData = [...cellData, ...generateCellData()];
     }
     return cellData.map((data: nbformat.ICodeCell | nbformat.IMarkdownCell | nbformat.IRawCell | IMessageCell, key: number) => {

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -453,7 +453,7 @@ export class MainStateController implements IMessageHandler {
     public toggleVariableExplorer = () => {
         this.sendMessage(InteractiveWindowMessages.VariableExplorerToggle, !this.pendingState.variablesVisible);
         this.setState({ variablesVisible: !this.pendingState.variablesVisible });
-        if (!this.pendingState.variablesVisible) {
+        if (this.pendingState.variablesVisible) {
             this.refreshVariables();
         }
     }

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -299,13 +299,13 @@ export class MainStateController implements IMessageHandler {
             this.sendMessage(InteractiveWindowMessages.RemoveCell, { id: cellId });
 
             // Recompute select/focus if this item has either
-            let newSelection = this.pendingState.selectedCell;
-            let newFocused = this.pendingState.focusedCell;
+            let newSelection = this.pendingState.selectedCellId;
+            let newFocused = this.pendingState.focusedCellId;
             const newVMs = [...this.pendingState.cellVMs.filter(c => c.cell.id !== cellId)];
             const nextOrPrev = index === this.pendingState.cellVMs.length - 1 ? index - 1 : index;
-            if (this.pendingState.selectedCell === cellId || this.pendingState.focusedCell === cellId) {
+            if (this.pendingState.selectedCellId === cellId || this.pendingState.focusedCellId === cellId) {
                 if (nextOrPrev >= 0) {
-                    newVMs[nextOrPrev] = { ...newVMs[nextOrPrev], selected: true, focused: this.pendingState.focusedCell === cellId };
+                    newVMs[nextOrPrev] = { ...newVMs[nextOrPrev], selected: true, focused: this.pendingState.focusedCellId === cellId };
                     newSelection = newVMs[nextOrPrev].cell.id;
                     newFocused = newVMs[nextOrPrev].focused ? newVMs[nextOrPrev].cell.id : undefined;
                 }
@@ -501,7 +501,7 @@ export class MainStateController implements IMessageHandler {
 
     public codeLostFocus = (cellId: string) => {
         this.onCodeLostFocus(cellId);
-        if (this.pendingState.focusedCell === cellId) {
+        if (this.pendingState.focusedCellId === cellId) {
             const newVMs = [...this.pendingState.cellVMs];
             // Switch the old vm
             const oldSelect = this.findCellIndex(cellId);
@@ -515,10 +515,10 @@ export class MainStateController implements IMessageHandler {
 
     public codeGotFocus = (cellId: string | undefined) => {
         // Skip if already has focus
-        if (cellId !== this.pendingState.focusedCell) {
+        if (cellId !== this.pendingState.focusedCellId) {
             const newVMs = [...this.pendingState.cellVMs];
             // Switch the old vm
-            const oldSelect = this.findCellIndex(this.pendingState.selectedCell);
+            const oldSelect = this.findCellIndex(this.pendingState.selectedCellId);
             if (oldSelect >= 0) {
                 newVMs[oldSelect] = { ...newVMs[oldSelect], selected: false, focused: false };
             }
@@ -534,10 +534,10 @@ export class MainStateController implements IMessageHandler {
 
     public selectCell = (cellId: string, focusedCell?: string) => {
         // Skip if already the same cell
-        if (this.pendingState.selectedCell !== cellId || this.pendingState.focusedCell !== focusedCell) {
+        if (this.pendingState.selectedCellId !== cellId || this.pendingState.focusedCellId !== focusedCell) {
             const newVMs = [...this.pendingState.cellVMs];
             // Switch the old vm
-            const oldSelect = this.findCellIndex(this.pendingState.selectedCell);
+            const oldSelect = this.findCellIndex(this.pendingState.selectedCellId);
             if (oldSelect >= 0) {
                 newVMs[oldSelect] = { ...newVMs[oldSelect], selected: false, focused: false };
             }

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -553,6 +553,11 @@ export class MainStateController implements IMessageHandler {
             const cellVMs = [...this.pendingState.cellVMs];
             cellVMs[index] = immutable.updateIn(this.pendingState.cellVMs[index], ['cell', 'data', 'cell_type'], () => newType);
             this.setState({ cellVMs });
+            if (newType === 'code') {
+                this.sendMessage(InteractiveWindowMessages.InsertCell, { id: cellId, index });
+            } else {
+                this.sendMessage(InteractiveWindowMessages.RemoveCell, { id: cellId });
+            }
         }
     }
 

--- a/src/datascience-ui/interactive-common/markdown.tsx
+++ b/src/datascience-ui/interactive-common/markdown.tsx
@@ -34,7 +34,10 @@ export class Markdown extends React.Component<IMarkdownProps> {
     }
 
     public render() {
+        const classes = 'markdown-editor-area';
+
         return (
+            <div className={classes}>
                 <Editor
                     codeTheme={this.props.codeTheme}
                     autoFocus={this.props.autoFocus}
@@ -57,6 +60,7 @@ export class Markdown extends React.Component<IMarkdownProps> {
                     showLineNumbers={this.props.showLineNumbers}
                     useQuickEdit={this.props.useQuickEdit}
                 />
+            </div>
         );
     }
 

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -182,8 +182,8 @@ export class NativeCell extends React.Component<INativeCellProps> {
     private onMouseClick = (ev: React.MouseEvent<HTMLDivElement>) => {
         if (ev.nativeEvent.target) {
             const elem = ev.nativeEvent.target as HTMLElement;
-            if (!elem.className.includes('image')) {
-                // Not a click on an image, select the cell.
+            if (!elem.className.includes('image-button')) {
+                // Not a click on an button in a toolbar, select the cell.
                 ev.stopPropagation();
                 this.lastKeyPressed = undefined;
                 const focusedCell = this.isFocused() ? this.cellId : undefined;

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -670,11 +670,6 @@ export class NativeCell extends React.Component<INativeCellProps> {
     }
 
     private onMarkdownUnfocused = () => {
-        // Indicate not showing the editor anymore. The equivalent of this
-        // is not when we receive focus but when we GIVE focus to the markdown editor
-        // otherwise we wouldn't be able to display it.
-        this.setState({showingMarkdownEditor: false});
-
         // There might be a pending focus loss handler.
         if (this.pendingFocusLoss) {
             const func = this.pendingFocusLoss;

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -186,11 +186,16 @@ export class NativeCell extends React.Component<INativeCellProps, INativeCellSta
     }
 
     private onMouseClick = (ev: React.MouseEvent<HTMLDivElement>) => {
-        // When we receive a click, propagate upwards. Might change our state
-        ev.stopPropagation();
-        this.lastKeyPressed = undefined;
-        const focusedCell = this.isFocused() ? this.cellId : undefined;
-        this.props.stateController.selectCell(this.cellId, focusedCell);
+        if (ev.nativeEvent.target) {
+            const elem = ev.nativeEvent.target as HTMLElement;
+            if (!elem.className.includes('image')) {
+                // Not a click on an image, select the cell.
+                ev.stopPropagation();
+                this.lastKeyPressed = undefined;
+                const focusedCell = this.isFocused() ? this.cellId : undefined;
+                this.props.stateController.selectCell(this.cellId, focusedCell);
+            }
+        }
     }
 
     private onMouseDoubleClick = (ev: React.MouseEvent<HTMLDivElement>) => {
@@ -293,12 +298,8 @@ export class NativeCell extends React.Component<INativeCellProps, INativeCellSta
                 if (this.lastKeyPressed === 'd' && !this.isFocused()  && this.isSelected()) {
                     e.stopPropagation();
                     this.lastKeyPressed = undefined; // Reset it so we don't keep deleting
-                    const cellToSelect = this.getPrevCellId() || this.getNextCellId();
                     this.props.stateController.possiblyDeleteCell(cellId);
                     this.props.stateController.sendCommand(NativeCommandType.DeleteCell, 'keyboard');
-                    if (cellToSelect) {
-                        this.moveSelection(cellToSelect);
-                    }
                 }
                 break;
             case 'a':
@@ -546,14 +547,8 @@ export class NativeCell extends React.Component<INativeCellProps, INativeCellSta
     private renderMiddleToolbar = () => {
         const cellId = this.props.cellVM.cell.id;
         const deleteCell = () => {
-            const cellToSelect = this.getNextCellId() || this.getPrevCellId();
             this.props.stateController.possiblyDeleteCell(cellId);
             this.props.stateController.sendCommand(NativeCommandType.DeleteCell, 'mouse');
-            setTimeout(() => {
-                if (cellToSelect) {
-                    this.moveSelection(cellToSelect);
-                }
-            }, 10);
         };
         const runAbove = () => {
             this.props.stateController.runAbove(cellId);

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -33,6 +33,7 @@ interface INativeCellProps {
     maxTextSize?: number;
     stateController: NativeEditorStateController;
     monacoTheme: string | undefined;
+    lastCell: boolean;
     focusCell(cellId: string, focusCode: boolean): void;
     selectCell(cellId: string): void;
 }
@@ -502,7 +503,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         };
         const canMoveUp = this.props.stateController.canMoveUp(cellId);
         const canMoveDown = this.props.stateController.canMoveDown(cellId);
-        const addButtonRender = this.getNextCellId() !== undefined ?
+        const addButtonRender = !this.props.lastCell ?
             <div className='navbar-add-button'>
                 <ImageButton baseTheme={this.props.baseTheme} onClick={this.addNewCell} tooltip={getLocString('DataScience.insertBelow', 'Insert cell below')}>
                     <Image baseTheme={this.props.baseTheme} class='image-button-image' image={ImageName.InsertBelow} />

--- a/src/datascience-ui/native-editor/nativeEditor.less
+++ b/src/datascience-ui/native-editor/nativeEditor.less
@@ -115,6 +115,16 @@
     background: var(--override-widget-background, var(--vscode-notifications-background));
 }
 
+.markdown-editor-area {
+    position: relative;
+    width:100%;
+    padding-right: 10px;
+    margin-bottom: 0px;
+    padding-left: 2px;
+    padding-top: 2px;
+    background: var(--override-widget-background, var(--vscode-notifications-background));
+}
+
 .code-watermark {
     top: 5px; /* Account for extra padding and border in native editor */
 }

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -402,6 +402,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     }
 
     private focusCell = (cellId: string, focusCode: boolean): void => {
+        this.stateController.selectCell(cellId, focusCode ? cellId : undefined);
         const ref = this.cellRefs.get(cellId);
         if (ref && ref.current) {
             ref.current.giveFocus(focusCode);

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -3,7 +3,6 @@
 'use strict';
 import './nativeEditor.less';
 
-import * as immutable from 'immutable';
 import * as React from 'react';
 
 import { noop } from '../../client/common/utils/misc';
@@ -291,7 +290,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         } else if (bottom < visibleTop) {
                             continue;
                         } else {
-                            cellVMs[i] = immutable.merge(cellVM, { useQuickEdit: false });
+                            cellVMs[i] = {...cellVM, useQuickEdit: false };
                             makeChange = true;
                         }
                     }

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -147,7 +147,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     private moveSelectionToExisting = (cellId: string) => {
         // Cell should already exist in the UI
         if (this.contentPanelRef) {
-            const wasFocused = this.state.focusedCell !== undefined;
+            const wasFocused = this.state.focusedCellId !== undefined;
             this.stateController.selectCell(cellId, wasFocused ? cellId : undefined);
             this.focusCell(cellId, wasFocused ? true : false);
         }
@@ -159,7 +159,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         if (cells.find(c => c.id === id)) {
             // Force selection change right now as we don't need the cell to exist
             // to make it selected (otherwise we'll get a flash)
-            const wasFocused = this.state.focusedCell !== undefined;
+            const wasFocused = this.state.focusedCellId !== undefined;
             this.stateController.selectCell(id, wasFocused ? id : undefined);
 
             // Then wait to give it actual input focus
@@ -416,8 +416,8 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
     }
 
     private scrollDiv = (_div: HTMLDivElement) => {
-        if (this.state.newCell) {
-            const newCell = this.state.newCell;
+        if (this.state.newCellId) {
+            const newCell = this.state.newCellId;
             this.stateController.setState({newCell: undefined});
             // Bounce this so state has time to update.
             setTimeout(() => {

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -3,6 +3,7 @@
 'use strict';
 import './nativeEditor.less';
 
+import * as immutable from 'immutable';
 import * as React from 'react';
 
 import { noop } from '../../client/common/utils/misc';
@@ -24,8 +25,6 @@ import { NativeEditorStateController } from './nativeEditorStateController';
 // tslint:disable: react-this-binding-issue
 // tslint:disable-next-line:no-require-imports no-var-requires
 const debounce = require('lodash/debounce') as typeof import('lodash/debounce');
-// tslint:disable-next-line: no-require-imports
-import cloneDeep = require('lodash/cloneDeep');
 
 interface INativeEditorProps {
     skipDefault: boolean;
@@ -292,8 +291,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         } else if (bottom < visibleTop) {
                             continue;
                         } else {
-                            cellVMs[i] = cloneDeep(cellVM);
-                            cellVMs[i].useQuickEdit = false;
+                            cellVMs[i] = immutable.merge(cellVM, { useQuickEdit: false });
                             makeChange = true;
                         }
                     }
@@ -395,10 +393,6 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         baseTheme={this.props.baseTheme}
                         codeTheme={this.props.codeTheme}
                         monacoTheme={this.state.monacoTheme}
-                        showLineNumbers={cellVM.showLineNumbers}
-                        selectedCell={this.state.selectedCell}
-                        focusedCell={this.state.focusedCell}
-                        hideOutput={cellVM.hideOutput}
                         focusCell={this.focusCell}
                         selectCell={this.selectCell}
                     />

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -395,6 +395,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                         monacoTheme={this.state.monacoTheme}
                         focusCell={this.focusCell}
                         selectCell={this.selectCell}
+                        lastCell={lastLine !== null}
                     />
                 </ErrorBoundary>
                 {lastLine}

--- a/src/datascience-ui/native-editor/nativeEditorStateController.ts
+++ b/src/datascience-ui/native-editor/nativeEditorStateController.ts
@@ -93,7 +93,7 @@ export class NativeEditorStateController extends MainStateController {
         const pos = selectedCell ? cells.findIndex(cvm => cvm.cell.id === this.getState().selectedCell) + 1 : cells.length;
         this.setState({ newCell: id });
         const vm = this.insertCell(createEmptyCell(id, null), pos);
-        this.sendMessage(InteractiveWindowMessages.InsertCell, { id, index: pos });
+        this.sendMessage(InteractiveWindowMessages.InsertCell, { id, code: '', codeCellAbove: this.firstCodeCellAbove(id) });
         if (vm) {
             // Make sure the new cell is monaco
             vm.useQuickEdit = false;
@@ -154,7 +154,7 @@ export class NativeEditorStateController extends MainStateController {
             const id = uuid();
             this.setState({ newCell: id });
             this.insertCell(createEmptyCell(id, null), index, isMonaco);
-            this.sendMessage(InteractiveWindowMessages.InsertCell, { id, index });
+            this.sendMessage(InteractiveWindowMessages.InsertCell, { id, code: '', codeCellAbove: this.firstCodeCellAbove(id) });
             this.resumeUpdates();
             return id;
         }
@@ -168,7 +168,7 @@ export class NativeEditorStateController extends MainStateController {
             const id = uuid();
             this.setState({ newCell: id });
             this.insertCell(createEmptyCell(id, null), index + 1, isMonaco);
-            this.sendMessage(InteractiveWindowMessages.InsertCell, { id, index: index + 1 });
+            this.sendMessage(InteractiveWindowMessages.InsertCell, { id, code: '', codeCellAbove: this.firstCodeCellAbove(id) });
             this.resumeUpdates();
             return id;
         }
@@ -184,7 +184,7 @@ export class NativeEditorStateController extends MainStateController {
                 cellVMs: cellVms,
                 undoStack: this.pushStack(this.getState().undoStack, origVms)
             });
-            this.sendMessage(InteractiveWindowMessages.MoveCell, { id: cellId!, oldIndex: index, newIndex: index - 1 });
+            this.sendMessage(InteractiveWindowMessages.SwapCells, { firstCell: cellId!, secondCell: cellVms[index].cell.id });
         }
     }
 
@@ -198,7 +198,7 @@ export class NativeEditorStateController extends MainStateController {
                 cellVMs: cellVms,
                 undoStack: this.pushStack(this.getState().undoStack, origVms)
             });
-            this.sendMessage(InteractiveWindowMessages.MoveCell, { id: cellId!, oldIndex: index, newIndex: index + 1 });
+            this.sendMessage(InteractiveWindowMessages.SwapCells, { firstCell: cellId!, secondCell: cellVms[index].cell.id });
         }
     }
 

--- a/src/datascience-ui/native-editor/nativeEditorStateController.ts
+++ b/src/datascience-ui/native-editor/nativeEditorStateController.ts
@@ -112,7 +112,9 @@ export class NativeEditorStateController extends MainStateController {
                 inputBlockShow: true,
                 inputBlockText: '',
                 inputBlockCollapseNeeded: false,
-                inputBlockToggled: noop
+                inputBlockToggled: noop,
+                selected: cells[0].selected,
+                focused: cells[0].focused
             };
             this.setState({ cellVMs: [newVM], undoStack: this.pushStack(this.getState().undoStack, cells) });
         } else {

--- a/src/datascience-ui/native-editor/nativeEditorStateController.ts
+++ b/src/datascience-ui/native-editor/nativeEditorStateController.ts
@@ -93,6 +93,7 @@ export class NativeEditorStateController extends MainStateController {
         const pos = selectedCell ? cells.findIndex(cvm => cvm.cell.id === this.getState().selectedCell) + 1 : cells.length;
         this.setState({ newCell: id });
         const vm = this.insertCell(createEmptyCell(id, null), pos);
+        this.sendMessage(InteractiveWindowMessages.InsertCell, { id, index: pos });
         if (vm) {
             // Make sure the new cell is monaco
             vm.useQuickEdit = false;
@@ -153,6 +154,7 @@ export class NativeEditorStateController extends MainStateController {
             const id = uuid();
             this.setState({ newCell: id });
             this.insertCell(createEmptyCell(id, null), index, isMonaco);
+            this.sendMessage(InteractiveWindowMessages.InsertCell, { id, index });
             this.resumeUpdates();
             return id;
         }
@@ -166,6 +168,7 @@ export class NativeEditorStateController extends MainStateController {
             const id = uuid();
             this.setState({ newCell: id });
             this.insertCell(createEmptyCell(id, null), index + 1, isMonaco);
+            this.sendMessage(InteractiveWindowMessages.InsertCell, { id, index: index + 1 });
             this.resumeUpdates();
             return id;
         }
@@ -181,6 +184,7 @@ export class NativeEditorStateController extends MainStateController {
                 cellVMs: cellVms,
                 undoStack: this.pushStack(this.getState().undoStack, origVms)
             });
+            this.sendMessage(InteractiveWindowMessages.MoveCell, { id: cellId!, oldIndex: index, newIndex: index - 1 });
         }
     }
 
@@ -194,6 +198,7 @@ export class NativeEditorStateController extends MainStateController {
                 cellVMs: cellVms,
                 undoStack: this.pushStack(this.getState().undoStack, origVms)
             });
+            this.sendMessage(InteractiveWindowMessages.MoveCell, { id: cellId!, oldIndex: index, newIndex: index + 1 });
         }
     }
 

--- a/src/datascience-ui/native-editor/nativeEditorStateController.ts
+++ b/src/datascience-ui/native-editor/nativeEditorStateController.ts
@@ -87,10 +87,10 @@ export class NativeEditorStateController extends MainStateController {
 
     public addNewCell = (): ICellViewModel | undefined => {
         const cells = this.getState().cellVMs;
-        const selectedCell = this.getState().selectedCell;
+        const selectedCell = this.getState().selectedCellId;
         this.suspendUpdates();
         const id = uuid();
-        const pos = selectedCell ? cells.findIndex(cvm => cvm.cell.id === this.getState().selectedCell) + 1 : cells.length;
+        const pos = selectedCell ? cells.findIndex(cvm => cvm.cell.id === this.getState().selectedCellId) + 1 : cells.length;
         this.setState({ newCell: id });
         const vm = this.insertCell(createEmptyCell(id, null), pos);
         this.sendMessage(InteractiveWindowMessages.InsertCell, { id, code: '', codeCellAbove: this.firstCodeCellAbove(id) });
@@ -184,7 +184,7 @@ export class NativeEditorStateController extends MainStateController {
                 cellVMs: cellVms,
                 undoStack: this.pushStack(this.getState().undoStack, origVms)
             });
-            this.sendMessage(InteractiveWindowMessages.SwapCells, { firstCell: cellId!, secondCell: cellVms[index].cell.id });
+            this.sendMessage(InteractiveWindowMessages.SwapCells, { firstCellId: cellId!, secondCellId: cellVms[index].cell.id });
         }
     }
 
@@ -198,7 +198,7 @@ export class NativeEditorStateController extends MainStateController {
                 cellVMs: cellVms,
                 undoStack: this.pushStack(this.getState().undoStack, origVms)
             });
-            this.sendMessage(InteractiveWindowMessages.SwapCells, { firstCell: cellId!, secondCell: cellVms[index].cell.id });
+            this.sendMessage(InteractiveWindowMessages.SwapCells, { firstCellId: cellId!, secondCellId: cellVms[index].cell.id });
         }
     }
 

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -157,7 +157,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
                 }
             }));
 
-            // Track focus changes to make sure we update our widget parent and
+            // Track focus changes to make sure we update our widget parent and widget position
             this.subscriptions.push(editor.onDidFocusEditorWidget(() => {
                 this.throttledUpdateWidgetPosition();
                 this.updateWidgetParent(editor);

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -316,7 +316,6 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
 
     private startUpdateWidgetPosition = () => {
         this.throttledUpdateWidgetPosition();
-        this.updateWidgetParent(this.state.editor);
     }
 
     private updateBackgroundStyle = () => {
@@ -384,13 +383,19 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
                 // Make sure to attach to a real dom node.
                 if (!this.state.attached && this.state.editor && this.monacoContainer) {
                     this.containerRef.current.appendChild(this.monacoContainer);
-
-                    // Make sure our suggest and hover windows show up on top of other stuff
-                    this.updateWidgetParent(this.state.editor);
+                    this.monacoContainer.addEventListener('mousemove', this.onContainerMove);
                 }
                 this.setState({visibleLineCount: currLineCount, attached: true});
                 this.state.editor.layout({width, height});
             }
+        }
+    }
+
+    private onContainerMove = () => {
+        if (!this.widgetParent && !this.state.parentUpdated && this.monacoContainer) {
+            this.updateWidgetParent(this.state.editor);
+            this.startUpdateWidgetPosition();
+            this.monacoContainer.removeEventListener('mousemove', this.onContainerMove);
         }
     }
 

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -384,7 +384,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
                 this.state.editor.layout({width, height});
 
                 // Also need to update our widget positions
-                this.throttledUpdateWidgetPosition(width);
+                this.throttledUpdateWidgetPosition(width); // Potentially skip this as mouse enter should be good enough. Maybe focus too.
             }
         }
     }

--- a/src/test/datascience/intellisense.unit.test.ts
+++ b/src/test/datascience/intellisense.unit.test.ts
@@ -160,7 +160,7 @@ suite('DataScience Intellisense Unit Tests', () => {
     }
 
     function swapCells(id1: string, id2: string): Promise<void> {
-        return sendMessage(InteractiveWindowMessages.SwapCells, { firstCell: id1, secondCell: id2 });
+        return sendMessage(InteractiveWindowMessages.SwapCells, { firstCellId: id1, secondCellId: id2 });
     }
 
     function insertCell(id: string, code: string, codeCellAbove?: string): Promise<void> {

--- a/src/test/datascience/intellisense.unit.test.ts
+++ b/src/test/datascience/intellisense.unit.test.ts
@@ -18,11 +18,30 @@ import {
     IInteractiveWindowMapping,
     InteractiveWindowMessages
 } from '../../client/datascience/interactive-common/interactiveWindowTypes';
-import { IInteractiveWindowListener, IInteractiveWindowProvider, IJupyterExecution } from '../../client/datascience/types';
+import {
+    ICell,
+    IInteractiveWindowListener,
+    IInteractiveWindowProvider,
+    IJupyterExecution
+} from '../../client/datascience/types';
+import { generateCells } from '../../datascience-ui/interactive-common/mainState';
 import { MockAutoSelectionService } from '../mocks/autoSelector';
 import { MockLanguageClient } from './mockLanguageClient';
 
 // tslint:disable:no-any unified-signatures
+const TestCellContents = `myvar = """ # Lorem Ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nullam eget varius ligula, eget fermentum mauris.
+Cras ultrices, enim sit amet iaculis ornare, nisl nibh aliquet elit, sed ultrices velit ipsum dignissim nisl.
+Nunc quis orci ante. Vivamus vel blandit velit.
+","Sed mattis dui diam, et blandit augue mattis vestibulum.
+Suspendisse ornare interdum velit. Suspendisse potenti.
+Morbi molestie lacinia sapien nec porttitor. Nam at vestibulum nisi.
+"""
+df
+df
+`;
 
 // tslint:disable-next-line: max-func-body-length
 suite('DataScience Intellisense Unit Tests', () => {
@@ -133,13 +152,23 @@ suite('DataScience Intellisense Unit Tests', () => {
     }
 
     function removeCell(id: string): Promise<void> {
-        sendMessage(InteractiveWindowMessages.RemoveCell, { id }).ignoreErrors();
-        return Promise.resolve();
+        return sendMessage(InteractiveWindowMessages.RemoveCell, { id });
     }
 
     function removeAllCells(): Promise<void> {
-        sendMessage(InteractiveWindowMessages.DeleteAllCells).ignoreErrors();
-        return Promise.resolve();
+        return sendMessage(InteractiveWindowMessages.DeleteAllCells);
+    }
+
+    function swapCells(id1: string, id2: string): Promise<void> {
+        return sendMessage(InteractiveWindowMessages.SwapCells, { firstCell: id1, secondCell: id2 });
+    }
+
+    function insertCell(id: string, code: string, codeCellAbove?: string): Promise<void> {
+        return sendMessage(InteractiveWindowMessages.InsertCell, { id, code, codeCellAbove });
+    }
+
+    function loadAllCells(cells: ICell[]): Promise<void> {
+        return sendMessage(InteractiveWindowMessages.LoadAllCellsComplete, { cells });
     }
 
     test('Add a single cell', async () => {
@@ -288,4 +317,98 @@ suite('DataScience Intellisense Unit Tests', () => {
         await addCell('import baz', '3');
         expect(languageClient.getDocumentContents()).to.be.eq('import sys\nimport foo\nimport bar\nimport baz\nsys', 'Document not set');
     });
+
+    test('Load remove and insert', async () => {
+        const cells = generateCells('foo.py', 1);
+        await loadAllCells(cells);
+        expect(languageClient.getDocumentContents()).to.be.eq(TestCellContents, 'Load all cells is failing');
+        await removeAllCells();
+        expect(languageClient.getDocumentContents()).to.be.eq('', 'Remove all cells is failing');
+        await insertCell('6', 'foo');
+        expect(languageClient.getDocumentContents()).to.be.eq('foo\n', 'Insert after remove');
+        await insertCell('7', 'bar', '6');
+        expect(languageClient.getDocumentContents()).to.be.eq('foo\nbar\n', 'Double insert after remove');
+    });
+
+    test('Swap cells around', async () => {
+        const cells = generateCells('foo.py', 1);
+        await loadAllCells(cells);
+        await swapCells('1', '2'); // 2nd cell is markdown
+        expect(languageClient.getDocumentContents()).to.be.eq(TestCellContents, 'Swap cells should skip swapping on markdown');
+        await swapCells('1', '3');
+        const afterSwap = `df
+myvar = """ # Lorem Ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nullam eget varius ligula, eget fermentum mauris.
+Cras ultrices, enim sit amet iaculis ornare, nisl nibh aliquet elit, sed ultrices velit ipsum dignissim nisl.
+Nunc quis orci ante. Vivamus vel blandit velit.
+","Sed mattis dui diam, et blandit augue mattis vestibulum.
+Suspendisse ornare interdum velit. Suspendisse potenti.
+Morbi molestie lacinia sapien nec porttitor. Nam at vestibulum nisi.
+"""
+df
+`;
+        expect(languageClient.getDocumentContents()).to.be.eq(afterSwap, 'Swap cells failed');
+        await swapCells('1', '3');
+        expect(languageClient.getDocumentContents()).to.be.eq(TestCellContents, 'Swap cells back failed');
+    });
+
+    test('Insert and swap', async () => {
+        const cells = generateCells('foo.py', 1);
+        await loadAllCells(cells);
+        expect(languageClient.getDocumentContents()).to.be.eq(TestCellContents, 'Load all cells is failing');
+        await insertCell('6', 'foo');
+        const afterInsert = `foo
+myvar = """ # Lorem Ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nullam eget varius ligula, eget fermentum mauris.
+Cras ultrices, enim sit amet iaculis ornare, nisl nibh aliquet elit, sed ultrices velit ipsum dignissim nisl.
+Nunc quis orci ante. Vivamus vel blandit velit.
+","Sed mattis dui diam, et blandit augue mattis vestibulum.
+Suspendisse ornare interdum velit. Suspendisse potenti.
+Morbi molestie lacinia sapien nec porttitor. Nam at vestibulum nisi.
+"""
+df
+df
+`;
+        expect(languageClient.getDocumentContents()).to.be.eq(afterInsert, 'Insert cell failed');
+        await insertCell('7', 'foo', '1');
+        const afterInsert2 = `foo
+myvar = """ # Lorem Ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nullam eget varius ligula, eget fermentum mauris.
+Cras ultrices, enim sit amet iaculis ornare, nisl nibh aliquet elit, sed ultrices velit ipsum dignissim nisl.
+Nunc quis orci ante. Vivamus vel blandit velit.
+","Sed mattis dui diam, et blandit augue mattis vestibulum.
+Suspendisse ornare interdum velit. Suspendisse potenti.
+Morbi molestie lacinia sapien nec porttitor. Nam at vestibulum nisi.
+"""
+foo
+df
+df
+`;
+        expect(languageClient.getDocumentContents()).to.be.eq(afterInsert2, 'Insert2 cell failed');
+        await removeCell('7');
+        expect(languageClient.getDocumentContents()).to.be.eq(afterInsert, 'Remove 2 cell failed');
+        await swapCells('1', '3');
+        const afterSwap = `foo
+df
+myvar = """ # Lorem Ipsum
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Nullam eget varius ligula, eget fermentum mauris.
+Cras ultrices, enim sit amet iaculis ornare, nisl nibh aliquet elit, sed ultrices velit ipsum dignissim nisl.
+Nunc quis orci ante. Vivamus vel blandit velit.
+","Sed mattis dui diam, et blandit augue mattis vestibulum.
+Suspendisse ornare interdum velit. Suspendisse potenti.
+Morbi molestie lacinia sapien nec porttitor. Nam at vestibulum nisi.
+"""
+df
+`;
+        expect(languageClient.getDocumentContents()).to.be.eq(afterSwap, 'Swap cell failed');
+    });
+
 });

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -118,16 +118,16 @@ for _ in range(50):
             return Promise.resolve({ result: result, haveMore: loops > 0 });
         });
 
-        await addCell(wrapper, badPanda, true, 4);
+        await addCell(wrapper, badPanda, true);
         verifyHtmlOnCell(wrapper, 'NativeCell', `has no attribute 'read'`, CellPosition.Last);
 
-        await addCell(wrapper, goodPanda, true, 4);
+        await addCell(wrapper, goodPanda, true);
         verifyHtmlOnCell(wrapper, 'NativeCell', `<td>`, CellPosition.Last);
 
-        await addCell(wrapper, matPlotLib, true, 5);
+        await addCell(wrapper, matPlotLib, true, 6);
         verifyHtmlOnCell(wrapper, 'NativeCell', matPlotLibResults, CellPosition.Last);
 
-        await addCell(wrapper, spinningCursor, true, 3 + (ioc.mockJupyter ? (cursors.length * 3) : 50));
+        await addCell(wrapper, spinningCursor, true, 4 + (ioc.mockJupyter ? (cursors.length * 3) : 50));
         verifyHtmlOnCell(wrapper, 'NativeCell', '<div>', CellPosition.Last);
     }, () => { return ioc; });
 


### PR DESCRIPTION
For #7483 

Made a number of adjustments to increase perf
- Change load all cells to not send updates on each cell added. Wait till they're all done
- Change render of all cells to not use global state, this allows us to skip rendering cells that haven't changed
- Rework intellisense to not react to sendInfo messages, but instead react to specific changes. SendInfo happens too often and is too expensive to parse constantly
- Rework monaco editor to not update widget parents until absolutely necessary

Added some more unit tests for the intellisense changes.

There's still a bunch of work left to do though. We need to virtualize the monaco editors somehow as they are the big bottleneck on opening now. A notebook with 500 cells in it takes 10 seconds just to show the first render. Resizing after that requires 5 seconds after resizing the window to calm down.
