### PR TITLE
add token back in

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1074,7 +1074,15 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
 
                         // Determine the connection URI of the connected server to display
                         if (connectionInfo) {
-                            connectionInfo.localLaunch ? localizedUri = localize.DataScience.localJupyterServer() : localizedUri = connectionInfo.baseUrl;
+                            if (connectionInfo.localLaunch) {
+                                localizedUri = localize.DataScience.localJupyterServer();
+                            } else {
+                                if (connectionInfo.token) {
+                                    localizedUri = `${connectionInfo.baseUrl}?token=${connectionInfo.token}`;
+                                } else {
+                                    localizedUri = connectionInfo.baseUrl;
+                                }
+                            }
                         }
 
                         const name = kernelSpec.display_name || kernelSpec.name;


### PR DESCRIPTION
Add the token back into the URL from a previous change. I misinterpreted Rich's comment on the review to think that it was supposed to not be present, but it is. 

Addendum to this fix today:
https://github.com/microsoft/vscode-python/pull/9161

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [ ] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
