### PR TITLE
Fix #8865: Extension shouldn't enable the "RedirectOutput" debug flag by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tmp/**
 test-results.xml
 uitests/out/**
 !build/
+debug*.log
+ptvsd*.log
+pydevd*.log

--- a/news/2 Fixes/8865.md
+++ b/news/2 Fixes/8865.md
@@ -1,0 +1,1 @@
+Do not set "redirectOutput": true by default when not specified in launch.json, unless "console" is "internalConsole".

--- a/src/client/debugger/extension/configuration/resolvers/launch.ts
+++ b/src/client/debugger/extension/configuration/resolvers/launch.ts
@@ -114,7 +114,10 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
         if (debugConfiguration.jinja) {
             this.debugOption(debugOptions, DebugOptions.Jinja);
         }
-        if (debugConfiguration.redirectOutput || debugConfiguration.redirectOutput === undefined) {
+        if (debugConfiguration.redirectOutput === undefined && debugConfiguration.console === 'internalConsole') {
+            debugConfiguration.redirectOutput = true;
+        }
+        if (debugConfiguration.redirectOutput) {
             this.debugOption(debugOptions, DebugOptions.RedirectOutput);
         }
         if (debugConfiguration.sudo) {


### PR DESCRIPTION
For #8865 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
