### PR TITLE
Fix flakey CI test - cancel 

### DIFF
--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -639,7 +639,7 @@ suite('DataScience notebook tests', () => {
     }
 
     async function testCancelableMethod<T>(method: (t: CancellationToken) => Promise<T>, messageFormat: string, short?: boolean): Promise<boolean> {
-        const timeouts = short ? [10, 20, 30, 100] : [100, 200, 300, 1000];
+        const timeouts = short ? [10, 20, 30, 100] : [300, 400, 500, 1000];
         // tslint:disable-next-line:prefer-for-of
         for (let i = 0; i < timeouts.length; i += 1) {
             await testCancelableCall(method, messageFormat, timeouts[i]);

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -615,9 +615,7 @@ suite('DataScience notebook tests', () => {
 
     async function testCancelableCall<T>(method: (t: CancellationToken) => Promise<T>, messageFormat: string, timeout: number): Promise<boolean> {
         const tokenSource = new TaggedCancellationTokenSource(messageFormat.format(timeout.toString()));
-        let canceled = false;
         const disp = setTimeout((_s) => {
-            canceled = true;
             tokenSource.cancel();
         }, timeout, tokenSource.tag);
 
@@ -625,8 +623,6 @@ suite('DataScience notebook tests', () => {
             // tslint:disable-next-line:no-string-literal
             (tokenSource.token as any)['tag'] = messageFormat.format(timeout.toString());
             await method(tokenSource.token);
-            // We might get here before the cancel finishes
-            assert.ok(!canceled, messageFormat.format(timeout.toString()));
         } catch (exc) {
             // This should happen. This means it was canceled.
             assert.ok(exc instanceof CancellationError, `Non cancellation error found : ${exc.stack}`);


### PR DESCRIPTION
The cancel test is sometimes timing out when canceling. 

What I think is happening is this:

- await Call to method to test with cancel token
- timer for cancel is scheduled
- call completes
- timer is pulled off the async queue
- cancel flag is set
- token is canceled
- promise is already complete, so cancel does not throw exception
- promise result is pulled off the async queue
- test fails saying cancel failed to fire

The timing on this would have to be pretty close to perfect (hence the randomness of the failures). I modified the test to not fail in this case.