### PR TITLE
Use new VS Code filesystem API.

### DIFF
--- a/news/3 Code Health/6911.md
+++ b/news/3 Code Health/6911.md
@@ -1,0 +1,1 @@
+Use the new VS Code filesystem API as much as possible.

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -178,12 +178,17 @@ export class RawFileSystem implements IRawFileSystem {
     ) { }
 
     // Create a new object using common-case default values.
-    public static withDefaults(): RawFileSystem{
+    public static withDefaults(
+        path?: IRawPath,
+        vscfs?: IVSCodeFileSystemAPI,
+        nodefs?: IRawFS,
+        fsExtra?: IRawFSExtra
+    ): RawFileSystem{
         return new RawFileSystem(
-            FileSystemPaths.withDefaults(),
-            vscode.workspace.fs,
-            fs,
-            fsextra
+            path || FileSystemPaths.withDefaults(),
+            vscfs || vscode.workspace.fs,
+            nodefs || fs,
+            fsExtra || fsextra
         );
     }
 
@@ -335,14 +340,20 @@ export class FileSystemUtils implements IFileSystemUtils {
         protected readonly globFile: (pat: string) => Promise<string[]>
     ) { }
     // Create a new object using common-case default values.
-    public static withDefaults(): FileSystemUtils {
-        const paths = FileSystemPaths.withDefaults();
+    public static withDefaults(
+        raw?: IRawFileSystem,
+        path?: IFileSystemPaths,
+        tmp?: ITempFileSystem,
+        getHash?: (data: string) => string,
+        globFile?: (pat: string) => Promise<string[]>
+    ): FileSystemUtils {
+        const paths = path || FileSystemPaths.withDefaults();
         return new FileSystemUtils(
-            new RawFileSystem(paths, vscode.workspace.fs, fs, fsextra),
+            raw || RawFileSystem.withDefaults(paths),
             paths,
-            TempFileSystem.withDefaults(),
-            getHashString,
-            util.promisify(glob)
+            tmp || TempFileSystem.withDefaults(),
+            getHash || getHashString,
+            globFile || util.promisify(glob)
         );
     }
 

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -354,7 +354,7 @@ export class FileSystemUtils implements IFileSystemUtils {
     ): Promise<boolean> {
         let stat: FileStat;
         try {
-            stat = await this.raw.stat(filename);
+            stat = await this._stat(filename);
         } catch (err) {
             return false;
         }
@@ -395,7 +395,7 @@ export class FileSystemUtils implements IFileSystemUtils {
             tmpFile = await this.tmp.createFile('___vscpTest___', dirname);
         } catch {
             // Use a stat call to ensure the directory exists.
-            await this.raw.stat(dirname);
+            await this._stat(dirname);
             return true;
         }
         tmpFile.dispose();
@@ -412,6 +412,10 @@ export class FileSystemUtils implements IFileSystemUtils {
         const files = await this.globFile(globPattern);
         return Array.isArray(files) ? files : [];
     }
+
+    public async _stat(filename: string): Promise<FileStat> {
+        return this.raw.stat(filename);
+    }
 }
 
 // We *could* use ICryptoUtils, but it's a bit overkill, issue tracked
@@ -425,7 +429,7 @@ function getHashString(data: string): string {
 // more aliases (to cause less churn)
 @injectable()
 export class FileSystem implements IFileSystem {
-    private readonly utils: FileSystemUtils;
+    protected readonly utils: FileSystemUtils;
     constructor() {
         this.utils = FileSystemUtils.withDefaults();
     }
@@ -486,7 +490,7 @@ export class FileSystem implements IFileSystem {
     // aliases
 
     public async stat(filePath: string): Promise<FileStat> {
-        return this.utils.raw.stat(filePath);
+        return this.utils._stat(filePath);
     }
 
     public async readFile(filename: string): Promise<string> {

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -105,7 +105,7 @@ interface INewAPI {
     //createDirectory(uri: vscode.Uri): Thenable<void>;
     delete(uri: vscode.Uri, options?: {recursive: boolean; useTrash: boolean}): Thenable<void>;
     readDirectory(uri: vscode.Uri): Thenable<[string, FileType][]>;
-    //readFile(uri: vscode.Uri): Thenable<Uint8Array>;
+    readFile(uri: vscode.Uri): Thenable<Uint8Array>;
     //rename(source: vscode.Uri, target: vscode.Uri, options?: {overwrite: boolean}): Thenable<void>;
     //stat(uri: vscode.Uri): Thenable<vscode.FileStat>;
     //writeFile(uri: vscode.Uri, content: Uint8Array): Thenable<void>;
@@ -120,7 +120,6 @@ interface IRawFS {
 // This is the parts of the 'fs-extra' module that we use in RawFileSystem.
 interface IRawFSExtra {
     chmod(filePath: string, mode: string | number): Promise<void>;
-    readFile(path: string, encoding: string): Promise<string>;
     //tslint:disable-next-line:no-any
     writeFile(path: string, data: any, options: any): Promise<void>;
     stat(filename: string): Promise<fsextra.Stats>;
@@ -157,6 +156,13 @@ export class RawFileSystem implements IRawFileSystem {
     //****************************
     // VS Code API
 
+    public async readText(filename: string): Promise<string> {
+        const uri = vscode.Uri.file(filename);
+        const data = Buffer.from(
+            await this.newapi.readFile(uri));
+        return data.toString(ENCODING);
+    }
+
     public async rmtree(dirname: string): Promise<void> {
         const uri = vscode.Uri.file(dirname);
         return this.newapi.delete(uri, {
@@ -180,10 +186,6 @@ export class RawFileSystem implements IRawFileSystem {
 
     //****************************
     // fs-extra
-
-    public async readText(filename: string): Promise<string> {
-        return this.fsExtra.readFile(filename, ENCODING);
-    }
 
     public async writeText(filename: string, data: {}): Promise<void> {
         const options: fsextra.WriteFileOptions = {

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -453,7 +453,7 @@ function getHashString(data: string): string {
 // more aliases (to cause less churn)
 @injectable()
 export class FileSystem implements IFileSystem {
-    protected readonly utils: FileSystemUtils;
+    protected utils: FileSystemUtils;
     constructor() {
         this.utils = FileSystemUtils.withDefaults();
     }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -125,7 +125,7 @@ interface INewAPI {
     readFile(uri: vscode.Uri): Thenable<Uint8Array>;
     //rename(source: vscode.Uri, target: vscode.Uri, options?: {overwrite: boolean}): Thenable<void>;
     stat(uri: vscode.Uri): Thenable<FileStat>;
-    //writeFile(uri: vscode.Uri, content: Uint8Array): Thenable<void>;
+    writeFile(uri: vscode.Uri, content: Uint8Array): Thenable<void>;
 }
 
 // This is the parts of node's 'fs' module that we use in RawFileSystem.
@@ -137,8 +137,6 @@ interface IRawFS {
 // This is the parts of the 'fs-extra' module that we use in RawFileSystem.
 interface IRawFSExtra {
     chmod(filePath: string, mode: string | number): Promise<void>;
-    //tslint:disable-next-line:no-any
-    writeFile(path: string, data: any, options: any): Promise<void>;
     lstat(filename: string): Promise<fsextra.Stats>;
     mkdirp(dirname: string): Promise<void>;
 
@@ -179,6 +177,12 @@ export class RawFileSystem implements IRawFileSystem {
         return data.toString(ENCODING);
     }
 
+    public async writeText(filename: string, text: string): Promise<void> {
+        const uri = vscode.Uri.file(filename);
+        const data = Buffer.from(text);
+        await this.newapi.writeFile(uri, data);
+    }
+
     public async rmtree(dirname: string): Promise<void> {
         const uri = vscode.Uri.file(dirname);
         return this.newapi.delete(uri, {
@@ -207,13 +211,6 @@ export class RawFileSystem implements IRawFileSystem {
 
     //****************************
     // fs-extra
-
-    public async writeText(filename: string, data: {}): Promise<void> {
-        const options: fsextra.WriteFileOptions = {
-            encoding: ENCODING
-        };
-        await this.fsExtra.writeFile(filename, data, options);
-    }
 
     public async mkdirp(dirname: string): Promise<void> {
         return this.fsExtra.mkdirp(dirname);

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -21,6 +21,7 @@ import {
 } from './types';
 
 // tslint:disable:max-classes-per-file
+// tslint:disable:no-suspicious-comment
 
 const ENCODING: string = 'utf8';
 
@@ -203,6 +204,11 @@ export class RawFileSystem implements IRawFileSystem {
 
     public async rmtree(dirname: string): Promise<void> {
         const uri = vscode.Uri.file(dirname);
+        // TODO (https://github.com/microsoft/vscode/issues/84177)
+        //   The docs say "throws - FileNotFound when uri doesn't exist".
+        //   However, it happily does nothing (at least for remote-over-SSH).
+        //   So we have to manually stat, just to be sure.
+        await this.newapi.stat(uri);
         return this.newapi.delete(uri, {
             recursive: true,
             useTrash: false
@@ -228,6 +234,9 @@ export class RawFileSystem implements IRawFileSystem {
     }
 
     public async mkdirp(dirname: string): Promise<void> {
+        // TODO https://github.com/microsoft/vscode/issues/84175
+        //   Hopefully VS Code provides this method in their API
+        //   so we don't have to roll our own.
         const stack = [dirname];
         while (stack.length > 0) {
             const current = stack.pop() || '';
@@ -261,6 +270,12 @@ export class RawFileSystem implements IRawFileSystem {
     public async copyFile(src: string, dest: string): Promise<void> {
         const srcURI = vscode.Uri.file(src);
         const destURI = vscode.Uri.file(dest);
+        // TODO (https://github.com/microsoft/vscode/issues/84177)
+        //   The docs say "throws - FileNotFound when parent of
+        //   destination doesn't exist".  However, it happily creates
+        //   the parent directory (at least for remote-over-SSH).
+        //   So we have to manually stat, just to be sure.
+        await this.newapi.stat(vscode.Uri.file(this.path.dirname(dest)));
         await this.newapi.copy(srcURI, destURI, {
             overwrite: true
         });
@@ -270,11 +285,14 @@ export class RawFileSystem implements IRawFileSystem {
     // fs-extra
 
     public async chmod(filename: string, mode: string | number): Promise<void> {
+        // TODO https://github.com/microsoft/vscode/issues/84175
+        //   This functionality has been requested for the VS Code API.
         return this.fsExtra.chmod(filename, mode);
     }
 
     public async lstat(filename: string): Promise<FileStat> {
-        // At the moment the new VS Code API does not seem to support lstat...
+        // TODO https://github.com/microsoft/vscode/issues/84175
+        //   This functionality has been requested for the VS Code API.
         const stat = await this.fsExtra.lstat(filename);
         return convertFileStat(stat);
     }
@@ -283,11 +301,15 @@ export class RawFileSystem implements IRawFileSystem {
     // non-async (fs-extra)
 
     public statSync(filename: string): FileStat {
+        // TODO https://github.com/microsoft/vscode/issues/84175
+        //   This functionality has been requested for the VS Code API.
         const stat = this.fsExtra.statSync(filename);
         return convertFileStat(stat);
     }
 
     public readTextSync(filename: string): string {
+        // TODO https://github.com/microsoft/vscode/issues/84175
+        //   This functionality has been requested for the VS Code API.
         return this.fsExtra.readFileSync(filename, ENCODING);
     }
 
@@ -295,6 +317,8 @@ export class RawFileSystem implements IRawFileSystem {
     // non-async (fs)
 
     public createWriteStream(filename: string): WriteStream {
+        // TODO https://github.com/microsoft/vscode/issues/84175
+        //   This functionality has been requested for the VS Code API.
         return this.nodefs.createWriteStream(filename);
     }
 }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -133,13 +133,14 @@ export class TempFileSystem {
 }
 
 // This is the parts of the vscode.workspace.fs API that we use here.
+// See: https://code.visualstudio.com/api/references/vscode-api#FileSystem
+// Note that we have used all the API functions *except* "rename()".
 interface INewAPI {
     copy(source: vscode.Uri, target: vscode.Uri, options?: {overwrite: boolean}): Thenable<void>;
     createDirectory(uri: vscode.Uri): Thenable<void>;
     delete(uri: vscode.Uri, options?: {recursive: boolean; useTrash: boolean}): Thenable<void>;
     readDirectory(uri: vscode.Uri): Thenable<[string, FileType][]>;
     readFile(uri: vscode.Uri): Thenable<Uint8Array>;
-    //rename(source: vscode.Uri, target: vscode.Uri, options?: {overwrite: boolean}): Thenable<void>;
     stat(uri: vscode.Uri): Thenable<FileStat>;
     writeFile(uri: vscode.Uri, content: Uint8Array): Thenable<void>;
 }

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -47,6 +47,7 @@ export interface ITempFileSystem {
 
 export interface IFileSystemPaths {
     join(...filenames: string[]): string;
+    dirname(filename: string): string;
     normCase(filename: string): string;
 }
 

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -104,7 +104,7 @@ export interface IRawFileSystem {
 export const IFileSystemUtils = Symbol('IFileSystemUtils');
 export interface IFileSystemUtils {
     readonly raw: IRawFileSystem;
-    readonly path: IFileSystemPaths;
+    readonly paths: IFileSystemPaths;
     readonly tmp: ITempFileSystem;
 
     //***********************

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import * as fs from 'fs';
-import * as fsextra from 'fs-extra';
 import { SemVer } from 'semver';
 import * as vscode from 'vscode';
 import { Architecture, OSType } from '../utils/platform';
@@ -52,7 +51,7 @@ export interface IFileSystemPaths {
 }
 
 export import FileType = vscode.FileType;
-export type FileStat = fsextra.Stats;
+export type FileStat = vscode.FileStat;
 export type WriteStream = fs.WriteStream;
 
 // Later we will drop "IFileSystem", switching usage to
@@ -157,7 +156,7 @@ export interface IFileSystem {
     search(globPattern: string): Promise<string[]>;
     arePathsSame(path1: string, path2: string): boolean;
 
-    stat(filePath: string): Promise<vscode.FileStat>;
+    stat(filePath: string): Promise<FileStat>;
     readFile(filename: string): Promise<string>;
     writeFile(filename: string, data: {}): Promise<void>;
     chmod(filename: string, mode: string): Promise<void>;

--- a/src/client/workspaceSymbols/provider.ts
+++ b/src/client/workspaceSymbols/provider.ts
@@ -43,7 +43,13 @@ export class WorkspaceSymbolProvider implements IWorspaceSymbolProvider {
             .filter(generator => generator !== undefined && generator.enabled)
             .map(async generator => {
                 // load tags
-                const items = await parseTags(generator!.workspaceFolder.fsPath, generator!.tagFilePath, query, token);
+                const items = await parseTags(
+                    generator!.workspaceFolder.fsPath,
+                    generator!.tagFilePath,
+                    query,
+                    token,
+                    this.fs
+                );
                 if (!Array.isArray(items)) {
                     return [];
                 }

--- a/src/test/common/crypto.unit.test.ts
+++ b/src/test/common/crypto.unit.test.ts
@@ -4,19 +4,23 @@
 'use strict';
 
 import { assert, expect } from 'chai';
+import * as fsextra from 'fs-extra';
 import * as path from 'path';
 import { CryptoUtils } from '../../client/common/crypto';
-import { FileSystem } from '../../client/common/platform/fileSystem';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 
 // tslint:disable-next-line: max-func-body-length
 suite('Crypto Utils', async () => {
     let crypto: CryptoUtils;
-    const fs = new FileSystem();
-    const file = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'test', 'common', 'randomWords.txt');
     setup(() => {
         crypto = new CryptoUtils();
     });
+    async function getWordList(): Promise<string[]> {
+        const file = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src', 'test', 'common', 'randomWords.txt');
+        const words = await fsextra.readFile(file, 'utf8');
+        return words.split('\n');
+    }
+
     test('If hashFormat equals `number`, method createHash() returns a number', async () => {
         const hash = crypto.createHash('blabla', 'number');
         assert.typeOf(hash, 'number', 'Type should be a number');
@@ -52,8 +56,7 @@ suite('Crypto Utils', async () => {
         assert.notEqual(hash1, hash2, 'Hashes should be different strings');
     });
     test('If hashFormat equals `number`, ensure numbers are uniformly distributed on scale from 0 to 100', async () => {
-        const words = await fs.readFile(file);
-        const wordList = words.split('\n');
+        const wordList = await getWordList();
         const buckets: number[] = Array(100).fill(0);
         const hashes = Array(10).fill(0);
         for (const w of wordList) {
@@ -72,8 +75,7 @@ suite('Crypto Utils', async () => {
         }
     });
     test('If hashFormat equals `number`, on a scale of 0 to 100, small difference in the input on average produce large differences (about 33) in the output ', async () => {
-        const words = await fs.readFile(file);
-        const wordList = words.split('\n');
+        const wordList = await getWordList();
         const buckets: number[] = Array(100).fill(0);
         let hashes: number[] = [];
         let totalDifference = 0;

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -415,64 +415,6 @@ suite('Raw FileSystem', () => {
         });
     });
 
-    suite('listdir', () => {
-        test('mixed', async () => {
-            // Create the target directory and its contents.
-            const dirname = await fix.createDirectory('x/y/z');
-            await fix.createFile('x/y/z/__init__.py', '');
-            const script = await fix.createFile('x/y/z/__main__.py', '<script here>');
-            await fix.createFile('x/y/z/spam.py', '...');
-            await fix.createSocket('x/y/z/ipc.sock');
-            await fix.createFile('x/y/z/eggs.py', '"""..."""');
-            await fix.createSymlink(
-                'x/y/z/info.py',
-                // Link to an ignored file.
-                await fix.createFile('x/_info.py', '<info here>') // source
-            );
-            await fix.createDirectory('x/y/z/w');
-            // Create other files and directories (should be ignored).
-            await fix.createSymlink(
-                'my-script.py',
-                // Link to a listed file.
-                script // source (__main__.py)
-            );
-            const ignored1 = await fix.createFile('x/__init__.py', '');
-            await fix.createFile('x/y/__init__.py', '');
-            await fix.createSymlink(
-                'x/y/z/w/__init__.py',
-                ignored1 // source (x/__init__.py)
-            );
-            await fix.createDirectory('x/y/z/w/data');
-            await fix.createFile('x/y/z/w/data/v1.json');
-
-            const entries = await filesystem.listdir(dirname);
-
-            expect(entries.sort()).to.deep.equal([
-                ['__init__.py', FileType.File],
-                ['__main__.py', FileType.File],
-                ['eggs.py', FileType.File],
-                ['info.py', FileType.SymbolicLink],
-                ['ipc.sock', FileType.Unknown],
-                ['spam.py', FileType.File],
-                ['w', FileType.Directory]
-            ]);
-        });
-
-        test('empty', async () => {
-            const dirname = await fix.createDirectory('x/y/z/eggs');
-
-            const entries = await filesystem.listdir(dirname);
-
-            expect(entries).to.deep.equal([]);
-        });
-
-        test('fails if the directory does not exist', async () => {
-            const promise = filesystem.listdir(DOES_NOT_EXIST);
-
-            await expect(promise).to.eventually.be.rejected;
-        });
-    });
-
     suite('copyFile', () => {
         test('the source file gets copied (same directory)', async () => {
             const data = '<content>';
@@ -780,61 +722,6 @@ suite('FileSystem Utils', () => {
             const exists = await utils.directoryExists(dirname);
 
             expect(exists).to.equal(true);
-        });
-    });
-
-    suite('getSubDirectories', () => {
-        test('mixed types', async () => {
-            const symlinkSource = await fix.createFile('x/info.py');
-            const dirname = await fix.createDirectory('x/y/z/scripts');
-            const subdir1 = await fix.createDirectory('x/y/z/scripts/w');
-            await fix.createFile('x/y/z/scripts/spam.py');
-            const subdir2 = await fix.createDirectory('x/y/z/scripts/v');
-            await fix.createFile('x/y/z/scripts/eggs.py');
-            await fix.createSocket('x/y/z/scripts/spam.sock');
-            await fix.createSymlink('x/y/z/scripts/other', symlinkSource);
-            await fix.createFile('x/y/z/scripts/data.json');
-
-            const results = await utils.getSubDirectories(dirname);
-
-            expect(results.sort()).to.deep.equal([
-                subdir2,
-                subdir1
-            ]);
-        });
-
-        test('empty if the directory does not exist', async () => {
-            const entries = await utils.getSubDirectories(DOES_NOT_EXIST);
-
-            expect(entries).to.deep.equal([]);
-        });
-    });
-
-    suite('getFiles', () => {
-        test('mixed types', async () => {
-            const symlinkSource = await fix.createFile('x/info.py');
-            const dirname = await fix.createDirectory('x/y/z/scripts');
-            await fix.createDirectory('x/y/z/scripts/w');
-            const file1 = await fix.createFile('x/y/z/scripts/spam.py');
-            await fix.createDirectory('x/y/z/scripts/v');
-            const file2 = await fix.createFile('x/y/z/scripts/eggs.py');
-            await fix.createSocket('x/y/z/scripts/spam.sock');
-            await fix.createSymlink('x/y/z/scripts/other', symlinkSource);
-            const file3 = await fix.createFile('x/y/z/scripts/data.json');
-
-            const results = await utils.getFiles(dirname);
-
-            expect(results.sort()).to.deep.equal([
-                file3,
-                file2,
-                file1
-            ]);
-        });
-
-        test('empty if the directory does not exist', async () => {
-            const entries = await utils.getFiles(DOES_NOT_EXIST);
-
-            expect(entries).to.deep.equal([]);
         });
     });
 

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -313,47 +313,17 @@ suite('Raw FileSystem', () => {
         });
     });
 
-    suite('stat', () => {
-        test('gets the info for an existing file', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py', '...');
-            const expected = await fsextra.stat(filename);
-
-            const stat = await filesystem.stat(filename);
-
-            expect(stat).to.deep.equal(expected);
-        });
-
-        test('gets the info for an existing directory', async () => {
-            const dirname = await fix.createDirectory('x/y/z/spam');
-            const expected = await fsextra.stat(dirname);
-
-            const stat = await filesystem.stat(dirname);
-
-            expect(stat).to.deep.equal(expected);
-        });
-
-        test('for symlinks, gets the info for the linked file', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py', '...');
-            const symlink = await fix.createSymlink('x/y/z/eggs.py', filename);
-            const expected = await fsextra.stat(filename);
-
-            const stat = await filesystem.stat(symlink);
-
-            expect(stat).to.deep.equal(expected);
-        });
-
-        test('fails if the file does not exist', async () => {
-            const promise = filesystem.stat(DOES_NOT_EXIST);
-
-            await expect(promise).to.eventually.be.rejected;
-        });
-    });
-
     suite('lstat', () => {
         test('for symlinks, gives the link info', async () => {
             const filename = await fix.createFile('x/y/z/spam.py', '...');
             const symlink = await fix.createSymlink('x/y/z/eggs.py', filename);
-            const expected = await fsextra.lstat(symlink);
+            const old = await fsextra.lstat(symlink);
+            const expected = {
+                type: FileType.SymbolicLink,
+                size: old.size,
+                ctime: old.ctimeMs,
+                mtime: old.mtimeMs
+            };
 
             const stat = await filesystem.lstat(symlink);
 
@@ -362,7 +332,13 @@ suite('Raw FileSystem', () => {
 
         test('for normal files, gives the file info', async () => {
             const filename = await fix.createFile('x/y/z/spam.py', '...');
-            const expected = await fsextra.stat(filename);
+            const old = await fsextra.stat(filename);
+            const expected = {
+                type: FileType.File,
+                size: old.size,
+                ctime: old.ctimeMs,
+                mtime: old.mtimeMs
+            };
 
             const stat = await filesystem.lstat(filename);
 
@@ -431,7 +407,13 @@ suite('Raw FileSystem', () => {
     suite('statSync', () => {
         test('gets the info for an existing file', async () => {
             const filename = await fix.createFile('x/y/z/spam.py', '...');
-            const expected = await fsextra.stat(filename);
+            const old = await fsextra.stat(filename);
+            const expected = {
+                type: FileType.File,
+                size: old.size,
+                ctime: old.ctimeMs,
+                mtime: old.mtimeMs
+            };
 
             const stat = filesystem.statSync(filename);
 
@@ -440,7 +422,13 @@ suite('Raw FileSystem', () => {
 
         test('gets the info for an existing directory', async () => {
             const dirname = await fix.createDirectory('x/y/z/spam');
-            const expected = await fsextra.stat(dirname);
+            const old = await fsextra.stat(dirname);
+            const expected = {
+                type: FileType.Directory,
+                size: old.size,
+                ctime: old.ctimeMs,
+                mtime: old.mtimeMs
+            };
 
             const stat = filesystem.statSync(dirname);
 
@@ -450,7 +438,13 @@ suite('Raw FileSystem', () => {
         test('for symlinks, gets the info for the linked file', async () => {
             const filename = await fix.createFile('x/y/z/spam.py', '...');
             const symlink = await fix.createSymlink('x/y/z/eggs.py', filename);
-            const expected = await fsextra.stat(filename);
+            const old = await fsextra.stat(filename);
+            const expected = {
+                type: FileType.File,
+                size: old.size,
+                ctime: old.ctimeMs,
+                mtime: old.mtimeMs
+            };
 
             const stat = filesystem.statSync(symlink);
 
@@ -589,100 +583,6 @@ suite('FileSystem Utils', () => {
             const result = utils.arePathsSame(file1, file2);
 
             expect(result).to.equal(expected);
-        });
-    });
-
-    suite('pathExists', () => {
-        test('file missing (any)', async () => {
-            const exists = await utils.pathExists(DOES_NOT_EXIST);
-
-            expect(exists).to.equal(false);
-        });
-
-        Object.keys(FileType).forEach(ft => {
-            test(`file missing (${ft})`, async () => {
-                //tslint:disable-next-line:no-any
-                const exists = await utils.pathExists(DOES_NOT_EXIST, ft as any as FileType);
-
-                expect(exists).to.equal(false);
-            });
-        });
-
-        test('any', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py');
-
-            const exists = await utils.pathExists(filename);
-
-            expect(exists).to.equal(true);
-        });
-
-        test('want file, got file', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py');
-
-            const exists = await utils.pathExists(filename, FileType.File);
-
-            expect(exists).to.equal(true);
-        });
-
-        test('want file, not file', async () => {
-            const filename = await fix.createDirectory('x/y/z/spam.py');
-
-            const exists = await utils.pathExists(filename, FileType.File);
-
-            expect(exists).to.equal(false);
-        });
-
-        test('want directory, got directory', async () => {
-            const dirname = await fix.createDirectory('x/y/z/spam');
-
-            const exists = await utils.pathExists(dirname, FileType.Directory);
-
-            expect(exists).to.equal(true);
-        });
-
-        test('want directory, not directory', async () => {
-            const dirname = await fix.createFile('x/y/z/spam');
-
-            const exists = await utils.pathExists(dirname, FileType.Directory);
-
-            expect(exists).to.equal(false);
-        });
-
-        test('symlink', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py', '...');
-            const symlink = await fix.createSymlink('x/y/z/eggs.py', filename);
-
-            const exists = await utils.pathExists(symlink, FileType.SymbolicLink);
-
-            expect(exists).to.equal(false);
-        });
-
-        test('unknown', async () => {
-            const sockFile = await fix.createSocket('x/y/z/ipc.sock');
-
-            const exists = await utils.pathExists(sockFile, FileType.Unknown);
-
-            expect(exists).to.equal(false);
-        });
-    });
-
-    suite('fileExists', () => {
-        test('want file, got file', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py');
-
-            const exists = await utils.fileExists(filename);
-
-            expect(exists).to.equal(true);
-        });
-    });
-
-    suite('directoryExists', () => {
-        test('want directory, got directory', async () => {
-            const dirname = await fix.createDirectory('x/y/z/spam');
-
-            const exists = await utils.directoryExists(dirname);
-
-            expect(exists).to.equal(true);
         });
     });
 

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -316,58 +316,6 @@ suite('Raw FileSystem', () => {
         });
     });
 
-    suite('copyFile', () => {
-        test('the source file gets copied (same directory)', async () => {
-            const data = '<content>';
-            const src = await fix.createFile('x/y/z/spam.py', data);
-            const dest = await fix.resolve('x/y/z/spam.py.bak');
-            await assertDoesNotExist(dest);
-
-            await filesystem.copyFile(src, dest);
-
-            const actual = await fsextra.readFile(dest)
-                .then(buffer => buffer.toString());
-            expect(actual).to.equal(data);
-            const original = await fsextra.readFile(src)
-                .then(buffer => buffer.toString());
-            expect(original).to.equal(data);
-        });
-
-        test('the source file gets copied (different directory)', async () => {
-            const data = '<content>';
-            const src = await fix.createFile('x/y/z/spam.py', data);
-            const dest = await fix.resolve('x/y/eggs.py');
-            await assertDoesNotExist(dest);
-
-            await filesystem.copyFile(src, dest);
-
-            const actual = await fsextra.readFile(dest)
-                .then(buffer => buffer.toString());
-            expect(actual).to.equal(data);
-            const original = await fsextra.readFile(src)
-                .then(buffer => buffer.toString());
-            expect(original).to.equal(data);
-        });
-
-        test('fails if the source does not exist', async () => {
-            const dest = await fix.resolve('x/spam.py');
-
-            const promise = filesystem.copyFile(DOES_NOT_EXIST, dest);
-
-            await expect(promise).to.eventually.be.rejected;
-        });
-
-        test('fails if the target parent directory does not exist', async () => {
-            const src = await fix.createFile('x/spam.py', '...');
-            const dest = await fix.resolve('y/eggs.py', false);
-            await assertDoesNotExist(path.dirname(dest));
-
-            const promise = filesystem.copyFile(src, dest);
-
-            await expect(promise).to.eventually.be.rejected;
-        });
-    });
-
     suite('statSync', () => {
         test('gets the info for an existing file', async () => {
             const filename = await fix.createFile('x/y/z/spam.py', '...');

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -199,45 +199,6 @@ suite('Raw FileSystem', () => {
         await fix.cleanUp();
     });
 
-    suite('readText', () => {
-        test('returns contents of a file', async () => {
-            const expected = '<some text>';
-            const filename = await fix.createFile('x/y/z/spam.py', expected);
-
-            const content = await filesystem.readText(filename);
-
-            expect(content).to.be.equal(expected);
-        });
-
-        test('always UTF-8', async () => {
-            const expected = '... 😁 ...';
-            const filename = await fix.createFile('x/y/z/spam.py', expected);
-
-            const text = await filesystem.readText(filename);
-
-            expect(text).to.equal(expected);
-        });
-
-        test('returns garbage if encoding is UCS-2', async () => {
-            const filename = await fix.resolve('spam.py');
-            // There are probably cases where this would fail too.
-            // However, the extension never has to deal with non-UTF8
-            // cases, so it doesn't matter too much.
-            const original = '... 😁 ...';
-            await fsextra.writeFile(filename, original, { encoding: 'ucs2' });
-
-            const text = await filesystem.readText(filename);
-
-            expect(text).to.equal('.\u0000.\u0000.\u0000 \u0000=�\u0001� \u0000.\u0000.\u0000.\u0000');
-        });
-
-        test('throws an exception if file does not exist', async () => {
-            const promise = filesystem.readText(DOES_NOT_EXIST);
-
-            await expect(promise).to.eventually.be.rejected;
-        });
-    });
-
     suite('writeText', () => {
         test('creates the file if missing', async () => {
             const filename = await fix.resolve('x/y/z/spam.py');
@@ -822,24 +783,6 @@ suite('FileSystem - legacy aliases', () => {
             fsextra.unlinkSync(fileToAppendTo);
         }
     }
-
-    test('ReadFile returns contents of a file', async () => {
-        const file = __filename;
-        const filesystem = new FileSystem();
-        const expectedContents = await fsextra.readFile(file).then(buffer => buffer.toString());
-
-        const content = await filesystem.readFile(file);
-
-        expect(content).to.be.equal(expectedContents);
-    });
-
-    test('ReadFile throws an exception if file does not exist', async () => {
-        const filesystem = new FileSystem();
-
-        const readPromise = filesystem.readFile('xyz');
-
-        await expect(readPromise).to.be.rejectedWith();
-    });
 
     suite('Case sensitivity', () => {
         const path1 = 'c:\\users\\Peter Smith\\my documents\\test.txt';

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -199,28 +199,6 @@ suite('Raw FileSystem', () => {
         await fix.cleanUp();
     });
 
-    suite('mkdirp', () => {
-        test('creates the directory and all missing parents', async () => {
-            await fix.createDirectory('x');
-            // x/y, x/y/z, and x/y/z/spam are all missing.
-            const dirname = await fix.resolve('x/y/z/spam', false);
-            await assertDoesNotExist(dirname);
-
-            await filesystem.mkdirp(dirname);
-
-            await assertExists(dirname);
-        });
-
-        test('works if the directory already exists', async () => {
-            const dirname = await fix.createDirectory('spam');
-            await assertExists(dirname);
-
-            await filesystem.mkdirp(dirname);
-
-            await assertExists(dirname);
-        });
-    });
-
     suite('chmod (non-Windows)', () => {
         suiteSetup(function () {
             // On Windows, chmod won't have any effect on the file itself.

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -199,42 +199,6 @@ suite('Raw FileSystem', () => {
         await fix.cleanUp();
     });
 
-    suite('writeText', () => {
-        test('creates the file if missing', async () => {
-            const filename = await fix.resolve('x/y/z/spam.py');
-            await assertDoesNotExist(filename);
-            const data = 'line1\nline2\n';
-
-            await filesystem.writeText(filename, data);
-
-            const actual = await fsextra.readFile(filename)
-                .then(buffer => buffer.toString());
-            expect(actual).to.equal(data);
-        });
-
-        test('always UTF-8', async () => {
-            const filename = await fix.resolve('x/y/z/spam.py');
-            const data = '... 😁 ...';
-
-            await filesystem.writeText(filename, data);
-
-            const actual = await fsextra.readFile(filename)
-                .then(buffer => buffer.toString());
-            expect(actual).to.equal(data);
-        });
-
-        test('overwrites existing file', async () => {
-            const filename = await fix.createFile('x/y/z/spam.py', '...');
-            const data = 'line1\nline2\n';
-
-            await filesystem.writeText(filename, data);
-
-            const actual = await fsextra.readFile(filename)
-                .then(buffer => buffer.toString());
-            expect(actual).to.equal(data);
-        });
-    });
-
     suite('mkdirp', () => {
         test('creates the directory and all missing parents', async () => {
             await fix.createDirectory('x');

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -468,16 +468,17 @@ suite('FileSystem Utils', () => {
             const file1 = await fix.createFile('x/y/z/scripts/spam.py');
             await fix.createDirectory('x/y/z/scripts/v');
             const file2 = await fix.createFile('x/y/z/scripts/eggs.py');
-            await fix.createSocket('x/y/z/scripts/spam.sock');
+            const file3 = await fix.createSocket('x/y/z/scripts/spam.sock');
             await fix.createSymlink('x/y/z/scripts/other', symlinkSource);
-            const file3 = await fix.createFile('x/y/z/scripts/data.json');
+            const file4 = await fix.createFile('x/y/z/scripts/data.json');
 
             const results = await utils.getFiles(dirname);
 
             expect(results.sort()).to.deep.equal([
-                file3,
+                file4,
                 file2,
-                file1
+                file1,
+                file3
             ]);
         });
 

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -253,6 +253,28 @@ suite('Raw FileSystem', () => {
         });
     });
 
+    suite('mkdirp', () => {
+        test('creates the directory and all missing parents', async () => {
+            await fix.createDirectory('x');
+            // x/y, x/y/z, and x/y/z/spam are all missing.
+            const dirname = await fix.resolve('x/y/z/spam', false);
+            await assertDoesNotExist(dirname);
+
+            await filesystem.mkdirp(dirname);
+
+            await assertExists(dirname);
+        });
+
+        test('works if the directory already exists', async () => {
+            const dirname = await fix.createDirectory('spam');
+            await assertExists(dirname);
+
+            await filesystem.mkdirp(dirname);
+
+            await assertExists(dirname);
+        });
+    });
+
     suite('copyFile', () => {
         test('the source file gets copied (same directory)', async () => {
             const data = '<content>';

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -19,6 +19,7 @@ import {
 // are found in filesystem.functional.test.ts.
 
 // tslint:disable:max-func-body-length chai-vague-errors
+// tslint:disable:no-suspicious-comment
 
 suite('Raw FileSystem', () => {
     let filesystem: IRawFileSystem;
@@ -148,9 +149,11 @@ suite('Raw FileSystem', () => {
             return {
                 type: filetype,
                 size: old.size,
-                // XXX Apparently VS Code's new "fs" has granularity of seconds.
-                // So we round to the nearest integer.
-                // XXX ctime is showing up as 0.
+                // TODO (https://github.com/microsoft/vscode/issues/84177)
+                //   FileStat.ctime and FileStat.mtime only have 1-second resolution.
+                //   So for now we round to the nearest integer.
+                // TODO (https://github.com/microsoft/vscode/issues/84177)
+                //   FileStat.ctime is consistently 0 instead of the actual ctime.
                 ctime: 0,
                 //ctime: Math.round(old.ctimeMs),
                 mtime: Math.round(old.mtimeMs)

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -233,8 +233,8 @@ suite('Raw FileSystem', () => {
                 ['__init__.py', FileType.File],
                 ['__main__.py', FileType.File],
                 ['eggs.py', FileType.File],
-                ['info.py', FileType.SymbolicLink],
-                ['ipc.sock', FileType.Unknown],
+                ['info.py', FileType.SymbolicLink | FileType.File],
+                ['ipc.sock', FileType.File], // This isn't "Unknown" for some reason.
                 ['spam.py', FileType.File],
                 ['w', FileType.Directory]
             ]);

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -70,6 +70,42 @@ suite('Raw FileSystem', () => {
         });
     });
 
+    suite('writeText', () => {
+        test('creates the file if missing', async () => {
+            const filename = await fix.resolve('x/y/z/spam.py');
+            await assertDoesNotExist(filename);
+            const data = 'line1\nline2\n';
+
+            await filesystem.writeText(filename, data);
+
+            const actual = await fsextra.readFile(filename)
+                .then(buffer => buffer.toString());
+            expect(actual).to.equal(data);
+        });
+
+        test('always UTF-8', async () => {
+            const filename = await fix.resolve('x/y/z/spam.py');
+            const data = '... 😁 ...';
+
+            await filesystem.writeText(filename, data);
+
+            const actual = await fsextra.readFile(filename)
+                .then(buffer => buffer.toString());
+            expect(actual).to.equal(data);
+        });
+
+        test('overwrites existing file', async () => {
+            const filename = await fix.createFile('x/y/z/spam.py', '...');
+            const data = 'line1\nline2\n';
+
+            await filesystem.writeText(filename, data);
+
+            const actual = await fsextra.readFile(filename)
+                .then(buffer => buffer.toString());
+            expect(actual).to.equal(data);
+        });
+    });
+
     suite('rmtree', () => {
         test('deletes the directory and everything in it', async () => {
             const dirname = await fix.createDirectory('x');

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -7,6 +7,7 @@ import {
     FileSystemUtils, RawFileSystem
 } from '../../../client/common/platform/fileSystem';
 import {
+    FileType,
     IFileSystemUtils, IRawFileSystem
 } from '../../../client/common/platform/types';
 import {
@@ -63,6 +64,64 @@ suite('Raw FileSystem', () => {
             await expect(promise).to.eventually.be.rejected;
         });
     });
+
+    suite('listdir', () => {
+        test('mixed', async () => {
+            // Create the target directory and its contents.
+            const dirname = await fix.createDirectory('x/y/z');
+            await fix.createFile('x/y/z/__init__.py', '');
+            const script = await fix.createFile('x/y/z/__main__.py', '<script here>');
+            await fix.createFile('x/y/z/spam.py', '...');
+            await fix.createSocket('x/y/z/ipc.sock');
+            await fix.createFile('x/y/z/eggs.py', '"""..."""');
+            await fix.createSymlink(
+                'x/y/z/info.py',
+                // Link to an ignored file.
+                await fix.createFile('x/_info.py', '<info here>') // source
+            );
+            await fix.createDirectory('x/y/z/w');
+            // Create other files and directories (should be ignored).
+            await fix.createSymlink(
+                'my-script.py',
+                // Link to a listed file.
+                script // source (__main__.py)
+            );
+            const ignored1 = await fix.createFile('x/__init__.py', '');
+            await fix.createFile('x/y/__init__.py', '');
+            await fix.createSymlink(
+                'x/y/z/w/__init__.py',
+                ignored1 // source (x/__init__.py)
+            );
+            await fix.createDirectory('x/y/z/w/data');
+            await fix.createFile('x/y/z/w/data/v1.json');
+
+            const entries = await filesystem.listdir(dirname);
+
+            expect(entries.sort()).to.deep.equal([
+                ['__init__.py', FileType.File],
+                ['__main__.py', FileType.File],
+                ['eggs.py', FileType.File],
+                ['info.py', FileType.SymbolicLink],
+                ['ipc.sock', FileType.Unknown],
+                ['spam.py', FileType.File],
+                ['w', FileType.Directory]
+            ]);
+        });
+
+        test('empty', async () => {
+            const dirname = await fix.createDirectory('x/y/z/eggs');
+
+            const entries = await filesystem.listdir(dirname);
+
+            expect(entries).to.deep.equal([]);
+        });
+
+        test('fails if the directory does not exist', async () => {
+            const promise = filesystem.listdir(DOES_NOT_EXIST);
+
+            await expect(promise).to.eventually.be.rejected;
+        });
+    });
 });
 
 suite('FileSystem Utils', () => {
@@ -74,6 +133,61 @@ suite('FileSystem Utils', () => {
     });
     teardown(async () => {
         await fix.cleanUp();
+    });
+
+    suite('getSubDirectories', () => {
+        test('mixed types', async () => {
+            const symlinkSource = await fix.createFile('x/info.py');
+            const dirname = await fix.createDirectory('x/y/z/scripts');
+            const subdir1 = await fix.createDirectory('x/y/z/scripts/w');
+            await fix.createFile('x/y/z/scripts/spam.py');
+            const subdir2 = await fix.createDirectory('x/y/z/scripts/v');
+            await fix.createFile('x/y/z/scripts/eggs.py');
+            await fix.createSocket('x/y/z/scripts/spam.sock');
+            await fix.createSymlink('x/y/z/scripts/other', symlinkSource);
+            await fix.createFile('x/y/z/scripts/data.json');
+
+            const results = await utils.getSubDirectories(dirname);
+
+            expect(results.sort()).to.deep.equal([
+                subdir2,
+                subdir1
+            ]);
+        });
+
+        test('empty if the directory does not exist', async () => {
+            const entries = await utils.getSubDirectories(DOES_NOT_EXIST);
+
+            expect(entries).to.deep.equal([]);
+        });
+    });
+
+    suite('getFiles', () => {
+        test('mixed types', async () => {
+            const symlinkSource = await fix.createFile('x/info.py');
+            const dirname = await fix.createDirectory('x/y/z/scripts');
+            await fix.createDirectory('x/y/z/scripts/w');
+            const file1 = await fix.createFile('x/y/z/scripts/spam.py');
+            await fix.createDirectory('x/y/z/scripts/v');
+            const file2 = await fix.createFile('x/y/z/scripts/eggs.py');
+            await fix.createSocket('x/y/z/scripts/spam.sock');
+            await fix.createSymlink('x/y/z/scripts/other', symlinkSource);
+            const file3 = await fix.createFile('x/y/z/scripts/data.json');
+
+            const results = await utils.getFiles(dirname);
+
+            expect(results.sort()).to.deep.equal([
+                file3,
+                file2,
+                file1
+            ]);
+        });
+
+        test('empty if the directory does not exist', async () => {
+            const entries = await utils.getFiles(DOES_NOT_EXIST);
+
+            expect(entries).to.deep.equal([]);
+        });
     });
 
     suite('isDirReadonly', () => {

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import * as fsextra from 'fs-extra';
+import {
+    FileSystemUtils, RawFileSystem
+} from '../../../client/common/platform/fileSystem';
+import {
+    IFileSystemUtils, IRawFileSystem
+} from '../../../client/common/platform/types';
+import {
+    DOES_NOT_EXIST, assertDoesNotExist, assertExists, FSFixture, WINDOWS
+} from './filesystem.functional.test';
+
+// Note: all functional tests that do not trigger the VS Code "fs" API
+// are found in filesystem.functional.test.ts.
+
+// tslint:disable:max-func-body-length chai-vague-errors
+
+suite('Raw FileSystem', () => {
+    let filesystem: IRawFileSystem;
+    let fix: FSFixture;
+    setup(() => {
+        filesystem = RawFileSystem.withDefaults();
+        fix = new FSFixture();
+    });
+    teardown(async () => {
+        await fix.cleanUp();
+    });
+
+    suite('rmtree', () => {
+        test('deletes the directory and everything in it', async () => {
+            const dirname = await fix.createDirectory('x');
+            const filename = await fix.createFile('x/y/z/spam.py');
+            await assertExists(filename);
+
+            await filesystem.rmtree(dirname);
+
+            await assertDoesNotExist(dirname);
+        });
+
+        test('fails if the directory does not exist', async () => {
+            const promise = filesystem.rmtree(DOES_NOT_EXIST);
+
+            await expect(promise).to.eventually.be.rejected;
+        });
+    });
+
+    suite('rmfile', () => {
+        test('deletes the file', async () => {
+            const filename = await fix.createFile('x/y/z/spam.py', '...');
+            await assertExists(filename);
+
+            await filesystem.rmfile(filename);
+
+            await assertDoesNotExist(filename);
+        });
+
+        test('fails if the file does not exist', async () => {
+            const promise = filesystem.rmfile(DOES_NOT_EXIST);
+
+            await expect(promise).to.eventually.be.rejected;
+        });
+    });
+});
+
+suite('FileSystem Utils', () => {
+    let utils: IFileSystemUtils;
+    let fix: FSFixture;
+    setup(() => {
+        utils = FileSystemUtils.withDefaults();
+        fix = new FSFixture();
+    });
+    teardown(async () => {
+        await fix.cleanUp();
+    });
+
+    suite('isDirReadonly', () => {
+        suite('non-Windows', () => {
+            suiteSetup(function () {
+                if (WINDOWS) {
+                    // tslint:disable-next-line:no-invalid-this
+                    this.skip();
+                }
+            });
+
+            // On Windows, chmod won't have any effect on the file itself.
+            test('is readonly', async () => {
+                const dirname = await fix.createDirectory('x/y/z/spam');
+                await fsextra.chmod(dirname, 0o444);
+
+                const isReadonly = await utils.isDirReadonly(dirname);
+
+                expect(isReadonly).to.equal(true);
+            });
+        });
+
+        test('is not readonly', async () => {
+            const dirname = await fix.createDirectory('x/y/z/spam');
+
+            const isReadonly = await utils.isDirReadonly(dirname);
+
+            expect(isReadonly).to.equal(false);
+        });
+
+        test('fails if the file does not exist', async () => {
+            const promise = utils.isDirReadonly(DOES_NOT_EXIST);
+
+            await expect(promise).to.eventually.be.rejected;
+        });
+    });
+});

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -3,8 +3,9 @@
 
 import { expect } from 'chai';
 import * as fsextra from 'fs-extra';
+import * as path from 'path';
 import {
-    FileSystemUtils, RawFileSystem
+    FileSystem, FileSystemUtils, RawFileSystem
 } from '../../../client/common/platform/fileSystem';
 import {
     FileType,
@@ -28,6 +29,45 @@ suite('Raw FileSystem', () => {
     });
     teardown(async () => {
         await fix.cleanUp();
+    });
+
+    suite('readText', () => {
+        test('returns contents of a file', async () => {
+            const expected = '<some text>';
+            const filename = await fix.createFile('x/y/z/spam.py', expected);
+
+            const content = await filesystem.readText(filename);
+
+            expect(content).to.be.equal(expected);
+        });
+
+        test('always UTF-8', async () => {
+            const expected = '... 😁 ...';
+            const filename = await fix.createFile('x/y/z/spam.py', expected);
+
+            const text = await filesystem.readText(filename);
+
+            expect(text).to.equal(expected);
+        });
+
+        test('returns garbage if encoding is UCS-2', async () => {
+            const filename = await fix.resolve('spam.py');
+            // There are probably cases where this would fail too.
+            // However, the extension never has to deal with non-UTF8
+            // cases, so it doesn't matter too much.
+            const original = '... 😁 ...';
+            await fsextra.writeFile(filename, original, { encoding: 'ucs2' });
+
+            const text = await filesystem.readText(filename);
+
+            expect(text).to.equal('.\u0000.\u0000.\u0000 \u0000=�\u0001� \u0000.\u0000.\u0000.\u0000');
+        });
+
+        test('throws an exception if file does not exist', async () => {
+            const promise = filesystem.readText(DOES_NOT_EXIST);
+
+            await expect(promise).to.eventually.be.rejected;
+        });
     });
 
     suite('rmtree', () => {
@@ -223,5 +263,36 @@ suite('FileSystem Utils', () => {
 
             await expect(promise).to.eventually.be.rejected;
         });
+    });
+});
+
+suite('FileSystem - legacy aliases', () => {
+    const fileToAppendTo = path.join(__dirname, 'created_for_testing_dummy.txt');
+    setup(() => {
+        cleanTestFiles(); // This smells like functional testing...
+    });
+    teardown(cleanTestFiles);
+    function cleanTestFiles() {
+        if (fsextra.existsSync(fileToAppendTo)) {
+            fsextra.unlinkSync(fileToAppendTo);
+        }
+    }
+
+    test('ReadFile returns contents of a file', async () => {
+        const file = __filename;
+        const filesystem = new FileSystem();
+        const expectedContents = await fsextra.readFile(file).then(buffer => buffer.toString());
+
+        const content = await filesystem.readFile(file);
+
+        expect(content).to.be.equal(expectedContents);
+    });
+
+    test('ReadFile throws an exception if file does not exist', async () => {
+        const filesystem = new FileSystem();
+
+        const readPromise = filesystem.readFile('xyz');
+
+        await expect(readPromise).to.be.rejectedWith();
     });
 });

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -12,7 +12,7 @@ import {
     IFileSystemUtils, IRawFileSystem
 } from '../../../client/common/platform/types';
 import {
-    DOES_NOT_EXIST, assertDoesNotExist, assertExists, FSFixture, WINDOWS
+    assertDoesNotExist, assertExists, DOES_NOT_EXIST, FSFixture, WINDOWS
 } from './filesystem.functional.test';
 
 // Note: all functional tests that do not trigger the VS Code "fs" API

--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -23,9 +23,11 @@ import {
 suite('Raw FileSystem', () => {
     let filesystem: IRawFileSystem;
     let fix: FSFixture;
-    setup(() => {
+    setup(async () => {
         filesystem = RawFileSystem.withDefaults();
         fix = new FSFixture();
+
+        await assertDoesNotExist(DOES_NOT_EXIST);
     });
     teardown(async () => {
         await fix.cleanUp();

--- a/src/test/common/platform/filesystem.unit.test.ts
+++ b/src/test/common/platform/filesystem.unit.test.ts
@@ -22,6 +22,7 @@ interface IRawFS {
     // VS Code
     delete(uri: Uri, options?: {recursive: boolean; useTrash: boolean}): Thenable<void>;
     readDirectory(uri: Uri): Thenable<[string, FileType][]>;
+    readFile(uri: Uri): Thenable<Uint8Array>;
 
     // node "fs"
     //tslint:disable-next-line:no-any
@@ -31,7 +32,6 @@ interface IRawFS {
 
     // "fs-extra"
     chmod(filePath: string, mode: string): Promise<void>;
-    readFile(path: string, encoding: string): Promise<string>;
     //tslint:disable-next-line:no-any
     writeFile(path: string, data: any, options: any): Promise<void>;
     stat(filename: string): Promise<fsextra.Stats>;
@@ -255,8 +255,9 @@ suite('Raw FileSystem', () => {
         test('wraps the low-level function', async () => {
             const filename = 'x/y/z/spam.py';
             const expected = '<text>';
-            raw.setup(r => r.readFile(filename, TypeMoq.It.isAny()))
-                .returns(() => Promise.resolve(expected));
+            const data = Buffer.from(expected);
+            raw.setup(r => r.readFile(Uri.file(filename)))
+                .returns(() => Promise.resolve(data));
 
             const text = await filesystem.readText(filename);
 
@@ -266,9 +267,10 @@ suite('Raw FileSystem', () => {
 
         test('always UTF-8', async () => {
             const filename = 'x/y/z/spam.py';
-            const expected = '<text>';
-            raw.setup(r => r.readFile(filename, 'utf8'))
-                .returns(() => Promise.resolve(expected));
+            const expected = '... 😁 ...';
+            const data = Buffer.from(expected);
+            raw.setup(r => r.readFile(Uri.file(filename)))
+                .returns(() => Promise.resolve(data));
 
             const text = await filesystem.readText(filename);
 

--- a/src/test/common/platform/filesystem.unit.test.ts
+++ b/src/test/common/platform/filesystem.unit.test.ts
@@ -300,23 +300,25 @@ suite('Raw FileSystem', () => {
         if (stat.type === FileType.File) {
             old!.setup(s => s.isFile())
                 .returns(() => true);
+        } else if (stat.type === FileType.Directory) {
+            old!.setup(s => s.isFile())
+                .returns(() => false);
+            old!.setup(s => s.isDirectory())
+                .returns(() => true);
+        } else if (stat.type === FileType.SymbolicLink) {
+            old!.setup(s => s.isFile())
+                .returns(() => false);
+            old!.setup(s => s.isDirectory())
+                .returns(() => false);
+            old!.setup(s => s.isSymbolicLink())
+                .returns(() => true);
         } else {
             old!.setup(s => s.isFile())
                 .returns(() => false);
-            if (stat.type === FileType.Directory) {
-                old!.setup(s => s.isDirectory())
-                    .returns(() => true);
-            } else {
-                old!.setup(s => s.isDirectory())
-                    .returns(() => false);
-                if (stat.type === FileType.SymbolicLink) {
-                    old!.setup(s => s.isSymbolicLink())
-                        .returns(() => true);
-                } else {
-                    old!.setup(s => s.isSymbolicLink())
-                        .returns(() => false);
-                }
-            }
+            old!.setup(s => s.isDirectory())
+                .returns(() => false);
+            old!.setup(s => s.isSymbolicLink())
+                .returns(() => false);
         }
         old!.setup(s => s.size)
             .returns(() => stat.size);

--- a/src/test/common/platform/filesystem.unit.test.ts
+++ b/src/test/common/platform/filesystem.unit.test.ts
@@ -506,7 +506,7 @@ suite('Raw FileSystem', () => {
                 ['dev1', FileType.Unknown],
                 ['w', FileType.Directory],
                 ['spam.py', FileType.File],
-                ['other', FileType.SymbolicLink]
+                ['other', FileType.SymbolicLink | FileType.File]
             ];
             raw.setup(r => r.readDirectory(Uri.file(dirname)))
                 .returns(() => Promise.resolve(expected));

--- a/src/test/common/platform/filesystem.unit.test.ts
+++ b/src/test/common/platform/filesystem.unit.test.ts
@@ -51,18 +51,12 @@ interface IRawFS {
     stat(uri: Uri): Thenable<FileStat>;
     writeFile(uri: Uri, content: Uint8Array): Thenable<void>;
 
-    // node "fs"
-    //tslint:disable-next-line:no-any
-    open(filename: string, flags: number, callback: any): void;
-    //tslint:disable-next-line:no-any
-    close(fd: number, callback: any): void;
-    createWriteStream(dest: string): fs.WriteStream;
-
     // "fs-extra"
     chmod(filePath: string, mode: string): Promise<void>;
     lstat(filename: string): Promise<fsextra.Stats>;
     statSync(filename: string): fsextra.Stats;
     readFileSync(path: string, encoding: string): string;
+    createWriteStream(dest: string): fs.WriteStream;
 
     // fs paths (IFileSystemPaths)
     join(...filenames: string[]): string;
@@ -279,7 +273,6 @@ suite('Raw FileSystem', () => {
         raw = TypeMoq.Mock.ofType<IRawFS>(undefined, TypeMoq.MockBehavior.Strict);
         oldStat = createMockLegacyStat();
         filesystem = new RawFileSystem(
-            raw.object,
             raw.object,
             raw.object,
             raw.object

--- a/src/test/common/platform/filesystem.unit.test.ts
+++ b/src/test/common/platform/filesystem.unit.test.ts
@@ -24,6 +24,7 @@ interface IRawFS {
     readDirectory(uri: Uri): Thenable<[string, FileType][]>;
     readFile(uri: Uri): Thenable<Uint8Array>;
     stat(uri: Uri): Thenable<FileStat>;
+    writeFile(uri: Uri, content: Uint8Array): Thenable<void>;
 
     // node "fs"
     //tslint:disable-next-line:no-any
@@ -33,8 +34,6 @@ interface IRawFS {
 
     // "fs-extra"
     chmod(filePath: string, mode: string): Promise<void>;
-    //tslint:disable-next-line:no-any
-    writeFile(path: string, data: any, options: any): Promise<void>;
     lstat(filename: string): Promise<fsextra.Stats>;
     mkdirp(dirname: string): Promise<void>;
     statSync(filename: string): fsextra.Stats;
@@ -340,11 +339,24 @@ suite('Raw FileSystem', () => {
     suite('writeText', () => {
         test('wraps the low-level function', async () => {
             const filename = 'x/y/z/spam.py';
-            const data = '<data>';
-            raw.setup(r => r.writeFile(filename, data, { encoding: 'utf8' }))
+            const text = '<data>';
+            const data = Buffer.from(text);
+            raw.setup(r => r.writeFile(Uri.file(filename), data))
                 .returns(() => Promise.resolve());
 
-            await filesystem.writeText(filename, data);
+            await filesystem.writeText(filename, text);
+
+            verifyAll();
+        });
+
+        test('always UTF-8', async () => {
+            const filename = 'x/y/z/spam.py';
+            const text = '... 😁 ...';
+            const data = Buffer.from(text);
+            raw.setup(r => r.writeFile(Uri.file(filename), data))
+                .returns(() => Promise.resolve());
+
+            await filesystem.writeText(filename, text);
 
             verifyAll();
         });

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -298,6 +298,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     constructor() {
         super();
+        this.vscode = false;
         const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
         this.shouldMockJupyter = !isRollingBuild;
         this.asyncRegistry = new AsyncDisposableRegistry();

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -298,7 +298,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     constructor() {
         super();
-        this.vscode = false;
+        this.useVSCodeAPI = false;
         const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
         this.shouldMockJupyter = !isRollingBuild;
         this.asyncRegistry = new AsyncDisposableRegistry();

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as fsextra from 'fs-extra';
 import { Container } from 'inversify';
+import * as path from 'path';
 import { anything, instance, mock, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
 import { Disposable, Memento, OutputChannel } from 'vscode';
@@ -13,7 +15,7 @@ import { PathUtils } from '../client/common/platform/pathUtils';
 import { PlatformService } from '../client/common/platform/platformService';
 import { RegistryImplementation } from '../client/common/platform/registry';
 import { registerTypes as platformRegisterTypes } from '../client/common/platform/serviceRegistry';
-import { IFileSystem, IPlatformService, IRegistry } from '../client/common/platform/types';
+import { FileStat, FileType, IFileSystem, IPlatformService, IRegistry } from '../client/common/platform/types';
 import { BufferDecoder } from '../client/common/process/decoder';
 import { ProcessService } from '../client/common/process/proc';
 import { PythonExecutionFactory } from '../client/common/process/pythonExecutionFactory';
@@ -22,6 +24,7 @@ import { registerTypes as processRegisterTypes } from '../client/common/process/
 import { IBufferDecoder, IProcessServiceFactory, IPythonExecutionFactory, IPythonToolExecutionService } from '../client/common/process/types';
 import { registerTypes as commonRegisterTypes } from '../client/common/serviceRegistry';
 import { GLOBAL_MEMENTO, ICurrentProcess, IDisposableRegistry, ILogger, IMemento, IOutputChannel, IPathUtils, IsWindows, WORKSPACE_MEMENTO } from '../client/common/types';
+import { createDeferred } from '../client/common/utils/async';
 import { registerTypes as variableRegisterTypes } from '../client/common/variables/serviceRegistry';
 import { registerTypes as formattersRegisterTypes } from '../client/formatters/serviceRegistry';
 import { EnvironmentActivationService } from '../client/interpreter/activation/service';
@@ -58,7 +61,77 @@ import { MockMemento } from './mocks/mementos';
 import { MockProcessService } from './mocks/proc';
 import { MockProcess } from './mocks/process';
 
+// This is necessary for unit tests and functional tests, since they
+// do not run under VS Code so they do not have access to the actual
+// "vscode" namespace.
+class LegacyFileSystem extends FileSystem {
+    public async readFile(filename: string): Promise<string> {
+        return fsextra.readFile(filename, 'utf8');
+    }
+    public async writeFile(filename: string, data: {}): Promise<void> {
+        const options: fsextra.WriteFileOptions = {
+            encoding: 'utf8'
+        };
+        return fsextra.writeFile(filename, data, options);
+    }
+    public async deleteDirectory(dirname: string): Promise<void> {
+        return fsextra.stat(dirname)
+            .then(() => fsextra.remove(dirname));
+    }
+    public async deleteFile(filename: string): Promise<void> {
+        return fsextra.unlink(filename);
+    }
+    public async listdir(dirname: string): Promise<[string, FileType][]> {
+        const names: string[] = await fsextra.readdir(dirname);
+        const promises = names
+            .map(name => {
+                 const filename = path.join(dirname, name);
+                 return this.utils.raw.lstat(filename)
+                     .then(stat => [name, stat.type] as [string, FileType])
+                     .catch(() => [name, FileType.Unknown] as [string, FileType]);
+            });
+        return Promise.all(promises);
+    }
+    public async createDirectory(dirname: string): Promise<void> {
+        return fsextra.mkdirp(dirname);
+    }
+    public async copyFile(src: string, dest: string): Promise<void> {
+        const deferred = createDeferred<void>();
+        const rs = fsextra.createReadStream(src)
+            .on('error', (err) => {
+                deferred.reject(err);
+            });
+        const ws = fsextra.createWriteStream(dest)
+            .on('error', (err) => {
+                deferred.reject(err);
+            }).on('close', () => {
+                deferred.resolve();
+            });
+        rs.pipe(ws);
+        return deferred.promise;
+    }
+    protected async _stat(filePath: string): Promise<FileStat> {
+        const stat = await fsextra.stat(filePath);
+        let fileType = FileType.Unknown;
+        if (stat.isFile()) {
+            fileType = FileType.File;
+        } else if (stat.isDirectory()) {
+            fileType = FileType.Directory;
+        } else if (stat.isSymbolicLink()) {
+            fileType = FileType.SymbolicLink;
+        }
+        return {
+            type: fileType,
+            size: stat.size,
+            ctime: stat.ctimeMs,
+            mtime: stat.mtimeMs
+        };
+    }
+}
+
 export class IocContainer {
+    public vscode = true;
+
     public readonly serviceManager: IServiceManager;
     public readonly serviceContainer: IServiceContainer;
 
@@ -105,7 +178,10 @@ export class IocContainer {
     }
     public registerFileSystemTypes() {
         this.serviceManager.addSingleton<IPlatformService>(IPlatformService, PlatformService);
-        this.serviceManager.addSingleton<IFileSystem>(IFileSystem, FileSystem);
+        this.serviceManager.addSingleton<IFileSystem>(
+            IFileSystem,
+            this.vscode ? FileSystem : LegacyFileSystem
+        );
     }
     public registerProcessTypes() {
         processRegisterTypes(this.serviceManager);

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -130,7 +130,11 @@ class LegacyFileSystem extends FileSystem {
 }
 
 export class IocContainer {
-    public vscode = true;
+    // This may be set (before any registration happens) to indicate
+    // whether or not IOC should depend on the VS Code API (e.g. the
+    // "vscode" module).  So in "functional" tests, this should be set
+    // to "false".
+    public useVSCodeAPI = true;
 
     public readonly serviceManager: IServiceManager;
     public readonly serviceContainer: IServiceContainer;
@@ -180,7 +184,7 @@ export class IocContainer {
         this.serviceManager.addSingleton<IPlatformService>(IPlatformService, PlatformService);
         this.serviceManager.addSingleton<IFileSystem>(
             IFileSystem,
-            this.vscode ? FileSystem : LegacyFileSystem
+            this.useVSCodeAPI ? FileSystem : LegacyFileSystem
         );
     }
     public registerProcessTypes() {

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -83,6 +83,7 @@ mockedVSCode.DebugAdapterExecutable = vscodeMocks.vscMock.DebugAdapterExecutable
 mockedVSCode.DebugAdapterServer = vscodeMocks.vscMock.DebugAdapterServer;
 mockedVSCode.QuickInputButtons = vscodeMocks.vscMockExtHostedTypes.QuickInputButtons;
 mockedVSCode.FileType = vscodeMocks.vscMock.FileType;
+mockedVSCode.FileSystemError = vscodeMocks.vscMockExtHostedTypes.FileSystemError;
 
 // This API is used in src/client/telemetry/telemetry.ts
 const extensions = TypeMoq.Mock.ofType<typeof vscode.extensions>();


### PR DESCRIPTION
(for #6911)

This PR builds on #7915, focusing only on the move to the new filesystem API.  Note that there are 6 functions (in addition to `glob()` and `tmp.file()`) that I was not able to convert due to a lack of functionality in the new API.  I have opened upstream issues to address that.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- ~[ ] Has sufficient logging.~
- ~[ ] Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
