### PR TITLE
Disable sending startup telemetry when running CI

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -150,9 +150,11 @@ async function activateUnsafe(context: ExtensionContext): Promise<IExtensionApi>
 
     serviceManager.get<ICodeExecutionManager>(ICodeExecutionManager).registerCommands();
 
-    // tslint:disable-next-line:no-suspicious-comment
-    // TODO: Move this down to right before durations.endActivateTime is set.
-    sendStartupTelemetry(Promise.all([activationDeferred.promise, activationPromise]), serviceContainer).ignoreErrors();
+    if (!isTestExecution()) {
+        // tslint:disable-next-line:no-suspicious-comment
+        // TODO: Move this down to right before durations.endActivateTime is set.
+        sendStartupTelemetry(Promise.all([activationDeferred.promise, activationPromise]), serviceContainer).ignoreErrors();
+    }
 
     const workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
     const interpreterManager = serviceContainer.get<IInterpreterService>(IInterpreterService);


### PR DESCRIPTION
For #9231 #8750

Sending startup telemetry does a lot work to get telemetry data, which is of no use. It also sends `conda --version` to terminal, which is known to cause #8750

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
