### PR TITLE
After pasting code, arrow keys don't navigate in a cell.

### DIFF
--- a/news/2 Fixes/8495.md
+++ b/news/2 Fixes/8495.md
@@ -1,0 +1,1 @@
+After pasting code, arrow keys don't navigate in a cell.

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -312,9 +312,9 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
             const cursor = this.state.editor.getPosition();
             if (cursor) {
                 const top = this.state.editor.getTopForPosition(cursor.lineNumber, cursor.column);
-                const lines = this.getVisibleLines();
-                const lineTops = lines.length === this.lineTops.length ? this.lineTops : this.computeLineTops();
-                for (let i = 0; i < lines.length; i += 1) {
+                const count = this.getVisibleLineCount();
+                const lineTops = count === this.lineTops.length ? this.lineTops : this.computeLineTops();
+                for (let i = 0; i < count; i += 1) {
                     if (top <= lineTops[i]) {
                         return i;
                     }
@@ -340,10 +340,12 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
 
     private computeLineTops(): number[] {
         const lines = this.getVisibleLines();
+
+        // Lines are not sorted by monaco, so we have to sort them by their top value
         this.lineTops = lines.map(l => {
             const match = l.style.top ? /(.+)px/.exec(l.style.top) : null;
             return match ? parseInt(match[0], 10) : Infinity;
-        });
+        }).sort((a, b) => a - b);
         return this.lineTops;
     }
 
@@ -352,7 +354,6 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         const visibleLineDivs = this.getVisibleLines();
         const current = this.getCurrentVisibleLine();
         if (current !== undefined && current >= 0) {
-            window.console.log(`Scrolling to line ${current}`);
             visibleLineDivs[current].scrollIntoView({ behavior: 'auto', block: 'nearest', inline: 'nearest' });
         }
     }


### PR DESCRIPTION
For #8495

Monaco doesn't sort the view lines when it creates them, messing up our computation for figuring out the current line using the offset of the cursor.