### PR TITLE
Fix scrolling in large cells.

### DIFF
--- a/news/2 Fixes/8895.md
+++ b/news/2 Fixes/8895.md
@@ -1,0 +1,1 @@
+Fix scrolling in large cells.

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -219,13 +219,13 @@ export class NativeCell extends React.Component<INativeCellProps> {
         switch (e.code) {
             case 'ArrowUp':
             case 'k':
-                if ((isFocusedWhenNotSuggesting && e.editorInfo!.isFirstLine) || !this.isFocused()) {
+                if ((isFocusedWhenNotSuggesting && e.editorInfo!.isFirstLine && !e.shiftKey) || !this.isFocused()) {
                     this.arrowUpFromCell(e);
                 }
                 break;
             case 'ArrowDown':
             case 'j':
-                if ((isFocusedWhenNotSuggesting && e.editorInfo!.isLastLine) || !this.isFocused()) {
+                if ((isFocusedWhenNotSuggesting && e.editorInfo!.isLastLine && !e.shiftKey) || !this.isFocused()) {
                     this.arrowDownFromCell(e);
                 }
                 break;


### PR DESCRIPTION
For #8895 

Scrolling in large notebook cells can jump around when the editor gets focus. The root cause of this being the focus change event causes the scroll. Waiting till after focus is complete allows the cursor to change first.

There was also a potentially bad problem of not using the correct index when scrolling. This occurs  when editing a cell.

Did not add any tests as not sure how to detect scroll position in enzyme. It doesn't render anything so the visible line tops wouldn't actually have any height.
