### PR TITLE
Fix insert to not reuse monaco editors

### DIFF
--- a/news/2 Fixes/8194.md
+++ b/news/2 Fixes/8194.md
@@ -1,0 +1,1 @@
+Inserting a cell in a notebook can sometimes cause the contents to be the cell below it.

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -325,12 +325,12 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps, IM
         }
     }
 
-    private renderCell = (cellVM: ICellViewModel, index: number, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
+    private renderCell = (cellVM: ICellViewModel, _index: number, containerRef?: React.RefObject<HTMLDivElement>): JSX.Element | null => {
         const cellRef = React.createRef<InteractiveCell>();
         this.cellRefs.set(cellVM.cell.id, cellRef);
         return (
-            <div key={index} id={cellVM.cell.id} ref={containerRef}>
-                <ErrorBoundary key={index}>
+            <div key={cellVM.cell.id} id={cellVM.cell.id} ref={containerRef}>
+                <ErrorBoundary>
                     <InteractiveCell
                         ref={cellRef}
                         role='listitem'

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -500,7 +500,8 @@ export class NativeCell extends React.Component<INativeCellProps> {
         const newCell = this.props.stateController.insertBelow(this.props.cellVM.cell.id, true);
         this.props.stateController.sendCommand(NativeCommandType.AddToEnd, 'mouse');
         if (newCell) {
-            this.props.focusCell(newCell, true);
+            // Make async because the click changes focus.
+            setTimeout(() => this.props.focusCell(newCell, true), 0);
         }
     }
 

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -393,8 +393,8 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
             this.debounceUpdateVisibleCells();
         }
         return (
-            <div key={index} id={cellVM.cell.id} ref={containerRef}>
-                <ErrorBoundary key={index}>
+            <div key={cellVM.cell.id} id={cellVM.cell.id} ref={containerRef}>
+                <ErrorBoundary>
                     <NativeCell
                         ref={cellRef}
                         role='listitem'


### PR DESCRIPTION
For #8194 

Switch from index to id for items in the list (this prevents the same item from being reused)
