### PR TITLE
Add jupyter logging so that users can see what jupyter commands we run

### DIFF
--- a/news/1 Enhancements/9086.md
+++ b/news/1 Enhancements/9086.md
@@ -1,0 +1,1 @@
+Log jupyter stdout to an output tab in VS code.

--- a/package.nls.json
+++ b/package.nls.json
@@ -134,6 +134,7 @@
     "OutputChannelNames.languageServer": "Python Language Server",
     "OutputChannelNames.python": "Python",
     "OutputChannelNames.pythonTest": "Python Test Log",
+    "OutputChannelNames.jupyterServer" : "Jupyter Server",
     "ExtensionSurveyBanner.bannerMessage": "Can you please take 2 minutes to tell us how the Python extension is working for you?",
     "ExtensionSurveyBanner.maybeLater": "Maybe later",
     "ExtensionChannels.installingInsidersMessage": "Installing Insiders... ",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -82,6 +82,7 @@ export namespace OutputChannelNames {
     export const languageServer = localize('OutputChannelNames.languageServer', 'Python Language Server');
     export const python = localize('OutputChannelNames.python', 'Python');
     export const pythonTest = localize('OutputChannelNames.pythonTest', 'Python Test Log');
+    export const jupyterServer = localize('OutputChannelNames.jupyterServer', 'Jupyter Server');
 }
 
 export namespace Logging {

--- a/src/client/datascience/jupyter/jupyterOutputListener.ts
+++ b/src/client/datascience/jupyter/jupyterOutputListener.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import '../../common/extensions';
+
+import { inject, injectable } from 'inversify';
+
+import { IApplicationShell } from '../../common/application/types';
+import { traceInfo } from '../../common/logger';
+import { IOutputChannel } from '../../common/types';
+import * as localize from '../../common/utils/localize';
+import { IJupyterOutputListener } from '../types';
+
+@injectable()
+export class JupyterOutputListener implements IJupyterOutputListener {
+    private output: IOutputChannel | undefined;
+    constructor(
+        @inject(IApplicationShell) private appShell: IApplicationShell
+    ) {
+    }
+
+    public onOutput(data: string) {
+        traceInfo(data);
+        this.getOutputChannel().append(data);
+    }
+
+    private getOutputChannel(): IOutputChannel {
+        if (!this.output) {
+            this.output = this.appShell.createOutputChannel(localize.OutputChannelNames.jupyterServer());
+        }
+        return this.output;
+    }
+
+}

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -34,6 +34,7 @@ import { JupyterDebugger } from './jupyter/jupyterDebugger';
 import { JupyterExecutionFactory } from './jupyter/jupyterExecutionFactory';
 import { JupyterExporter } from './jupyter/jupyterExporter';
 import { JupyterImporter } from './jupyter/jupyterImporter';
+import { JupyterOutputListener } from './jupyter/jupyterOutputListener';
 import { JupyterPasswordConnect } from './jupyter/jupyterPasswordConnect';
 import { JupyterServerFactory } from './jupyter/jupyterServerFactory';
 import { JupyterSessionManagerFactory } from './jupyter/jupyterSessionManagerFactory';
@@ -66,6 +67,7 @@ import {
     IJupyterCommandFactory,
     IJupyterDebugger,
     IJupyterExecution,
+    IJupyterOutputListener,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
     IJupyterVariables,
@@ -129,4 +131,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<NotebookStarter>(NotebookStarter, NotebookStarter);
     serviceManager.addSingleton<KernelSelector>(KernelSelector, KernelSelector);
     serviceManager.addSingleton<KernelSelectionProvider>(KernelSelectionProvider, KernelSelectionProvider);
+    serviceManager.addSingleton<IJupyterOutputListener>(IJupyterOutputListener, JupyterOutputListener);
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -145,6 +145,11 @@ export interface IJupyterExecution extends IAsyncDisposable {
     refreshCommands(): Promise<void>;
 }
 
+export const IJupyterOutputListener = Symbol('IJupyterOutputListener');
+export interface IJupyterOutputListener {
+    onOutput(data: string): void;
+}
+
 export const IJupyterDebugger = Symbol('IJupyterDebugger');
 export interface IJupyterDebugger {
     startDebugging(notebook: INotebook): Promise<void>;

--- a/src/datascience-ui/react-common/postOffice.ts
+++ b/src/datascience-ui/react-common/postOffice.ts
@@ -82,6 +82,7 @@ export class PostOffice implements IDisposable {
             const vscodeApi = this.vscodeApi;
             // Replace console.log with sending a message
             const customConsole = {
+                ...originalConsole,
                 // tslint:disable-next-line: no-any no-function-expression
                 log: function (message?: any, ..._optionalParams: any[]) {
                     originalConsole.log.apply(arguments);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -84,7 +84,14 @@ import { IDotNetCompatibilityService } from '../../client/common/dotnet/types';
 import { ExperimentsManager } from '../../client/common/experiments';
 import { InstallationChannelManager } from '../../client/common/installer/channelManager';
 import { ProductInstaller } from '../../client/common/installer/productInstaller';
-import { CTagsProductPathService, DataScienceProductPathService, FormatterProductPathService, LinterProductPathService, RefactoringLibraryProductPathService, TestFrameworkProductPathService } from '../../client/common/installer/productPath';
+import {
+    CTagsProductPathService,
+    DataScienceProductPathService,
+    FormatterProductPathService,
+    LinterProductPathService,
+    RefactoringLibraryProductPathService,
+    TestFrameworkProductPathService
+} from '../../client/common/installer/productPath';
 import { ProductService } from '../../client/common/installer/productService';
 import { IInstallationChannelManager, IProductPathService, IProductService } from '../../client/common/installer/types';
 import { Logger } from '../../client/common/logger';
@@ -171,6 +178,7 @@ import { JupyterDebugger } from '../../client/datascience/jupyter/jupyterDebugge
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
 import { JupyterExporter } from '../../client/datascience/jupyter/jupyterExporter';
 import { JupyterImporter } from '../../client/datascience/jupyter/jupyterImporter';
+import { JupyterOutputListener } from '../../client/datascience/jupyter/jupyterOutputListener';
 import { JupyterPasswordConnect } from '../../client/datascience/jupyter/jupyterPasswordConnect';
 import { JupyterServerFactory } from '../../client/datascience/jupyter/jupyterServerFactory';
 import { JupyterSessionManagerFactory } from '../../client/datascience/jupyter/jupyterSessionManagerFactory';
@@ -203,6 +211,7 @@ import {
     IJupyterCommandFactory,
     IJupyterDebugger,
     IJupyterExecution,
+    IJupyterOutputListener,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
     IJupyterVariables,
@@ -705,6 +714,9 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             this.serviceManager.addSingleton<IJupyterPasswordConnect>(IJupyterPasswordConnect, JupyterPasswordConnect);
             this.serviceManager.addSingleton<IProcessLogger>(IProcessLogger, ProcessLogger);
         }
+
+        const output = mock(JupyterOutputListener);
+        this.serviceManager.addSingletonInstance<IJupyterOutputListener>(IJupyterOutputListener, instance(output));
 
         const dummyDisposable = {
             dispose: () => { return; }

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -13,7 +13,16 @@ import { anyString, anything, deepEqual, instance, match, mock, reset, verify, w
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 import * as TypeMoq from 'typemoq';
 import * as uuid from 'uuid/v4';
-import { CancellationToken, CancellationTokenSource, ConfigurationChangeEvent, Disposable, Event, EventEmitter, Uri } from 'vscode';
+import {
+    CancellationToken,
+    CancellationTokenSource,
+    ConfigurationChangeEvent,
+    Disposable,
+    Event,
+    EventEmitter,
+    Uri
+} from 'vscode';
+
 import { ApplicationShell } from '../../client/common/application/applicationShell';
 import { IApplicationShell, IWorkspaceService } from '../../client/common/application/types';
 import { WorkspaceService } from '../../client/common/application/workspace';
@@ -45,6 +54,7 @@ import { Identifiers, PythonDaemonModule } from '../../client/datascience/consta
 import { JupyterCommandFactory } from '../../client/datascience/jupyter/jupyterCommand';
 import { JupyterCommandFinder } from '../../client/datascience/jupyter/jupyterCommandFinder';
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
+import { JupyterOutputListener } from '../../client/datascience/jupyter/jupyterOutputListener';
 import { KernelSelector } from '../../client/datascience/jupyter/kernels/kernelSelector';
 import { NotebookStarter } from '../../client/datascience/jupyter/notebookStarter';
 import {
@@ -735,7 +745,8 @@ suite('Jupyter Execution', async () => {
             path: ''
         };
         when(kernelSelector.getKernelForLocalConnection(anything(), anything(), anything())).thenResolve({ kernelSpec });
-        notebookStarter = new NotebookStarter(instance(executionFactory), commandFinder, instance(fileSystem), instance(serviceContainer), instance(interpreterService));
+        const listener = mock(JupyterOutputListener);
+        notebookStarter = new NotebookStarter(instance(executionFactory), commandFinder, instance(fileSystem), instance(serviceContainer), instance(interpreterService), instance(listener));
         when(serviceContainer.get<KernelSelector>(KernelSelector)).thenReturn(instance(kernelSelector));
         when(serviceContainer.get<NotebookStarter>(NotebookStarter)).thenReturn(notebookStarter);
         return {


### PR DESCRIPTION
For #9086 

We decided in triage we needed this before the release. This pipes stdout and stderr from the server to an output window for VS code.
