### PR TITLE
Preliminary support for widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,6 +1251,150 @@
                 }
             }
         },
+        "@jupyterlab/outputarea": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/outputarea/-/outputarea-1.2.2.tgz",
+            "integrity": "sha512-Eo2P4idncgQfPorjTCIFgP2K9GuOGxZ51ij88cbYiWonu2BEqqceGJCXuFGrnYLq6CaWsn9yhN6sIkr8WS+LEw==",
+            "dev": true,
+            "requires": {
+                "@jupyterlab/apputils": "^1.2.1",
+                "@jupyterlab/coreutils": "^3.2.0",
+                "@jupyterlab/observables": "^2.4.0",
+                "@jupyterlab/rendermime": "^1.2.1",
+                "@jupyterlab/rendermime-interfaces": "^1.5.0",
+                "@jupyterlab/services": "^4.2.0",
+                "@phosphor/algorithm": "^1.2.0",
+                "@phosphor/coreutils": "^1.3.1",
+                "@phosphor/disposable": "^1.3.0",
+                "@phosphor/messaging": "^1.3.0",
+                "@phosphor/properties": "^1.1.3",
+                "@phosphor/signaling": "^1.3.0",
+                "@phosphor/widgets": "^1.9.0"
+            },
+            "dependencies": {
+                "@jupyterlab/coreutils": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
+                    "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/commands": "^1.7.0",
+                        "@phosphor/coreutils": "^1.3.1",
+                        "@phosphor/disposable": "^1.3.0",
+                        "@phosphor/properties": "^1.1.3",
+                        "@phosphor/signaling": "^1.3.0",
+                        "ajv": "^6.5.5",
+                        "json5": "^2.1.0",
+                        "minimist": "~1.2.0",
+                        "moment": "^2.24.0",
+                        "path-posix": "~1.0.0",
+                        "url-parse": "~1.4.3"
+                    }
+                },
+                "@phosphor/algorithm": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
+                    "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA==",
+                    "dev": true
+                },
+                "@phosphor/disposable": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
+                    "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0",
+                        "@phosphor/signaling": "^1.3.1"
+                    }
+                },
+                "@phosphor/signaling": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
+                    "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "@jupyterlab/rendermime": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
+            "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
+            "dev": true,
+            "requires": {
+                "@jupyterlab/apputils": "^1.2.1",
+                "@jupyterlab/codemirror": "^1.2.1",
+                "@jupyterlab/coreutils": "^3.2.0",
+                "@jupyterlab/observables": "^2.4.0",
+                "@jupyterlab/rendermime-interfaces": "^1.5.0",
+                "@jupyterlab/services": "^4.2.0",
+                "@phosphor/algorithm": "^1.2.0",
+                "@phosphor/coreutils": "^1.3.1",
+                "@phosphor/messaging": "^1.3.0",
+                "@phosphor/signaling": "^1.3.0",
+                "@phosphor/widgets": "^1.9.0",
+                "lodash.escape": "^4.0.1",
+                "marked": "^0.7.0"
+            },
+            "dependencies": {
+                "@jupyterlab/coreutils": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
+                    "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/commands": "^1.7.0",
+                        "@phosphor/coreutils": "^1.3.1",
+                        "@phosphor/disposable": "^1.3.0",
+                        "@phosphor/properties": "^1.1.3",
+                        "@phosphor/signaling": "^1.3.0",
+                        "ajv": "^6.5.5",
+                        "json5": "^2.1.0",
+                        "minimist": "~1.2.0",
+                        "moment": "^2.24.0",
+                        "path-posix": "~1.0.0",
+                        "url-parse": "~1.4.3"
+                    }
+                },
+                "@phosphor/algorithm": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
+                    "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA==",
+                    "dev": true
+                },
+                "@phosphor/disposable": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
+                    "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0",
+                        "@phosphor/signaling": "^1.3.1"
+                    }
+                },
+                "@phosphor/signaling": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
+                    "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "@jupyterlab/rendermime-interfaces": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
+            "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
+            "dev": true,
+            "requires": {
+                "@phosphor/coreutils": "^1.3.1",
+                "@phosphor/widgets": "^1.9.0"
+            }
+        },
         "@jupyterlab/services": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
@@ -1317,6 +1461,136 @@
                     "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
                     "requires": {
                         "async-limiter": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "@jupyterlab/statusbar": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
+            "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
+            "dev": true,
+            "requires": {
+                "@jupyterlab/apputils": "^1.2.1",
+                "@jupyterlab/codeeditor": "^1.2.0",
+                "@jupyterlab/coreutils": "^3.2.0",
+                "@jupyterlab/services": "^4.2.0",
+                "@jupyterlab/ui-components": "^1.2.1",
+                "@phosphor/algorithm": "^1.2.0",
+                "@phosphor/coreutils": "^1.3.1",
+                "@phosphor/disposable": "^1.3.0",
+                "@phosphor/messaging": "^1.3.0",
+                "@phosphor/signaling": "^1.3.0",
+                "@phosphor/widgets": "^1.9.0",
+                "react": "~16.8.4",
+                "typestyle": "^2.0.1"
+            },
+            "dependencies": {
+                "@jupyterlab/coreutils": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
+                    "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/commands": "^1.7.0",
+                        "@phosphor/coreutils": "^1.3.1",
+                        "@phosphor/disposable": "^1.3.0",
+                        "@phosphor/properties": "^1.1.3",
+                        "@phosphor/signaling": "^1.3.0",
+                        "ajv": "^6.5.5",
+                        "json5": "^2.1.0",
+                        "minimist": "~1.2.0",
+                        "moment": "^2.24.0",
+                        "path-posix": "~1.0.0",
+                        "url-parse": "~1.4.3"
+                    }
+                },
+                "@phosphor/algorithm": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
+                    "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA==",
+                    "dev": true
+                },
+                "@phosphor/disposable": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
+                    "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0",
+                        "@phosphor/signaling": "^1.3.1"
+                    }
+                },
+                "@phosphor/signaling": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
+                    "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "@jupyterlab/ui-components": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
+            "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
+            "dev": true,
+            "requires": {
+                "@blueprintjs/core": "^3.9.0",
+                "@blueprintjs/select": "^3.3.0",
+                "@jupyterlab/coreutils": "^3.2.0",
+                "@phosphor/coreutils": "^1.3.1",
+                "@phosphor/messaging": "^1.3.0",
+                "@phosphor/virtualdom": "^1.2.0",
+                "@phosphor/widgets": "^1.9.0",
+                "react": "~16.8.4",
+                "typestyle": "^2.0.1"
+            },
+            "dependencies": {
+                "@jupyterlab/coreutils": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
+                    "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/commands": "^1.7.0",
+                        "@phosphor/coreutils": "^1.3.1",
+                        "@phosphor/disposable": "^1.3.0",
+                        "@phosphor/properties": "^1.1.3",
+                        "@phosphor/signaling": "^1.3.0",
+                        "ajv": "^6.5.5",
+                        "json5": "^2.1.0",
+                        "minimist": "~1.2.0",
+                        "moment": "^2.24.0",
+                        "path-posix": "~1.0.0",
+                        "url-parse": "~1.4.3"
+                    }
+                },
+                "@phosphor/algorithm": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
+                    "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA==",
+                    "dev": true
+                },
+                "@phosphor/disposable": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
+                    "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0",
+                        "@phosphor/signaling": "^1.3.1"
+                    }
+                },
+                "@phosphor/signaling": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
+                    "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+                    "dev": true,
+                    "requires": {
+                        "@phosphor/algorithm": "^1.2.0"
                     }
                 }
             }
@@ -16435,6 +16709,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
             "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "requirejs": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+            "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg==",
             "dev": true
         },
         "requires-port": {

--- a/package.json
+++ b/package.json
@@ -2893,6 +2893,7 @@
         "redux": "^4.0.4",
         "redux-logger": "^3.0.6",
         "relative": "^3.0.2",
+        "requirejs": "^2.3.6",
         "retyped-diff-match-patch-tsd-ambient": "^1.0.0-0",
         "rewiremock": "^3.13.0",
         "sass-loader": "^7.1.0",

--- a/src/client/common/utils/serializers.ts
+++ b/src/client/common/utils/serializers.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+/**
+ * Serialize ArraBuffer and ArrayBufferView into a fomat such that they are json serializable.
+ *
+ * @export
+ * @param {(undefined | (ArrayBuffer | ArrayBufferView)[])} buffers
+ * @returns
+ */
+export function serializeDataViews(buffers: undefined | (ArrayBuffer | ArrayBufferView)[]) {
+    if (!buffers || !Array.isArray(buffers) || buffers.length === 0) {
+        return;
+    }
+    // tslint:disable-next-line: no-any
+    const newBufferView: any[] = [];
+    // tslint:disable-next-line: prefer-for-of
+    for (let i = 0; i < buffers.length; i += 1) {
+        const item = buffers[i];
+        if ('buffer' in item && 'byteOffset' in item) {
+            // It is an ArrayBufferView
+            // tslint:disable-next-line: no-any
+            const buffer = Array.apply(null, new Uint8Array(item.buffer as any) as any);
+            newBufferView.push({
+                ...item,
+                byteLength: item.byteLength,
+                byteOffset: item.byteOffset,
+                buffer
+                // tslint:disable-next-line: no-any
+            } as any);
+        } else {
+            // tslint:disable-next-line: no-any
+            newBufferView.push(Array.apply(null, new Uint8Array(item as any) as any) as any);
+        }
+    }
+
+    // tslint:disable-next-line: no-any
+    return newBufferView;
+}
+
+/**
+ * Deserializes ArrayBuffer and ArrayBufferView from a format that was json serializable into actual ArrayBuffer and ArrayBufferViews.
+ *
+ * @export
+ * @param {(undefined | (ArrayBuffer | ArrayBufferView)[])} buffers
+ * @returns
+ */
+export function deserializeDataViews(buffers: undefined | (ArrayBuffer | ArrayBufferView)[]) {
+    if (!Array.isArray(buffers) || buffers.length === 0){
+        return buffers;
+    }
+    const newBufferView: (ArrayBuffer | ArrayBufferView)[] = [];
+    // tslint:disable-next-line: prefer-for-of
+    for (let i = 0; i < buffers.length; i += 1) {
+        const item = buffers[i];
+        if ('buffer' in item && 'byteOffset' in item){
+            const buffer = new Uint8Array(item.buffer).buffer;
+            // It is an ArrayBufferView
+            // tslint:disable-next-line: no-any
+            const bufferView = new DataView(buffer, item.byteOffset, item.byteLength);
+            newBufferView.push(bufferView);
+        } else {
+            const buffer = new Uint8Array(item).buffer;
+            // tslint:disable-next-line: no-any
+            newBufferView.push(buffer);
+        }
+    }
+}

--- a/src/client/common/utils/serializers.ts
+++ b/src/client/common/utils/serializers.ts
@@ -67,4 +67,5 @@ export function deserializeDataViews(buffers: undefined | (ArrayBuffer | ArrayBu
             newBufferView.push(buffer);
         }
     }
+    return newBufferView;
 }

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -85,6 +85,9 @@ export enum InteractiveWindowMessages {
     FocusedCellEditor = 'focused_cell_editor',
     MonacoReady = 'monaco_ready',
     ClearAllOutputs = 'clear_all_outputs',
+}
+
+export enum IPyWidgetMessages {
     IPyWidgets_display_data_msg = 'IPyWidgets_display_data_msg',
     IPyWidgets_comm_msg = 'IPyWidgets_comm_msg',
     IPyWidgets_comm_open = 'IPyWidgets_comm_open',
@@ -96,7 +99,6 @@ export enum InteractiveWindowMessages {
     IPyWidgets_ShellSend_resolve = 'IPyWidgets_ShellSend_resolve',
     IPyWidgets_ShellSend_reject = 'IPyWidgets_ShellSend_reject'
 }
-
 export enum NativeCommandType {
     AddToEnd = 0,
     ArrowDown,
@@ -288,17 +290,17 @@ export interface IFocusedCellEditor {
 // Map all messages to specific payloads
 export class IInteractiveWindowMapping {
     // tslint:disable-next-line: no-any
-    public [InteractiveWindowMessages.IPyWidgets_ShellSend]: { data: any; metadata: any; commId: string; requestId: string; buffers?: any[]; disposeOnDone?: boolean; targetName?   : string; msgType: string   };
+    public [IPyWidgetMessages.IPyWidgets_ShellSend]: { data: any; metadata: any; commId: string; requestId: string; buffers?: any[]; disposeOnDone?: boolean; targetName?   : string; msgType: string   };
     // tslint:disable-next-line: no-any
-    public [InteractiveWindowMessages.IPyWidgets_ShellSend_onIOPub]: { requestId: string; msg: KernelMessage.IIOPubMessage };
-    public [InteractiveWindowMessages.IPyWidgets_ShellSend_reply]: { requestId: string; msg: KernelMessage.IShellMessage };
-    public [InteractiveWindowMessages.IPyWidgets_ShellSend_resolve]: { requestId: string; msg?: KernelMessage.IShellMessage };
+    public [IPyWidgetMessages.IPyWidgets_ShellSend_onIOPub]: { requestId: string; msg: KernelMessage.IIOPubMessage };
+    public [IPyWidgetMessages.IPyWidgets_ShellSend_reply]: { requestId: string; msg: KernelMessage.IShellMessage };
+    public [IPyWidgetMessages.IPyWidgets_ShellSend_resolve]: { requestId: string; msg?: KernelMessage.IShellMessage };
     // tslint:disable-next-line: no-any
-    public [InteractiveWindowMessages.IPyWidgets_ShellSend_reject]: { requestId: string; msg?: any };
-    public [InteractiveWindowMessages.IPyWidgets_registerCommTarget]: string;
-    public [InteractiveWindowMessages.IPyWidgets_comm_open]: KernelMessage.ICommOpenMsg;
-    public [InteractiveWindowMessages.IPyWidgets_comm_msg]: KernelMessage.ICommMsgMsg;
-    public [InteractiveWindowMessages.IPyWidgets_display_data_msg]: KernelMessage.IDisplayDataMsg;
+    public [IPyWidgetMessages.IPyWidgets_ShellSend_reject]: { requestId: string; msg?: any };
+    public [IPyWidgetMessages.IPyWidgets_registerCommTarget]: string;
+    public [IPyWidgetMessages.IPyWidgets_comm_open]: KernelMessage.ICommOpenMsg;
+    public [IPyWidgetMessages.IPyWidgets_comm_msg]: KernelMessage.ICommMsgMsg;
+    public [IPyWidgetMessages.IPyWidgets_display_data_msg]: KernelMessage.IDisplayDataMsg;
 
     public [InteractiveWindowMessages.StartCell]: ICell;
     public [InteractiveWindowMessages.FinishCell]: ICell;

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -3,6 +3,7 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
+import { KernelMessage } from '@jupyterlab/services';
 import { CssMessages, IGetCssRequest, IGetCssResponse, IGetMonacoThemeRequest } from '../messages';
 import { IGetMonacoThemeResponse } from '../monacoMessages';
 import { ICell, IInteractiveWindowInfo, IJupyterVariable, IJupyterVariablesResponse } from '../types';
@@ -83,7 +84,17 @@ export enum InteractiveWindowMessages {
     ExecutionRendered = 'rendered_execution',
     FocusedCellEditor = 'focused_cell_editor',
     MonacoReady = 'monaco_ready',
-    ClearAllOutputs = 'clear_all_outputs'
+    ClearAllOutputs = 'clear_all_outputs',
+    IPyWidgets_display_data_msg = 'IPyWidgets_display_data_msg',
+    IPyWidgets_comm_msg = 'IPyWidgets_comm_msg',
+    IPyWidgets_comm_open = 'IPyWidgets_comm_open',
+    IPyWidgets_ShellSend = 'IPyWidgets_ShellSend',
+    IPyWidgets_ShellCommOpen = 'IPyWidgets_ShellCommOpen',
+    IPyWidgets_registerCommTarget = 'IPyWidgets_registerCommTarget',
+    IPyWidgets_ShellSend_onIOPub = 'IPyWidgets_ShellSend_onIOPub',
+    IPyWidgets_ShellSend_reply = 'IPyWidgets_ShellSend_reply',
+    IPyWidgets_ShellSend_resolve = 'IPyWidgets_ShellSend_resolve',
+    IPyWidgets_ShellSend_reject = 'IPyWidgets_ShellSend_reject'
 }
 
 export enum NativeCommandType {
@@ -276,6 +287,19 @@ export interface IFocusedCellEditor {
 
 // Map all messages to specific payloads
 export class IInteractiveWindowMapping {
+    // tslint:disable-next-line: no-any
+    public [InteractiveWindowMessages.IPyWidgets_ShellSend]: { data: any; metadata: any; commId: string; requestId: string; buffers?: any[]; disposeOnDone?: boolean; targetName?   : string; msgType: string   };
+    // tslint:disable-next-line: no-any
+    public [InteractiveWindowMessages.IPyWidgets_ShellSend_onIOPub]: { requestId: string; msg: KernelMessage.IIOPubMessage };
+    public [InteractiveWindowMessages.IPyWidgets_ShellSend_reply]: { requestId: string; msg: KernelMessage.IShellMessage };
+    public [InteractiveWindowMessages.IPyWidgets_ShellSend_resolve]: { requestId: string; msg?: KernelMessage.IShellMessage };
+    // tslint:disable-next-line: no-any
+    public [InteractiveWindowMessages.IPyWidgets_ShellSend_reject]: { requestId: string; msg?: any };
+    public [InteractiveWindowMessages.IPyWidgets_registerCommTarget]: string;
+    public [InteractiveWindowMessages.IPyWidgets_comm_open]: KernelMessage.ICommOpenMsg;
+    public [InteractiveWindowMessages.IPyWidgets_comm_msg]: KernelMessage.ICommMsgMsg;
+    public [InteractiveWindowMessages.IPyWidgets_display_data_msg]: KernelMessage.IDisplayDataMsg;
+
     public [InteractiveWindowMessages.StartCell]: ICell;
     public [InteractiveWindowMessages.FinishCell]: ICell;
     public [InteractiveWindowMessages.UpdateCell]: ICell;

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -84,7 +84,7 @@ export enum InteractiveWindowMessages {
     ExecutionRendered = 'rendered_execution',
     FocusedCellEditor = 'focused_cell_editor',
     MonacoReady = 'monaco_ready',
-    ClearAllOutputs = 'clear_all_outputs',
+    ClearAllOutputs = 'clear_all_outputs'
 }
 
 export enum IPyWidgetMessages {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -22,7 +22,7 @@ import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { concatMultilineStringInput, splitMultilineString } from '../common';
 import { EditorContexts, Identifiers, NativeKeyboardCommandTelemetryLookup, NativeMouseCommandTelemetryLookup, Telemetry } from '../constants';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
-import { IEditCell, IInsertCell, INativeCommand, InteractiveWindowMessages, IPyWidgetMessages, IRemoveCell, ISaveAll, ISubmitNewCell, ISwapCells } from '../interactive-common/interactiveWindowTypes';
+import { IEditCell, IInsertCell, INativeCommand, InteractiveWindowMessages, IRemoveCell, ISaveAll, ISubmitNewCell, ISwapCells } from '../interactive-common/interactiveWindowTypes';
 import { InvalidNotebookFileError } from '../jupyter/invalidNotebookFileError';
 import { CellState, ICell, ICodeCssGenerator, IDataScienceErrorHandler, IDataViewerProvider, IInteractiveWindowInfo, IInteractiveWindowListener, IJupyterDebugger, IJupyterExecution, IJupyterVariables, INotebookEditor, INotebookEditorProvider, INotebookExporter, INotebookImporter, INotebookServerOptions, IStatusProvider, IThemeFinder } from '../types';
 

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -22,7 +22,7 @@ import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { concatMultilineStringInput, splitMultilineString } from '../common';
 import { EditorContexts, Identifiers, NativeKeyboardCommandTelemetryLookup, NativeMouseCommandTelemetryLookup, Telemetry } from '../constants';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
-import { IEditCell, IInsertCell, INativeCommand, InteractiveWindowMessages, IRemoveCell, ISaveAll, ISubmitNewCell, ISwapCells } from '../interactive-common/interactiveWindowTypes';
+import { IEditCell, IInsertCell, INativeCommand, InteractiveWindowMessages, IPyWidgetMessages, IRemoveCell, ISaveAll, ISubmitNewCell, ISwapCells } from '../interactive-common/interactiveWindowTypes';
 import { InvalidNotebookFileError } from '../jupyter/invalidNotebookFileError';
 import { CellState, ICell, ICodeCssGenerator, IDataScienceErrorHandler, IDataViewerProvider, IInteractiveWindowInfo, IInteractiveWindowListener, IJupyterDebugger, IJupyterExecution, IJupyterVariables, INotebookEditor, INotebookEditorProvider, INotebookExporter, INotebookImporter, INotebookServerOptions, IStatusProvider, IThemeFinder } from '../types';
 

--- a/src/datascience-ui/interactive-common/redux/postOffice.ts
+++ b/src/datascience-ui/interactive-common/redux/postOffice.ts
@@ -5,7 +5,8 @@ import * as Redux from 'redux';
 
 import {
     IInteractiveWindowMapping,
-    InteractiveWindowMessages
+    InteractiveWindowMessages,
+    IPyWidgetMessages
 } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { CssMessages } from '../../../client/datascience/messages';
 import { PostOffice } from '../../react-common/postOffice';
@@ -95,6 +96,7 @@ export enum IncomingMessageActions {
 }
 
 export const AllowedMessages = [...Object.values(InteractiveWindowMessages), ...Object.values(CssMessages)];
+export const AllowedIPyWidgetMessages = [...Object.values(IPyWidgetMessages)];
 
 // Actions created from messages
 export function createPostableAction<M extends IInteractiveWindowMapping, T extends keyof M = keyof M>(message: T, payload?: M[T]): Redux.AnyAction {

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -5,8 +5,10 @@ import * as fastDeepEqual from 'fast-deep-equal';
 import * as Redux from 'redux';
 import { createLogger } from 'redux-logger';
 
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import { Identifiers } from '../../../client/datascience/constants';
-import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { CellState } from '../../../client/datascience/types';
 import { IMainState } from '../../interactive-common/mainState';
 import { generateMonacoReducer, IMonacoState } from '../../native-editor/redux/reducers/monaco';
@@ -14,7 +16,7 @@ import { PostOffice } from '../../react-common/postOffice';
 import { combineReducers, createQueueableActionMiddleware, QueuableAction } from '../../react-common/reduxUtils';
 import { computeEditorOptions, loadDefaultSettings } from '../../react-common/settingsReactSide';
 import { createEditableCellVM, generateTestState } from '../mainState';
-import { AllowedMessages, createPostableAction, generatePostOfficeSendReducer, IncomingMessageActions } from './postOffice';
+import { AllowedIPyWidgetMessages, AllowedMessages, createPostableAction, generatePostOfficeSendReducer, IncomingMessageActions } from './postOffice';
 
 function generateDefaultState(skipDefault: boolean, testMode: boolean, baseTheme: string, editable: boolean): IMainState {
     const defaultSettings = loadDefaultSettings();
@@ -198,8 +200,9 @@ export interface IStore {
     main: IMainState;
     monaco: IMonacoState;
     post: {};
-    // Required only for ipywidgets (to send & receive messages).
-    postOffice: PostOffice;
+    // tslint:disable-next-line: no-any
+    widgetMessagses: Observable<{type: string; payload?: any}>;
+    sendMessage<M extends IInteractiveWindowMapping, T extends keyof M>(type: T, payload?: M[T]): void;
 }
 
 export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode: boolean, editable: boolean, reducerMap: M) {
@@ -216,12 +219,15 @@ export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode
     // Create another reducer for handling monaco state
     const monacoReducer = generateMonacoReducer(testMode, postOffice);
 
+    // tslint:disable-next-line: no-any
+    const widgetMessages = new Subject<{type: string; payload?: any}>();
     // Combine these together
     const rootReducer = Redux.combineReducers<IStore>({
         main: mainReducer,
         monaco: monacoReducer,
         post: postOfficeReducer,
-        postOffice: () => postOffice
+        widgetMessagses: () => widgetMessages.asObservable(),
+        sendMessage: () => postOffice.sendMessage.bind(postOffice)
     });
 
     // Create our middleware
@@ -243,6 +249,9 @@ export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode
                 // - Have one reducer for incoming
                 // - Have another reducer for outgoing
                 store.dispatch({ type: `action.${message}`, payload });
+            }
+            if (AllowedIPyWidgetMessages.find(k => k === message)) {
+                widgetMessages.next({ type: message, payload });
             }
             return true;
         }

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -198,6 +198,8 @@ export interface IStore {
     main: IMainState;
     monaco: IMonacoState;
     post: {};
+    // Required only for ipywidgets (to send & receive messages).
+    postOffice: PostOffice;
 }
 
 export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode: boolean, editable: boolean, reducerMap: M) {
@@ -218,7 +220,8 @@ export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode
     const rootReducer = Redux.combineReducers<IStore>({
         main: mainReducer,
         monaco: monacoReducer,
-        post: postOfficeReducer
+        post: postOfficeReducer,
+        postOffice: () => postOffice
     });
 
     // Create our middleware

--- a/src/datascience-ui/ipywidgets/README.md
+++ b/src/datascience-ui/ipywidgets/README.md
@@ -1,0 +1,15 @@
+# Hosting ipywidgets in non-notebook contexxt
+* Much of the work is influenced by sample `web3` from https://github.com/jupyter-widgets/ipywidgets/blob/master/examples/web3
+* Displaying `ipywidgets` in non notebook context requires 3 things:
+    * [requirejs](https://requirejs.org)
+    * [HTML Manager](https://github.com/jupyter-widgets/ipywidgets/blob/master/examples/web3/src/manager.ts)
+    * Live Kerne (the widget manager plugs directly into the `kernel` messages to read/write and build data for displaying the data)
+
+# Kernel
+* As the kernel connection is only available in back end (`extension code`), the HTML manager will not work.
+* To get this working, all we need to do is create a `proxy kernel` connection in the `react` layer.
+* Thats what the code in this folder does (wraps the html manager + custom kernel connection)
+* Kernel messages from the extension are sent to this layer using the `postoffice`
+* Similarly messages from sent from html manager via the kernel are sent to the actual kernel via the postoffice.
+* However, the sequence and massaging of the kernel messages requires a lot of work. Baiscally majority of the message processing from `/node_modules/@jupyterlab/services/lib/kernel/*.js`
+    * Much of the message processing logic is borrowed from `comm.js`, `default.js`, `future.js`, `kernel.js` and `manager.js`.

--- a/src/datascience-ui/ipywidgets/callbackManager.ts
+++ b/src/datascience-ui/ipywidgets/callbackManager.ts
@@ -5,7 +5,7 @@
 
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 import { Deferred } from '../../client/common/utils/async';
-import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IPyWidgetMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 
 export class ClassicCommShellCallbackManager {
     private requestFutureMap = new Map<string, { future: Kernel.IShellFuture; deferred: Deferred<KernelMessage.IShellMessage | undefined> }>();
@@ -18,7 +18,7 @@ export class ClassicCommShellCallbackManager {
     // tslint:disable-next-line: no-any
     public async handleShellCallbacks(msg: string, payload?: any): Promise<void> {
         switch (msg) {
-            case InteractiveWindowMessages.IPyWidgets_ShellSend_onIOPub: {
+            case IPyWidgetMessages.IPyWidgets_ShellSend_onIOPub: {
                 // We got an `iopub` message on the comm for the `shell_` message that was sent by ipywidgets.
                 // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
                 // ipywidgets uses the `IComm.send` method.
@@ -27,7 +27,7 @@ export class ClassicCommShellCallbackManager {
                 reply.future.onIOPub(payload.msg);
                 break;
             }
-            case InteractiveWindowMessages.IPyWidgets_ShellSend_reply: {
+            case IPyWidgetMessages.IPyWidgets_ShellSend_reply: {
                 // We got a `reply` message on the comm for the `shell_` message that was sent by ipywidgets.
                 // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
                 // ipywidgets uses the `IComm.send` method.
@@ -36,7 +36,7 @@ export class ClassicCommShellCallbackManager {
                 reply.future.onReply(payload.msg);
                 break;
             }
-            case InteractiveWindowMessages.IPyWidgets_ShellSend_resolve: {
+            case IPyWidgetMessages.IPyWidgets_ShellSend_resolve: {
                 // We got a `reply` message on the comm for the `shell_` message that was sent by ipywidgets.
                 // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
                 // ipywidgets uses the `IComm.send` method.
@@ -46,7 +46,7 @@ export class ClassicCommShellCallbackManager {
                 reply.deferred.resolve(payload.msg);
                 break;
             }
-            case InteractiveWindowMessages.IPyWidgets_ShellSend_reject: {
+            case IPyWidgetMessages.IPyWidgets_ShellSend_reject: {
                 // We got a `reply` message on the comm for the `shell_` message that was sent by ipywidgets.
                 // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
                 // ipywidgets uses the `IComm.send` method.

--- a/src/datascience-ui/ipywidgets/callbackManager.ts
+++ b/src/datascience-ui/ipywidgets/callbackManager.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { Deferred } from '../../client/common/utils/async';
+import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+
+export class ClassicCommShellCallbackManager {
+    private requestFutureMap = new Map<string, { future: Kernel.IShellFuture; deferred: Deferred<KernelMessage.IShellMessage | undefined> }>();
+    public registerFuture(requestId: string, future: Kernel.IShellFuture, deferred: Deferred<KernelMessage.IShellMessage | undefined>) {
+        this.requestFutureMap.set(requestId, { future, deferred });
+    }
+    public unregisterFuture(requestId: string) {
+        this.requestFutureMap.delete(requestId);
+    }
+    // tslint:disable-next-line: no-any
+    public async handleShellCallbacks(msg: string, payload?: any): Promise<void> {
+        switch (msg) {
+            case InteractiveWindowMessages.IPyWidgets_ShellSend_onIOPub: {
+                // We got an `iopub` message on the comm for the `shell_` message that was sent by ipywidgets.
+                // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
+                // ipywidgets uses the `IComm.send` method.
+                const requestId = payload.requestId;
+                const reply = this.requestFutureMap.get(requestId)!;
+                reply.future.onIOPub(payload.msg);
+                break;
+            }
+            case InteractiveWindowMessages.IPyWidgets_ShellSend_reply: {
+                // We got a `reply` message on the comm for the `shell_` message that was sent by ipywidgets.
+                // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
+                // ipywidgets uses the `IComm.send` method.
+                const requestId = payload.requestId;
+                const reply = this.requestFutureMap.get(requestId)!;
+                reply.future.onReply(payload.msg);
+                break;
+            }
+            case InteractiveWindowMessages.IPyWidgets_ShellSend_resolve: {
+                // We got a `reply` message on the comm for the `shell_` message that was sent by ipywidgets.
+                // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
+                // ipywidgets uses the `IComm.send` method.
+                const requestId = payload.requestId;
+                const reply = this.requestFutureMap.get(requestId)!;
+                this.unregisterFuture(requestId);
+                reply.deferred.resolve(payload.msg);
+                break;
+            }
+            case InteractiveWindowMessages.IPyWidgets_ShellSend_reject: {
+                // We got a `reply` message on the comm for the `shell_` message that was sent by ipywidgets.
+                // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
+                // ipywidgets uses the `IComm.send` method.
+                const requestId = payload.requestId;
+                const reply = this.requestFutureMap.get(requestId)!;
+                this.unregisterFuture(requestId);
+                reply.deferred.reject(payload.msg);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+}

--- a/src/datascience-ui/ipywidgets/classicComm.ts
+++ b/src/datascience-ui/ipywidgets/classicComm.ts
@@ -8,7 +8,7 @@ import * as uuid from 'uuid/v4';
 import { createDeferred } from '../../client/common/utils/async';
 import { noop } from '../../client/common/utils/misc';
 import { serializeDataViews } from '../../client/common/utils/serializers';
-import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IPyWidgetMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { ClassicCommShellCallbackManager } from './callbackManager';
 import { IMessageSender } from './types';
 
@@ -50,7 +50,7 @@ export class ClassicComm implements Kernel.IComm {
         const msgType = 'comm_open';
         // Send this payload to the extension where we'll use the real comms to send to the kernel.
         // The response will be handled and sent back as messages to the UI as messages `shellSend_*`
-        this.messageSender.sendMessage(InteractiveWindowMessages.IPyWidgets_ShellSend, {
+        this.messageSender.sendMessage(IPyWidgetMessages.IPyWidgets_ShellSend, {
             data,
             metadata,
             commId,
@@ -99,7 +99,7 @@ export class ClassicComm implements Kernel.IComm {
         const msgType = 'comm_msg';
         // Send this payload to the extension where we'll use the real comms to send to the kernel.
         // The response will be handled and sent back as messages to the UI as messages `shellSend_*`
-        this.messageSender.sendMessage(InteractiveWindowMessages.IPyWidgets_ShellSend, {
+        this.messageSender.sendMessage(IPyWidgetMessages.IPyWidgets_ShellSend, {
             data,
             metadata,
             commId,

--- a/src/datascience-ui/ipywidgets/classicComm.ts
+++ b/src/datascience-ui/ipywidgets/classicComm.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+import * as uuid from 'uuid/v4';
+import { createDeferred } from '../../client/common/utils/async';
+import { noop } from '../../client/common/utils/misc';
+import { serializeDataViews } from '../../client/common/utils/serializers';
+import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { ClassicCommShellCallbackManager } from './callbackManager';
+import { IMessageSender } from './types';
+
+export class ClassicComm implements Kernel.IComm {
+    public isDisposed: boolean = false;
+    public onClose: (msg: KernelMessage.ICommCloseMsg) => void | PromiseLike<void> = noop;
+    public onMsg: (msg: KernelMessage.ICommMsgMsg) => void | PromiseLike<void> = noop;
+    private readonly registeredFutures: string[] = [];
+    constructor(
+        public readonly commId: string,
+        public readonly targetName: string,
+        private readonly messageSender: IMessageSender,
+        private readonly callbackManager: ClassicCommShellCallbackManager
+    ) {}
+    // tslint:disable-next-line: no-any
+    public open(data?: any, metadata?: any, buffers?: (ArrayBuffer | ArrayBufferView)[] | undefined): Kernel.IShellFuture {
+        // tslint:disable-next-line: no-console
+        const requestId = uuid();
+        const commId: string = this.commId;
+        const deferred = createDeferred<KernelMessage.IShellMessage | undefined>();
+        // Create a dummy response (IFuture) that we'll send to ipywidgets controls.
+        // Dummy because the actual IFuture object will be on the extension side.
+        // tslint:disable-next-line: no-any
+        const shellMessage = ({ header: { msg_id: requestId } } as any) as KernelMessage.IShellMessage;
+        const reply: Partial<Kernel.IShellFuture> = {
+            onIOPub: noop,
+            onReply: noop,
+            onStdin: noop,
+            done: deferred.promise,
+            msg: shellMessage
+        };
+        // tslint:disable-next-line: no-any
+        const future = (reply as any) as Kernel.IShellFuture;
+        // Keep track of the future.
+        // When messages arrive from extension we can resolve this future.
+        this.registeredFutures.push(requestId);
+        this.callbackManager.registerFuture(requestId, future, deferred);
+        const targetName = this.targetName;
+        const msgType = 'comm_open';
+        // Send this payload to the extension where we'll use the real comms to send to the kernel.
+        // The response will be handled and sent back as messages to the UI as messages `shellSend_*`
+        this.messageSender.sendMessage(InteractiveWindowMessages.IPyWidgets_ShellSend, {
+            data,
+            metadata,
+            commId,
+            requestId,
+            buffers: serializeDataViews(buffers),
+            targetName,
+            msgType
+        });
+
+        // ipywidgets will use this as a promise (ifuture).
+        return future;
+    }
+    // tslint:disable-next-line: no-any
+    public close(_data?: any, _metadata?: any, _buffers?: (ArrayBuffer | ArrayBufferView)[] | undefined): Kernel.IShellFuture {
+        this.registeredFutures.forEach(item => this.callbackManager.unregisterFuture(item));
+        throw new Error('VSCPython.IClassicComm.Close method not implemented!');
+    }
+    public dispose(): void {
+        this.registeredFutures.forEach(item => this.callbackManager.unregisterFuture(item));
+    }
+    // tslint:disable-next-line: no-any
+    public send(data: any, metadata?: any, buffers?: (ArrayBuffer | ArrayBufferView)[] | undefined, disposeOnDone?: boolean | undefined): Kernel.IShellFuture {
+        // tslint:disable-next-line: no-console
+        const requestId = uuid();
+        const commId: string = this.commId;
+        const deferred = createDeferred<KernelMessage.IShellMessage | undefined>();
+        // Create a dummy response (IFuture) that we'll send to ipywidgets controls.
+        // Dummy because the actual IFuture object will be on the extension side.
+        // tslint:disable-next-line: no-any
+        const shellMessage = ({ header: { msg_id: requestId } } as any) as KernelMessage.IShellMessage;
+        const reply: Partial<Kernel.IShellFuture> = {
+            onIOPub: noop,
+            onReply: noop,
+            onStdin: noop,
+            done: deferred.promise,
+            msg: shellMessage
+        };
+        // tslint:disable-next-line: no-any
+        const future = (reply as any) as Kernel.IShellFuture;
+        // Keep track of the future.
+        // When messages arrive from extension we can resolve this future.
+        this.registeredFutures.push(requestId);
+        this.callbackManager.registerFuture(requestId, future, deferred);
+        // const targetName = this.targetName;
+        const targetName = undefined;
+        const msgType = 'comm_msg';
+        // Send this payload to the extension where we'll use the real comms to send to the kernel.
+        // The response will be handled and sent back as messages to the UI as messages `shellSend_*`
+        this.messageSender.sendMessage(InteractiveWindowMessages.IPyWidgets_ShellSend, {
+            data,
+            metadata,
+            commId,
+            requestId,
+            disposeOnDone,
+            buffers: serializeDataViews(buffers),
+            targetName,
+            msgType
+        });
+
+        // ipywidgets will use this as a promise (ifuture).
+        return future;
+    }
+}

--- a/src/datascience-ui/ipywidgets/container.tsx
+++ b/src/datascience-ui/ipywidgets/container.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { IStore } from '../interactive-common/redux/store';
+import { PostOffice } from '../react-common/postOffice';
+import { WidgetManager } from './manager';
+
+type IProps = { postOffice: PostOffice };
+
+function mapStateToProps(state: IStore): IProps {
+    return { postOffice: state.postOffice } ;
+}
+// Default dispatcher (not required, but required for strictness).
+function mapDispatchToProps(dispatch: Function) {
+    return {dispatch};
+}
+
+class Container extends React.Component<IProps> {
+    private readonly widgetManager: WidgetManager;
+
+    constructor(props: IProps) {
+        super(props);
+        // Çreating a manager and registering the post office is all we need to do.
+        this.widgetManager = new WidgetManager(document.getElementById('rootWidget')!);
+        this.widgetManager.registerPostOffice(props.postOffice);
+    }
+    public render() {
+        return null;
+    }
+    public componentWillUnmount(){
+        this.widgetManager.dispose();
+    }
+}
+
+export const WidgetManagerComponent = connect(mapStateToProps, mapDispatchToProps)(Container);

--- a/src/datascience-ui/ipywidgets/container.tsx
+++ b/src/datascience-ui/ipywidgets/container.tsx
@@ -5,28 +5,28 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Observable } from 'rxjs/Observable';
+import { IInteractiveWindowMapping } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IStore } from '../interactive-common/redux/store';
-import { PostOffice } from '../react-common/postOffice';
 import { WidgetManager } from './manager';
 
-type IProps = { postOffice: PostOffice };
+// tslint:disable-next-line: no-any
+type Props = { messages: Observable<{type: string; payload?: any}>; sendMessage<M extends IInteractiveWindowMapping, T extends keyof M>(type: T, payload?: M[T]): void };
 
-function mapStateToProps(state: IStore): IProps {
-    return { postOffice: state.postOffice } ;
+function mapStateToProps(state: IStore): Props {
+    return { messages: state.widgetMessagses, sendMessage: state.sendMessage } ;
 }
 // Default dispatcher (not required, but required for strictness).
 function mapDispatchToProps(dispatch: Function) {
     return {dispatch};
 }
 
-class Container extends React.Component<IProps> {
+class Container extends React.Component<Props> {
     private readonly widgetManager: WidgetManager;
 
-    constructor(props: IProps) {
+    constructor(props: Props) {
         super(props);
-        // Çreating a manager and registering the post office is all we need to do.
-        this.widgetManager = new WidgetManager(document.getElementById('rootWidget')!);
-        this.widgetManager.registerPostOffice(props.postOffice);
+        this.widgetManager = new WidgetManager(document.getElementById('rootWidget')!, props.messages, props.sendMessage);
     }
     public render() {
         return null;

--- a/src/datascience-ui/ipywidgets/index.ts
+++ b/src/datascience-ui/ipywidgets/index.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+export { WidgetManager } from './manager';
+export { WidgetManagerComponent } from './container';

--- a/src/datascience-ui/ipywidgets/kernel.ts
+++ b/src/datascience-ui/ipywidgets/kernel.ts
@@ -128,6 +128,7 @@ export class ProxyKernel implements Partial<Kernel.IKernel> {
             try {
                 await this.onCommOpen(commOpenMessage);
             } catch (ex) {
+                // tslint:disable-next-line: no-console
                 console.error('Failed to exec commTargetCallback', ex);
             }
         }

--- a/src/datascience-ui/ipywidgets/kernel.ts
+++ b/src/datascience-ui/ipywidgets/kernel.ts
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+import * as uuid from 'uuid/v4';
+import { noop } from '../../client/common/utils/misc';
+import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { ClassicCommShellCallbackManager } from './callbackManager';
+import { ClassicComm } from './classicComm';
+import { CommTargetCallback, IMessageSender } from './types';
+
+type CommTargetRegisteredHandler = (targetName: string, callback: CommTargetCallback) => void;
+
+/**
+ * This is a proxy Kernel that ipython will use to communicate with jupyter.
+ * It only requires the `registerCommTarget` method to list to comm messages.
+ * That's why we only implement that method.
+ *
+ * @export
+ * @class ProxyKernel
+ * @implements {Partial<Kernel.IKernel>}
+ */
+export class ProxyKernel implements Partial<Kernel.IKernel> {
+    private commRegistrationMessagesToSend: string[] = [];
+    private readonly handlers: CommTargetRegisteredHandler[] = [];
+    private commTargetCallbacks = new Map<string, CommTargetCallback>();
+    private commsById = new Map<string, Kernel.IComm>();
+    private readonly shellCallbackManager = new ClassicCommShellCallbackManager();
+    constructor(private readonly messageSender: IMessageSender) {}
+    /**
+     * This method is used by ipywidgets manager.
+     *
+     * @param {string} targetName
+     * @param {CommTargetCallback} callback
+     * @memberof ProxyKernel
+     */
+    public registerCommTarget(targetName: string, callback: CommTargetCallback): void {
+        this.commRegistrationMessagesToSend.push(targetName);
+        this.handlers.forEach(handler => handler(targetName, callback));
+        this.commTargetCallbacks.set(targetName, callback);
+    }
+    public connectToComm(targetName: string, commId: string = uuid()): Kernel.IComm {
+        return this.commsById.get(commId) || this.createComm(targetName, commId);
+    }
+    public dispose() {
+        while (this.handlers.shift()) {
+            noop();
+        }
+    }
+    public initialize(): void {
+        this.commRegistrationMessagesToSend.forEach(targetName => this.messageSender.sendMessage(InteractiveWindowMessages.IPyWidgets_registerCommTarget, targetName));
+        this.commRegistrationMessagesToSend = [];
+    }
+    // tslint:disable-next-line: no-any
+    public async handleMessageAsync(msg: string, payload?: any): Promise<void> {
+        switch (msg) {
+            case InteractiveWindowMessages.IPyWidgets_comm_msg: {
+                // We got a `comm_msg` on the comm channel from kernel.
+                // These messages must be given to all widgets, to update their states.
+                // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
+                // ipywidgets uses the `IComm.send` method.
+
+                // These messages need to be propagated back on the `onMsg` callback.
+                const commMsg = payload as KernelMessage.ICommMsgMsg;
+                if (commMsg.content && commMsg.content.comm_id) {
+                    const comm = this.commsById.get(commMsg.content.comm_id);
+                    if (comm) {
+                        const promise = comm.onMsg(commMsg);
+                        if (promise) {
+                            await promise;
+                        }
+                    }
+                }
+                break;
+            }
+            case InteractiveWindowMessages.IPyWidgets_comm_open:
+                await this.handleCommOpen(msg, payload);
+                break;
+            default:
+                await this.shellCallbackManager.handleShellCallbacks(msg, payload);
+                break;
+        }
+    }
+    protected async onCommOpen(msg: KernelMessage.ICommOpenMsg) {
+        if (!msg.content || !msg.content.comm_id || msg.content.target_name !== 'jupyter.widget') {
+            throw new Error('Unknown comm open message');
+        }
+        const commTargetCallback = this.commTargetCallbacks.get(msg.content.target_name);
+        if (!commTargetCallback) {
+            throw new Error(`Comm Target callback not registered for ${msg.content.target_name}`);
+        }
+
+        const comm = this.createComm(msg.content.target_name, msg.content.comm_id);
+
+        // Invoke the CommOpen callbacks with the comm and the corresponding message.
+        // This is the handshake with the ipywidgets.
+        // At this point ipywidgets manager has the comm object it needs to communicate with the kernel.
+        const promise = commTargetCallback(comm, msg);
+        // tslint:disable-next-line: no-any
+        if (promise && (promise as any).then) {
+            await promise;
+        }
+    }
+    private createComm(targetName: string, commId: string): Kernel.IComm {
+        // Create the IComm object that ipywidgets will use to communicate directly with the kernel.
+        const comm = new ClassicComm(commId, targetName, this.messageSender, this.shellCallbackManager);
+        // const comm = this.createKernelCommForCommOpenCallback(msg);
+
+        // When messages arrive on `onMsg` in the comm component, we need to send these back.
+        // Remember, `comm` here is a bogus IComm object.
+        // The actual object is at the extension end. Back there we listen to messages arriving
+        // in the callback of `IComm.onMsg`, those will come into this class and we need to send
+        // them through the `comm` object. To propogate those messages we need to tie the delegate to the comm id.
+        this.commsById.set(commId, comm);
+        return comm;
+    }
+    // tslint:disable-next-line: no-any
+    private async handleCommOpen(msg: string, payload?: any): Promise<void> {
+        if (msg !== InteractiveWindowMessages.IPyWidgets_comm_open) {
+            return;
+        }
+        // Happens when a comm is opened (generatelly part of a cell execution).
+        // We're only interested in `comm_open` messages.
+        if (payload && payload.msg_type === 'comm_open') {
+            const commOpenMessage = payload as KernelMessage.ICommOpenMsg;
+            try {
+                await this.onCommOpen(commOpenMessage);
+            } catch (ex) {
+                console.error('Failed to exec commTargetCallback', ex);
+            }
+        }
+    }
+}

--- a/src/datascience-ui/ipywidgets/kernel.ts
+++ b/src/datascience-ui/ipywidgets/kernel.ts
@@ -6,7 +6,7 @@
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 import * as uuid from 'uuid/v4';
 import { noop } from '../../client/common/utils/misc';
-import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IPyWidgetMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { ClassicCommShellCallbackManager } from './callbackManager';
 import { ClassicComm } from './classicComm';
 import { CommTargetCallback, IMessageSender } from './types';
@@ -50,13 +50,13 @@ export class ProxyKernel implements Partial<Kernel.IKernel> {
         }
     }
     public initialize(): void {
-        this.commRegistrationMessagesToSend.forEach(targetName => this.messageSender.sendMessage(InteractiveWindowMessages.IPyWidgets_registerCommTarget, targetName));
+        this.commRegistrationMessagesToSend.forEach(targetName => this.messageSender.sendMessage(IPyWidgetMessages.IPyWidgets_registerCommTarget, targetName));
         this.commRegistrationMessagesToSend = [];
     }
     // tslint:disable-next-line: no-any
     public async handleMessageAsync(msg: string, payload?: any): Promise<void> {
         switch (msg) {
-            case InteractiveWindowMessages.IPyWidgets_comm_msg: {
+            case IPyWidgetMessages.IPyWidgets_comm_msg: {
                 // We got a `comm_msg` on the comm channel from kernel.
                 // These messages must be given to all widgets, to update their states.
                 // The `shell` message was sent using our custom `IComm` component provided to ipywidgets.
@@ -75,7 +75,7 @@ export class ProxyKernel implements Partial<Kernel.IKernel> {
                 }
                 break;
             }
-            case InteractiveWindowMessages.IPyWidgets_comm_open:
+            case IPyWidgetMessages.IPyWidgets_comm_open:
                 await this.handleCommOpen(msg, payload);
                 break;
             default:
@@ -118,7 +118,7 @@ export class ProxyKernel implements Partial<Kernel.IKernel> {
     }
     // tslint:disable-next-line: no-any
     private async handleCommOpen(msg: string, payload?: any): Promise<void> {
-        if (msg !== InteractiveWindowMessages.IPyWidgets_comm_open) {
+        if (msg !== IPyWidgetMessages.IPyWidgets_comm_open) {
             return;
         }
         // Happens when a comm is opened (generatelly part of a cell execution).

--- a/src/datascience-ui/ipywidgets/manager.ts
+++ b/src/datascience-ui/ipywidgets/manager.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { nbformat } from '@jupyterlab/services/node_modules/@jupyterlab/coreutils';
+import 'rxjs/add/operator/concatMap';
+import { IDisposable } from '../../client/common/types';
+import { createDeferred, Deferred } from '../../client/common/utils/async';
+import { noop } from '../../client/common/utils/misc';
+import { deserializeDataViews } from '../../client/common/utils/serializers';
+import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { PostOffice } from '../react-common/postOffice';
+import { ProxyKernel } from './kernel';
+import { IHtmlWidgetManager, IHtmlWidgetManagerCtor, IIPyWidgetManager, IMessageSender } from './types';
+
+// The HTMLWidgetManager will be exposed in the global variable `window.ipywidgets.main` (check webpack config - src/ipywidgets/webpack.config.js).
+// tslint:disable-next-line: no-any
+const HtmlWidgetManager = (window as any).vscIPyWidgets.WidgetManager as IHtmlWidgetManagerCtor;
+if (!HtmlWidgetManager) {
+    throw new Error('HtmlWidgetManager not defined. Please include/check ipywidgets.js file');
+}
+
+export class WidgetManager implements IIPyWidgetManager, IMessageSender {
+    public static instance: WidgetManager;
+    public manager!: IHtmlWidgetManager;
+    private readonly proxyKernel: ProxyKernel;
+    private postOffice!: PostOffice;
+    /**
+     * Contains promises related to model_ids that need to be displayed.
+     * When we receive a message from the kernel of type = `display_data` for a widget (`application/vnd.jupyter.widget-view+json`),
+     * then its time to display this.
+     * We need to keep track of this. A boolean is sufficient, but we're using a promise so we can be notified when it is ready.
+     *
+     * @private
+     * @memberof WidgetManager
+     */
+    private modelIdsToBeDisplayed = new Map<string, Deferred<void>>();
+    constructor(widgetContainer: HTMLElement) {
+            this.proxyKernel = new ProxyKernel(this);
+            // tslint:disable-next-line: no-any
+            const kernel = (this.proxyKernel as any) as Kernel.IKernel;
+            this.manager = new HtmlWidgetManager(kernel, widgetContainer);
+            WidgetManager.instance = this;
+    }
+    public dispose(): void {
+        this.proxyKernel.dispose();
+    }
+    public registerPostOffice(postOffice: PostOffice): void {
+        this.postOffice = postOffice;
+        // Process all messages sequentially.
+        postOffice.asObservable()
+            .concatMap(async msg => {
+                this.restoreBuffers(msg.payload);
+                await this.proxyKernel.handleMessageAsync(msg.type, msg.payload);
+                await this.handleMessageAsync(msg.type, msg.payload);
+            })
+            .subscribe();
+        this.proxyKernel.initialize();
+    }
+    public async clear(): Promise<void> {
+        await this.manager.clear_state();
+    }
+    /**
+     * This is the handler for all kernel messages.
+     * All messages must be processed sequentially (even when processed asynchronously).
+     *
+     * @param {string} msg
+     * @param {*} [payload]
+     * @returns {Promise<void>}
+     * @memberof WidgetManager
+     */
+    // tslint:disable-next-line: no-any
+    public async handleMessageAsync(msg: string, payload?: any): Promise<void> {
+        if (msg === InteractiveWindowMessages.IPyWidgets_display_data_msg) {
+            // General IOPub message
+            const displayMsg = payload as KernelMessage.IDisplayDataMsg;
+
+            if (displayMsg.content &&
+                displayMsg.content.data &&
+                displayMsg.content.data['application/vnd.jupyter.widget-view+json']) {
+                // tslint:disable-next-line: no-any
+                const data = displayMsg.content.data['application/vnd.jupyter.widget-view+json'] as any;
+                const modelId = data.model_id;
+
+                if (!this.modelIdsToBeDisplayed.has(modelId)){
+                    this.modelIdsToBeDisplayed.set(modelId, createDeferred());
+                }
+                const modelPromise = this.manager.get_model(data.model_id);
+                if (modelPromise){
+                    await modelPromise;
+                }
+                // Mark it as completed (i.e. ready to display).
+                this.modelIdsToBeDisplayed.get(modelId)!.resolve();
+            }
+        }
+    }
+    /**
+     * Renders a widget and returns a disposable (to remove the widget).
+     *
+     * @param {(nbformat.IMimeBundle & {model_id: string; version_major: number})} data
+     * @param {HTMLElement} ele
+     * @returns {Promise<{ dispose: Function }>}
+     * @memberof WidgetManager
+     */
+    public async renderWidget(data: nbformat.IMimeBundle & {model_id: string; version_major: number}, ele: HTMLElement): Promise<IDisposable> {
+        if (!data) {
+            throw new Error('application/vnd.jupyter.widget-view+json not in msg.content.data, as msg.content.data is \'undefined\'.');
+        }
+
+        if (!data || data.version_major !== 2) {
+            console.warn('Widget data not avaialble to render an ipywidget');
+            return { dispose: noop };
+        }
+
+        const modelId = data.model_id as string;
+        // Check if we have processed the data for this model.
+        // If not wait.
+        if (!this.modelIdsToBeDisplayed.has(modelId)){
+            this.modelIdsToBeDisplayed.set(modelId, createDeferred());
+        }
+        // Wait until it is flagged as ready to be processed.
+        // This widget manager must have recieved this message and performed all operations before this.
+        // Once all messages prior to this have been processed in sequence and this message is receievd,
+        // then, and only then are we ready to render the widget.
+        // I.e. this is a way of synchronzing the render with the processing of the messages.
+        await this.modelIdsToBeDisplayed.get(modelId)!.promise;
+
+        const modelPromise = this.manager.get_model(data.model_id);
+        if (!modelPromise) {
+            console.warn('Widget model not avaialble to render an ipywidget');
+            return { dispose: noop };
+        }
+
+        // ipywdigets may not have completed creating the model.
+        // ipywidgets have a promise, as the model may get created by a 3rd party library.
+        // That 3rd party library may not be available and may have to be downloaded.
+        // Hence the promise to wait until it has been created.
+        const model = await modelPromise;
+        const view = await this.manager.create_view(model, { el: ele });
+        // tslint:disable-next-line: no-any
+        return this.manager.display_view(view, { el: ele }).then(vw => ({ dispose: vw.remove.bind(vw) }));
+    }
+    public sendMessage<M extends IInteractiveWindowMapping, T extends keyof M>(type: T, payload?: M[T]) {
+        this.postOffice.sendMessage(type, payload);
+    }
+    private restoreBuffers(msg: KernelMessage.IIOPubMessage){
+        if (!msg || !Array.isArray(msg.buffers) || msg.buffers.length === 0){
+            return;
+        }
+        msg.buffers = deserializeDataViews(msg.buffers);
+    }
+}

--- a/src/datascience-ui/ipywidgets/types.ts
+++ b/src/datascience-ui/ipywidgets/types.ts
@@ -6,7 +6,6 @@
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 import { nbformat } from '@jupyterlab/services/node_modules/@jupyterlab/coreutils';
 import { IInteractiveWindowMapping } from '../../client/datascience/interactive-common/interactiveWindowTypes';
-import { PostOffice } from '../react-common/postOffice';
 
 export interface IMessageSender {
     sendMessage<M extends IInteractiveWindowMapping, T extends keyof M>(type: T, payload?: M[T]): void;
@@ -51,13 +50,6 @@ export interface IHtmlWidgetManager {
 // export interface IIPyWidgetManager extends IMessageHandler {
 export interface IIPyWidgetManager {
     dispose(): void;
-    /**
-     * To send and listen to messages (communicate with extension/backend).
-     *
-     * @param {PostOffice} postOffice
-     * @memberof IIPyWidgetManager
-     */
-    registerPostOffice(postOffice: PostOffice): void;
     /**
      * Clears/removes all the widgets
      *

--- a/src/datascience-ui/ipywidgets/types.ts
+++ b/src/datascience-ui/ipywidgets/types.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { nbformat } from '@jupyterlab/services/node_modules/@jupyterlab/coreutils';
+import { IInteractiveWindowMapping } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { PostOffice } from '../react-common/postOffice';
+
+export interface IMessageSender {
+    sendMessage<M extends IInteractiveWindowMapping, T extends keyof M>(type: T, payload?: M[T]): void;
+}
+
+export type CommTargetCallback = (comm: Kernel.IComm, msg: KernelMessage.ICommOpenMsg) => void | PromiseLike<void>;
+
+type WidgetView = { remove: Function };
+type WidgetModel = {};
+
+export type IHtmlWidgetManagerCtor = new (kernel: Kernel.IKernelConnection, el: HTMLElement) => IHtmlWidgetManager;
+
+export interface IHtmlWidgetManager {
+    /**
+     * Close all widgets and empty the widget state.
+     * @return Promise that resolves when the widget state is cleared.
+     */
+    clear_state(): Promise<void>;
+    /**
+     * Get a promise for a model by model id.
+     *
+     * #### Notes
+     * If a model is not found, undefined is returned (NOT a promise). However,
+     * the calling code should also deal with the case where a rejected promise
+     * is returned, and should treat that also as a model not found.
+     */
+    get_model(model_id: string): Promise<WidgetModel> | undefined;
+    /**
+     * Display a DOMWidget view.
+     *
+     */
+    display_view(view: WidgetView, options: { el: HTMLElement }): Promise<WidgetView>;
+    /**
+     * Creates a promise for a view of a given model
+     *
+     * Make sure the view creation is not out of order with
+     * any state updates.
+     */
+    create_view(model: WidgetModel, options: { el: HTMLElement }): Promise<WidgetView>;
+}
+
+// export interface IIPyWidgetManager extends IMessageHandler {
+export interface IIPyWidgetManager {
+    dispose(): void;
+    /**
+     * To send and listen to messages (communicate with extension/backend).
+     *
+     * @param {PostOffice} postOffice
+     * @memberof IIPyWidgetManager
+     */
+    registerPostOffice(postOffice: PostOffice): void;
+    /**
+     * Clears/removes all the widgets
+     *
+     * @memberof IIPyWidgetManager
+     */
+    clear(): Promise<void>;
+    /**
+     * Displays a widget for the mesasge with header.msg_type === 'display_data'.
+     * The widget is rendered in a given HTML element.
+     * Returns a disposable that can be used to dispose/remove the rendered Widget.
+     * The message must
+     *
+     * @param {KernelMessage.IIOPubMessage} msg
+     * @param {HTMLElement} ele
+     * @returns {Promise<{ dispose: Function }>}
+     * @memberof IIPyWidgetManager
+     */
+    renderWidget(data: nbformat.IMimeBundle, ele: HTMLElement): Promise<{ dispose: Function }>;
+}

--- a/src/datascience-ui/react-common/postOffice.ts
+++ b/src/datascience-ui/react-common/postOffice.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 'use strict';
 
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import { WebPanelMessage } from '../../client/common/application/types';
 import { IDisposable } from '../../client/common/types';
 import { logMessage } from './logger';
@@ -23,7 +25,8 @@ export interface IMessageHandler {
 
 // This special function talks to vscode from a web panel
 export declare function acquireVsCodeApi(): IVsCodeApi;
-
+// tslint:disable-next-line: no-any
+export type PostOfficeMessage = {type: string; payload?: any};
 // tslint:disable-next-line: no-unnecessary-class
 export class PostOffice implements IDisposable {
 
@@ -31,7 +34,14 @@ export class PostOffice implements IDisposable {
     private vscodeApi: IVsCodeApi | undefined;
     private handlers: IMessageHandler[] = [];
     private baseHandler = this.handleMessages.bind(this);
-
+    private readonly subject = new Subject<PostOfficeMessage>();
+    private readonly observable: Observable<PostOfficeMessage>;
+    constructor(){
+        this.observable = this.subject.asObservable();
+    }
+    public asObservable(): Observable<PostOfficeMessage> {
+        return this.observable;
+    }
     public dispose() {
         if (this.registered) {
             this.registered = false;
@@ -82,6 +92,7 @@ export class PostOffice implements IDisposable {
         if (this.handlers) {
             const msg = ev.data as WebPanelMessage;
             if (msg) {
+                this.subject.next({type: msg.type, payload: msg.payload});
                 this.handlers.forEach((h: IMessageHandler | null) => {
                     if (h) {
                         h.handleMessage(msg.type, msg.payload);

--- a/src/datascience-ui/react-common/postOffice.ts
+++ b/src/datascience-ui/react-common/postOffice.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
 import { WebPanelMessage } from '../../client/common/application/types';
 import { IDisposable } from '../../client/common/types';
 import { logMessage } from './logger';
@@ -34,14 +32,6 @@ export class PostOffice implements IDisposable {
     private vscodeApi: IVsCodeApi | undefined;
     private handlers: IMessageHandler[] = [];
     private baseHandler = this.handleMessages.bind(this);
-    private readonly subject = new Subject<PostOfficeMessage>();
-    private readonly observable: Observable<PostOfficeMessage>;
-    constructor(){
-        this.observable = this.subject.asObservable();
-    }
-    public asObservable(): Observable<PostOfficeMessage> {
-        return this.observable;
-    }
     public dispose() {
         if (this.registered) {
             this.registered = false;
@@ -92,7 +82,6 @@ export class PostOffice implements IDisposable {
         if (this.handlers) {
             const msg = ev.data as WebPanelMessage;
             if (msg) {
-                this.subject.next({type: msg.type, payload: msg.payload});
                 this.handlers.forEach((h: IMessageHandler | null) => {
                     if (h) {
                         h.handleMessage(msg.type, msg.payload);

--- a/src/ipywidgets/README.md
+++ b/src/ipywidgets/README.md
@@ -15,3 +15,10 @@
     * `amd` is not what we want, as out `react ui` doesn't use `amd`.
     * `umd` is does not work as we have multiple `entry points` in `webpack`.
     * Heres' the solution `define('@jupyter-widgets/controls', () => widgets);`
+* We bundling the widget controls into our JS and exposing them for AMD using `define`
+    * We could instead include `https://unpkg.com/browse/@jupyter-widgets/html-manager@0.18.3/dist/embed-amd.js`
+    * However this is a 3.2MB file.
+    * Then our Widget manager also needs the widget controls. That would mean widget controls get included twice, once in our bundle and the other in the above mentioned `embed-amd.js` file.
+    * Solution is to include everything thats in `embed-amd.js` into our bundle.
+    * The `embed-amd.js` includes source from files other than the widget controls, those include `libembed-amd.js` and `embed-amd-render.js`.
+        * The source for this can be found in [scripts/concat-amd-build.js](https://github.com/jupyter-widgets/ipywidgets/blob/857bee9c15ca25bd6b47b7777e8fcd07407214cf/packages/html-manager/scripts/concat-amd-build.js#L15)

--- a/src/ipywidgets/lib/embed-amd-render.js
+++ b/src/ipywidgets/lib/embed-amd-render.js
@@ -1,0 +1,10 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+window.require(['@jupyter-widgets/html-manager/dist/libembed-amd'], function (embed) {
+    if (document.readyState === 'complete') {
+        embed.renderWidgets();
+    }
+    else {
+        window.addEventListener('load', function () { embed.renderWidgets(); });
+    }
+});

--- a/src/ipywidgets/lib/libembed-amd.js
+++ b/src/ipywidgets/lib/libembed-amd.js
@@ -1,0 +1,87 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+import * as libembed from './libembed';
+let cdn = 'https://unpkg.com/';
+// find the data-cdn for any script tag, assuming it is only used for embed-amd.js
+const scripts = document.getElementsByTagName('script');
+Array.prototype.forEach.call(scripts, (script) => {
+    cdn = script.getAttribute('data-jupyter-widgets-cdn') || cdn;
+});
+/**
+ * Load a package using requirejs and return a promise
+ *
+ * @param pkg Package name or names to load
+ */
+let requirePromise = function (pkg) {
+    return new Promise((resolve, reject) => {
+        let require = window.requirejs;
+        if (require === undefined) {
+            reject("Requirejs is needed, please ensure it is loaded on the page.");
+        }
+        else {
+            require(pkg, resolve, reject);
+        }
+    });
+};
+function moduleNameToCDNUrl(moduleName, moduleVersion) {
+    let packageName = moduleName;
+    let fileName = 'index'; // default filename
+    // if a '/' is present, like 'foo/bar', packageName is changed to 'foo', and path to 'bar'
+    // We first find the first '/'
+    let index = moduleName.indexOf('/');
+    if ((index != -1) && (moduleName[0] == '@')) {
+        // if we have a namespace, it's a different story
+        // @foo/bar/baz should translate to @foo/bar and baz
+        // so we find the 2nd '/'
+        index = moduleName.indexOf('/', index + 1);
+    }
+    if (index != -1) {
+        fileName = moduleName.substr(index + 1);
+        packageName = moduleName.substr(0, index);
+    }
+    return `${cdn}${packageName}@${moduleVersion}/dist/${fileName}`;
+}
+/**
+ * Load an amd module locally and fall back to specified CDN if unavailable.
+ *
+ * @param moduleName The name of the module to load..
+ * @param version The semver range for the module, if loaded from a CDN.
+ *
+ * By default, the CDN service used is unpkg.com. However, this default can be
+ * overriden by specifying another URL via the HTML attribute
+ * "data-jupyter-widgets-cdn" on a script tag of the page.
+ *
+ * The semver range is only used with the CDN.
+ */
+export function requireLoader(moduleName, moduleVersion) {
+    return requirePromise([`${moduleName}`]).catch((err) => {
+        let failedId = err.requireModules && err.requireModules[0];
+        if (failedId) {
+            console.log(`Falling back to ${cdn} for ${moduleName}@${moduleVersion}`);
+            let require = window.requirejs;
+            if (require === undefined) {
+                throw new Error("Requirejs is needed, please ensure it is loaded on the page.");
+            }
+            const conf = { paths: {} };
+            conf.paths[moduleName] = moduleNameToCDNUrl(moduleName, moduleVersion);
+            require.undef(failedId);
+            require.config(conf);
+            return requirePromise([`${moduleName}`]);
+        }
+    });
+}
+/**
+ * Render widgets in a given element.
+ *
+ * @param element (default document.documentElement) The element containing widget state and views.
+ * @param loader (default requireLoader) The function used to look up the modules containing
+ * the widgets' models and views classes. (The default loader looks them up on unpkg.com)
+ */
+export function renderWidgets(element = document.documentElement, loader = requireLoader) {
+    requirePromise(['@jupyter-widgets/html-manager']).then((htmlmanager) => {
+        let managerFactory = () => {
+            return new htmlmanager.HTMLManager({ loader: loader });
+        };
+        libembed.renderWidgets(managerFactory, element);
+    });
+}

--- a/src/ipywidgets/lib/libembed.js
+++ b/src/ipywidgets/lib/libembed.js
@@ -1,0 +1,73 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+__webpack_public_path__ = window.__jupyter_widgets_assets_path__ || __webpack_public_path__;
+import 'font-awesome/css/font-awesome.css';
+import '@phosphor/widgets/style/index.css';
+import '@jupyter-widgets/controls/css/widgets.css';
+// Load json schema validator
+var Ajv = require('ajv');
+var widget_state_schema = require('@jupyter-widgets/schema').v2.state;
+var widget_view_schema = require('@jupyter-widgets/schema').v2.view;
+let ajv = new Ajv();
+let model_validate = ajv.compile(widget_state_schema);
+let view_validate = ajv.compile(widget_view_schema);
+/**
+ * Render the inline widgets inside a DOM element.
+ *
+ * @param managerFactory A function that returns a new HTMLManager
+ * @param element (default document.documentElement) The document element in which to process for widget state.
+ */
+export function renderWidgets(managerFactory, element = document.documentElement) {
+    let tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-state+json"]');
+    for (let i = 0; i != tags.length; ++i) {
+        renderManager(element, JSON.parse(tags[i].innerHTML), managerFactory);
+    }
+}
+/**
+ * Create a widget manager for a given widget state.
+ *
+ * @param element The DOM element to search for widget view state script tags
+ * @param widgetState The widget manager state
+ *
+ * #### Notes
+ *
+ * Widget view state should be in script tags with type
+ * "application/vnd.jupyter.widget-view+json". Any such script tag containing a
+ * model id the manager knows about is replaced with a rendered view.
+ * Additionally, if the script tag has a prior img sibling with class
+ * 'jupyter-widget', then that img tag is deleted.
+ */
+function renderManager(element, widgetState, managerFactory) {
+    let valid = model_validate(widgetState);
+    if (!valid) {
+        console.error('Model state has errors.', model_validate.errors);
+    }
+    let manager = managerFactory();
+    manager.set_state(widgetState).then(function (models) {
+        let tags = element.querySelectorAll('script[type="application/vnd.jupyter.widget-view+json"]');
+        for (let i = 0; i != tags.length; ++i) {
+            let viewtag = tags[i];
+            let widgetViewObject = JSON.parse(viewtag.innerHTML);
+            let valid = view_validate(widgetViewObject);
+            if (!valid) {
+                console.error('View state has errors.', view_validate.errors);
+            }
+            let model_id = widgetViewObject.model_id;
+            // Find the model id in the models. We should use .find, but IE
+            // doesn't support .find
+            let model = models.filter((item) => {
+                return item.model_id == model_id;
+            })[0];
+            if (model !== undefined) {
+                let prev = viewtag.previousElementSibling;
+                if (prev && prev.tagName === 'img' && prev.classList.contains('jupyter-widget')) {
+                    viewtag.parentElement.removeChild(prev);
+                }
+                let widgetTag = document.createElement('div');
+                widgetTag.className = 'widget-subarea';
+                viewtag.parentElement.insertBefore(widgetTag, viewtag);
+                manager.display_model(undefined, model, { el: widgetTag });
+            }
+        }
+    });
+}

--- a/src/ipywidgets/scripts/copyBuild.js
+++ b/src/ipywidgets/scripts/copyBuild.js
@@ -6,4 +6,14 @@
 const fs = require('fs');
 const path = require('path');
 
+const ipywidgetsFile = path.resolve(__dirname, '..', 'dist', 'ipywidgets', 'ipywidgets.js');
+
+const limembedAmdFile = path.resolve(__dirname, '..', 'dist', 'lib', 'amd', 'libembed-amd.js');
+const limembedAmdFileContents = fs.readFileSync(limembedAmdFile, {encoding: 'utf8'}).toString();
+
+const limembedAmdRendererFile = path.resolve(__dirname, '..', 'dist', 'lib', 'amd', 'embed-amd-render.js');
+const limembedAmdRendererFileContents = fs.readFileSync(limembedAmdRendererFile, {encoding: 'utf8'}).toString();
+
+fs.appendFileSync(ipywidgetsFile, `\n\n\n\n\n//(VS Code Python) Injected libembed-amd.js contents\n\n\n${limembedAmdFileContents}`);
+fs.appendFileSync(ipywidgetsFile, `\n\n\n\n\n//(VS Code Python) Injected embed-amd-render.js contents\n\n\n${limembedAmdRendererFileContents}`);
 fs.copyFileSync(path.resolve(__dirname, '..', 'dist', 'ipywidgets', 'ipywidgets.js'), path.resolve(__dirname, '..', '..', '..', 'out', 'datascience-ui', 'native-editor', 'ipywidgets.js'));

--- a/src/ipywidgets/scripts/copyBuild.js
+++ b/src/ipywidgets/scripts/copyBuild.js
@@ -17,3 +17,4 @@ const limembedAmdRendererFileContents = fs.readFileSync(limembedAmdRendererFile,
 fs.appendFileSync(ipywidgetsFile, `\n\n\n\n\n//(VS Code Python) Injected libembed-amd.js contents\n\n\n${limembedAmdFileContents}`);
 fs.appendFileSync(ipywidgetsFile, `\n\n\n\n\n//(VS Code Python) Injected embed-amd-render.js contents\n\n\n${limembedAmdRendererFileContents}`);
 fs.copyFileSync(path.resolve(__dirname, '..', 'dist', 'ipywidgets', 'ipywidgets.js'), path.resolve(__dirname, '..', '..', '..', 'out', 'datascience-ui', 'native-editor', 'ipywidgets.js'));
+fs.copyFileSync(path.resolve(__dirname, '..', 'dist', 'ipywidgets', 'ipywidgets.js'), path.resolve(__dirname, '..', '..', '..', 'out', 'datascience-ui', 'history-react', 'ipywidgets.js'));

--- a/src/ipywidgets/webpack.config.js
+++ b/src/ipywidgets/webpack.config.js
@@ -6,77 +6,159 @@
 // Copied from https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/html-manager/webpack.config.js
 
 const postcss = require('postcss');
-var path = require('path');
+const path = require('path');
+const version = require(path.join(__dirname, 'node_modules', '@jupyter-widgets', 'html-manager', 'package.json')).version;
 
-module.exports = {
-    mode: 'production',
-    entry: './out/index.js',
-    output: {
-        filename: 'ipywidgets.js',
-        path: path.resolve(__dirname, 'dist', 'ipywidgets'),
-        publicPath: 'built/',
-		library: "vscIPyWidgets",
-		libraryTarget: "window"
+const publicPath =  'https://unpkg.com/@jupyter-widgets/html-manager@' + version + '/dist/';
+const rules = [
+    { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+    // jquery-ui loads some images
+    { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+    // required to load font-awesome
+    {
+        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+        use: {
+            loader: 'url-loader',
+            options: {
+                limit: 10000,
+                mimetype: 'application/font-woff'
+            }
+        }
     },
-    module: {
-        rules: [
-            { test: /\.css$/, use: [
-                'style-loader',
-                'css-loader',
+    {
+        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+        use: {
+            loader: 'url-loader',
+            options: {
+                limit: 10000,
+                mimetype: 'application/octet-stream'
+            }
+        }
+    },
+    { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+    {
+        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+        use: {
+            loader: 'url-loader',
+            options: {
+                limit: 10000,
+                mimetype: 'image/svg+xml'
+            }
+        }
+    }
+];
+
+module.exports = [
+    {
+        mode: 'production',
+        entry: './out/index.js',
+        output: {
+            filename: 'ipywidgets.js',
+            path: path.resolve(__dirname, 'dist', 'ipywidgets'),
+            publicPath: 'built/',
+            library: 'vscIPyWidgets',
+            libraryTarget: 'window'
+        },
+        module: {
+            rules: [
                 {
-                    loader: 'postcss-loader',
-                    options: {
-                        plugins: [
-                            postcss.plugin('delete-tilde', function() {
-                                return function (css) {
-                                    css.walkAtRules('import', function(rule) {
-                                        rule.params = rule.params.replace('~', '');
-                                    });
-                                };
-                            }),
-                            postcss.plugin('prepend', function() {
-                                return function(css) {
-                                    css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';")
-                                }
-                            }),
-                            require('postcss-import')(),
-                            require('postcss-cssnext')()
-                        ]
+                    test: /\.css$/,
+                    use: [
+                        'style-loader',
+                        'css-loader',
+                        {
+                            loader: 'postcss-loader',
+                            options: {
+                                plugins: [
+                                    postcss.plugin('delete-tilde', function() {
+                                        return function(css) {
+                                            css.walkAtRules('import', function(rule) {
+                                                rule.params = rule.params.replace('~', '');
+                                            });
+                                        };
+                                    }),
+                                    postcss.plugin('prepend', function() {
+                                        return function(css) {
+                                            css.prepend("@import '@jupyter-widgets/controls/css/labvariables.css';");
+                                        };
+                                    }),
+                                    require('postcss-import')(),
+                                    require('postcss-cssnext')()
+                                ]
+                            }
+                        }
+                    ]
+                },
+                // jquery-ui loads some images
+                { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
+                // required to load font-awesome
+                {
+                    test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+                    use: {
+                        loader: 'url-loader',
+                        options: {
+                            limit: 10000,
+                            mimetype: 'application/font-woff'
+                        }
+                    }
+                },
+                {
+                    test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+                    use: {
+                        loader: 'url-loader',
+                        options: {
+                            limit: 10000,
+                            mimetype: 'application/font-woff'
+                        }
+                    }
+                },
+                {
+                    test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+                    use: {
+                        loader: 'url-loader',
+                        options: {
+                            limit: 10000,
+                            mimetype: 'application/octet-stream'
+                        }
+                    }
+                },
+                { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
+                {
+                    test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+                    use: {
+                        loader: 'url-loader',
+                        options: {
+                            limit: 10000,
+                            mimetype: 'image/svg+xml'
+                        }
                     }
                 }
-            ]},
-            // jquery-ui loads some images
-            { test: /\.(jpg|png|gif)$/, use: 'file-loader' },
-            // required to load font-awesome
-            { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, use: {
-                loader: 'url-loader',
-                options: {
-                    limit: 10000,
-                    mimetype: 'application/font-woff'
-                }
-            }},
-            { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, use: {
-                loader: 'url-loader',
-                options: {
-                    limit: 10000,
-                    mimetype: 'application/font-woff'
-                }
-            }},
-            { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, use: {
-                loader: 'url-loader',
-                options: {
-                    limit: 10000,
-                    mimetype: 'application/octet-stream'
-                }
-            }},
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, use: 'file-loader' },
-            { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, use: {
-                loader: 'url-loader',
-                options: {
-                    limit: 10000,
-                    mimetype: 'image/svg+xml'
-                }
-            }}
-        ]
+            ]
+        }
     },
-};
+    {
+        // script that renders widgets using the amd embedding and can render third-party custom widgets
+        entry: './lib/embed-amd-render.js',
+        output: {
+            filename: 'embed-amd-render.js',
+            path: path.resolve(__dirname, 'dist', 'lib', 'amd'),
+            publicPath: publicPath,
+        },
+        module: { rules: rules },
+        mode: 'production'
+    },
+
+    {
+        // embed library that depends on requirejs, and can load third-party widgets dynamically
+        entry: './lib/libembed-amd.js',
+        output: {
+            library: '@jupyter-widgets/html-manager/dist/libembed-amd',
+            filename: 'libembed-amd.js',
+            path: path.resolve(__dirname, 'dist', 'lib', 'amd'),
+            publicPath: publicPath,
+            libraryTarget: 'amd'
+        },
+        module: { rules: rules },
+        mode: 'production'
+    }
+];

--- a/src/ipywidgets/webpack.config.js
+++ b/src/ipywidgets/webpack.config.js
@@ -9,7 +9,7 @@ const postcss = require('postcss');
 const path = require('path');
 const version = require(path.join(__dirname, 'node_modules', '@jupyter-widgets', 'html-manager', 'package.json')).version;
 
-const publicPath =  'https://unpkg.com/@jupyter-widgets/html-manager@' + version + '/dist/';
+const publicPath = 'https://unpkg.com/@jupyter-widgets/html-manager@' + version + '/dist/';
 const rules = [
     { test: /\.css$/, use: ['style-loader', 'css-loader'] },
     // jquery-ui loads some images
@@ -17,6 +17,16 @@ const rules = [
     // required to load font-awesome
     {
         test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+        use: {
+            loader: 'url-loader',
+            options: {
+                limit: 10000,
+                mimetype: 'application/font-woff'
+            }
+        }
+    },
+    {
+        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
         use: {
             loader: 'url-loader',
             options: {
@@ -142,7 +152,7 @@ module.exports = [
         output: {
             filename: 'embed-amd-render.js',
             path: path.resolve(__dirname, 'dist', 'lib', 'amd'),
-            publicPath: publicPath,
+            publicPath: publicPath
         },
         module: { rules: rules },
         mode: 'production'

--- a/webpack.datascience-ui.config.js
+++ b/webpack.datascience-ui.config.js
@@ -38,6 +38,7 @@ module.exports = [
                 { from: './**/*.png', to: '.' },
                 { from: './**/*.svg', to: '.' },
                 { from: './**/*.css', to: '.' },
+                { from: path.join(__dirname, 'node_modules', 'requirejs', 'require.js'), to: path.join(__dirname, 'out', 'datascience-ui', 'native-editor') },
                 { from: './**/*theme*.json', to: '.' }
             ], { context: 'src' }),
             new MonacoWebpackPlugin({

--- a/webpack.datascience-ui.config.js
+++ b/webpack.datascience-ui.config.js
@@ -38,7 +38,7 @@ module.exports = [
                 { from: './**/*.png', to: '.' },
                 { from: './**/*.svg', to: '.' },
                 { from: './**/*.css', to: '.' },
-                { from: path.join(__dirname, 'node_modules', 'requirejs', 'require.js'), to: path.join(__dirname, 'out', 'datascience-ui', 'native-editor') },
+                { from: path.join(__dirname, 'node_modules', 'requirejs', 'require.js'), to: path.join(__dirname, 'out', 'datascience-ui', 'history-react') },
                 { from: './**/*theme*.json', to: '.' }
             ], { context: 'src' }),
             new MonacoWebpackPlugin({
@@ -137,6 +137,7 @@ module.exports = [
                 { from: './**/*.png', to: '.' },
                 { from: './**/*.svg', to: '.' },
                 { from: './**/*.css', to: '.' },
+                { from: path.join(__dirname, 'node_modules', 'requirejs', 'require.js'), to: path.join(__dirname, 'out', 'datascience-ui', 'native-editor') },
                 { from: './**/*theme*.json', to: '.' }
             ], { context: 'src' }),
             new MonacoWebpackPlugin({


### PR DESCRIPTION
For #3429 

Please read `README.md` (for details)

The widgets are not integrated. It will not do anything.
Opportunity to review the code and architecture.
Will be plugged in once we have the backend kernel comms done.
Lot more to be done.

No point adding unit tests, as all of this is related to comms. And I don't want to hardcode any comms related tests (i.e. hardcode the logic). 

* A better and accurate test is to ensure things work, i.e. widgets are rendered, when sending the right message.
* Or testing the widget state computed by jupyter widget manager when its give comms messages.
* Or run tests and verify the output is as required (this will eventually have to be done, to ensure widget support does NOT break - manual testing everyday is not practical).