### PR TITLE
WIP: Add "Run All" CodeLens for parametrized tests

### DIFF
--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -97,6 +97,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Tests_Run]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri, undefined | TestsToRun];
     // When command is invoked from a tree node, first argument is the node data.
     [Commands.Tests_Debug]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri, undefined | TestsToRun];
+    [Commands.Tests_Run_Parametrized]: [undefined, undefined | CommandSource, Uri, TestFunction[]];
     // When command is invoked from a tree node, first argument is the node data.
     [Commands.Tests_Discover]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri];
     [Commands.Tests_Run_Failed]: [undefined, CommandSource, Uri];

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -32,6 +32,7 @@ export namespace Commands {
     export const Tests_Run_Failed = 'python.runFailedTests';
     export const Sort_Imports = 'python.sortImports';
     export const Tests_Run = 'python.runtests';
+    export const Tests_Run_Parametrized = 'python.runParametrizedTests';
     export const Tests_Debug = 'python.debugtests';
     export const Tests_Ask_To_Stop_Test = 'python.askToStopTests';
     export const Tests_Ask_To_Stop_Discovery = 'python.askToStopTestDiscovery';

--- a/src/client/testing/codeLenses/testFiles.ts
+++ b/src/client/testing/codeLenses/testFiles.ts
@@ -227,6 +227,11 @@ function getFunctionCodeLens(file: Uri, functionsAndSuites: FunctionsAndSuites,
             title: `${getTestStatusIcons(functions)}${constants.Text.CodeLensDebugUnitTest} (Multiple)`,
             command: constants.Commands.Tests_Picker_UI_Debug,
             arguments: [undefined, CommandSource.codelens, file, functions]
+        }),
+        new CodeLens(range, {
+            title: `${getTestStatusIcons(functions)}Run All`,
+            command: constants.Commands.Tests_Run_Parametrized,
+            arguments: [undefined, CommandSource.codelens, file, functions]
         })
     ];
 }

--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -225,6 +225,13 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
         const testDisplay = this.serviceContainer.get<ITestDisplay>(ITestDisplay);
         testDisplay.displayFunctionTestPickerUI(cmdSource, testManager.workspaceFolder, testManager.workingDirectory, file, testFunctions, debug);
     }
+    public async runParametrizedTests(cmdSource: CommandSource, file: Uri, testFunctions: TestFunction[]) {
+        const testManager = await this.getTestManager(true, file);
+        if (!testManager) {
+            return;
+        }
+        await this.runTestsImpl(cmdSource, file, { testFunction: testFunctions });
+    }
     public viewOutput(_cmdSource: CommandSource) {
         sendTelemetryEvent(EventName.UNITTEST_VIEW_OUTPUT);
         this.outputChannel.show();
@@ -397,6 +404,10 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
             commandManager.registerCommand(
                 constants.Commands.Tests_Picker_UI_Debug,
                 (_, cmdSource: CommandSource = CommandSource.commandPalette, file: Uri, testFunctions: TestFunction[]) => this.displayPickerUI(cmdSource, file, testFunctions, true)
+            ),
+            commandManager.registerCommand(
+                constants.Commands.Tests_Run_Parametrized,
+                (_, cmdSource: CommandSource = CommandSource.commandPalette, file: Uri, testFunctions: TestFunction[]) => this.runParametrizedTests(cmdSource, file, testFunctions)
             ),
             commandManager.registerCommand(constants.Commands.Tests_Stop, (_, resource: Uri) => this.stopTests(resource)),
             commandManager.registerCommand(constants.Commands.Tests_ViewOutput, (_, cmdSource: CommandSource = CommandSource.commandPalette) => this.viewOutput(cmdSource)),


### PR DESCRIPTION
Related to #5608. 

This pull request aims to add a third code lens for running all parametrized tests that belong to a test function/method. Unlike suggested in the mentioned issue i found it more practical to not add the "Run All" option in the dropdown/picker. If one wants to run all parametrized tests that belong to a specific test he or she needs to only click this codelens and not click on run/debug test and then select that option from the dropdown/picker. So the usecase is more that one is able to select specific test with the first two codelenses that lets you select which specific test you want to run or debug, and to test if all of those parametrized tests run click on "Run All".

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [ ] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [ ] The wiki is updated with any design decisions/details.
