### PR TITLE
Fix gulp install python libs commands with `python`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -266,7 +266,7 @@ gulp.task('installPtvsdWheels', async () => {
         });
     if (!success) {
         console.info("Failed to install new PTVSD wheels using 'python3', attempting to install using 'python'");
-        await spawnAsync('python', args.concat(requirement)).catch(ex => console.error("Failed to install PTVSD 5.0 wheels using 'python'", ex));
+        await spawnAsync('python', args).catch(ex => console.error("Failed to install PTVSD 5.0 wheels using 'python'", ex));
     }
 });
 
@@ -283,7 +283,7 @@ gulp.task('installOldPtvsd', async () => {
         });
     if (!success) {
         console.info("Failed to install PTVSD using 'python3', attempting to install using 'python'");
-        await spawnAsync('python', args.concat(requirement)).catch(ex => console.error("Failed to install PTVSD using 'python'", ex));
+        await spawnAsync('python', args).catch(ex => console.error("Failed to install PTVSD using 'python'", ex));
     }
 });
 


### PR DESCRIPTION
Fix `installPtvsdWheels` and `installOldPtvsd` commands when run on a machine that doesn't have an alias for `python3`.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
