### PR TITLE
Fix variable explorer failures

### DIFF
--- a/news/3 Code Health/8124.md
+++ b/news/3 Code Health/8124.md
@@ -1,0 +1,1 @@
+Variable explorer tests failing on nightly.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1173,7 +1173,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         }
     }
 
-    private requestVariables = async (requestExecutionCount: number): Promise<void> => {
+    private async requestVariables(requestExecutionCount: number): Promise<void> {
         this.variableRequestStopWatch = new StopWatch();
 
         // Request our new list of variables

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -624,7 +624,11 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
                 // During normal operation, the react control will not be created before
                 // the webPanelListener
                 if (this.missedMessages.length && this.webPanelListener) {
-                    this.missedMessages.forEach(m => this.webPanelListener ? this.webPanelListener.onMessage(m.type, m.payload) : noop());
+                    // This needs to be async because we are being called in the ctor of the webpanel. It can't
+                    // handle some messages during the ctor.
+                    setTimeout(() => {
+                        this.missedMessages.forEach(m => this.webPanelListener ? this.webPanelListener.onMessage(m.type, m.payload) : noop());
+                    }, 0);
 
                     // Note, you might think we should clean up the messages. However since the mount only occurs once, we might
                     // create multiple webpanels with the same mount. We need to resend these messages to


### PR DESCRIPTION
For #8124 

Root cause was making a function into a property. This means it cannot be inherited.

However that function still cannot be called during the .ctor, so had to postpone message handling until after the ctor.

Running this through a nightly flake run too.