### PR TITLE
Fix `--pattern` switch typo in unittest discovery

### DIFF
--- a/news/2 Fixes/8465.md
+++ b/news/2 Fixes/8465.md
@@ -1,0 +1,1 @@
+Fix issue with test discovery when using `unittest` with `--pattern` flag.

--- a/src/client/testing/unittest/runner.ts
+++ b/src/client/testing/unittest/runner.ts
@@ -9,11 +9,7 @@ import { noop } from '../../common/utils/misc';
 import { IServiceContainer } from '../../ioc/types';
 import { UNITTEST_PROVIDER } from '../common/constants';
 import { Options } from '../common/runner';
-import {
-    ITestDebugLauncher, ITestManager, ITestResultsService,
-    ITestRunner, IUnitTestSocketServer, LaunchOptions,
-    TestRunOptions, Tests, TestStatus
-} from '../common/types';
+import { ITestDebugLauncher, ITestManager, ITestResultsService, ITestRunner, IUnitTestSocketServer, LaunchOptions, TestRunOptions, Tests, TestStatus } from '../common/types';
 import { IArgumentsHelper, ITestManagerRunner, IUnitTestHelper } from '../types';
 
 type TestStatusMap = {
@@ -169,7 +165,6 @@ export class TestManagerRunner implements ITestManagerRunner {
 
                 await this.removeListenersAfter(Promise.resolve());
             }
-
         }
 
         testResultsService.updateResults(options.tests);
@@ -184,7 +179,7 @@ export class TestManagerRunner implements ITestManagerRunner {
     private async removeListenersAfter(after: Promise<any>): Promise<any> {
         return after
             .then(() => this.server.removeAllListeners())
-            .catch((err) => {
+            .catch(err => {
                 this.server.removeAllListeners();
                 throw err; // keep propagating this downward
             });
@@ -194,7 +189,7 @@ export class TestManagerRunner implements ITestManagerRunner {
         const startTestDiscoveryDirectory = this.helper.getStartDirectory(args);
         let pattern = 'test*.py';
         const shortValue = this.argsHelper.getOptionValues(args, '-p');
-        const longValueValue = this.argsHelper.getOptionValues(args, '-pattern');
+        const longValueValue = this.argsHelper.getOptionValues(args, '--pattern');
         if (typeof shortValue === 'string') {
             pattern = shortValue;
         } else if (typeof longValueValue === 'string') {

--- a/src/test/testing/unittest/unittest.discovery.unit.test.ts
+++ b/src/test/testing/unittest/unittest.discovery.unit.test.ts
@@ -14,8 +14,10 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { UNITTEST_PROVIDER } from '../../../client/testing/common/constants';
 import { TestsHelper } from '../../../client/testing/common/testUtils';
 import { TestFlatteningVisitor } from '../../../client/testing/common/testVisitors/flatteningVisitor';
-import { ITestDiscoveryService, ITestRunner, ITestsParser,
-    Options, TestDiscoveryOptions, Tests, UnitTestParserOptions } from '../../../client/testing/common/types';
+import {
+    ITestDiscoveryService, ITestRunner, ITestsParser,
+    Options, TestDiscoveryOptions, Tests, UnitTestParserOptions
+} from '../../../client/testing/common/types';
 import { IArgumentsHelper } from '../../../client/testing/types';
 import { TestDiscoveryService } from '../../../client/testing/unittest/services/discoveryService';
 import { TestsParser } from '../../../client/testing/unittest/services/parserService';
@@ -53,7 +55,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-s')))
             .returns(() => dir)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
@@ -76,6 +78,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const result = await discoveryService.discoverTests(options.object);
 
         expect(result).to.be.equal(tests);
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -89,10 +92,10 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-s')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('--start-directory')))
             .returns(() => dir)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
@@ -115,6 +118,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const result = await discoveryService.discoverTests(options.object);
 
         expect(result).to.be.equal(tests);
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -128,10 +132,10 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-s')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('--start-directory')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
@@ -154,6 +158,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const result = await discoveryService.discoverTests(options.object);
 
         expect(result).to.be.equal(tests);
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -167,7 +172,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-p')))
             .returns(() => pattern)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
@@ -190,6 +195,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const result = await discoveryService.discoverTests(options.object);
 
         expect(result).to.be.equal(tests);
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -203,10 +209,10 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-p')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('--pattern')))
             .returns(() => pattern)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
@@ -229,6 +235,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const result = await discoveryService.discoverTests(options.object);
 
         expect(result).to.be.equal(tests);
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -242,10 +249,10 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-p')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('--pattern')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
@@ -268,6 +275,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const result = await discoveryService.discoverTests(options.object);
 
         expect(result).to.be.equal(tests);
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -281,10 +289,10 @@ suite('Unit Tests - Unittest - Discovery', () => {
         };
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('-p')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         argsHelper.setup(a => a.getOptionValues(typeMoq.It.isValue(args), typeMoq.It.isValue('--pattern')))
             .returns(() => undefined)
-            .verifiable(typeMoq.Times.once());
+            .verifiable(typeMoq.Times.atLeastOnce());
         runner.setup(r => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());
@@ -302,6 +310,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         const promise = discoveryService.discoverTests(options.object);
 
         await expect(promise).to.eventually.be.rejectedWith('cancelled');
+        argsHelper.verifyAll();
         runner.verifyAll();
         testParser.verifyAll();
     });
@@ -473,7 +482,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
             }
         });
     });
-    test('Ensure discovery will not fail with blank content' , async () => {
+    test('Ensure discovery will not fail with blank content', async () => {
         const testHelper: TestsHelper = new TestsHelper(new TestFlatteningVisitor(), serviceContainer.object);
 
         const testsParser: TestsParser = new TestsParser(testHelper);

--- a/src/test/testing/unittest/unittest.discovery.unit.test.ts
+++ b/src/test/testing/unittest/unittest.discovery.unit.test.ts
@@ -193,7 +193,7 @@ suite('Unit Tests - Unittest - Discovery', () => {
         runner.verifyAll();
         testParser.verifyAll();
     });
-    test('Ensure discovery is invoked with the right args without a pattern defined with ---pattern', async () => {
+    test('Ensure discovery is invoked with the right args without a pattern defined with --pattern', async () => {
         const args: string[] = [];
         const runOutput = 'xyz';
         const tests: Tests = {


### PR DESCRIPTION
For #8465

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)

@eirki Thank you for providing a solution.