### PR TITLE
Disable buttons on doing something that makes the UI busy

### DIFF
--- a/news/2 Fixes/8716.md
+++ b/news/2 Fixes/8716.md
@@ -1,0 +1,1 @@
+Disable interrupt, export, and restart buttons when already performing an interrupt, export, or restart for Notebooks and the Interactive window.

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -113,6 +113,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps> {
                         <ImageButton
                             baseTheme={this.props.baseTheme}
                             onClick={this.props.interruptKernel}
+                            disabled={this.props.busy}
                             tooltip={getLocString('DataScience.interruptKernel', 'Interrupt IPython kernel')}
                         >
                             <Image baseTheme={this.props.baseTheme} class="image-button-image" image={ImageName.Interrupt} />
@@ -120,6 +121,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps> {
                         <ImageButton
                             baseTheme={this.props.baseTheme}
                             onClick={this.props.restartKernel}
+                            disabled={this.props.busy}
                             tooltip={getLocString('DataScience.restartServer', 'Restart IPython kernel')}
                         >
                             <Image baseTheme={this.props.baseTheme} class="image-button-image" image={ImageName.Restart} />
@@ -130,7 +132,7 @@ export class InteractivePanel extends React.Component<IInteractivePanelProps> {
                         <ImageButton
                             baseTheme={this.props.baseTheme}
                             onClick={this.props.export}
-                            disabled={this.props.cellVMs.length === 0}
+                            disabled={this.props.cellVMs.length === 0 || this.props.busy}
                             tooltip={getLocString('DataScience.export', 'Export as Jupyter notebook')}
                         >
                             <Image baseTheme={this.props.baseTheme} class="image-button-image" image={ImageName.SaveAs} />

--- a/src/datascience-ui/interactive-common/redux/reducers/kernel.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/kernel.ts
@@ -21,15 +21,21 @@ export namespace Kernel {
     export function restartKernel<T>(arg: CommonReducerArg<T>): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.RestartKernel));
 
-        // Doesn't modify anything right now. Might set a busy flag or kernel state in the future
-        return arg.prevState;
+        // Set busy until kernel is restarted
+        return {
+            ...arg.prevState,
+            busy: true
+        };
     }
 
     export function interruptKernel<T>(arg: CommonReducerArg<T>): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.Interrupt));
 
-        // Doesn't modify anything right now. Might set a busy flag or kernel state in the future
-        return arg.prevState;
+        // Set busy until kernel is finished interrupting
+        return {
+            ...arg.prevState,
+            busy: true
+        };
     }
 
     export function updateStatus<T>(arg: CommonReducerArg<T, IServerState>): IMainState {

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -12,7 +12,12 @@ export namespace Transfer {
     export function exportCells<T>(arg: CommonReducerArg<T>): IMainState {
         const cellContents = arg.prevState.cellVMs.map(v => v.cell);
         arg.queueAction(createPostableAction(InteractiveWindowMessages.Export, cellContents));
-        return arg.prevState;
+
+        // Indicate busy
+        return {
+            ...arg.prevState,
+            busy: true
+        };
     }
 
     export function save<T>(arg: CommonReducerArg<T>): IMainState {

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -159,13 +159,19 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
         return (
             <div id="toolbar-panel">
                 <div className="toolbar-menu-bar">
-                    <ImageButton baseTheme={this.props.baseTheme} onClick={runAll} className="native-button" tooltip={getLocString('DataScience.runAll', 'Run All Cells')}>
+                    <ImageButton
+                        baseTheme={this.props.baseTheme}
+                        onClick={runAll}
+                        disabled={this.props.busy}
+                        className="native-button"
+                        tooltip={getLocString('DataScience.runAll', 'Run All Cells')}
+                    >
                         <Image baseTheme={this.props.baseTheme} class="image-button-image" image={ImageName.RunAll} />
                     </ImageButton>
                     <ImageButton
                         baseTheme={this.props.baseTheme}
                         onClick={runAbove}
-                        disabled={!canRunAbove}
+                        disabled={!canRunAbove || this.props.busy}
                         className="native-button"
                         tooltip={getLocString('DataScience.runAbove', 'Run cells above')}
                     >
@@ -174,7 +180,7 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
                     <ImageButton
                         baseTheme={this.props.baseTheme}
                         onClick={runBelow}
-                        disabled={!canRunBelow}
+                        disabled={!canRunBelow || this.props.busy}
                         className="native-button"
                         tooltip={getLocString('DataScience.runBelow', 'Run cell and below')}
                     >
@@ -183,6 +189,7 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
                     <ImageButton
                         baseTheme={this.props.baseTheme}
                         onClick={this.props.restartKernel}
+                        disabled={this.props.busy}
                         className="native-button"
                         tooltip={getLocString('DataScience.restartServer', 'Restart IPython kernel')}
                     >
@@ -191,6 +198,7 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
                     <ImageButton
                         baseTheme={this.props.baseTheme}
                         onClick={this.props.interruptKernel}
+                        disabled={this.props.busy}
                         className="native-button"
                         tooltip={getLocString('DataScience.interruptKernel', 'Interrupt IPython kernel')}
                     >
@@ -223,7 +231,7 @@ export class NativeEditor extends React.Component<INativeEditorProps> {
                     <ImageButton
                         baseTheme={this.props.baseTheme}
                         onClick={this.props.export}
-                        disabled={!this.props.cellVMs.length}
+                        disabled={!this.props.cellVMs.length || this.props.busy}
                         className="native-button"
                         tooltip={getLocString('DataScience.exportAsPythonFileTooltip', 'Save As Python File')}
                     >


### PR DESCRIPTION
For #8716

This is the minimum bar for interrupt/restart/export. Prevent the buttons from being run when in the middle of an operation.