### PR TITLE
Bypass conda service when creating daemons

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -278,13 +278,6 @@ export class KernelService {
             });
         }
         if (!kernel) {
-            // Possible user doesn't have kernelspec installed.
-            kernel = await this.getKernelSpecFromStdOut(output.stdout).catch(ex => {
-                traceError('Failed to get kernelspec from stdout', ex);
-                return undefined;
-            });
-        }
-        if (!kernel) {
             const error = `Kernel not created with the name ${name}, display_name ${interpreter.displayName}. Output is ${output.stdout}`;
             throw new Error(error);
         }

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -278,6 +278,13 @@ export class KernelService {
             });
         }
         if (!kernel) {
+            // Possible user doesn't have kernelspec installed.
+            kernel = await this.getKernelSpecFromStdOut(output.stdout).catch(ex => {
+                traceError('Failed to get kernelspec from stdout', ex);
+                return undefined;
+            });
+        }
+        if (!kernel) {
             const error = `Kernel not created with the name ${name}, display_name ${interpreter.displayName}. Output is ${output.stdout}`;
             throw new Error(error);
         }

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -241,7 +241,7 @@ export class NotebookStarter implements Disposable {
         const isActiveInterpreter = activeInterpreter ? activeInterpreter.path === interpreter.path : false;
         const daemon = await (isActiveInterpreter
             ? this.executionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path })
-            : this.executionFactory.createActivatedEnvironment({ allowEnvironmentFetchExceptions: true, interpreter }));
+            : this.executionFactory.createActivatedEnvironment({ allowEnvironmentFetchExceptions: true, interpreter, bypassCondaExecution: true }));
         // We have a small python file here that we will execute to get the server info from all running Jupyter instances
         const newOptions: SpawnOptions = { mergeStdOutErr: true, token: cancelToken };
         const file = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'datascience', 'getServerInfo.py');


### PR DESCRIPTION
Related to #9444
(do not use conda service `conda run` when starting the daemon)