### PR TITLE
Do not auto save if notebook is untitled

### DIFF
--- a/src/client/datascience/interactive-ipynb/autoSaveService.ts
+++ b/src/client/datascience/interactive-ipynb/autoSaveService.ts
@@ -120,7 +120,7 @@ export class AutoSaveService implements IInteractiveWindowListener {
     private save() {
         this.clearTimeout();
         const notebook = this.getNotebook();
-        if (notebook && notebook.isDirty) {
+        if (notebook && notebook.isDirty && !notebook.isUntitled) {
             // Notify webview to perform a save.
             this.postEmitter.fire({ message: InteractiveWindowMessages.DoSave, payload: undefined });
         } else {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -725,8 +725,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
                 fileToSaveTo = await this.applicationShell.showSaveDialog({
                     saveLabel: localize.DataScience.dirtyNotebookDialogTitle(),
-                    filters: filtersObject,
-                    defaultUri: this.isUntitled ? undefined : this.file
+                    filters: filtersObject
                 });
             }
 

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -151,6 +151,10 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         return this._file;
     }
 
+    public get isUntitled(): boolean {
+        const baseName = path.basename(this.file.fsPath);
+        return baseName.includes(localize.DataScience.untitledNotebookFileName());
+    }
     public dispose(): void {
         super.dispose();
         this.close().ignoreErrors();
@@ -713,9 +717,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             let isDirty = this._dirty;
 
             // Ask user for a save as dialog if no title
-            const baseName = path.basename(this.file.fsPath);
-            const isUntitled = baseName.includes(localize.DataScience.untitledNotebookFileName());
-            if (isUntitled) {
+            if (this.isUntitled) {
                 const filtersKey = localize.DataScience.dirtyNotebookDialogFilter();
                 const filtersObject: { [name: string]: string[] } = {};
                 filtersObject[filtersKey] = ['ipynb'];
@@ -724,7 +726,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                 fileToSaveTo = await this.applicationShell.showSaveDialog({
                     saveLabel: localize.DataScience.dirtyNotebookDialogTitle(),
                     filters: filtersObject,
-                    defaultUri: isUntitled ? undefined : this.file
+                    defaultUri: this.isUntitled ? undefined : this.file
                 });
             }
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -252,6 +252,10 @@ export interface INotebookEditor extends IInteractiveBase {
     modified: Event<INotebookEditor>;
     saved: Event<INotebookEditor>;
     /**
+     * Is this notebook representing an untitled file which has never been saved yet.
+     */
+    readonly isUntitled: boolean;
+    /**
      * `true` if there are unpersisted changes.
      */
     readonly isDirty: boolean;


### PR DESCRIPTION
When attempting to auto save untitled notebooks, user will be presented with a save dialog.
This shouldn't be done as `auto save` is not initiated by the user.