### PR TITLE
Fix codelens action for opening a dropdown on parametrized tests in windows 10

### DIFF
--- a/news/2 Fixes/8627.md
+++ b/news/2 Fixes/8627.md
@@ -1,0 +1,1 @@
+Fixes that the test selection drop-down did not open when a code lens for a parameterized test was clicked on windows.

--- a/src/client/testing/display/picker.ts
+++ b/src/client/testing/display/picker.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { QuickPickItem, Uri } from 'vscode';
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import * as constants from '../../common/constants';
+import { IFileSystem } from '../../common/platform/types';
 import { IServiceContainer } from '../../ioc/types';
 import { CommandSource } from '../common/constants';
 import { FlattenedTestFunction, ITestCollectionStorageService, TestFile, TestFunction, Tests, TestStatus, TestsToRun } from '../common/types';
@@ -12,7 +13,7 @@ import { ITestDisplay } from '../types';
 export class TestDisplay implements ITestDisplay {
     private readonly testCollectionStorage: ITestCollectionStorageService;
     private readonly appShell: IApplicationShell;
-    constructor(@inject(IServiceContainer) serviceRegistry: IServiceContainer,
+    constructor(@inject(IServiceContainer) private readonly serviceRegistry: IServiceContainer,
         @inject(ICommandManager) private readonly commandManager: ICommandManager) {
         this.testCollectionStorage = serviceRegistry.get<ITestCollectionStorageService>(ITestCollectionStorageService);
         this.appShell = serviceRegistry.get<IApplicationShell>(IApplicationShell);
@@ -57,7 +58,8 @@ export class TestDisplay implements ITestDisplay {
             return;
         }
         const fileName = file.fsPath;
-        const testFile = tests.testFiles.find(item => item.name === fileName || item.fullPath === fileName);
+        const fs = this.serviceRegistry.get<IFileSystem>(IFileSystem);
+        const testFile = tests.testFiles.find(item => item.name === fileName || fs.arePathsSame(item.fullPath, fileName));
         if (!testFile) {
             return;
         }

--- a/src/test/testing/display/picker.functional.test.ts
+++ b/src/test/testing/display/picker.functional.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Uri } from 'vscode';
+import { ApplicationShell } from '../../../client/common/application/applicationShell';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { IApplicationShell, ICommandManager } from '../../../client/common/application/types';
+import { FileSystem } from '../../../client/common/platform/fileSystem';
+import { PlatformService } from '../../../client/common/platform/platformService';
+import { IFileSystem } from '../../../client/common/platform/types';
+import { ServiceContainer } from '../../../client/ioc/container';
+import { IServiceContainer } from '../../../client/ioc/types';
+import { CommandSource } from '../../../client/testing/common/constants';
+import { TestCollectionStorageService } from '../../../client/testing/common/services/storageService';
+import { ITestCollectionStorageService, TestFunction, Tests } from '../../../client/testing/common/types';
+import { TestDisplay } from '../../../client/testing/display/picker';
+import { createEmptyResults } from '../results';
+
+// tslint:disable:no-any
+
+// tslint:disable-next-line: max-func-body-length
+suite('Testing - TestDisplay', () => {
+    const wkspace = Uri.file(__dirname);
+    let mockedCommandManager: ICommandManager;
+    let mockedServiceContainer: IServiceContainer;
+    let mockedTestCollectionStorage: ITestCollectionStorageService;
+    let mockedAppShell: IApplicationShell;
+    let testDisplay: TestDisplay;
+
+    function fullPathInTests(collectedTests: Tests, fullpath?: string): Tests {
+        collectedTests.testFiles = [{
+            fullPath: fullpath ? fullpath : 'path/to/testfile',
+            ...anything()
+        }];
+        return collectedTests;
+    }
+
+    setup(() => {
+        mockedCommandManager = mock(CommandManager);
+        mockedServiceContainer = mock(ServiceContainer);
+        mockedTestCollectionStorage = mock(TestCollectionStorageService);
+        mockedAppShell = mock(ApplicationShell);
+        when(mockedServiceContainer.get<ITestCollectionStorageService>(ITestCollectionStorageService))
+            .thenReturn(instance(mockedTestCollectionStorage));
+        when(mockedServiceContainer.get<IApplicationShell>(IApplicationShell))
+            .thenReturn(instance(mockedAppShell));
+
+        testDisplay = new TestDisplay(instance(mockedServiceContainer), instance(mockedCommandManager));
+    });
+
+    suite('displayFunctionTestPickerUI', () => {
+        const paths: { [key: string]: any } = {
+            match: {
+                fullPath: '/path/to/testfile',
+                fileName: '/path/to/testfile'
+            },
+            mismatch: {
+                fullPath: '/path/to/testfile',
+                fileName: '/testfile/to/path'
+            }
+        };
+        let tests: Tests;
+
+        function codeLensTestFunctions(testfunctions?: TestFunction[]): TestFunction[] {
+            if (!testfunctions) {
+                return [{ ...anything() }];
+            }
+            const functions: TestFunction[] = [];
+            testfunctions.forEach(fn => functions.push(fn));
+            return functions;
+        }
+
+        setup(() => {
+            tests = createEmptyResults();
+            when(mockedServiceContainer.get<IFileSystem>(IFileSystem)).thenReturn(new FileSystem(new PlatformService()));
+            when(mockedTestCollectionStorage.getTests(wkspace)).thenReturn(tests);
+            when(mockedAppShell.showQuickPick(anything(), anything())).thenResolve();
+        });
+
+        test(`Test that a dropdown picker for parametrized tests is shown if compared paths are equal (OS independent) (#8627)`, () => {
+            const { fullPath, fileName } = paths.match;
+            fullPathInTests(tests, fullPath);
+
+            testDisplay.displayFunctionTestPickerUI(CommandSource.commandPalette, wkspace, 'rootDirectory', Uri.file(fileName), codeLensTestFunctions());
+
+            verify(mockedAppShell.showQuickPick(anything(), anything())).once();
+        });
+
+        test(`Test that a dropdown picker for parametrized tests is NOT shown if compared paths are NOT equal (OS independent) (#8627)`, () => {
+            const { fullPath, fileName } = paths.mismatch;
+            fullPathInTests(tests, fullPath);
+
+            testDisplay.displayFunctionTestPickerUI(CommandSource.commandPalette, wkspace, 'rootDirectory', Uri.file(fileName), codeLensTestFunctions());
+
+            verify(mockedAppShell.showQuickPick(anything(), anything())).never();
+        });
+
+        test(`Test that clicking a codelens on parametrized tests opens a dropdown picker on windows (#8627)`, function () {
+            if (process.platform !== 'win32') {
+                // tslint:disable-next-line: no-invalid-this
+                this.skip();
+            }
+            // The error described in #8627 originated from the problem that the casing of the drive letter was different
+            // in a test items fullPath property to the one of a file that contained the clicked parametrized test.
+            const fileName = 'c:\\path\\to\\testfile';
+            fullPathInTests(tests, 'C:\\path\\to\\testfile');
+
+            testDisplay.displayFunctionTestPickerUI(CommandSource.commandPalette, wkspace, 'rootDirectory', Uri.file(fileName), codeLensTestFunctions());
+
+            verify(mockedAppShell.showQuickPick(anything(), anything())).once();
+        });
+    });
+});

--- a/src/test/testing/display/picker.unit.test.ts
+++ b/src/test/testing/display/picker.unit.test.ts
@@ -3,14 +3,22 @@
 
 'use strict';
 
-import { anything, instance, mock, verify } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Uri } from 'vscode';
+import { ApplicationShell } from '../../../client/common/application/applicationShell';
 import { CommandManager } from '../../../client/common/application/commandManager';
+import { IApplicationShell, ICommandManager } from '../../../client/common/application/types';
 import { Commands } from '../../../client/common/constants';
+import { FileSystem } from '../../../client/common/platform/fileSystem';
+import { IFileSystem } from '../../../client/common/platform/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
+import { ServiceContainer } from '../../../client/ioc/container';
+import { IServiceContainer } from '../../../client/ioc/types';
 import { CommandSource } from '../../../client/testing/common/constants';
-import { TestsToRun } from '../../../client/testing/common/types';
-import { onItemSelected, Type } from '../../../client/testing/display/picker';
+import { TestCollectionStorageService } from '../../../client/testing/common/services/storageService';
+import { ITestCollectionStorageService, TestFunction, Tests, TestsToRun } from '../../../client/testing/common/types';
+import { onItemSelected, TestDisplay, Type } from '../../../client/testing/display/picker';
+import { createEmptyResults } from '../results';
 
 // tslint:disable:no-any
 
@@ -96,6 +104,77 @@ suite('Unit Tests - Picker (execution of commands)', () => {
                     }
                 });
             });
+        });
+    });
+});
+
+suite('Testing - TestDisplay', () => {
+    const wkspace = Uri.file(__dirname);
+    let mockedCommandManager: ICommandManager;
+    let mockedServiceContainer: IServiceContainer;
+    let mockedTestCollectionStorage: ITestCollectionStorageService;
+    let mockedAppShell: IApplicationShell;
+    let mockedFileSytem: IFileSystem;
+    let testDisplay: TestDisplay;
+
+    function fullPathInTests(collectedTests: Tests, fullpath?: string): Tests {
+        collectedTests.testFiles = [{
+            fullPath: fullpath ? fullpath : 'path/to/testfile',
+            ...anything()
+        }];
+        return collectedTests;
+    }
+
+    setup(() => {
+        mockedCommandManager = mock(CommandManager);
+        mockedServiceContainer = mock(ServiceContainer);
+        mockedTestCollectionStorage = mock(TestCollectionStorageService);
+        mockedAppShell = mock(ApplicationShell);
+        when(mockedServiceContainer.get<ITestCollectionStorageService>(ITestCollectionStorageService))
+            .thenReturn(instance(mockedTestCollectionStorage));
+        when(mockedServiceContainer.get<IApplicationShell>(IApplicationShell))
+            .thenReturn(instance(mockedAppShell));
+
+        testDisplay = new TestDisplay(instance(mockedServiceContainer), instance(mockedCommandManager));
+    });
+
+    suite('displayFunctionTestPickerUI', () => {
+        const fileName = Uri.file('path/to/testfile');
+        let tests: Tests;
+
+        function codeLensTestFunctions(testfunctions?: TestFunction[]): TestFunction[] {
+            if (!testfunctions) {
+                return [{ ...anything() }];
+            }
+            const functions: TestFunction[] = [];
+            testfunctions.forEach(fn => functions.push(fn));
+            return functions;
+        }
+
+        setup(() => {
+            tests = createEmptyResults();
+            mockedFileSytem = mock(FileSystem);
+            when(mockedServiceContainer.get<IFileSystem>(IFileSystem)).thenReturn(instance(mockedFileSytem));
+            when(mockedTestCollectionStorage.getTests(wkspace)).thenReturn(tests);
+            when(mockedAppShell.showQuickPick(anything(), anything())).thenResolve();
+        });
+
+        test(`Test that a dropdown picker for parametrized tests is shown if compared paths are equal (#8627)`, () => {
+            fullPathInTests(tests);
+            when(mockedFileSytem.arePathsSame(anything(), anything())).thenReturn(true);
+
+            testDisplay.displayFunctionTestPickerUI(CommandSource.commandPalette, wkspace, 'rootDirectory', fileName, codeLensTestFunctions());
+
+            verify(mockedAppShell.showQuickPick(anything(), anything())).once();
+        });
+
+        test(`Test that a dropdown picker for parametrized tests is NOT shown if compared paths are NOT equal (#8627)`, () => {
+            fullPathInTests(tests);
+            when(mockedFileSytem.arePathsSame(anything(), anything())).thenReturn(false);
+
+            testDisplay.displayFunctionTestPickerUI(CommandSource.commandPalette, wkspace, 'rootDirectory', fileName, codeLensTestFunctions());
+
+            verify(mockedAppShell.showQuickPick(anything(), anything())).never();
         });
     });
 });


### PR DESCRIPTION
Fixes #8627. When the path of an actual test file (given by vscode.Uri.fsPath) is later compared against the fullPath of a single item of tests.TestFiles the drive letter mismatches and aborts further actions despite the rest of the path is the same.


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
