### PR TITLE
Remove --ci flag from install_ptvsd.py

### DIFF
--- a/build/ci/templates/steps/build.yml
+++ b/build/ci/templates/steps/build.yml
@@ -30,7 +30,6 @@ steps:
       inputs:
           scriptSource: "filePath"
           scriptPath: "./pythonFiles/install_ptvsd.py"
-          arguments: "--ci"
           failOnStderr: true
 
     - bash: npm run clean

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -143,7 +143,6 @@ steps:
     inputs:
         scriptSource: "filePath"
         scriptPath: "./pythonFiles/install_ptvsd.py"
-        arguments: "--ci"
         failOnStderr: true
     condition: and(eq(variables['NeedsPythonTestReqs'], 'true'), eq(variables['PythonVersion'], '3.7'))
 

--- a/news/2 Fixes/7814.md
+++ b/news/2 Fixes/7814.md
@@ -1,0 +1,1 @@
+Remove --ci flag from install_ptvsd.py to fix execution of "Setup" instructions from CONTRIBUTING.md.

--- a/pythonFiles/install_ptvsd.py
+++ b/pythonFiles/install_ptvsd.py
@@ -12,9 +12,7 @@ PYPI_PTVSD_URL = "https://pypi.org/pypi/ptvsd/json"
 
 
 def install_ptvsd():
-    # If we are in CI use the packaging module installed in PYTHONFILES.
-    if len(sys.argv) == 2 and sys.argv[1] == "--ci":
-        sys.path.insert(0, PYTHONFILES)
+    sys.path.insert(0, PYTHONFILES)
     from packaging.requirements import Requirement
 
     with open(REQUIREMENTS, "r", encoding="utf-8") as reqsfile:


### PR DESCRIPTION
For #7698

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
