### PR TITLE
remove the '$0' from the parenthesis when intellisense adds it.

### DIFF
--- a/news/2 Fixes/8101.md
+++ b/news/2 Fixes/8101.md
@@ -1,0 +1,1 @@
+Prevented '$0' from appearing inside brackets when using intellisense autocomplete.

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -188,6 +188,13 @@ export class Editor extends React.Component<IEditorProps, IEditorState> {
     private modelChanged = (e: monacoEditor.editor.IModelContentChangedEvent) => {
         if (this.state.model) {
             this.props.onChange(e.changes, this.state.model);
+            const value = this.state.model.getValue();
+
+            // the second condition means that the changes are more than one character,
+            // like intellisense or a ctrl + v
+            if (value.includes('($0)') && e.changes[0].rangeLength > 0) {
+                this.state.model.setValue(value.replace('($0)', '()'));
+            }
         }
     }
 

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -190,10 +190,14 @@ export class Editor extends React.Component<IEditorProps, IEditorState> {
             this.props.onChange(e.changes, this.state.model);
             const value = this.state.model.getValue();
 
-            // the second condition means that the changes are more than one character,
-            // like intellisense or a ctrl + v
-            if (value.includes('($0)') && e.changes[0].rangeLength > 0) {
+            if (value.includes('($0)')) {
                 this.state.model.setValue(value.replace('($0)', '()'));
+                const pos = this.state.model.getPositionAt(value.length - 3);
+                setTimeout(() => {
+                    if (this.state.editor) {
+                        this.state.editor.setPosition(pos);
+                    }
+                }, 0);
             }
         }
     }


### PR DESCRIPTION
Cursor position still appears at the end instead of inside
the parenthesis.

For #8101

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
