### PR TITLE
Make shift+enter work in DS and non-DS scenarios

### DIFF
--- a/news/2 Fixes/9437.md
+++ b/news/2 Fixes/9437.md
@@ -1,0 +1,1 @@
+Shift+Enter can no longer send multiple lines to the interactive window.

--- a/news/2 Fixes/9439.md
+++ b/news/2 Fixes/9439.md
@@ -1,0 +1,1 @@
+Shift+Enter can no longer run code in the terminal.

--- a/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
+++ b/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
@@ -9,7 +9,7 @@ import { Disposable, Uri } from 'vscode';
 import { ICommandManager, IDocumentManager, IWorkspaceService } from '../../common/application/types';
 import '../../common/extensions';
 import { IFileSystem, IPlatformService } from '../../common/platform/types';
-import { IPythonExecutionFactory, PythonExecutionInfo } from '../../common/process/types';
+import { PythonExecutionInfo } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { DjangoContextInitializer } from './djangoContext';
@@ -25,10 +25,9 @@ export class DjangoShellCodeExecutionProvider extends TerminalCodeExecutionProvi
         @inject(IPlatformService) platformService: IPlatformService,
         @inject(ICommandManager) commandManager: ICommandManager,
         @inject(IFileSystem) fileSystem: IFileSystem,
-        @inject(IPythonExecutionFactory) pythonExecFactory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) disposableRegistry: Disposable[]
     ) {
-        super(terminalServiceFactory, configurationService, workspace, disposableRegistry, platformService, pythonExecFactory);
+        super(terminalServiceFactory, configurationService, workspace, disposableRegistry, platformService);
         this.terminalTitle = 'Django Shell';
         disposableRegistry.push(new DjangoContextInitializer(documentManager, workspace, fileSystem, commandManager));
     }

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import '../../common/extensions';
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Range, TextEditor, Uri } from 'vscode';
+
 import { IApplicationShell, IDocumentManager } from '../../common/application/types';
 import { EXTENSION_ROOT_DIR, PYTHON_LANGUAGE } from '../../common/constants';
-import '../../common/extensions';
 import { traceError } from '../../common/logger';
-import { IFileSystem } from '../../common/platform/types';
-import { IProcessServiceFactory, IPythonExecutionFactory } from '../../common/process/types';
+import { IProcessServiceFactory } from '../../common/process/types';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { ICodeExecutionHelper } from '../types';
@@ -19,13 +19,11 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
     private readonly documentManager: IDocumentManager;
     private readonly applicationShell: IApplicationShell;
     private readonly processServiceFactory: IProcessServiceFactory;
-    private readonly fileSystem: IFileSystem;
     private readonly interpreterService: IInterpreterService;
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.documentManager = serviceContainer.get<IDocumentManager>(IDocumentManager);
         this.applicationShell = serviceContainer.get<IApplicationShell>(IApplicationShell);
         this.processServiceFactory = serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
-        this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
         this.interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     }
     public async normalizeLines(code: string, resource?: Uri): Promise<string> {

--- a/src/client/terminals/codeExecution/helper.ts
+++ b/src/client/terminals/codeExecution/helper.ts
@@ -8,7 +8,9 @@ import { IApplicationShell, IDocumentManager } from '../../common/application/ty
 import { EXTENSION_ROOT_DIR, PYTHON_LANGUAGE } from '../../common/constants';
 import '../../common/extensions';
 import { traceError } from '../../common/logger';
-import { IPythonExecutionFactory } from '../../common/process/types';
+import { IFileSystem } from '../../common/platform/types';
+import { IProcessServiceFactory, IPythonExecutionFactory } from '../../common/process/types';
+import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { ICodeExecutionHelper } from '../types';
 
@@ -16,11 +18,15 @@ import { ICodeExecutionHelper } from '../types';
 export class CodeExecutionHelper implements ICodeExecutionHelper {
     private readonly documentManager: IDocumentManager;
     private readonly applicationShell: IApplicationShell;
-    private readonly pythonServiceFactory: IPythonExecutionFactory;
+    private readonly processServiceFactory: IProcessServiceFactory;
+    private readonly fileSystem: IFileSystem;
+    private readonly interpreterService: IInterpreterService;
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.documentManager = serviceContainer.get<IDocumentManager>(IDocumentManager);
         this.applicationShell = serviceContainer.get<IApplicationShell>(IApplicationShell);
-        this.pythonServiceFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
+        this.processServiceFactory = serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
+        this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
+        this.interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
     }
     public async normalizeLines(code: string, resource?: Uri): Promise<string> {
         try {
@@ -30,9 +36,10 @@ export class CodeExecutionHelper implements ICodeExecutionHelper {
             // On windows cr is not handled well by python when passing in/out via stdin/stdout.
             // So just remove cr from the input.
             code = code.replace(new RegExp('\\r', 'g'), '');
+            const interpreter = await this.interpreterService.getActiveInterpreter(resource);
+            const processService = await this.processServiceFactory.create(resource);
             const args = [path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'normalizeForInterpreter.py'), code];
-            const processService = await this.pythonServiceFactory.create({ resource });
-            const proc = await processService.exec(args, { throwOnStdErr: true });
+            const proc = await processService.exec(interpreter?.path || 'python', args, { throwOnStdErr: true });
 
             return proc.stdout;
         } catch (ex) {

--- a/src/client/terminals/codeExecution/repl.ts
+++ b/src/client/terminals/codeExecution/repl.ts
@@ -7,7 +7,6 @@ import { inject, injectable } from 'inversify';
 import { Disposable } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
 import { IPlatformService } from '../../common/platform/types';
-import { IPythonExecutionFactory } from '../../common/process/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { TerminalCodeExecutionProvider } from './terminalCodeExecution';
@@ -18,11 +17,10 @@ export class ReplProvider extends TerminalCodeExecutionProvider {
         @inject(ITerminalServiceFactory) terminalServiceFactory: ITerminalServiceFactory,
         @inject(IConfigurationService) configurationService: IConfigurationService,
         @inject(IWorkspaceService) workspace: IWorkspaceService,
-        @inject(IPythonExecutionFactory) pythonExecFactory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) disposableRegistry: Disposable[],
         @inject(IPlatformService) platformService: IPlatformService
     ) {
-        super(terminalServiceFactory, configurationService, workspace, disposableRegistry, platformService, pythonExecFactory);
+        super(terminalServiceFactory, configurationService, workspace, disposableRegistry, platformService);
         this.terminalTitle = 'REPL';
     }
 }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -64,11 +64,6 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         const command = pythonSettings.pythonPath;
         const launchArgs = pythonSettings.terminal.launchArgs;
 
-        const condaExecutionService = await this.pythonExecFactory.createCondaExecutionService(command, undefined, resource);
-        if (condaExecutionService) {
-            return condaExecutionService.getExecutionInfo([...launchArgs, ...args]);
-        }
-
         const isWindows = this.platformService.isWindows;
 
         return {

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -9,7 +9,7 @@ import { Disposable, Uri } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
 import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';
-import { IPythonExecutionFactory, PythonExecutionInfo } from '../../common/process/types';
+import { PythonExecutionInfo } from '../../common/process/types';
 import { ITerminalService, ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { ICodeExecutionService } from '../../terminals/types';
@@ -24,8 +24,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
         @inject(IConfigurationService) protected readonly configurationService: IConfigurationService,
         @inject(IWorkspaceService) protected readonly workspace: IWorkspaceService,
         @inject(IDisposableRegistry) protected readonly disposables: Disposable[],
-        @inject(IPlatformService) protected readonly platformService: IPlatformService,
-        @inject(IPythonExecutionFactory) private readonly pythonExecFactory: IPythonExecutionFactory
+        @inject(IPlatformService) protected readonly platformService: IPlatformService
     ) {}
 
     public async executeFile(file: Uri) {

--- a/src/test/terminals/codeExecution/djangoShellCodeExect.unit.test.ts
+++ b/src/test/terminals/codeExecution/djangoShellCodeExect.unit.test.ts
@@ -54,7 +54,6 @@ suite('Terminal - Django Shell Code Execution', () => {
             platform.object,
             commandManager.object,
             fileSystem.object,
-            pythonExecutionFactory.object,
             disposables
         );
 

--- a/src/test/terminals/codeExecution/djangoShellCodeExect.unit.test.ts
+++ b/src/test/terminals/codeExecution/djangoShellCodeExect.unit.test.ts
@@ -185,9 +185,7 @@ suite('Terminal - Django Shell Code Execution', () => {
         const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         const processService = TypeMoq.Mock.ofType<IProcessService>();
         const condaExecutionService = new CondaExecutionService(serviceContainer.object, processService.object, pythonPath, condaFile, condaEnv);
-        const hasEnvName = condaEnv.name !== '';
-        const condaArgs = ['run', ...(hasEnvName ? ['-n', condaEnv.name] : ['-p', condaEnv.path]), 'python'];
-        const expectedTerminalArgs = [...condaArgs, ...terminalArgs, 'manage.py', 'shell'];
+        const expectedTerminalArgs = [...terminalArgs, 'manage.py', 'shell'];
         pythonExecutionFactory
             .setup(p => p.createCondaExecutionService(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(condaExecutionService));
@@ -195,8 +193,8 @@ suite('Terminal - Django Shell Code Execution', () => {
         const replCommandArgs = await (executor as DjangoShellCodeExecutionProvider).getExecutableInfo(resource);
 
         expect(replCommandArgs).not.to.be.an('undefined', 'Conda command args are undefined');
-        expect(replCommandArgs.command).to.be.equal(condaFile, 'Incorrect conda path');
-        expect(replCommandArgs.args).to.be.deep.equal(expectedTerminalArgs, 'Incorrect conda arguments');
+        expect(replCommandArgs.command).to.be.equal(pythonPath, 'Repl should use python not conda');
+        expect(replCommandArgs.args).to.be.deep.equal(expectedTerminalArgs, 'Incorrect terminal arguments');
     }
 
     test('Ensure conda args including env name are passed when using a conda environment with a name', async () => {

--- a/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
+++ b/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
@@ -231,7 +231,6 @@ suite('Terminal - Code Execution', () => {
                 const expectedPythonPath = isWindows ? pythonPath.replace(/\\/g, '/') : pythonPath;
                 const expectedArgs = terminalArgs.concat(file.fsPath.fileToCommandArgument());
                 terminalService.verify(async t => t.sendCommand(TypeMoq.It.isValue(expectedPythonPath), TypeMoq.It.isValue(expectedArgs)), TypeMoq.Times.once());
-                pythonExecutionFactory.verify(async p => p.createCondaExecutionService(pythonPath, undefined, file), TypeMoq.Times.once());
             }
 
             test('Ensure python file execution script is sent to terminal on windows', async () => {
@@ -270,12 +269,9 @@ suite('Terminal - Code Execution', () => {
 
                 await executor.executeFile(file);
 
-                const hasEnvName = condaEnv.name !== '';
-                const condaArgs = ['run', ...(hasEnvName ? ['-n', condaEnv.name] : ['-p', condaEnv.path]), 'python'];
-                const expectedArgs = [...condaArgs, ...terminalArgs, file.fsPath.fileToCommandArgument()];
+                const expectedArgs = [...terminalArgs, file.fsPath.fileToCommandArgument()];
 
-                pythonExecutionFactory.verify(async p => p.createCondaExecutionService(pythonPath, undefined, file), TypeMoq.Times.once());
-                terminalService.verify(async t => t.sendCommand(TypeMoq.It.isValue(condaFile), TypeMoq.It.isValue(expectedArgs)), TypeMoq.Times.once());
+                terminalService.verify(async t => t.sendCommand(TypeMoq.It.isValue(pythonPath), TypeMoq.It.isValue(expectedArgs)), TypeMoq.Times.once());
             }
 
             test('Ensure conda args with conda env name are sent to terminal if there is a conda environment with a name', async () => {
@@ -301,7 +297,6 @@ suite('Terminal - Code Execution', () => {
                 expect(replCommandArgs).not.to.be.an('undefined', 'Command args is undefined');
                 expect(replCommandArgs.command).to.be.equal(expectedPythonPath, 'Incorrect python path');
                 expect(replCommandArgs.args).to.be.deep.equal(expectedTerminalArgs, 'Incorrect arguments');
-                pythonExecutionFactory.verify(async p => p.createCondaExecutionService(pythonPath, undefined, undefined), TypeMoq.Times.once());
             }
 
             test('Ensure fully qualified python path is escaped when building repl args on Windows', async () => {
@@ -351,17 +346,14 @@ suite('Terminal - Code Execution', () => {
                     .setup(p => p.createCondaExecutionService(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                     .returns(() => Promise.resolve(condaExecutionService));
 
-                const hasEnvName = condaEnv.name !== '';
-                const condaArgs = ['run', ...(hasEnvName ? ['-n', condaEnv.name] : ['-p', condaEnv.path]), 'python'];
                 const djangoArgs = isDjangoRepl ? ['manage.py', 'shell'] : [];
-                const expectedTerminalArgs = [...condaArgs, ...terminalArgs, ...djangoArgs];
+                const expectedTerminalArgs = [...terminalArgs, ...djangoArgs];
 
                 const replCommandArgs = await (executor as TerminalCodeExecutionProvider).getExecutableInfo();
 
                 expect(replCommandArgs).not.to.be.an('undefined', 'Conda command args are undefined');
-                expect(replCommandArgs.command).to.be.equal('conda', 'Incorrect conda path');
-                expect(replCommandArgs.args).to.be.deep.equal(expectedTerminalArgs, 'Incorrect conda arguments');
-                pythonExecutionFactory.verify(async p => p.createCondaExecutionService(pythonPath, undefined, undefined), TypeMoq.Times.once());
+                expect(replCommandArgs.command).to.be.equal(pythonPath, 'Repl needs to use python, not conda');
+                expect(replCommandArgs.args).to.be.deep.equal(expectedTerminalArgs, 'Incorrect terminal arguments');
             }
 
             test('Ensure conda args with env name are returned when building repl args with a conda env with a name', async () => {

--- a/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
+++ b/src/test/terminals/codeExecution/terminalCodeExec.unit.test.ts
@@ -67,18 +67,11 @@ suite('Terminal - Code Execution', () => {
 
             switch (testSuiteName) {
                 case 'Terminal Execution': {
-                    executor = new TerminalCodeExecutionProvider(
-                        terminalFactory.object,
-                        configService.object,
-                        workspace.object,
-                        disposables,
-                        platform.object,
-                        pythonExecutionFactory.object
-                    );
+                    executor = new TerminalCodeExecutionProvider(terminalFactory.object, configService.object, workspace.object, disposables, platform.object);
                     break;
                 }
                 case 'Repl Execution': {
-                    executor = new ReplProvider(terminalFactory.object, configService.object, workspace.object, pythonExecutionFactory.object, disposables, platform.object);
+                    executor = new ReplProvider(terminalFactory.object, configService.object, workspace.object, disposables, platform.object);
                     expectedTerminalTitle = 'REPL';
                     break;
                 }
@@ -97,7 +90,6 @@ suite('Terminal - Code Execution', () => {
                         platform.object,
                         commandManager.object,
                         fileSystem.object,
-                        pythonExecutionFactory.object,
                         disposables
                     );
                     expectedTerminalTitle = 'Django Shell';


### PR DESCRIPTION
Fixes #9437, #9439

Root cause was the normalizeForInterpreter cannot be run (or does it need to be run) with conda run. This wasn't working because of the need to escape \n on the conda run command line.

Additionally, when starting a REPL, conda run cannot be used as it sits there waiting for python to come back. Instead, just plain python must be called.

Testing for this has to be done manually at this point as we don't have a Conda environment on our test machines. See https://github.com/microsoft/vscode-python/issues/9443 for supporting that.