### PR TITLE
Revert calling mypy with relatives paths (regression)

### DIFF
--- a/news/2 Fixes/9496.md
+++ b/news/2 Fixes/9496.md
@@ -1,0 +1,1 @@
+Revert changes related to calling `mypy` with relative paths.

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import { CancellationToken, OutputChannel, TextDocument } from 'vscode';
 import '../common/extensions';
 import { Product } from '../common/types';
@@ -14,9 +13,7 @@ export class MyPy extends BaseLinter {
     }
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-        const cwd = this.getWorkspaceRootPath(document);
-        const relativePath = path.relative(cwd, document.uri.fsPath);
-        const messages = await this.run([relativePath], document, cancellation, REGEX);
+        const messages = await this.run([document.uri.fsPath], document, cancellation, REGEX);
         messages.forEach(msg => {
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.mypyCategorySeverity);
             msg.code = msg.type;

--- a/src/test/linters/lint.args.test.ts
+++ b/src/test/linters/lint.args.test.ts
@@ -139,8 +139,7 @@ suite('Linting - Arguments', () => {
                 });
                 test('MyPy', async () => {
                     const linter = new MyPy(outputChannel.object, serviceContainer);
-                    const expectedPath = workspaceUri ? path.join(path.basename(path.dirname(fileUri.fsPath)), path.basename(fileUri.fsPath)) : path.basename(fileUri.fsPath);
-                    const expectedArgs = [expectedPath];
+                    const expectedArgs = [fileUri.fsPath];
                     await testLinter(linter, expectedArgs);
                 });
                 test('Pydocstyle', async () => {

--- a/src/test/linters/mypy.unit.test.ts
+++ b/src/test/linters/mypy.unit.test.ts
@@ -6,20 +6,12 @@
 // tslint:disable:no-object-literal-type-assertion
 
 import { expect } from 'chai';
-import * as path from 'path';
-import * as sinon from 'sinon';
-import { anything, instance, mock, when } from 'ts-mockito';
-import { CancellationToken, CancellationTokenSource, TextDocument, Uri } from 'vscode';
-import { Product } from '../../client/common/types';
-import { ServiceContainer } from '../../client/ioc/container';
 import { parseLine } from '../../client/linters/baseLinter';
-import { LinterManager } from '../../client/linters/linterManager';
-import { MyPy, REGEX } from '../../client/linters/mypy';
-import { ILinterManager, ILintMessage, LintMessageSeverity } from '../../client/linters/types';
-import { MockOutputChannel } from '../mockClasses';
+import { REGEX } from '../../client/linters/mypy';
+import { ILintMessage } from '../../client/linters/types';
 
 // This following is a real-world example. See gh=2380.
-// tslint:disable:no-multiline-string no-any max-func-body-length
+// tslint:disable-next-line:no-multiline-string
 const output = `
 provider.pyi:10: error: Incompatible types in assignment (expression has type "str", variable has type "int")
 provider.pyi:11: error: Name 'not_declared_var' is not defined
@@ -69,74 +61,5 @@ suite('Linting - MyPy', () => {
 
             expect(msg).to.deep.equal(expected);
         }
-    });
-});
-
-suite('Test Linter', () => {
-    class TestMyPyLinter extends MyPy {
-        // tslint:disable: no-unnecessary-override
-        public async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
-            return super.runLinter(document, cancellation);
-        }
-        public getWorkspaceRootPath(document: TextDocument): string {
-            return super.getWorkspaceRootPath(document);
-        }
-        public async run(args: string[], document: TextDocument, cancellation: CancellationToken, regEx: string = REGEX): Promise<ILintMessage[]> {
-            return super.run(args, document, cancellation, regEx);
-        }
-        public parseMessagesSeverity(error: string, severity: any): LintMessageSeverity {
-            return super.parseMessagesSeverity(error, severity);
-        }
-    }
-
-    let linter: TestMyPyLinter;
-    let getWorkspaceRootPathStub: sinon.SinonStub<[TextDocument], string>;
-    let runStub: sinon.SinonStub<[string[], TextDocument, CancellationToken, (string | undefined)?], Promise<ILintMessage[]>>;
-    const token = new CancellationTokenSource().token;
-    teardown(() => sinon.restore());
-    setup(() => {
-        const linterManager = mock(LinterManager);
-        when(linterManager.getLinterInfo(anything())).thenReturn({ product: Product.mypy } as any);
-        const serviceContainer = mock(ServiceContainer);
-        when(serviceContainer.get<ILinterManager>(ILinterManager)).thenReturn(instance(linterManager));
-        getWorkspaceRootPathStub = sinon.stub(TestMyPyLinter.prototype, 'getWorkspaceRootPath');
-        runStub = sinon.stub(TestMyPyLinter.prototype, 'run');
-        linter = new TestMyPyLinter(instance(mock(MockOutputChannel)), instance(serviceContainer));
-    });
-
-    test('Get cwd based on document', async () => {
-        const fileUri = Uri.file(path.join('a', 'b', 'c', 'd', 'e', 'filename.py'));
-        const cwd = path.join('a', 'b', 'c');
-        const doc = ({ uri: fileUri } as any) as TextDocument;
-        getWorkspaceRootPathStub.callsFake(() => cwd);
-        runStub.callsFake(() => Promise.resolve([]));
-
-        await linter.runLinter(doc, token);
-
-        expect(getWorkspaceRootPathStub.callCount).to.equal(1);
-        expect(getWorkspaceRootPathStub.args[0]).to.deep.equal([doc]);
-    });
-    test('Pass relative path of document to linter', async () => {
-        const fileUri = Uri.file(path.join('a', 'b', 'c', 'd', 'e', 'filename.py'));
-        const cwd = path.join('a', 'b', 'c');
-        const doc = ({ uri: fileUri } as any) as TextDocument;
-        getWorkspaceRootPathStub.callsFake(() => cwd);
-        runStub.callsFake(() => Promise.resolve([]));
-
-        await linter.runLinter(doc, token);
-
-        expect(runStub.callCount).to.equal(1);
-        expect(runStub.args[0]).to.deep.equal([[path.relative(cwd, fileUri.fsPath)], doc, token, REGEX]);
-    });
-    test('Return empty messages', async () => {
-        const fileUri = Uri.file(path.join('a', 'b', 'c', 'd', 'e', 'filename.py'));
-        const cwd = path.join('a', 'b', 'c');
-        const doc = ({ uri: fileUri } as any) as TextDocument;
-        getWorkspaceRootPathStub.callsFake(() => cwd);
-        runStub.callsFake(() => Promise.resolve([]));
-
-        const messages = await linter.runLinter(doc, token);
-
-        expect(messages).to.be.deep.equal([]);
     });
 });


### PR DESCRIPTION
Reverting https://github.com/microsoft/vscode-python/pull/5834 for #9496.

🛠 Created https://github.com/microsoft/vscode-python/issues/9501 as a work item to re-introduce the behaviour that #5834 was originally fixing.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
