### PR TITLE
Force the pytest root dir to always be the workspace root.

### DIFF
--- a/news/2 Fixes/6548.md
+++ b/news/2 Fixes/6548.md
@@ -1,0 +1,1 @@
+Force the pytest root dir to always be the workspace root folder.

--- a/src/client/testing/pytest/runner.ts
+++ b/src/client/testing/pytest/runner.ts
@@ -51,6 +51,8 @@ export class TestManagerRunner implements ITestManagerRunner {
             const testArgs = this.argsService.filterArguments(args, [JunitXmlArg]);
             testArgs.splice(0, 0, `${JunitXmlArg}=${xmlLogFile}`);
 
+            testArgs.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
+
             // Positional arguments control the tests to be run.
             testArgs.push(...testPaths);
 

--- a/src/client/testing/pytest/services/discoveryService.ts
+++ b/src/client/testing/pytest/services/discoveryService.ts
@@ -48,6 +48,7 @@ export class TestDiscoveryService implements ITestDiscoveryService {
         if (args.indexOf('-s') === -1) {
             args.splice(0, 0, '-s');
         }
+        args.splice(0, 0, '--rootdir', options.workspaceFolder.fsPath);
         return args;
     }
     protected async discoverTestsInTestDirectory(options: TestDiscoveryOptions): Promise<Tests> {

--- a/src/test/testing/pytest/services/discoveryService.unit.test.ts
+++ b/src/test/testing/pytest/services/discoveryService.unit.test.ts
@@ -102,7 +102,11 @@ suite('Unit Tests - PyTest - Discovery', () => {
         };
 
         const filteredArgs = options.args;
-        const expectedArgs = ['-s', ...filteredArgs];
+        const expectedArgs = [
+            '--rootdir', __dirname,
+            '-s',
+            ...filteredArgs
+        ];
         when(argsService.filterArguments(deepEqual(options.args), TestFilter.discovery)).thenReturn(filteredArgs);
 
         const args = discoveryService.buildTestCollectionArgs(options);
@@ -121,7 +125,11 @@ suite('Unit Tests - PyTest - Discovery', () => {
         };
 
         const filteredArgs = options.args;
-        const expectedArgs = ['-s', ...filteredArgs];
+        const expectedArgs = [
+            '--rootdir', __dirname,
+            '-s',
+            ...filteredArgs
+        ];
         when(argsService.filterArguments(deepEqual(options.args), TestFilter.discovery)).thenReturn(filteredArgs);
 
         const args = discoveryService.buildTestCollectionArgs(options);
@@ -140,7 +148,12 @@ suite('Unit Tests - PyTest - Discovery', () => {
         };
 
         const filteredArgs = options.args;
-        const expectedArgs = ['-s', '--cache-clear', ...filteredArgs];
+        const expectedArgs = [
+            '--rootdir', __dirname,
+            '-s',
+            '--cache-clear',
+            ...filteredArgs
+        ];
         when(argsService.filterArguments(deepEqual(options.args), TestFilter.discovery)).thenReturn(filteredArgs);
 
         const args = discoveryService.buildTestCollectionArgs(options);


### PR DESCRIPTION
(for #6548)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- ~[ ] Appropriate comments and documentation strings in the code~
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
