### PR TITLE
Never update cell contents from the extension side

### DIFF
--- a/news/2 Fixes/8215.md
+++ b/news/2 Fixes/8215.md
@@ -1,0 +1,1 @@
+Prevent code from changing in the Notebook Editor while running a cell.

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -1160,24 +1160,19 @@ export class MainStateController implements IMessageHandler {
             // Check to see if our code still matches for the cell (in liveshare it might be updated from the other side)
             // if (concatMultilineStringInput(this.pendingState.cellVMs[index].cell.data.source) !== concatMultilineStringInput(cell.data.source)) {
 
-            // If cell state changes, then update just the state and the cell data (excluding source).
             // Prevent updates to the source, as its possible we have recieved a response for a cell execution
             // and the user has updated the cell text since then.
-            if (this.pendingState.cellVMs[index].cell.state !== cell.state) {
-                newVMs[index] = {
-                    ...newVMs[index],
-                    cell: {
-                        ...newVMs[index].cell,
-                        state: cell.state,
-                        data: {
-                            ...cell.data,
-                            source: newVMs[index].cell.data.source
-                        }
+            newVMs[index] = {
+                ...newVMs[index],
+                cell: {
+                    ...newVMs[index].cell,
+                    state: cell.state,
+                    data: {
+                        ...cell.data,
+                        source: newVMs[index].cell.data.source
                     }
-                };
-            } else {
-                newVMs[index] = { ...newVMs[index], cell: cell };
-            }
+                }
+            };
 
             this.setState({
                 cellVMs: newVMs,


### PR DESCRIPTION
For #8215 

I cannot repro this bug, but the code looks like it _might_ be possible to cause an update. A cell would have to be in the error state when the user typed and executing would have to immediately cause an error. In this situation, the typing that occurred after execution would be lost.

Anyway there's no reason to ever update the source of a cell unless
- We get liveshare to work
- We let the interactive window update cells after running them