### PR TITLE
CTRL+Z should not undo at the top level

### DIFF
--- a/news/2 Fixes/7999.md
+++ b/news/2 Fixes/7999.md
@@ -1,0 +1,1 @@
+CTRL+Z is deleting cells. It should only undo changes inside of the code for a cell. 'Z' and 'SHIFT+Z' are for undoing/redoing cell adds/moves.

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -97,6 +97,7 @@ export enum NativeCommandType {
     InsertBelow,
     MoveCellDown,
     MoveCellUp,
+    Redo,
     Run,
     RunAbove,
     RunAll,

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -267,31 +267,35 @@ export class MainStateController implements IMessageHandler {
     }
 
     public redo = () => {
-        // Pop one off of our redo stack and update our undo
-        const cells = this.pendingState.redoStack[this.pendingState.redoStack.length - 1];
-        const redoStack = this.pendingState.redoStack.slice(0, this.pendingState.redoStack.length - 1);
-        const undoStack = this.pushStack(this.pendingState.undoStack, this.pendingState.cellVMs);
-        this.sendMessage(InteractiveWindowMessages.Redo);
-        this.setState({
-            cellVMs: cells,
-            undoStack: undoStack,
-            redoStack: redoStack,
-            skipNextScroll: true
-        });
+        if (this.pendingState.redoStack.length > 0) {
+            // Pop one off of our redo stack and update our undo
+            const cells = this.pendingState.redoStack[this.pendingState.redoStack.length - 1];
+            const redoStack = this.pendingState.redoStack.slice(0, this.pendingState.redoStack.length - 1);
+            const undoStack = this.pushStack(this.pendingState.undoStack, this.pendingState.cellVMs);
+            this.sendMessage(InteractiveWindowMessages.Redo);
+            this.setState({
+                cellVMs: cells,
+                undoStack: undoStack,
+                redoStack: redoStack,
+                skipNextScroll: true
+            });
+        }
     }
 
     public undo = () => {
-        // Pop one off of our undo stack and update our redo
-        const cells = this.pendingState.undoStack[this.pendingState.undoStack.length - 1];
-        const undoStack = this.pendingState.undoStack.slice(0, this.pendingState.undoStack.length - 1);
-        const redoStack = this.pushStack(this.pendingState.redoStack, this.pendingState.cellVMs);
-        this.sendMessage(InteractiveWindowMessages.Undo);
-        this.setState({
-            cellVMs: cells,
-            undoStack: undoStack,
-            redoStack: redoStack,
-            skipNextScroll: true
-        });
+        if (this.pendingState.undoStack.length > 0) {
+            // Pop one off of our undo stack and update our redo
+            const cells = this.pendingState.undoStack[this.pendingState.undoStack.length - 1];
+            const undoStack = this.pendingState.undoStack.slice(0, this.pendingState.undoStack.length - 1);
+            const redoStack = this.pushStack(this.pendingState.redoStack, this.pendingState.cellVMs);
+            this.sendMessage(InteractiveWindowMessages.Undo);
+            this.setState({
+                cellVMs: cells,
+                undoStack: undoStack,
+                redoStack: redoStack,
+                skipNextScroll: true
+            });
+        }
     }
 
     public deleteCell = (cellId: string) => {

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -325,10 +325,17 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 }
                 break;
             case 'z':
-                if (!this.isFocused() && this.props.stateController.canUndo()) {
-                    e.stopPropagation();
-                    this.props.stateController.undo();
-                    this.props.stateController.sendCommand(NativeCommandType.Undo, 'keyboard');
+            case 'Z':
+                if (!this.isFocused()) {
+                    if (e.shiftKey && !e.ctrlKey && !e.altKey && this.props.stateController.canRedo()) {
+                        e.stopPropagation();
+                        this.props.stateController.redo();
+                        this.props.stateController.sendCommand(NativeCommandType.Redo, 'keyboard');
+                    } else if (!e.shiftKey && !e.altKey && !e.ctrlKey && this.props.stateController.canUndo()) {
+                        e.stopPropagation();
+                        this.props.stateController.undo();
+                        this.props.stateController.sendCommand(NativeCommandType.Undo, 'keyboard');
+                    }
                 }
                 break;
 

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -365,6 +365,18 @@ export class NativeEditor extends React.Component<INativeEditorProps, IMainState
                 }
                 break;
             }
+            case 'z':
+            case 'Z':
+                if (event.shiftKey && !event.ctrlKey && !event.altKey && this.stateController.canRedo()) {
+                    event.stopPropagation();
+                    this.stateController.redo();
+                    this.stateController.sendCommand(NativeCommandType.Redo, 'keyboard');
+                } else if (!event.shiftKey && !event.altKey && !event.ctrlKey && this.stateController.canUndo()) {
+                    event.stopPropagation();
+                    this.stateController.undo();
+                    this.stateController.sendCommand(NativeCommandType.Undo, 'keyboard');
+                }
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
For #7999 

CTRL+Z was not being checked separately from just plain 'Z'

