### PR TITLE
Set needs IPythonReqs to true for nightly builds

### DIFF
--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -447,16 +447,19 @@ stages:
             VMImageName: 'macos-10.13'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
+            NeedsIPythonReqs: true
         'Linux-Py3.7':
             PythonVersion: '3.7'
             VMImageName: 'ubuntu-16.04'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
+            NeedsIPythonReqs: true
         'Win-Py3.7':
             PythonVersion: '3.7'
             VMImageName: 'vs2017-win2016'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
+            NeedsIPythonReqs: true
 
     pool:
       vmImage: $(VMImageName)


### PR DESCRIPTION
Smoke tests require IPython and its dependencies to be installed.