### PR TITLE
Make nb metadata available to jupyter startup and kernel selection layers

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -231,7 +231,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     }
 
     public async getNotebookOptions(): Promise<INotebookServerOptions> {
-        const options = this.ipynbProvider.getNotebookOptions();
+        const options = await this.ipynbProvider.getNotebookOptions();
         const metadata = this.notebookJson.metadata;
         return {
             ...options,

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -231,7 +231,12 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     }
 
     public async getNotebookOptions(): Promise<INotebookServerOptions> {
-        return this.ipynbProvider.getNotebookOptions();
+        const options = this.ipynbProvider.getNotebookOptions();
+        const metadata = this.notebookJson.metadata;
+        return {
+            ...options,
+            metadata
+        };
     }
 
     public runAllCells() {

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import { nbformat } from '@jupyterlab/coreutils';
 import * as cp from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
@@ -56,7 +57,7 @@ export class NotebookStarter implements Disposable {
         }
     }
     // tslint:disable-next-line: max-func-body-length
-    public async start(useDefaultConfig: boolean, cancelToken?: CancellationToken): Promise<{ connection: IConnection; kernelSpec: IJupyterKernelSpec | undefined }> {
+    public async start(options: {useDefaultConfig: boolean; metadata?: nbformat.INotebookMetadata}, cancelToken?: CancellationToken): Promise<{ connection: IConnection; kernelSpec: IJupyterKernelSpec | undefined }> {
         traceInfo('Starting Notebook');
         const notebookCommandPromise = this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
         // Now actually launch it
@@ -67,7 +68,7 @@ export class NotebookStarter implements Disposable {
             tempDirPromise.then(dir => this.disposables.push(dir)).ignoreErrors();
             // Before starting the notebook process, make sure we generate a kernel spec
             const [args, kernelSpec, notebookCommand] = await Promise.all([
-                this.generateArguments(useDefaultConfig, tempDirPromise),
+                this.generateArguments(options.useDefaultConfig, tempDirPromise),
                 this.kernelService.getMatchingKernelSpec(undefined, cancelToken),
                 notebookCommandPromise
             ]);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -194,7 +194,6 @@ export interface IJupyterKernel {
 
 export interface IJupyterKernelSpec extends IAsyncDisposable {
     name: string | undefined;
-    display_name?: string;
     language: string | undefined;
     path: string | undefined;
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -110,6 +110,7 @@ export interface INotebookServerOptions {
     workingDir?: string;
     interpreterPath?: string;
     purpose: string;
+    metadata?: nbformat.INotebookMetadata;
 }
 
 export const INotebookExecutionLogger = Symbol('INotebookExecutionLogger');
@@ -193,6 +194,7 @@ export interface IJupyterKernel {
 
 export interface IJupyterKernelSpec extends IAsyncDisposable {
     name: string | undefined;
+    display_name?: string;
     language: string | undefined;
     path: string | undefined;
 }


### PR DESCRIPTION
For #8612 
Make nb metadata available for code starting the notebook and selecting kernel.
This is required to ensure we select an existing kernel from the notebook metadata.
