### PR TITLE
Smoke tests does not depend on build stage

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -265,8 +265,7 @@ stages:
 
 
 - stage: Smoke
-  dependsOn:
-  - Build
+  dependsOn: []
   jobs:
   - job: 'Smoke'
     dependsOn: []

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -93,8 +93,7 @@ stages:
       - template: templates/test_phases.yml
 
 - stage: Smoke
-  dependsOn:
-  - Build
+  dependsOn: []
   jobs:
   - job: 'Smoke'
     dependsOn: []


### PR DESCRIPTION
Currently smoke tests rely on the Build stage to complete, that's slow and unnecessary.
Ensure Smoke tests run immediately in the pipeline (faster PR pipeline)
