### PR TITLE
Add ability to pick a remote kernel into the kernel UI

### DIFF
--- a/news/2 Fixes/3763.md
+++ b/news/2 Fixes/3763.md
@@ -1,0 +1,1 @@
+Add ability to pick a remote kernel

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -134,6 +134,11 @@ export class JupyterExecutionBase implements IJupyterExecution {
                     // Create a server that we will then attempt to connect to.
                     result = this.serviceContainer.get<INotebookServer>(INotebookServer);
 
+                    // In a remote situation, figure out a kernel spec too.
+                    if (!kernelSpecInterpreter.kernelSpec && connection) {
+                        kernelSpecInterpreter = await this.kernelSelector.getKernelForRemoteConnection(connection, options?.metadata, cancelToken);
+                    }
+
                     // Populate the launch info that we are starting our server with
                     const launchInfo: INotebookServerLaunchInfo = {
                         connectionInfo: connection!,
@@ -154,7 +159,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                 } catch (err) {
                     // Cleanup after ourselves. server may be running partially.
                     if (result) {
-                        traceInfo('Killing server because of error');
+                        traceInfo(`Killing server because of error ${err}`);
                         await result.dispose();
                     }
                     if (err instanceof JupyterWaitForIdleError && tryCount < maxTries) {
@@ -191,9 +196,9 @@ export class JupyterExecutionBase implements IJupyterExecution {
             // If we're here, then starting jupyter timeout.
             // Kill any existing connections.
             connection?.dispose();
-            sendTelemetryEvent(Telemetry.JupyterStartTimeout, stopWatch.elapsedTime, {timeout: stopWatch.elapsedTime});
+            sendTelemetryEvent(Telemetry.JupyterStartTimeout, stopWatch.elapsedTime, { timeout: stopWatch.elapsedTime });
             this.appShell.showErrorMessage(localize.DataScience.jupyterStartTimedout(), localize.Common.openOutputPanel()).then(selection => {
-                if (selection === localize.Common.openOutputPanel()){
+                if (selection === localize.Common.openOutputPanel()) {
                     this.jupyterOutputChannel.show();
                 }
             }, noop);

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-'use strict';
+import '../../../common/extensions';
 
 import { nbformat } from '@jupyterlab/coreutils';
 import { inject, injectable } from 'inversify';
 import { CancellationToken } from 'vscode-jsonrpc';
+
 import { IApplicationShell } from '../../../common/application/types';
-import '../../../common/extensions';
 import { traceError, traceInfo, traceVerbose } from '../../../common/logger';
 import { IInstaller, Product } from '../../../common/types';
 import * as localize from '../../../common/utils/localize';
@@ -15,7 +14,7 @@ import { noop } from '../../../common/utils/misc';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
-import { IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
+import { IConnection, IJupyterKernelSpec, IJupyterSessionManager, IJupyterSessionManagerFactory } from '../../types';
 import { KernelSelectionProvider } from './kernelSelections';
 import { KernelService } from './kernelService';
 import { IKernelSpecQuickPickItem } from './types';
@@ -39,8 +38,9 @@ export class KernelSelector {
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(KernelService) private readonly kernelService: KernelService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IInstaller) private readonly installer: IInstaller
-    ) {}
+        @inject(IInstaller) private readonly installer: IInstaller,
+        @inject(IJupyterSessionManagerFactory) private readonly jupyterSessionManagerFactory: IJupyterSessionManagerFactory
+    ) { }
     /**
      * Selects a kernel from a remote session.
      *
@@ -113,7 +113,73 @@ export class KernelSelector {
         }
         return selection;
     }
-    private async selectKernel(suggestions: IKernelSpecQuickPickItem[], session?: IJupyterSessionManager, cancelToken?: CancellationToken){
+
+    /**
+     * Gets a kernel that needs to be used with a remote session.
+     * (will attempt to find the best matching kernel, or prompt user to use current interpreter or select one).
+     *
+     * @param {IJupyterSessionManager} [sessionManager]
+     * @param {nbformat.INotebookMetadata} [notebookMetadata]
+     * @param {CancellationToken} [cancelToken]
+     * @returns {Promise<KernelSpecInterpreter>}
+     * @memberof KernelSelector
+     */
+    // tslint:disable-next-line: cyclomatic-complexity
+    public async getKernelForRemoteConnection(
+        connInfo: IConnection,
+        notebookMetadata?: nbformat.INotebookMetadata,
+        cancelToken?: CancellationToken
+    ): Promise<KernelSpecInterpreter> {
+        const sessionManager = await this.jupyterSessionManagerFactory.create(connInfo);
+        const [interpreter, specs] = await Promise.all([this.interpreterService.getActiveInterpreter(undefined), this.kernelService.getKernelSpecs(sessionManager, cancelToken)]);
+        let bestMatch: IJupyterKernelSpec | undefined;
+        let bestScore = 0;
+        for (let i = 0; specs && i < specs?.length; i = i + 1) {
+            const spec = specs[i];
+            let score = 0;
+
+            // First match on language. No point if not python.
+            if (spec && spec.language && spec.language.toLocaleLowerCase() === 'python') {
+                // Language match
+                score += 1;
+
+                // See if the path matches. Don't bother if the language doesn't.
+                if (spec && spec.path && spec.path.length > 0 && interpreter && spec.path === interpreter.path) {
+                    // Path match
+                    score += 10;
+                }
+
+                // See if the version is the same
+                if (interpreter && interpreter.version && spec && spec.name) {
+                    // Search for a digit on the end of the name. It should match our major version
+                    const match = /\D+(\d+)/.exec(spec.name);
+                    if (match && match !== null && match.length > 0) {
+                        // See if the version number matches
+                        const nameVersion = parseInt(match[0], 10);
+                        if (nameVersion && nameVersion === interpreter.version.major) {
+                            score += 4;
+                        }
+                    }
+                }
+
+                // See if the display name already matches.
+                if (spec.display_name && spec.display_name === notebookMetadata?.kernelspec?.display_name) {
+                    score += 2;
+                }
+            }
+
+            if (score > bestScore) {
+                bestMatch = spec;
+                bestScore = score;
+            }
+        }
+
+        return {
+            kernelSpec: bestMatch,
+            interpreter: interpreter
+        };
+    }
+    private async selectKernel(suggestions: IKernelSpecQuickPickItem[], session?: IJupyterSessionManager, cancelToken?: CancellationToken) {
         const selection = await this.applicationShell.showQuickPick(suggestions, { placeHolder: localize.DataScience.selectKernel() }, cancelToken);
         if (!selection?.selection) {
             return {};

--- a/src/datascience-ui/history-react/interactivePanel.less
+++ b/src/datascience-ui/history-react/interactivePanel.less
@@ -1,2 +1,8 @@
 /* Import common styles and then override them below */
 @import "../interactive-common/common.css";
+
+.toolbar-menu-bar-child {
+    background: var(--override-background, var(--vscode-editor-background));
+    z-index: 10;
+}
+

--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -446,6 +446,10 @@ body, html {
     right: 3px;
     margin-top: 2px;
     color: var(--vscode-editor-foreground);
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    grid-template-rows: 1fr;
+    max-width: 60%;
 }
 
 .kernel-status-section {
@@ -463,11 +467,28 @@ body, html {
     height: 17px;
     margin: 0 5px 0 5px;
     float: left;
+    grid-column-start: 2;
+    grid-column-end: 2;
 }
 
 .kernel-status-text {
     float: left;
     padding-right: 5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.kernel-status-server {
+    grid-column-start: 1;
+    grid-column-end: 1;
+    display: grid;
+    grid-template-columns: 1fr auto;
+}
+
+.kernel-status-status {
+    grid-column-start: 3;
+    grid-column-end: 3;
 }
 
 .kernel-status-icon {

--- a/src/datascience-ui/interactive-common/kernelSelection.tsx
+++ b/src/datascience-ui/interactive-common/kernelSelection.tsx
@@ -30,12 +30,11 @@ export class KernelSelection extends React.Component<IKernelSelectionProps> {
             fontSize: this.props.font.size > 2 ? this.props.font.size - 2 : this.props.font.size,
             fontFamily: this.props.font.family
         };
-
-        const kernelSelectionClass = this.isKernelSelectionAllowed ? 'kernel-status-section kernel-status-section-hoverable' : 'kernel-status-section';
+        const kernelSelectionClass = this.isKernelSelectionAllowed ? 'kernel-status-section kernel-status-section-hoverable kernel-status-status' : 'kernel-status-section kernel-status-status';
         return (
             <div className='kernel-status' style={dynamicFont}>
-                <div className='kernel-status-section' role='button'>
-                    <div className='kernel-status-text'>
+                <div className='kernel-status-section kernel-status-server' role='button'>
+                    <div className='kernel-status-text' title={this.props.kernel.localizedUri}>
                     {getLocString('DataScience.jupyterServer', 'Jupyter Server')}: {this.props.kernel.localizedUri}
                     </div>
                     <Image baseTheme={this.props.baseTheme} class='image-button-image kernel-status-icon' image={this.getIcon()} />

--- a/src/datascience-ui/native-editor/nativeEditor.less
+++ b/src/datascience-ui/native-editor/nativeEditor.less
@@ -287,6 +287,8 @@
 
 .native-button {
     margin-top: 3px;
+    background: var(--override-background, var(--vscode-editor-background));
+    z-index: 10;
 }
 
 #toolbar-panel {

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-'use strict';
-
 import { nbformat } from '@jupyterlab/coreutils';
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { EventEmitter } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
+
 import { ApplicationShell } from '../../../../client/common/application/applicationShell';
 import { IApplicationShell } from '../../../../client/common/application/types';
 import { PYTHON_LANGUAGE } from '../../../../client/common/constants';
@@ -17,10 +16,11 @@ import * as localize from '../../../../client/common/utils/localize';
 import { noop } from '../../../../client/common/utils/misc';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
+import { JupyterSessionManagerFactory } from '../../../../client/datascience/jupyter/jupyterSessionManagerFactory';
 import { KernelSelectionProvider } from '../../../../client/datascience/jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
-import { IJupyterSessionManager } from '../../../../client/datascience/types';
+import { IConnection, IJupyterSessionManager, IJupyterSessionManagerFactory } from '../../../../client/datascience/types';
 import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../../client/interpreter/interpreterService';
 
@@ -29,10 +29,22 @@ suite('Data Science - KernelSelector', () => {
     let kernelSelectionProvider: KernelSelectionProvider;
     let kernelService: KernelService;
     let sessionManager: IJupyterSessionManager;
+    let sessionManagerFactory: IJupyterSessionManagerFactory;
     let kernelSelector: KernelSelector;
     let interpreterService: IInterpreterService;
     let appShell: IApplicationShell;
     let installer: IInstaller;
+    const dummyEvent = new EventEmitter<number>();
+    const connection: IConnection = {
+        // tslint:disable-next-line: no-http-string
+        baseUrl: 'http://foobar',
+        token: '1234',
+        hostName: 'foobar',
+        localLaunch: false,
+        localProcExitCode: undefined,
+        disconnected: dummyEvent.event,
+        dispose: noop
+    };
     const kernelSpec = {
         argv: [],
         display_name: 'Something',
@@ -52,6 +64,8 @@ suite('Data Science - KernelSelector', () => {
 
     setup(() => {
         sessionManager = mock(JupyterSessionManager);
+        sessionManagerFactory = mock(JupyterSessionManagerFactory);
+        when(sessionManagerFactory.create(anything())).thenResolve(instance(sessionManager));
         kernelService = mock(KernelService);
         kernelSelectionProvider = mock(KernelSelectionProvider);
         appShell = mock(ApplicationShell);
@@ -62,7 +76,8 @@ suite('Data Science - KernelSelector', () => {
             instance(appShell),
             instance(kernelService),
             instance(interpreterService),
-            instance(installer)
+            instance(installer),
+            instance(sessionManagerFactory)
         );
     });
     teardown(() => sinon.restore());
@@ -267,6 +282,128 @@ suite('Data Science - KernelSelector', () => {
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
             verify(kernelService.searchAndRegisterKernel(interpreter, anything())).once();
+            verify(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).never();
+            verify(kernelService.findMatchingInterpreter(kernelSpec, anything())).never();
+            verify(appShell.showQuickPick(anything(), anything(), anything())).never();
+            verify(kernelService.registerKernel(anything(), anything())).never();
+        });
+        test('Remote search works', async () => {
+            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).thenResolve(undefined);
+            when(kernelService.getKernelSpecs(anything(), anything())).thenResolve([
+                {
+                    name: 'bar',
+                    display_name: 'foo',
+                    language: 'CSharp',
+                    path: '/foo/dotnet',
+                    argv: []
+                },
+                {
+                    name: 'foo',
+                    display_name: 'foo',
+                    language: 'Python',
+                    path: '/foo/python',
+                    argv: []
+                }
+            ]);
+            when(interpreterService.getActiveInterpreter(undefined)).thenResolve(interpreter);
+            when(kernelService.searchAndRegisterKernel(interpreter, anything())).thenResolve(kernelSpec);
+            when(kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything())).thenResolve();
+
+            const kernel = await kernelSelector.getKernelForRemoteConnection(connection, undefined);
+
+            assert.ok(kernel.kernelSpec, 'No kernel spec found for remote');
+            assert.equal(kernel.kernelSpec?.display_name, 'foo', 'Did not find the python kernel spec');
+            assert.isOk(kernel.interpreter === interpreter);
+            assert.isOk(selectLocalKernelStub.notCalled);
+            verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+            verify(kernelService.searchAndRegisterKernel(interpreter, anything())).never();
+            verify(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).never();
+            verify(kernelService.findMatchingInterpreter(kernelSpec, anything())).never();
+            verify(appShell.showQuickPick(anything(), anything(), anything())).never();
+            verify(kernelService.registerKernel(anything(), anything())).never();
+        });
+        test('Remote search prefers same name as long as it is python', async () => {
+            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).thenResolve(undefined);
+            when(kernelService.getKernelSpecs(anything(), anything())).thenResolve([
+                {
+                    name: 'bar',
+                    display_name: 'foo',
+                    language: 'CSharp',
+                    path: '/foo/dotnet',
+                    argv: []
+                },
+                {
+                    name: 'foo',
+                    display_name: 'zip',
+                    language: 'Python',
+                    path: '/foo/python',
+                    argv: []
+                },
+                {
+                    name: 'foo',
+                    display_name: 'foo',
+                    language: 'Python',
+                    path: '/foo/python',
+                    argv: []
+                }
+            ]);
+            when(interpreterService.getActiveInterpreter(undefined)).thenResolve(interpreter);
+            when(kernelService.searchAndRegisterKernel(interpreter, anything())).thenResolve(kernelSpec);
+            when(kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything())).thenResolve();
+
+            const kernel = await kernelSelector.getKernelForRemoteConnection(connection, { orig_nbformat: 4, kernelspec: { display_name: 'foo', name: 'foo' } });
+
+            assert.ok(kernel.kernelSpec, 'No kernel spec found for remote');
+            assert.equal(kernel.kernelSpec?.display_name, 'foo', 'Did not find the preferred python kernel spec');
+            assert.isOk(kernel.interpreter === interpreter);
+            assert.isOk(selectLocalKernelStub.notCalled);
+            verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+            verify(kernelService.searchAndRegisterKernel(interpreter, anything())).never();
+            verify(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).never();
+            verify(kernelService.findMatchingInterpreter(kernelSpec, anything())).never();
+            verify(appShell.showQuickPick(anything(), anything(), anything())).never();
+            verify(kernelService.registerKernel(anything(), anything())).never();
+        });
+        test('Remote search prefers same version', async () => {
+            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).thenResolve(undefined);
+            when(kernelService.getKernelSpecs(anything(), anything())).thenResolve([
+                {
+                    name: 'bar',
+                    display_name: 'fod',
+                    language: 'CSharp',
+                    path: '/foo/dotnet',
+                    argv: []
+                },
+                {
+                    name: 'python2',
+                    display_name: 'zip',
+                    language: 'Python',
+                    path: '/foo/python',
+                    argv: []
+                },
+                {
+                    name: 'python3',
+                    display_name: 'foo',
+                    language: 'Python',
+                    path: '/foo/python',
+                    argv: []
+                }
+            ]);
+            when(interpreterService.getActiveInterpreter(undefined)).thenResolve(interpreter);
+            when(kernelService.searchAndRegisterKernel(interpreter, anything())).thenResolve(kernelSpec);
+            when(kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything())).thenResolve();
+
+            const kernel = await kernelSelector.getKernelForRemoteConnection(connection, { orig_nbformat: 4, kernelspec: { display_name: 'foo', name: 'foo' } });
+
+            assert.ok(kernel.kernelSpec, 'No kernel spec found for remote');
+            assert.equal(kernel.kernelSpec?.display_name, 'foo', 'Did not find the preferred python kernel spec');
+            assert.isOk(kernel.interpreter === interpreter);
+            assert.isOk(selectLocalKernelStub.notCalled);
+            verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
+            verify(kernelService.searchAndRegisterKernel(interpreter, anything())).never();
             verify(kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())).never();
             verify(kernelService.findMatchingInterpreter(kernelSpec, anything())).never();
             verify(appShell.showQuickPick(anything(), anything(), anything())).never();


### PR DESCRIPTION
For #3763 

Kernel UI didn't support remote kernel picking. Now it does by asking the remote system for the best matching kernel.