### PR TITLE
Add ability to retry starting a session when starting a session fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "onCommand:python.viewLanguageServerOutput",
         "onCommand:python.viewTestOutput",
         "onCommand:python.viewOutput",
-        "onCommand:python.datascience.viewTestOutput",
+        "onCommand:python.datascience.viewJupyterOutput",
         "onCommand:python.selectAndRunTestMethod",
         "onCommand:python.selectAndDebugTestMethod",
         "onCommand:python.selectAndRunTestFile",
@@ -240,8 +240,8 @@
                 }
             },
             {
-                "command": "python.datascience.viewTestOutput",
-                "title": "%python.command.python.datascience.viewTestOutput.title%",
+                "command": "python.datascience.viewJupyterOutput",
+                "title": "%python.command.python.datascience.viewJupyterOutput.title%",
                 "category": "Python"
             },
             {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "onCommand:python.viewLanguageServerOutput",
         "onCommand:python.viewTestOutput",
         "onCommand:python.viewOutput",
+        "onCommand:python.datascience.viewTestOutput",
         "onCommand:python.selectAndRunTestMethod",
         "onCommand:python.selectAndDebugTestMethod",
         "onCommand:python.selectAndRunTestFile",
@@ -237,6 +238,11 @@
                     "light": "resources/light/repl.svg",
                     "dark": "resources/dark/repl.svg"
                 }
+            },
+            {
+                "command": "python.datascience.viewTestOutput",
+                "title": "%python.command.python.datascience.viewTestOutput.title%",
+                "category": "Python"
             },
             {
                 "command": "python.viewLanguageServerOutput",

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,7 +14,7 @@
     "python.command.python.refactorExtractMethod.title": "Extract Method",
     "python.command.python.viewOutput.title": "Show Output",
     "python.command.python.viewTestOutput.title": "Show Test Output",
-    "python.command.python.datascience.viewTestOutput.title": "Show Jupyter Output",
+    "python.command.python.datascience.viewJupyterOutput.title": "Show Jupyter Output",
     "python.command.python.viewLanguageServerOutput.title": "Show Language Server Output",
     "python.command.python.selectAndRunTestMethod.title": "Run Test Method ...",
     "python.command.python.selectAndDebugTestMethod.title": "Debug Test Method ...",

--- a/package.nls.json
+++ b/package.nls.json
@@ -400,6 +400,7 @@
     "DataScience.fallBackToRegisterAndUseActiveInterpeterAsKernel": "Couldn't find kernel '{0}' that the notebook was created with. Registering a new kernel using the current interpreter.",
     "DataScience.fallBackToPromptToUseActiveInterpreterOrSelectAKernel": "Couldn't find kernel '{0}' that the notebook was created with.",
     "DataScience.selectKernel": "Select a Kernel",
+    "DataScience.selectDifferentKernel": "Select a different Kernel",
     "products.installingModule": "Installing {0}",
     "DataScience.switchingKernelProgress": "Switching kernel to '{0}'",
     "DataScience.sessionStartFailedWithKernel": "Failed to start a session for the Kernel '{0}'. \nView Jupyter [log](command:{1}) for further details."

--- a/package.nls.json
+++ b/package.nls.json
@@ -402,5 +402,5 @@
     "DataScience.selectKernel": "Select a Kernel",
     "products.installingModule": "Installing {0}",
     "DataScience.switchingKernelProgress": "Switching kernel to '{0}'",
-    "DataScience.sessionStartFailedWithKernel": "Failed to start a session for the selected kernel '{0}'. View Jupyter [logs](command:{1}) for further details."
+    "DataScience.sessionStartFailedWithKernel": "Failed to start a session for the Kernel '{0}'. \nView Jupyter [log](command:{1}) for further details."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,7 @@
     "python.command.python.refactorExtractMethod.title": "Extract Method",
     "python.command.python.viewOutput.title": "Show Output",
     "python.command.python.viewTestOutput.title": "Show Test Output",
+    "python.command.python.datascience.viewTestOutput.title": "Show Jupyter Output",
     "python.command.python.viewLanguageServerOutput.title": "Show Language Server Output",
     "python.command.python.selectAndRunTestMethod.title": "Run Test Method ...",
     "python.command.python.selectAndDebugTestMethod.title": "Debug Test Method ...",
@@ -222,6 +223,7 @@
     "DataScience.exportingFormat": "Exporting {0}",
     "DataScience.exportCancel": "Cancel",
     "Common.canceled": "Canceled",
+    "Common.cancel": "Cancel",
     "DataScience.importChangeDirectoryComment": "{0} Change working directory from the workspace root to the ipynb file location. Turn this addition off with the DataScience.changeDirOnImportExport setting",
     "DataScience.exportChangeDirectoryComment": "# Change directory to VSCode workspace root so that relative path loads work correctly. Turn this addition off with the DataScience.changeDirOnImportExport setting",
     "DataScience.interruptKernelStatus": "Interrupting IPython Kernel",
@@ -399,5 +401,6 @@
     "DataScience.fallBackToPromptToUseActiveInterpreterOrSelectAKernel": "Couldn't find kernel '{0}' that the notebook was created with.",
     "DataScience.selectKernel": "Select a Kernel",
     "products.installingModule": "Installing {0}",
-    "DataScience.switchingKernelProgress": "Switching kernel to '{0}'"
+    "DataScience.switchingKernelProgress": "Switching kernel to '{0}'",
+    "DataScience.sessionStartFailedWithKernel": "Failed to start a session for the selected kernel '{0}'. View Jupyter [logs](command:{1}) for further details."
 }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -137,4 +137,5 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.DebugContinue]: [];
     [DSCommands.RunCurrentCellAndAddBelow]: [string];
     [DSCommands.ScrollToCell]: [string, string];
+    [DSCommands.ViewJupyterOutput]: [];
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -28,6 +28,7 @@ export namespace Diagnostics {
 
 export namespace Common {
     export const canceled = localize('Common.canceled', 'Canceled');
+    export const cancel = localize('Common.cancel', 'Cancel');
     export const gotIt = localize('Common.gotIt', 'Got it!');
     export const loadingExtension = localize('Common.loadingPythonExtension', 'Python extension loading...');
     export const openOutputPanel = localize('Common.openOutputPanel', 'Show output');
@@ -166,7 +167,7 @@ export namespace DataScience {
     export const restartingKernelStatus = localize('DataScience.restartingKernelStatus', 'Restarting IPython Kernel');
     export const restartingKernelFailed = localize('DataScience.restartingKernelFailed', 'Kernel restart failed. Jupyter server is hung. Please reload VS code.');
     export const interruptingKernelFailed = localize('DataScience.interruptingKernelFailed', 'Kernel interrupt failed. Jupyter server is hung. Please reload VS code.');
-
+    export const sessionStartFailedWithKernel = localize('DataScience.sessionStartFailedWithKernel', 'Failed to start a session for the selected kernel \'{0}\'. View Jupyter [logs](command:{1}) for further details.');
     export const executingCode = localize('DataScience.executingCode', 'Executing Cell');
     export const collapseAll = localize('DataScience.collapseAll', 'Collapse all cell inputs');
     export const expandAll = localize('DataScience.expandAll', 'Expand all cell inputs');

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -167,7 +167,7 @@ export namespace DataScience {
     export const restartingKernelStatus = localize('DataScience.restartingKernelStatus', 'Restarting IPython Kernel');
     export const restartingKernelFailed = localize('DataScience.restartingKernelFailed', 'Kernel restart failed. Jupyter server is hung. Please reload VS code.');
     export const interruptingKernelFailed = localize('DataScience.interruptingKernelFailed', 'Kernel interrupt failed. Jupyter server is hung. Please reload VS code.');
-    export const sessionStartFailedWithKernel = localize('DataScience.sessionStartFailedWithKernel', 'Failed to start a session for the selected kernel \'{0}\'. View Jupyter [logs](command:{1}) for further details.');
+    export const sessionStartFailedWithKernel = localize('DataScience.sessionStartFailedWithKernel', 'Failed to start a session for the Kernel \'{0}\'. \nView Jupyter [log](command:{1}) for further details.');
     export const executingCode = localize('DataScience.executingCode', 'Executing Cell');
     export const collapseAll = localize('DataScience.collapseAll', 'Collapse all cell inputs');
     export const expandAll = localize('DataScience.expandAll', 'Expand all cell inputs');

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -231,6 +231,7 @@ export namespace DataScience {
     export const jupyterServer = localize('DataScience.jupyterServer', 'Jupyter Server');
     export const noKernel = localize('DataScience.noKernel', 'No Kernel');
     export const selectKernel = localize('DataScience.selectKernel', 'Select a Kernel');
+    export const selectDifferentKernel = localize('DataScience.selectDifferentKernel', 'Select a different Kernel');
     export const localJupyterServer = localize('DataScience.localJupyterServer', 'local');
     export const pandasTooOldForViewingFormat = localize('DataScience.pandasTooOldForViewingFormat', 'Python package \'pandas\' is version {0}. Version 0.20 or greater is required for viewing data.');
     export const pandasRequiredForViewing = localize('DataScience.pandasRequiredForViewing', 'Python package \'pandas\' is required for viewing data.');

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -58,7 +58,7 @@ export namespace Commands {
     export const RunCurrentCellAndAddBelow = 'python.datascience.runcurrentcellandaddbelow';
     export const ScrollToCell = 'python.datascience.scrolltocell';
     export const CreateNewNotebook = 'python.datascience.createnewnotebook';
-    export const ViewJupyterOutput = 'python.datascience.viewTestOutput';
+    export const ViewJupyterOutput = 'python.datascience.viewJupyterOutput';
 }
 
 export namespace CodeLensCommands {
@@ -108,7 +108,6 @@ export namespace RegExpValues {
     export const SvgWidthRegex = /(\<svg.*width=\")(.*?)\"/;
     export const SvgSizeTagRegex = /\<svg.*tag=\"sizeTag=\{(.*),\s*(.*)\}\"/;
     export const StyleTagRegex = /\<style[\s\S]*\<\/style\>/m;
-
 }
 
 export enum Telemetry {
@@ -323,7 +322,7 @@ export namespace Identifiers {
 }
 
 export namespace CodeSnippits {
-    export const ChangeDirectory = ['{0}', '{1}', 'import os', 'try:', '\tos.chdir(os.path.join(os.getcwd(), \'{2}\'))', '\tprint(os.getcwd())', 'except:', '\tpass', ''];
+    export const ChangeDirectory = ['{0}', '{1}', 'import os', 'try:', "\tos.chdir(os.path.join(os.getcwd(), '{2}'))", '\tprint(os.getcwd())', 'except:', '\tpass', ''];
     export const ChangeDirectoryCommentIdentifier = '# ms-python.python added'; // Not translated so can compare.
     export const ImportIPython = '{0}\nfrom IPython import get_ipython\n\n{1}';
     export const MatplotLibInitSvg = `import matplotlib\n%matplotlib inline\n${Identifiers.MatplotLibDefaultParams} = dict(matplotlib.rcParams)\n%config InlineBackend.figure_formats = 'svg', 'png'`;

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -322,7 +322,7 @@ export namespace Identifiers {
 }
 
 export namespace CodeSnippits {
-    export const ChangeDirectory = ['{0}', '{1}', 'import os', 'try:', "\tos.chdir(os.path.join(os.getcwd(), '{2}'))", '\tprint(os.getcwd())', 'except:', '\tpass', ''];
+    export const ChangeDirectory = ['{0}', '{1}', 'import os', 'try:', '\tos.chdir(os.path.join(os.getcwd(), \'{2}\'))', '\tprint(os.getcwd())', 'except:', '\tpass', ''];
     export const ChangeDirectoryCommentIdentifier = '# ms-python.python added'; // Not translated so can compare.
     export const ImportIPython = '{0}\nfrom IPython import get_ipython\n\n{1}';
     export const MatplotLibInitSvg = `import matplotlib\n%matplotlib inline\n${Identifiers.MatplotLibDefaultParams} = dict(matplotlib.rcParams)\n%config InlineBackend.figure_formats = 'svg', 'png'`;

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -58,6 +58,7 @@ export namespace Commands {
     export const RunCurrentCellAndAddBelow = 'python.datascience.runcurrentcellandaddbelow';
     export const ScrollToCell = 'python.datascience.scrolltocell';
     export const CreateNewNotebook = 'python.datascience.createnewnotebook';
+    export const ViewJupyterOutput = 'python.datascience.viewTestOutput';
 }
 
 export namespace CodeLensCommands {
@@ -154,6 +155,7 @@ export enum Telemetry {
     ConnectRemoteJupyter = 'DATASCIENCE.CONNECTREMOTEJUPYTER',
     ConnectFailedJupyter = 'DATASCIENCE.CONNECTFAILEDJUPYTER',
     ConnectRemoteFailedJupyter = 'DATASCIENCE.CONNECTREMOTEFAILEDJUPYTER',
+    StartSessionFailedJupyter = 'DATASCIENCE.START_SESSION_FAILED_JUPYTER',
     ConnectRemoteSelfCertFailedJupyter = 'DATASCIENCE.CONNECTREMOTESELFCERTFAILEDJUPYTER',
     RegisterAndUseInterpreterAsKernel = 'DATASCIENCE.REGISTER_AND_USE_INTERPRETER_AS_KERNEL',
     UseInterpreterAsKernel = 'DATASCIENCE.USE_INTERPRETER_AS_KERNEL',

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -32,7 +32,7 @@ import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { generateCellRangesFromDocument } from '../cellFactory';
 import { CellMatcher } from '../cellMatcher';
 import { addToUriList } from '../common';
-import { Identifiers, Settings, Telemetry } from '../constants';
+import { Commands, Identifiers, Settings, Telemetry } from '../constants';
 import { ColumnWarningSize } from '../data-viewing/types';
 import { DataScience } from '../datascience';
 import {
@@ -49,6 +49,7 @@ import {
 } from '../interactive-common/interactiveWindowTypes';
 import { JupyterInstallError } from '../jupyter/jupyterInstallError';
 import { JupyterSelfCertsError } from '../jupyter/jupyterSelfCertsError';
+import { JupyterSessionStartError } from '../jupyter/jupyterSession';
 import { JupyterKernelPromiseFailedError } from '../jupyter/kernels/jupyterKernelPromiseFailedError';
 import { KernelSpecInterpreter } from '../jupyter/kernels/kernelSelector';
 import { CssMessages } from '../messages';
@@ -1318,28 +1319,66 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         }
 
         if (kernel && (kernel.kernelSpec || kernel.kernelModel) && this.notebook) {
-            const switchKernel = async (newKernel: KernelSpecInterpreter) => {
-                if (newKernel.interpreter) {
-                    this.notebook!.setInterpreter(newKernel.interpreter);
-                }
-
-                // Change the kernel. A status update should fire that changes our display
-                await this.notebook!.setKernelSpec(newKernel.kernelSpec || newKernel.kernelModel!, this.configService.getSettings().datascience.jupyterLaunchTimeout);
-
-                // Add in a new sys info
-                await this.addSysInfo(SysInfoReason.New);
-            };
-
-            const kernelDisplayName = kernel.kernelSpec?.display_name || kernel.kernelModel?.display_name;
-            const kernelName = kernel.kernelSpec?.name || kernel.kernelModel?.name;
-            // One of them is bound to be non-empty.
-            const displayName = kernelDisplayName || kernelName || '';
-            const options: ProgressOptions = {
-                location: ProgressLocation.Notification,
-                cancellable: false,
-                title: localize.DataScience.switchingKernelProgress().format(displayName)
-            };
-            await this.applicationShell.withProgress(options, async (_, __) => switchKernel(kernel!));
+            await this.switchKernelWithRetry(kernel);
         }
+    }
+    private async switchKernelWithRetry(kernel: KernelSpecInterpreter){
+        const settings = this.configuration.getSettings();
+        const isLocalConnection = settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
+        if (!isLocalConnection){
+            return this.switchKernel(kernel);
+        }
+
+        // Keep retrying, until it works or user cancels.
+        // Sometimes if a bad kernel is selected, starting a session can fail.
+        // In such cases we need to let the user know about this and prompt them to select another kernel.
+        // tslint:disable-next-line: no-constant-condition
+        while (true) {
+            try {
+                await this.switchKernel(kernel);
+            } catch (ex) {
+                if (ex instanceof JupyterSessionStartError && isLocalConnection) {
+                    // Looks like we were unable to start a session for the local connection.
+                    // Possibly something wrong with the kernel.
+                    // At this point we have a valid jupyter server.
+                    const displayName = kernel.kernelSpec?.display_name || kernel.kernelModel?.display_name || kernel.kernelSpec?.name || kernel.kernelModel?.name || '';
+                    const message = localize.DataScience.sessionStartFailedWithKernel().format(displayName, Commands.ViewJupyterOutput);
+                    const selectKernel = localize.DataScience.selectKernel();
+                    const cancel = localize.Common.cancel();
+                    const selection = await this.applicationShell.showErrorMessage(message, selectKernel, cancel);
+                    if (selection === selectKernel) {
+                        kernel = await this.dataScience.selectLocalJupyterKernel(kernel.kernelSpec || kernel.kernelModel);
+                        if (Object.keys(kernel).length > 0){
+                            continue;
+                        }
+                    }
+                }
+                throw ex;
+            }
+        }
+    }
+    private async switchKernel(kernel: KernelSpecInterpreter): Promise<void> {
+        const switchKernel = async (newKernel: KernelSpecInterpreter) => {
+            // Change the kernel. A status update should fire that changes our display
+            await this.notebook!.setKernelSpec(newKernel.kernelSpec || newKernel.kernelModel!, this.configService.getSettings().datascience.jupyterLaunchTimeout);
+
+            if (newKernel.interpreter) {
+                this.notebook!.setInterpreter(newKernel.interpreter);
+            }
+
+            // Add in a new sys info
+            await this.addSysInfo(SysInfoReason.New);
+        };
+
+        const kernelDisplayName = kernel.kernelSpec?.display_name || kernel.kernelModel?.display_name;
+        const kernelName = kernel.kernelSpec?.name || kernel.kernelModel?.name;
+        // One of them is bound to be non-empty.
+        const displayName = kernelDisplayName || kernelName || '';
+        const options: ProgressOptions = {
+            location: ProgressLocation.Notification,
+            cancellable: false,
+            title: localize.DataScience.switchingKernelProgress().format(displayName)
+        };
+        await this.applicationShell.withProgress(options, async (_, __) => switchKernel(kernel!));
     }
 }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1343,7 +1343,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                     // At this point we have a valid jupyter server.
                     const displayName = kernel.kernelSpec?.display_name || kernel.kernelModel?.display_name || kernel.kernelSpec?.name || kernel.kernelModel?.name || '';
                     const message = localize.DataScience.sessionStartFailedWithKernel().format(displayName, Commands.ViewJupyterOutput);
-                    const selectKernel = localize.DataScience.selectKernel();
+                    const selectKernel = localize.DataScience.selectDifferentKernel();
                     const cancel = localize.Common.cancel();
                     const selection = await this.applicationShell.showErrorMessage(message, selectKernel, cancel);
                     if (selection === selectKernel) {

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1307,8 +1307,8 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         const settings = this.configuration.getSettings();
 
         let kernel: KernelSpecInterpreter | undefined;
-
-        if (settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch) {
+        const isLocalConnection = this.notebook?.server.getConnectionInfo()?.localLaunch ?? settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
+        if (isLocalConnection) {
             kernel = await this.dataScience.selectLocalJupyterKernel(this.notebook?.getKernelSpec());
         } else if (this.notebook) {
             const connInfo = this.notebook.server.getConnectionInfo();
@@ -1324,7 +1324,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     }
     private async switchKernelWithRetry(kernel: KernelSpecInterpreter){
         const settings = this.configuration.getSettings();
-        const isLocalConnection = settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
+        const isLocalConnection = this.notebook?.server.getConnectionInfo()?.localLaunch ?? settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
         if (!isLocalConnection){
             return this.switchKernel(kernel);
         }

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -6,7 +6,7 @@ import { CancellationToken, Event, EventEmitter } from 'vscode';
 
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../common/application/types';
 import { Cancellation } from '../../common/cancellation';
-import { traceInfo } from '../../common/logger';
+import { traceError, traceInfo } from '../../common/logger';
 import { IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
@@ -163,12 +163,13 @@ export class JupyterExecutionBase implements IJupyterExecution {
                             traceInfo(`Connection complete for ${options ? options.purpose : 'unknown type of'} server`);
                             break;
                         } catch (ex) {
+                            traceError('Failed to connect to server', ex);
                             if (ex instanceof JupyterSessionStartError && isLocalConnection) {
                                 // Keep retrying, until it works or user cancels.
                                 // Sometimes if a bad kernel is selected, starting a session can fail.
                                 // In such cases we need to let the user know about this and prompt them to select another kernel.
                                 const message = localize.DataScience.sessionStartFailedWithKernel().format(launchInfo.kernelSpec?.display_name || launchInfo.kernelSpec?.name || '', Commands.ViewJupyterOutput);
-                                const selectKernel = localize.DataScience.selectKernel();
+                                const selectKernel = localize.DataScience.selectDifferentKernel();
                                 const cancel = localize.Common.cancel();
                                 const selection = await this.appShell.showErrorMessage(message, selectKernel, cancel);
                                 if (selection === selectKernel) {

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -14,7 +14,7 @@ import { StopWatch } from '../../common/utils/stopWatch';
 import { IInterpreterService, PythonInterpreter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import { JupyterCommands, Telemetry } from '../constants';
+import { Commands, JupyterCommands, Telemetry } from '../constants';
 import {
     IConnection,
     IJupyterExecution,
@@ -26,6 +26,7 @@ import {
 import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder';
 import { JupyterInstallError } from './jupyterInstallError';
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
+import { JupyterSessionStartError } from './jupyterSession';
 import { createRemoteConnectionInfo } from './jupyterUtils';
 import { JupyterWaitForIdleError } from './jupyterWaitForIdleError';
 import { KernelSelector, KernelSpecInterpreter } from './kernels/kernelSelector';
@@ -107,7 +108,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
         return this.isNotebookSupported(cancelToken);
     }
 
-    //tslint:disable:cyclomatic-complexity
+    //tslint:disable:cyclomatic-complexity max-func-body-length
     public connectToNotebookServer(options?: INotebookServerOptions, cancelToken?: CancellationToken): Promise<INotebookServer | undefined> {
         // Return nothing if we cancel
         return Cancellation.race(async () => {
@@ -116,8 +117,9 @@ export class JupyterExecutionBase implements IJupyterExecution {
             let kernelSpecInterpreter: KernelSpecInterpreter | undefined;
             let kernelSpecInterpreterPromise: Promise<KernelSpecInterpreter> = Promise.resolve({});
             traceInfo(`Connecting to ${options ? options.purpose : 'unknown type of'} server`);
+            const isLocalConnection = !options || !options.uri;
 
-            if (!options || !options.uri) {
+            if (isLocalConnection) {
                 // Get hold of the kernelspec and corresponding (matching) interpreter that'll be used as the spec.
                 // We can do this in parallel, while starting the server (faster).
                 traceInfo(`Getting kernel specs for ${options ? options.purpose : 'unknown type of'} server`);
@@ -153,11 +155,38 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         enableDebugging: options ? options.enableDebugging : false
                     };
 
-                    traceInfo(`Connecting to process for ${options ? options.purpose : 'unknown type of'} server`);
-                    await result.connect(launchInfo, cancelToken);
-                    traceInfo(`Connection complete for ${options ? options.purpose : 'unknown type of'} server`);
+                    // tslint:disable-next-line: no-constant-condition
+                    while (true) {
+                        try {
+                            traceInfo(`Connecting to process for ${options ? options.purpose : 'unknown type of'} server`);
+                            await result.connect(launchInfo, cancelToken);
+                            traceInfo(`Connection complete for ${options ? options.purpose : 'unknown type of'} server`);
+                            break;
+                        } catch (ex) {
+                            if (ex instanceof JupyterSessionStartError && isLocalConnection) {
+                                // Keep retrying, until it works or user cancels.
+                                // Sometimes if a bad kernel is selected, starting a session can fail.
+                                // In such cases we need to let the user know about this and prompt them to select another kernel.
+                                const message = localize.DataScience.sessionStartFailedWithKernel().format(launchInfo.kernelSpec?.display_name || launchInfo.kernelSpec?.name || '', Commands.ViewJupyterOutput);
+                                const selectKernel = localize.DataScience.selectKernel();
+                                const cancel = localize.Common.cancel();
+                                const selection = await this.appShell.showErrorMessage(message, selectKernel, cancel);
+                                if (selection === selectKernel) {
+                                    const sessionManagerFactory = this.serviceContainer.get<IJupyterSessionManagerFactory>(IJupyterSessionManagerFactory);
+                                    const sessionManager = await sessionManagerFactory.create(connection);
+                                    const kernelInterpreter = await this.kernelSelector.selectLocalKernel(sessionManager, cancelToken, launchInfo.kernelSpec);
+                                    if (Object.keys(kernelInterpreter).length > 0){
+                                        launchInfo.interpreter = kernelInterpreter.interpreter;
+                                        launchInfo.kernelSpec = kernelInterpreter.kernelSpec || kernelInterpreter.kernelModel;
+                                        continue;
+                                    }
+                                }
+                            }
+                            throw ex;
+                        }
+                    }
 
-                    sendTelemetryEvent(launchInfo.uri ? Telemetry.ConnectRemoteJupyter : Telemetry.ConnectLocalJupyter);
+                    sendTelemetryEvent(isLocalConnection ? Telemetry.ConnectLocalJupyter : Telemetry.ConnectRemoteJupyter);
                     return result;
                 } catch (err) {
                     // Cleanup after ourselves. server may be running partially.
@@ -176,7 +205,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         tryCount += 1;
                     } else if (connection) {
                         // Something else went wrong
-                        if (options && options.uri) {
+                        if (!isLocalConnection) {
                             sendTelemetryEvent(Telemetry.ConnectRemoteFailedJupyter);
 
                             // Check for the self signed certs error specifically

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -509,9 +509,6 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     public async setKernelSpec(spec: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void> {
-        // Change our own kernel spec
-        this.launchInfo.kernelSpec = spec;
-
         // We need to start a new session with the new kernel spec
         if (this.session) {
             // Turn off setup
@@ -520,8 +517,15 @@ export class JupyterNotebookBase implements INotebook {
             // Change the kernel on the session
             await this.session.changeKernel(spec, timeoutMS);
 
+            // Change our own kernel spec
+            // Only after session was successfully created.
+            this.launchInfo.kernelSpec = spec;
+
             // Rerun our initial setup
             await this.initialize();
+        } else {
+            // Change our own kernel spec
+            this.launchInfo.kernelSpec = spec;
         }
     }
 

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1645,4 +1645,11 @@ export interface IEventNamePropertyMapping {
          */
         promptedToSelect?: boolean;
     };
+    /**
+     * Telemetry event sent when starting a session for a local connection failed.
+     *
+     * @type {(undefined | never)}
+     * @memberof IEventNamePropertyMapping
+     */
+    [Telemetry.StartSessionFailedJupyter]: undefined | never;
 }

--- a/src/test/datascience/datascience.unit.test.ts
+++ b/src/test/datascience/datascience.unit.test.ts
@@ -33,6 +33,7 @@ import {
     extractInputText,
     ICellViewModel
 } from '../../datascience-ui/interactive-common/mainState';
+import { MockOutputChannel } from '../mockClasses';
 import { MockMemento } from '../mocks/mementos';
 import { MockCommandManager } from './mockCommandManager';
 import { MockDocumentManager } from './mockDocumentManager';
@@ -327,7 +328,8 @@ class Pizza(object):
             storage,
             instance(jupyterSessionManagerFactory),
             multiStepFactory,
-            kernelSelector
+            kernelSelector,
+            new MockOutputChannel('Jupyter')
         );
     }
 

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -281,7 +281,7 @@ suite('Data Science - JupyterSession', () => {
                 when(restartSession.kernel).thenReturn(instance(restartKernel));
                 when(sessionManager.startNew(anything())).thenCall(() => {
                     newSessionCreated.resolve();
-                    return instance(restartSession);
+                    return Promise.resolve(instance(restartSession));
                 });
             });
             teardown(() => {


### PR DESCRIPTION
For #9187 
* When starting a new session fails (e.g. due to bunked kernel or the like), allow user to recover by starting a new session with a different kernel.