### PR TITLE
Hide the parameters list when editor doesn't have focus

### DIFF
--- a/news/2 Fixes/7851.md
+++ b/news/2 Fixes/7851.md
@@ -1,0 +1,1 @@
+Hide the parameters intellisense widget in the `Notebook Editor` when it is not longer required.

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -475,6 +475,8 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         // Find all parameter widgets related to this monaco editor that are currently displayed.
         const visibleParameterHintsWidgets: Element[] = Array.prototype.slice.call(this.widgetParent.querySelectorAll('.parameter-hints-widget.visible'));
         if (hoverElements.length === 0 && visibleParameterHintsWidgets.length === 0){
+            // If user is not hovering over anything and there are no visible parameter widgets,
+            // then, we have nothing to do but get out of here.
             return;
         }
 
@@ -536,13 +538,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         // However some of the parameter widgets associated with this monaco editor are visible.
         // We need to hide them.
 
-        // Solution 1: Send the `Escape` key stroke to monaco, this will hide the parameters widget.
-        // tslint:disable-next-line: no-any
-        const eventOptions = {key: 'Escape', code: 27, keyCode: 27, bubbles: true, cancelable: true } as any;
-        const editorDom = this.state.editor.getDomNode()!;
-        editorDom.dispatchEvent(new KeyboardEvent('keydown', eventOptions));
-
-        // Solution 2: Hitting escape on the monaco editor when it doesn't have focus doesn't work.
+        // Solution: Hitting escape on the monaco editor when it doesn't have focus doesn't work.
         // Hence we need to hide it manually (as well).
         knownParameterHintsWidgets.forEach(widget => {
             widget.setAttribute('class', widget.className.split(' ').filter(cls => cls !== 'visible').join(' '));

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -462,6 +462,10 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
      * the parameter widget for this monaco editor.
      *
      * Notes: See issue https://github.com/microsoft/vscode-python/issues/7851 for further info.
+     * Hide the parameter widget if all of the following conditions have been met:
+     * - ditor doesn't have focus
+     * - Mouse is not over the editor
+     * - Mouse is not over (hovering) the parameter widget
      *
      * @private
      * @returns

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -461,6 +461,8 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
      * This will hide the parameter widget if the user is not hovering over
      * the parameter widget for this monaco editor.
      *
+     * Notes: See issue https://github.com/microsoft/vscode-python/issues/7851 for further info.
+     *
      * @private
      * @returns
      * @memberof MonacoEditor

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -540,8 +540,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         // However some of the parameter widgets associated with this monaco editor are visible.
         // We need to hide them.
 
-        // Solution: Hitting escape on the monaco editor when it doesn't have focus doesn't work.
-        // Hence we need to hide it manually (as well).
+        // Solution: Hide the widgets manually.
         knownParameterHintsWidgets.forEach(widget => {
             widget.setAttribute('class', widget.className.split(' ').filter(cls => cls !== 'visible').join(' '));
             if (widget.style.visibility !== 'hidden') {


### PR DESCRIPTION
For #7851

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
