### PR TITLE
Sort python processes first

### DIFF
--- a/src/client/debugger/extension/attachQuickPick/provider.ts
+++ b/src/client/debugger/extension/attachQuickPick/provider.ts
@@ -45,7 +45,7 @@ export class AttachProcessProvider implements IAttachProcessProvider {
                         return 1;
                     }
 
-                    return aPython ? compare(aDetail!, bDetail!) : compare(aDetail!, bDetail!);
+                    return aPython ? compare(aDetail!, bDetail!) : compare(bDetail!, aDetail!);
                 }
 
                 return compare(aLabel, bLabel);

--- a/src/client/debugger/extension/attachQuickPick/provider.ts
+++ b/src/client/debugger/extension/attachQuickPick/provider.ts
@@ -34,8 +34,8 @@ export class AttachProcessProvider implements IAttachProcessProvider {
                     return aLower < bLower ? -1 : 1;
                 };
 
-                const aPython = aLabel.startsWith('python');
-                const bPython = bLabel.startsWith('python');
+                const aPython = aLabel.indexOf('python') !== -1;
+                const bPython = bLabel.indexOf('python') !== -1;
 
                 if (aPython || bPython) {
                     if (aPython && !bPython) {

--- a/src/client/debugger/extension/attachQuickPick/provider.ts
+++ b/src/client/debugger/extension/attachQuickPick/provider.ts
@@ -34,8 +34,8 @@ export class AttachProcessProvider implements IAttachProcessProvider {
                     return aLower < bLower ? -1 : 1;
                 };
 
-                const aPython = aLabel.indexOf('python') !== -1;
-                const bPython = bLabel.indexOf('python') !== -1;
+                const aPython = aLabel.startsWith('python');
+                const bPython = bLabel.startsWith('python');
 
                 if (aPython || bPython) {
                     if (aPython && !bPython) {

--- a/src/test/debugger/extension/attachQuickPick/provider.unit.test.ts
+++ b/src/test/debugger/extension/attachQuickPick/provider.unit.test.ts
@@ -25,15 +25,288 @@ suite('Attach to process - process provider', () => {
 
     let provider: AttachProcessProvider;
 
-    const psOutput = `
+    setup(() => {
+        platformService = mock(PlatformService);
+        processService = mock(ProcessService);
+        processServiceFactory = mock(ProcessServiceFactory);
+        when(processServiceFactory.create()).thenResolve(instance(processService));
+
+        provider = new AttachProcessProvider(instance(platformService), instance(processServiceFactory));
+    });
+
+    test('The Linux process list command should be called if the platform is Linux', async () => {
+        when(platformService.isMac).thenReturn(false);
+        when(platformService.isLinux).thenReturn(true);
+        const psOutput = `
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
+1 launchd                                            launchd\n\
+41 syslogd                                            syslogd\n\
+146 kextd                                              kextd\n\
+`;
+        const expectedOutput: IAttachItem[] = [
+            {
+                label: 'launchd',
+                description: '1',
+                detail: 'launchd',
+                id: '1'
+            },
+            {
+                label: 'syslogd',
+                description: '41',
+                detail: 'syslogd',
+                id: '41'
+            },
+            {
+                label: 'kextd',
+                description: '146',
+                detail: 'kextd',
+                id: '146'
+            }
+        ];
+        when(processService.exec(PsProcessParser.psLinuxCommand.command, anything(), anything())).thenResolve({ stdout: psOutput });
+
+        const attachItems = await provider._getInternalProcessEntries();
+
+        verify(processService.exec(PsProcessParser.psLinuxCommand.command, PsProcessParser.psLinuxCommand.args, anything())).once();
+        assert.deepEqual(attachItems, expectedOutput);
+    });
+
+    test('The macOS process list command should be called if the platform is macOS', async () => {
+        when(platformService.isMac).thenReturn(true);
+        const psOutput = `
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
+1 launchd                                            launchd\n\
+41 syslogd                                            syslogd\n\
+146 kextd                                              kextd\n\
+`;
+        const expectedOutput: IAttachItem[] = [
+            {
+                label: 'launchd',
+                description: '1',
+                detail: 'launchd',
+                id: '1'
+            },
+            {
+                label: 'syslogd',
+                description: '41',
+                detail: 'syslogd',
+                id: '41'
+            },
+            {
+                label: 'kextd',
+                description: '146',
+                detail: 'kextd',
+                id: '146'
+            }
+        ];
+        when(processService.exec(PsProcessParser.psDarwinCommand.command, anything(), anything())).thenResolve({ stdout: psOutput });
+
+        const attachItems = await provider._getInternalProcessEntries();
+
+        verify(processService.exec(PsProcessParser.psDarwinCommand.command, PsProcessParser.psDarwinCommand.args, anything())).once();
+        assert.deepEqual(attachItems, expectedOutput);
+    });
+
+    test('The Windows process list command should be called if the platform is Windows', async () => {
+        const windowsOutput = `
+CommandLine=\r\n\
+Name=System\r\n\
+ProcessId=4\r\n\
+\r\n\
+\r\n\
+CommandLine=sihost.exe\r\n\
+Name=sihost.exe\r\n\
+ProcessId=5728\r\n\
+\r\n\
+\r\n\
+CommandLine=C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc\r\n\
+Name=svchost.exe\r\n\
+ProcessId=5912\r\n\
+`;
+        const expectedOutput: IAttachItem[] = [
+            {
+                label: 'System',
+                description: '4',
+                detail: '',
+                id: '4'
+            },
+            {
+                label: 'sihost.exe',
+                description: '5728',
+                detail: 'sihost.exe',
+                id: '5728'
+            },
+            {
+                label: 'svchost.exe',
+                description: '5912',
+                detail: 'C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc',
+                id: '5912'
+            }
+        ];
+        when(platformService.isMac).thenReturn(false);
+        when(platformService.isLinux).thenReturn(false);
+        when(platformService.isWindows).thenReturn(true);
+        when(processService.exec(WmicProcessParser.wmicCommand.command, anything(), anything())).thenResolve({ stdout: windowsOutput });
+
+        const attachItems = await provider._getInternalProcessEntries();
+
+        verify(processService.exec(WmicProcessParser.wmicCommand.command, WmicProcessParser.wmicCommand.args, anything())).once();
+        assert.deepEqual(attachItems, expectedOutput);
+    });
+
+    test('An error should be thrown if the platform is neither Linux, macOS or Windows', async () => {
+        when(platformService.isMac).thenReturn(false);
+        when(platformService.isLinux).thenReturn(false);
+        when(platformService.isWindows).thenReturn(false);
+        when(platformService.osType).thenReturn(OSType.Unknown);
+
+        const promise = provider._getInternalProcessEntries();
+
+        await expect(promise).to.eventually.be.rejectedWith(`Operating system '${OSType.Unknown}' not supported.`);
+    });
+
+    suite('POSIX getAttachItems (Linux)', () => {
+        setup(() => {
+            when(platformService.isMac).thenReturn(false);
+            when(platformService.isLinux).thenReturn(true);
+        });
+
+        test('Items returned by getAttachItems should be sorted alphabetically', async () => {
+            const psOutput = `
     aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
     1 launchd                                            launchd\n\
-   41 syslogd                                            syslogd\n\
-  146 kextd                                              kextd\n\
-31896 python                                             python script.py\n\
+    41 syslogd                                            syslogd\n\
+    146 kextd                                              kextd\n\
 `;
+            const expectedOutput: IAttachItem[] = [
+                {
+                    label: 'kextd',
+                    description: '146',
+                    detail: 'kextd',
+                    id: '146'
+                },
+                {
+                    label: 'launchd',
+                    description: '1',
+                    detail: 'launchd',
+                    id: '1'
+                },
+                {
+                    label: 'syslogd',
+                    description: '41',
+                    detail: 'syslogd',
+                    id: '41'
+                }
+            ];
+            when(processService.exec(PsProcessParser.psLinuxCommand.command, anything(), anything())).thenResolve({ stdout: psOutput });
 
-    const windowsOutput = `
+            const output = await provider.getAttachItems();
+
+            assert.deepEqual(output, expectedOutput);
+        });
+
+        test('Python processes should be at the top of the list returned by getAttachItems', async () => {
+            const psOutput = `
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
+     1 launchd                                            launchd\n\
+    41 syslogd                                            syslogd\n\
+    96 python                                             python\n\
+   146 kextd                                              kextd\n\
+ 31896 python                                             python script.py\n\
+`;
+            const expectedOutput: IAttachItem[] = [
+                {
+                    label: 'python',
+                    description: '96',
+                    detail: 'python',
+                    id: '96'
+                },
+                {
+                    label: 'python',
+                    description: '31896',
+                    detail: 'python script.py',
+                    id: '31896'
+                },
+                {
+                    label: 'kextd',
+                    description: '146',
+                    detail: 'kextd',
+                    id: '146'
+                },
+                {
+                    label: 'launchd',
+                    description: '1',
+                    detail: 'launchd',
+                    id: '1'
+                },
+                {
+                    label: 'syslogd',
+                    description: '41',
+                    detail: 'syslogd',
+                    id: '41'
+                }
+            ];
+            when(processService.exec(PsProcessParser.psLinuxCommand.command, anything(), anything())).thenResolve({ stdout: psOutput });
+
+            const output = await provider.getAttachItems();
+
+            assert.deepEqual(output, expectedOutput);
+        });
+    });
+
+    // tslint:disable-next-line: max-func-body-length
+    suite('Windows getAttachItems', () => {
+        setup(() => {
+            when(platformService.isMac).thenReturn(false);
+            when(platformService.isLinux).thenReturn(false);
+            when(platformService.isWindows).thenReturn(true);
+        });
+
+        test('Items returned by getAttachItems should be sorted alphabetically', async () => {
+            const windowsOutput = `
+CommandLine=\r\n\
+Name=System\r\n\
+ProcessId=4\r\n\
+\r\n\
+\r\n\
+CommandLine=\r\n\
+Name=svchost.exe\r\n\
+ProcessId=5372\r\n\
+\r\n\
+\r\n\
+CommandLine=sihost.exe\r\n\
+Name=sihost.exe\r\n\
+ProcessId=5728\r\n\
+`;
+            const expectedOutput: IAttachItem[] = [
+                {
+                    label: 'sihost.exe',
+                    description: '5728',
+                    detail: 'sihost.exe',
+                    id: '5728'
+                },
+                {
+                    label: 'svchost.exe',
+                    description: '5372',
+                    detail: '',
+                    id: '5372'
+                },
+                {
+                    label: 'System',
+                    description: '4',
+                    detail: '',
+                    id: '4'
+                }
+            ];
+            when(processService.exec(WmicProcessParser.wmicCommand.command, anything(), anything())).thenResolve({ stdout: windowsOutput });
+
+            const output = await provider.getAttachItems();
+
+            assert.deepEqual(output, expectedOutput);
+        });
+
+        test('Python processes should be at the top of the list returned by getAttachItems', async () => {
+            const windowsOutput = `
 CommandLine=\r\n\
 Name=System\r\n\
 ProcessId=4\r\n\
@@ -57,254 +330,55 @@ ProcessId=5912\r\n\
 CommandLine=C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/hello_world.py\r\n\
 Name=python.exe\r\n\
 ProcessId=6028\r\n\
-`;
+\r\n\
+\r\n\
+CommandLine=C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/foo_bar.py\r\n\
+Name=python.exe\r\n\
+ProcessId=8026\r\n\
+            `;
+            const expectedOutput: IAttachItem[] = [
+                {
+                    label: 'python.exe',
+                    description: '8026',
+                    detail: 'C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/foo_bar.py',
+                    id: '8026'
+                },
+                {
+                    label: 'python.exe',
+                    description: '6028',
+                    detail: 'C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/hello_world.py',
+                    id: '6028'
+                },
+                {
+                    label: 'sihost.exe',
+                    description: '5728',
+                    detail: 'sihost.exe',
+                    id: '5728'
+                },
+                {
+                    label: 'svchost.exe',
+                    description: '5372',
+                    detail: '',
+                    id: '5372'
+                },
+                {
+                    label: 'svchost.exe',
+                    description: '5912',
+                    detail: 'C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc',
+                    id: '5912'
+                },
+                {
+                    label: 'System',
+                    description: '4',
+                    detail: '',
+                    id: '4'
+                }
+            ];
+            when(processService.exec(WmicProcessParser.wmicCommand.command, anything(), anything())).thenResolve({ stdout: windowsOutput });
 
-    setup(() => {
-        platformService = mock(PlatformService);
-        processService = mock(ProcessService);
-        when(processService.exec(WmicProcessParser.wmicCommand.command, anything(), anything())).thenResolve({ stdout: windowsOutput });
-        when(processService.exec(PsProcessParser.psLinuxCommand.command, anything(), anything())).thenResolve({ stdout: psOutput });
-        when(processService.exec(PsProcessParser.psDarwinCommand.command, anything(), anything())).thenResolve({ stdout: psOutput });
-        processServiceFactory = mock(ProcessServiceFactory);
-        when(processServiceFactory.create()).thenResolve(instance(processService));
+            const output = await provider.getAttachItems();
 
-        provider = new AttachProcessProvider(instance(platformService), instance(processServiceFactory));
-    });
-
-    test('The Linux process list command should be called if the platform is Linux', async () => {
-        when(platformService.isMac).thenReturn(false);
-        when(platformService.isLinux).thenReturn(true);
-        const expectedOutput: IAttachItem[] = [
-            {
-                label: 'launchd',
-                description: '1',
-                detail: 'launchd',
-                id: '1'
-            },
-            {
-                label: 'syslogd',
-                description: '41',
-                detail: 'syslogd',
-                id: '41'
-            },
-            {
-                label: 'kextd',
-                description: '146',
-                detail: 'kextd',
-                id: '146'
-            },
-            {
-                label: 'python',
-                description: '31896',
-                detail: 'python script.py',
-                id: '31896'
-            }
-        ];
-
-        const attachItems = await provider._getInternalProcessEntries();
-
-        verify(processService.exec(PsProcessParser.psLinuxCommand.command, PsProcessParser.psLinuxCommand.args, anything())).once();
-        assert.deepEqual(attachItems, expectedOutput);
-    });
-
-    test('The macOS process list command should be called if the platform is macOS', async () => {
-        when(platformService.isMac).thenReturn(true);
-        const expectedOutput: IAttachItem[] = [
-            {
-                label: 'launchd',
-                description: '1',
-                detail: 'launchd',
-                id: '1'
-            },
-            {
-                label: 'syslogd',
-                description: '41',
-                detail: 'syslogd',
-                id: '41'
-            },
-            {
-                label: 'kextd',
-                description: '146',
-                detail: 'kextd',
-                id: '146'
-            },
-            {
-                label: 'python',
-                description: '31896',
-                detail: 'python script.py',
-                id: '31896'
-            }
-        ];
-
-        const attachItems = await provider._getInternalProcessEntries();
-
-        verify(processService.exec(PsProcessParser.psDarwinCommand.command, PsProcessParser.psDarwinCommand.args, anything())).once();
-        assert.deepEqual(attachItems, expectedOutput);
-    });
-
-    test('The Windows process list command should be called if the platform is Windows', async () => {
-        when(platformService.isMac).thenReturn(false);
-        when(platformService.isLinux).thenReturn(false);
-        when(platformService.isWindows).thenReturn(true);
-        const expectedOutput: IAttachItem[] = [
-            {
-                label: 'System',
-                description: '4',
-                detail: '',
-                id: '4'
-            },
-            {
-                label: 'svchost.exe',
-                description: '5372',
-                detail: '',
-                id: '5372'
-            },
-            {
-                label: 'sihost.exe',
-                description: '5728',
-                detail: 'sihost.exe',
-                id: '5728'
-            },
-            {
-                label: 'svchost.exe',
-                description: '5912',
-                detail: 'C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc',
-                id: '5912'
-            },
-            {
-                label: 'python.exe',
-                description: '6028',
-                detail: 'C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/hello_world.py',
-                id: '6028'
-            }
-        ];
-
-        const attachItems = await provider._getInternalProcessEntries();
-
-        verify(processService.exec(WmicProcessParser.wmicCommand.command, WmicProcessParser.wmicCommand.args, anything())).once();
-        assert.deepEqual(attachItems, expectedOutput);
-    });
-
-    test('An error should be thrown if the platform is neither Linux, macOS or Windows', async () => {
-        when(platformService.isMac).thenReturn(false);
-        when(platformService.isLinux).thenReturn(false);
-        when(platformService.isWindows).thenReturn(false);
-        when(platformService.osType).thenReturn(OSType.Unknown);
-
-        const promise = provider._getInternalProcessEntries();
-
-        await expect(promise).to.eventually.be.rejectedWith(`Operating system '${OSType.Unknown}' not supported.`);
-    });
-
-    test('Items returned by getAttachItems should be sorted alphabetically on Linux', async () => {
-        when(platformService.isMac).thenReturn(false);
-        when(platformService.isLinux).thenReturn(true);
-        const expectedOutput: IAttachItem[] = [
-            {
-                label: 'kextd',
-                description: '146',
-                detail: 'kextd',
-                id: '146'
-            },
-            {
-                label: 'launchd',
-                description: '1',
-                detail: 'launchd',
-                id: '1'
-            },
-            {
-                label: 'python',
-                description: '31896',
-                detail: 'python script.py',
-                id: '31896'
-            },
-            {
-                label: 'syslogd',
-                description: '41',
-                detail: 'syslogd',
-                id: '41'
-            }
-        ];
-
-        const output = await provider.getAttachItems();
-
-        assert.deepEqual(output, expectedOutput);
-    });
-
-    test('Items returned by getAttachItems should be sorted alphabetically on macOS', async () => {
-        when(platformService.isMac).thenReturn(true);
-        const expectedOutput: IAttachItem[] = [
-            {
-                label: 'kextd',
-                description: '146',
-                detail: 'kextd',
-                id: '146'
-            },
-            {
-                label: 'launchd',
-                description: '1',
-                detail: 'launchd',
-                id: '1'
-            },
-            {
-                label: 'python',
-                description: '31896',
-                detail: 'python script.py',
-                id: '31896'
-            },
-            {
-                label: 'syslogd',
-                description: '41',
-                detail: 'syslogd',
-                id: '41'
-            }
-        ];
-
-        const output = await provider.getAttachItems();
-
-        assert.deepEqual(output, expectedOutput);
-    });
-
-    test('Items returned by getAttachItems should be sorted alphabetically on Windows', async () => {
-        when(platformService.isMac).thenReturn(false);
-        when(platformService.isLinux).thenReturn(false);
-        when(platformService.isWindows).thenReturn(true);
-        const expectedOutput: IAttachItem[] = [
-            {
-                label: 'python.exe',
-                description: '6028',
-                detail: 'C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/hello_world.py',
-                id: '6028'
-            },
-            {
-                label: 'sihost.exe',
-                description: '5728',
-                detail: 'sihost.exe',
-                id: '5728'
-            },
-            {
-                label: 'svchost.exe',
-                description: '5372',
-                detail: '',
-                id: '5372'
-            },
-            {
-                label: 'svchost.exe',
-                description: '5912',
-                detail: 'C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc',
-                id: '5912'
-            },
-
-            {
-                label: 'System',
-                description: '4',
-                detail: '',
-                id: '4'
-            }
-        ];
-
-        const output = await provider.getAttachItems();
-
-        assert.deepEqual(output, expectedOutput);
+            assert.deepEqual(output, expectedOutput);
+        });
     });
 });

--- a/src/test/debugger/extension/attachQuickPick/provider.unit.test.ts
+++ b/src/test/debugger/extension/attachQuickPick/provider.unit.test.ts
@@ -37,11 +37,10 @@ suite('Attach to process - process provider', () => {
     test('The Linux process list command should be called if the platform is Linux', async () => {
         when(platformService.isMac).thenReturn(false);
         when(platformService.isLinux).thenReturn(true);
-        const psOutput = `
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
-1 launchd                                            launchd\n\
-41 syslogd                                            syslogd\n\
-146 kextd                                              kextd\n\
+        const psOutput = `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+1 launchd                                            launchd
+41 syslogd                                            syslogd
+146 kextd                                              kextd
 `;
         const expectedOutput: IAttachItem[] = [
             {
@@ -73,11 +72,10 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
 
     test('The macOS process list command should be called if the platform is macOS', async () => {
         when(platformService.isMac).thenReturn(true);
-        const psOutput = `
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
-1 launchd                                            launchd\n\
-41 syslogd                                            syslogd\n\
-146 kextd                                              kextd\n\
+        const psOutput = `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+1 launchd                                            launchd
+41 syslogd                                            syslogd
+146 kextd                                              kextd
 `;
         const expectedOutput: IAttachItem[] = [
             {
@@ -108,20 +106,19 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
     });
 
     test('The Windows process list command should be called if the platform is Windows', async () => {
-        const windowsOutput = `
-CommandLine=\r\n\
-Name=System\r\n\
-ProcessId=4\r\n\
-\r\n\
-\r\n\
-CommandLine=sihost.exe\r\n\
-Name=sihost.exe\r\n\
-ProcessId=5728\r\n\
-\r\n\
-\r\n\
-CommandLine=C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc\r\n\
-Name=svchost.exe\r\n\
-ProcessId=5912\r\n\
+        const windowsOutput = `CommandLine=\r
+Name=System\r
+ProcessId=4\r
+\r
+\r
+CommandLine=sihost.exe\r
+Name=sihost.exe\r
+ProcessId=5728\r
+\r
+\r
+CommandLine=C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc\r
+Name=svchost.exe\r
+ProcessId=5912\r
 `;
         const expectedOutput: IAttachItem[] = [
             {
@@ -172,11 +169,10 @@ ProcessId=5912\r\n\
         });
 
         test('Items returned by getAttachItems should be sorted alphabetically', async () => {
-            const psOutput = `
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
-    1 launchd                                            launchd\n\
-    41 syslogd                                            syslogd\n\
-    146 kextd                                              kextd\n\
+            const psOutput = `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    1 launchd                                            launchd
+    41 syslogd                                            syslogd
+    146 kextd                                              kextd
 `;
             const expectedOutput: IAttachItem[] = [
                 {
@@ -206,13 +202,12 @@ ProcessId=5912\r\n\
         });
 
         test('Python processes should be at the top of the list returned by getAttachItems', async () => {
-            const psOutput = `
-    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\
-     1 launchd                                            launchd\n\
-    41 syslogd                                            syslogd\n\
-    96 python                                             python\n\
-   146 kextd                                              kextd\n\
- 31896 python                                             python script.py\n\
+            const psOutput = `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     1 launchd                                            launchd
+    41 syslogd                                            syslogd
+    96 python                                             python
+   146 kextd                                              kextd
+ 31896 python                                             python script.py
 `;
             const expectedOutput: IAttachItem[] = [
                 {
@@ -263,20 +258,19 @@ ProcessId=5912\r\n\
         });
 
         test('Items returned by getAttachItems should be sorted alphabetically', async () => {
-            const windowsOutput = `
-CommandLine=\r\n\
-Name=System\r\n\
-ProcessId=4\r\n\
-\r\n\
-\r\n\
-CommandLine=\r\n\
-Name=svchost.exe\r\n\
-ProcessId=5372\r\n\
-\r\n\
-\r\n\
-CommandLine=sihost.exe\r\n\
-Name=sihost.exe\r\n\
-ProcessId=5728\r\n\
+            const windowsOutput = `CommandLine=\r
+Name=System\r
+ProcessId=4\r
+\r
+\r
+CommandLine=\r
+Name=svchost.exe\r
+ProcessId=5372\r
+\r
+\r
+CommandLine=sihost.exe\r
+Name=sihost.exe\r
+ProcessId=5728\r
 `;
             const expectedOutput: IAttachItem[] = [
                 {
@@ -306,35 +300,34 @@ ProcessId=5728\r\n\
         });
 
         test('Python processes should be at the top of the list returned by getAttachItems', async () => {
-            const windowsOutput = `
-CommandLine=\r\n\
-Name=System\r\n\
-ProcessId=4\r\n\
-\r\n\
-\r\n\
-CommandLine=\r\n\
-Name=svchost.exe\r\n\
-ProcessId=5372\r\n\
-\r\n\
-\r\n\
-CommandLine=sihost.exe\r\n\
-Name=sihost.exe\r\n\
-ProcessId=5728\r\n\
-\r\n\
-\r\n\
-CommandLine=C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc\r\n\
-Name=svchost.exe\r\n\
-ProcessId=5912\r\n\
-\r\n\
-\r\n\
-CommandLine=C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/hello_world.py\r\n\
-Name=python.exe\r\n\
-ProcessId=6028\r\n\
-\r\n\
-\r\n\
-CommandLine=C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/foo_bar.py\r\n\
-Name=python.exe\r\n\
-ProcessId=8026\r\n\
+            const windowsOutput = `CommandLine=\r
+Name=System\r
+ProcessId=4\r
+\r
+\r
+CommandLine=\r
+Name=svchost.exe\r
+ProcessId=5372\r
+\r
+\r
+CommandLine=sihost.exe\r
+Name=sihost.exe\r
+ProcessId=5728\r
+\r
+\r
+CommandLine=C:\\WINDOWS\\system32\\svchost.exe -k UnistackSvcGroup -s CDPUserSvc\r
+Name=svchost.exe\r
+ProcessId=5912\r
+\r
+\r
+CommandLine=C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/hello_world.py\r
+Name=python.exe\r
+ProcessId=6028\r
+\r
+\r
+CommandLine=C:\\Users\\Contoso\\AppData\\Local\\Programs\\Python\\Python37\\python.exe c:/Users/Contoso/Documents/foo_bar.py\r
+Name=python.exe\r
+ProcessId=8026\r
             `;
             const expectedOutput: IAttachItem[] = [
                 {


### PR DESCRIPTION
For #8701 

Had to refactor the unit tests as well

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
