### PR TITLE
Stop using global storage for notebook data and debounce updates

### DIFF
--- a/news/2 Fixes/8961.md
+++ b/news/2 Fixes/8961.md
@@ -1,0 +1,1 @@
+Fix slowdown in Notebook editor caused by using global storage for too much data.

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -1,31 +1,86 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
+import '../../common/extensions';
+
 import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
 import * as detectIndent from 'detect-indent';
 import { inject, injectable, multiInject, named } from 'inversify';
 import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { Event, EventEmitter, Memento, TextEditor, Uri, ViewColumn } from 'vscode';
-import { IApplicationShell, ICommandManager, IDocumentManager, ILiveShareApi, IWebPanelProvider, IWorkspaceService } from '../../common/application/types';
+
+import {
+    IApplicationShell,
+    ICommandManager,
+    IDocumentManager,
+    ILiveShareApi,
+    IWebPanelProvider,
+    IWorkspaceService
+} from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
-import '../../common/extensions';
 import { traceError } from '../../common/logger';
 import { IFileSystem, TemporaryFile } from '../../common/platform/types';
-import { GLOBAL_MEMENTO, IConfigurationService, IDisposableRegistry, IMemento, WORKSPACE_MEMENTO } from '../../common/types';
+import {
+    GLOBAL_MEMENTO,
+    IConfigurationService,
+    ICryptoUtils,
+    IDisposableRegistry,
+    IExtensionContext,
+    IMemento,
+    WORKSPACE_MEMENTO
+} from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
+import { noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { EXTENSION_ROOT_DIR } from '../../constants';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { concatMultilineStringInput, splitMultilineString } from '../common';
-import { EditorContexts, Identifiers, NativeKeyboardCommandTelemetryLookup, NativeMouseCommandTelemetryLookup, Telemetry } from '../constants';
+import {
+    EditorContexts,
+    Identifiers,
+    NativeKeyboardCommandTelemetryLookup,
+    NativeMouseCommandTelemetryLookup,
+    Telemetry
+} from '../constants';
 import { DataScience } from '../datascience';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
-import { IEditCell, IInsertCell, INativeCommand, InteractiveWindowMessages, IRemoveCell, ISaveAll, ISubmitNewCell, ISwapCells } from '../interactive-common/interactiveWindowTypes';
+import {
+    IEditCell,
+    IInsertCell,
+    INativeCommand,
+    InteractiveWindowMessages,
+    IRemoveCell,
+    ISaveAll,
+    ISubmitNewCell,
+    ISwapCells
+} from '../interactive-common/interactiveWindowTypes';
 import { InvalidNotebookFileError } from '../jupyter/invalidNotebookFileError';
-import { CellState, ICell, ICodeCssGenerator, IDataScience, IDataScienceErrorHandler, IDataViewerProvider, IInteractiveWindowInfo, IInteractiveWindowListener, IJupyterDebugger, IJupyterExecution, IJupyterVariables, INotebookEditor, INotebookEditorProvider, INotebookExporter, INotebookImporter, INotebookServerOptions, IStatusProvider, IThemeFinder } from '../types';
+import {
+    CellState,
+    ICell,
+    ICodeCssGenerator,
+    IDataScience,
+    IDataScienceErrorHandler,
+    IDataViewerProvider,
+    IInteractiveWindowInfo,
+    IInteractiveWindowListener,
+    IJupyterDebugger,
+    IJupyterExecution,
+    IJupyterVariables,
+    INotebookEditor,
+    INotebookEditorProvider,
+    INotebookExporter,
+    INotebookImporter,
+    INotebookServerOptions,
+    IStatusProvider,
+    IThemeFinder
+} from '../types';
+
+// tslint:disable-next-line:no-require-imports no-var-requires
+const debounce = require('lodash/debounce') as typeof import('lodash/debounce');
 
 const nativeEditorDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', 'native-editor');
 enum AskForSaveResult {
@@ -41,6 +96,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     private modifiedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
     private savedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
     private metadataUpdatedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
+    private savedToStorageEmitter: EventEmitter<string> = new EventEmitter<string>();
     private loadedPromise: Deferred<void> = createDeferred<void>();
     private _file: Uri = Uri.file('');
     private _dirty: boolean = false;
@@ -50,6 +106,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     private loadedAllCells: boolean = false;
     private indentAmount: string = ' ';
     private notebookJson: Partial<nbformat.INotebookContent> = {};
+    private debouncedWriteToStorage = debounce(this.writeToStorage.bind(this), 250);
 
     constructor(
         @multiInject(IInteractiveWindowListener) listeners: IInteractiveWindowListener[],
@@ -76,7 +133,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         @inject(IDataScience) dataScience: DataScience,
         @inject(IDataScienceErrorHandler) errorHandler: IDataScienceErrorHandler,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private globalStorage: Memento,
-        @inject(IMemento) @named(WORKSPACE_MEMENTO) private localStorage: Memento
+        @inject(IMemento) @named(WORKSPACE_MEMENTO) private localStorage: Memento,
+        @inject(ICryptoUtils) private crypto: ICryptoUtils,
+        @inject(IExtensionContext) private context: IExtensionContext
     ) {
         super(
             listeners,
@@ -105,6 +164,10 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             localize.DataScience.nativeEditorTitle(),
             ViewColumn.Active
         );
+    }
+
+    public get savedToStorage(): Event<string> {
+        return this.savedToStorageEmitter.event;
     }
 
     public get visible(): boolean {
@@ -593,24 +656,72 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
      */
     private async getStoredContents(): Promise<string | undefined> {
         const key = this.getStorageKey();
-        const data = this.globalStorage.get<{ contents?: string; lastModifiedTimeMs?: number }>(key);
-        // Check whether the file has been modified since the last time the contents were saved.
-        if (data && data.lastModifiedTimeMs && !this.isUntitled && this.file.scheme === 'file') {
-            const stat = await this.fileSystem.stat(this.file.fsPath);
-            if (stat.mtime > data.lastModifiedTimeMs) {
-                return;
+
+        // First look in the global storage file location
+        let result = await this.getStoredContentsFromFile(key);
+        if (!result) {
+            result = await this.getStoredContentsFromGlobalStorage(key);
+            if (!result) {
+                result = await this.getStoredContentsFromLocalStorage(key);
             }
         }
-        if (data && !this.isUntitled && data.contents) {
-            return data.contents;
-        }
 
+        return result;
+    }
+
+    private async getStoredContentsFromFile(key: string): Promise<string | undefined> {
+        // Hash the key. We'll use this as the file name
+        const hashed = `${this.crypto.createHash(key, 'string')}.ipynb`;
+
+        try {
+            // Use this to read from the extension global location
+            const contents = await this.fileSystem.readFile(path.join(this.context.globalStoragePath, hashed));
+            const data = JSON.parse(contents);
+            // Check whether the file has been modified since the last time the contents were saved.
+            if (data && data.lastModifiedTimeMs && !this.isUntitled && this.file.scheme === 'file') {
+                const stat = await this.fileSystem.stat(this.file.fsPath);
+                if (stat.mtime > data.lastModifiedTimeMs) {
+                    return;
+                }
+            }
+            if (data && !this.isUntitled && data.contents) {
+                return data.contents;
+            }
+        } catch {
+            noop();
+        }
+    }
+
+    private async getStoredContentsFromGlobalStorage(key: string): Promise<string | undefined> {
+        try {
+            const data = this.globalStorage.get<{ contents?: string; lastModifiedTimeMs?: number }>(key);
+
+            // Make sure we don't use this method ever again
+            await this.globalStorage.update(key, undefined);
+
+            // Check whether the file has been modified since the last time the contents were saved.
+            if (data && data.lastModifiedTimeMs && !this.isUntitled && this.file.scheme === 'file') {
+                const stat = await this.fileSystem.stat(this.file.fsPath);
+                if (stat.mtime > data.lastModifiedTimeMs) {
+                    return;
+                }
+            }
+            if (data && !this.isUntitled && data.contents) {
+                return data.contents;
+            }
+        } catch {
+            noop();
+        }
+    }
+
+    private async getStoredContentsFromLocalStorage(key: string): Promise<string | undefined> {
         const workspaceData = this.localStorage.get<string>(key);
         if (workspaceData && !this.isUntitled) {
             // Make sure to clear so we don't use this again.
             this.localStorage.update(key, undefined);
 
             // Transfer this to global storage so we use that next time instead
+
             const stat = await this.fileSystem.stat(this.file.fsPath);
             this.globalStorage.update(key, { contents: workspaceData, lastModifiedTimeMs: stat ? stat.mtime : undefined });
 
@@ -630,9 +741,26 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
      */
     private async storeContents(contents?: string): Promise<void> {
         const key = this.getStorageKey();
+        const file = `${this.crypto.createHash(key, 'string')}.ipynb`;
+        const filePath = path.join(this.context.globalStoragePath, file);
+
         // Keep track of the time when this data was saved.
         // This way when we retrieve the data we can compare it against last modified date of the file.
-        await this.globalStorage.update(key, contents ? { contents, lastModifiedTimeMs: Date.now() } : undefined);
+        const specialContents = contents ? JSON.stringify({ contents, lastModifiedTimeMs: Date.now() }) : undefined;
+
+        // Write but debounced (wait at least 250 ms)
+        return this.debouncedWriteToStorage(filePath, specialContents);
+    }
+
+    private async writeToStorage(filePath: string, contents?: string): Promise<void> {
+        if (contents) {
+            await this.fileSystem.createDirectory(path.dirname(filePath));
+            return this.fileSystem.writeFile(filePath, contents).then(() => this.savedToStorageEmitter.fire(contents));
+        } else {
+            if (this.fileSystem.directoryExists(path.dirname(filePath))) {
+                return this.fileSystem.deleteFile(filePath).then(() => this.savedToStorageEmitter.fire(undefined));
+            }
+        }
     }
 
     private async close(): Promise<void> {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -292,11 +292,12 @@ export interface INotebookEditorProvider {
 // For native editing, the INotebookEditor acts like a TextEditor and a TextDocument together
 export const INotebookEditor = Symbol('INotebookEditor');
 export interface INotebookEditor extends IInteractiveBase {
-    closed: Event<INotebookEditor>;
-    executed: Event<INotebookEditor>;
-    modified: Event<INotebookEditor>;
-    saved: Event<INotebookEditor>;
-    metadataUpdated: Event<INotebookEditor>;
+    readonly closed: Event<INotebookEditor>;
+    readonly executed: Event<INotebookEditor>;
+    readonly modified: Event<INotebookEditor>;
+    readonly saved: Event<INotebookEditor>;
+    readonly metadataUpdated: Event<INotebookEditor>;
+    readonly savedToStorage: Event<string>;
     /**
      * Is this notebook representing an untitled file which has never been saved yet.
      */

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -297,7 +297,6 @@ export interface INotebookEditor extends IInteractiveBase {
     readonly modified: Event<INotebookEditor>;
     readonly saved: Event<INotebookEditor>;
     readonly metadataUpdated: Event<INotebookEditor>;
-    readonly savedToStorage: Event<string>;
     /**
      * Is this notebook representing an untitled file which has never been saved yet.
      */

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -4,6 +4,7 @@
 import * as child_process from 'child_process';
 import { ReactWrapper } from 'enzyme';
 import { interfaces } from 'inversify';
+import * as os from 'os';
 import * as path from 'path';
 import { SemVer } from 'semver';
 import { anything, instance, mock, when } from 'ts-mockito';
@@ -471,9 +472,9 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.add<INotebookEditor>(INotebookEditor, NativeEditor);
         this.serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NativeEditorCommandListener);
         this.serviceManager.addSingletonInstance<IOutputChannel>(IOutputChannel, mock(MockOutputChannel), JUPYTER_OUTPUT_CHANNEL);
-        this.serviceManager.addSingletonInstance<ICryptoUtils>(ICryptoUtils, mock(CryptoUtils));
+        this.serviceManager.addSingleton<ICryptoUtils>(ICryptoUtils, CryptoUtils);
         const mockExtensionContext = TypeMoq.Mock.ofType<IExtensionContext>();
-        mockExtensionContext.setup(m => m.globalStoragePath).returns(() => testWorkspaceFolder);
+        mockExtensionContext.setup(m => m.globalStoragePath).returns(() => os.tmpdir());
         this.serviceManager.addSingletonInstance<IExtensionContext>(IExtensionContext, mockExtensionContext.object);
 
         this.serviceManager.addSingleton<ITerminalHelper>(ITerminalHelper, TerminalHelper);

--- a/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
@@ -255,7 +255,7 @@ suite('Data Science - Native Editor', () => {
         when(webPanelProvider.create(matcher())).thenResolve(instance(webPanel));
         lastWriteFileValue = undefined;
         wroteToFileEvent = new EventEmitter<string>();
-        fileSystem.setup(f => f.writeFile(typemoq.It.isAny(), typemoq.It.isAny())).returns((a1, a2) => {
+        fileSystem.setup(f => f.writeFile(typemoq.It.isAny(), typemoq.It.isAny())).returns((_a1, a2) => {
             lastWriteFileValue = a2;
             setTimeout(() => wroteToFileEvent.fire(a2));
             return Promise.resolve();
@@ -369,7 +369,6 @@ suite('Data Science - Native Editor', () => {
         });
         editor.onMessage(InteractiveWindowMessages.InsertCell, { index: 0, cell: createEmptyCell('1', 1) });
         expect(editor.cells).to.be.lengthOf(4);
-
 
         // Wait for contents to be stored in memento.
         // Editor will save uncommitted changes into storage, wait for it to be saved.

--- a/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
@@ -30,7 +30,7 @@ import { CryptoUtils } from '../../../client/common/crypto';
 import { LiveShareApi } from '../../../client/common/liveshare/liveshare';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IConfigurationService, ICryptoUtils, IExtensionContext } from '../../../client/common/types';
-import { createDeferred } from '../../../client/common/utils/async';
+import { createDeferred, Deferred } from '../../../client/common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
 import { CodeCssGenerator } from '../../../client/datascience/codeCssGenerator';
 import { DataViewerProvider } from '../../../client/datascience/data-viewing/dataViewerProvider';
@@ -95,6 +95,7 @@ suite('Data Science - Native Editor', () => {
     let context: typemoq.IMock<IExtensionContext>;
     let crypto: ICryptoUtils;
     let lastWriteFileValue: any;
+    let wroteToFilePromise: Deferred<boolean>;
     const baseFile = `{
  "cells": [
   {
@@ -253,8 +254,10 @@ suite('Data Science - Native Editor', () => {
         };
         when(webPanelProvider.create(matcher())).thenResolve(instance(webPanel));
         lastWriteFileValue = undefined;
-        fileSystem.setup(f => f.writeFile(typemoq.It.isAny(), typemoq.It.isAny())).returns((_a1, a2) => {
+        wroteToFilePromise = createDeferred<boolean>();
+        fileSystem.setup(f => f.writeFile(typemoq.It.isAny(), typemoq.It.isAny())).returns((a1, a2) => {
             lastWriteFileValue = a2;
+            setTimeout(() => wroteToFilePromise.resolve(true));
             return Promise.resolve();
         });
         fileSystem.setup(f => f.readFile(typemoq.It.isAny())).returns((_a1) => {
@@ -353,18 +356,14 @@ suite('Data Science - Native Editor', () => {
         const editor = createEditor();
         await editor.load(baseFile, file);
         expect(await editor.getContents()).to.be.equal(baseFile);
-        const savedPromise = createDeferred<string | undefined>();
-        const disposable = editor.savedToStorage((c: string) => savedPromise.resolve(c));
         editor.onMessage(InteractiveWindowMessages.InsertCell, { index: 0, cell: createEmptyCell('1', 1) });
         expect(editor.cells).to.be.lengthOf(4);
 
         // Wait for contents to be stored in memento.
         // Editor will save uncommitted changes into storage, wait for it to be saved.
-        await waitForCondition(async () => { await savedPromise.promise; return true; }, 500, 'Storage not updated');
-        disposable.dispose();
+        await waitForCondition(() => wroteToFilePromise.promise, 500, 'Storage not updated');
 
         // Confirm contents were saved.
-        expect(await savedPromise.promise).not.to.be.undefined;
         expect(await editor.getContents()).not.to.be.equal(baseFile);
 
         return editor;
@@ -392,8 +391,9 @@ suite('Data Science - Native Editor', () => {
 
         // Verify contents are different.
         // Meaning it was not loaded from file, but loaded from our storage.
-        expect(await newEditor.getContents()).not.to.be.equal(baseFile);
-        const notebook = JSON.parse(await newEditor.getContents());
+        const contents = await newEditor.getContents();
+        expect(contents).not.to.be.equal(baseFile);
+        const notebook = JSON.parse(contents);
         // 4 cells (1 extra for what was added)
         expect(notebook.cells).to.be.lengthOf(4);
     });

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -116,6 +116,8 @@ export class MockJupyterManager implements IJupyterSessionManager {
         // Setup our default cells that happen for everything
         this.addCell(CodeSnippits.MatplotLibInitSvg);
         this.addCell(CodeSnippits.MatplotLibInitPng);
+        this.addCell(CodeSnippits.ConfigSvg);
+        this.addCell(CodeSnippits.ConfigPng);
         this.addCell(`import sys\r\nsys.path.append('undefined')\r\nsys.path`);
         this.addCell(`import ptvsd\r\nptvsd.enable_attach(('localhost', 0))`);
         this.addCell('matplotlib.style.use(\'dark_background\')');

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -797,6 +797,7 @@ for _ in range(50):
 
             test('Pressing \'Alt+Enter\' on a selected cell adds a new cell below it', async () => {
                 // Initially 3 cells.
+                wrapper.update();
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
                 const update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
@@ -811,6 +812,7 @@ for _ in range(50):
             });
 
             test('Auto brackets work', async () => {
+                wrapper.update();
                 // Initially 3 cells.
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
@@ -851,6 +853,7 @@ for _ in range(50):
 
             test('Pressing \'a\' on a selected cell adds a cell at the current position', async () => {
                 // Initially 3 cells.
+                wrapper.update();
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
                 // const secondCell = wrapper.find('NativeCell').at(1);
@@ -871,6 +874,7 @@ for _ in range(50):
 
             test('Pressing \'b\' on a selected cell adds a cell after the current position', async () => {
                 // Initially 3 cells.
+                wrapper.update();
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
                 clickCell(1);

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -563,6 +563,7 @@ for _ in range(50):
         });
 
         function clickCell(cellIndex: number) {
+            wrapper.update();
             wrapper
                 .find(NativeCell)
                 .at(cellIndex)
@@ -573,6 +574,7 @@ for _ in range(50):
         function simulateKeyPressOnCell(cellIndex: number, keyboardEvent: Partial<IKeyboardEvent> & { code: string }) {
             const event = { ...createKeyboardEventForCell(keyboardEvent), ...keyboardEvent };
             const id = `NotebookImport#${cellIndex}`;
+            wrapper.update();
             wrapper
                 .find(NativeCell)
                 .at(cellIndex)
@@ -696,6 +698,7 @@ for _ in range(50):
             test('Pressing \'Enter\' on a selected cell, results in focus being set to the code', async () => {
                 // For some reason we cannot allow setting focus to monaco editor.
                 // Tests are known to fall over if allowed.
+                wrapper.update();
                 const editor = wrapper
                     .find(NativeCell)
                     .at(1)
@@ -835,6 +838,7 @@ for _ in range(50):
 
             test('Pressing \'d\' on a selected cell twice deletes the cell', async () => {
                 // Initially 3 cells.
+                wrapper.update();
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
                 clickCell(2);


### PR DESCRIPTION
For #8961

We were using global storage to save a copy of every notebook every time it changed. Turns out this is really slow. Under the covers it looks like VS code reads the entire file into memory on every update, finds the key value pair for the storage, and then writes it back out.

This global storage file was then getting really really big and causing a huge read on every update.

Changed the algorithm to write a new file to the global storage location that is a hash of the notebook file name. Only ever have to rewrite this file (we only read it on load).

Also debounced the write so we don't do it too often.