### PR TITLE
Add telemetry for control groups of the debug adapter experiments

### DIFF
--- a/news/2 Fixes/7817.md
+++ b/news/2 Fixes/7817.md
@@ -1,0 +1,1 @@
+Add telemetry for control groups in debug adapter experiments.

--- a/src/client/debugger/extension/adapter/activator.ts
+++ b/src/client/debugger/extension/adapter/activator.ts
@@ -22,6 +22,8 @@ export class DebugAdapterActivator implements IExtensionSingleActivationService 
     public async activate(): Promise<void> {
         if (this.experimentsManager.inExperiment(DebugAdapterDescriptorFactory.experiment)) {
             this.disposables.push(this.debugService.registerDebugAdapterDescriptorFactory(DebuggerTypeName, this.factory));
+        } else {
+            this.experimentsManager.sendTelemetryIfInExperiment(DebugAdapterDescriptorFactory.control);
         }
     }
 }

--- a/src/client/debugger/extension/adapter/factory.ts
+++ b/src/client/debugger/extension/adapter/factory.ts
@@ -61,6 +61,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
      */
     public async useNewPtvsd(pythonPath: string): Promise<boolean> {
         if (!this.experimentsManager.inExperiment(DebugAdapterNewPtvsd.experiment)) {
+            this.experimentsManager.sendTelemetryIfInExperiment(DebugAdapterNewPtvsd.control);
             return false;
         }
 

--- a/src/test/debugger/extension/adapter/activator.unit.test.ts
+++ b/src/test/debugger/extension/adapter/activator.unit.test.ts
@@ -4,40 +4,107 @@
 'use strict';
 
 import * as assert from 'assert';
-import { anything, instance, mock, verify, when } from 'ts-mockito';
+// tslint:disable-next-line: match-default-export-name
+import rewiremock from 'rewiremock';
+import { anything, instance, mock, spy, verify, when } from 'ts-mockito';
 import { IExtensionSingleActivationService } from '../../../../client/activation/types';
+import { ApplicationEnvironment } from '../../../../client/common/application/applicationEnvironment';
 import { DebugService } from '../../../../client/common/application/debugService';
 import { IDebugService } from '../../../../client/common/application/types';
+import { WorkspaceService } from '../../../../client/common/application/workspace';
+import { ConfigurationService } from '../../../../client/common/configuration/service';
+import { CryptoUtils } from '../../../../client/common/crypto';
 import { DebugAdapterDescriptorFactory as DebugAdapterExperiment } from '../../../../client/common/experimentGroups';
 import { ExperimentsManager } from '../../../../client/common/experiments';
-import { IDisposableRegistry, IExperimentsManager } from '../../../../client/common/types';
+import { HttpClient } from '../../../../client/common/net/httpClient';
+import { PersistentStateFactory } from '../../../../client/common/persistentState';
+import { FileSystem } from '../../../../client/common/platform/fileSystem';
+import { IDisposableRegistry, IPythonSettings } from '../../../../client/common/types';
 import { DebugAdapterActivator } from '../../../../client/debugger/extension/adapter/activator';
 import { DebugAdapterDescriptorFactory } from '../../../../client/debugger/extension/adapter/factory';
 import { IDebugAdapterDescriptorFactory } from '../../../../client/debugger/extension/types';
+import { clearTelemetryReporter } from '../../../../client/telemetry';
+import { EventName } from '../../../../client/telemetry/constants';
 import { noop } from '../../../core';
+import { MockOutputChannel } from '../../../mockClasses';
 
+// tslint:disable-next-line: max-func-body-length
 suite('Debugging - Adapter Factory Registration', () => {
+    const oldValueOfVSC_PYTHON_UNIT_TEST = process.env.VSC_PYTHON_UNIT_TEST;
+    const oldValueOfVSC_PYTHON_CI_TEST = process.env.VSC_PYTHON_CI_TEST;
     let activator: IExtensionSingleActivationService;
     let debugService: IDebugService;
     let factory: IDebugAdapterDescriptorFactory;
     let disposableRegistry: IDisposableRegistry;
-    let experimentsManager: IExperimentsManager;
+    let experimentsManager: ExperimentsManager;
+    let spiedInstance: ExperimentsManager;
+
+    class Reporter {
+        public static eventNames: string[] = [];
+        public static properties: Record<string, string>[] = [];
+        public static measures: {}[] = [];
+        public sendTelemetryEvent(eventName: string, properties?: {}, measures?: {}) {
+            Reporter.eventNames.push(eventName);
+            Reporter.properties.push(properties!);
+            Reporter.measures.push(measures!);
+        }
+    }
+
     setup(() => {
+        const workspaceService = mock(WorkspaceService);
+        const httpClient = mock(HttpClient);
+        const crypto = mock(CryptoUtils);
+        const appEnvironment = mock(ApplicationEnvironment);
+        const persistentStateFactory = mock(PersistentStateFactory);
+        const output = mock(MockOutputChannel);
+        const configurationService = mock(ConfigurationService);
+        const fs = mock(FileSystem);
+
+        process.env.VSC_PYTHON_UNIT_TEST = undefined;
+        process.env.VSC_PYTHON_CI_TEST = undefined;
+        rewiremock.enable();
+        rewiremock('vscode-extension-telemetry').with({ default: Reporter });
+
+        // tslint:disable-next-line: no-any
+        when(configurationService.getSettings(undefined)).thenReturn(({ experiments: { enabled: true } } as any) as IPythonSettings);
+        experimentsManager = new ExperimentsManager(
+            instance(persistentStateFactory),
+            instance(workspaceService),
+            instance(httpClient),
+            instance(crypto),
+            instance(appEnvironment),
+            instance(output),
+            instance(fs),
+            instance(configurationService)
+        );
+        spiedInstance = spy(experimentsManager);
+
         debugService = mock(DebugService);
         factory = mock(DebugAdapterDescriptorFactory);
-        experimentsManager = mock(ExperimentsManager);
         disposableRegistry = [];
-        activator = new DebugAdapterActivator(instance(debugService), instance(factory), disposableRegistry, instance(experimentsManager));
+        activator = new DebugAdapterActivator(instance(debugService), instance(factory), disposableRegistry, experimentsManager);
     });
+
+    teardown(() => {
+        process.env.VSC_PYTHON_UNIT_TEST = oldValueOfVSC_PYTHON_UNIT_TEST;
+        process.env.VSC_PYTHON_CI_TEST = oldValueOfVSC_PYTHON_CI_TEST;
+        Reporter.properties = [];
+        Reporter.eventNames = [];
+        Reporter.measures = [];
+        rewiremock.disable();
+        clearTelemetryReporter();
+    });
+
     test('Register Adapter Factory if inside the DA experiment', async () => {
-        when(experimentsManager.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(true);
+        when(spiedInstance.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(true);
 
         await activator.activate();
 
         verify(debugService.registerDebugAdapterDescriptorFactory('python', instance(factory))).once();
     });
+
     test('Register a disposable item if inside the DA experiment', async () => {
-        when(experimentsManager.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(true);
+        when(spiedInstance.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(true);
         const disposable = { dispose: noop };
         when(debugService.registerDebugAdapterDescriptorFactory(anything(), anything())).thenReturn(disposable);
 
@@ -45,18 +112,47 @@ suite('Debugging - Adapter Factory Registration', () => {
 
         assert.deepEqual(disposableRegistry, [disposable]);
     });
+
+    test('Send experiment group telemetry if inside the DA experiment', async () => {
+        when(spiedInstance.userExperiments).thenReturn([{ name: DebugAdapterExperiment.experiment, salt: DebugAdapterExperiment.experiment, min: 0, max: 0 }]);
+
+        await activator.activate();
+
+        assert.deepEqual(Reporter.eventNames, [EventName.PYTHON_EXPERIMENTS]);
+        assert.deepEqual(Reporter.properties, [{ expName: DebugAdapterExperiment.experiment }]);
+    });
+
     test('Don\'t register the Adapter Factory if not inside the DA experiment', async () => {
-        when(experimentsManager.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(false);
+        when(spiedInstance.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(false);
 
         await activator.activate();
 
         verify(debugService.registerDebugAdapterDescriptorFactory('python', instance(factory))).never();
     });
+
     test('Don\'t register a disposable item if not inside the DA experiment', async () => {
-        when(experimentsManager.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(false);
+        when(spiedInstance.inExperiment(DebugAdapterExperiment.experiment)).thenReturn(false);
 
         await activator.activate();
 
         assert.deepEqual(disposableRegistry, []);
+    });
+
+    test('Send control group telemetry if inside the DA experiment control group', async () => {
+        when(spiedInstance.userExperiments).thenReturn([{ name: DebugAdapterExperiment.control, salt: DebugAdapterExperiment.control, min: 0, max: 0 }]);
+
+        await activator.activate();
+
+        assert.deepEqual(Reporter.eventNames, [EventName.PYTHON_EXPERIMENTS]);
+        assert.deepEqual(Reporter.properties, [{ expName: DebugAdapterExperiment.control }]);
+    });
+
+    test('Don\'t send any telemetry if not inside the DA experiment nor control group', async () => {
+        when(spiedInstance.userExperiments).thenReturn([]);
+
+        await activator.activate();
+
+        assert.deepEqual(Reporter.eventNames, []);
+        assert.deepEqual(Reporter.properties, []);
     });
 });


### PR DESCRIPTION
For #7817 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
