### PR TITLE
Test debug configuration should use `internalConsole`.

### DIFF
--- a/news/2 Fixes/9259.md
+++ b/news/2 Fixes/9259.md
@@ -1,0 +1,1 @@
+Set test debug console default to be `internalConsole`.

--- a/package.json
+++ b/package.json
@@ -1261,12 +1261,12 @@
                             },
                             "console": {
                                 "enum": [
-                                    "none",
+                                    "internalConsole",
                                     "integratedTerminal",
                                     "externalTerminal"
                                 ],
                                 "description": "Where to launch the debug target: internal console, integrated terminal, or external terminal.",
-                                "default": "none"
+                                "default": "internalConsole"
                             },
                             "cwd": {
                                 "type": "string",


### PR DESCRIPTION
For #9259

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)

