### PR TITLE
Try caching npm 

### DIFF
--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -7,3 +7,5 @@ variables:
   VSC_PYTHON_FORCE_LOGGING: true # Enable this to turn on console output for the logger
   VSC_PYTHON_LOG_FILE: '$(Build.ArtifactStagingDirectory)/pvsc.log'
   CI_BRANCH_NAME: ${Build.SourceBranchName}
+  npm_config_cache: $(Pipeline.Workspace)/.npm
+

--- a/build/ci/templates/steps/initialization.yml
+++ b/build/ci/templates/steps/initialization.yml
@@ -63,6 +63,12 @@ steps:
           verbose: true
           customCommand: "install -g npm@$(NpmVersion)"
 
+    # Cache the node modules directory as this shouldn't change that often
+    - uses: actions/cache@v1
+      with:
+      path: node_modules
+      key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
     # In the past installs of npm, node-pre-gyp 0.12.0 was installed.
     # However in the latest versions, 0.11.0 is getting isntalled.
     # - bash: |

--- a/build/ci/templates/steps/initialization.yml
+++ b/build/ci/templates/steps/initialization.yml
@@ -19,9 +19,6 @@ parameters:
   sqlite: 'false'
   installVSCEorNPX: 'true'
 
-variables:
-  npm_config_cache: $(Pipeline.Workspace)/.npm
-
 steps:
     - bash: |
           printenv
@@ -80,9 +77,9 @@ steps:
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#nodejsnpm
     - task: CacheBeta@0
       inputs:
-      key: npm | $(Agent.OS) | package-lock.json
-      path: $(npm_config_cache)
-      displayName: Cache npm
+          key: npm | $(Agent.OS) | package-lock.json
+          path: $(npm_config_cache)
+          displayName: Cache npm
 
     - task: Npm@1
       displayName: "npm ci"

--- a/build/ci/templates/steps/initialization.yml
+++ b/build/ci/templates/steps/initialization.yml
@@ -19,6 +19,9 @@ parameters:
   sqlite: 'false'
   installVSCEorNPX: 'true'
 
+variables:
+  npm_config_cache: $(Pipeline.Workspace)/.npm
+
 steps:
     - bash: |
           printenv
@@ -63,12 +66,6 @@ steps:
           verbose: true
           customCommand: "install -g npm@$(NpmVersion)"
 
-    # Cache the node modules directory as this shouldn't change that often
-    - uses: actions/cache@v1
-      with:
-      path: node_modules
-      key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-
     # In the past installs of npm, node-pre-gyp 0.12.0 was installed.
     # However in the latest versions, 0.11.0 is getting isntalled.
     # - bash: |
@@ -79,15 +76,21 @@ steps:
     #   displayName: 'Uninstall canvas and install build from source (only for Linux)'
     #   condition: and(succeeded(), eq(variables['Agent.Os'], 'Linux'))
 
-    # Using npm install because we're caching the node_modules directory. If we
-    # cache node_modules, npm ci would delete it, so we have to use install here
+    # See the help here on how to cache npm
+    # https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#nodejsnpm
+    - task: CacheBeta@0
+      inputs:
+      key: npm | $(Agent.OS) | package-lock.json
+      path: $(npm_config_cache)
+      displayName: Cache npm
+
     - task: Npm@1
-      displayName: "npm install"
+      displayName: "npm ci"
       inputs:
           workingDir: ${{ parameters.workingDirectory }}
           command: custom
           verbose: true
-          customCommand: install
+          customCommand: ci
 
     # On Mac, the command `node` doesn't always point to the current node version.
     # Debugger tests use the variable process.env.NODE_PATH

--- a/build/ci/templates/steps/initialization.yml
+++ b/build/ci/templates/steps/initialization.yml
@@ -79,13 +79,15 @@ steps:
     #   displayName: 'Uninstall canvas and install build from source (only for Linux)'
     #   condition: and(succeeded(), eq(variables['Agent.Os'], 'Linux'))
 
+    # Using npm install because we're caching the node_modules directory. If we
+    # cache node_modules, npm ci would delete it, so we have to use install here
     - task: Npm@1
-      displayName: "npm ci"
+      displayName: "npm install"
       inputs:
           workingDir: ${{ parameters.workingDirectory }}
           command: custom
           verbose: true
-          customCommand: ci
+          customCommand: install
 
     # On Mac, the command `node` doesn't always point to the current node version.
     # Debugger tests use the variable process.env.NODE_PATH

--- a/build/ci/templates/steps/initialization.yml
+++ b/build/ci/templates/steps/initialization.yml
@@ -79,6 +79,8 @@ steps:
       inputs:
           key: npm | $(Agent.OS) | package-lock.json
           path: $(npm_config_cache)
+          restoreKeys: |
+            npm | $(Agent.OS)
           displayName: Cache npm
 
     - task: Npm@1

--- a/package.json
+++ b/package.json
@@ -2661,7 +2661,7 @@
         "package": "gulp clean && gulp prePublishBundle && vsce package -o ms-python-insiders.vsix",
         "compile": "tsc -watch -p ./",
         "compile-webviews-watch": "npx npx -n --max_old_space_size=4096 webpack --config webpack.datascience-ui.config.js --watch",
-        "dump-datascience-webpack-stats": "npx -n --max_old_space_size=4096 webpack --config webpack.datascience-ui.config.js --profile --json > tmp/ds-stats.json",
+        "dump-datascience-webpack-stats": "npx -n --max_old_space_size=4096 webpack --config webpack.datascience-ui.config.js --mode production --profile --json > tmp/ds-stats.json",
         "compile-webviews": "gulp compile-webviews",
         "compile-webviews-verbose": "npx webpack --config webpack.datascience-ui.config.js",
         "postinstall": "node ./build/ci/postInstall.js",

--- a/package.json
+++ b/package.json
@@ -2661,7 +2661,7 @@
         "package": "gulp clean && gulp prePublishBundle && vsce package -o ms-python-insiders.vsix",
         "compile": "tsc -watch -p ./",
         "compile-webviews-watch": "npx npx -n --max_old_space_size=4096 webpack --config webpack.datascience-ui.config.js --watch",
-        "dump-datascience-webpack-stats": "npx -n --max_old_space_size=4096 webpack --config webpack.datascience-ui.config.js --mode production --profile --json > tmp/ds-stats.json",
+        "dump-datascience-webpack-stats": "npx -n --max_old_space_size=4096 webpack --config webpack.datascience-ui.config.js --profile --json > tmp/ds-stats.json",
         "compile-webviews": "gulp compile-webviews",
         "compile-webviews-verbose": "npx webpack --config webpack.datascience-ui.config.js",
         "postinstall": "node ./build/ci/postInstall.js",


### PR DESCRIPTION
Added cache for npm

Not sure it helps in the default case. The npm cache works but npm ci still stakes about the same amount of time. Maybe when the network is down it will prevent failures.