### PR TITLE
Don't prompt to update inheritEnv when on Windows

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -126,7 +126,7 @@
     "Experiments.inGroup": "User belongs to experiment group '{0}'",
     "Interpreters.RefreshingInterpreters": "Refreshing Python Interpreters",
     "Interpreters.LoadingInterpreters": "Loading Python Interpreters",
-    "Interpreters.condaInheritEnvMessage": "We noticed you're using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we suggest the \"terminal.integrated.inheritEnv\" setting to be changed to false. Would you like to update this setting?",
+    "Interpreters.condaInheritEnvMessage": "We noticed you're using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change \"terminal.integrated.inheritEnv\" to false in your user settings.",
     "Logging.CurrentWorkingDirectory": "cwd:",
     "Common.doNotShowAgain": "Do not show again",
     "Common.reload": "Reload",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -61,7 +61,7 @@ export namespace Experiments {
 export namespace Interpreters {
     export const loading = localize('Interpreters.LoadingInterpreters', 'Loading Python Interpreters');
     export const refreshing = localize('Interpreters.RefreshingInterpreters', 'Refreshing Python Interpreters');
-    export const condaInheritEnvMessage = localize('Interpreters.condaInheritEnvMessage', 'We noticed you\'re using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we suggest the \"terminal.integrated.inheritEnv\" setting to be changed to false. Would you like to update this setting?');
+    export const condaInheritEnvMessage = localize('Interpreters.condaInheritEnvMessage', 'We noticed you\'re using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change \"terminal.integrated.inheritEnv\" to false in your user settings.');
     export const environmentPromptMessage = localize('Interpreters.environmentPromptMessage', 'We noticed a new virtual environment has been created. Do you want to select it for the workspace folder?');
     export const selectInterpreterTip = localize('Interpreters.selectInterpreterTip', 'Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar');
 }

--- a/src/client/interpreter/virtualEnvs/condaInheritEnvPrompt.ts
+++ b/src/client/interpreter/virtualEnvs/condaInheritEnvPrompt.ts
@@ -6,6 +6,7 @@ import { ConfigurationTarget, Uri } from 'vscode';
 import { IExtensionActivationService } from '../../activation/types';
 import { IApplicationShell, IWorkspaceService } from '../../common/application/types';
 import { traceDecorators, traceError } from '../../common/logger';
+import { IPlatformService } from '../../common/platform/types';
 import { IBrowserService, IPersistentStateFactory } from '../../common/types';
 import { Common, InteractiveShiftEnterBanner, Interpreters } from '../../common/utils/localize';
 import { sendTelemetryEvent } from '../../telemetry';
@@ -22,8 +23,9 @@ export class CondaInheritEnvPrompt implements IExtensionActivationService {
         @inject(IBrowserService) private browserService: IBrowserService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IPersistentStateFactory) private readonly persistentStateFactory: IPersistentStateFactory,
+        @inject(IPlatformService) private readonly platformService: IPlatformService,
         @optional() public hasPromptBeenShownInCurrentSession: boolean = false
-    ) { }
+    ) {}
 
     public async activate(resource: Uri): Promise<void> {
         this.initializeInBackground(resource).ignoreErrors();
@@ -63,6 +65,9 @@ export class CondaInheritEnvPrompt implements IExtensionActivationService {
     @traceDecorators.error('Failed to check whether to display prompt for conda inherit env setting')
     public async shouldShowPrompt(resource: Uri): Promise<boolean> {
         if (this.hasPromptBeenShownInCurrentSession) {
+            return false;
+        }
+        if (this.platformService.isWindows) {
             return false;
         }
         const interpreter = await this.interpreterService.getActiveInterpreter(resource);

--- a/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
@@ -147,7 +147,8 @@ suite('Conda Inherit Env Prompt', async () => {
                 .verifiable(TypeMoq.Times.once());
             workspaceConfig
                 .setup(ws => ws.inspect<boolean>('integrated.inheritEnv'))
-                .returns(() => undefined);
+                .returns(() => undefined)
+                .verifiable(TypeMoq.Times.once());
             const result = await condaInheritEnvPrompt.shouldShowPrompt(resource);
             expect(result).to.equal(false, 'Prompt should not be shown');
             expect(condaInheritEnvPrompt.hasPromptBeenShownInCurrentSession).to.equal(false, 'Should be false');

--- a/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
@@ -228,7 +228,9 @@ suite('Conda Inherit Env Prompt', async () => {
                 .setup(ws => ws.getConfiguration('terminal', resource))
                 .returns(() => workspaceConfig.object)
                 .verifiable(TypeMoq.Times.once());
-            workspaceConfig.setup(ws => ws.inspect<boolean>('integrated.inheritEnv')).returns(() => settings as any);
+            workspaceConfig
+                .setup(ws => ws.inspect<boolean>('integrated.inheritEnv'))
+                .returns(() => settings as any);
             const result = await condaInheritEnvPrompt.shouldShowPrompt(resource);
             expect(result).to.equal(true, 'Prompt should be shown');
             expect(condaInheritEnvPrompt.hasPromptBeenShownInCurrentSession).to.equal(true, 'Should be true');


### PR DESCRIPTION
For #7607 
- Don't prompt to update inheritEnv when on Windows
- Update wording (#7861)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
