### PR TITLE
Use Octicons in Code Lenses

### DIFF
--- a/news/1 Enhancements/7192.md
+++ b/news/1 Enhancements/7192.md
@@ -1,0 +1,1 @@
+Use Octicons in Code Lenses. (thanks [Aidan Dang](https://github.com/AidanGG))

--- a/src/client/testing/codeLenses/testFiles.ts
+++ b/src/client/testing/codeLenses/testFiles.ts
@@ -144,14 +144,16 @@ export class TestFileCodeLensProvider implements CodeLensProvider {
 function getTestStatusIcon(status?: TestStatus): string {
     switch (status) {
         case TestStatus.Pass: {
-            return '✔ ';
+            return `${constants.Octicons.Test_Pass} `;
         }
-        case TestStatus.Error:
+        case TestStatus.Error: {
+            return `${constants.Octicons.Test_Error} `;
+        }
         case TestStatus.Fail: {
-            return '✘ ';
+            return `${constants.Octicons.Test_Fail} `;
         }
         case TestStatus.Skipped: {
-            return '⊘ ';
+            return `${constants.Octicons.Test_Skip} `;
         }
         default: {
             return '';
@@ -163,15 +165,19 @@ function getTestStatusIcons(fns: TestFunction[]): string {
     const statuses: string[] = [];
     let count = fns.filter(fn => fn.status === TestStatus.Pass).length;
     if (count > 0) {
-        statuses.push(`✔ ${count}`);
-    }
-    count = fns.filter(fn => fn.status === TestStatus.Error || fn.status === TestStatus.Fail).length;
-    if (count > 0) {
-        statuses.push(`✘ ${count}`);
+        statuses.push(`${constants.Octicons.Test_Pass} ${count}`);
     }
     count = fns.filter(fn => fn.status === TestStatus.Skipped).length;
     if (count > 0) {
-        statuses.push(`⊘ ${count}`);
+        statuses.push(`${constants.Octicons.Test_Skip} ${count}`);
+    }
+    count = fns.filter(fn => fn.status === TestStatus.Fail).length;
+    if (count > 0) {
+        statuses.push(`${constants.Octicons.Test_Fail} ${count}`);
+    }
+    count = fns.filter(fn => fn.status === TestStatus.Error).length;
+    if (count > 0) {
+        statuses.push(`${constants.Octicons.Test_Error} ${count}`);
     }
 
     return statuses.join(' ');
@@ -219,12 +225,12 @@ function getFunctionCodeLens(file: Uri, functionsAndSuites: FunctionsAndSuites,
     // Find all flattened functions.
     return [
         new CodeLens(range, {
-            title: `${getTestStatusIcons(functions)}${constants.Text.CodeLensRunUnitTest} (Multiple)`,
+            title: `${getTestStatusIcons(functions)} ${constants.Text.CodeLensRunUnitTest} (Multiple)`,
             command: constants.Commands.Tests_Picker_UI,
             arguments: [undefined, CommandSource.codelens, file, functions]
         }),
         new CodeLens(range, {
-            title: `${getTestStatusIcons(functions)}${constants.Text.CodeLensDebugUnitTest} (Multiple)`,
+            title: `${getTestStatusIcons(functions)} ${constants.Text.CodeLensDebugUnitTest} (Multiple)`,
             command: constants.Commands.Tests_Picker_UI_Debug,
             arguments: [undefined, CommandSource.codelens, file, functions]
         })


### PR DESCRIPTION
For #7192. This also adds a missing space and splits out the four cases to be consistent with the status bar: https://github.com/microsoft/vscode-python/blob/b0e89947d0b3cf9ad04b78ecc5a840e365ab6516/src/client/testing/display/main.ts#L84-L99

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] ~Appropriate comments and documentation strings in the code~
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] ~Unit tests & system/integration tests are added/updated~
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
