### PR TITLE
Support custom python debug adapter path

### DIFF
--- a/news/1 Enhancements/8720.md
+++ b/news/1 Enhancements/8720.md
@@ -1,0 +1,1 @@
+Support for custom python debug adapter.

--- a/src/client/debugger/extension/adapter/factory.ts
+++ b/src/client/debugger/extension/adapter/factory.ts
@@ -54,6 +54,10 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
                         sendTelemetryEvent(EventName.DEBUGGER_ATTACH_TO_LOCAL_PROCESS);
                     }
 
+                    if (configuration.debugAdapterPath) {
+                        return new DebugAdapterExecutable(pythonPath, [configuration.debugAdapterPath, ...logArgs]);
+                    }
+
                     if (await this.useNewPtvsd(pythonPath)) {
                         sendTelemetryEvent(EventName.DEBUG_ADAPTER_USING_WHEELS_PATH, undefined, { usingWheels: true });
                         return new DebugAdapterExecutable(pythonPath, [path.join(ptvsdPathToUse, 'wheels', 'ptvsd', 'adapter'), ...logArgs]);

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -50,7 +50,7 @@ export interface IKnownAttachDebugArguments extends ICommonDebugArguments {
     localRoot?: string;
     remoteRoot?: string;
 
-    // Internal files used to attach to subprocess using python debug adapter
+    // Internal field used to attach to subprocess using python debug adapter
     subProcessId?: number;
 
     processId?: number;
@@ -72,6 +72,9 @@ export interface IKnownLaunchRequestArguments extends ICommonDebugArguments {
     env?: Record<string, string | undefined>;
     envFile: string;
     console?: ConsoleType;
+
+    // Internal field used to set custom python debug adapter (for testing)
+    debugAdapterPath?: string;
 }
 // tslint:disable-next-line:interface-name
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments, IKnownLaunchRequestArguments, DebugConfiguration {

--- a/src/test/debugger/extension/adapter/factory.unit.test.ts
+++ b/src/test/debugger/extension/adapter/factory.unit.test.ts
@@ -396,4 +396,15 @@ suite('Debugging - Adapter Factory', () => {
         assert.deepEqual(Reporter.eventNames, []);
         assert.deepEqual(Reporter.properties, []);
     });
+
+    test('Use custom debug adapter path when specified', async () => {
+        const customAdapterPath = 'custom/debug/adapter/path';
+        const session = createSession({ debugAdapterPath: customAdapterPath });
+        const debugExecutable = new DebugAdapterExecutable(pythonPath, [customAdapterPath]);
+
+        when(spiedInstance.inExperiment(DebugAdapterNewPtvsd.experiment)).thenReturn(true);
+        const descriptor = await factory.createDebugAdapterDescriptor(session, nodeExecutable);
+
+        assert.deepEqual(descriptor, debugExecutable);
+    });
 });


### PR DESCRIPTION
For #8720

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code


I had made this change earlier to create a VSIX build for the debugger team. This PR should still be blocked by #6816 