### PR TITLE
Ensure intellisense is displayed only for one cell at a time

### DIFF
--- a/news/2 Fixes/8007.md
+++ b/news/2 Fixes/8007.md
@@ -1,0 +1,1 @@
+Ensure intellisense (& similar widgets/popups) are dispaled for one cell in the Notebook editor.

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -18,6 +18,16 @@ const throttle = require('lodash/throttle') as typeof import('lodash/throttle');
 import './monacoEditor.css';
 
 const LINE_HEIGHT = 18;
+enum WidgetCSSSelector {
+    /**
+     * CSS Selector for the parameters widget displayed by Monaco.
+     */
+    Parameters = '.parameter-hints-widget',
+    /**
+     * CSS Selector for the hover widget displayed by Monaco.
+     */
+    Hover = '.monaco-editor-hover'
+}
 
 export interface IMonacoEditorProps {
     language: string;
@@ -139,6 +149,9 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
             if (model) {
                 this.subscriptions.push(model.onDidChangeContent(() => {
                     this.windowResized();
+                    if (this.state.editor && this.state.editor.hasWidgetFocus()){
+                        this.hideAllOtherHoverAndParameterWidgets();
+                    }
                 }));
             }
 
@@ -175,6 +188,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
             this.subscriptions.push(editor.onDidFocusEditorWidget(() => {
                 this.throttledUpdateWidgetPosition();
                 this.updateWidgetParent(editor);
+                this.hideAllOtherHoverAndParameterWidgets();
             }));
 
             // Update our margin to include the correct line number style
@@ -195,6 +209,12 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
 
             // Tell our parent the editor is ready to use
             this.props.editorMounted(editor);
+
+            if (editor){
+                this.subscriptions.push(editor.onMouseMove(() => {
+                    this.hideAllOtherHoverAndParameterWidgets();
+                }));
+            }
         }
     }
 
@@ -491,7 +511,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         }
 
         // Find all parameter widgets related to this monaco editor.
-        const knownParameterHintsWidgets: HTMLDivElement[] = Array.prototype.slice.call(this.widgetParent.querySelectorAll('.parameter-hints-widget'));
+        const knownParameterHintsWidgets: HTMLDivElement[] = Array.prototype.slice.call(this.widgetParent.querySelectorAll(WidgetCSSSelector.Parameters));
 
         // Lets not assume we'll have the exact same DOM for parameter widgets.
         // So, just remove the event handler, and add it again later.
@@ -549,14 +569,44 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         // We need to hide them.
 
         // Solution: Hide the widgets manually.
-        knownParameterHintsWidgets.forEach(widget => {
-            widget.setAttribute('class', widget.className.split(' ').filter(cls => cls !== 'visible').join(' '));
-            if (widget.style.visibility !== 'hidden') {
-                widget.style.visibility = 'hidden';
-            }
-        });
+        this.hideWidgets(this.widgetParent, [WidgetCSSSelector.Parameters]);
     }
-
+    /**
+     * Hides widgets such as parameters and hover, that belong to a given parent HTML element.
+     *
+     * @private
+     * @param {HTMLDivElement} widgetParent
+     * @param {string[]} selectors
+     * @memberof MonacoEditor
+     */
+    private hideWidgets(widgetParent: HTMLDivElement, selectors: string[]){
+        for (const selector of selectors){
+            for (const widget of Array.from<HTMLDivElement>(widgetParent.querySelectorAll(selector))) {
+                widget.setAttribute('class', widget.className.split(' ').filter((cls: string) => cls !== 'visible').join(' '));
+                if (widget.style.visibility !== 'hidden') {
+                    widget.style.visibility = 'hidden';
+                }
+            }
+        }
+    }
+    /**
+     * Hides the hover and parameters widgets related to other monaco editors.
+     * Use this to ensure we only display hover/parameters widgets for current editor (by hiding others).
+     *
+     * @private
+     * @returns
+     * @memberof MonacoEditor
+     */
+    private hideAllOtherHoverAndParameterWidgets(){
+        const root = document.getElementById('root');
+        if (!root || !this.widgetParent){
+            return;
+        }
+        const widgetParents: HTMLDivElement[] = Array.prototype.slice.call(root.querySelectorAll('div.monaco-editor-pretend-parent'));
+        widgetParents
+        .filter(widgetParent => widgetParent !== this.widgetParent)
+        .forEach(widgetParent => this.hideWidgets(widgetParent, [WidgetCSSSelector.Parameters, WidgetCSSSelector.Hover]));
+    }
     private updateMargin(editor: monacoEditor.editor.IStandaloneCodeEditor) {
         const editorNode = editor.getDomNode();
         if (editorNode) {

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -15,6 +15,7 @@ const debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 // tslint:disable-next-line:no-require-imports no-var-requires
 const throttle = require('lodash/throttle') as typeof import('lodash/throttle');
 
+import { debounceSync } from '../../client/common/utils/decorators';
 import './monacoEditor.css';
 
 const LINE_HEIGHT = 18;
@@ -597,6 +598,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
      * @returns
      * @memberof MonacoEditor
      */
+    @debounceSync(200)
     private hideAllOtherHoverAndParameterWidgets(){
         const root = document.getElementById('root');
         if (!root || !this.widgetParent){

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -15,7 +15,6 @@ const debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 // tslint:disable-next-line:no-require-imports no-var-requires
 const throttle = require('lodash/throttle') as typeof import('lodash/throttle');
 
-import { debounceSync } from '../../client/common/utils/decorators';
 import './monacoEditor.css';
 
 const LINE_HEIGHT = 18;
@@ -86,6 +85,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         this.containerRef = React.createRef<HTMLDivElement>();
         this.measureWidthRef = React.createRef<HTMLDivElement>();
         this.debouncedUpdateEditorSize = debounce(this.updateEditorSize.bind(this), 150);
+        this.hideAllOtherHoverAndParameterWidgets = debounce(this.hideAllOtherHoverAndParameterWidgets.bind(this), 150);
 
         // JSDOM has MutationObserver in the window object
         if ('MutationObserver' in window) {

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -598,7 +598,6 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
      * @returns
      * @memberof MonacoEditor
      */
-    @debounceSync(200)
     private hideAllOtherHoverAndParameterWidgets(){
         const root = document.getElementById('root');
         if (!root || !this.widgetParent){


### PR DESCRIPTION
For #8007

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [n/a] Has sufficient logging.
- [n/a] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [n/a] The wiki is updated with any design decisions/details.
