### PR TITLE
Re-enable support for source maps

### DIFF
--- a/news/2 Fixes/8686.md
+++ b/news/2 Fixes/8686.md
@@ -1,0 +1,1 @@
+Re-enable support for source-maps.

--- a/src/client/sourceMapSupport.ts
+++ b/src/client/sourceMapSupport.ts
@@ -26,6 +26,7 @@ export class SourceMapSupport {
             return;
         }
         await this.enableSourceMaps(true);
+        require('source-map-support').install();
         const localize = require('./common/utils/localize') as typeof import('./common/utils/localize');
         const disable = localize.Diagnostics.disableSourceMaps();
         this.vscode.window.showWarningMessage(localize.Diagnostics.warnSourceMaps(), disable).then(selection => {

--- a/src/test/sourceMapSupport.unit.test.ts
+++ b/src/test/sourceMapSupport.unit.test.ts
@@ -7,13 +7,13 @@
 
 import { expect } from 'chai';
 import * as path from 'path';
+import rewiremock from 'rewiremock';
+import * as sinon from 'sinon';
 import { ConfigurationTarget, Disposable } from 'vscode';
 import { Diagnostics } from '../client/common/utils/localize';
 import { EXTENSION_ROOT_DIR } from '../client/constants';
 import { initialize, SourceMapSupport } from '../client/sourceMapSupport';
 import { noop, sleep } from './core';
-import * as sinon from 'sinon';
-import rewiremock from 'rewiremock';
 
 suite('Source Map Support', () => {
     function createVSCStub(isEnabled: boolean = false, selectDisableButton: boolean = false) {

--- a/src/test/sourceMapSupport.unit.test.ts
+++ b/src/test/sourceMapSupport.unit.test.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-// tslint:disable:no-any no-unused-expression chai-vague-errors no-unnecessary-override max-func-body-length max-classes-per-file match-default-export-name
+// tslint:disable:no-unused-expression chai-vague-errors no-unnecessary-override max-func-body-length max-classes-per-file match-default-export-name
 
 import { expect } from 'chai';
 import * as path from 'path';
@@ -24,6 +24,7 @@ suite('Source Map Support', () => {
         };
         const vscode = {
             workspace: {
+                // tslint:disable-next-line: no-any
                 getConfiguration: (setting: string, _defaultValue: any) => {
                     if (setting !== 'python.diagnostics') {
                         return;
@@ -63,6 +64,7 @@ suite('Source Map Support', () => {
     });
     test('Test message is not displayed when source maps are not enabled', async () => {
         const stub = createVSCStub(false);
+        // tslint:disable-next-line: no-any
         initialize(stub.vscode as any);
         await sleep(100);
         expect(stub.stubInfo.configValueRetrieved).to.be.equal(true, 'Config Value not retrieved');
@@ -74,6 +76,7 @@ suite('Source Map Support', () => {
             protected async enableSourceMaps(_enable: boolean) {
                 noop();
             }
+        // tslint:disable-next-line: no-any
         }(stub.vscode as any);
         rewiremock.enable();
         const installStub = sinon.stub();
@@ -91,6 +94,7 @@ suite('Source Map Support', () => {
             protected async enableSourceMaps(_enable: boolean) {
                 noop();
             }
+        // tslint:disable-next-line: no-any
         }(stub.vscode as any);
 
         await instance.initialize();
@@ -110,6 +114,7 @@ suite('Source Map Support', () => {
                 sourceFilesPassed.push(sourceFile);
                 return Promise.resolve();
             }
+        // tslint:disable-next-line: no-any
         }(stub.vscode as any);
 
         await instance.enableSourceMaps(enableSourceMaps);

--- a/src/test/sourceMapSupport.unit.test.ts
+++ b/src/test/sourceMapSupport.unit.test.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-// tslint:disable:no-any no-unused-expression chai-vague-errors no-unnecessary-override max-func-body-length max-classes-per-file
+// tslint:disable:no-any no-unused-expression chai-vague-errors no-unnecessary-override max-func-body-length max-classes-per-file match-default-export-name
 
 import { expect } from 'chai';
 import * as path from 'path';


### PR DESCRIPTION
For #8686

Would have saved a lot of time when looking into  https://github.com/microsoft/vscode-python/issues/8665

This PR merely reverts a change introduced in https://github.com/Microsoft/vscode-python/issues/3905
(basically we initialize source maps manually, something we used to do all along).
