### PR TITLE
Add "Run All/Debug All" dropdown picker for parametrized tests

### DIFF
--- a/news/1 Enhancements/5608.md
+++ b/news/1 Enhancements/5608.md
@@ -1,0 +1,1 @@
+Add QuickPick dropdown option _Run All/Debug All_ when clicking on a Code Lens for a parametrized test to be able to run/debug all belonging test variants at once. Thanks to [Philipp Loose](https://github.com/phloose)

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -97,6 +97,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [Commands.Tests_Run]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri, undefined | TestsToRun];
     // When command is invoked from a tree node, first argument is the node data.
     [Commands.Tests_Debug]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri, undefined | TestsToRun];
+    [Commands.Tests_Run_Parametrized]: [undefined, undefined | CommandSource, Uri, TestFunction[], boolean];
     // When command is invoked from a tree node, first argument is the node data.
     [Commands.Tests_Discover]: [undefined | TestWorkspaceFolder, undefined | CommandSource, undefined | Uri];
     [Commands.Tests_Run_Failed]: [undefined, CommandSource, Uri];

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -32,6 +32,7 @@ export namespace Commands {
     export const Tests_Run_Failed = 'python.runFailedTests';
     export const Sort_Imports = 'python.sortImports';
     export const Tests_Run = 'python.runtests';
+    export const Tests_Run_Parametrized = 'python.runParametrizedTests';
     export const Tests_Debug = 'python.debugtests';
     export const Tests_Ask_To_Stop_Test = 'python.askToStopTests';
     export const Tests_Ask_To_Stop_Discovery = 'python.askToStopTestDiscovery';

--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -225,6 +225,13 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
         const testDisplay = this.serviceContainer.get<ITestDisplay>(ITestDisplay);
         testDisplay.displayFunctionTestPickerUI(cmdSource, testManager.workspaceFolder, testManager.workingDirectory, file, testFunctions, debug);
     }
+    public async runParametrizedTests(cmdSource: CommandSource, resource: Uri, testFunctions: TestFunction[], debug?: boolean) {
+        const testManager = await this.getTestManager(true, resource);
+        if (!testManager) {
+            return;
+        }
+        await this.runTestsImpl(cmdSource, resource, { testFunction: testFunctions }, undefined, debug);
+    }
     public viewOutput(_cmdSource: CommandSource) {
         sendTelemetryEvent(EventName.UNITTEST_VIEW_OUTPUT);
         this.outputChannel.show();
@@ -397,6 +404,10 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
             commandManager.registerCommand(
                 constants.Commands.Tests_Picker_UI_Debug,
                 (_, cmdSource: CommandSource = CommandSource.commandPalette, file: Uri, testFunctions: TestFunction[]) => this.displayPickerUI(cmdSource, file, testFunctions, true)
+            ),
+            commandManager.registerCommand(
+                constants.Commands.Tests_Run_Parametrized,
+                (_, cmdSource: CommandSource = CommandSource.commandPalette, resource: Uri, testFunctions: TestFunction[], debug: boolean) => this.runParametrizedTests(cmdSource, resource, testFunctions, debug)
             ),
             commandManager.registerCommand(constants.Commands.Tests_Stop, (_, resource: Uri) => this.stopTests(resource)),
             commandManager.registerCommand(constants.Commands.Tests_ViewOutput, (_, cmdSource: CommandSource = CommandSource.commandPalette) => this.viewOutput(cmdSource)),

--- a/src/test/testing/display/picker.unit.test.ts
+++ b/src/test/testing/display/picker.unit.test.ts
@@ -16,7 +16,7 @@ import { onItemSelected, Type } from '../../../client/testing/display/picker';
 
 suite('Unit Tests - Picker (execution of commands)', () => {
     getNamesAndValues<Type>(Type).forEach(item => {
-        getNamesAndValues<CommandSource>(Type).forEach(commandSource => {
+        getNamesAndValues<CommandSource>(CommandSource).forEach(commandSource => {
             [true, false].forEach(debug => {
                 test(`Invoking command for selection ${item.name} from ${commandSource.name} (${debug ? 'Debug' : 'No debug'})`, async () => {
                     const commandManager = mock(CommandManager);
@@ -24,6 +24,14 @@ suite('Unit Tests - Picker (execution of commands)', () => {
 
                     const testFunction = 'some test Function';
                     const selection = { type: item.value, fn: { testFunction } };
+                    // Getting the value of CommandSource.commandPalette in getNamesAndValues(CommandSource)
+                    // fails because the names and values object is build by accessing the CommandSource enum
+                    // properties by value. In case of commandpalette the property is commandPalette and the
+                    // respective value is commandpalette which do not match and thus return undefined for value.
+                    if (commandSource.name === 'commandpalette') {
+                        commandSource.value = CommandSource.commandPalette;
+                    }
+
                     onItemSelected(instance(commandManager), commandSource.value, workspaceUri, selection as any, debug);
 
                     switch (selection.type) {

--- a/src/test/testing/display/picker.unit.test.ts
+++ b/src/test/testing/display/picker.unit.test.ts
@@ -23,7 +23,14 @@ suite('Unit Tests - Picker (execution of commands)', () => {
                     const workspaceUri = Uri.file(__filename);
 
                     const testFunction = 'some test Function';
-                    const selection = { type: item.value, fn: { testFunction } };
+                    const testFunctions = [{
+                        name: 'some_name',
+                        nameToRun: 'some_name_to_run',
+                        time: 0,
+                        resource: workspaceUri
+                    }];
+                    const selection = { type: item.value, fn: { testFunction }, fns: testFunctions };
+
                     // Getting the value of CommandSource.commandPalette in getNamesAndValues(CommandSource)
                     // fails because the names and values object is build by accessing the CommandSource enum
                     // properties by value. In case of commandpalette the property is commandPalette and the
@@ -46,6 +53,10 @@ suite('Unit Tests - Picker (execution of commands)', () => {
                         }
                         case Type.RunAll: {
                             verify(commandManager.executeCommand(Commands.Tests_Run, undefined, commandSource.value, workspaceUri, undefined)).once();
+                            return;
+                        }
+                        case Type.RunParametrized: {
+                            verify(commandManager.executeCommand(Commands.Tests_Run_Parametrized, undefined, commandSource.value, workspaceUri, selection.fns, debug)).once();
                             return;
                         }
                         case Type.ReDiscover: {


### PR DESCRIPTION
Related to #5608 

This pull requests adds a picker option (_Run All/Debug All_) to the dropdown that shows when clicking on the code lens for a parametrized test. That way it is possible to run/debug all test variants that belong to a parametrized tests.

_Run All_:
![run_all](https://user-images.githubusercontent.com/37411699/69483737-4e675980-0e2b-11ea-8f18-80104ba3f38c.png)

_Debug All_:
![debug_all](https://user-images.githubusercontent.com/37411699/69483738-532c0d80-0e2b-11ea-9a06-9dae2b7586af.png)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] ~Has sufficient logging.~
- [x] ~Has telemetry for enhancements.~
- [x] Unit tests & system/integration tests are added/updated
- [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- [x] ~The wiki is updated with any design decisions/details.~
