### PR TITLE
Fix session startup shutdown flakey test

### DIFF
--- a/news/2 Fixes/8167.md
+++ b/news/2 Fixes/8167.md
@@ -1,0 +1,1 @@
+Fix closing a Notebook Editor to actually wait for the kernel to restart.

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -589,7 +589,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                     await this.saveToDisk();
 
                     // Close it
-                    actuallyClose().ignoreErrors();
+                    await actuallyClose();
                     break;
 
                 case AskForSaveResult.No:
@@ -597,7 +597,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                     await this.setClean();
 
                     // Close it
-                    actuallyClose().ignoreErrors();
+                    await actuallyClose();
                     break;
 
                 default:
@@ -607,7 +607,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             }
         } else {
             // Not dirty, just close normally.
-            actuallyClose().ignoreErrors();
+            return actuallyClose();
         }
     }
 

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -157,9 +157,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         const baseName = path.basename(this.file.fsPath);
         return baseName.includes(localize.DataScience.untitledNotebookFileName());
     }
-    public dispose(): void {
+    public dispose(): Promise<void> {
         super.dispose();
-        this.close().ignoreErrors();
+        return this.close();
     }
 
     public get contents(): string {


### PR DESCRIPTION
For #8167 

Root cause here was not waiting on the close promise (which in turn waits on the restart)

