### PR TITLE
Remove unnecessary DS interactive notebook debugger test

### DIFF
--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -221,12 +221,6 @@ suite('DataScience Debugger tests', () => {
         await debugCell('#%%\nprint("bar")');
     });
 
-    // Debugging with a breakpoint requires the file to actually exist on disk.
-
-    test('Debug cell with breakpoint in another file', async () => {
-        await debugCell('#%%\nprint("bar")\nprint("baz")', new Range(new Position(3, 0), new Position(3, 0)), 'bar.py');
-    });
-
     test('Debug remote', async () => {
         const python = await getNotebookCapableInterpreter(ioc, processFactory);
         const procService = await processFactory.create();


### PR DESCRIPTION
For #8483 

Testing breakpoints in external file is part of debugger functionality.
Remove this test as its considered standard debugger functionality that we (DS) don't need.