### PR TITLE
Fix monaco editor style differences between insiders and shipping

### DIFF
--- a/news/2 Fixes/8006.md
+++ b/news/2 Fixes/8006.md
@@ -1,0 +1,1 @@
+Signature help is overflowing out of the signature help widget on the Notebook Editor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13329,9 +13329,9 @@
             "dev": true
         },
         "monaco-editor": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.16.2.tgz",
-            "integrity": "sha512-NtGrFzf54jADe7qsWh3lazhS7Kj0XHkJUGBq9fA/Jbwc+sgVcyfsYF6z2AQ7hPqDC+JmdOt/OwFjBnRwqXtx6w==",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.18.1.tgz",
+            "integrity": "sha512-fmL+RFZ2Hrezy+X/5ZczQW51LUmvzfcqOurnkCIRFTyjdVjzR7JvENzI6+VKBJzJdPh6EYL4RoWl92b2Hrk9fw==",
             "dev": true
         },
         "monaco-editor-textmate": {

--- a/package.json
+++ b/package.json
@@ -2856,7 +2856,7 @@
         "mocha": "^6.1.4",
         "mocha-junit-reporter": "^1.17.0",
         "mocha-multi-reporters": "^1.1.7",
-        "monaco-editor": "0.16.2",
+        "monaco-editor": "0.18.1",
         "monaco-editor-webpack-plugin": "^1.7.0",
         "nock": "^10.0.6",
         "node-has-native-dependencies": "^1.0.2",

--- a/src/datascience-ui/interactive-common/intellisenseProvider.ts
+++ b/src/datascience-ui/interactive-common/intellisenseProvider.ts
@@ -3,8 +3,10 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import * as uuid from 'uuid/v4';
+
 import { IDisposable } from '../../client/common/types';
 import { createDeferred, Deferred } from '../../client/common/utils/async';
+import { noop } from '../../client/common/utils/misc';
 import {
     IInteractiveWindowMapping,
     InteractiveWindowMessages,
@@ -13,7 +15,6 @@ import {
     IProvideSignatureHelpResponse
 } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IMessageHandler, PostOffice } from '../react-common/postOffice';
-import { noop } from '../../client/common/utils/misc';
 
 interface IRequestData<T> {
     promise: Deferred<T>;

--- a/src/datascience-ui/react-common/monacoEditor.css
+++ b/src/datascience-ui/react-common/monacoEditor.css
@@ -126,3 +126,7 @@
     border-right-style: solid;
     border-right-width: 1px;
 }
+
+.monaco-editor .parameter-hints-widget > .wrapper {
+	overflow: hidden;
+}


### PR DESCRIPTION
For #8006 

Upgrade to latest monaco (latest on npm anyway)
Add style to make sure we match how monaco behaves in insiders
Checked that style is fine with shipping VS code too.

