### PR TITLE
Reduce content logged in redux logger

### DIFF
--- a/src/datascience-ui/react-common/logger.ts
+++ b/src/datascience-ui/react-common/logger.ts
@@ -10,6 +10,7 @@ export function logMessage(message: string) {
     // put here to prevent having to disable the console log warning
 
     if (enableLogger) {
+        console.error('hello');
         // tslint:disable-next-line: no-console
         console.log(message);
     }

--- a/src/datascience-ui/react-common/logger.ts
+++ b/src/datascience-ui/react-common/logger.ts
@@ -10,7 +10,6 @@ export function logMessage(message: string) {
     // put here to prevent having to disable the console log warning
 
     if (enableLogger) {
-        console.error('hello');
         // tslint:disable-next-line: no-console
         console.log(message);
     }


### PR DESCRIPTION
For #8483
The logs are around 700MB. This attempts to reduce the size by removing unnecessary stuff from being logged by the redux logger