### PR TITLE
Fix test discovery crash in pytest adapter on doctest (lineno is None)

### DIFF
--- a/news/2 Fixes/7487.md
+++ b/news/2 Fixes/7487.md
@@ -1,0 +1,2 @@
+Fix a crash when using pytest to discover doctests with unknown line number.
+(thanks [Olivier Grisel](https://github.com/ogrisel/))

--- a/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
+++ b/pythonFiles/testing_tools/adapter/pytest/_pytest_item.py
@@ -274,14 +274,16 @@ def _get_location(item, testroot, relfile, #*,
                     # function to be in relfile.  So here we ignore any
                     # other file and just say "somewhere in relfile".
                     lineno = None
-            if lineno is None:
-                lineno = -1  # i.e. "unknown"
         elif _matches_relfile(srcfile, testroot, relfile):
             srcfile = relfile
         # Otherwise we just return the info from item.location as-is.
 
         if not srcfile.startswith('.' + _pathsep):
             srcfile = '.' + _pathsep + srcfile
+
+    if lineno is None:
+        lineno = -1  # i.e. "unknown"
+
     # from pytest, line numbers are 0-based
     location = '{}:{}'.format(srcfile, int(lineno) + 1)
     return location, fullname


### PR DESCRIPTION
For #7487

- ~[x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)~
- ~[x] Title summarizes what is changing~
- ~[x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)~
- ~[x] Appropriate comments and documentation strings in the code~
- [ ] Unit tests & system/integration tests are added/updated


I am not sure how to change the test suite to add a none regression for this one.
