### PR TITLE
Fix arrowing up and down to save code too

### DIFF
--- a/news/2 Fixes/8491.md
+++ b/news/2 Fixes/8491.md
@@ -1,0 +1,1 @@
+Arrowing up and down through cells can lose code that was just typed.

--- a/src/datascience-ui/interactive-common/mainStateController.ts
+++ b/src/datascience-ui/interactive-common/mainStateController.ts
@@ -559,6 +559,18 @@ export class MainStateController implements IMessageHandler {
         }
     }
 
+    public updateCode = (cellId: string, code: string) => {
+        const index = this.pendingState.cellVMs.findIndex(c => c.cell.id === cellId);
+        if (index > 0) {
+            const cellVMs = [...this.pendingState.cellVMs];
+            const current = this.pendingState.cellVMs[index];
+            const newCell = { ...current, inputBlockText: code, cell: { ...current.cell, data: { ...current.cell.data, source: code } } };
+            // tslint:disable-next-line: no-any
+            cellVMs[index] = (newCell as any); // This is because IMessageCell doesn't fit in here. But message cells can't change type
+            this.setState({ cellVMs });
+        }
+    }
+
     public changeCellType = (cellId: string, newType: 'code' | 'markdown') => {
         const index = this.pendingState.cellVMs.findIndex(c => c.cell.id === cellId);
         if (index >= 0 && this.pendingState.cellVMs[index].cell.data.cell_type !== newType) {

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -385,6 +385,9 @@ export class NativeCell extends React.Component<INativeCellProps> {
         const prevCellId = this.getPrevCellId();
         if (prevCellId) {
             e.stopPropagation();
+            if (e.editorInfo) {
+                this.props.stateController.updateCode(this.getCell().id, e.editorInfo.contents);
+            }
             this.moveSelection(prevCellId, this.isFocused(), CursorPos.Bottom);
         }
 
@@ -396,6 +399,9 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
         if (nextCellId) {
             e.stopPropagation();
+            if (e.editorInfo) {
+                this.props.stateController.updateCode(this.getCell().id, e.editorInfo.contents);
+            }
             this.moveSelection(nextCellId, this.isFocused(), CursorPos.Top);
         }
 


### PR DESCRIPTION
For #8491

We need to save code whenever leaving an editor. 

I'm beginning to think we should just update the state whenever we type. It would eliminate all of these goofy problems. Just worried it would refresh too much.