### PR TITLE
Fix shift+enter to take focus out except for on a new cell

### DIFF
--- a/news/2 Fixes/8069.md
+++ b/news/2 Fixes/8069.md
@@ -1,0 +1,1 @@
+Make shift+enter not take focus unless about to add a new cell.

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -210,14 +210,10 @@ export function generateCells(filePath: string, repetitions: number): ICell[] {
     for (let i = 0; i < repetitions; i += 1) {
         cellData = [...cellData, ...generateCellData()];
     }
-    // Dynamically require vscode, this is testing code.
-    // Obfuscate the import to prevent webpack from picking this up.
-    // tslint:disable-next-line: no-eval (webpack is smart enough to look for `require` and `eval`).
-    const Uri = eval('req' + 'uire')('vscode').Uri;
     return cellData.map((data: nbformat.ICodeCell | nbformat.IMarkdownCell | nbformat.IRawCell | IMessageCell, key: number) => {
         return {
             id: key.toString(),
-            file: Uri.file(path.join(filePath, 'foo.py')).fsPath,
+            file: path.join(filePath, 'foo.py').toLowerCase(),
             line: 1,
             state: key === cellData.length - 1 ? CellState.executing : CellState.finished,
             type: key === 3 ? 'preview' : 'execute',

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -385,7 +385,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         const prevCellId = this.getPrevCellId();
         if (prevCellId) {
             e.stopPropagation();
-            this.moveSelection(prevCellId, true);
+            this.moveSelection(prevCellId, this.isFocused());
         }
 
         this.props.stateController.sendCommand(NativeCommandType.ArrowUp, 'keyboard');
@@ -396,7 +396,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
         if (nextCellId) {
             e.stopPropagation();
-            this.moveSelection(nextCellId, true);
+            this.moveSelection(nextCellId, this.isFocused());
         }
 
         this.props.stateController.sendCommand(NativeCommandType.ArrowDown, 'keyboard');

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -36,7 +36,8 @@ interface INativeCellProps {
     lastCell: boolean;
     font: IFont;
     focusCell(cellId: string, focusCode: boolean): void;
-    selectCell(cellId: string): void;
+    selectCell(cellId: string, focusCode: boolean): void;
+
 }
 
 // tslint:disable: react-this-binding-issue
@@ -311,7 +312,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 if (isFocusedWhenNotSuggesting || !this.isFocused()) {
                     e.stopPropagation();
                     const cell = this.props.stateController.insertAbove(cellId, true);
-                    this.moveSelection(cell!);
+                    this.moveSelection(cell!, true);
                     this.props.stateController.sendCommand(NativeCommandType.InsertAbove, 'keyboard');
                 }
                 break;
@@ -319,7 +320,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 if (isFocusedWhenNotSuggesting || !this.isFocused()) {
                     e.stopPropagation();
                     const cell = this.props.stateController.insertBelow(cellId, true);
-                    this.moveSelection(cell!);
+                    this.moveSelection(cell!, true);
                     this.props.stateController.sendCommand(NativeCommandType.InsertBelow, 'keyboard');
                 }
                 break;
@@ -384,7 +385,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         const prevCellId = this.getPrevCellId();
         if (prevCellId) {
             e.stopPropagation();
-            this.moveSelection(prevCellId);
+            this.moveSelection(prevCellId, true);
         }
 
         this.props.stateController.sendCommand(NativeCommandType.ArrowUp, 'keyboard');
@@ -395,7 +396,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
         if (nextCellId) {
             e.stopPropagation();
-            this.moveSelection(nextCellId);
+            this.moveSelection(nextCellId, true);
         }
 
         this.props.stateController.sendCommand(NativeCommandType.ArrowDown, 'keyboard');
@@ -436,14 +437,17 @@ export class NativeCell extends React.Component<INativeCellProps> {
         // Submit this cell
         this.submitCell(possibleContents);
 
-        // Move to the next cell if we have one and give it focus
+        // Move to the next cell if we have one
+        let focus = false;
         let nextCell = this.getNextCellId();
         if (!nextCell) {
-            // At the bottom insert a cell to move to instead
+            // At the bottom insert a cell to move to instead. Focus if this is the case. This is how
+            // a Jupyter notebook works
             nextCell = this.props.stateController.insertBelow(this.cellId, true);
+            focus = true;
         }
         if (nextCell) {
-            this.moveSelection(nextCell);
+            this.moveSelection(nextCell, focus);
         }
     }
 
@@ -456,7 +460,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
         // On next update, move the new cell
         if (nextCell) {
-            this.moveSelection(nextCell);
+            this.moveSelection(nextCell, true);
         }
     }
 
@@ -470,8 +474,8 @@ export class NativeCell extends React.Component<INativeCellProps> {
         this.props.stateController.sendCommand(NativeCommandType.Run, 'keyboard');
     }
 
-    private moveSelection = (cellId: string) => {
-        this.props.selectCell(cellId);
+    private moveSelection(cellId: string, focusCode: boolean) {
+        this.props.selectCell(cellId, focusCode);
     }
 
     private submitCell = (possibleContents?: string) => {

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -145,29 +145,26 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
         noop();
     }
 
-    private moveSelectionToExisting = (cellId: string) => {
+    private moveSelectionToExisting = (cellId: string, focusCode: boolean) => {
         // Cell should already exist in the UI
         if (this.contentPanelRef) {
-            const wasFocused = this.state.focusedCellId !== undefined;
-            this.stateController.selectCell(cellId, wasFocused ? cellId : undefined);
-            this.focusCell(cellId, wasFocused ? true : false);
+            this.stateController.selectCell(cellId, focusCode ? cellId : undefined);
+            this.focusCell(cellId, focusCode ? true : false);
         }
     }
 
-    private selectCell = (id: string) => {
+    private selectCell = (id: string, focusCode: boolean) => {
         // Check to see that this cell already exists in our window (it's part of the rendered state)
         const cells = this.state.cellVMs.map(c => c.cell).filter(c => c.data.cell_type !== 'messages');
         if (cells.find(c => c.id === id)) {
             // Force selection change right now as we don't need the cell to exist
             // to make it selected (otherwise we'll get a flash)
-            const wasFocused = this.state.focusedCellId !== undefined;
-            this.stateController.selectCell(id, wasFocused ? id : undefined);
-
-            // Then wait to give it actual input focus
-            setTimeout(() => this.moveSelectionToExisting(id), 1);
-        } else {
-            this.moveSelectionToExisting(id);
+            this.stateController.selectCell(id, focusCode ? id : undefined);
         }
+
+        // Then wait to give it actual input focus. The cell may not exist yet so we can't just
+        // force focus immediately.
+        setTimeout(() => this.moveSelectionToExisting(id, focusCode), 1);
     }
 
     // tslint:disable: react-this-binding-issue

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -705,7 +705,7 @@ for _ in range(50):
                 assert.ok(isCellSelected(wrapper, 'NativeCell', 1));
             });
 
-            test('Pressing \'Altr+Enter\' on a selected cell adds a new cell below it', async () => {
+            test('Pressing \'Alt+Enter\' on a selected cell adds a new cell below it', async () => {
                 // Initially 3 cells.
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
@@ -714,8 +714,8 @@ for _ in range(50):
                 simulateKeyPressOnCell(1, { code: 'Enter', altKey: true, editorInfo: undefined });
                 await update;
 
-                // The second cell should be selected.
-                assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
+                // The second cell should be focused.
+                assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
                 // There should be 4 cells.
                 assert.equal(wrapper.find('NativeCell').length, 4);
             });
@@ -870,12 +870,18 @@ for _ in range(50):
                     simulateKeyPressOnCell(0, { code: 'a' });
                     await update;
 
-                    // There should be 4 cells and first cell is selected & nothing focused.
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
+                    // There should be 4 cells and first cell is focused.
+                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
                     assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
+                    assert.equal(isCellFocused(wrapper, 'NativeCell', 0), true);
                     assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
                     assert.equal(wrapper.find('NativeCell').length, 4);
+
+                    // Unfocus the cell
+                    update = waitForUpdate(wrapper, NativeEditor, 1);
+                    simulateKeyPressOnCell(0, { code: 'Escape' });
+                    await update;
+                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
 
                     // Press 'z' to undo.
                     update = waitForUpdate(wrapper, NativeEditor, 1);

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -647,8 +647,15 @@ for _ in range(50):
             });
 
             test('Pressing \'Shift+Enter\' on a selected cell executes the cell and advances to the next cell', async () => {
+                let update = waitForUpdate(wrapper, NativeEditor, 1);
                 clickCell(1);
-                const update = waitForUpdate(wrapper, NativeEditor, 7);
+                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                await update;
+
+                // The 2nd cell should be focused
+                assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
+
+                update = waitForUpdate(wrapper, NativeEditor, 7);
                 simulateKeyPressOnCell(1, { code: 'Enter', shiftKey: true, editorInfo: undefined });
                 await update;
                 wrapper.update();
@@ -658,6 +665,31 @@ for _ in range(50):
 
                 // The third cell should be selected.
                 assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
+
+                // The third cell should not be focused
+                assert.ok(!isCellFocused(wrapper, 'NativeCell', 2));
+
+                // Shift+enter on the last cell, it should behave differently. It should be selected and focused
+
+                // First focus the cell.
+                update = waitForUpdate(wrapper, NativeEditor, 2);
+                clickCell(2);
+                simulateKeyPressOnCell(2, { code: 'Enter', editorInfo: undefined });
+                await update;
+
+                // The 3rd cell should be focused
+                assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
+
+                update = waitForUpdate(wrapper, NativeEditor, 7);
+                simulateKeyPressOnCell(2, { code: 'Enter', shiftKey: true, editorInfo: undefined });
+                await update;
+                wrapper.update();
+
+                // The fourth cell should be focused and not selected.
+                assert.ok(!isCellSelected(wrapper, 'NativeCell', 3));
+
+                // The fourth cell should be focused
+                assert.ok(isCellFocused(wrapper, 'NativeCell', 3));
             });
 
             test('Pressing \'Ctrl+Enter\' on a selected cell executes the cell and cell selection is not changed', async () => {


### PR DESCRIPTION
For #8069 

Make shift+enter/alt+enter behave like a jupyter notebook with respect to focus

- Focus in a cell, and not creating a new cell, move to next cell and make command mode
- Focus in a cell and new cell, move to next cell and take focus
- Focus not in a cell and new cell, move to next cell and take focus

