### PR TITLE
outputs will appear as a single textbox, with one scrollbar

### DIFF
--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -345,7 +345,6 @@ export class CellOutput extends React.Component<ICellOutputProps> {
 
     // tslint:disable-next-line: max-func-body-length
     private renderOutputs(outputs: nbformat.IOutput[]): JSX.Element[] {
-        // return outputs.map(this.renderOutput);
         return [this.renderOutput(outputs)];
     }
 

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -351,10 +351,8 @@ export class CellOutput extends React.Component<ICellOutputProps> {
 
     private renderOutput = (outputs: nbformat.IOutput[]): JSX.Element => {
         const buffer: JSX.Element[] = [];
-        const transformedList: ICellOutput[] = [];
-        outputs.forEach(output => {
-            transformedList.push(this.transformOutput(output));
-        });
+        let transformedList: ICellOutput[] = [];
+        transformedList = outputs.map(this.transformOutput);
 
         transformedList.forEach(transformed => {
             let mimetype = transformed.mimeType;
@@ -385,16 +383,16 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                         </div>
                     );
                 }
-            }
-
-            if (transformed.data) {
-                const keys = Object.keys(transformed.data);
-                mimetype = keys.length > 0 ? keys[0] : 'unknown';
             } else {
-                mimetype = 'unknown';
+                if (transformed.data) {
+                    const keys = Object.keys(transformed.data);
+                    mimetype = keys.length > 0 ? keys[0] : 'unknown';
+                } else {
+                    mimetype = 'unknown';
+                }
+                const str: string = this.getUnknownMimeTypeFormatString().format(mimetype);
+                buffer.push(<div>{str}</div>);
             }
-            const str: string = this.getUnknownMimeTypeFormatString().format(mimetype);
-            buffer.push(<div>{str}</div>);
         });
 
         // Create a default set of properties

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -351,8 +351,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
 
     private renderOutput = (outputs: nbformat.IOutput[]): JSX.Element => {
         const buffer: JSX.Element[] = [];
-        let transformedList: ICellOutput[] = [];
-        transformedList = outputs.map(this.transformOutput);
+        const transformedList = outputs.map(this.transformOutput);
 
         transformedList.forEach(transformed => {
             let mimetype = transformed.mimeType;

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -345,59 +345,68 @@ export class CellOutput extends React.Component<ICellOutputProps> {
 
     // tslint:disable-next-line: max-func-body-length
     private renderOutputs(outputs: nbformat.IOutput[]): JSX.Element[] {
-        return outputs.map(this.renderOutput);
+        // return outputs.map(this.renderOutput);
+        return [this.renderOutput(outputs)];
     }
 
-    private renderOutput = (output: nbformat.IOutput, index: number): JSX.Element => {
-        const transformed = this.transformOutput(output);
-        let mimetype = transformed.mimeType;
+    private renderOutput = (outputs: nbformat.IOutput[]): JSX.Element => {
+        const buffer: JSX.Element[] = [];
+        const transformedList: ICellOutput[] = [];
+        outputs.forEach(output => {
+            transformedList.push(this.transformOutput(output));
+        });
 
-        // If that worked, use the transform
-        if (mimetype) {
-            // Get the matching React.Component for that mimetype
-            const Transform = transforms[mimetype];
+        transformedList.forEach(transformed => {
+            let mimetype = transformed.mimeType;
 
-            // Create a default set of properties
-            const style: React.CSSProperties = {
-            };
+            // If that worked, use the transform
+            if (mimetype) {
+                // Get the matching React.Component for that mimetype
+                const Transform = transforms[mimetype];
 
-            // Create a scrollbar style if necessary
-            if (transformed.renderWithScrollbars && this.props.maxTextSize) {
-                style.overflowX = 'auto';
-                style.overflowY = 'auto';
-                style.maxHeight = `${this.props.maxTextSize}px`;
-            }
+                let className = transformed.isText ? 'cell-output-text' : 'cell-output-html';
+                className = transformed.isError ? `${className} cell-output-error` : className;
 
-            let className = transformed.isText ? 'cell-output-text' : 'cell-output-html';
-            className = transformed.isError ? `${className} cell-output-error` : className;
-
-            // If we are not theming plots then wrap them in a white span
-            if (transformed.outputSpanClassName) {
-                return (
-                    <div role='group' key={index} onDoubleClick={transformed.doubleClick} onClick={this.click} className={className} style={style}>
-                        <span className={transformed.outputSpanClassName}>
+                // If we are not theming plots then wrap them in a white span
+                if (transformed.outputSpanClassName) {
+                    buffer.push(
+                        <div role='group' onDoubleClick={transformed.doubleClick} onClick={this.click} className={className}>
+                            <span className={transformed.outputSpanClassName}>
+                                {transformed.extraButton}
+                                <Transform data={transformed.data} />
+                            </span>
+                        </div>
+                    );
+                } else {
+                    buffer.push(
+                        <div role='group' onDoubleClick={transformed.doubleClick} onClick={this.click} className={className}>
                             {transformed.extraButton}
                             <Transform data={transformed.data} />
-                        </span>
-                    </div>
-                );
-            } else {
-                return (
-                    <div role='group' key={index} onDoubleClick={transformed.doubleClick} onClick={this.click} className={className} style={style}>
-                        {transformed.extraButton}
-                        <Transform data={transformed.data} />
-                    </div>
-                );
+                        </div>
+                    );
+                }
             }
+
+            if (transformed.data) {
+                const keys = Object.keys(transformed.data);
+                mimetype = keys.length > 0 ? keys[0] : 'unknown';
+            } else {
+                mimetype = 'unknown';
+            }
+            const str: string = this.getUnknownMimeTypeFormatString().format(mimetype);
+            buffer.push(<div>{str}</div>);
+        });
+
+        // Create a default set of properties
+        const style: React.CSSProperties = {
+        };
+
+        // Create a scrollbar style if necessary
+        if (transformedList.some(transformed => transformed.renderWithScrollbars) && this.props.maxTextSize) {
+            style.overflowY = 'auto';
+            style.maxHeight = `${this.props.maxTextSize}px`;
         }
 
-        if (output.data) {
-            const keys = Object.keys(output.data);
-            mimetype = keys.length > 0 ? keys[0] : 'unknown';
-        } else {
-            mimetype = 'unknown';
-        }
-        const str: string = this.getUnknownMimeTypeFormatString().format(mimetype);
-        return <div key={index}>{str}</div>;
+        return <div style={style}>{buffer}</div>;
     }
 }


### PR DESCRIPTION
For #8049

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
