### PR TITLE
Scrape output to get the details of the registered kernel

### DIFF
--- a/news/2 Fixes/9444.md
+++ b/news/2 Fixes/9444.md
@@ -1,0 +1,1 @@
+Scrape output to get the details of the registered kernel.

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -123,9 +123,12 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         processService.on('exec', processLogger.logProcess.bind(processLogger));
         this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry).push(processService);
 
-        const condaExecutionService = await this.createCondaExecutionService(pythonPath, processService);
-        if (condaExecutionService) {
-            return condaExecutionService;
+        // Allow parts of the code to ignore conda run.
+        if (!options.bypassCondaExecution){
+            const condaExecutionService = await this.createCondaExecutionService(pythonPath, processService);
+            if (condaExecutionService) {
+                return condaExecutionService;
+            }
         }
 
         return new PythonExecutionService(this.serviceContainer, processService, pythonPath);

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -74,7 +74,12 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         const disposables = this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry);
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
         const logger = this.serviceContainer.get<IProcessLogger>(IProcessLogger);
-        const activatedProcPromise = this.createActivatedEnvironment({ allowEnvironmentFetchExceptions: true, pythonPath: pythonPath, resource: options.resource });
+        const activatedProcPromise = this.createActivatedEnvironment({
+            allowEnvironmentFetchExceptions: true,
+            pythonPath: pythonPath,
+            resource: options.resource,
+            bypassCondaExecution: true
+        });
 
         // No daemon support in Python 2.7.
         const interpreter = await interpreterService.getInterpreterDetails(pythonPath);

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -124,7 +124,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         this.serviceContainer.get<IDisposableRegistry>(IDisposableRegistry).push(processService);
 
         // Allow parts of the code to ignore conda run.
-        if (!options.bypassCondaExecution){
+        if (!options.bypassCondaExecution) {
             const condaExecutionService = await this.createCondaExecutionService(pythonPath, processService);
             if (condaExecutionService) {
                 return condaExecutionService;

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -101,6 +101,13 @@ export type ExecutionFactoryCreateWithEnvironmentOptions = {
     pythonPath?: string;
     interpreter?: PythonInterpreter;
     allowEnvironmentFetchExceptions?: boolean;
+    /**
+     * Ignore running `conda run` when running code.
+     * It is known to fail in certain scenarios. Where necessary we might want to bypass this.
+     *
+     * @type {boolean}
+     */
+    bypassCondaExecution?: boolean;
 };
 export interface IPythonExecutionFactory {
     create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService>;

--- a/src/client/datascience/jupyter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/jupyterCommand.ts
@@ -209,7 +209,7 @@ export class InterpreterJupyterKernelSpecCommand extends InterpreterJupyterComma
         }
         try {
             // Try getting kernels using python script, if that fails (even if there's output in stderr) rethrow original exception.
-            const activatedEnv = await this.pythonExecutionFactory.createActivatedEnvironment({ interpreter });
+            const activatedEnv = await this.pythonExecutionFactory.createActivatedEnvironment({ interpreter, bypassCondaExecution: true });
             return activatedEnv.exec([path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'datascience', 'getJupyterKernels.py')], { ...options, throwOnStdErr: true });
         } catch (innerEx) {
             traceError('Failed to get a list of the kernelspec using python script', innerEx);

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -220,7 +220,7 @@ export class KernelService {
      * @memberof KernelService
      */
     // tslint:disable-next-line: max-func-body-length
-     @captureTelemetry(Telemetry.RegisterInterpreterAsKernel, undefined, true)
+    @captureTelemetry(Telemetry.RegisterInterpreterAsKernel, undefined, true)
     @traceDecorators.error('Failed to register an interpreter as a kernel')
     public async registerKernel(interpreter: PythonInterpreter, cancelToken?: CancellationToken): Promise<IJupyterKernelSpec | undefined> {
         if (!interpreter.displayName) {

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -219,7 +219,8 @@ export class KernelService {
      * @returns {Promise<IJupyterKernelSpec>}
      * @memberof KernelService
      */
-    @captureTelemetry(Telemetry.RegisterInterpreterAsKernel, undefined, true)
+    // tslint:disable-next-line: max-func-body-length
+     @captureTelemetry(Telemetry.RegisterInterpreterAsKernel, undefined, true)
     @traceDecorators.error('Failed to register an interpreter as a kernel')
     public async registerKernel(interpreter: PythonInterpreter, cancelToken?: CancellationToken): Promise<IJupyterKernelSpec | undefined> {
         if (!interpreter.displayName) {

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -269,7 +269,7 @@ export class KernelService {
             await sleep(500);
             kernel = await this.findMatchingKernelSpec({ display_name: interpreter.displayName, name }, undefined, cancelToken);
         }
-        if (!kernel){
+        if (!kernel) {
             // Possible user doesn't have kernelspec installed.
             kernel = await this.getKernelSpecFromStdOut(output.stdout).catch(ex => {
                 traceError('Failed to get kernelspec from stdout', ex);
@@ -363,7 +363,7 @@ export class KernelService {
      * @memberof KernelService
      */
     @traceDecorators.error('Failed to parse kernel creation stdout')
-    private async getKernelSpecFromStdOut(output : string): Promise<JupyterKernelSpec | undefined> {
+    private async getKernelSpecFromStdOut(output: string): Promise<JupyterKernelSpec | undefined> {
         if (!output) {
             return;
         }
@@ -372,20 +372,20 @@ export class KernelService {
         // `Installed kernel <kernelname> in <path>`
         const regEx = NamedRegexp('Installed\\skernelspec\\s(?<name>\\w*)\\sin\\s(?<path>.*)', 'g');
         const match = regEx.exec(output);
-        if (!match || !match.groups()){
+        if (!match || !match.groups()) {
             return;
         }
 
-        type RegExGroup = {name: string; path: string};
+        type RegExGroup = { name: string; path: string };
         const groups = match.groups() as RegExGroup | undefined;
 
-        if (!groups || !groups.name || !groups.path){
+        if (!groups || !groups.name || !groups.path) {
             traceError('Kernel Output not parsed', output);
             throw new Error('Unable to parse output to get the kernel info');
         }
 
         const specFile = path.join(groups.path, 'kernel.json');
-        if (!await this.fileSystem.fileExists(specFile)) {
+        if (!(await this.fileSystem.fileExists(specFile))) {
             throw new Error('KernelSpec file not found');
         }
 
@@ -434,5 +434,5 @@ export class KernelService {
             // This is failing for some folks. In that case return nothing
             return [];
         }
-    };
+    }
 }

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -28,7 +28,7 @@ import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { LiveKernelModel } from './types';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
-const NamedRegexp = require('named-js-regexp');
+const NamedRegexp = require('named-js-regexp') as typeof import('named-js-regexp');
 
 /**
  * Helper to ensure we can differentiate between two types in union types, keeping typing information.
@@ -153,10 +153,10 @@ export class KernelService {
         // Check if kernel is `Python2` or `Python3` or a similar generic kernel.
         const regEx = NamedRegexp('python\\s*(?<version>(\\d+))', 'g');
         const match = regEx.exec(kernelSpec.name.toLowerCase());
-        if (match) {
+        if (match && match.groups()) {
             // 3. Look for interpreter with same major version
 
-            const majorVersion = parseInt(match.groups().version, 10) || 0;
+            const majorVersion = parseInt(match.groups()!.version, 10) || 0;
             // If the major versions match, that's sufficient.
             if (!majorVersion || (activeInterpreter?.version && activeInterpreter.version.major === majorVersion)) {
                 traceInfo(`Using current interpreter for kernel ${kernelSpec.name}, ${kernelSpec.display_name}`);
@@ -269,6 +269,13 @@ export class KernelService {
             await sleep(500);
             kernel = await this.findMatchingKernelSpec({ display_name: interpreter.displayName, name }, undefined, cancelToken);
         }
+        if (!kernel){
+            // Possible user doesn't have kernelspec installed.
+            kernel = await this.getKernelSpecFromStdOut(output.stdout).catch(ex => {
+                traceError('Failed to get kernelspec from stdout', ex);
+                return undefined;
+            });
+        }
         if (!kernel) {
             const error = `Kernel not created with the name ${name}, display_name ${interpreter.displayName}. Output is ${output.stdout}`;
             throw new Error(error);
@@ -347,7 +354,47 @@ export class KernelService {
         return `${interpreter.displayName || ''}${uuid()}`.replace(/[^A-Za-z0-9]/g, '').toLowerCase();
     }
 
-    private enumerateSpecs = async (_cancelToken?: CancellationToken): Promise<JupyterKernelSpec[]> => {
+    /**
+     * Will scrape kernelspec info from the output when a new kernel is created.
+     *
+     * @private
+     * @param {string} output
+     * @returns {JupyterKernelSpec}
+     * @memberof KernelService
+     */
+    @traceDecorators.error('Failed to parse kernel creation stdout')
+    private async getKernelSpecFromStdOut(output : string): Promise<JupyterKernelSpec | undefined> {
+        if (!output) {
+            return;
+        }
+
+        // Output should be of the form
+        // `Installed kernel <kernelname> in <path>`
+        const regEx = NamedRegexp('Installed\\skernelspec\\s(?<name>\\w*)\\sin\\s(?<path>.*)', 'g');
+        const match = regEx.exec(output);
+        if (!match || !match.groups()){
+            return;
+        }
+
+        type RegExGroup = {name: string; path: string};
+        const groups = match.groups() as RegExGroup | undefined;
+
+        if (!groups || !groups.name || !groups.path){
+            traceError('Kernel Output not parsed', output);
+            throw new Error('Unable to parse output to get the kernel info');
+        }
+
+        const specFile = path.join(groups.path, 'kernel.json');
+        if (!await this.fileSystem.fileExists(specFile)) {
+            throw new Error('KernelSpec file not found');
+        }
+
+        const kernelModel = JSON.parse(await this.fileSystem.readFile(specFile));
+        kernelModel.name = groups.name;
+        return new JupyterKernelSpec(kernelModel as Kernel.ISpecModel, specFile);
+    }
+
+    private async enumerateSpecs(_cancelToken?: CancellationToken): Promise<JupyterKernelSpec[]> {
         // Ignore errors if there are no kernels.
         const kernelSpecCommand = await this.commandFinder.findBestCommand(JupyterCommands.KernelSpecCommand).catch(noop);
 


### PR DESCRIPTION
For #9444
* Also added ability to bypass `conda run` when creating a process exec service