### PR TITLE
Fix max output size to be passed down to rendering

### DIFF
--- a/news/2 Fixes/8010.md
+++ b/news/2 Fixes/8010.md
@@ -1,0 +1,1 @@
+Fix python.dataScience.maxOutputSize to be honored again.

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -144,6 +144,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
                                     baseTheme={this.props.baseTheme}
                                     expandImage={this.props.expandImage}
                                     openLink={this.props.openLink}
+                                    maxTextSize={this.props.maxTextSize}
                                 />
                             </div>
                         </div>

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -254,7 +254,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                         data: concatMultilineStringOutput(data as nbformat.MultilineString),
                         isText,
                         isError,
-                        renderWithScrollbars,
+                        renderWithScrollbars: true,
                         extraButton,
                         doubleClick: noop
                     };

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -697,6 +697,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     baseTheme={this.props.baseTheme}
                     expandImage={this.props.stateController.showPlot}
                     openLink={this.props.stateController.openLink}
+                    maxTextSize={this.props.maxTextSize}
                  />
             );
         }


### PR DESCRIPTION
For #8010

This is a regression caused by the native editor refactoring.