### PR TITLE
Port blue icon and altair background fixes into release

### DIFF
--- a/news/2 Fixes/8423.md
+++ b/news/2 Fixes/8423.md
@@ -1,0 +1,1 @@
+Add a white backtground for most non-text mimetypes. This lets stuff like Atlair look good in dark mode.

--- a/news/2 Fixes/8424.md
+++ b/news/2 Fixes/8424.md
@@ -1,0 +1,1 @@
+Export to python button is blue in native editor.

--- a/src/datascience-ui/native-editor/nativeEditor.less
+++ b/src/datascience-ui/native-editor/nativeEditor.less
@@ -302,15 +302,6 @@
     color: var(--override-foreground, var(--vscode-editor-foreground));
 }
 
-.save-button {
-    background: var(--vscode-button-background);
-    color: var(--vscode-button-foreground);
-    padding: 2px;
-    border: none;
-    cursor: pointer;
-    margin:2px 4px;
-}
-
 .native-button {
     margin-top: 3px;
 }

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -249,7 +249,7 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                     <ImageButton baseTheme={this.state.baseTheme} onClick={this.saveFromToolbar} disabled={!this.state.dirty} className='native-button' tooltip={getLocString('DataScience.save', 'Save File')}>
                         <Image baseTheme={this.state.baseTheme} class='image-button-image' image={ImageName.SaveAs} />
                     </ImageButton>
-                    <ImageButton baseTheme={this.state.baseTheme} onClick={this.stateController.export} disabled={!this.stateController.canExport()} className='save-button' tooltip={getLocString('DataScience.exportAsPythonFileTooltip', 'Save As Python File')}>
+                    <ImageButton baseTheme={this.state.baseTheme} onClick={this.stateController.export} disabled={!this.stateController.canExport()} className='native-button' tooltip={getLocString('DataScience.exportAsPythonFileTooltip', 'Save As Python File')}>
                         <Image baseTheme={this.state.baseTheme} class='image-button-image' image={ImageName.ExportToPython} />
                     </ImageButton>
                 </div>

--- a/src/test/datascience/manualTestFiles/manualTestFile.py
+++ b/src/test/datascience/manualTestFiles/manualTestFile.py
@@ -1,4 +1,4 @@
-# To run this file either conda or pip install the following: jupyter, numpy, matplotlib, pandas, tqdm, bokeh
+# To run this file either conda or pip install the following: jupyter, numpy, matplotlib, pandas, tqdm, bokeh, vega_datasets, altair, vega
 
 # %% Basic Imports
 import numpy as np
@@ -18,13 +18,13 @@ p = figure(plot_width=400, plot_height=400)
 p.circle([1,2,3,4,5], [6,7,2,4,5], size=15, line_color="navy", fill_color="orange", fill_alpha=0.5)
 show(p)
 
-#%% Progress bar
+# %% Progress bar
 from tqdm import trange
 import time
 for i in trange(100):
     time.sleep(0.01)
 
-#%% [markdown]
+# %% [markdown]
 # # Heading
 # ## Sub-heading
 # *bold*,_italic_,`monospace`
@@ -39,20 +39,32 @@ for i in trange(100):
 #
 # [Link](http://www.microsoft.com)
 
-#%% Magics
+# %% Magics
 %whos
 
-#%% Some extra variable types for the variable explorer
+# %% Some extra variable types for the variable explorer
 myNparray = np.array([['Bob', 1, 2, 3], ['Alice', 4, 5, 6], ['Gina', 7, 8, 9]])
 myDataFrame = pd.DataFrame(myNparray, columns=['name', 'b', 'c', 'd'])
 mySeries = myDataFrame['name']
 myList = [x ** 2 for x in range(0, 100000)]
 myString = 'testing testing testing'
 
-#%%
+# %% Latex
 %%latex
 \begin{align}
 \nabla \cdot \vec{\mathbf{E}} & = 4 \pi \rho \\
 \nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t} & = \vec{\mathbf{0}} \\
 \nabla \cdot \vec{\mathbf{B}} & = 0
 \end{align}
+
+# %% Altair (vega)
+import altair as alt
+from vega_datasets import data
+
+iris = data.iris()
+
+alt.Chart(iris).mark_point().encode(
+    x='petalLength',
+    y='petalWidth',
+    color='species'
+)


### PR DESCRIPTION
For #
https://github.com/microsoft/vscode-python/pull/8452
https://github.com/microsoft/vscode-python/pull/8449

Porting the above PRs into release

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
