### PR TITLE
Default python.workspaceSymbols.enabled to false

### DIFF
--- a/news/2 Fixes/9046.md
+++ b/news/2 Fixes/9046.md
@@ -1,0 +1,1 @@
+Set `python.workspaceSymbols.enabled` to false by default.

--- a/package.json
+++ b/package.json
@@ -2483,7 +2483,7 @@
                 "python.workspaceSymbols.enabled": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Set to 'true' to enable Workspace Symbol provider using ctags.",
+                    "description": "Set to 'true' to enable ctags to provide Workspace Symbols.",
                     "scope": "resource"
                 },
                 "python.workspaceSymbols.exclusionPatterns": {

--- a/package.json
+++ b/package.json
@@ -2482,8 +2482,8 @@
                 },
                 "python.workspaceSymbols.enabled": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Set to 'false' to disable Workspace Symbol provider using ctags.",
+                    "default": false,
+                    "description": "Set to 'true' to enable Workspace Symbol provider using ctags.",
                     "scope": "resource"
                 },
                 "python.workspaceSymbols.exclusionPatterns": {


### PR DESCRIPTION
For #9046 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
