### PR TITLE
Don't fail if pytest --with-doctest doesn't include lineno

### DIFF
--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -250,6 +250,9 @@ def _get_location(item, testroot, relfile, #*,
     # over item.location in this function.
 
     srcfile, lineno, fullname = item.location
+    if lineno is None:
+        # Happens in doctests and tests imported from other modules
+        lineno = -1  # i.e. "unknown"
     if _matches_relfile(srcfile, testroot, relfile):
         srcfile = relfile
     else:
@@ -271,8 +274,6 @@ def _get_location(item, testroot, relfile, #*,
                     # function to be in relfile.  So here we ignore any
                     # other file and just say "somewhere in relfile".
                     lineno = None
-            if lineno is None:
-                lineno = -1  # i.e. "unknown"
         elif _matches_relfile(srcfile, testroot, relfile):
             srcfile = relfile
         # Otherwise we just return the info from item.location as-is.


### PR DESCRIPTION
I've been seeing the following traceback in one of my projects
(https://github.com/bardin-lab/readtagger) when discovering tests within vscode:
```
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/_pytest/main.py", line 442, in perform_collect
INTERNALERROR>     session=self, config=self.config, items=items
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 86, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_discovery.py", line 80, in pytest_collection_modifyitems
INTERNALERROR>     test, parents = self.parse_item(item)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_discovery.py", line 65, in parse_item
INTERNALERROR>     return parse_item(item)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 162, in parse_item
INTERNALERROR>     location, fullname = _get_location(item, testroot, relfile)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 143, in <lambda>
INTERNALERROR>     _get_location=(lambda *a: _get_location(*a)),
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 282, in _get_location
INTERNALERROR>     location = '{}:{}'.format(srcfile, int(lineno) + 1)
INTERNALERROR> TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
INTERNALERROR>
INTERNALERROR> During handling of the above exception, another exception occurred:
INTERNALERROR>
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/_pytest/main.py", line 193, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/_pytest/main.py", line 236, in _main
INTERNALERROR>     config.hook.pytest_collection(session=session)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 86, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/_pytest/main.py", line 246, in pytest_collection
INTERNALERROR>     return session.perform_collect()
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/_pytest/main.py", line 445, in perform_collect
INTERNALERROR>     hook.pytest_collection_finish(session=self)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/manager.py", line 86, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/Users/mvandenb/src/readtagger/.venv/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_discovery.py", line 94, in pytest_collection_finish
INTERNALERROR>     test, parents = self.parse_item(item)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_discovery.py", line 65, in parse_item
INTERNALERROR>     return parse_item(item)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 162, in parse_item
INTERNALERROR>     location, fullname = _get_location(item, testroot, relfile)
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 143, in <lambda>
INTERNALERROR>     _get_location=(lambda *a: _get_location(*a)),
INTERNALERROR>   File "/Users/mvandenb/.vscode/extensions/ms-python.python-2019.10.44104/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py", line 282, in _get_location
INTERNALERROR>     location = '{}:{}'.format(srcfile, int(lineno) + 1)
INTERNALERROR> TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```
This patch seems to fix that problem.

I also tried adding a test like this:
```
diff --git a/pythonFiles/tests/testing_tools/adapter/test_discovery.py b/pythonFiles/tests/testing_tools/adapter/test_discovery.py
index ce6b615c..e62a46ff 100644
--- a/pythonFiles/tests/testing_tools/adapter/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/test_discovery.py
@@ -436,6 +436,19 @@ class DiscoveredTestsTests(unittest.TestCase):
                 markers=[],
                 parentid=relfile,
                 ),
+             # With --doctest-module, no line number
+            TestInfo(
+                id=relfile + '::test_eggs',
+                name='test_eggs',
+                path=TestPath(
+                    root=testroot,
+                    relfile=relfile,
+                    func=None,
+                    ),
+                source='{}'.format(relfile),
+                markers=[],
+                parentid=relfile,
+                ),
             TestInfo(
                 id=relfile + '::test_eggs.TestSpam',
                 name='test_eggs.TestSpam',

```
But this fails outright with

```
test_discovery.py:450:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = TestInfo(id='./x/y/z/test_eggs.py::test_eggs', name='test_eggs', path=TestPath(root='/a/b/c', relfile='./x/y/z/test_eggs.py', func=None, sub=None), source='./x/y/z/test_eggs.py', markers=[], parentid='./x/y/z/test_eggs.py', kind='function')
args = (), kwargs = {'id': './x/y/z/test_eggs.py::test_eggs', 'markers': [], 'name': 'test_eggs', 'parentid': './x/y/z/test_eggs.py', ...}, srcfile = '', _ = ''
lineno = './x/y/z/test_eggs.py'

    def __init__(self, *args, **kwargs):
        if self.id is None:
            raise TypeError('missing id')
        if self.name is None:
            raise TypeError('missing name')
        if self.path is None:
            raise TypeError('missing path')
        if self.source is None:
            raise TypeError('missing source')
        else:
            srcfile, _, lineno = self.source.rpartition(':')
            if not srcfile or not lineno or int(lineno) < 0:
>               raise ValueError('bad source {!r}'.format(self.source))
E               ValueError: bad source './x/y/z/test_eggs.py'

../../../testing_tools/adapter/info.py:96: ValueError
```

Which makes it seem like lineno should always be set. Not sure then
whether this is the proper fix, or whether there is a bug in the
--with-doctest functionality of pytest or whether I just have a
particularly strange setup.

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
