### PR TITLE
Add missing decorator in test service

### DIFF
--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -466,6 +466,7 @@ suite('DataScience notebook tests', () => {
                 throw new Error('Method not implemented');
             }
         }
+        @injectable()
         class EmptyPathService implements IKnownSearchPathsForInterpreters {
             public getSearchPaths(): string[] {
                 return [];


### PR DESCRIPTION
Not sure how tests are running when this is missing (this causes code to fall over).

![Screen Shot 2019-11-26 at 13 03 49](https://user-images.githubusercontent.com/1948812/69672558-353df300-104d-11ea-941a-08bda3fb706c.png)
