### PR TITLE
WIP - Ensure pipelines treat dataScience branch as a master branch

### DIFF
--- a/build/ci/templates/steps/build.yml
+++ b/build/ci/templates/steps/build.yml
@@ -40,12 +40,12 @@ steps:
     # I.e. skip on in PRs.
     - bash: npm run checkDependencies
       displayName: "Check Dependencies"
-      condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'master'), startsWith(variables['Build.SourceBranchName'], 'release')))
+      condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'dataScience'), eq(variables['Build.SourceBranchName'], 'master'), startsWith(variables['Build.SourceBranchName'], 'release')))
 
     - bash: |
           npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
       displayName: "Update dev Version of Extension"
-      condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
+      condition: and(succeeded(), or(eq(variables['Build.SourceBranchName'], 'dataScience'), eq(variables['Build.SourceBranchName'], 'master')))
 
     - bash: |
           npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID --updateChangelog

--- a/build/ci/templates/steps/build_compile.yml
+++ b/build/ci/templates/steps/build_compile.yml
@@ -43,7 +43,7 @@ steps:
     - bash: |
           npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
       displayName: "Update dev Version of Extension"
-      condition: and(succeeded(), eq(variables['build'], 'true'), eq(variables['Build.SourceBranchName'], 'master'))
+      condition: and(succeeded(), eq(variables['build'], 'true'), or(eq(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.SourceBranchName'], 'dataScience')))
 
     - bash: |
           npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID --updateChangelog

--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -4,7 +4,7 @@ name: '$(Year:yyyy).$(Month).0.$(BuildID)-ci'
 #        on changes in the news and .vscode folders.
 trigger:
   branches:
-    include: ["master", "release*"]
+    include: ["master", "dataScience", "release*"]
   paths:
     exclude: ["/news/1 Enhancements", "/news/2 Fixes", "/news/3 Code Health", "/.vscode"]
 

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -15,6 +15,7 @@ schedules:
   branches:
     include:
     - master
+    - dataScience
     - release*
   always: true
 

--- a/build/ci/vscode-python-nightly-flake-ci.yaml
+++ b/build/ci/vscode-python-nightly-flake-ci.yaml
@@ -17,6 +17,7 @@ schedules:
   branches:
     include:
     - master
+    - dataScience
     - release*
   # False here so we don't run these long tests over and over on release branch if the source isn't changing
   always: false

--- a/build/ci/vscode-python-nightly-uitest.yaml
+++ b/build/ci/vscode-python-nightly-uitest.yaml
@@ -9,6 +9,7 @@ schedules:
   branches:
     include:
     - master
+    - dataScience
     - releases*
 
 # Variables that are available for the entire pipeline.

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -6,7 +6,7 @@ name: '$(Year:yyyy).$(Month).0.$(BuildID)-pr'
 pr:
   autoCancel: true
   branches:
-    include: ["master", "release*"]
+    include: ["master", "dataScience", "release*"]
   paths:
     exclude: ["/news/1 Enhancements", "/news/2 Fixes", "/news/3 Code Health", "/.vscode"]
 

--- a/news/3 Code Health/9435.md
+++ b/news/3 Code Health/9435.md
@@ -1,0 +1,1 @@
+Ensure pipelines treat dataScience branch as a master branch.


### PR DESCRIPTION
For #9435 
* Ensure PR, CI, nightly and flaky pipelines run against this new branch
* Will make changes to pipeline to upload a VSIX for datascience from this new branch (so we don't have to wait for stuff to be merged back into master - useful for PMs)