### PR TITLE
When automatically opening the `Notebook Editor`, non file schemes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -149,14 +149,13 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                //"--grep", "<suite name>",
+                "--grep", "wow",
                 "--timeout=300000"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
-            "preLaunchTask": "Compile",
-            "skipFiles": ["<node_internals>/**"]
+            // "skipFiles": ["<node_internals>/**"]
         },
         {
             "name": "Functional Tests (without VS Code, *.functional.test.ts)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -149,13 +149,14 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                "--grep", "wow",
+                 //"--grep", "<suite name>",
                 "--timeout=300000"
             ],
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],
-            // "skipFiles": ["<node_internals>/**"]
+            "preLaunchTask": "Compile",
+            "skipFiles": ["<node_internals>/**"]
         },
         {
             "name": "Functional Tests (without VS Code, *.functional.test.ts)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -149,7 +149,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                 //"--grep", "<suite name>",
+                //"--grep", "<suite name>",
                 "--timeout=300000"
             ],
             "outFiles": [

--- a/news/2 Fixes/7905.md
+++ b/news/2 Fixes/7905.md
@@ -1,0 +1,1 @@
+When automatically opening the `Notebook Editor`, then ignore uris that do not have a `file` scheme

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -136,8 +136,8 @@ export class NativeEditorProvider implements INotebookEditorProvider, IAsyncDisp
     private async create(file: Uri, contents: string): Promise<INotebookEditor> {
         const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
         await editor.load(contents, file);
-        // this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
-        // this.disposables.push(editor.executed(this.onExecutedEditor.bind(this)));
+        this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
+        this.disposables.push(editor.executed(this.onExecutedEditor.bind(this)));
         await editor.show();
         return editor;
     }

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -202,7 +202,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, IAsyncDisp
     private isNotebook(document: TextDocument) {
         // Only support file uris (we don't want to automatically open any other ipynb file from another resource as a notebook).
         // E.g. when opening a document for comparison, the scheme is `git`, in live share the scheme is `vsls`.
-        const validUriScheme = document.uri.scheme === 'file';
+        const validUriScheme = document.uri.scheme === 'file' || document.uri.scheme === 'vsls';
         return validUriScheme && (document.languageId === JUPYTER_LANGUAGE || path.extname(document.fileName).toLocaleLowerCase() === '.ipynb');
     }
 }

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -34,26 +34,19 @@ export class NativeEditorProvider implements INotebookEditorProvider, IAsyncDisp
         @inject(IDataScienceErrorHandler) private dataScienceErrorHandler: IDataScienceErrorHandler
 
     ) {
-        console.log(1);
         asyncRegistry.push(this);
-        console.log(2);
 
         // No live share sync required as open document from vscode will give us our contents.
 
         // Look through the file system for ipynb files to see how many we have in the workspace. Don't wait
         // on this though.
-        console.log(3);
         const findFilesPromise = this.workspace.findFiles('**/*.ipynb');
-        console.log(4);
         if (findFilesPromise && findFilesPromise.then) {
-            console.log(5);
             findFilesPromise.then(r => this.notebookCount += r.length);
         }
 
         // Listen to document open commands. We use this to launch an ipynb editor
-        console.log(1);
         const disposable = this.documentManager.onDidOpenTextDocument(this.onOpenedDocument);
-        console.log(1);
         this.disposables.push(disposable);
 
         // Since we may have activated after a document was opened, also run open document for all documents.
@@ -186,31 +179,21 @@ export class NativeEditorProvider implements INotebookEditorProvider, IAsyncDisp
     }
 
     private onOpenedDocument = async (document: TextDocument) => {
-        console.log('opened');
         // See if this is an ipynb file
         if (this.isNotebook(document) && this.configuration.getSettings().datascience.useNotebookEditor) {
-            console.log('2');
             try {
                 const contents = document.getText();
                 const uri = document.uri;
 
                 // Open our own editor.
-                console.log('a');
                 await this.open(uri, contents);
-                console.log('b');
 
                 // Then switch back to the ipynb and close it.
                 // If we don't do it in this order, the close will switch to the wrong item
-                console.log('c');
                 await this.documentManager.showTextDocument(document);
-                console.log('d');
                 const command = 'workbench.action.closeActiveEditor';
-                console.log('e');
                 await this.cmdManager.executeCommand(command);
-                console.log('f');
             } catch (e) {
-                console.log('Error')
-                console.error(e);
                 return this.dataScienceErrorHandler.handleError(e);
             }
         }

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
@@ -26,7 +26,7 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { sleep } from '../../core';
 
 // tslint:disable: max-func-body-length
-suite('wow Data Science - Native Editor Provider', () => {
+suite('Data Science - Native Editor Provider', () => {
     let workspace: IWorkspaceService;
     let configService: IConfigurationService;
     let fileSystem: IFileSystem;

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
@@ -107,9 +107,12 @@ suite('Data Science - Native Editor Provider', () => {
         await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('some text file.txt'), false);
     });
     test('Open the notebook editor when an ipynb file is opened with a file scheme', async () => {
-        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('fil:///some file.ipynb'), true);
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.parse('file:///some file.ipynb'), true);
     });
-    test('Do not open the notebook editor when an ipynb file is opened with a non-file scheme', async () => {
+    test('Open the notebook editor when an ipynb file is opened with a vsls scheme (live share)', async () => {
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.parse('vsls:///some file.ipynb'), true);
+    });
+    test('Do not open the notebook editor when an ipynb file is opened with a git scheme (comparing staged/modified files)', async () => {
         await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.parse('git://some//text file.txt'), false);
     });
 });

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
@@ -6,7 +6,7 @@
 // tslint:disable: no-any
 
 import { expect } from 'chai';
-import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import { instance, mock, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { EventEmitter, TextDocument, Uri } from 'vscode';
 import { CommandManager } from '../../../client/common/application/commandManager';
@@ -17,14 +17,13 @@ import { AsyncDisposableRegistry } from '../../../client/common/asyncDisposableR
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { FileSystem } from '../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { IConfigurationService, IPythonSettings } from '../../../client/common/types';
+import { IConfigurationService } from '../../../client/common/types';
 import { DataScienceErrorHandler } from '../../../client/datascience/errorHandler/errorHandler';
-import { NativeEditor } from '../../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorProvider } from '../../../client/datascience/interactive-ipynb/nativeEditorProvider';
 import { IDataScienceErrorHandler, INotebookEditor } from '../../../client/datascience/types';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
-import { noop, sleep } from '../../core';
+import { sleep } from '../../core';
 
 // tslint:disable: max-func-body-length
 suite('wow Data Science - Native Editor Provider', () => {
@@ -66,60 +65,6 @@ suite('wow Data Science - Native Editor Provider', () => {
         textDocument.setup(t => t.getText()).returns(() => content);
         return textDocument.object;
     }
-    // class MockNativeEditor implements INotebookEditor {
-    //     closed: Event<INotebookEditor>;
-    //     executed: Event<INotebookEditor>;
-    //     modified: Event<INotebookEditor>;
-    //     saved: Event<INotebookEditor>;
-    //     isDirty: boolean;
-    //     file: Uri;
-    //     visible: boolean;
-    //     active: boolean;
-    //     onExecutedCode: Event<string>;
-    //     public load(_contents: string, _file: Uri): Promise<void> {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadrunAllCells(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadrunSelectedCell(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadaddCellBelow(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadshow(): Promise<void> {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadstartProgress(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadstopProgress(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadundoCells(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadredoCells(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadremoveAllCells(): void {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadinterruptKernel(): Promise<void> {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loadrestartKernel(): Promise<void> {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public loaddispose() {
-    //         throw new Error('Method not implemented.');
-    //     }
-    //     public load(contents: string, file: Uri): Promise<void>{}
-    //     runAllCells(): void;
-    //     runSelectedCell(): void;
-    //     addCellBelow(): void;
-    // }
     async function testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(uri: Uri, shouldOpenNotebookEditor: boolean) {
         const eventEmitter = new EventEmitter<TextDocument>();
         const editor = typemoq.Mock.ofType<INotebookEditor>();
@@ -161,7 +106,10 @@ suite('wow Data Science - Native Editor Provider', () => {
     test('Do not open the notebook editor when a txt file is opened', async () => {
         await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('some text file.txt'), false);
     });
-    test('Do not open the notebook editor when an ipynb file is opened with a non-save', async () => {
-        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('some text file.txt'), false);
+    test('Open the notebook editor when an ipynb file is opened with a file scheme', async () => {
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('fil:///some file.ipynb'), true);
+    });
+    test('Do not open the notebook editor when an ipynb file is opened with a non-file scheme', async () => {
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.parse('git://some//text file.txt'), false);
     });
 });

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.unit.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable: no-any
+
+import { expect } from 'chai';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
+import * as typemoq from 'typemoq';
+import { EventEmitter, TextDocument, Uri } from 'vscode';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { DocumentManager } from '../../../client/common/application/documentManager';
+import { ICommandManager, IDocumentManager, IWorkspaceService } from '../../../client/common/application/types';
+import { WorkspaceService } from '../../../client/common/application/workspace';
+import { AsyncDisposableRegistry } from '../../../client/common/asyncDisposableRegistry';
+import { ConfigurationService } from '../../../client/common/configuration/service';
+import { FileSystem } from '../../../client/common/platform/fileSystem';
+import { IFileSystem } from '../../../client/common/platform/types';
+import { IConfigurationService, IPythonSettings } from '../../../client/common/types';
+import { DataScienceErrorHandler } from '../../../client/datascience/errorHandler/errorHandler';
+import { NativeEditor } from '../../../client/datascience/interactive-ipynb/nativeEditor';
+import { NativeEditorProvider } from '../../../client/datascience/interactive-ipynb/nativeEditorProvider';
+import { IDataScienceErrorHandler, INotebookEditor } from '../../../client/datascience/types';
+import { ServiceContainer } from '../../../client/ioc/container';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { noop, sleep } from '../../core';
+
+// tslint:disable: max-func-body-length
+suite('wow Data Science - Native Editor Provider', () => {
+    let workspace: IWorkspaceService;
+    let configService: IConfigurationService;
+    let fileSystem: IFileSystem;
+    let doctManager: IDocumentManager;
+    let dsErrorHandler: IDataScienceErrorHandler;
+    let cmdManager: ICommandManager;
+    let svcContainer: IServiceContainer;
+
+    setup(() => {
+        svcContainer = mock(ServiceContainer);
+        configService = mock(ConfigurationService);
+        fileSystem = mock(FileSystem);
+        doctManager = mock(DocumentManager);
+        dsErrorHandler = mock(DataScienceErrorHandler);
+        cmdManager = mock(CommandManager);
+        workspace = mock(WorkspaceService);
+    });
+
+    function createNotebookProvider() {
+        return new NativeEditorProvider(
+            instance(svcContainer),
+            instance(mock(AsyncDisposableRegistry)),
+            [],
+            instance(workspace),
+            instance(configService),
+            instance(fileSystem),
+            instance(doctManager),
+            instance(cmdManager),
+            instance(dsErrorHandler)
+        );
+    }
+    function createTextDocument(uri: Uri, content: string) {
+        const textDocument = typemoq.Mock.ofType<TextDocument>();
+        textDocument.setup(t => t.uri).returns(() => uri);
+        textDocument.setup(t => t.fileName).returns(() => uri.fsPath);
+        textDocument.setup(t => t.getText()).returns(() => content);
+        return textDocument.object;
+    }
+    // class MockNativeEditor implements INotebookEditor {
+    //     closed: Event<INotebookEditor>;
+    //     executed: Event<INotebookEditor>;
+    //     modified: Event<INotebookEditor>;
+    //     saved: Event<INotebookEditor>;
+    //     isDirty: boolean;
+    //     file: Uri;
+    //     visible: boolean;
+    //     active: boolean;
+    //     onExecutedCode: Event<string>;
+    //     public load(_contents: string, _file: Uri): Promise<void> {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadrunAllCells(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadrunSelectedCell(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadaddCellBelow(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadshow(): Promise<void> {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadstartProgress(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadstopProgress(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadundoCells(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadredoCells(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadremoveAllCells(): void {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadinterruptKernel(): Promise<void> {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loadrestartKernel(): Promise<void> {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public loaddispose() {
+    //         throw new Error('Method not implemented.');
+    //     }
+    //     public load(contents: string, file: Uri): Promise<void>{}
+    //     runAllCells(): void;
+    //     runSelectedCell(): void;
+    //     addCellBelow(): void;
+    // }
+    async function testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(uri: Uri, shouldOpenNotebookEditor: boolean) {
+        const eventEmitter = new EventEmitter<TextDocument>();
+        const editor = typemoq.Mock.ofType<INotebookEditor>();
+        when(configService.getSettings()).thenReturn({ datascience: { useNotebookEditor: true } } as any);
+        when(doctManager.onDidOpenTextDocument).thenReturn(eventEmitter.event);
+        editor.setup(e => e.closed).returns(() => new EventEmitter<INotebookEditor>().event);
+        editor.setup(e => e.executed).returns(() => new EventEmitter<INotebookEditor>().event);
+        editor.setup(e => (e as any).then).returns(() => undefined);
+        when(svcContainer.get<INotebookEditor>(INotebookEditor)).thenReturn(editor.object);
+
+        // Ensure the editor is created and the load and show methods are invoked.
+        const invocationCount = shouldOpenNotebookEditor ? 1 : 0;
+        editor
+            .setup(e => e.load(typemoq.It.isAny(), typemoq.It.isAny()))
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.exactly(invocationCount));
+        editor
+            .setup(e => e.show())
+            .returns(() => Promise.resolve())
+            .verifiable(typemoq.Times.exactly(invocationCount));
+
+        const notebookEditor = createNotebookProvider();
+
+        // Open a text document.
+        const textDoc = createTextDocument(uri, 'hello');
+        eventEmitter.fire(textDoc);
+
+        // wait for callbacks to get executed.
+        await sleep(1);
+
+        // If we're to open the notebook, then there must be 1, else 0.
+        expect(notebookEditor.editors).to.be.lengthOf(shouldOpenNotebookEditor ? 1 : 0);
+        editor.verifyAll();
+    }
+
+    test('Open the notebook editor when an ipynb file is opened', async () => {
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('some file.ipynb'), true);
+    });
+    test('Do not open the notebook editor when a txt file is opened', async () => {
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('some text file.txt'), false);
+    });
+    test('Do not open the notebook editor when an ipynb file is opened with a non-save', async () => {
+        await testAutomaticallyOpeningNotebookEditorWhenOpeningFiles(Uri.file('some text file.txt'), false);
+    });
+});


### PR DESCRIPTION
For #7905

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
