### PR TITLE
Make sure to wait for idle on changeKernel

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1319,7 +1319,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                 }
 
                 // Change the kernel. A status update should fire that changes our display
-                await this.notebook!.setKernelSpec(newKernel.kernelSpec || newKernel.kernelModel!);
+                await this.notebook!.setKernelSpec(newKernel.kernelSpec || newKernel.kernelModel!, this.configService.getSettings().datascience.jupyterLaunchTimeout);
 
                 // Add in a new sys info
                 await this.addSysInfo(SysInfoReason.New);

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -508,7 +508,7 @@ export class JupyterNotebookBase implements INotebook {
         return this.launchInfo.kernelSpec;
     }
 
-    public async setKernelSpec(spec: IJupyterKernelSpec | LiveKernelModel): Promise<void> {
+    public async setKernelSpec(spec: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void> {
         // Change our own kernel spec
         this.launchInfo.kernelSpec = spec;
 
@@ -518,7 +518,7 @@ export class JupyterNotebookBase implements INotebook {
             this.ranInitialSetup = false;
 
             // Change the kernel on the session
-            await this.session.changeKernel(spec);
+            await this.session.changeKernel(spec, timeoutMS);
 
             // Rerun our initial setup
             await this.initialize();

--- a/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
@@ -199,7 +199,7 @@ export class GuestJupyterNotebook extends LiveShareParticipantGuest(LiveSharePar
         return;
     }
 
-    public setKernelSpec(_spec: IJupyterKernelSpec | LiveKernelModel): Promise<void> {
+    public setKernelSpec(_spec: IJupyterKernelSpec | LiveKernelModel, _timeout: number): Promise<void> {
         return Promise.resolve();
     }
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -104,7 +104,7 @@ export interface INotebook extends IAsyncDisposable {
     addLogger(logger: INotebookExecutionLogger): void;
     getMatchingInterpreter(): PythonInterpreter | undefined;
     getKernelSpec(): IJupyterKernelSpec | LiveKernelModel | undefined;
-    setKernelSpec(spec: IJupyterKernelSpec | LiveKernelModel): Promise<void>;
+    setKernelSpec(spec: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void>;
     setInterpreter(interpeter: PythonInterpreter): void;
 }
 
@@ -179,7 +179,7 @@ export interface IJupyterSession extends IAsyncDisposable {
     ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined;
     requestComplete(content: KernelMessage.ICompleteRequestMsg['content']): Promise<KernelMessage.ICompleteReplyMsg | undefined>;
     sendInputReply(content: string): void;
-    changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel): Promise<void>;
+    changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void>;
 }
 
 export const IJupyterSessionManagerFactory = Symbol('IJupyterSessionManagerFactory');

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -146,7 +146,7 @@ class MockJupyterNotebook implements INotebook {
         return;
     }
 
-    public setKernelSpec(_spec: IJupyterKernelSpec | LiveKernelModel): Promise<void> {
+    public setKernelSpec(_spec: IJupyterKernelSpec | LiveKernelModel, _timeout: number): Promise<void> {
         return Promise.resolve();
     }
 

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-'use strict';
-
 import { ContentsManager, Kernel, ServerConnection, Session, SessionManager } from '@jupyterlab/services';
 import { DefaultKernel } from '@jupyterlab/services/lib/kernel/default';
 import { KernelFutureHandler } from '@jupyterlab/services/lib/kernel/future';
@@ -12,8 +9,10 @@ import { assert } from 'chai';
 import * as sinon from 'sinon';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
+
 import { createDeferred, Deferred } from '../../../client/common/utils/async';
 import { DataScience } from '../../../client/common/utils/localize';
+import { noop } from '../../../client/common/utils/misc';
 import { JupyterSession } from '../../../client/datascience/jupyter/jupyterSession';
 import { KernelSelector } from '../../../client/datascience/jupyter/kernels/kernelSelector';
 import { LiveKernelModel } from '../../../client/datascience/jupyter/kernels/types';
@@ -179,6 +178,7 @@ suite('Data Science - JupyterSession', () => {
             });
         });
         suite('Remote Sessions', async () => {
+            let restartCount = 0;
             const newActiveRemoteKernel: LiveKernelModel = {
                 argv: [],
                 display_name: 'new kernel',
@@ -187,8 +187,21 @@ suite('Data Science - JupyterSession', () => {
                 path: 'path',
                 lastActivityTime: new Date(),
                 numberOfConnections: 1,
-                // tslint:disable-next-line: no-any
-                session: {} as any,
+                session: {
+                    statusChanged: {
+                        connect: noop
+                    },
+                    kernelChanged: {
+                        connect: noop
+                    },
+                    kernel: {
+                        status: 'idle',
+                        restart: () => restartCount = restartCount + 1
+                    },
+                    shutdown: () => Promise.resolve(),
+                    isRemoteSession: false
+                    // tslint:disable-next-line: no-any
+                } as any,
                 id: 'liveKernel'
             };
             let remoteSession: ISession;
@@ -206,7 +219,7 @@ suite('Data Science - JupyterSession', () => {
                     const signal = mock(Signal);
                     when(remoteSession.statusChanged).thenReturn(instance(signal));
                     verify(sessionManager.startNew(anything())).once();
-                    when(sessionManager.connectTo(newActiveRemoteKernel.session)).thenReturn(instance(remoteSession));
+                    when(sessionManager.connectTo(newActiveRemoteKernel.session)).thenReturn(newActiveRemoteKernel.session as any);
 
                     assert.isFalse(remoteSessionInstance.isRemoteSession);
                     await jupyterSession.changeKernel(newActiveRemoteKernel, 10000);
@@ -220,7 +233,7 @@ suite('Data Science - JupyterSession', () => {
                 });
                 test('Will flag new session as being remote', async () => {
                     // Confirm the new session is flagged as remote
-                    assert.isTrue(remoteSessionInstance.isRemoteSession);
+                    assert.isTrue(newActiveRemoteKernel.session.isRemoteSession);
                 });
                 test('Will note create a new session', async () => {
                     verify(sessionManager.startNew(anything())).once();
@@ -231,7 +244,7 @@ suite('Data Science - JupyterSession', () => {
                     await jupyterSession.restart(0);
 
                     // We should restart the kernel, not the session.
-                    verify(remoteKernel.restart()).once();
+                    assert.equal(restartCount, 1, 'Did not restart the kernel');
                     verify(remoteSession.shutdown()).never();
                     verify(remoteSession.dispose()).never();
                 });

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -219,6 +219,7 @@ suite('Data Science - JupyterSession', () => {
                     const signal = mock(Signal);
                     when(remoteSession.statusChanged).thenReturn(instance(signal));
                     verify(sessionManager.startNew(anything())).once();
+                    // tslint:disable-next-line: no-any
                     when(sessionManager.connectTo(newActiveRemoteKernel.session)).thenReturn(newActiveRemoteKernel.session as any);
 
                     assert.isFalse(remoteSessionInstance.isRemoteSession);

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -209,7 +209,7 @@ suite('Data Science - JupyterSession', () => {
                     when(sessionManager.connectTo(newActiveRemoteKernel.session)).thenReturn(instance(remoteSession));
 
                     assert.isFalse(remoteSessionInstance.isRemoteSession);
-                    await jupyterSession.changeKernel(newActiveRemoteKernel);
+                    await jupyterSession.changeKernel(newActiveRemoteKernel, 10000);
                 });
                 test('Will shutdown to old session', async () => {
                     verify(session.shutdown()).once();
@@ -284,7 +284,7 @@ suite('Data Science - JupyterSession', () => {
                     path: 'path'
                 };
 
-                await jupyterSession.changeKernel(newKernel);
+                await jupyterSession.changeKernel(newKernel, 10000);
 
                 // Wait untill a new session has been started.
                 await newSessionCreated.promise;

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -133,7 +133,7 @@ export class MockJupyterSession implements IJupyterSession {
         this.completionTimeout = timeout;
     }
 
-    public changeKernel(_kernel: IJupyterKernelSpec | LiveKernelModel): Promise<void> {
+    public changeKernel(_kernel: IJupyterKernelSpec | LiveKernelModel, _timeoutMS: number): Promise<void> {
         return Promise.resolve();
     }
 


### PR DESCRIPTION
We aren't waiting for idle when changing kernels.
If we believe idle state is necessary for execution, we should wait for idle.