### PR TITLE
Fix padding between line # & code in native editor

### DIFF
--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -169,7 +169,7 @@ export namespace Effects {
         return {
             ...arg.prevState,
             settings: newSettings,
-            editorOptions: newEditorOptions,
+            editorOptions: { ...newEditorOptions, lineDecorationsWidth: 5},
             font: {
                 size: newFontSize,
                 family: newFontFamily


### PR DESCRIPTION
For #9201
Restores changes lost as part of redux refactor.
Old code here https://github.com/microsoft/vscode-python/issues/9201#issuecomment-567249280