### PR TITLE
Gathered nb's from py don't show original file.

### DIFF
--- a/src/client/datascience/gather/gatherListener.ts
+++ b/src/client/datascience/gather/gatherListener.ts
@@ -8,6 +8,7 @@ import { IConfigurationService } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { generateCellsFromString } from '../cellFactory';
+import { Identifiers } from '../constants';
 import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../interactive-common/interactiveWindowTypes';
 import { ICell, IGatherExecution, IInteractiveWindowListener, IInteractiveWindowProvider, IJupyterExecution, INotebook, INotebookEditorProvider, INotebookExporter } from '../types';
 import { GatherLogger } from './gatherLogger';
@@ -102,11 +103,11 @@ export class GatherListener implements IInteractiveWindowListener {
         if (this.configService.getSettings().datascience.gatherToScript) {
             await this.showFile(slicedProgram, cell.file);
         } else {
-            await this.showNotebook(slicedProgram);
+            await this.showNotebook(slicedProgram, cell);
         }
     }
 
-    private async showNotebook(slicedProgram: string) {
+    private async showNotebook(slicedProgram: string, cell: ICell) {
         if (slicedProgram) {
             let cells: ICell[] = [{
                 id: uuid(),
@@ -115,7 +116,7 @@ export class GatherListener implements IInteractiveWindowListener {
                 state: 0,
                 data: {
                     cell_type: 'markdown',
-                    source: localize.DataScience.gatheredNotebookDescriptionInMarkdown().format(this.notebookUri.fsPath),
+                    source: localize.DataScience.gatheredNotebookDescriptionInMarkdown().format(cell.file === Identifiers.EmptyFileName ? this.notebookUri.fsPath : cell.file),
                     metadata: {}
                 }
             }];


### PR DESCRIPTION
For #8373 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
