### PR TITLE
Correctly handle interpreter changes for Interactive and Notebook

### DIFF
--- a/news/2 Fixes/8019.md
+++ b/news/2 Fixes/8019.md
@@ -1,0 +1,1 @@
+Correctly restart jupyter sessions when the active interpreter is changed.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -935,7 +935,9 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
 
     private onInterpreterChanged = () => {
         // Update our load promise. We need to restart the jupyter server
-        this.loadPromise = this.reloadWithNew();
+        if (this.loadPromise) {
+            this.loadPromise = this.reloadWithNew();
+        }
     }
 
     private async stopServer(): Promise<void> {

--- a/src/client/datascience/jupyter/liveshare/guestJupyterExecution.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterExecution.ts
@@ -63,7 +63,7 @@ export class GuestJupyterExecution extends LiveShareParticipantGuest(JupyterExec
             commandFactory,
             serviceContainer);
         asyncRegistry.push(this);
-        this.serverCache = new ServerCache(configuration, workspace, fileSystem);
+        this.serverCache = new ServerCache(configuration, workspace, fileSystem, interpreterService);
     }
 
     public async dispose(): Promise<void> {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterExecution.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterExecution.ts
@@ -64,7 +64,7 @@ export class HostJupyterExecution
             configService,
             commandFactory,
             serviceContainer);
-        this.serverCache = new ServerCache(configService, workspace, fileSys);
+        this.serverCache = new ServerCache(configService, workspace, fileSys, interpreterService);
     }
 
     public async dispose(): Promise<void> {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -107,6 +107,7 @@ export interface INotebookServerOptions {
     usingDarkTheme?: boolean;
     useDefaultConfig?: boolean;
     workingDir?: string;
+    interpreterPath?: string;
     purpose: string;
 }
 

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -599,9 +599,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         const interpreterManager = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
         interpreterManager.initialize();
 
-        if (this.mockJupyter) {
-            this.mockJupyter.addInterpreter(this.workingPython, SupportedCommands.all);
-        }
+        this.addInterpreter(this.workingPython, SupportedCommands.all);
     }
 
     // tslint:disable:any
@@ -716,6 +714,12 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     public enableJedi(enabled: boolean) {
         this.pythonSettings.jediEnabled = enabled;
+    }
+
+    public addInterpreter(newInterpreter: PythonInterpreter, commands: SupportedCommands) {
+        if (this.mockJupyter) {
+            this.mockJupyter.addInterpreter(newInterpreter, commands);
+        }
     }
 
     private findPythonPath(): string {

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -528,9 +528,6 @@ suite('DataScience notebook tests', () => {
 
         // Real Jupyter doesn't help this test at all and is tricky to set up for it, so just skip it
         if (!isRollingBuild) {
-            //jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
-            //processFactory = ioc.serviceManager.get<IProcessServiceFactory>(IProcessServiceFactory);
-
             const server = await createNotebook(true);
 
             // Create again, we should get the same server from the cache

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs-extra';
 import { injectable } from 'inversify';
 import * as os from 'os';
 import * as path from 'path';
+import { SemVer } from 'semver';
 import { Readable, Writable } from 'stream';
 import { anything, instance, mock, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
@@ -23,6 +24,7 @@ import { IFileSystem } from '../../client/common/platform/types';
 import { IProcessServiceFactory, IPythonExecutionFactory, Output } from '../../client/common/process/types';
 import { createDeferred, waitForPromise } from '../../client/common/utils/async';
 import { noop } from '../../client/common/utils/misc';
+import { Architecture } from '../../client/common/utils/platform';
 import { concatMultilineStringInput } from '../../client/datascience/common';
 import { Identifiers } from '../../client/datascience/constants';
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
@@ -42,6 +44,7 @@ import {
 import {
     IInterpreterService,
     IKnownSearchPathsForInterpreters,
+    InterpreterType,
     PythonInterpreter
 } from '../../client/interpreter/contracts';
 import { generateTestState, ICellViewModel } from '../../datascience-ui/interactive-common/mainState';
@@ -49,6 +52,7 @@ import { asyncDump } from '../common/asyncDump';
 import { sleep } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 import { getConnectionInfo, getIPConnectionInfo, getNotebookCapableInterpreter } from './jupyterHelpers';
+import { SupportedCommands } from './mockJupyterManager';
 import { MockPythonService } from './mockPythonService';
 
 // tslint:disable:no-any no-multiline-string max-func-body-length no-console max-classes-per-file trailing-comma
@@ -516,6 +520,41 @@ suite('DataScience notebook tests', () => {
         } finally {
             importer.dispose();
             temp.dispose();
+        }
+    });
+
+    runTest('Change Interpreter', async () => {
+        const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
+
+        // Real Jupyter doesn't help this test at all and is tricky to set up for it, so just skip it
+        if (!isRollingBuild) {
+            //jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
+            //processFactory = ioc.serviceManager.get<IProcessServiceFactory>(IProcessServiceFactory);
+
+            const server = await createNotebook(true);
+
+            // Create again, we should get the same server from the cache
+            const server2 = await createNotebook(true);
+            assert.equal(server, server2, 'With no settings changed we should return the cached server');
+
+            // Create a new mock interpreter with a different path
+            const newPython: PythonInterpreter = {
+                path: '/foo/bar/baz/python.exe',
+                version: new SemVer('3.6.6-final'),
+                sysVersion: '1.0.0.0',
+                sysPrefix: 'Python',
+                type: InterpreterType.Unknown,
+                architecture: Architecture.x64,
+            };
+
+            // Add interpreter into mock jupyter service and set it as active
+            ioc.addInterpreter(newPython, SupportedCommands.all);
+
+            // Create a new notebook, we should not be the same anymore
+            const server3 = await createNotebook(true);
+            assert.notEqual(server, server3, 'With interpreter changed we should return a new server');
+        } else {
+            console.log(`Skipping Change Interpreter test in non-mocked Jupyter case`);
         }
     });
 


### PR DESCRIPTION
For #8019 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
