### PR TITLE
Fix unit test build error

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -741,10 +741,11 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
     private fixupCell(cell: nbformat.ICell): nbformat.ICell {
         // Source is usually a single string on input. Convert back to an array
-        return {
+        return ({
             ...cell,
             source: splitMultilineString(cell.source)
-        };
+            // tslint:disable-next-line: no-any
+        } as any) as nbformat.ICell; // nyc (code coverage) barfs on this so just trick it.
     }
 
     private async extractPythonMainVersion(notebookData: Partial<nbformat.INotebookContent>): Promise<number> {


### PR DESCRIPTION
Unit tests are failing to run because of a tsnode compiler error:

```
F:\vscode-python-3\node_modules\ts-node\src\index.ts:245
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/client/datascience/interactive-ipynb/nativeEditor.ts:744:9 - error TS2322: Type '{ source: string[]; cell_type: "code"; metadata: Partial<ICodeCellMetadata>; outputs: IOutput[]; execution_count: number | null; } | { source: string[]; cell_type: "raw"; metadata: Partial<IRawCellMetadata>; attachments?: IAttachments | undefined; } | { ...; } | { ...; }' is not assignable to type 'ICell'.
  Type '{ source: string[]; cell_type: "code"; metadata: Partial<ICodeCellMetadata>; outputs: IOutput[]; execution_count: number | null; }' is not assignable to type 'ICell'.
    Type '{ source: string[]; cell_type: "code"; metadata: Partial<ICodeCellMetadata>; outputs: IOutput[]; execution_count: number | null; }' is not assignable to type 'IUnrecognizedCell'.
      Property 'metadata' is incompatible with index signature.
        Type 'Partial<ICodeCellMetadata>' is not assignable to type 'JSONValue'.
          Type 'Partial<ICodeCellMetadata>' is not assignable to type 'string'
```

