### PR TITLE
Fix: blockComment typo in .ipynb tokenizer

### DIFF
--- a/src/datascience-ui/interactive-common/tokenizer.ts
+++ b/src/datascience-ui/interactive-common/tokenizer.ts
@@ -20,7 +20,7 @@ export function registerMonacoLanguage() {
         {
             comments: {
                 lineComment: '#',
-                blockComment: ['\'\'\'', '\"\"\"']
+                blockComment: ['\"\"\"', '\"\"\"']
             },
             brackets: [
                 ['{', '}'],


### PR DESCRIPTION
`blockComment: ['\"\"\"', '\"\"\"']` use is similar to the main vscode .py interface.