### PR TITLE
Increase extension activation time and handle errors

### DIFF
--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER } from './ciConstants';
 
-export const MAX_EXTENSION_ACTIVATION_TIME = 120_000;
+export const MAX_EXTENSION_ACTIVATION_TIME = 720_000;
 export const TEST_TIMEOUT = 25000;
 export const TEST_RETRYCOUNT = 3;
 export const IS_SMOKE_TEST = process.env.VSC_PYTHON_SMOKE_TEST === '1';

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER } from './ciConstants';
 
-export const MAX_EXTENSION_ACTIVATION_TIME = 720_000;
+export const MAX_EXTENSION_ACTIVATION_TIME = 180_000;
 export const TEST_TIMEOUT = 25000;
 export const TEST_RETRYCOUNT = 3;
 export const IS_SMOKE_TEST = process.env.VSC_PYTHON_SMOKE_TEST === '1';

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -4,6 +4,7 @@
 import * as path from 'path';
 import { IS_CI_SERVER, IS_CI_SERVER_TEST_DEBUGGER } from './ciConstants';
 
+// Activating extension for Multiroot and Debugger CI tests for Windows takes just over 2 minutes sometimes, so 3 minutes seems like a safe margin
 export const MAX_EXTENSION_ACTIVATION_TIME = 180_000;
 export const TEST_TIMEOUT = 25000;
 export const TEST_RETRYCOUNT = 3;

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -146,7 +146,14 @@ export async function run(): Promise<void> {
     // Setup test files that need to be run.
     testFiles.forEach(file => mocha.addFile(path.join(testsRoot, file)));
 
-    await activatePythonExtensionScript();
+    // tslint:disable: no-console
+    console.log('Try activating python extension');
+    try {
+        await activatePythonExtensionScript();
+    } catch (ex) {
+        console.log('Failed activating python extension within timeout');
+        console.log(ex);
+    }
 
     // Run the tests.
     await new Promise<void>((resolve, reject) => {

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -109,11 +109,8 @@ function activatePythonExtensionScript() {
     });
     const initializationPromise = initialize();
     const promise = Promise.race([initializationPromise, failed]);
-    promise.catch(ex => console.error(ex)).finally(() => clearTimeout(timer!))
-        // tslint:disable-next-line: no-console
-        console.error(ex);
-        clearTimeout(timer!);
-    });
+    // tslint:disable-next-line: no-console
+    promise.catch(ex => console.error(ex)).finally(() => clearTimeout(timer!));
     return initializationPromise;
 }
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -147,9 +147,10 @@ export async function run(): Promise<void> {
     testFiles.forEach(file => mocha.addFile(path.join(testsRoot, file)));
 
     // tslint:disable: no-console
-    console.log('Try activating python extension');
+    console.time('Time taken to activate the extension');
     try {
         await activatePythonExtensionScript();
+        console.timeEnd('Time taken to activate the extension');
     } catch (ex) {
         console.log('Failed activating python extension within timeout');
         console.log(ex);

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -109,7 +109,7 @@ function activatePythonExtensionScript() {
     });
     const initializationPromise = initialize();
     const promise = Promise.race([initializationPromise, failed]);
-    promise.then(() => clearTimeout(timer!)).catch(() => {
+    promise.catch(ex => console.error(ex)).finally(() => clearTimeout(timer!))
         // tslint:disable-next-line: no-console
         console.error(ex);
         clearTimeout(timer!);

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -110,7 +110,7 @@ function activatePythonExtensionScript() {
     const initializationPromise = initialize();
     const promise = Promise.race([initializationPromise, failed]);
     // tslint:disable-next-line: no-console
-    promise.catch(ex => console.error(ex)).finally(() => clearTimeout(timer!));
+    promise.catch(e => console.error(e)).finally(() => clearTimeout(timer!)).ignoreErrors();
     return initializationPromise;
 }
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -14,7 +14,6 @@ if ((Reflect as any).metadata === undefined) {
 import * as glob from 'glob';
 import * as Mocha from 'mocha';
 import * as path from 'path';
-import { traceError } from '../client/common/logger';
 import { IS_CI_SERVER_TEST_DEBUGGER, MOCHA_REPORTER_JUNIT } from './ciConstants';
 import { IS_MULTI_ROOT_TEST, IS_SMOKE_TEST, MAX_EXTENSION_ACTIVATION_TIME, TEST_RETRYCOUNT, TEST_TIMEOUT } from './constants';
 import { initialize } from './initialize';
@@ -110,8 +109,9 @@ function activatePythonExtensionScript() {
     });
     const initializationPromise = initialize();
     const promise = Promise.race([initializationPromise, failed]);
-    promise.then(() => clearTimeout(timer!)).catch((e) => {
-        traceError(e);
+    promise.then(() => clearTimeout(timer!)).catch(() => {
+        // tslint:disable-next-line: no-console
+        console.error(ex);
         clearTimeout(timer!);
     });
     return initializationPromise;
@@ -157,7 +157,7 @@ export async function run(): Promise<void> {
         await activatePythonExtensionScript();
         console.timeEnd('Time taken to activate the extension');
     } catch (ex) {
-        traceError('Failed to activate python extension without errors', ex);
+        console.error('Failed to activate python extension without errors', ex);
     }
 
     // Run the tests.

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -110,7 +110,7 @@ function activatePythonExtensionScript() {
     const initializationPromise = initialize();
     const promise = Promise.race([initializationPromise, failed]);
     // tslint:disable-next-line: no-console
-    promise.catch(e => console.error(e)).finally(() => clearTimeout(timer!)).ignoreErrors();
+    promise.finally(() => clearTimeout(timer!)).catch(e => console.error(e));
     return initializationPromise;
 }
 

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -8,7 +8,7 @@
 import * as glob from 'glob';
 import * as Mocha from 'mocha';
 import * as path from 'path';
-import { IS_SMOKE_TEST } from './constants';
+import { IS_SMOKE_TEST, MAX_EXTENSION_ACTIVATION_TIME } from './constants';
 import { initialize } from './initialize';
 
 // Linux: prevent a weird NPE when mocha on Linux requires the window size from the TTY.
@@ -66,10 +66,10 @@ export async function run(): Promise<void> {
      * @returns
      */
     function initializationScript() {
-        const ex = new Error('Failed to initialize Python extension for tests after 2 minutes');
+        const ex = new Error('Failed to initialize Python extension for tests after 3 minutes');
         let timer: NodeJS.Timer | undefined;
         const failed = new Promise((_, reject) => {
-            timer = setTimeout(() => reject(ex), 120_000);
+            timer = setTimeout(() => reject(ex), MAX_EXTENSION_ACTIVATION_TIME);
         });
         const promise = Promise.race([initialize(), failed]);
         promise.then(() => clearTimeout(timer!)).catch(() => clearTimeout(timer!));


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/8750

Earlier tests were not run if extension didn't activate within 2 minutes, which was the core reason of the flaky CI.

I've now changed that to log error if extension didn't activate within timeout, but not stop activating the extension or running the tests after timeout. But the downside is that we can't easily see the error.

I wish if Azdo could show a warning if extension didn't activate within reasonable time, but AFAICS that does not seem to be possible.