### PR TITLE
Process service test fails to exit correctly on Windows

### DIFF
--- a/src/test/common/process/proc.unit.test.ts
+++ b/src/test/common/process/proc.unit.test.ts
@@ -6,48 +6,48 @@
 // tslint:disable:no-any max-func-body-length no-invalid-this max-classes-per-file
 
 import { expect } from 'chai';
-import { spawn } from 'child_process';
+import { ChildProcess, execSync, spawn } from 'child_process';
 import { ProcessService } from '../../../client/common/process/proc';
-import { createDeferred } from '../../../client/common/utils/async';
+import { createDeferred, Deferred } from '../../../client/common/utils/async';
 import { PYTHON_PATH } from '../../common';
+
+interface IProcData {
+    proc: ChildProcess;
+    exited: Deferred<Boolean>;
+}
 
 suite('Process - Process Service', function () {
     // tslint:disable-next-line:no-invalid-this
     this.timeout(5000);
-    let procIdsToKill: number[] = [];
+    const procsToKill: IProcData[] = [];
     teardown(() => {
-        // tslint:disable-next-line:no-require-imports
-        const killProcessTree = require('tree-kill');
-        procIdsToKill.forEach(pid => {
-            try {
-                killProcessTree(pid);
-            } catch {
-                // Ignore.
+        procsToKill.forEach(p => {
+            if (!p.exited.resolved) {
+                p.proc.kill();
             }
         });
-        procIdsToKill = [];
     });
 
-    function spawnProc() {
+    function spawnProc(): IProcData {
         const proc = spawn(PYTHON_PATH, ['-c', 'while(True): import time;time.sleep(0.5);print(1)']);
         const exited = createDeferred<Boolean>();
         proc.on('exit', () => exited.resolve(true));
-        procIdsToKill.push(proc.pid);
+        procsToKill.push({ proc, exited });
 
-        return { pid: proc.pid, exited: exited.promise };
+        return procsToKill[procsToKill.length - 1];
     }
 
     test('Process is killed', async () => {
         const proc = spawnProc();
 
-        ProcessService.kill(proc.pid);
+        ProcessService.kill(proc.proc.pid);
 
-        expect(await proc.exited).to.equal(true, 'process did not die');
+        expect(await proc.exited.promise).to.equal(true, 'process did not die');
     });
     test('Process is alive', async () => {
         const proc = spawnProc();
 
-        expect(ProcessService.isAlive(proc.pid)).to.equal(true, 'process is not alive');
+        expect(ProcessService.isAlive(proc.proc.pid)).to.equal(true, 'process is not alive');
     });
 
 });

--- a/src/test/common/process/proc.unit.test.ts
+++ b/src/test/common/process/proc.unit.test.ts
@@ -6,7 +6,7 @@
 // tslint:disable:no-any max-func-body-length no-invalid-this max-classes-per-file
 
 import { expect } from 'chai';
-import { ChildProcess, execSync, spawn } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import { ProcessService } from '../../../client/common/process/proc';
 import { createDeferred, Deferred } from '../../../client/common/utils/async';
 import { PYTHON_PATH } from '../../common';


### PR DESCRIPTION
When running this test on Windows, I keep getting an error killing the process (I believe treekill is to blame).

This logic resolves the problem.
