### PR TITLE
Fix command palette and other keyboard shortcuts to work in the http server

### DIFF
--- a/news/2 Fixes/8976.md
+++ b/news/2 Fixes/8976.md
@@ -1,0 +1,1 @@
+Command palette (and other keyboard shortcuts) don't work from the Interactive/Notebook editor in the insider's build (or when setting 'useWebViewServer')

--- a/src/client/common/application/webPanels/webPanel.ts
+++ b/src/client/common/application/webPanels/webPanel.ts
@@ -197,6 +197,10 @@ export class WebPanel implements IWebPanel {
                             if (ev.data.data.type && ev.data.data.type === '${InteractiveWindowMessages.Started}') {
                                 copyStylesToHostFrame();
                             }
+                        } else if (ev.data && ev.data.command === 'did-keydown') {
+                            window.console.log('keydown-passthrough');
+                            const keyboardEvent = new KeyboardEvent('keydown', {...ev.data.data, bubbles: true, cancelable: true, view: window});
+                            document.dispatchEvent(keyboardEvent);
                         } else if (!isFromFrame) {
                             window.console.log('posting to frame');
                             window.console.log(ev.data.type);

--- a/src/client/common/application/webPanels/webPanelServer.ts
+++ b/src/client/common/application/webPanels/webPanelServer.ts
@@ -170,6 +170,22 @@ export class WebPanelServer {
                 let state = ${state ? `JSON.parse("${JSON.stringify(state)}")` : undefined};
                 window.console.log('acquired vscode api');
 
+                // Special case, because we don't have a way to get the vscode api more than once,
+                // hook up some global handlers here.
+                document.addEventListener('keydown', (e) => {
+                    // Forward this message to the inner most frame that VS code owns.
+                    originalPostMessage({ command: 'did-keydown', data: {
+                        key: e.key,
+                        keyCode: e.keyCode,
+                        code: e.code,
+                        shiftKey: e.shiftKey,
+                        altKey: e.altKey,
+                        ctrlKey: e.ctrlKey,
+                        metaKey: e.metaKey,
+                        repeat: e.repeat
+                    }}, '*');
+                })
+
                 return () => {
                     if (acquired) {
                         throw new Error('An instance of the VS Code API has already been acquired');


### PR DESCRIPTION
For #8976

Had to forward keydown events to the inner frame so that VS code would see them. They listen to keydown events to bring up global shortcuts.

There are other events that are listened to in the normal case, but we don't need to forward them as well because we handle them ourselves differently (link clicks)