### PR TITLE
Moved the toolbar to render right below inputs.

### DIFF
--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -161,7 +161,6 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     {this.renderCollapseBar(true)}
                     {this.renderControls()}
                     {this.renderInput()}
-                    {this.renderMiddleToolbar()}
                 </div>
                 {this.renderAddDivider(true)}
                 <div className='cell-row-container'>
@@ -629,26 +628,29 @@ export class NativeCell extends React.Component<INativeCellProps> {
     private renderInput = () => {
         if (this.shouldRenderInput()) {
             return (
-                <CellInput
-                    cellVM={this.props.cellVM}
-                    editorOptions={this.props.stateController.getState().editorOptions}
-                    history={undefined}
-                    autoFocus={this.props.autoFocus}
-                    codeTheme={this.props.codeTheme}
-                    onCodeChange={this.props.stateController.codeChange}
-                    onCodeCreated={this.props.stateController.editableCodeCreated}
-                    testMode={this.props.testMode ? true : false}
-                    showWatermark={false}
-                    ref={this.inputRef}
-                    monacoTheme={this.props.monacoTheme}
-                    openLink={this.props.stateController.openLink}
-                    editorMeasureClassName={undefined}
-                    focused={this.isCodeCell() ? this.onCodeFocused : this.onMarkdownFocused}
-                    unfocused={this.isCodeCell() ? this.onCodeUnfocused : this.onMarkdownUnfocused}
-                    keyDown={this.keyDownInput}
-                    showLineNumbers={this.props.cellVM.showLineNumbers}
-                    font={this.props.font}
-                />
+                <div>
+                    <CellInput
+                        cellVM={this.props.cellVM}
+                        editorOptions={this.props.stateController.getState().editorOptions}
+                        history={undefined}
+                        autoFocus={this.props.autoFocus}
+                        codeTheme={this.props.codeTheme}
+                        onCodeChange={this.props.stateController.codeChange}
+                        onCodeCreated={this.props.stateController.editableCodeCreated}
+                        testMode={this.props.testMode ? true : false}
+                        showWatermark={false}
+                        ref={this.inputRef}
+                        monacoTheme={this.props.monacoTheme}
+                        openLink={this.props.stateController.openLink}
+                        editorMeasureClassName={undefined}
+                        focused={this.isCodeCell() ? this.onCodeFocused : this.onMarkdownFocused}
+                        unfocused={this.isCodeCell() ? this.onCodeUnfocused : this.onMarkdownUnfocused}
+                        keyDown={this.keyDownInput}
+                        showLineNumbers={this.props.cellVM.showLineNumbers}
+                        font={this.props.font}
+                    />
+                    {this.renderMiddleToolbar()}
+                </div>
             );
         }
         return null;


### PR DESCRIPTION
This saves a bit of space with single line block of code.

For #8052

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
