### PR TITLE
Factor out the tempfile-related code.

### DIFF
--- a/src/client/common/platform/fs-temp.ts
+++ b/src/client/common/platform/fs-temp.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as tmp from 'tmp';
-import { TemporaryFile } from './types';
+import { ITempFileSystem, TemporaryFile } from './types';
 
 interface IRawTempFS {
     // tslint:disable-next-line:no-any
@@ -10,7 +10,7 @@ interface IRawTempFS {
 }
 
 // Operations related to temporary files and directories.
-export class TemporaryFileSystem {
+export class TemporaryFileSystem implements ITempFileSystem {
     // prettier-ignore
     constructor(
         private readonly raw: IRawTempFS

--- a/src/client/common/platform/fs-temp.ts
+++ b/src/client/common/platform/fs-temp.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as tmp from 'tmp';
+import { TemporaryFile } from './types';
+
+interface IRawTempFS {
+    // tslint:disable-next-line:no-any
+    file(config: tmp.Options, callback?: (err: any, path: string, fd: number, cleanupCallback: () => void) => void): void;
+}
+
+export class TemporaryFileSystem {
+    // prettier-ignore
+    constructor(
+        private readonly raw: IRawTempFS
+    ) { }
+    public static withDefaults(): TemporaryFileSystem {
+        // prettier-ignore
+        return new TemporaryFileSystem(
+            tmp
+        );
+    }
+
+    public createFile(suffix: string): Promise<TemporaryFile> {
+        const opts = {
+            postfix: suffix
+        };
+        return new Promise<TemporaryFile>((resolve, reject) => {
+            this.raw.file(opts, (err, filename, _fd, cleanUp) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve({
+                    filePath: filename,
+                    dispose: cleanUp
+                });
+            });
+        });
+    }
+}

--- a/src/client/common/platform/fs-temp.ts
+++ b/src/client/common/platform/fs-temp.ts
@@ -9,6 +9,7 @@ interface IRawTempFS {
     file(config: tmp.Options, callback?: (err: any, path: string, fd: number, cleanupCallback: () => void) => void): void;
 }
 
+// Operations related to temporary files and directories.
 export class TemporaryFileSystem {
     // prettier-ignore
     constructor(
@@ -21,6 +22,7 @@ export class TemporaryFileSystem {
         );
     }
 
+    // Create a new temp file with the given filename suffix.
     public createFile(suffix: string): Promise<TemporaryFile> {
         const opts = {
             postfix: suffix

--- a/src/client/common/platform/types.ts
+++ b/src/client/common/platform/types.ts
@@ -47,6 +47,10 @@ export interface IPlatformService {
 export type TemporaryFile = { filePath: string } & vscode.Disposable;
 export type TemporaryDirectory = { path: string } & vscode.Disposable;
 
+export interface ITempFileSystem {
+    createFile(suffix: string): Promise<TemporaryFile>;
+}
+
 //===========================
 // FS paths
 

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { convertStat, FileSystem } from '../../../client/common/platform/fileSystem';
 import { FileSystemPaths, FileSystemPathUtils } from '../../../client/common/platform/fs-paths';
 import { PlatformService } from '../../../client/common/platform/platformService';
-import { FileType, TemporaryFile } from '../../../client/common/platform/types';
+import { FileType } from '../../../client/common/platform/types';
 import { sleep } from '../../../client/common/utils/async';
 // prettier-ignore
 import {
@@ -1124,66 +1124,6 @@ suite('FileSystem', () => {
                 const files = await fileSystem.search(pattern);
 
                 expect(files).to.deep.equal([]);
-            });
-        });
-
-        suite('createTemporaryFile', () => {
-            async function createTemporaryFile(suffix: string): Promise<TemporaryFile> {
-                const tempfile = await fileSystem.createTemporaryFile(suffix);
-                fix.addFSCleanup(tempfile.filePath, tempfile.dispose);
-                return tempfile;
-            }
-
-            test('TemporaryFile is created properly', async () => {
-                const tempfile = await fileSystem.createTemporaryFile('.tmp');
-                fix.addFSCleanup(tempfile.filePath, tempfile.dispose);
-                await assertExists(tempfile.filePath);
-
-                expect(tempfile.filePath.endsWith('.tmp')).to.equal(true, `bad suffix on ${tempfile.filePath}`);
-            });
-
-            test('TemporaryFile is disposed properly', async () => {
-                const tempfile = await createTemporaryFile('.tmp');
-                await assertExists(tempfile.filePath);
-
-                tempfile.dispose();
-
-                await assertDoesNotExist(tempfile.filePath);
-            });
-
-            test('Ensure creating a temporary file results in a unique temp file path', async () => {
-                const tempFile = await createTemporaryFile('.tmp');
-                const tempFile2 = await createTemporaryFile('.tmp');
-
-                const filename1 = tempFile.filePath;
-                const filename2 = tempFile2.filePath;
-
-                expect(filename1).to.not.equal(filename2);
-            });
-
-            test('Ensure writing to a temp file is supported via file stream', async function() {
-                if (WINDOWS) {
-                    // tslint:disable-next-line:no-invalid-this
-                    this.skip();
-                }
-                const tempfile = await createTemporaryFile('.tmp');
-                const stream = fileSystem.createWriteStream(tempfile.filePath);
-                fix.addCleanup(() => stream.destroy());
-                const data = '...';
-
-                stream.write(data, 'utf8');
-
-                const actual = await fs.readFile(tempfile.filePath, 'utf8');
-                expect(actual).to.equal(data);
-            });
-
-            test('Ensure chmod works against a temporary file', async () => {
-                // Note that on Windows chmod is a noop.
-                const tempfile = await createTemporaryFile('.tmp');
-
-                const promise = fs.chmod(tempfile.filePath, '7777');
-
-                await expect(promise).to.not.eventually.be.rejected;
             });
         });
 

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -1127,6 +1127,18 @@ suite('FileSystem', () => {
             });
         });
 
+        suite('createFile', () => {
+            // tested fully in the TemporaryFileSystem tests.
+
+            test('calls wrapped object', async () => {
+                const tempfile = await fileSystem.createTemporaryFile('.tmp');
+                fix.addFSCleanup(tempfile.filePath, tempfile.dispose);
+                await assertExists(tempfile.filePath);
+
+                expect(tempfile.filePath.endsWith('.tmp')).to.equal(true);
+            });
+        });
+
         suite('isDirReadonly', () => {
             suite('non-Windows', () => {
                 suiteSetup(function() {

--- a/src/test/common/platform/fs-temp.functional.test.ts
+++ b/src/test/common/platform/fs-temp.functional.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// tslint:disable:max-func-body-length chai-vague-errors
+
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import { TemporaryFileSystem } from '../../../client/common/platform/fs-temp';
+import { TemporaryFile } from '../../../client/common/platform/types';
+// prettier-ignore
+import {
+    assertDoesNotExist, assertExists, FSFixture, WINDOWS
+} from './utils';
+
+suite('FileSystem - TemporaryFileSystem', () => {
+    let tmpfs: TemporaryFileSystem;
+    let fix: FSFixture;
+    setup(async () => {
+        tmpfs = TemporaryFileSystem.withDefaults();
+        fix = new FSFixture();
+    });
+    teardown(async () => {
+        await fix.cleanUp();
+    });
+
+    suite('createFile', () => {
+        async function createFile(suffix: string): Promise<TemporaryFile> {
+            const tempfile = await tmpfs.createFile(suffix);
+            fix.addFSCleanup(tempfile.filePath, tempfile.dispose);
+            return tempfile;
+        }
+
+        test('TemporaryFile is created properly', async () => {
+            const tempfile = await tmpfs.createFile('.tmp');
+            fix.addFSCleanup(tempfile.filePath, tempfile.dispose);
+            await assertExists(tempfile.filePath);
+
+            expect(tempfile.filePath.endsWith('.tmp')).to.equal(true, `bad suffix on ${tempfile.filePath}`);
+        });
+
+        test('TemporaryFile is disposed properly', async () => {
+            const tempfile = await createFile('.tmp');
+            await assertExists(tempfile.filePath);
+
+            tempfile.dispose();
+
+            await assertDoesNotExist(tempfile.filePath);
+        });
+
+        test('Ensure creating a temporary file results in a unique temp file path', async () => {
+            const tempFile = await createFile('.tmp');
+            const tempFile2 = await createFile('.tmp');
+
+            const filename1 = tempFile.filePath;
+            const filename2 = tempFile2.filePath;
+
+            expect(filename1).to.not.equal(filename2);
+        });
+
+        test('Ensure writing to a temp file is supported via file stream', async function() {
+            if (WINDOWS) {
+                // tslint:disable-next-line:no-invalid-this
+                this.skip();
+            }
+            const tempfile = await createFile('.tmp');
+            const stream = fs.createWriteStream(tempfile.filePath);
+            fix.addCleanup(() => stream.destroy());
+            const data = '...';
+
+            stream.write(data, 'utf8');
+
+            const actual = await fs.readFile(tempfile.filePath, 'utf8');
+            expect(actual).to.equal(data);
+        });
+
+        test('Ensure chmod works against a temporary file', async () => {
+            // Note that on Windows chmod is a noop.
+            const tempfile = await createFile('.tmp');
+
+            const promise = fs.chmod(tempfile.filePath, '7777');
+
+            await expect(promise).to.not.eventually.be.rejected;
+        });
+    });
+});

--- a/src/test/common/platform/fs-temp.unit.test.ts
+++ b/src/test/common/platform/fs-temp.unit.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// tslint:disable:max-func-body-length
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import { TemporaryFileSystem } from '../../../client/common/platform/fs-temp';
+
+interface IDeps {
+    // tmp module
+    // tslint:disable-next-line:no-any
+    file(config: { postfix?: string }, callback?: (err: any, path: string, fd: number, cleanupCallback: () => void) => void): void;
+}
+
+suite('FileSystem - temp files', () => {
+    let deps: TypeMoq.IMock<IDeps>;
+    let temp: TemporaryFileSystem;
+    setup(() => {
+        deps = TypeMoq.Mock.ofType<IDeps>(undefined, TypeMoq.MockBehavior.Strict);
+        temp = new TemporaryFileSystem(deps.object);
+    });
+    function verifyAll() {
+        deps.verifyAll();
+    }
+
+    suite('createFile', () => {
+        test(`fails if the raw call fails`, async () => {
+            const failure = new Error('oops');
+            // prettier-ignore
+            deps.setup(d => d.file({ postfix: '.tmp' }, TypeMoq.It.isAny()))
+                .throws(failure);
+
+            const promise = temp.createFile('.tmp');
+
+            await expect(promise).to.eventually.be.rejected;
+            verifyAll();
+        });
+
+        test(`fails if the raw call "returns" an error`, async () => {
+            const failure = new Error('oops');
+            deps.setup(d => d.file({ postfix: '.tmp' }, TypeMoq.It.isAny()))
+                // tslint:disable-next-line:no-empty
+                .callback((_cfg, cb) => cb(failure, '...', -1, () => {}));
+
+            const promise = temp.createFile('.tmp');
+
+            await expect(promise).to.eventually.be.rejected;
+            verifyAll();
+        });
+    });
+});


### PR DESCRIPTION
(for #8995)

This separates the tempfile stuff from the broader "fs utils".  This helps keep the code focused.  It's part of what we reverted in #8970.