### PR TITLE
Added tests for src\client\activation\languageServer\languageServerFolderService.ts

### DIFF
--- a/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
@@ -9,6 +9,7 @@ import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
 import { Uri } from 'vscode';
 import { LanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';
+import { ILanguageServerPackageService } from '../../../client/activation/types';
 import { IServiceContainer } from '../../../client/ioc/types';
 
 // tslint:disable-next-line:max-func-body-length
@@ -26,8 +27,13 @@ suite('xLanguage Server Folder Service', () => {
             path: 'path/to/currentLSDirectoryName',
             version: new SemVer('1.2.3')
         };
+        let languageServerPackageService: TypeMoq.IMock<ILanguageServerPackageService>;
         setup(() => {
+            languageServerPackageService = TypeMoq.Mock.ofType<ILanguageServerPackageService>();
             serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+            serviceContainer
+                .setup(s => s.get<ILanguageServerPackageService>(ILanguageServerPackageService))
+                .returns(() => languageServerPackageService.object);
         });
         teardown(() => {
             sinon.restore();
@@ -46,8 +52,10 @@ suite('xLanguage Server Folder Service', () => {
         test('Returns current Language server directory name if fetching latest LS version returns undefined', async () => {
             shouldLookForNewLS = sinon.stub(LanguageServerFolderService.prototype, 'shouldLookForNewLanguageServer');
             shouldLookForNewLS.resolves(true);
-            const serverVersion = sinon.stub(LanguageServerFolderService.prototype, 'getLatestLanguageServerVersion');
-            serverVersion.resolves(undefined);
+            languageServerPackageService
+                .setup(l => l.getLatestNugetPackageVersion(resource))
+                // tslint:disable-next-line: no-any
+                .returns(() => Promise.resolve(undefined) as any);
             getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
             getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
             languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
@@ -63,8 +71,9 @@ suite('xLanguage Server Folder Service', () => {
                 version: new SemVer('1.1.3'),
                 uri: 'nugetUri'
             };
-            const serverVersion = sinon.stub(LanguageServerFolderService.prototype, 'getLatestLanguageServerVersion');
-            serverVersion.resolves(nugetPackage);
+            languageServerPackageService
+                .setup(l => l.getLatestNugetPackageVersion(resource))
+                .returns(() => Promise.resolve(nugetPackage));
             getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
             getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
             languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
@@ -80,8 +89,9 @@ suite('xLanguage Server Folder Service', () => {
                 version: new SemVer('1.3.2'),
                 uri: 'nugetUri'
             };
-            const serverVersion = sinon.stub(LanguageServerFolderService.prototype, 'getLatestLanguageServerVersion');
-            serverVersion.resolves(nugetPackage);
+            languageServerPackageService
+                .setup(l => l.getLatestNugetPackageVersion(resource))
+                .returns(() => Promise.resolve(nugetPackage));
             getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
             getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
             languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);

--- a/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { expect } from 'chai';
+import { SemVer } from 'semver';
+import * as sinon from 'sinon';
+import * as TypeMoq from 'typemoq';
+import { Uri } from 'vscode';
+import { LanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';
+import { IServiceContainer } from '../../../client/ioc/types';
+
+// tslint:disable-next-line:max-func-body-length
+suite('xLanguage Server Folder Service', () => {
+    let serviceContainer: TypeMoq.IMock<IServiceContainer>;
+    let languageServerFolderService: LanguageServerFolderService;
+    const resource = Uri.parse('a');
+
+    suite('Method getLanguageServerFolderName()', async () => {
+        // tslint:disable-next-line: no-any
+        let shouldLookForNewLS: sinon.SinonStub<any>;
+        // tslint:disable-next-line: no-any
+        let getCurrentLanguageServerDirectory: sinon.SinonStub<any>;
+        const currentLSDirectory = {
+            path: 'path/to/currentLSDirectoryName',
+            version: new SemVer('1.2.3')
+        };
+        setup(() => {
+            serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
+        });
+        teardown(() => {
+            sinon.restore();
+        });
+
+        test('Returns current Language server directory name if rule says we should not look for new LS', async () => {
+            shouldLookForNewLS = sinon.stub(LanguageServerFolderService.prototype, 'shouldLookForNewLanguageServer');
+            shouldLookForNewLS.resolves(false);
+            getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
+            getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
+            languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
+            const lsFolderName = await languageServerFolderService.getLanguageServerFolderName(resource);
+            expect(lsFolderName).to.equal('currentLSDirectoryName');
+        });
+
+        test('Returns current Language server directory name if fetching latest LS version returns undefined', async () => {
+            shouldLookForNewLS = sinon.stub(LanguageServerFolderService.prototype, 'shouldLookForNewLanguageServer');
+            shouldLookForNewLS.resolves(true);
+            const serverVersion = sinon.stub(LanguageServerFolderService.prototype, 'getLatestLanguageServerVersion');
+            serverVersion.resolves(undefined);
+            getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
+            getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
+            languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
+            const lsFolderName = await languageServerFolderService.getLanguageServerFolderName(resource);
+            expect(lsFolderName).to.equal('currentLSDirectoryName');
+        });
+
+        test('Returns current Language server directory name if fetched latest LS version is less than the current LS version', async () => {
+            shouldLookForNewLS = sinon.stub(LanguageServerFolderService.prototype, 'shouldLookForNewLanguageServer');
+            shouldLookForNewLS.resolves(true);
+            const nugetPackage = {
+                package: 'packageName',
+                version: new SemVer('1.1.3'),
+                uri: 'nugetUri'
+            };
+            const serverVersion = sinon.stub(LanguageServerFolderService.prototype, 'getLatestLanguageServerVersion');
+            serverVersion.resolves(nugetPackage);
+            getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
+            getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
+            languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
+            const lsFolderName = await languageServerFolderService.getLanguageServerFolderName(resource);
+            expect(lsFolderName).to.equal('currentLSDirectoryName');
+        });
+
+        test('Returns expected Language server directory name otherwise', async () => {
+            shouldLookForNewLS = sinon.stub(LanguageServerFolderService.prototype, 'shouldLookForNewLanguageServer');
+            shouldLookForNewLS.resolves(true);
+            const nugetPackage = {
+                package: 'packageName',
+                version: new SemVer('1.3.2'),
+                uri: 'nugetUri'
+            };
+            const serverVersion = sinon.stub(LanguageServerFolderService.prototype, 'getLatestLanguageServerVersion');
+            serverVersion.resolves(nugetPackage);
+            getCurrentLanguageServerDirectory = sinon.stub(LanguageServerFolderService.prototype, 'getCurrentLanguageServerDirectory');
+            getCurrentLanguageServerDirectory.resolves(currentLSDirectory);
+            languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
+            const lsFolderName = await languageServerFolderService.getLanguageServerFolderName(resource);
+            expect(lsFolderName).to.equal('languageServer.1.3.2');
+        });
+    });
+});

--- a/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
@@ -130,7 +130,7 @@ suite('Language Server Folder Service', () => {
             languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
         });
 
-        test(('If current folder is provided and setting `python.downloadLanguageServer` is set to false, return false'), async () => {
+        test(('Returns false if current folder is provided and setting `python.downloadLanguageServer` is set to false'), async () => {
             const settings = {
                 downloadLanguageServer: false,
                 autoUpdateLanguageServer: true
@@ -143,7 +143,7 @@ suite('Language Server Folder Service', () => {
             expect(result).to.equal(false, 'Should be false');
         });
 
-        test(('If current folder is provided and setting `python.autoUpdateLanguageServer` is set to false, return false'), async () => {
+        test(('Returns false if current folder is provided and setting `python.autoUpdateLanguageServer` is set to false'), async () => {
             const settings = {
                 downloadLanguageServer: true,
                 autoUpdateLanguageServer: false
@@ -156,7 +156,7 @@ suite('Language Server Folder Service', () => {
             expect(result).to.equal(false, 'Should be false');
         });
 
-        test(('Otherwise, use rule to infer if we should look for LS'), async () => {
+        test(('Returns whatever the rule to infer LS returns otherwise'), async () => {
             const settings = {
                 downloadLanguageServer: true,
                 autoUpdateLanguageServer: false
@@ -191,7 +191,7 @@ suite('Language Server Folder Service', () => {
             languageServerFolderService = new LanguageServerFolderService(serviceContainer.object);
         });
 
-        test(('If setting `python.downloadLanguageServer` is set to false, return the expected LS directory'), async () => {
+        test(('Returns the expected LS directory if setting `python.downloadLanguageServer` is set to false'), async () => {
             const settings = {
                 downloadLanguageServer: false
             };
@@ -207,7 +207,7 @@ suite('Language Server Folder Service', () => {
             assert.deepEqual(result, expectedLSDirectory);
         });
 
-        test(('Return `undefined` if no LS directory exists'), async () => {
+        test(('Returns `undefined` if no LS directory exists'), async () => {
             const settings = {
                 downloadLanguageServer: true
             };
@@ -223,7 +223,7 @@ suite('Language Server Folder Service', () => {
             assert.deepEqual(result, undefined);
         });
 
-        test(('Return the LS directory with highest version if multiple LS directories exists'), async () => {
+        test(('Returns the LS directory with highest version if multiple LS directories exists'), async () => {
             const settings = {
                 downloadLanguageServer: true
             };

--- a/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
+++ b/src/test/activation/languageServer/languageServerFolderService.unit.test.ts
@@ -227,7 +227,7 @@ suite('Language Server Folder Service', () => {
             const settings = {
                 downloadLanguageServer: true
             };
-            const directories = ['path/to/languageServer.0.9.3', 'path/to/languageServer.1.0.7', 'path/to/languageServer.1.2.3', 'path/to/languageServer.1.2.3.5'];
+            const directories = ['path/to/languageServer', 'path/to/languageServer.0.9.3', 'path/to/languageServer.1.0.7', 'path/to/languageServer.1.2.3', 'path/to/languageServer.1.2.3.5'];
             const expectedLSDirectory = {
                 path: 'path/to/languageServer.1.2.3',
                 version: semver.parse('1.2.3', true)!


### PR DESCRIPTION
For #9231 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
