### PR TITLE
Allow the language server to choose its default caching mode

### DIFF
--- a/news/2 Fixes/7821.md
+++ b/news/2 Fixes/7821.md
@@ -1,0 +1,1 @@
+Allow the language server to pick a default caching mode.

--- a/package.json
+++ b/package.json
@@ -1934,11 +1934,12 @@
                 "python.analysis.cachingLevel": {
                     "type": "string",
                     "enum": [
+                        "Default",
                         "None",
                         "System",
                         "Library"
                     ],
-                    "default": "None",
+                    "default": "Default",
                     "description": "Defines which types of modules get their analysis cached.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
For #7821

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Appropriate comments and documentation strings in the code~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
