### PR TITLE
Ensure arguments are generated correctly for `getRemoteLauncherCommand` when in debugger experiment

### DIFF
--- a/news/2 Fixes/8685.md
+++ b/news/2 Fixes/8685.md
@@ -1,0 +1,1 @@
+Ensure arguments are generated correctly for `getRemoteLauncherCommand` when in debugger experiment.

--- a/src/client/debugger/extension/adapter/factory.ts
+++ b/src/client/debugger/extension/adapter/factory.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { DebugAdapterDescriptor, DebugAdapterExecutable, DebugAdapterServer, DebugSession, WorkspaceFolder } from 'vscode';
 import { IApplicationShell } from '../../../common/application/types';
-import { DebugAdapterNewPtvsd } from '../../../common/experimentGroups';
+import { DebugAdapterDescriptorFactory as DebugAdapterExperiment, DebugAdapterNewPtvsd } from '../../../common/experimentGroups';
 import { traceVerbose } from '../../../common/logger';
 import { IExperimentsManager } from '../../../common/types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
@@ -26,7 +26,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IExperimentsManager) private readonly experimentsManager: IExperimentsManager
-    ) {}
+    ) { }
     public async createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): Promise<DebugAdapterDescriptor> {
         const configuration = session.configuration as (LaunchRequestArguments | AttachRequestArguments);
 
@@ -86,6 +86,9 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
 
     public getRemotePtvsdArgs(remoteDebugOptions: RemoteDebugOptions): string[] {
         const waitArgs = remoteDebugOptions.waitUntilDebuggerAttaches ? ['--wait'] : [];
+        if (this.experimentsManager.inExperiment(DebugAdapterExperiment.experiment) && this.experimentsManager.inExperiment(DebugAdapterNewPtvsd.experiment)) {
+            return ['--host', remoteDebugOptions.host, '--port', remoteDebugOptions.port.toString(), ...waitArgs];
+        }
         return ['--default', '--host', remoteDebugOptions.host, '--port', remoteDebugOptions.port.toString(), ...waitArgs];
     }
 

--- a/src/test/extension.unit.test.ts
+++ b/src/test/extension.unit.test.ts
@@ -59,14 +59,14 @@ suite('Extension API Debugger', () => {
 
     test('Test debug launcher args (no-wait and in experiment)', async () => {
         mockInExperiment();
-        when(debugAdapterFactory.getRemotePtvsdArgs(anything())).thenReturn(['--default', '--host', 'something', '--port', '1234']);
+        when(debugAdapterFactory.getRemotePtvsdArgs(anything())).thenReturn(['--host', 'something', '--port', '1234']);
 
         const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
             'something',
             1234,
             false
         );
-        const expectedArgs = [ptvsdPath, '--default', '--host', 'something', '--port', '1234'];
+        const expectedArgs = [ptvsdPath, '--host', 'something', '--port', '1234'];
 
         expect(args).to.be.deep.equal(expectedArgs);
     });
@@ -86,14 +86,14 @@ suite('Extension API Debugger', () => {
 
     test('Test debug launcher args (wait and in experiment)', async () => {
         mockInExperiment();
-        when(debugAdapterFactory.getRemotePtvsdArgs(anything())).thenReturn(['--default', '--host', 'something', '--port', '1234', '--wait']);
+        when(debugAdapterFactory.getRemotePtvsdArgs(anything())).thenReturn(['--host', 'something', '--port', '1234', '--wait']);
 
         const args = await buildApi(Promise.resolve(), instance(experimentsManager), instance(debugAdapterFactory), instance(configurationService)).debug.getRemoteLauncherCommand(
             'something',
             1234,
             true
         );
-        const expectedArgs = [ptvsdPath, '--default', '--host', 'something', '--port', '1234', '--wait'];
+        const expectedArgs = [ptvsdPath, '--host', 'something', '--port', '1234', '--wait'];
 
         expect(args).to.be.deep.equal(expectedArgs);
     });


### PR DESCRIPTION
For #8685

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Unit tests & system/integration tests are added/updated
