### PR TITLE
More places in DS code to bypass conda run

### DIFF
--- a/src/client/datascience/jupyter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/jupyterCommand.ts
@@ -105,7 +105,7 @@ class InterpreterJupyterCommand implements IJupyterCommand {
                     }
                 }
             }
-            return pythonExecutionFactory.createActivatedEnvironment({ interpreter: this._interpreter });
+            return pythonExecutionFactory.createActivatedEnvironment({ interpreter: this._interpreter, bypassCondaExecution: true });
         });
     }
     public interpreter(): Promise<PythonInterpreter | undefined> {

--- a/src/client/datascience/jupyter/jupyterCommandFinder.ts
+++ b/src/client/datascience/jupyter/jupyterCommandFinder.ts
@@ -359,7 +359,7 @@ export class JupyterCommandFinderImpl {
     private async createExecutionService(interpreter: PythonInterpreter): Promise<IPythonExecutionService> {
         const [currentInterpreter, pythonService] = await Promise.all([
             this.interpreterService.getActiveInterpreter(undefined),
-            this.executionFactory.createActivatedEnvironment({ resource: undefined, interpreter, allowEnvironmentFetchExceptions: true })
+            this.executionFactory.createActivatedEnvironment({ resource: undefined, interpreter, allowEnvironmentFetchExceptions: true, bypassCondaExecution: true })
         ]);
 
         // Use daemons for current interpreter, when using any other interpreter, do not use a daemon.


### PR DESCRIPTION
For #9444
Found two more places where we could end up using `conda run`.
Bypass this as well to ensure we use `activated environment` variables instead, we know this is guaranteed to work.

This is all that's remaining as far as I know where DS code is using `conda run`.
We know at least from one user that `conda run` has failed to get list of kernels.