### PR TITLE
Copy *.trie files related to fontkit as part of webpacking

### DIFF
--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -68,6 +68,7 @@ const config = {
             onEnd: [
                 {
                     copy: [
+                        { source: './node_modules/fontkit/*.trie', destination: './out/client/node_modules' },
                         { source: './node_modules/pdfkit/js/data/*.*', destination: './out/client/node_modules/data' },
                         { source: './node_modules/pdfkit/js/pdfkit.js', destination: './out/client/node_modules/' }
                     ]

--- a/build/webpack/webpack.extension.config.ts
+++ b/build/webpack/webpack.extension.config.ts
@@ -75,6 +75,7 @@ const config: Configuration = {
             onEnd: [
                 {
                     copy: [
+                        { source: './node_modules/fontkit/*.trie', destination: './out/client/node_modules' },
                         { source: './node_modules/pdfkit/js/data/*.*', destination: './out/client/node_modules/data' },
                         { source: './node_modules/pdfkit/js/pdfkit.js', destination: './out/client/node_modules/' }
                     ]

--- a/news/2 Fixes/7899.md
+++ b/news/2 Fixes/7899.md
@@ -1,0 +1,1 @@
+Ensure the `*.trie` files related to `font kit` npm module are copied into the output directory as part of the `Webpack` bundling operation.


### PR DESCRIPTION
For #7899

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [n/a] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [n/a] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
