### PR TITLE
Use `noop` from src instead of tests directory

### DIFF
--- a/src/client/datascience/cellFactory.ts
+++ b/src/client/datascience/cellFactory.ts
@@ -6,8 +6,8 @@ import '../common/extensions';
 import * as uuid from 'uuid/v4';
 import { Range, TextDocument } from 'vscode';
 
-import { noop } from '../../test/core';
 import { IDataScienceSettings } from '../common/types';
+import { noop } from '../common/utils/misc';
 import { CellMatcher } from './cellMatcher';
 import { appendLineFeed, generateMarkdownFromCodeLines, parseForComments } from './common';
 import { CellState, ICell } from './types';

--- a/src/client/datascience/common.ts
+++ b/src/client/datascience/common.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
-
-import { noop } from '../../test/core';
+import { noop } from '../common/utils/misc';
 
 const SingleQuoteMultiline = '\'\'\'';
 const DoubleQuoteMultiline = '\"\"\"';

--- a/src/client/datascience/jupyter/liveshare/guestJupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterSessionManager.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { CancellationToken } from 'vscode-jsonrpc';
 
-import { noop } from '../../../../test/core';
+import { noop } from '../../../common/utils/misc';
 import { IConnection, IJupyterKernelSpec, IJupyterSession, IJupyterSessionManager } from '../../types';
 
 export class GuestJupyterSessionManager implements IJupyterSessionManager {

--- a/src/client/datascience/jupyter/liveshare/guestJupyterSessionManagerFactory.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterSessionManagerFactory.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import { noop } from '../../../../test/core';
+import { noop } from '../../../common/utils/misc';
 import { IConnection, IJupyterSessionManager, IJupyterSessionManagerFactory } from '../../types';
 import { GuestJupyterSessionManager } from './guestJupyterSessionManager';
 

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -11,7 +11,6 @@ import { concatMultilineStringInput, concatMultilineStringOutput } from '../../c
 import { Identifiers } from '../../client/datascience/constants';
 import { CellState } from '../../client/datascience/types';
 import { ClassType } from '../../client/ioc/types';
-import { noop } from '../../test/core';
 import { Image, ImageName } from '../react-common/image';
 import { ImageButton } from '../react-common/imageButton';
 import { getLocString } from '../react-common/locReactSide';
@@ -24,6 +23,7 @@ const ansiToHtml = require('ansi-to-html');
 
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
+import { noop } from '../../client/common/utils/misc';
 
 interface ICellOutputProps {
     cellVM: ICellViewModel;

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -8,11 +8,11 @@ import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import * as path from 'path';
 
 import { IDataScienceSettings } from '../../client/common/types';
+import { noop } from '../../client/common/utils/misc';
 import { CellMatcher } from '../../client/datascience/cellMatcher';
 import { concatMultilineStringInput, splitMultilineString } from '../../client/datascience/common';
 import { Identifiers } from '../../client/datascience/constants';
 import { CellState, ICell, IJupyterVariable, IMessageCell } from '../../client/datascience/types';
-import { noop } from '../../test/core';
 import { InputHistory } from './inputHistory';
 
 export interface ICellViewModel {


### PR DESCRIPTION
Currently we're pulling `noop` from the tests directory (i.e. pulling resources from tests folder into the build).