### PR TITLE
Fix for toggling cell type with keyboard

### DIFF
--- a/news/2 Fixes/9078.md
+++ b/news/2 Fixes/9078.md
@@ -1,0 +1,1 @@
+'y' and 'm' keys toggle cell type but also add a 'y' or 'm' to the cell.

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -242,15 +242,17 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 }
                 break;
             case 'y':
-                if (!this.isFocused() && this.isSelected()) {
+                if (!this.isFocused() && this.isSelected() && this.isMarkdownCell()) {
                     e.stopPropagation();
+                    e.preventDefault();
                     this.props.changeCellType(cellId, this.getCurrentCode());
                     this.props.sendCommand(NativeCommandType.ChangeToCode, 'keyboard');
                 }
                 break;
             case 'm':
-                if (!this.isFocused() && this.isSelected()) {
+                if (!this.isFocused() && this.isSelected() && this.isCodeCell()) {
                     e.stopPropagation();
+                    e.preventDefault();
                     this.props.changeCellType(cellId, this.getCurrentCode());
                     this.props.sendCommand(NativeCommandType.ChangeToMarkdown, 'keyboard');
                 }


### PR DESCRIPTION
For #9078 

We do have a test that verifies output but simulating a key press doesn't also send a keyup, so it never showed up. 

I'd rather not start adding keyup to every test right now (to make them more realistic). I've added an issue for that.
https://github.com/microsoft/vscode-python/issues/9084