### PR TITLE
Indent on `async for` and `async with`

### DIFF
--- a/news/1 Enhancements/7344.md
+++ b/news/1 Enhancements/7344.md
@@ -1,0 +1,1 @@
+Automatically indent following `async for` and `async with` statements.

--- a/src/client/language/languageConfiguration.ts
+++ b/src/client/language/languageConfiguration.ts
@@ -54,10 +54,12 @@ export function getLanguageConfiguration(): LanguageConfiguration {
                                 async \\s+ def |
                                 except |
                                 for |
+                                async \\s+ for |
                                 if |
                                 elif |
                                 while |
-                                with
+                                with |
+                                async \\s+ with
                             )
                             \\b .*
                         ) |

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -145,6 +145,7 @@ suite('Language Configuration', () => {
             'async def :',
             'async :',
             'async for spam in bacon:',
+            'async with context:',
             'async with context in manager:',
             'class Test:',
             'class Test(object):',

--- a/src/test/language/languageConfiguration.unit.test.ts
+++ b/src/test/language/languageConfiguration.unit.test.ts
@@ -19,6 +19,8 @@ const NEEDS_INDENT = [
 ];
 const INDENT_ON_ENTER = [  // block-beginning statements
     /^async\s+def\b/,
+    /^async\s+for\b/,
+    /^async\s+with\b/,
     /^class\b/,
     /^def\b/,
     /^with\b/,
@@ -142,6 +144,8 @@ suite('Language Configuration', () => {
             'async def test(self):',
             'async def :',
             'async :',
+            'async for spam in bacon:',
+            'async with context in manager:',
             'class Test:',
             'class Test(object):',
             'class :',


### PR DESCRIPTION
For #7344

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [x] The wiki is updated with any design decisions/details.
