### PR TITLE
Handle kernel interrupt correctly (due to changes in @jupyterlab)

### DIFF
--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -730,7 +730,6 @@ export class JupyterNotebookBase implements INotebook {
 
                     // When the request finishes we are done
                     request.done
-                        .finally(() => exitHandlerDisposable?.dispose())
                         .then(() => subscriber.complete(this.sessionStartTime))
                         .catch(e => {
                             // @jupyterlab/services throws a `Canceled` error when the kernel is interrupted.
@@ -740,7 +739,8 @@ export class JupyterNotebookBase implements INotebook {
                             } else {
                                 subscriber.error(this.sessionStartTime, e);
                             }
-                        });
+                        })
+                        .finally(() => exitHandlerDisposable?.dispose()).ignoreErrors();
                 } else {
                     subscriber.error(this.sessionStartTime, this.getDisposedError());
                 }

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -628,12 +628,15 @@ export class JupyterNotebookBase implements INotebook {
         }
     }
 
-    private handleIOPub(subscriber: CellSubscriber, silent: boolean | undefined, clearState: Map<string, boolean>, msg: KernelMessage.IIOPubMessage) {
+    private handleIOPub(subscriber: CellSubscriber, silent: boolean | undefined, msg: KernelMessage.IIOPubMessage) {
         // tslint:disable-next-line:no-require-imports
         const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
 
         // Create a trimming function. Only trim user output. Silent output requires the full thing
         const trimFunc = silent ? (s: string) => s : this.trimOutput.bind(this);
+
+        // Keep track of our clear state
+        const clearState: Map<string, boolean> = new Map<string, boolean>();
 
         try {
             if (jupyterLab.KernelMessage.isExecuteResultMsg(msg)) {
@@ -723,7 +726,7 @@ export class JupyterNotebookBase implements INotebook {
                     });
 
                     // Listen to messages.
-                    request.onIOPub = this.handleIOPub.bind(this, subscriber, silent, clearState);
+                    request.onIOPub = this.handleIOPub.bind(this, subscriber, silent);
                     request.onStdin = this.handleInputRequest.bind(this, subscriber);
 
                     // When the request finishes we are done

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -733,6 +733,8 @@ export class JupyterNotebookBase implements INotebook {
                         .finally(() => exitHandlerDisposable?.dispose())
                         .then(() => subscriber.complete(this.sessionStartTime))
                         .catch(e => {
+                            // @jupyterlab/services throws a `Canceled` error when the kernel is interrupted.
+                            // Such an error must be ignored.
                             if (e && e instanceof Error && e.message === 'Canceled'){
                                 subscriber.complete(this.sessionStartTime);
                             } else {

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -712,7 +712,6 @@ export class JupyterNotebookBase implements INotebook {
                     });
                 }
 
-
                 // Keep track of our clear state
                 const clearState: Map<string, boolean> = new Map<string, boolean>();
 

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -715,9 +715,6 @@ export class JupyterNotebookBase implements INotebook {
                     });
                 }
 
-                // Keep track of our clear state
-                const clearState: Map<string, boolean> = new Map<string, boolean>();
-
                 // Listen to the reponse messages and update state as we go
                 if (request) {
                     // Stop handling the request if the subscriber is canceled.

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -628,15 +628,12 @@ export class JupyterNotebookBase implements INotebook {
         }
     }
 
-    private handleIOPub(subscriber: CellSubscriber, silent: boolean | undefined, msg: KernelMessage.IIOPubMessage) {
+    private handleIOPub(subscriber: CellSubscriber, silent: boolean | undefined, clearState: Map<string, boolean>, msg: KernelMessage.IIOPubMessage) {
         // tslint:disable-next-line:no-require-imports
         const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
 
         // Create a trimming function. Only trim user output. Silent output requires the full thing
         const trimFunc = silent ? (s: string) => s : this.trimOutput.bind(this);
-
-        // Keep track of our clear state
-        const clearState: Map<string, boolean> = new Map<string, boolean>();
 
         try {
             if (jupyterLab.KernelMessage.isExecuteResultMsg(msg)) {
@@ -715,6 +712,10 @@ export class JupyterNotebookBase implements INotebook {
                     });
                 }
 
+
+                // Keep track of our clear state
+                const clearState: Map<string, boolean> = new Map<string, boolean>();
+
                 // Listen to the reponse messages and update state as we go
                 if (request) {
                     // Stop handling the request if the subscriber is canceled.
@@ -723,7 +724,7 @@ export class JupyterNotebookBase implements INotebook {
                     });
 
                     // Listen to messages.
-                    request.onIOPub = this.handleIOPub.bind(this, subscriber, silent);
+                    request.onIOPub = this.handleIOPub.bind(this, subscriber, silent, clearState);
                     request.onStdin = this.handleInputRequest.bind(this, subscriber);
 
                     // When the request finishes we are done

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -729,7 +729,8 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     private findPythonPath(): string {
         try {
-            const output = child_process.execFileSync('python', ['-c', 'import sys;print(sys.executable)'], { encoding: 'utf8' });
+            // Give preference to the CI test python (could also be set in launch.json for debugging).
+            const output = child_process.execFileSync(process.env.CI_PYTHON_PATH || 'python', ['-c', 'import sys;print(sys.executable)'], { encoding: 'utf8' });
             return output.replace(/\r?\n/g, '');
         } catch (ex) {
             return 'python';

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { nbformat } from '@jupyterlab/coreutils';
-import * as assert from 'assert';
+import { assert } from 'chai';
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs-extra';
 import { injectable } from 'inversify';

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { nbformat } from '@jupyterlab/coreutils';
-import { expect, assert } from 'chai';
+import { assert } from 'chai';
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs-extra';
 import { injectable } from 'inversify';
@@ -702,7 +702,7 @@ suite('DataScience notebook tests', () => {
             result === InterruptResult.Restarted,
             `Timed out before interrupt for result: ${result}: ${code}`);
 
-            return result;
+        return result;
     }
 
     runTest('Interrupt kernel', async () => {

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { nbformat } from '@jupyterlab/coreutils';
-import { assert } from 'chai';
+import * as assert from 'assert';
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs-extra';
 import { injectable } from 'inversify';
@@ -692,11 +692,7 @@ suite('DataScience notebook tests', () => {
         // Then we should get our finish unless there was a restart
         await waitForPromise(finishedPromise.promise, sleepMs);
         assert.equal(finishedBefore, false, 'Finished before the interruption');
-        // If there's an error, we only allow the `Canceled` error throw by @jupyterlab.
-        // This error gets thrown when kernel is interrupted.
-        if (error) {
-            assert.equal(error?.message, 'Canceled', 'Error must be thrown during interrupt');
-        }
+        assert.equal(error, undefined, 'Error thrown during interrupt');
         assert.ok(finishedPromise.completed ||
             result === InterruptResult.TimedOut ||
             result === InterruptResult.Restarted,

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -672,7 +672,7 @@ suite('DataScience notebook tests', () => {
         let interrupted = false;
         let finishedBefore = false;
         const finishedPromise = createDeferred();
-        let error: Error | undefined;
+        let error;
         const observable = notebook!.executeObservable(code, Uri.file('foo.py').fsPath, 0, uuid(), false);
         observable.subscribe(c => {
             if (c.length > 0 && c[0].state === CellState.error) {


### PR DESCRIPTION
For #8483

Updates to @jupyterlab has resulted in some minor changes to how code works when a kernel is interrupted.
Also introduced changes to allow debugging functional tests locally with CI_PYTHON_PATH