### PR TITLE
Use VSC API instead of hardcoding the uri resource vscode-resource

### DIFF
--- a/news/3 Code Health/7832.md
+++ b/news/3 Code Health/7832.md
@@ -1,0 +1,1 @@
+Update version of `@types/vscode`.

--- a/news/3 Code Health/7834.md
+++ b/news/3 Code Health/7834.md
@@ -1,0 +1,1 @@
+Use `Webview.asWebviewUri` to generate a URI for use in the `Webview Panel` instead of hardcoding the resource `vscode-resource`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,9 +2382,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.36.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.36.0.tgz",
-            "integrity": "sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==",
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.38.0.tgz",
+            "integrity": "sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==",
             "dev": true
         },
         "@types/webpack": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.36.0"
+        "vscode": "^1.38.0"
     },
     "keywords": [
         "python",
@@ -2791,7 +2791,7 @@
         "@types/tmp": "0.0.33",
         "@types/untildify": "^3.0.0",
         "@types/uuid": "^3.4.3",
-        "@types/vscode": "^1.36.0",
+        "@types/vscode": "^1.38.0",
         "@types/webpack-bundle-analyzer": "^2.13.0",
         "@types/winreg": "^1.2.30",
         "@types/ws": "^6.0.1",

--- a/src/client/common/application/webPanel.ts
+++ b/src/client/common/application/webPanel.ts
@@ -5,8 +5,7 @@ import '../../common/extensions';
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { Uri, ViewColumn, WebviewPanel, window } from 'vscode';
-
+import { Uri, ViewColumn, Webview, WebviewPanel, window } from 'vscode';
 import * as localize from '../../common/utils/localize';
 import { Identifiers } from '../../datascience/constants';
 import { IServiceContainer } from '../../ioc/types';
@@ -89,7 +88,7 @@ export class WebPanel implements IWebPanel {
 
                 // Call our special function that sticks this script inside of an html page
                 // and translates all of the paths to vscode-resource URIs
-                this.panel.webview.html = this.generateReactHtml(mainScriptPath, embeddedCss, settings);
+                this.panel.webview.html = this.generateReactHtml(mainScriptPath, this.panel.webview, embeddedCss, settings);
 
                 // Reset when the current panel is closed
                 this.disposableRegistry.push(this.panel.onDidDispose(() => {
@@ -118,11 +117,9 @@ export class WebPanel implements IWebPanel {
     }
 
     // tslint:disable-next-line:no-any
-    private generateReactHtml(mainScriptPath: string, embeddedCss?: string, settings?: any) {
-        const uriBasePath = Uri.file(`${path.dirname(mainScriptPath)}/`);
-        const uriPath = Uri.file(mainScriptPath);
-        const uriBase = uriBasePath.with({ scheme: 'vscode-resource' });
-        const uri = uriPath.with({ scheme: 'vscode-resource' });
+    private generateReactHtml(mainScriptPath: string, webView: Webview, embeddedCss?: string, settings?: any) {
+        const uriBase = webView.asWebviewUri(Uri.file(`${path.dirname(mainScriptPath)}/`));
+        const uri = webView.asWebviewUri(Uri.file(mainScriptPath));
         const locDatabase = localize.getCollectionJSON();
         const style = embeddedCss ? embeddedCss : '';
         const settingsString = settings ? JSON.stringify(settings) : '{}';


### PR DESCRIPTION
For #7834

Depends on PR (https://github.com/microsoft/vscode-python/pull/7833) to update the package.json


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
