### PR TITLE
Prevent updates to cell text when stauts of cell has changed

### DIFF
--- a/news/2 Fixes/7844.md
+++ b/news/2 Fixes/7844.md
@@ -1,0 +1,1 @@
+Prevent updates to the cell text when cell execution of the same cell has commenced or completed.

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -1112,10 +1112,23 @@ export class MainStateController implements IMessageHandler {
             // we won't actually update.
             const newVMs = [...this.pendingState.cellVMs];
 
+            // Live share has been disabled for now, see https://github.com/microsoft/vscode-python/issues/7972
             // Check to see if our code still matches for the cell (in liveshare it might be updated from the other side)
-            if (concatMultilineString(this.pendingState.cellVMs[index].cell.data.source) !== concatMultilineString(cell.data.source)) {
-                const newText = extractInputText(cell, getSettings());
-                newVMs[index] = { ...newVMs[index], cell: cell, inputBlockText: newText };
+            // if (concatMultilineString(this.pendingState.cellVMs[index].cell.data.source) !== concatMultilineString(cell.data.source)) {
+
+            // If cell state changes, then update just the state and the cell data (excluding source).
+            if (this.pendingState.cellVMs[index].cell.state !== cell.state) {
+                newVMs[index] = {
+                                    ...newVMs[index],
+                                    cell: {
+                                        ...newVMs[index].cell,
+                                        state: cell.state,
+                                        data: {
+                                            ...cell.data,
+                                            source: newVMs[index].cell.data.source
+                                        }
+                                    }
+                                };
             } else {
                 newVMs[index] = { ...newVMs[index], cell: cell };
             }

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -1117,6 +1117,8 @@ export class MainStateController implements IMessageHandler {
             // if (concatMultilineString(this.pendingState.cellVMs[index].cell.data.source) !== concatMultilineString(cell.data.source)) {
 
             // If cell state changes, then update just the state and the cell data (excluding source).
+            // Prevent updates to the source, as its possible we have recieved a response for a cell execution
+            // and the user has updated the cell text since then.
             if (this.pendingState.cellVMs[index].cell.state !== cell.state) {
                 newVMs[index] = {
                                     ...newVMs[index],


### PR DESCRIPTION
For #7844

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [no] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
