### PR TITLE
Populate survey links with variables

### DIFF
--- a/news/1 Enhancements/8484.md
+++ b/news/1 Enhancements/8484.md
@@ -1,0 +1,1 @@
+Populate survey links with variables

--- a/src/client/activation/extensionSurvey.ts
+++ b/src/client/activation/extensionSurvey.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { inject, injectable, optional } from 'inversify';
+import * as querystring from 'querystring';
 import * as vscode from 'vscode';
 import { IApplicationEnvironment, IApplicationShell } from '../common/application/types';
 import { ShowExtensionSurveyPrompt } from '../common/experimentGroups';
@@ -90,11 +91,13 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
     }
 
     private launchSurvey() {
-        const extensionVersion = encodeURIComponent(this.appEnvironment.packageJson.version);
-        const vscodeVersion = encodeURIComponent(vscode.version);
-        const machineId = encodeURIComponent(this.appEnvironment.machineId);
-        const platform = encodeURIComponent(this.platformService.osType);
-        const url = `https://aka.ms/AA5rjx5?o=${platform}&v=${vscodeVersion}&e=${extensionVersion}&m=${machineId}`;
+        const query = querystring.stringify({
+            o: encodeURIComponent(this.platformService.osType), // platform
+            v: encodeURIComponent(vscode.version),
+            e: encodeURIComponent(this.appEnvironment.packageJson.version), // extension version
+            m: encodeURIComponent(this.appEnvironment.machineId)
+        });
+        const url = `https://aka.ms/AA5rjx5?${query}`;
         this.browserService.launch(url);
     }
 }

--- a/src/client/activation/extensionSurvey.ts
+++ b/src/client/activation/extensionSurvey.ts
@@ -5,7 +5,6 @@
 
 import { inject, injectable, optional } from 'inversify';
 import * as querystring from 'querystring';
-import * as vscode from 'vscode';
 import { IApplicationEnvironment, IApplicationShell } from '../common/application/types';
 import { ShowExtensionSurveyPrompt } from '../common/experimentGroups';
 import '../common/extensions';
@@ -93,7 +92,7 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
     private launchSurvey() {
         const query = querystring.stringify({
             o: encodeURIComponent(this.platformService.osType), // platform
-            v: encodeURIComponent(vscode.version),
+            v: encodeURIComponent(this.appEnvironment.vscodeVersion),
             e: encodeURIComponent(this.appEnvironment.packageJson.version), // extension version
             m: encodeURIComponent(this.appEnvironment.machineId)
         });

--- a/src/client/activation/extensionSurvey.ts
+++ b/src/client/activation/extensionSurvey.ts
@@ -4,10 +4,12 @@
 'use strict';
 
 import { inject, injectable, optional } from 'inversify';
-import { IApplicationShell } from '../common/application/types';
+import * as vscode from 'vscode';
+import { IApplicationEnvironment, IApplicationShell } from '../common/application/types';
 import { ShowExtensionSurveyPrompt } from '../common/experimentGroups';
 import '../common/extensions';
 import { traceDecorators } from '../common/logger';
+import { IPlatformService } from '../common/platform/types';
 import {
     IBrowserService, IExperimentsManager, IPersistentStateFactory, IRandom
 } from '../common/types';
@@ -33,6 +35,8 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
         @inject(IPersistentStateFactory) private persistentState: IPersistentStateFactory,
         @inject(IRandom) private random: IRandom,
         @inject(IExperimentsManager) private experiments: IExperimentsManager,
+        @inject(IApplicationEnvironment) private appEnvironment: IApplicationEnvironment,
+        @inject(IPlatformService) private platformService: IPlatformService,
         @optional() private sampleSizePerOneHundredUsers: number = 10,
         @optional() private waitTimeToShowSurvey: number = WAIT_TIME_TO_SHOW_SURVEY) { }
 
@@ -86,6 +90,11 @@ export class ExtensionSurveyPrompt implements IExtensionSingleActivationService 
     }
 
     private launchSurvey() {
-        this.browserService.launch('https://aka.ms/AA5rjx5');
+        const extensionVersion = encodeURIComponent(this.appEnvironment.packageJson.version);
+        const vscodeVersion = encodeURIComponent(vscode.version);
+        const machineId = encodeURIComponent(this.appEnvironment.machineId);
+        const platform = encodeURIComponent(this.platformService.osType);
+        const url = `https://aka.ms/AA5rjx5?o=${platform}&v=${vscodeVersion}&e=${extensionVersion}&m=${machineId}`;
+        this.browserService.launch(url);
     }
 }

--- a/src/client/common/application/applicationEnvironment.ts
+++ b/src/client/common/application/applicationEnvironment.ts
@@ -34,6 +34,9 @@ export class ApplicationEnvironment implements IApplicationEnvironment {
     public get appName(): string {
         return vscode.env.appName;
     }
+    public get vscodeVersion(): string {
+        return vscode.version;
+    }
     public get appRoot(): string {
         return vscode.env.appRoot;
     }

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -903,6 +903,10 @@ export interface IApplicationEnvironment {
      * @memberof IApplicationShell
      */
     readonly extensionChannel: Channel;
+    /**
+     * The version of the editor.
+     */
+    readonly vscodeVersion: string;
 }
 
 export const IWebPanelMessageListener = Symbol('IWebPanelMessageListener');

--- a/src/test/activation/extensionSurvey.unit.test.ts
+++ b/src/test/activation/extensionSurvey.unit.test.ts
@@ -7,7 +7,6 @@ import { assert, expect } from 'chai';
 import * as sinon from 'sinon';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
-import * as vscode from 'vscode';
 import { ExtensionSurveyPrompt, extensionSurveyStateKeys } from '../../client/activation/extensionSurvey';
 import { IApplicationEnvironment, IApplicationShell } from '../../client/common/application/types';
 import { ShowExtensionSurveyPrompt } from '../../client/common/experimentGroups';
@@ -164,9 +163,6 @@ suite('Extension survey prompt - showSurvey()', () => {
     let platformService: TypeMoq.IMock<IPlatformService>;
     let appEnvironment: TypeMoq.IMock<IApplicationEnvironment>;
     let extensionSurveyPrompt: ExtensionSurveyPrompt;
-    const packageJson = {
-        version: 'extensionVersion'
-    };
     setup(() => {
         appShell = TypeMoq.Mock.ofType<IApplicationShell>();
         browserService = TypeMoq.Mock.ofType<IBrowserService>();
@@ -183,11 +179,18 @@ suite('Extension survey prompt - showSurvey()', () => {
     });
 
     test('Launch survey if \'Yes\' option is clicked', async () => {
+        const packageJson = {
+            version: 'extensionVersion'
+        };
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
-        const expectedUrl = `https://aka.ms/AA5rjx5?o=Windows&v=${vscode.version}&e=extensionVersion&m=machineId`;
+        const expectedUrl = `https://aka.ms/AA5rjx5?o=Windows&v=vscodeVersion&e=extensionVersion&m=machineId`;
         appEnvironment
             .setup(a => a.packageJson)
             .returns(() => packageJson)
+            .verifiable(TypeMoq.Times.once());
+        appEnvironment
+            .setup(a => a.vscodeVersion)
+            .returns(() => 'vscodeVersion')
             .verifiable(TypeMoq.Times.once());
         appEnvironment
             .setup(a => a.machineId)
@@ -228,9 +231,8 @@ suite('Extension survey prompt - showSurvey()', () => {
 
     test('Do nothing if \'Maybe later\' option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
-        appEnvironment
-            .setup(a => a.packageJson)
-            .returns(() => packageJson)
+        platformService
+            .setup(p => p.osType)
             .verifiable(TypeMoq.Times.never());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
@@ -257,14 +259,13 @@ suite('Extension survey prompt - showSurvey()', () => {
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
-        appEnvironment.verifyAll();
+        platformService.verifyAll();
     });
 
     test('Do nothing if no option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
-        appEnvironment
-            .setup(a => a.packageJson)
-            .returns(() => packageJson)
+        platformService
+            .setup(p => p.osType)
             .verifiable(TypeMoq.Times.never());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
@@ -291,14 +292,13 @@ suite('Extension survey prompt - showSurvey()', () => {
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
-        appEnvironment.verifyAll();
+        platformService.verifyAll();
     });
 
     test('Disable prompt if \'Do not show again\' option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
-        appEnvironment
-            .setup(a => a.packageJson)
-            .returns(() => packageJson)
+        platformService
+            .setup(p => p.osType)
             .verifiable(TypeMoq.Times.never());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
@@ -325,7 +325,7 @@ suite('Extension survey prompt - showSurvey()', () => {
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
-        appEnvironment.verifyAll();
+        platformService.verifyAll();
     });
 });
 

--- a/src/test/activation/extensionSurvey.unit.test.ts
+++ b/src/test/activation/extensionSurvey.unit.test.ts
@@ -7,13 +7,16 @@ import { assert, expect } from 'chai';
 import * as sinon from 'sinon';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as TypeMoq from 'typemoq';
+import * as vscode from 'vscode';
 import { ExtensionSurveyPrompt, extensionSurveyStateKeys } from '../../client/activation/extensionSurvey';
-import { IApplicationShell } from '../../client/common/application/types';
+import { IApplicationEnvironment, IApplicationShell } from '../../client/common/application/types';
 import { ShowExtensionSurveyPrompt } from '../../client/common/experimentGroups';
 import { PersistentStateFactory } from '../../client/common/persistentState';
+import { IPlatformService } from '../../client/common/platform/types';
 import { IBrowserService, IExperimentsManager, IPersistentState, IPersistentStateFactory, IRandom } from '../../client/common/types';
 import { createDeferred } from '../../client/common/utils/async';
 import { Common, ExtensionSurveyBanner, LanguageService } from '../../client/common/utils/localize';
+import { OSType } from '../../client/common/utils/platform';
 import { sleep } from '../core';
 
 // tslint:disable:no-any
@@ -25,6 +28,8 @@ suite('Extension survey prompt - shouldShowBanner()', () => {
     let random: TypeMoq.IMock<IRandom>;
     let persistentStateFactory: IPersistentStateFactory;
     let experiments: TypeMoq.IMock<IExperimentsManager>;
+    let platformService: TypeMoq.IMock<IPlatformService>;
+    let appEnvironment: TypeMoq.IMock<IApplicationEnvironment>;
     let disableSurveyForTime: TypeMoq.IMock<IPersistentState<any>>;
     let doNotShowAgain: TypeMoq.IMock<IPersistentState<any>>;
     let extensionSurveyPrompt: ExtensionSurveyPrompt;
@@ -36,9 +41,11 @@ suite('Extension survey prompt - shouldShowBanner()', () => {
         persistentStateFactory = mock(PersistentStateFactory);
         disableSurveyForTime = TypeMoq.Mock.ofType<IPersistentState<any>>();
         doNotShowAgain = TypeMoq.Mock.ofType<IPersistentState<any>>();
+        platformService = TypeMoq.Mock.ofType<IPlatformService>();
+        appEnvironment = TypeMoq.Mock.ofType<IApplicationEnvironment>();
         when(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.disableSurveyForTime, false, anything())).thenReturn(disableSurveyForTime.object);
         when(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.doNotShowAgain, false)).thenReturn(doNotShowAgain.object);
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 10);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 10);
     });
     test('Returns false if do not show again is clicked', async () => {
         random
@@ -110,7 +117,7 @@ suite('Extension survey prompt - shouldShowBanner()', () => {
     });
 
     test('Always return true if sample size is 100', async () => {
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 100);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 100);
         disableSurveyForTime
             .setup(d => d.value)
             .returns(() => false);
@@ -127,7 +134,7 @@ suite('Extension survey prompt - shouldShowBanner()', () => {
     });
 
     test('Always return false if sample size is 0', async () => {
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 0);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 0);
         disableSurveyForTime
             .setup(d => d.value)
             .returns(() => false);
@@ -154,7 +161,12 @@ suite('Extension survey prompt - showSurvey()', () => {
     let persistentStateFactory: IPersistentStateFactory;
     let disableSurveyForTime: TypeMoq.IMock<IPersistentState<any>>;
     let doNotShowAgain: TypeMoq.IMock<IPersistentState<any>>;
+    let platformService: TypeMoq.IMock<IPlatformService>;
+    let appEnvironment: TypeMoq.IMock<IApplicationEnvironment>;
     let extensionSurveyPrompt: ExtensionSurveyPrompt;
+    const packageJson = {
+        version: 'extensionVersion'
+    };
     setup(() => {
         appShell = TypeMoq.Mock.ofType<IApplicationShell>();
         browserService = TypeMoq.Mock.ofType<IBrowserService>();
@@ -162,20 +174,35 @@ suite('Extension survey prompt - showSurvey()', () => {
         persistentStateFactory = mock(PersistentStateFactory);
         disableSurveyForTime = TypeMoq.Mock.ofType<IPersistentState<any>>();
         doNotShowAgain = TypeMoq.Mock.ofType<IPersistentState<any>>();
+        platformService = TypeMoq.Mock.ofType<IPlatformService>();
+        appEnvironment = TypeMoq.Mock.ofType<IApplicationEnvironment>();
         when(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.disableSurveyForTime, false, anything())).thenReturn(disableSurveyForTime.object);
         when(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.doNotShowAgain, false)).thenReturn(doNotShowAgain.object);
         experiments = TypeMoq.Mock.ofType<IExperimentsManager>();
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 10);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 10);
     });
 
     test('Launch survey if \'Yes\' option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
+        const expectedUrl = `https://aka.ms/AA5rjx5?o=Windows&v=${vscode.version}&e=extensionVersion&m=machineId`;
+        appEnvironment
+            .setup(a => a.packageJson)
+            .returns(() => packageJson)
+            .verifiable(TypeMoq.Times.once());
+        appEnvironment
+            .setup(a => a.machineId)
+            .returns(() => 'machineId')
+            .verifiable(TypeMoq.Times.once());
+        platformService
+            .setup(a => a.osType)
+            .returns(() => OSType.Windows)
+            .verifiable(TypeMoq.Times.once());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
             .returns(() => Promise.resolve(LanguageService.bannerLabelYes()))
             .verifiable(TypeMoq.Times.once());
         browserService
-            .setup(s => s.launch(TypeMoq.It.isAny()))
+            .setup(s => s.launch(expectedUrl))
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.once());
         disableSurveyForTime
@@ -186,17 +213,25 @@ suite('Extension survey prompt - showSurvey()', () => {
             .setup(d => d.updateValue(true))
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.never());
+
         await extensionSurveyPrompt.showSurvey();
+
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.disableSurveyForTime, false, anything())).once();
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.doNotShowAgain, false)).never();
         appShell.verifyAll();
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
+        appEnvironment.verifyAll();
+        platformService.verifyAll();
     });
 
     test('Do nothing if \'Maybe later\' option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
+        appEnvironment
+            .setup(a => a.packageJson)
+            .returns(() => packageJson)
+            .verifiable(TypeMoq.Times.never());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
             .returns(() => Promise.resolve(ExtensionSurveyBanner.maybeLater()))
@@ -213,17 +248,24 @@ suite('Extension survey prompt - showSurvey()', () => {
             .setup(d => d.updateValue(true))
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.never());
+
         await extensionSurveyPrompt.showSurvey();
+
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.disableSurveyForTime, false, anything())).never();
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.doNotShowAgain, false)).never();
         appShell.verifyAll();
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
+        appEnvironment.verifyAll();
     });
 
     test('Do nothing if no option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
+        appEnvironment
+            .setup(a => a.packageJson)
+            .returns(() => packageJson)
+            .verifiable(TypeMoq.Times.never());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
             .returns(() => Promise.resolve(undefined))
@@ -240,17 +282,24 @@ suite('Extension survey prompt - showSurvey()', () => {
             .setup(d => d.updateValue(true))
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.never());
+
         await extensionSurveyPrompt.showSurvey();
+
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.disableSurveyForTime, false, anything())).never();
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.doNotShowAgain, false)).never();
         appShell.verifyAll();
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
+        appEnvironment.verifyAll();
     });
 
     test('Disable prompt if \'Do not show again\' option is clicked', async () => {
         const prompts = [LanguageService.bannerLabelYes(), ExtensionSurveyBanner.maybeLater(), Common.doNotShowAgain()];
+        appEnvironment
+            .setup(a => a.packageJson)
+            .returns(() => packageJson)
+            .verifiable(TypeMoq.Times.never());
         appShell
             .setup(a => a.showInformationMessage(ExtensionSurveyBanner.bannerMessage(), ...prompts))
             .returns(() => Promise.resolve(Common.doNotShowAgain()))
@@ -267,13 +316,16 @@ suite('Extension survey prompt - showSurvey()', () => {
             .setup(d => d.updateValue(true))
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.once());
+
         await extensionSurveyPrompt.showSurvey();
+
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.disableSurveyForTime, false, anything())).never();
         verify(persistentStateFactory.createGlobalPersistentState(extensionSurveyStateKeys.doNotShowAgain, false)).once();
         appShell.verifyAll();
         browserService.verifyAll();
         disableSurveyForTime.verifyAll();
         doNotShowAgain.verifyAll();
+        appEnvironment.verifyAll();
     });
 });
 
@@ -287,12 +339,16 @@ suite('Extension survey prompt - activate()', () => {
     let showSurvey: sinon.SinonStub<any>;
     let experiments: TypeMoq.IMock<IExperimentsManager>;
     let extensionSurveyPrompt: ExtensionSurveyPrompt;
+    let platformService: TypeMoq.IMock<IPlatformService>;
+    let appEnvironment: TypeMoq.IMock<IApplicationEnvironment>;
     setup(() => {
         appShell = TypeMoq.Mock.ofType<IApplicationShell>();
         browserService = TypeMoq.Mock.ofType<IBrowserService>();
         random = TypeMoq.Mock.ofType<IRandom>();
         persistentStateFactory = mock(PersistentStateFactory);
         experiments = TypeMoq.Mock.ofType<IExperimentsManager>();
+        platformService = TypeMoq.Mock.ofType<IPlatformService>();
+        appEnvironment = TypeMoq.Mock.ofType<IApplicationEnvironment>();
     });
 
     teardown(() => {
@@ -303,7 +359,7 @@ suite('Extension survey prompt - activate()', () => {
         shouldShowBanner = sinon.stub(ExtensionSurveyPrompt.prototype, 'shouldShowBanner');
         shouldShowBanner.callsFake(() => false);
         showSurvey = sinon.stub(ExtensionSurveyPrompt.prototype, 'showSurvey');
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 10);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 10);
         experiments
             .setup(exp => exp.inExperiment(ShowExtensionSurveyPrompt.enabled))
             .returns(() => false)
@@ -327,7 +383,7 @@ suite('Extension survey prompt - activate()', () => {
             return Promise.resolve();
         });
         // waitTimeToShowSurvey = 50 ms
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 10, 50);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 10, 50);
         experiments
             .setup(exp => exp.inExperiment(ShowExtensionSurveyPrompt.enabled))
             .returns(() => true)
@@ -355,7 +411,7 @@ suite('Extension survey prompt - activate()', () => {
             return Promise.resolve();
         });
         // waitTimeToShowSurvey = 50 ms
-        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, 10, 50);
+        extensionSurveyPrompt = new ExtensionSurveyPrompt(appShell.object, browserService.object, instance(persistentStateFactory), random.object, experiments.object, appEnvironment.object, platformService.object, 10, 50);
         experiments
             .setup(exp => exp.inExperiment(ShowExtensionSurveyPrompt.enabled))
             .returns(() => true)


### PR DESCRIPTION
For #8484 

Also edited original URL settings to allow parameter passing.
Survey link: https://aka.ms/AA5rjx5

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate~
- ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)~
- ~[ ] The wiki is updated with any design decisions/details.~
