### PR TITLE
Faster datascience unit tests (without loading jsdom)

### DIFF
--- a/src/test/datascience/datascience.unit.test.ts
+++ b/src/test/datascience/datascience.unit.test.ts
@@ -35,11 +35,11 @@ import {
 } from '../../datascience-ui/interactive-common/mainState';
 import { MockOutputChannel } from '../mockClasses';
 import { MockMemento } from '../mocks/mementos';
+import { defaultDataScienceSettings } from './helpers';
 import { MockCommandManager } from './mockCommandManager';
 import { MockDocumentManager } from './mockDocumentManager';
 import { MockInputBox } from './mockInputBox';
 import { MockQuickPick } from './mockQuickPick';
-import { defaultDataScienceSettings } from './testHelpers';
 
 // tslint:disable: max-func-body-length
 suite('Data Science Tests', () => {

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { IDataScienceSettings } from '../../client/common/types';
+
+// The default base set of data science settings to use
+export function defaultDataScienceSettings(): IDataScienceSettings {
+    return {
+        allowImportFromNotebook: true,
+        jupyterLaunchTimeout: 10,
+        jupyterLaunchRetries: 3,
+        enabled: true,
+        jupyterServerURI: 'local',
+        // tslint:disable-next-line: no-invalid-template-strings
+        notebookFileRoot: '${fileDirname}',
+        changeDirOnImportExport: false,
+        useDefaultConfigForJupyter: true,
+        jupyterInterruptTimeout: 10000,
+        searchForJupyter: true,
+        showCellInputCode: true,
+        collapseCellInputCodeByDefault: true,
+        allowInput: true,
+        maxOutputSize: 400,
+        errorBackgroundColor: '#FFFFFF',
+        sendSelectionToInteractiveWindow: false,
+        variableExplorerExclude: 'module;function;builtin_function_or_method',
+        codeRegularExpression: '^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])',
+        markdownRegularExpression: '^(#\\s*%%\\s*\\[markdown\\]|#\\s*\\<markdowncell\\>)',
+        enablePlotViewer: true,
+        runStartupCommands: '',
+        debugJustMyCode: true
+    };
+}

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -22,6 +22,7 @@ import { InteractivePanel } from '../../datascience-ui/history-react/interactive
 import { ImageButton } from '../../datascience-ui/react-common/imageButton';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 import { createDocument } from './editor-integration/helpers';
+import { defaultDataScienceSettings } from './helpers';
 import {
     addCode,
     getInteractiveCellResults,
@@ -37,7 +38,6 @@ import {
     addMockData,
     CellInputState,
     CellPosition,
-    defaultDataScienceSettings,
     enterInput,
     escapePath,
     findButton,

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -31,10 +31,11 @@ import { IMonacoEditorState, MonacoEditor } from '../../datascience-ui/react-com
 import { waitForCondition } from '../common';
 import { createTemporaryFile } from '../utils/fs';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { defaultDataScienceSettings } from './helpers';
 import { MockDocumentManager } from './mockDocumentManager';
 import { addCell, closeNotebook, createNewEditor, getNativeCellResults, mountNativeWebView, openEditor, runMountedTest, setupWebview } from './nativeEditorTestHelpers';
 import { waitForUpdate } from './reactHelpers';
-import { addContinuousMockData, addMockData, CellPosition, createKeyboardEventForCell, defaultDataScienceSettings, escapePath, findButton, getLastOutputCell, getNativeFocusedEditor, getOutputCell, injectCode, isCellFocused, isCellMarkdown, isCellSelected, srcDirectory, typeCode, verifyCellIndex, verifyHtmlOnCell, waitForMessage, waitForMessageResponse } from './testHelpers';
+import { addContinuousMockData, addMockData, CellPosition, createKeyboardEventForCell, escapePath, findButton, getLastOutputCell, getNativeFocusedEditor, getOutputCell, injectCode, isCellFocused, isCellMarkdown, isCellSelected, srcDirectory, typeCode, verifyCellIndex, verifyHtmlOnCell, waitForMessage, waitForMessageResponse } from './testHelpers';
 
 use(chaiAsPromised);
 

--- a/src/test/datascience/testHelpers.tsx
+++ b/src/test/datascience/testHelpers.tsx
@@ -576,35 +576,6 @@ export function findButton(
     }
 }
 
-// The default base set of data science settings to use
-export function defaultDataScienceSettings(): IDataScienceSettings {
-    return {
-        allowImportFromNotebook: true,
-        jupyterLaunchTimeout: 10,
-        jupyterLaunchRetries: 3,
-        enabled: true,
-        jupyterServerURI: 'local',
-        // tslint:disable-next-line: no-invalid-template-strings
-        notebookFileRoot: '${fileDirname}',
-        changeDirOnImportExport: false,
-        useDefaultConfigForJupyter: true,
-        jupyterInterruptTimeout: 10000,
-        searchForJupyter: true,
-        showCellInputCode: true,
-        collapseCellInputCodeByDefault: true,
-        allowInput: true,
-        maxOutputSize: 400,
-        errorBackgroundColor: '#FFFFFF',
-        sendSelectionToInteractiveWindow: false,
-        variableExplorerExclude: 'module;function;builtin_function_or_method',
-        codeRegularExpression: '^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])',
-        markdownRegularExpression: '^(#\\s*%%\\s*\\[markdown\\]|#\\s*\\<markdowncell\\>)',
-        enablePlotViewer: true,
-        runStartupCommands: '',
-        debugJustMyCode: true
-    };
-}
-
 export function getMainPanel<P>(wrapper: ReactWrapper<any, Readonly<{}>>, mainClass: React.ComponentClass<any>): P | undefined {
     const mainObj = wrapper.find(mainClass);
     if (mainObj) {

--- a/src/test/datascience/testHelpers.tsx
+++ b/src/test/datascience/testHelpers.tsx
@@ -11,7 +11,6 @@ import { isString } from 'util';
 import { CancellationToken } from 'vscode';
 
 import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
-import { IDataScienceSettings } from '../../client/common/types';
 import { createDeferred } from '../../client/common/utils/async';
 import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterExecution } from '../../client/datascience/types';


### PR DESCRIPTION
Ensure jsdom is not a requirement for `*.unit.test.ts` files to ensure unit tests can run fast.
Moves a dependency used by by `*.unit.test.ts` files from `*.tsx` into a `*.ts` file (without a dependency on react/dom)