### PR TITLE
Preserve notebook changes over uncommitted changes

### DIFF
--- a/news/2 Fixes/8025.md
+++ b/news/2 Fixes/8025.md
@@ -1,0 +1,1 @@
+Opening a notebook a second time round with changes (made from another editor) should be preserved.

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -9,7 +9,7 @@ import * as glob from 'glob';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import * as tmp from 'tmp';
-import { FileStat, Uri, workspace } from 'vscode';
+import { FileStat } from 'vscode';
 import { createDeferred } from '../utils/async';
 import { IFileSystem, IPlatformService, TemporaryFile } from './types';
 
@@ -21,7 +21,11 @@ export class FileSystem implements IFileSystem {
         return path.sep;
     }
     public async stat(filePath: string): Promise<FileStat> {
-        return workspace.fs.stat(Uri.file(filePath));
+        // Do not import vscode directly, as this isn't available in the Debugger Context.
+        // If stat is used in debugger context, it will fail, however theres a separate PR that will resolve this.
+        // tslint:disable-next-line: no-require-imports
+        const vscode = require('vscode');
+        return vscode.workspace.fs.stat(vscode.Uri.file(filePath));
     }
 
     public objectExists(filePath: string, statCheck: (s: fs.Stats) => boolean): Promise<boolean> {

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -9,15 +9,45 @@ import * as glob from 'glob';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import * as tmp from 'tmp';
+import * as vscode from 'vscode';
 import { createDeferred } from '../utils/async';
 import { IFileSystem, IPlatformService, TemporaryFile } from './types';
 
 @injectable()
 export class FileSystem implements IFileSystem {
-    constructor(@inject(IPlatformService) private platformService: IPlatformService) { }
+    constructor(@inject(IPlatformService) private platformService: IPlatformService) {}
 
     public get directorySeparatorChar(): string {
         return path.sep;
+    }
+    public async stat(filePath: string): Promise<vscode.FileStat> {
+        try {
+            // Use a try catch, if this filesystem class is used in the debugger context.
+            // Within the debugger context, the `vscode` package is not available.
+            // tslint:disable-next-line: no-require-imports
+            const vsc = require('vscode') as typeof vscode;
+            return vsc.workspace.fs.stat(vsc.Uri.file(filePath));
+        } catch {
+            const stat = await fs.lstat(filePath);
+            // We're inside the debugger context, at this point we do not have access to VS Code.
+            // Hence use traditional fs apii and hard code the enum values.
+            let type: vscode.FileType = 0;
+            if (stat.isDirectory()) {
+                type = 2;
+            }
+            if (stat.isFile()) {
+                type = 1;
+            }
+            if (stat.isSymbolicLink()) {
+                type = 64;
+            }
+            return {
+                ctime: stat.ctimeMs,
+                mtime: stat.mtimeMs,
+                size: stat.size,
+                type
+            };
+        }
     }
 
     public objectExists(filePath: string, statCheck: (s: fs.Stats) => boolean): Promise<boolean> {
@@ -32,7 +62,7 @@ export class FileSystem implements IFileSystem {
     }
 
     public fileExists(filePath: string): Promise<boolean> {
-        return this.objectExists(filePath, (stats) => stats.isFile());
+        return this.objectExists(filePath, stats => stats.isFile());
     }
     public fileExistsSync(filePath: string): boolean {
         return fs.existsSync(filePath);
@@ -52,7 +82,7 @@ export class FileSystem implements IFileSystem {
     }
 
     public directoryExists(filePath: string): Promise<boolean> {
-        return this.objectExists(filePath, (stats) => stats.isDirectory());
+        return this.objectExists(filePath, stats => stats.isDirectory());
     }
 
     public createDirectory(directoryPath: string): Promise<void> {
@@ -61,7 +91,7 @@ export class FileSystem implements IFileSystem {
 
     public deleteDirectory(directoryPath: string): Promise<void> {
         const deferred = createDeferred<void>();
-        fs.rmdir(directoryPath, err => err ? deferred.reject(err) : deferred.resolve());
+        fs.rmdir(directoryPath, err => (err ? deferred.reject(err) : deferred.resolve()));
         return deferred.promise;
     }
 
@@ -71,19 +101,17 @@ export class FileSystem implements IFileSystem {
                 if (error) {
                     return resolve([]);
                 }
-                const subDirs = (
-                    await Promise.all(
-                        files.map(async name => {
-                            const fullPath = path.join(rootDir, name);
-                            try {
-                                if ((await fs.stat(fullPath)).isDirectory()) {
-                                    return fullPath;
-                                }
-                                // tslint:disable-next-line:no-empty
-                            } catch (ex) { }
-                        })
-                    ))
-                    .filter(dir => dir !== undefined) as string[];
+                const subDirs = (await Promise.all(
+                    files.map(async name => {
+                        const fullPath = path.join(rootDir, name);
+                        try {
+                            if ((await fs.stat(fullPath)).isDirectory()) {
+                                return fullPath;
+                            }
+                            // tslint:disable-next-line:no-empty
+                        } catch (ex) {}
+                    })
+                )).filter(dir => dir !== undefined) as string[];
                 resolve(subDirs);
             });
         });
@@ -128,21 +156,24 @@ export class FileSystem implements IFileSystem {
 
     public copyFile(src: string, dest: string): Promise<void> {
         const deferred = createDeferred<void>();
-        const rs = fs.createReadStream(src).on('error', (err) => {
+        const rs = fs.createReadStream(src).on('error', err => {
             deferred.reject(err);
         });
-        const ws = fs.createWriteStream(dest).on('error', (err) => {
-            deferred.reject(err);
-        }).on('close', () => {
-            deferred.resolve();
-        });
+        const ws = fs
+            .createWriteStream(dest)
+            .on('error', err => {
+                deferred.reject(err);
+            })
+            .on('close', () => {
+                deferred.resolve();
+            });
         rs.pipe(ws);
         return deferred.promise;
     }
 
     public deleteFile(filename: string): Promise<void> {
         const deferred = createDeferred<void>();
-        fs.unlink(filename, err => err ? deferred.reject(err) : deferred.resolve());
+        fs.unlink(filename, err => (err ? deferred.reject(err) : deferred.resolve()));
         return deferred.promise;
     }
 
@@ -152,7 +183,9 @@ export class FileSystem implements IFileSystem {
                 if (err) {
                     reject(err);
                 } else {
-                    const actual = createHash('sha512').update(`${stats.ctimeMs}-${stats.mtimeMs}`).digest('hex');
+                    const actual = createHash('sha512')
+                        .update(`${stats.ctimeMs}-${stats.mtimeMs}`)
+                        .digest('hex');
                     resolve(actual);
                 }
             });

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -4,7 +4,7 @@
 import * as fs from 'fs';
 import * as fsextra from 'fs-extra';
 import { SemVer } from 'semver';
-import { Disposable } from 'vscode';
+import { Disposable, FileStat } from 'vscode';
 import { Architecture, OSType } from '../utils/platform';
 
 export enum RegistryHive {
@@ -38,6 +38,7 @@ export type TemporaryDirectory = { path: string } & Disposable;
 export const IFileSystem = Symbol('IFileSystem');
 export interface IFileSystem {
     directorySeparatorChar: string;
+    stat(filePath: string): Promise<FileStat>;
     objectExists(path: string, statCheck: (s: fs.Stats) => boolean): Promise<boolean>;
     fileExists(path: string): Promise<boolean>;
     fileExistsSync(path: string): boolean;

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -553,7 +553,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     }
     /**
      * Gets any unsaved changes to the notebook file.
-     * If the file has been modified since the uncommited changes were stored, then ignore the uncommited changes.
+     * If the file has been modified since the uncommitted changes were stored, then ignore the uncommitted changes.
      *
      * @private
      * @returns {(Promise<string | undefined>)}
@@ -572,9 +572,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     }
 
     /**
-     * Stores the uncommited notebook changes into a temporary location.
+     * Stores the uncommitted notebook changes into a temporary location.
      * Also keep track of the current time. This way we can check whether changes were
-     * made to the file since the last time uncommited changes were stored.
+     * made to the file since the last time uncommitted changes were stored.
      *
      * @private
      * @param {string} [contents]

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -21,7 +21,7 @@ import {
 import { ContextKey } from '../../common/contextKey';
 import { traceError } from '../../common/logger';
 import { IFileSystem, TemporaryFile } from '../../common/platform/types';
-import { IConfigurationService, IDisposableRegistry, IMemento, WORKSPACE_MEMENTO } from '../../common/types';
+import { GLOBAL_MEMENTO, IConfigurationService, IDisposableRegistry, IMemento } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { StopWatch } from '../../common/utils/stopWatch';
@@ -112,7 +112,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         @inject(IJupyterDebugger) jupyterDebugger: IJupyterDebugger,
         @inject(INotebookImporter) private importer: INotebookImporter,
         @inject(IDataScienceErrorHandler) errorHandler: IDataScienceErrorHandler,
-        @inject(IMemento) @named(WORKSPACE_MEMENTO) private workspaceStorage: Memento
+        @inject(IMemento) @named(GLOBAL_MEMENTO) private globalStorage: Memento
     ) {
         super(
             listeners,
@@ -184,7 +184,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         await this.show();
 
         // See if this file was stored in storage prior to shutdown
-        const dirtyContents = this.getStoredContents();
+        const dirtyContents = await this.getStoredContents();
         if (dirtyContents) {
             // This means we're dirty. Indicate dirty and load from this content
             return this.loadContents(dirtyContents, true);
@@ -551,14 +551,41 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     private getStorageKey(): string {
         return `notebook-storage-${this._file.toString()}`;
     }
-
-    private getStoredContents(): string | undefined {
-        return this.workspaceStorage.get<string>(this.getStorageKey());
+    /**
+     * Gets any unsaved changes to the notebook file.
+     * If the file has been modified since the uncommited changes were stored, then ignore the uncommited changes.
+     *
+     * @private
+     * @returns {(Promise<string | undefined>)}
+     * @memberof NativeEditor
+     */
+    private async getStoredContents(): Promise<string | undefined> {
+        const data = this.globalStorage.get<{contents?: string; lastModifiedTimeMs?: number}>(this.getStorageKey());
+        // Check whether the file has been modified since the last time the contents were saved.
+        if (data && data.lastModifiedTimeMs && !this.isUntitled){
+            const stat = await this.fileSystem.stat(this.file.fsPath);
+            if (stat.mtime > data.lastModifiedTimeMs){
+                return;
+            }
+        }
+        return data ? data.contents : undefined;
     }
 
+    /**
+     * Stores the uncommited notebook changes into a temporary location.
+     * Also keep track of the current time. This way we can check whether changes were
+     * made to the file since the last time uncommited changes were stored.
+     *
+     * @private
+     * @param {string} [contents]
+     * @returns {Promise<void>}
+     * @memberof NativeEditor
+     */
     private async storeContents(contents?: string): Promise<void> {
         const key = this.getStorageKey();
-        await this.workspaceStorage.update(key, contents);
+        // Keep track of the time when this data was saved.
+        // This way when we retrieve the data we can compare it against last modified date of the file.
+        await this.globalStorage.update(key, {contents, lastModifiedTimeMs: Date.now()});
     }
 
     private async close(): Promise<void> {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -562,7 +562,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     private async getStoredContents(): Promise<string | undefined> {
         const data = this.globalStorage.get<{contents?: string; lastModifiedTimeMs?: number}>(this.getStorageKey());
         // Check whether the file has been modified since the last time the contents were saved.
-        if (data && data.lastModifiedTimeMs && !this.isUntitled){
+        if (data && data.lastModifiedTimeMs && !this.isUntitled && this.file.scheme === 'file'){
             const stat = await this.fileSystem.stat(this.file.fsPath);
             if (stat.mtime > data.lastModifiedTimeMs){
                 return;

--- a/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { expect } from 'chai';
-import { instance, mock, when } from 'ts-mockito';
+import { anything, instance, mock, when } from 'ts-mockito';
 import { ConfigurationChangeEvent, Disposable, EventEmitter, TextEditor, Uri } from 'vscode';
 
 import { ApplicationShell } from '../../../client/common/application/applicationShell';
@@ -24,6 +24,7 @@ import { LiveShareApi } from '../../../client/common/liveshare/liveshare';
 import { FileSystem } from '../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IConfigurationService } from '../../../client/common/types';
+import { sleep } from '../../../client/common/utils/async';
 import { CodeCssGenerator } from '../../../client/datascience/codeCssGenerator';
 import { DataViewerProvider } from '../../../client/datascience/data-viewing/dataViewerProvider';
 import { DataScienceErrorHandler } from '../../../client/datascience/errorHandler/errorHandler';
@@ -55,7 +56,7 @@ import { InterpreterService } from '../../../client/interpreter/interpreterServi
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
 
-// tslint:disable: no-any
+// tslint:disable: no-any chai-vague-errors no-unused-expression
 
 // tslint:disable: max-func-body-length
 suite('Data Science - Native Editor', () => {
@@ -298,5 +299,105 @@ suite('Data Science - Native Editor', () => {
         expect(editor.cells[0].id).to.be.match(/NotebookImport#1/);
         editor.onMessage(InteractiveWindowMessages.DeleteAllCells, {});
         expect(editor.cells).to.be.lengthOf(0);
+    });
+
+    async function loadEditorAddCellAndWaitForMementoUpdate(file: Uri){
+        const editor = createEditor();
+        await editor.load(baseFile, file);
+        expect(editor.contents).to.be.equal(baseFile);
+        editor.onMessage(InteractiveWindowMessages.InsertCell, { index: 0, cell: createEmptyCell('1', 1) });
+        expect(editor.cells).to.be.lengthOf(4);
+
+        // Wait for contents to be stored in memento.
+        await sleep(1);
+
+        // Confirm contents were saved.
+        expect(storage.get(`notebook-storage-${file.toString()}`)).not.to.be.undefined;
+        expect(editor.contents).not.to.be.equal(baseFile);
+
+        return editor;
+    }
+
+    test('Editing a notebook will save uncommited changes into memento', async () => {
+        const file = Uri.parse('file://foo.ipynb');
+
+        // Initially nothing in memento
+        expect(storage.get(`notebook-storage-${file.toString()}`)).to.be.undefined;
+
+        await loadEditorAddCellAndWaitForMementoUpdate(file);
+    });
+
+    test('Opening a notebook will restore uncommited changes', async () => {
+        const file = Uri.parse('file://foo.ipynb');
+        when(fileSystem.stat(anything())).thenResolve({mtime: 1} as any);
+
+        // Initially nothing in memento
+        expect(storage.get(`notebook-storage-${file.toString()}`)).to.be.undefined;
+
+        const editor = await loadEditorAddCellAndWaitForMementoUpdate(file);
+
+        // Close the editor.
+        editor.dispose();
+
+        // Open a new one.
+        const newEditor = createEditor();
+        await newEditor.load(baseFile, file);
+
+        // Verify contents are different.
+        // Meaning it was not loaded from file, but loaded from our storage.
+        expect(newEditor.contents).not.to.be.equal(baseFile);
+        const notebook = JSON.parse(newEditor.contents);
+        // 4 cells (1 extra for what was added)
+        expect(notebook.cells).to.be.lengthOf(4);
+    });
+
+    test('Opening a notebook will restore uncommited changes (ignoring contents of file)', async () => {
+        const file = Uri.parse('file://foo.ipynb');
+        when(fileSystem.stat(anything())).thenResolve({mtime: 1} as any);
+
+        // Initially nothing in memento
+        expect(storage.get(`notebook-storage-${file.toString()}`)).to.be.undefined;
+
+        const editor = await loadEditorAddCellAndWaitForMementoUpdate(file);
+
+        // Close the editor.
+        editor.dispose();
+
+        // Open a new one with the same file.
+        const newEditor = createEditor();
+        // However, pass in some bosu content, to confirm it is NOT loaded from file.
+        await newEditor.load('crap', file);
+
+        // Verify contents are different.
+        // Meaning it was not loaded from file, but loaded from our storage.
+        expect(newEditor.contents).not.to.be.equal(baseFile);
+        const notebook = JSON.parse(newEditor.contents);
+        // 4 cells (1 extra for what was added)
+        expect(notebook.cells).to.be.lengthOf(4);
+    });
+
+    test('Opening a notebook will NOT restore uncommited changes if file has been modified since', async () => {
+        const file = Uri.parse('file://foo.ipynb');
+        when(fileSystem.stat(anything())).thenResolve({mtime: 1} as any);
+
+        // Initially nothing in memento
+        expect(storage.get(`notebook-storage-${file.toString()}`)).to.be.undefined;
+
+        const editor = await loadEditorAddCellAndWaitForMementoUpdate(file);
+
+        // Close the editor.
+        editor.dispose();
+
+        // Mimic changes to file (by returning a new modified time).
+        when(fileSystem.stat(anything())).thenResolve({mtime: Date.now()} as any);
+
+        // Open a new one.
+        const newEditor = createEditor();
+        await newEditor.load(baseFile, file);
+
+        // Verify contents are different.
+        // Meaning it was not loaded from file, but loaded from our storage.
+        expect(newEditor.contents).to.be.equal(baseFile);
+        expect(newEditor.cells).to.be.lengthOf(3);
     });
 });

--- a/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
@@ -318,7 +318,7 @@ suite('Data Science - Native Editor', () => {
         return editor;
     }
 
-    test('Editing a notebook will save uncommited changes into memento', async () => {
+    test('Editing a notebook will save uncommitted changes into memento', async () => {
         const file = Uri.parse('file://foo.ipynb');
 
         // Initially nothing in memento
@@ -327,7 +327,7 @@ suite('Data Science - Native Editor', () => {
         await loadEditorAddCellAndWaitForMementoUpdate(file);
     });
 
-    test('Opening a notebook will restore uncommited changes', async () => {
+    test('Opening a notebook will restore uncommitted changes', async () => {
         const file = Uri.parse('file://foo.ipynb');
         when(fileSystem.stat(anything())).thenResolve({mtime: 1} as any);
 
@@ -351,7 +351,7 @@ suite('Data Science - Native Editor', () => {
         expect(notebook.cells).to.be.lengthOf(4);
     });
 
-    test('Opening a notebook will restore uncommited changes (ignoring contents of file)', async () => {
+    test('Opening a notebook will restore uncommitted changes (ignoring contents of file)', async () => {
         const file = Uri.parse('file://foo.ipynb');
         when(fileSystem.stat(anything())).thenResolve({mtime: 1} as any);
 
@@ -376,7 +376,7 @@ suite('Data Science - Native Editor', () => {
         expect(notebook.cells).to.be.lengthOf(4);
     });
 
-    test('Opening a notebook will NOT restore uncommited changes if file has been modified since', async () => {
+    test('Opening a notebook will NOT restore uncommitted changes if file has been modified since', async () => {
         const file = Uri.parse('file://foo.ipynb');
         when(fileSystem.stat(anything())).thenResolve({mtime: 1} as any);
 

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -59,6 +59,7 @@ import {
     verifyHtmlOnCell,
     waitForMessageResponse
 } from './testHelpers';
+import { IFileSystem } from '../../client/common/platform/types';
 
 use(chaiAsPromised);
 
@@ -270,6 +271,9 @@ for _ in range(50):
         }, () => { return ioc; });
 
         runMountedTest('Startup and shutdown', async (wrapper) => {
+            // Stub the `stat` method to return a dummy value.
+            sinon.stub(ioc.serviceContainer.get<IFileSystem>(IFileSystem), 'stat').resolves({mtime: 0} as any);
+
             addMockData(ioc, 'b=2\nb', 2);
             addMockData(ioc, 'c=3\nc', 3);
 

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -13,6 +13,7 @@ import * as TypeMoq from 'typemoq';
 import { Disposable, TextDocument, TextEditor, Uri, WindowState } from 'vscode';
 
 import { IApplicationShell, IDocumentManager } from '../../client/common/application/types';
+import { IFileSystem } from '../../client/common/platform/types';
 import { createDeferred, waitForPromise } from '../../client/common/utils/async';
 import { createTemporaryFile } from '../../client/common/utils/fs';
 import { noop } from '../../client/common/utils/misc';
@@ -59,7 +60,6 @@ import {
     verifyHtmlOnCell,
     waitForMessageResponse
 } from './testHelpers';
-import { IFileSystem } from '../../client/common/platform/types';
 
 use(chaiAsPromised);
 


### PR DESCRIPTION
For #8025

**Other changes**
I have change the code to use the global memento storage. 
The uncommitted changes made to a notebook file must be store in a central location irrespective of the current workspace. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n//a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
