### PR TITLE
Remove IFileSystemUtils from IoC container

### DIFF
--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -318,7 +318,6 @@ export class RawFileSystem implements IRawFileSystem {
 }
 
 // High-level filesystem operations used by the extension.
-@injectable()
 export class FileSystemUtils implements IFileSystemUtils {
     constructor(
         public readonly raw: IRawFileSystem,

--- a/src/client/common/platform/serviceRegistry.ts
+++ b/src/client/common/platform/serviceRegistry.ts
@@ -3,14 +3,13 @@
 'use strict';
 
 import { IServiceManager } from '../../ioc/types';
-import { FileSystem, FileSystemUtils } from './fileSystem';
+import { FileSystem } from './fileSystem';
 import { PlatformService } from './platformService';
 import { RegistryImplementation } from './registry';
-import { IFileSystem, IFileSystemUtils, IPlatformService, IRegistry } from './types';
+import { IFileSystem, IPlatformService, IRegistry } from './types';
 
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IPlatformService>(IPlatformService, PlatformService);
     serviceManager.addSingleton<IFileSystem>(IFileSystem, FileSystem);
-    serviceManager.addSingletonInstance<IFileSystemUtils>(IFileSystemUtils, FileSystemUtils.withDefaults());
     serviceManager.addSingleton<IRegistry>(IRegistry, RegistryImplementation);
 }

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -101,7 +101,6 @@ export interface IRawFileSystem {
 }
 
 // High-level filesystem operations used by the extension.
-export const IFileSystemUtils = Symbol('IFileSystemUtils');
 export interface IFileSystemUtils {
     readonly raw: IRawFileSystem;
     readonly paths: IFileSystemPaths;


### PR DESCRIPTION
For #8307 
Removing IFileSystemUtils from the IOC container as this then means we have 2 ways of accessing FIleSystem related stuff (IFileSystem and IFileSystemUtils).

From what I can tell FileSystemUtils is used purely in fileSystem class and doesn't need to be exposed outside. Hence we shouldn't even need the IFileSystemUtils interface, as the class is sufficient. Though i'm not removing that here as thats a point of preference. There are other similar interfaces as well. Not sure why they exist instead of using pure classes.

This PR ensures we continue to have one way for FS stuff and theres no confusion.