### PR TITLE
Fixes to streaming image data

### DIFF
--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -712,7 +712,6 @@ export class JupyterNotebookBase implements INotebook {
                     });
                 }
 
-
                 // Keep track of our clear state
                 const clearState: Map<string, boolean> = new Map<string, boolean>();
 

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -628,15 +628,12 @@ export class JupyterNotebookBase implements INotebook {
         }
     }
 
-    private handleIOPub(subscriber: CellSubscriber, silent: boolean | undefined, msg: KernelMessage.IIOPubMessage) {
+    private handleIOPub(subscriber: CellSubscriber, silent: boolean | undefined, clearState: Map<string, boolean>, msg: KernelMessage.IIOPubMessage) {
         // tslint:disable-next-line:no-require-imports
         const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
 
         // Create a trimming function. Only trim user output. Silent output requires the full thing
         const trimFunc = silent ? (s: string) => s : this.trimOutput.bind(this);
-
-        // Keep track of our clear state
-        const clearState: Map<string, boolean> = new Map<string, boolean>();
 
         try {
             if (jupyterLab.KernelMessage.isExecuteResultMsg(msg)) {
@@ -715,6 +712,10 @@ export class JupyterNotebookBase implements INotebook {
                     });
                 }
 
+
+                // Keep track of our clear state
+                const clearState: Map<string, boolean> = new Map<string, boolean>();
+
                 // Listen to the reponse messages and update state as we go
                 if (request) {
                     // Stop handling the request if the subscriber is canceled.
@@ -723,7 +724,7 @@ export class JupyterNotebookBase implements INotebook {
                     });
 
                     // Listen to messages.
-                    request.onIOPub = this.handleIOPub.bind(this, subscriber, silent);
+                    request.onIOPub = this.handleIOPub.bind(this, subscriber, silent, clearState);
                     request.onStdin = this.handleInputRequest.bind(this, subscriber);
 
                     // When the request finishes we are done


### PR DESCRIPTION
For #8483
Basically the images returned from livelossplot were concatenated (resulting in the display of multiple images, instead of one).