### PR TITLE
Fix markdown disappearing after editing and hitting the escape key.

### DIFF
--- a/news/2 Fixes/8045.md
+++ b/news/2 Fixes/8045.md
@@ -1,0 +1,1 @@
+Fix markdown disappearing after editing and hitting the escape key.

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -210,14 +210,10 @@ export function generateCells(filePath: string, repetitions: number): ICell[] {
     for (let i = 0; i < repetitions; i += 1) {
         cellData = [...cellData, ...generateCellData()];
     }
-    // Dynamically require vscode, this is testing code.
-    // Obfuscate the import to prevent webpack from picking this up.
-    // tslint:disable-next-line: no-eval (webpack is smart enough to look for `require` and `eval`).
-    const Uri = eval('req' + 'uire')('vscode').Uri;
     return cellData.map((data: nbformat.ICodeCell | nbformat.IMarkdownCell | nbformat.IRawCell | IMessageCell, key: number) => {
         return {
             id: key.toString(),
-            file: Uri.file(path.join(filePath, 'foo.py')).fsPath,
+            file: path.join(filePath, 'foo.py'),
             line: 1,
             state: key === cellData.length - 1 ? CellState.executing : CellState.finished,
             type: key === 3 ? 'preview' : 'execute',

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -210,10 +210,14 @@ export function generateCells(filePath: string, repetitions: number): ICell[] {
     for (let i = 0; i < repetitions; i += 1) {
         cellData = [...cellData, ...generateCellData()];
     }
+    // Dynamically require vscode, this is testing code.
+    // Obfuscate the import to prevent webpack from picking this up.
+    // tslint:disable-next-line: no-eval (webpack is smart enough to look for `require` and `eval`).
+    const Uri = eval('req' + 'uire')('vscode').Uri;
     return cellData.map((data: nbformat.ICodeCell | nbformat.IMarkdownCell | nbformat.IRawCell | IMessageCell, key: number) => {
         return {
             id: key.toString(),
-            file: path.join(filePath, 'foo.py'),
+            file: Uri.file(path.join(filePath, 'foo.py')).fsPath,
             line: 1,
             state: key === cellData.length - 1 ? CellState.executing : CellState.finished,
             type: key === 3 ? 'preview' : 'execute',

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -374,6 +374,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         // Unfocus the current cell by giving focus to the cell itself
         if (this.wrapperRef && this.wrapperRef.current && this.isFocused()) {
             e.stopPropagation();
+            this.isCodeCell() ? this.onCodeUnfocused() : this.onMarkdownUnfocused();
             this.props.focusCell(this.cellId, false);
             this.props.stateController.sendCommand(NativeCommandType.Unfocus, 'keyboard');
         }


### PR DESCRIPTION
For #8045 

Hitting the escape key was never actually causing a focus loss because of refactoring done around updating the render stage.