### PR TITLE
Active editor context keys with appropriate events

### DIFF
--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -24,7 +24,7 @@ export class Activation implements IExtensionSingleActivationService {
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService
-    ) { }
+    ) {
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.interpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -24,7 +24,7 @@ export class Activation implements IExtensionSingleActivationService {
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService
-    ) {
+    ) {}
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.interpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -12,6 +12,7 @@ import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
 import { IInterpreterService } from '../interpreter/contracts';
 import { sendTelemetryEvent } from '../telemetry';
 import { PythonDaemonModule, Telemetry } from './constants';
+import { ActiveEditorContextService } from './context/activeEditorContext';
 import { INotebookEditor, INotebookEditorProvider } from './types';
 
 @injectable()
@@ -21,11 +22,13 @@ export class Activation implements IExtensionSingleActivationService {
         @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory,
-        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry
-    ) {}
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+        @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService
+    ) { }
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.interpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
+        await this.contextService.activate();
     }
 
     private onDidOpenNotebookEditor(_: INotebookEditor) {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -79,10 +79,12 @@ export namespace EditorContexts {
     export const HaveInteractiveCells = 'python.datascience.haveinteractivecells';
     export const HaveRedoableCells = 'python.datascience.haveredoablecells';
     export const HaveInteractive = 'python.datascience.haveinteractive';
+    export const IsInteractive = 'python.datascience.isinteractive';
     export const OwnsSelection = 'python.datascience.ownsSelection';
     export const HaveNativeCells = 'python.datascience.havenativecells';
     export const HaveNativeRedoableCells = 'python.datascience.havenativeredoablecells';
     export const HaveNative = 'python.datascience.havenative';
+    export const IsNative = 'python.datascience.isnative';
     export const HaveCellSelected = 'python.datascience.havecellselected';
 }
 

--- a/src/client/datascience/context/activeEditorContext.ts
+++ b/src/client/datascience/context/activeEditorContext.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { ICommandManager } from '../../common/application/types';
+import { ContextKey } from '../../common/contextKey';
+import { IDisposable, IDisposableRegistry } from '../../common/types';
+import { EditorContexts } from '../constants';
+import { IInteractiveWindow, IInteractiveWindowProvider, INotebookEditor, INotebookEditorProvider } from '../types';
+
+@injectable()
+export class ActiveEditorContextService implements IExtensionSingleActivationService, IDisposable {
+    private readonly disposables: IDisposable[] = [];
+    constructor(
+        @inject(IInteractiveWindowProvider) private readonly interactiveProvider: IInteractiveWindowProvider,
+        @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry
+    ) {
+        disposables.push(this);
+    }
+    public dispose() {
+        this.disposables.forEach(item => item.dispose());
+    }
+    public async activate(): Promise<void> {
+        this.interactiveProvider.onDidChangeActiveInteractiveWindow(this.onDidChangeActiveInteractiveWindow, this, this.disposables);
+        this.notebookProvider.onDidChangeActiveNotebookEditor(this.onDidChangeActiveNotebookEditor, this, this.disposables);
+    }
+
+    private onDidChangeActiveInteractiveWindow(e?: IInteractiveWindow) {
+        const interactiveContext = new ContextKey(EditorContexts.IsInteractive, this.commandManager);
+        interactiveContext.set(!!e).ignoreErrors();
+    }
+    private onDidChangeActiveNotebookEditor(e?: INotebookEditor) {
+        const interactiveContext = new ContextKey(EditorContexts.IsNative, this.commandManager);
+        interactiveContext.set(!!e).ignoreErrors();
+    }
+}

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -63,6 +63,10 @@ const NotebookTransferKey = 'notebook-transfered';
 
 @injectable()
 export class NativeEditor extends InteractiveBase implements INotebookEditor {
+    public get onDidChangeViewState(): Event<void> {
+        return this._onDidChangeViewState.event;
+    }
+    private _onDidChangeViewState = new EventEmitter<void>();
     private closedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
     private executedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
     private modifiedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
@@ -472,6 +476,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // Update our contexts
         const interactiveContext = new ContextKey(EditorContexts.HaveNative, this.commandManager);
         interactiveContext.set(visible && active).catch();
+        this._onDidChangeViewState.fire();
     }
 
     protected async closeBecauseOfFailure(_exc: Error): Promise<void> {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -162,7 +162,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, IAsyncDisp
     }
 
     private async create(file: Uri, contents: string): Promise<INotebookEditor> {
-    const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
+        const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
         await editor.load(contents, file);
         this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
         this.disposables.push(editor.executed(this.onExecutedEditor.bind(this)));

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -40,6 +40,16 @@ const historyReactDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', '
 
 @injectable()
 export class InteractiveWindow extends InteractiveBase implements IInteractiveWindow {
+    public get onDidChangeViewState(): Event<void> {
+        return this._onDidChangeViewState.event;
+    }
+    private _onDidChangeViewState = new EventEmitter<void>();
+    public get visible(): boolean {
+        return this.viewState.visible;
+    }
+    public get active(): boolean {
+        return this.viewState.active;
+    }
     private closedEvent: EventEmitter<IInteractiveWindow> = new EventEmitter<IInteractiveWindow>();
     private waitingForExportCells: boolean = false;
     private trackedJupyterStart: boolean = false;
@@ -217,6 +227,10 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
     @captureTelemetry(Telemetry.ScrolledToCell)
     public scrollToCell(id: string): void {
         this.postMessage(InteractiveWindowMessages.ScrollToCell, { id }).ignoreErrors();
+    }
+    protected async onViewStateChanged(visible: boolean, active: boolean) {
+        super.onViewStateChanged(visible, active);
+        this._onDidChangeViewState.fire();
     }
 
     @captureTelemetry(Telemetry.SubmitCellThroughInput, undefined, false)

--- a/src/client/datascience/interactive-window/interactiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/interactiveWindowProvider.ts
@@ -22,6 +22,11 @@ interface ISyncData {
 
 @injectable()
 export class InteractiveWindowProvider implements IInteractiveWindowProvider, IAsyncDisposable {
+
+    public get onDidChangeActiveInteractiveWindow(): Event<IInteractiveWindow | undefined> {
+        return this._onDidChangeActiveInteractiveWindow.event;
+    }
+    private readonly _onDidChangeActiveInteractiveWindow = new EventEmitter<IInteractiveWindow | undefined>();
     private activeInteractiveWindow: IInteractiveWindow | undefined;
     private postOffice: PostOffice;
     private id: string;
@@ -108,9 +113,15 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
         this.disposables.push(handler);
         this.activeInteractiveWindowExecuteHandler = this.activeInteractiveWindow.onExecutedCode(this.onInteractiveWindowExecute);
         this.disposables.push(this.activeInteractiveWindowExecuteHandler);
+        this.disposables.push(this.activeInteractiveWindow.onDidChangeViewState(() => this.raiseOnDidChangeActiveInteractiveWindow()));
+        this.raiseOnDidChangeActiveInteractiveWindow();
         return this.activeInteractiveWindow;
     }
 
+    private raiseOnDidChangeActiveInteractiveWindow(){
+        const currentWindow = this.getActive();
+        this._onDidChangeActiveInteractiveWindow.fire(currentWindow?.active && currentWindow.visible ? currentWindow : undefined);
+    }
     private onPeerCountChanged(newCount: number) {
         // If we're losing peers, resolve all syncs
         if (newCount < this.postOffice.peerCount) {
@@ -159,7 +170,8 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
                 this.activeInteractiveWindowExecuteHandler = undefined;
             }
         }
-    };
+        this.raiseOnDidChangeActiveInteractiveWindow();
+    }
 
     private async synchronizeCreate(): Promise<void> {
         // Create a new pending wait if necessary

--- a/src/client/datascience/interactive-window/interactiveWindowProvider.ts
+++ b/src/client/datascience/interactive-window/interactiveWindowProvider.ts
@@ -22,7 +22,6 @@ interface ISyncData {
 
 @injectable()
 export class InteractiveWindowProvider implements IInteractiveWindowProvider, IAsyncDisposable {
-
     public get onDidChangeActiveInteractiveWindow(): Event<IInteractiveWindow | undefined> {
         return this._onDidChangeActiveInteractiveWindow.event;
     }
@@ -118,7 +117,7 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
         return this.activeInteractiveWindow;
     }
 
-    private raiseOnDidChangeActiveInteractiveWindow(){
+    private raiseOnDidChangeActiveInteractiveWindow() {
         const currentWindow = this.getActive();
         this._onDidChangeActiveInteractiveWindow.fire(currentWindow?.active && currentWindow.visible ? currentWindow : undefined);
     }
@@ -171,7 +170,7 @@ export class InteractiveWindowProvider implements IInteractiveWindowProvider, IA
             }
         }
         this.raiseOnDidChangeActiveInteractiveWindow();
-    }
+    };
 
     private async synchronizeCreate(): Promise<void> {
         // Create a new pending wait if necessary

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -8,6 +8,7 @@ import { CodeCssGenerator } from './codeCssGenerator';
 import { CommandRegistry } from './commands/commandRegistry';
 import { KernelSwitcherCommand } from './commands/kernelSwitcher';
 import { JupyterServerSelectorCommand } from './commands/serverSelector';
+import { ActiveEditorContextService } from './context/activeEditorContext';
 import { DataViewer } from './data-viewing/dataViewer';
 import { DataViewerProvider } from './data-viewing/dataViewerProvider';
 import { DataScience } from './datascience';
@@ -151,4 +152,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<JupyterInterpreterConfigurationService>(JupyterInterpreterConfigurationService, JupyterInterpreterConfigurationService);
     serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
     serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
+    serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -248,6 +248,7 @@ export interface INotebookExporter extends Disposable {
 
 export const IInteractiveWindowProvider = Symbol('IInteractiveWindowProvider');
 export interface IInteractiveWindowProvider {
+    readonly onDidChangeActiveInteractiveWindow: Event<IInteractiveWindow | undefined>;
     onExecutedCode: Event<string>;
     getActive(): IInteractiveWindow | undefined;
     getOrCreateActive(): Promise<IInteractiveWindow>;
@@ -274,6 +275,9 @@ export interface IInteractiveBase extends Disposable {
 
 export const IInteractiveWindow = Symbol('IInteractiveWindow');
 export interface IInteractiveWindow extends IInteractiveBase {
+    readonly onDidChangeViewState: Event<void>;
+    readonly visible: boolean;
+    readonly active: boolean;
     closed: Event<IInteractiveWindow>;
     addCode(code: string, file: string, line: number, editor?: TextEditor, runningStopWatch?: StopWatch): Promise<boolean>;
     addMessage(message: string): Promise<void>;
@@ -290,6 +294,7 @@ export interface INotebookEditorProvider {
     readonly activeEditor: INotebookEditor | undefined;
     readonly editors: INotebookEditor[];
     readonly onDidOpenNotebookEditor: Event<INotebookEditor>;
+    readonly onDidChangeActiveNotebookEditor: Event<INotebookEditor | undefined>;
     open(file: Uri, contents: string): Promise<INotebookEditor>;
     show(file: Uri): Promise<INotebookEditor | undefined>;
     createNew(contents?: string): Promise<INotebookEditor>;
@@ -299,6 +304,7 @@ export interface INotebookEditorProvider {
 // For native editing, the INotebookEditor acts like a TextEditor and a TextDocument together
 export const INotebookEditor = Symbol('INotebookEditor');
 export interface INotebookEditor extends IInteractiveBase {
+    readonly onDidChangeViewState: Event<void>;
     readonly closed: Event<INotebookEditor>;
     readonly executed: Event<INotebookEditor>;
     readonly modified: Event<INotebookEditor>;

--- a/src/test/datascience/activation.unit.test.ts
+++ b/src/test/datascience/activation.unit.test.ts
@@ -10,6 +10,7 @@ import { PythonExecutionFactory } from '../../client/common/process/pythonExecut
 import { IPythonExecutionFactory } from '../../client/common/process/types';
 import { Activation } from '../../client/datascience/activation';
 import { PythonDaemonModule } from '../../client/datascience/constants';
+import { ActiveEditorContextService } from '../../client/datascience/context/activeEditorContext';
 import { NativeEditor } from '../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorProvider } from '../../client/datascience/interactive-ipynb/nativeEditorProvider';
 import { INotebookEditor, INotebookEditorProvider } from '../../client/datascience/types';
@@ -26,7 +27,7 @@ suite('Data Science - Activation', () => {
     let executionFactory: IPythonExecutionFactory;
     let openedEventEmitter: EventEmitter<INotebookEditor>;
     let interpreterEventEmitter: EventEmitter<void>;
-
+    let contextService: ActiveEditorContextService;
     setup(async () => {
         openedEventEmitter = new EventEmitter<INotebookEditor>();
         interpreterEventEmitter = new EventEmitter<void>();
@@ -34,16 +35,17 @@ suite('Data Science - Activation', () => {
         notebookProvider = mock(NativeEditorProvider);
         interpreterService = mock(InterpreterService);
         executionFactory = mock(PythonExecutionFactory);
+        contextService = mock(ActiveEditorContextService);
         when(notebookProvider.onDidOpenNotebookEditor).thenReturn(openedEventEmitter.event);
         when(interpreterService.onDidChangeInterpreter).thenReturn(interpreterEventEmitter.event);
         when(executionFactory.createDaemon(anything())).thenResolve();
-
-        activator = new Activation(instance(notebookProvider), instance(interpreterService), instance(executionFactory), []);
+        when(contextService.activate()).thenResolve();
+        activator = new Activation(instance(notebookProvider), instance(interpreterService), instance(executionFactory), [], instance(contextService));
         await activator.activate();
     });
 
     async function testCreatingDaemonWhenOpeningANotebook() {
-        const notebook = mock(NativeEditor);
+        const notebook: INotebookEditor = mock(NativeEditor);
         const interpreter = ({ path: 'MY_PY' } as any) as PythonInterpreter;
 
         when(interpreterService.getActiveInterpreter(undefined)).thenResolve(interpreter);

--- a/src/test/datascience/testInteractiveWindowProvider.ts
+++ b/src/test/datascience/testInteractiveWindowProvider.ts
@@ -15,6 +15,9 @@ import { IServiceContainer } from '../../client/ioc/types';
 
 @injectable()
 export class TestInteractiveWindowProvider implements IInteractiveWindowProvider {
+    public get onDidChangeActiveInteractiveWindow() {
+        return this.realProvider.onDidChangeActiveInteractiveWindow;
+    }
     private realProvider: InteractiveWindowProvider;
     constructor(
         @inject(ILiveShareApi) liveShare: ILiveShareApi,

--- a/src/test/datascience/testNativeEditorProvider.ts
+++ b/src/test/datascience/testNativeEditorProvider.ts
@@ -16,6 +16,9 @@ import { IServiceContainer } from '../../client/ioc/types';
 
 @injectable()
 export class TestNativeEditorProvider implements INotebookEditorProvider {
+    public get onDidChangeActiveNotebookEditor() {
+        return this.realProvider.onDidChangeActiveNotebookEditor;
+    }
     private realProvider: NativeEditorProvider;
     private _onDidOpenNotebookEditor = new EventEmitter<INotebookEditor>();
     public get onDidOpenNotebookEditor(): Event<INotebookEditor> {


### PR DESCRIPTION
Part of #8869, #9228 

* Single location for setting context variables (testable)
* Ability to detect whether interactive window or native editor has focus (vs it is available/visible)
    * This is required to enable/disable commands when focus changes (today we enable the commands regardless once native editor or interactive window is available)

**Will require a subsequent PR to add the context keys.**

A PR that I had started on during the December holidays.
(minor events and moved initialization of context keys into a separate class).