### PR TITLE
Move command finder and related behind a class

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -201,7 +201,7 @@
     "DataScience.notebookVersionFormat": "Jupyter Notebook Version: {0}",
     "DataScience.jupyterKernelNotSupportedOnActive": "Jupyter kernel cannot be started from '{0}'. Using closest match {1} instead.\r\nError starting original kernel: {2}",
     "DataScience.jupyterKernelSpecNotFound": "Cannot create a Jupyter kernel spec and none are available for use",
-    "DataScience.jupyterKernelSpecModuleNotFound": "'Kernelspec' module not installed in the selected interpreter ({0}).\n Please update 'jupyter'",
+    "DataScience.jupyterKernelSpecModuleNotFound": "'Kernelspec' module not installed in the selected interpreter ({0}).\n Please re-install or update 'jupyter'.",
     "DataScience.jupyterGetVariablesBadResults": "Failed to fetch variable info from the Jupyter server.",
     "DataScience.liveShareConnectFailure": "Cannot connect to host Jupyter session. URI not found.",
     "DataScience.liveShareCannotSpawnNotebooks": "Spawning Jupyter notebooks is not supported over a live share connection",

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -17,21 +17,22 @@ import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { PythonInterpreter } from '../../../interpreter/contracts';
 import { InterpreterService } from '../../../interpreter/interpreterService';
 import { JupyterCommands, PythonDaemonModule } from '../../constants';
-import { IJupyterInterpreterExecutionService } from '../../types';
+import { IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterServerInfo } from '../jupyterConnection';
 import { JupyterInstallError } from '../jupyterInstallError';
 import { JupyterKernelSpec } from '../kernels/jupyterKernelSpec';
 import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder';
 
 /**
- * Responsible for using the command finder for all execution of code against interpreter(s) related to jupyter and the like.
+ * Responsible for execution of jupyter sub commands using the command finder and related classes.
+ * The plan is to deprecate this class in the future along with to JupyterCommandFinder and related classes.
  *
  * @export
  * @class JupyterCommandFinderInterpreterExecutionService
  * @implements {IJupyterInterpreterExecutionService}
  */
 @injectable()
-export class JupyterCommandFinderInterpreterExecutionService implements IJupyterInterpreterExecutionService {
+export class JupyterCommandFinderInterpreterExecutionService implements IJupyterSubCommandExecutionService {
     constructor(
         @inject(JupyterCommandFinder) private readonly commandFinder: JupyterCommandFinder,
         @inject(InterpreterService) private readonly interpreterService: InterpreterService,

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -14,8 +14,7 @@ import { IPythonExecutionFactory, ObservableExecutionResult, SpawnOptions } from
 import { DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
-import { PythonInterpreter } from '../../../interpreter/contracts';
-import { InterpreterService } from '../../../interpreter/interpreterService';
+import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { JupyterCommands, PythonDaemonModule } from '../../constants';
 import { IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterServerInfo } from '../jupyterConnection';
@@ -35,7 +34,7 @@ import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder
 export class JupyterCommandFinderInterpreterExecutionService implements IJupyterSubCommandExecutionService {
     constructor(
         @inject(JupyterCommandFinder) private readonly commandFinder: JupyterCommandFinder,
-        @inject(InterpreterService) private readonly interpreterService: InterpreterService,
+        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory
     ) {}

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -29,7 +29,7 @@ import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder
  *
  * @export
  * @class JupyterCommandFinderInterpreterExecutionService
- * @implements {IJupyterInterpreterExecutionService}
+ * @implements {IJupyterSubCommandExecutionService}
  */
 @injectable()
 export class JupyterCommandFinderInterpreterExecutionService implements IJupyterSubCommandExecutionService {

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel } from '@jupyterlab/services';
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { CancellationToken } from 'vscode';
+import { Cancellation, createPromiseFromCancellation } from '../../../common/cancellation';
+import { traceError, traceInfo, traceWarning } from '../../../common/logger';
+import { IFileSystem } from '../../../common/platform/types';
+import { IPythonExecutionFactory, ObservableExecutionResult, SpawnOptions } from '../../../common/process/types';
+import { DataScience } from '../../../common/utils/localize';
+import { noop } from '../../../common/utils/misc';
+import { EXTENSION_ROOT_DIR } from '../../../constants';
+import { PythonInterpreter } from '../../../interpreter/contracts';
+import { InterpreterService } from '../../../interpreter/interpreterService';
+import { JupyterCommands, PythonDaemonModule } from '../../constants';
+import { IJupyterInterpreterExecutionService } from '../../types';
+import { JupyterServerInfo } from '../jupyterConnection';
+import { JupyterInstallError } from '../jupyterInstallError';
+import { JupyterKernelSpec } from '../kernels/jupyterKernelSpec';
+import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder';
+
+/**
+ * Responsible for using the command finder for all execution of code against interpreter(s) related to jupyter and the like.
+ *
+ * @export
+ * @class JupyterCommandFinderInterpreterExecutionService
+ * @implements {IJupyterInterpreterExecutionService}
+ */
+@injectable()
+export class JupyterCommandFinderInterpreterExecutionService implements IJupyterInterpreterExecutionService {
+    constructor(
+        @inject(JupyterCommandFinder) private readonly commandFinder: JupyterCommandFinder,
+        @inject(InterpreterService) private readonly interpreterService: InterpreterService,
+        @inject(IFileSystem) private readonly fs: IFileSystem,
+        @inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory
+    ) {}
+
+    public refreshCommands(): Promise<void> {
+        return this.commandFinder.clearCache();
+    }
+    public async isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean> {
+        // See if we can find the command notebook
+        return Cancellation.race(() => this.isCommandSupported(JupyterCommands.NotebookCommand, cancelToken), cancelToken);
+    }
+    public async isExportSupported(cancelToken?: CancellationToken): Promise<boolean> {
+        // See if we can find the command nbconvert
+        return Cancellation.race(() => this.isCommandSupported(JupyterCommands.ConvertCommand, cancelToken), cancelToken);
+    }
+    public async getReasonForJupyterNotebookNotBeingSupported(): Promise<string> {
+        const notebook = await this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
+        return notebook.error ? notebook.error : DataScience.notebookNotFound();
+    }
+    public async getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined> {
+        // This should be the best interpreter for notebooks
+        const found = await this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand, token);
+        if (found && found.command) {
+            return found.command.interpreter();
+        }
+
+        return undefined;
+    }
+    public async startNotebook(notebookArgs: string[], options: SpawnOptions): Promise<ObservableExecutionResult<string>> {
+        // First we find a way to start a notebook server
+        const notebookCommand = await this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
+        this.checkNotebookCommand(notebookCommand);
+        return notebookCommand!.command!.execObservable(notebookArgs, options);
+    }
+
+    public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
+        const [interpreter, activeInterpreter] = await Promise.all([this.getSelectedInterpreter(token), this.interpreterService.getActiveInterpreter()]);
+        if (!interpreter) {
+            return;
+        }
+        // Create a daemon only when using the current interpreter.
+        // We dont' want to create daemons for all interpreters.
+        const isActiveInterpreter = activeInterpreter ? activeInterpreter.path === interpreter.path : false;
+        const daemon = await (isActiveInterpreter
+            ? this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path })
+            : this.pythonExecutionFactory.createActivatedEnvironment({ allowEnvironmentFetchExceptions: true, interpreter, bypassCondaExecution: true }));
+
+        // We have a small python file here that we will execute to get the server info from all running Jupyter instances
+        const newOptions: SpawnOptions = { mergeStdOutErr: true, token: token };
+        const file = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'datascience', 'getServerInfo.py');
+        const serverInfoString = await daemon.exec([file], newOptions);
+
+        let serverInfos: JupyterServerInfo[];
+        try {
+            // Parse out our results, return undefined if we can't suss it out
+            serverInfos = JSON.parse(serverInfoString.stdout.trim()) as JupyterServerInfo[];
+        } catch (err) {
+            traceWarning('Failed to parse JSON when getting server info out from getServerInfo.py', err);
+            return;
+        }
+        return serverInfos;
+    }
+    public async exportNotebookToPython(file: string, template?: string, token?: CancellationToken): Promise<string> {
+        // First we find a way to start a nbconvert
+        const convert = await this.commandFinder.findBestCommand(JupyterCommands.ConvertCommand);
+        if (!convert.command) {
+            throw new Error(DataScience.jupyterNbConvertNotSupported());
+        }
+
+        // Wait for the nbconvert to finish
+        const args = template ? [file, '--to', 'python', '--stdout', '--template', template] : [file, '--to', 'python', '--stdout'];
+        return convert.command.exec(args, { throwOnStdErr: true, encoding: 'utf8', token }).then(output => output.stdout);
+    }
+    public async launchNotebook(notebookFile: string): Promise<void> {
+        // First we find a way to start a notebook server
+        const notebookCommand = await this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
+        this.checkNotebookCommand(notebookCommand);
+
+        const args: string[] = [`--NotebookApp.file_to_run=${notebookFile}`];
+
+        // Don't wait for the exec to finish and don't dispose. It's up to the user to kill the process
+        notebookCommand.command!.exec(args, { throwOnStdErr: false, encoding: 'utf8' }).ignoreErrors();
+    }
+
+    public async getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]> {
+        // Ignore errors if there are no kernels.
+        const kernelSpecCommand = await this.commandFinder.findBestCommand(JupyterCommands.KernelSpecCommand).catch(noop);
+
+        if (!kernelSpecCommand || !kernelSpecCommand.command) {
+            return [];
+        }
+        if (Cancellation.isCanceled(token)) {
+            return [];
+        }
+        try {
+            traceInfo('Asking for kernelspecs from jupyter');
+
+            // Ask for our current list.
+            const output = await kernelSpecCommand.command.exec(['list', '--json'], { throwOnStdErr: true, encoding: 'utf8' });
+
+            traceInfo('Parsing kernelspecs from jupyter');
+            // This should give us back a key value pair we can parse
+            const jsOut = JSON.parse(output.stdout.trim()) as { kernelspecs: Record<string, { resource_dir: string; spec: Omit<Kernel.ISpecModel, 'name'> }> };
+            const kernelSpecs = jsOut.kernelspecs;
+            const specs = await Promise.race([
+                Promise.all(
+                    Object.keys(kernelSpecs).map(async kernelName => {
+                        const specFile = path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json');
+                        const spec = kernelSpecs[kernelName].spec;
+                        // Add the missing name property.
+                        const model = {
+                            ...spec,
+                            name: kernelName
+                        };
+                        // Check if the spec file exists.
+                        if (await this.fs.fileExists(specFile)) {
+                            return new JupyterKernelSpec(model as Kernel.ISpecModel, specFile);
+                        } else {
+                            return;
+                        }
+                    })
+                ),
+                createPromiseFromCancellation({ cancelAction: 'resolve', defaultValue: [], token })
+            ]);
+            return specs.filter(item => !!item).map(item => item as JupyterKernelSpec);
+        } catch (ex) {
+            traceError('Failed to list kernels', ex);
+            // This is failing for some folks. In that case return nothing
+            return [];
+        }
+    }
+    private checkNotebookCommand(notebook: IFindCommandResult) {
+        if (!notebook.command) {
+            const errorMessage = notebook.error ? notebook.error : DataScience.notebookNotFound();
+            throw new JupyterInstallError(DataScience.jupyterNotSupported().format(errorMessage), DataScience.pythonInteractiveHelpLink());
+        }
+    }
+    private async isCommandSupported(command: JupyterCommands, cancelToken?: CancellationToken): Promise<boolean> {
+        // See if we can find the command
+        try {
+            const result = await this.commandFinder.findBestCommand(command, cancelToken);
+
+            // Note to self, if result is undefined, check that your test is actually
+            // setting up different services correctly. Some method must be undefined.
+            return result.command !== undefined;
+        } catch (err) {
+            traceWarning(`Checking command ${command}`, err);
+            return false;
+        }
+    }
+}

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -35,7 +35,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
     private usablePythonInterpreter: PythonInterpreter | undefined;
     private eventEmitter: EventEmitter<void> = new EventEmitter<void>();
     private disposed: boolean = false;
-    private readonly jupyterInterpreterService: IJupyterInterpreterExecutionService;
+    private readonly jupyterInterpreterService: IJupyterSubCommandExecutionService;
 
     constructor(
         _liveShare: ILiveShareApi,
@@ -49,7 +49,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
         private readonly jupyterOutputChannel: IOutputChannel,
         private readonly serviceContainer: IServiceContainer
     ) {
-        this.jupyterInterpreterService = serviceContainer.get<IJupyterInterpreterExecutionService>(JupyterSubCommandExecutionService);
+        this.jupyterInterpreterService = serviceContainer.get<IJupyterSubCommandExecutionService>(JupyterSubCommandExecutionService);
         this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(() => this.onSettingsChanged()));
         this.disposableRegistry.push(this);
 

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -19,10 +19,10 @@ import {
     IConnection,
     IJupyterExecution,
     IJupyterSessionManagerFactory,
+    IJupyterSubCommandExecutionService,
     INotebookServer,
     INotebookServerLaunchInfo,
-    INotebookServerOptions,
-    JupyterSubCommandExecutionService
+    INotebookServerOptions
 } from '../types';
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
 import { JupyterSessionStartError } from './jupyterSession';
@@ -49,7 +49,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
         private readonly jupyterOutputChannel: IOutputChannel,
         private readonly serviceContainer: IServiceContainer
     ) {
-        this.jupyterInterpreterService = serviceContainer.get<IJupyterSubCommandExecutionService>(JupyterSubCommandExecutionService);
+        this.jupyterInterpreterService = serviceContainer.get<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService);
         this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(() => this.onSettingsChanged()));
         this.disposableRegistry.push(this);
 

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -7,17 +7,23 @@ import { CancellationToken, CancellationTokenSource, Event, EventEmitter } from 
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../common/application/types';
 import { Cancellation } from '../../common/cancellation';
 import { traceError, traceInfo } from '../../common/logger';
-import { IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../../common/types';
+import { IConfigurationService, IDisposableRegistry, IOutputChannel } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { IInterpreterService, PythonInterpreter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import { Commands, JupyterCommands, Telemetry } from '../constants';
-import { IConnection, IJupyterExecution, IJupyterSessionManagerFactory, INotebookServer, INotebookServerLaunchInfo, INotebookServerOptions } from '../types';
-import { IFindCommandResult, JupyterCommandFinder } from './interpreter/jupyterCommandFinder';
-import { JupyterInstallError } from './jupyterInstallError';
+import { Commands, Telemetry } from '../constants';
+import {
+    IConnection,
+    IJupyterExecution,
+    IJupyterInterpreterExecutionService,
+    IJupyterSessionManagerFactory,
+    INotebookServer,
+    INotebookServerLaunchInfo,
+    INotebookServerOptions
+} from '../types';
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
 import { JupyterSessionStartError } from './jupyterSession';
 import { createRemoteConnectionInfo } from './jupyterUtils';
@@ -29,12 +35,11 @@ export class JupyterExecutionBase implements IJupyterExecution {
     private usablePythonInterpreter: PythonInterpreter | undefined;
     private eventEmitter: EventEmitter<void> = new EventEmitter<void>();
     private disposed: boolean = false;
-    private readonly commandFinder: JupyterCommandFinder;
+    private readonly jupyterInterpreterService: IJupyterInterpreterExecutionService;
 
     constructor(
         _liveShare: ILiveShareApi,
         private readonly interpreterService: IInterpreterService,
-        private readonly logger: ILogger,
         private readonly disposableRegistry: IDisposableRegistry,
         workspace: IWorkspaceService,
         private readonly configuration: IConfigurationService,
@@ -44,7 +49,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
         private readonly jupyterOutputChannel: IOutputChannel,
         private readonly serviceContainer: IServiceContainer
     ) {
-        this.commandFinder = serviceContainer.get<JupyterCommandFinder>(JupyterCommandFinder);
+        this.jupyterInterpreterService = serviceContainer.get<IJupyterInterpreterExecutionService>(IJupyterInterpreterExecutionService);
         this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(() => this.onSettingsChanged()));
         this.disposableRegistry.push(this);
 
@@ -69,30 +74,29 @@ export class JupyterExecutionBase implements IJupyterExecution {
     }
 
     public async refreshCommands(): Promise<void> {
-        await this.commandFinder.clearCache();
+        await this.jupyterInterpreterService.refreshCommands();
     }
 
     public isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean> {
         // See if we can find the command notebook
-        return Cancellation.race(() => this.isCommandSupported(JupyterCommands.NotebookCommand, cancelToken), cancelToken);
+        return this.jupyterInterpreterService.isNotebookSupported(cancelToken);
     }
 
     public async getNotebookError(): Promise<string> {
-        const notebook = await this.findBestCommand(JupyterCommands.NotebookCommand);
-        return notebook.error ? notebook.error : localize.DataScience.notebookNotFound();
+        return this.jupyterInterpreterService.getReasonForJupyterNotebookNotBeingSupported();
     }
 
     public async getUsableJupyterPython(cancelToken?: CancellationToken): Promise<PythonInterpreter | undefined> {
         // Only try to compute this once.
         if (!this.usablePythonInterpreter && !this.disposed) {
-            this.usablePythonInterpreter = await Cancellation.race(() => this.getUsableJupyterPythonImpl(cancelToken), cancelToken);
+            this.usablePythonInterpreter = await Cancellation.race(() => this.jupyterInterpreterService.getSelectedInterpreter(cancelToken), cancelToken);
         }
         return this.usablePythonInterpreter;
     }
 
     public isImportSupported(cancelToken?: CancellationToken): Promise<boolean> {
         // See if we can find the command nbconvert
-        return Cancellation.race(() => this.isCommandSupported(JupyterCommands.ConvertCommand), cancelToken);
+        return this.jupyterInterpreterService.isExportSupported(cancelToken);
     }
 
     public isSpawnSupported(cancelToken?: CancellationToken): Promise<boolean> {
@@ -244,47 +248,16 @@ export class JupyterExecutionBase implements IJupyterExecution {
     }
 
     public async spawnNotebook(file: string): Promise<void> {
-        // First we find a way to start a notebook server
-        const notebookCommand = await this.findBestCommand(JupyterCommands.NotebookCommand);
-        this.checkNotebookCommand(notebookCommand);
-
-        const args: string[] = [`--NotebookApp.file_to_run=${file}`];
-
-        // Don't wait for the exec to finish and don't dispose. It's up to the user to kill the process
-        notebookCommand.command!.exec(args, { throwOnStdErr: false, encoding: 'utf8' }).ignoreErrors();
+        return this.jupyterInterpreterService.launchNotebook(file);
     }
 
     public async importNotebook(file: string, template: string | undefined): Promise<string> {
-        // First we find a way to start a nbconvert
-        const convert = await this.findBestCommand(JupyterCommands.ConvertCommand);
-        if (!convert.command) {
-            throw new Error(localize.DataScience.jupyterNbConvertNotSupported());
-        }
-
-        // Wait for the nbconvert to finish
-        const args = template ? [file, '--to', 'python', '--stdout', '--template', template] : [file, '--to', 'python', '--stdout'];
-        const result = await convert.command.exec(args, { throwOnStdErr: false, encoding: 'utf8' });
-        if (result.stderr) {
-            // Stderr on nbconvert doesn't indicate failure. Just log the result
-            this.logger.logInformation(result.stderr);
-        }
-        return result.stdout;
+        return this.jupyterInterpreterService.exportNotebookToPython(file, template);
     }
 
     public getServer(_options?: INotebookServerOptions): Promise<INotebookServer | undefined> {
         // This is cached at the host or guest level
         return Promise.resolve(undefined);
-    }
-
-    protected async findBestCommand(command: JupyterCommands, cancelToken?: CancellationToken): Promise<IFindCommandResult> {
-        return this.commandFinder.findBestCommand(command, cancelToken);
-    }
-
-    private checkNotebookCommand(notebook: IFindCommandResult) {
-        if (!notebook.command) {
-            const errorMessage = notebook.error ? notebook.error : localize.DataScience.notebookNotFound();
-            throw new JupyterInstallError(localize.DataScience.jupyterNotSupported().format(errorMessage), localize.DataScience.pythonInteractiveHelpLink());
-        }
     }
 
     private async startOrConnect(options?: INotebookServerOptions, cancelToken?: CancellationToken): Promise<IConnection> {
@@ -311,38 +284,10 @@ export class JupyterExecutionBase implements IJupyterExecution {
     // tslint:disable-next-line: max-func-body-length
     @captureTelemetry(Telemetry.StartJupyter)
     private async startNotebookServer(useDefaultConfig: boolean, cancelToken?: CancellationToken): Promise<IConnection> {
-        // First we find a way to start a notebook server
-        const notebookCommand = await this.findBestCommand(JupyterCommands.NotebookCommand, cancelToken);
-        this.checkNotebookCommand(notebookCommand);
         return this.notebookStarter.start(useDefaultConfig, cancelToken);
     }
-
-    private getUsableJupyterPythonImpl = async (cancelToken?: CancellationToken): Promise<PythonInterpreter | undefined> => {
-        // This should be the best interpreter for notebooks
-        const found = await this.findBestCommand(JupyterCommands.NotebookCommand, cancelToken);
-        if (found && found.command) {
-            return found.command.interpreter();
-        }
-
-        return undefined;
-    };
-
     private onSettingsChanged() {
         // Clear our usableJupyterInterpreter so that we recompute our values
         this.usablePythonInterpreter = undefined;
     }
-
-    private isCommandSupported = async (command: JupyterCommands, cancelToken?: CancellationToken): Promise<boolean> => {
-        // See if we can find the command
-        try {
-            const result = await this.findBestCommand(command, cancelToken);
-
-            // Note to self, if result is undefined, check that your test is actually
-            // setting up different services correctly. Some method must be undefined.
-            return result.command !== undefined;
-        } catch (err) {
-            this.logger.logWarning(err);
-            return false;
-        }
-    };
 }

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -18,11 +18,11 @@ import { Commands, Telemetry } from '../constants';
 import {
     IConnection,
     IJupyterExecution,
-    IJupyterInterpreterExecutionService,
     IJupyterSessionManagerFactory,
     INotebookServer,
     INotebookServerLaunchInfo,
-    INotebookServerOptions
+    INotebookServerOptions,
+    JupyterSubCommandExecutionService
 } from '../types';
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
 import { JupyterSessionStartError } from './jupyterSession';
@@ -49,7 +49,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
         private readonly jupyterOutputChannel: IOutputChannel,
         private readonly serviceContainer: IServiceContainer
     ) {
-        this.jupyterInterpreterService = serviceContainer.get<IJupyterInterpreterExecutionService>(IJupyterInterpreterExecutionService);
+        this.jupyterInterpreterService = serviceContainer.get<IJupyterInterpreterExecutionService>(JupyterSubCommandExecutionService);
         this.disposableRegistry.push(this.interpreterService.onDidChangeInterpreter(() => this.onSettingsChanged()));
         this.disposableRegistry.push(this);
 

--- a/src/client/datascience/jupyter/jupyterExecutionFactory.ts
+++ b/src/client/datascience/jupyter/jupyterExecutionFactory.ts
@@ -6,7 +6,7 @@ import { CancellationToken, Event, EventEmitter } from 'vscode';
 
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
-import { IAsyncDisposable, IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../../common/types';
+import { IAsyncDisposable, IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, IOutputChannel } from '../../common/types';
 import { IInterpreterService, PythonInterpreter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { JUPYTER_OUTPUT_CHANNEL } from '../constants';
@@ -24,7 +24,6 @@ type JupyterExecutionClassType = {
     new (
         liveShare: ILiveShareApi,
         interpreterService: IInterpreterService,
-        logger: ILogger,
         disposableRegistry: IDisposableRegistry,
         asyncRegistry: IAsyncDisposableRegistry,
         fileSystem: IFileSystem,
@@ -47,7 +46,6 @@ export class JupyterExecutionFactory implements IJupyterExecution, IAsyncDisposa
     constructor(
         @inject(ILiveShareApi) liveShare: ILiveShareApi,
         @inject(IInterpreterService) interpreterService: IInterpreterService,
-        @inject(ILogger) logger: ILogger,
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
         @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
         @inject(IFileSystem) fileSystem: IFileSystem,
@@ -66,7 +64,6 @@ export class JupyterExecutionFactory implements IJupyterExecution, IAsyncDisposa
             GuestJupyterExecution,
             liveShare,
             interpreterService,
-            logger,
             disposableRegistry,
             asyncRegistry,
             fileSystem,

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -51,7 +51,7 @@ function isInterpreter(item: nbformat.IKernelspecMetadata | PythonInterpreter): 
 @injectable()
 export class KernelService {
     constructor(
-        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterExecService: IJupyterInterpreterExecutionService,
+        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterExecService: IJupyterSubCommandExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInstaller) private readonly installer: IInstaller,

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -21,9 +21,8 @@ import { noop } from '../../../common/utils/misc';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
-import { JupyterCommands, Telemetry } from '../../constants';
-import { IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
-import { JupyterCommandFinder } from '../interpreter/jupyterCommandFinder';
+import { Telemetry } from '../../constants';
+import { IJupyterInterpreterExecutionService, IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { LiveKernelModel } from './types';
 
@@ -52,7 +51,7 @@ function isInterpreter(item: nbformat.IKernelspecMetadata | PythonInterpreter): 
 @injectable()
 export class KernelService {
     constructor(
-        @inject(JupyterCommandFinder) private readonly commandFinder: JupyterCommandFinder,
+        @inject(IJupyterInterpreterExecutionService) private readonly jupyterInterpreterExecService: IJupyterInterpreterExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInstaller) private readonly installer: IInstaller,
@@ -405,45 +404,7 @@ export class KernelService {
         return new JupyterKernelSpec(kernelModel as Kernel.ISpecModel, specFile);
     }
 
-    private async enumerateSpecs(_cancelToken?: CancellationToken): Promise<JupyterKernelSpec[]> {
-        // Ignore errors if there are no kernels.
-        const kernelSpecCommand = await this.commandFinder.findBestCommand(JupyterCommands.KernelSpecCommand).catch(noop);
-
-        if (!kernelSpecCommand || !kernelSpecCommand.command) {
-            return [];
-        }
-        try {
-            traceInfo('Asking for kernelspecs from jupyter');
-
-            // Ask for our current list.
-            const output = await kernelSpecCommand.command.exec(['list', '--json'], { throwOnStdErr: true, encoding: 'utf8' });
-
-            traceInfo('Parsing kernelspecs from jupyter');
-            // This should give us back a key value pair we can parse
-            const jsOut = JSON.parse(output.stdout.trim()) as { kernelspecs: Record<string, { resource_dir: string; spec: Omit<Kernel.ISpecModel, 'name'> }> };
-            const kernelSpecs = jsOut.kernelspecs;
-            const specs = await Promise.all(
-                Object.keys(kernelSpecs).map(async kernelName => {
-                    const specFile = path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json');
-                    const spec = kernelSpecs[kernelName].spec;
-                    // Add the missing name property.
-                    const model = {
-                        ...spec,
-                        name: kernelName
-                    };
-                    // Check if the spec file exists.
-                    if (await this.fileSystem.fileExists(specFile)) {
-                        return new JupyterKernelSpec(model as Kernel.ISpecModel, specFile);
-                    } else {
-                        return;
-                    }
-                })
-            );
-            return specs.filter(item => !!item).map(item => item as JupyterKernelSpec);
-        } catch (ex) {
-            traceError('Failed to list kernels', ex);
-            // This is failing for some folks. In that case return nothing
-            return [];
-        }
+    private async enumerateSpecs(cancelToken?: CancellationToken): Promise<JupyterKernelSpec[]> {
+        return this.jupyterInterpreterExecService.getKernelSpecs(cancelToken);
     }
 }

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -22,7 +22,7 @@ import { IEnvironmentActivationService } from '../../../interpreter/activation/t
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
-import { IJupyterKernelSpec, IJupyterSessionManager, JupyterSubCommandExecutionService } from '../../types';
+import { IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { LiveKernelModel } from './types';
 
@@ -51,7 +51,7 @@ function isInterpreter(item: nbformat.IKernelspecMetadata | PythonInterpreter): 
 @injectable()
 export class KernelService {
     constructor(
-        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterExecService: IJupyterSubCommandExecutionService,
+        @inject(IJupyterSubCommandExecutionService) private readonly jupyterInterpreterExecService: IJupyterSubCommandExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInstaller) private readonly installer: IInstaller,

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -22,7 +22,7 @@ import { IEnvironmentActivationService } from '../../../interpreter/activation/t
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
-import { IJupyterInterpreterExecutionService, IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
+import { IJupyterKernelSpec, IJupyterSessionManager, JupyterSubCommandExecutionService } from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { LiveKernelModel } from './types';
 
@@ -51,7 +51,7 @@ function isInterpreter(item: nbformat.IKernelspecMetadata | PythonInterpreter): 
 @injectable()
 export class KernelService {
     constructor(
-        @inject(IJupyterInterpreterExecutionService) private readonly jupyterInterpreterExecService: IJupyterInterpreterExecutionService,
+        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterExecService: IJupyterInterpreterExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IInstaller) private readonly installer: IInstaller,

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -344,7 +344,7 @@ export class KernelService {
      * @memberof KernelService
      */
     public async getKernelSpecs(sessionManager?: IJupyterSessionManager, cancelToken?: CancellationToken): Promise<IJupyterKernelSpec[]> {
-        const enumerator = sessionManager ? sessionManager.getKernelSpecs() : this.enumerateSpecs(cancelToken);
+        const enumerator = sessionManager ? sessionManager.getKernelSpecs() : this.jupyterInterpreterExecService.getKernelSpecs(cancelToken);
         if (Cancellation.isCanceled(cancelToken)) {
             return [];
         }
@@ -402,9 +402,5 @@ export class KernelService {
         const kernelModel = JSON.parse(await this.fileSystem.readFile(specFile));
         kernelModel.name = groups.name;
         return new JupyterKernelSpec(kernelModel as Kernel.ISpecModel, specFile);
-    }
-
-    private async enumerateSpecs(cancelToken?: CancellationToken): Promise<JupyterKernelSpec[]> {
-        return this.jupyterInterpreterExecService.getKernelSpecs(cancelToken);
     }
 }

--- a/src/client/datascience/jupyter/liveshare/guestJupyterExecution.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterExecution.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vscode';
 
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../../common/application/types';
 import { IFileSystem } from '../../../common/platform/types';
-import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../../../common/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, IOutputChannel } from '../../../common/types';
 import * as localize from '../../../common/utils/localize';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { IServiceContainer } from '../../../ioc/types';
@@ -28,7 +28,6 @@ export class GuestJupyterExecution extends LiveShareParticipantGuest(JupyterExec
     constructor(
         liveShare: ILiveShareApi,
         interpreterService: IInterpreterService,
-        logger: ILogger,
         disposableRegistry: IDisposableRegistry,
         asyncRegistry: IAsyncDisposableRegistry,
         fileSystem: IFileSystem,
@@ -40,19 +39,7 @@ export class GuestJupyterExecution extends LiveShareParticipantGuest(JupyterExec
         jupyterOutputChannel: IOutputChannel,
         serviceContainer: IServiceContainer
     ) {
-        super(
-            liveShare,
-            interpreterService,
-            logger,
-            disposableRegistry,
-            workspace,
-            configuration,
-            kernelSelector,
-            notebookStarter,
-            appShell,
-            jupyterOutputChannel,
-            serviceContainer
-        );
+        super(liveShare, interpreterService, disposableRegistry, workspace, configuration, kernelSelector, notebookStarter, appShell, jupyterOutputChannel, serviceContainer);
         asyncRegistry.push(this);
         this.serverCache = new ServerCache(configuration, workspace, fileSystem);
     }

--- a/src/client/datascience/jupyter/liveshare/hostJupyterExecution.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterExecution.ts
@@ -8,7 +8,7 @@ import * as vsls from 'vsls/vscode';
 
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../../common/application/types';
 import { IFileSystem } from '../../../common/platform/types';
-import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, ILogger, IOutputChannel } from '../../../common/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, IOutputChannel } from '../../../common/types';
 import { noop } from '../../../common/utils/misc';
 import { IInterpreterService } from '../../../interpreter/contracts';
 import { IServiceContainer } from '../../../ioc/types';
@@ -29,7 +29,6 @@ export class HostJupyterExecution extends LiveShareParticipantHost(JupyterExecut
     constructor(
         liveShare: ILiveShareApi,
         interpreterService: IInterpreterService,
-        logger: ILogger,
         disposableRegistry: IDisposableRegistry,
         asyncRegistry: IAsyncDisposableRegistry,
         fileSys: IFileSystem,
@@ -41,19 +40,7 @@ export class HostJupyterExecution extends LiveShareParticipantHost(JupyterExecut
         jupyterOutputChannel: IOutputChannel,
         serviceContainer: IServiceContainer
     ) {
-        super(
-            liveShare,
-            interpreterService,
-            logger,
-            disposableRegistry,
-            workspace,
-            configService,
-            kernelSelector,
-            notebookStarter,
-            appShell,
-            jupyterOutputChannel,
-            serviceContainer
-        );
+        super(liveShare, interpreterService, disposableRegistry, workspace, configService, kernelSelector, notebookStarter, appShell, jupyterOutputChannel, serviceContainer);
         this.serverCache = new ServerCache(configService, workspace, fileSys);
         asyncRegistry.push(this);
     }

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -18,7 +18,7 @@ import { StopWatch } from '../../common/utils/stopWatch';
 import { IServiceContainer } from '../../ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { JUPYTER_OUTPUT_CHANNEL, Telemetry } from '../constants';
-import { IConnection, IJupyterInterpreterExecutionService } from '../types';
+import { IConnection, JupyterSubCommandExecutionService } from '../types';
 import { JupyterConnection } from './jupyterConnection';
 
 /**
@@ -33,7 +33,7 @@ import { JupyterConnection } from './jupyterConnection';
 export class NotebookStarter implements Disposable {
     private readonly disposables: IDisposable[] = [];
     constructor(
-        @inject(IJupyterInterpreterExecutionService) private readonly jupyterInterpreterService: IJupyterInterpreterExecutionService,
+        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterService: IJupyterInterpreterExecutionService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(IOutputChannel) @named(JUPYTER_OUTPUT_CHANNEL) private readonly jupyterOutputChannel: IOutputChannel

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -10,20 +10,16 @@ import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { CancellationToken, Disposable } from 'vscode';
 import { CancellationError } from '../../common/cancellation';
-import { traceInfo, traceWarning } from '../../common/logger';
+import { traceInfo } from '../../common/logger';
 import { IFileSystem, TemporaryDirectory } from '../../common/platform/types';
-import { IPythonExecutionFactory, SpawnOptions } from '../../common/process/types';
 import { IDisposable, IOutputChannel } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { StopWatch } from '../../common/utils/stopWatch';
-import { EXTENSION_ROOT_DIR } from '../../constants';
-import { IInterpreterService } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
-import { JUPYTER_OUTPUT_CHANNEL, JupyterCommands, PythonDaemonModule, Telemetry } from '../constants';
-import { IConnection } from '../types';
-import { JupyterCommandFinder } from './interpreter/jupyterCommandFinder';
-import { JupyterConnection, JupyterServerInfo } from './jupyterConnection';
+import { JUPYTER_OUTPUT_CHANNEL, Telemetry } from '../constants';
+import { IConnection, IJupyterInterpreterExecutionService } from '../types';
+import { JupyterConnection } from './jupyterConnection';
 
 /**
  * Responsible for starting a notebook.
@@ -37,11 +33,9 @@ import { JupyterConnection, JupyterServerInfo } from './jupyterConnection';
 export class NotebookStarter implements Disposable {
     private readonly disposables: IDisposable[] = [];
     constructor(
-        @inject(IPythonExecutionFactory) private readonly executionFactory: IPythonExecutionFactory,
-        @inject(JupyterCommandFinder) private readonly commandFinder: JupyterCommandFinder,
+        @inject(IJupyterInterpreterExecutionService) private readonly jupyterInterpreterService: IJupyterInterpreterExecutionService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
-        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IOutputChannel) @named(JUPYTER_OUTPUT_CHANNEL) private readonly jupyterOutputChannel: IOutputChannel
     ) {}
     public dispose() {
@@ -59,7 +53,6 @@ export class NotebookStarter implements Disposable {
     // tslint:disable-next-line: max-func-body-length
     public async start(useDefaultConfig: boolean, cancelToken?: CancellationToken): Promise<IConnection> {
         traceInfo('Starting Notebook');
-        const notebookCommandPromise = this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
         // Now actually launch it
         let exitCode: number | null = 0;
         try {
@@ -67,7 +60,7 @@ export class NotebookStarter implements Disposable {
             const tempDirPromise = this.generateTempDir();
             tempDirPromise.then(dir => this.disposables.push(dir)).ignoreErrors();
             // Before starting the notebook process, make sure we generate a kernel spec
-            const [args, notebookCommand] = await Promise.all([this.generateArguments(useDefaultConfig, tempDirPromise), notebookCommandPromise]);
+            const args = await this.generateArguments(useDefaultConfig, tempDirPromise);
 
             // Make sure we haven't canceled already.
             if (cancelToken && cancelToken.isCancellationRequested) {
@@ -78,7 +71,7 @@ export class NotebookStarter implements Disposable {
             traceInfo('Starting Jupyter Notebook');
             const stopWatch = new StopWatch();
             const [launchResult, tempDir] = await Promise.all([
-                notebookCommand!.command!.execObservable(args || [], { throwOnStdErr: false, encoding: 'utf8', token: cancelToken }),
+                this.jupyterInterpreterService.startNotebook(args || [], { throwOnStdErr: false, encoding: 'utf8', token: cancelToken }),
                 tempDirPromise
             ]);
 
@@ -97,7 +90,13 @@ export class NotebookStarter implements Disposable {
 
             // Wait for the connection information on this result
             traceInfo('Waiting for Jupyter Notebook');
-            const connection = await JupyterConnection.waitForConnection(tempDir.path, this.getJupyterServerInfo, launchResult, this.serviceContainer, cancelToken);
+            const connection = await JupyterConnection.waitForConnection(
+                tempDir.path,
+                this.jupyterInterpreterService.getRunningJupyterServers.bind(this.jupyterInterpreterService),
+                launchResult,
+                this.serviceContainer,
+                cancelToken
+            );
 
             // Fire off telemetry for the process being talkable
             sendTelemetryEvent(Telemetry.StartJupyterProcess, stopWatch.elapsedTime);
@@ -227,34 +226,4 @@ export class NotebookStarter implements Disposable {
             }
         };
     }
-    private getJupyterServerInfo = async (cancelToken?: CancellationToken): Promise<JupyterServerInfo[] | undefined> => {
-        const notebookCommand = await this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
-        if (!notebookCommand.command) {
-            return;
-        }
-        const [interpreter, activeInterpreter] = await Promise.all([notebookCommand.command.interpreter(), this.interpreterService.getActiveInterpreter()]);
-        if (!interpreter) {
-            return;
-        }
-        // Create a daemon only when using the current interpreter.
-        // We dont' want to create daemons for all interpreters.
-        const isActiveInterpreter = activeInterpreter ? activeInterpreter.path === interpreter.path : false;
-        const daemon = await (isActiveInterpreter
-            ? this.executionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path })
-            : this.executionFactory.createActivatedEnvironment({ allowEnvironmentFetchExceptions: true, interpreter, bypassCondaExecution: true }));
-        // We have a small python file here that we will execute to get the server info from all running Jupyter instances
-        const newOptions: SpawnOptions = { mergeStdOutErr: true, token: cancelToken };
-        const file = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'datascience', 'getServerInfo.py');
-        const serverInfoString = await daemon.exec([file], newOptions);
-
-        let serverInfos: JupyterServerInfo[];
-        try {
-            // Parse out our results, return undefined if we can't suss it out
-            serverInfos = JSON.parse(serverInfoString.stdout.trim()) as JupyterServerInfo[];
-        } catch (err) {
-            traceWarning('Failed to parse JSON when getting server info out from getServerInfo.py', err);
-            return;
-        }
-        return serverInfos;
-    };
 }

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -33,7 +33,7 @@ import { JupyterConnection } from './jupyterConnection';
 export class NotebookStarter implements Disposable {
     private readonly disposables: IDisposable[] = [];
     constructor(
-        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterService: IJupyterInterpreterExecutionService,
+        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterService: IJupyterSubCommandExecutionService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(IOutputChannel) @named(JUPYTER_OUTPUT_CHANNEL) private readonly jupyterOutputChannel: IOutputChannel

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -18,7 +18,7 @@ import { StopWatch } from '../../common/utils/stopWatch';
 import { IServiceContainer } from '../../ioc/types';
 import { sendTelemetryEvent } from '../../telemetry';
 import { JUPYTER_OUTPUT_CHANNEL, Telemetry } from '../constants';
-import { IConnection, JupyterSubCommandExecutionService } from '../types';
+import { IConnection, IJupyterSubCommandExecutionService } from '../types';
 import { JupyterConnection } from './jupyterConnection';
 
 /**
@@ -33,7 +33,7 @@ import { JupyterConnection } from './jupyterConnection';
 export class NotebookStarter implements Disposable {
     private readonly disposables: IDisposable[] = [];
     constructor(
-        @inject(JupyterSubCommandExecutionService) private readonly jupyterInterpreterService: IJupyterSubCommandExecutionService,
+        @inject(IJupyterSubCommandExecutionService) private readonly jupyterInterpreterService: IJupyterSubCommandExecutionService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(IOutputChannel) @named(JUPYTER_OUTPUT_CHANNEL) private readonly jupyterOutputChannel: IOutputChannel

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -34,6 +34,7 @@ import { InteractiveWindowCommandListener } from './interactive-window/interacti
 import { InteractiveWindowProvider } from './interactive-window/interactiveWindowProvider';
 import { JupyterCommandFactory } from './jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder } from './jupyter/interpreter/jupyterCommandFinder';
+import { JupyterCommandFinderInterpreterExecutionService } from './jupyter/interpreter/jupyterCommandInterpreterExecutionService';
 import { JupyterInterpreterConfigurationService } from './jupyter/interpreter/jupyterInterpreterConfiguration';
 import { JupyterInterpreterOldCacheStateStore } from './jupyter/interpreter/jupyterInterpreterOldCacheStateStore';
 import { JupyterInterpreterSelectionCommand } from './jupyter/interpreter/jupyterInterpreterSelectionCommand';
@@ -78,6 +79,7 @@ import {
     IJupyterCommandFactory,
     IJupyterDebugger,
     IJupyterExecution,
+    IJupyterInterpreterExecutionService,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
     IJupyterVariables,
@@ -153,4 +155,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
     serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
     serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
+    serviceManager.addSingleton<IJupyterInterpreterExecutionService>(IJupyterInterpreterExecutionService, JupyterCommandFinderInterpreterExecutionService);
 }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -79,9 +79,9 @@ import {
     IJupyterCommandFactory,
     IJupyterDebugger,
     IJupyterExecution,
-    IJupyterInterpreterExecutionService,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
+    IJupyterSubCommandExecutionService,
     IJupyterVariables,
     INotebookEditor,
     INotebookEditorProvider,
@@ -155,5 +155,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
     serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
     serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
-    serviceManager.addSingleton<IJupyterInterpreterExecutionService>(IJupyterInterpreterExecutionService, JupyterCommandFinderInterpreterExecutionService);
+    serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterCommandFinderInterpreterExecutionService);
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -604,7 +604,7 @@ export interface IDebugLocationTracker {
     getLocation(debugSession: DebugSession): IDebugLocation | undefined;
 }
 
-export const JupyterSubCommandExecutionService = Symbol('IJupyterSubCommandExecutionService');
+export const IJupyterSubCommandExecutionService = Symbol('IJupyterSubCommandExecutionService');
 /**
  * Responsible for execution of jupyter subcommands such as `notebook`, `nbconvert`, etc.
  * The executed code is as follows `python -m jupyter <subcommand>`.

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -14,7 +14,9 @@ import { IAsyncDisposable, IDataScienceSettings, IDisposable } from '../common/t
 import { StopWatch } from '../common/utils/stopWatch';
 import { PythonInterpreter } from '../interpreter/contracts';
 import { JupyterCommands } from './constants';
+import { JupyterServerInfo } from './jupyter/jupyterConnection';
 import { LiveKernelModel } from './jupyter/kernels/types';
+import { JupyterKernelSpec } from './jupyter/kernels/jupyterKernelSpec';
 
 // Main interface
 export const IDataScience = Symbol('IDataScience');
@@ -600,4 +602,68 @@ export const IDebugLocationTracker = Symbol('IDebugLocationTracker');
 export interface IDebugLocationTracker {
     updated: Event<void>;
     getLocation(debugSession: DebugSession): IDebugLocation | undefined;
+}
+
+export const IJupyterInterpreterExecutionService = Symbol('IJupyterInterpreterExecutionService');
+/**
+ * Responsible for execution of code against the interpreter used to launch jupyter.
+ *
+ * @export
+ * @interface IJupyterInterpreterExecutionService
+ */
+export interface IJupyterInterpreterExecutionService {
+    isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean>;
+    isExportSupported(cancelToken?: CancellationToken): Promise<boolean>;
+    getReasonForJupyterNotebookNotBeingSupported(): Promise<string>;
+    /**
+     * Used to refresh the command finder.
+     *
+     * @returns {Promise<void>}
+     * @memberof IJupyterInterpreterExecutionService
+     */
+    refreshCommands(): Promise<void>;
+    /**
+     * Gets the interpreter to be used for starting of jupyter server.
+     *
+     * @param {CancellationToken} [token]
+     * @returns {(Promise<PythonInterpreter | undefined>)}
+     * @memberof IJupyterInterpreterService
+     */
+    getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined>;
+    /**
+     * Starts the jupyter notebook server
+     *
+     * @param {string[]} notebookArgs
+     * @param {SpawnOptions} options
+     * @returns {Promise<ObservableExecutionResult<string>>}
+     * @memberof IJupyterInterpreterExecutionService
+     */
+    startNotebook(notebookArgs: string[], options: SpawnOptions): Promise<ObservableExecutionResult<string>>;
+    /**
+     * Gets a list of all locally running jupyter notebook servers.
+     *
+     * @param {CancellationToken} [token]
+     * @returns {(Promise<JupyterServerInfo[] | undefined>)}
+     * @memberof IJupyterInterpreterExecutionService
+     */
+    getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined>;
+    /**
+     * Exports a given notebook into a python file.
+     *
+     * @param {string} file
+     * @param {string} [template]
+     * @param {CancellationToken} [token]
+     * @returns {Promise<string>}
+     * @memberof IJupyterInterpreterExecutionService
+     */
+    exportNotebookToPython(file: string, template?: string, token?: CancellationToken): Promise<string>;
+    /**
+     * Opens an ipynb file in a new instance of a jupyter notebook server.
+     *
+     * @param {string} notebookFile
+     * @returns {Promise<void>}
+     * @memberof IJupyterInterpreterExecutionService
+     */
+    launchNotebook(notebookFile: string): Promise<void>;
+    getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]>;
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -604,13 +604,13 @@ export interface IDebugLocationTracker {
     getLocation(debugSession: DebugSession): IDebugLocation | undefined;
 }
 
-export const JupyterSubCommandExecutionService = Symbol('IJupyterInterpreterExecutionService');
+export const JupyterSubCommandExecutionService = Symbol('IJupyterSubCommandExecutionService');
 /**
  * Responsible for execution of jupyter subcommands such as `notebook`, `nbconvert`, etc.
  * The executed code is as follows `python -m jupyter <subcommand>`.
  *
  * @export
- * @interface IJupyterInterpreterExecutionService
+ * @interface IJupyterSubCommandExecutionService
  */
 export interface IJupyterSubCommandExecutionService {
     isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean>;
@@ -619,14 +619,14 @@ export interface IJupyterSubCommandExecutionService {
      * Error message indicating why jupyter notebook isn't supported.
      *
      * @returns {Promise<string>}
-     * @memberof IJupyterInterpreterExecutionService
+     * @memberof IJupyterSubCommandExecutionService
      */
     getReasonForJupyterNotebookNotBeingSupported(): Promise<string>;
     /**
      * Used to refresh the command finder.
      *
      * @returns {Promise<void>}
-     * @memberof IJupyterInterpreterExecutionService
+     * @memberof IJupyterSubCommandExecutionService
      */
     refreshCommands(): Promise<void>;
     /**
@@ -643,7 +643,7 @@ export interface IJupyterSubCommandExecutionService {
      * @param {string[]} notebookArgs
      * @param {SpawnOptions} options
      * @returns {Promise<ObservableExecutionResult<string>>}
-     * @memberof IJupyterInterpreterExecutionService
+     * @memberof IJupyterSubCommandExecutionService
      */
     startNotebook(notebookArgs: string[], options: SpawnOptions): Promise<ObservableExecutionResult<string>>;
     /**
@@ -651,7 +651,7 @@ export interface IJupyterSubCommandExecutionService {
      *
      * @param {CancellationToken} [token]
      * @returns {(Promise<JupyterServerInfo[] | undefined>)}
-     * @memberof IJupyterInterpreterExecutionService
+     * @memberof IJupyterSubCommandExecutionService
      */
     getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined>;
     /**
@@ -661,7 +661,7 @@ export interface IJupyterSubCommandExecutionService {
      * @param {string} [template]
      * @param {CancellationToken} [token]
      * @returns {Promise<string>}
-     * @memberof IJupyterInterpreterExecutionService
+     * @memberof IJupyterSubCommandExecutionService
      */
     exportNotebookToPython(file: string, template?: string, token?: CancellationToken): Promise<string>;
     /**
@@ -669,7 +669,7 @@ export interface IJupyterSubCommandExecutionService {
      *
      * @param {string} notebookFile
      * @returns {Promise<void>}
-     * @memberof IJupyterInterpreterExecutionService
+     * @memberof IJupyterSubCommandExecutionService
      */
     launchNotebook(notebookFile: string): Promise<void>;
     getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]>;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -15,8 +15,8 @@ import { StopWatch } from '../common/utils/stopWatch';
 import { PythonInterpreter } from '../interpreter/contracts';
 import { JupyterCommands } from './constants';
 import { JupyterServerInfo } from './jupyter/jupyterConnection';
-import { LiveKernelModel } from './jupyter/kernels/types';
 import { JupyterKernelSpec } from './jupyter/kernels/jupyterKernelSpec';
+import { LiveKernelModel } from './jupyter/kernels/types';
 
 // Main interface
 export const IDataScience = Symbol('IDataScience');
@@ -614,6 +614,12 @@ export const IJupyterInterpreterExecutionService = Symbol('IJupyterInterpreterEx
 export interface IJupyterInterpreterExecutionService {
     isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean>;
     isExportSupported(cancelToken?: CancellationToken): Promise<boolean>;
+    /**
+     * Error message indicating why jupyter notebook isn't supported.
+     *
+     * @returns {Promise<string>}
+     * @memberof IJupyterInterpreterExecutionService
+     */
     getReasonForJupyterNotebookNotBeingSupported(): Promise<string>;
     /**
      * Used to refresh the command finder.

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -604,14 +604,15 @@ export interface IDebugLocationTracker {
     getLocation(debugSession: DebugSession): IDebugLocation | undefined;
 }
 
-export const IJupyterInterpreterExecutionService = Symbol('IJupyterInterpreterExecutionService');
+export const JupyterSubCommandExecutionService = Symbol('IJupyterInterpreterExecutionService');
 /**
- * Responsible for execution of code against the interpreter used to launch jupyter.
+ * Responsible for execution of jupyter subcommands such as `notebook`, `nbconvert`, etc.
+ * The executed code is as follows `python -m jupyter <subcommand>`.
  *
  * @export
  * @interface IJupyterInterpreterExecutionService
  */
-export interface IJupyterInterpreterExecutionService {
+export interface IJupyterSubCommandExecutionService {
     isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean>;
     isExportSupported(cancelToken?: CancellationToken): Promise<boolean>;
     /**

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -486,14 +486,6 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<IProductPathService>(IProductPathService, RefactoringLibraryProductPathService, ProductType.RefactoringLibrary);
         this.serviceManager.addSingleton<IProductPathService>(IProductPathService, DataScienceProductPathService, ProductType.DataScience);
         this.serviceManager.addSingleton<IMultiStepInputFactory>(IMultiStepInputFactory, MultiStepInputFactory);
-        this.serviceManager.addSingleton<JupyterInterpreterStateStore>(JupyterInterpreterStateStore, JupyterInterpreterStateStore);
-        this.serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, JupyterInterpreterSelectionCommand);
-        this.serviceManager.addSingleton<JupyterInterpreterSelector>(JupyterInterpreterSelector, JupyterInterpreterSelector);
-        this.serviceManager.addSingleton<JupyterInterpreterConfigurationService>(JupyterInterpreterConfigurationService, JupyterInterpreterConfigurationService);
-        this.serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
-        this.serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
-        this.serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
-        this.serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterCommandFinderInterpreterExecutionService);
 
         // Don't check for dot net compatibility
         const dotNetCompability = mock(DotNetCompatibilityService);
@@ -671,6 +663,15 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         const currentProcess = new CurrentProcess();
         this.serviceManager.addSingletonInstance<ICurrentProcess>(ICurrentProcess, currentProcess);
         this.serviceManager.addSingleton<IRegistry>(IRegistry, RegistryImplementation);
+
+        this.serviceManager.addSingleton<JupyterInterpreterStateStore>(JupyterInterpreterStateStore, JupyterInterpreterStateStore);
+        this.serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, JupyterInterpreterSelectionCommand);
+        this.serviceManager.addSingleton<JupyterInterpreterSelector>(JupyterInterpreterSelector, JupyterInterpreterSelector);
+        this.serviceManager.addSingleton<JupyterInterpreterConfigurationService>(JupyterInterpreterConfigurationService, JupyterInterpreterConfigurationService);
+        this.serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
+        this.serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
+        this.serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
+        this.serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterCommandFinderInterpreterExecutionService);
 
         // Don't use conda at all during functional tests.
         const condaService = TypeMoq.Mock.ofType<ICondaService>();

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -21,6 +21,7 @@ import { LanguageServerFolderService } from '../../client/activation/languageSer
 import { LanguageServerPackageService } from '../../client/activation/languageServer/languageServerPackageService';
 import { LanguageServerManager } from '../../client/activation/languageServer/manager';
 import {
+    IExtensionSingleActivationService,
     ILanguageServerActivator,
     ILanguageServerAnalysisOptions,
     ILanguageServerCache,
@@ -121,6 +122,7 @@ import { EnvironmentVariablesProvider } from '../../client/common/variables/envi
 import { IEnvironmentVariablesProvider, IEnvironmentVariablesService } from '../../client/common/variables/types';
 import { CodeCssGenerator } from '../../client/datascience/codeCssGenerator';
 import { JUPYTER_OUTPUT_CHANNEL } from '../../client/datascience/constants';
+import { ActiveEditorContextService } from '../../client/datascience/context/activeEditorContext';
 import { DataViewer } from '../../client/datascience/data-viewing/dataViewer';
 import { DataViewerProvider } from '../../client/datascience/data-viewing/dataViewerProvider';
 import { DebugLocationTrackerFactory } from '../../client/datascience/debugLocationTrackerFactory';
@@ -139,6 +141,13 @@ import { InteractiveWindow } from '../../client/datascience/interactive-window/i
 import { InteractiveWindowCommandListener } from '../../client/datascience/interactive-window/interactiveWindowCommandListener';
 import { JupyterCommandFactory } from '../../client/datascience/jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder } from '../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
+import { JupyterCommandFinderInterpreterExecutionService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
+import { JupyterInterpreterConfigurationService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterConfiguration';
+import { JupyterInterpreterOldCacheStateStore } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore';
+import { JupyterInterpreterSelectionCommand } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterSelectionCommand';
+import { JupyterInterpreterSelector } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterSelector';
+import { JupyterInterpreterService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterService';
+import { JupyterInterpreterStateStore } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterStateStore';
 import { JupyterDebugger } from '../../client/datascience/jupyter/jupyterDebugger';
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
 import { JupyterExporter } from '../../client/datascience/jupyter/jupyterExporter';
@@ -177,6 +186,7 @@ import {
     IJupyterExecution,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
+    IJupyterSubCommandExecutionService,
     IJupyterVariables,
     INotebookEditor,
     INotebookEditorProvider,
@@ -476,6 +486,14 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<IProductPathService>(IProductPathService, RefactoringLibraryProductPathService, ProductType.RefactoringLibrary);
         this.serviceManager.addSingleton<IProductPathService>(IProductPathService, DataScienceProductPathService, ProductType.DataScience);
         this.serviceManager.addSingleton<IMultiStepInputFactory>(IMultiStepInputFactory, MultiStepInputFactory);
+        this.serviceManager.addSingleton<JupyterInterpreterStateStore>(JupyterInterpreterStateStore, JupyterInterpreterStateStore);
+        this.serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, JupyterInterpreterSelectionCommand);
+        this.serviceManager.addSingleton<JupyterInterpreterSelector>(JupyterInterpreterSelector, JupyterInterpreterSelector);
+        this.serviceManager.addSingleton<JupyterInterpreterConfigurationService>(JupyterInterpreterConfigurationService, JupyterInterpreterConfigurationService);
+        this.serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
+        this.serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
+        this.serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
+        this.serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterCommandFinderInterpreterExecutionService);
 
         // Don't check for dot net compatibility
         const dotNetCompability = mock(DotNetCompatibilityService);

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -53,6 +53,7 @@ import {
     ICell,
     IConnection,
     IJupyterKernelSpec,
+    IJupyterSubCommandExecutionService,
     INotebook,
     INotebookCompletion,
     INotebookExecutionLogger,
@@ -847,6 +848,7 @@ suite('Jupyter Execution', async () => {
             instance(fileSystem),
             instance(executionFactory)
         );
+        when(serviceContainer.get<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService)).thenReturn(jupyterCmdExecutionService);
         notebookStarter = new NotebookStarter(jupyterCmdExecutionService, instance(fileSystem), instance(serviceContainer), instance(jupyterOutputChannel));
         when(serviceContainer.get<KernelSelector>(KernelSelector)).thenReturn(instance(kernelSelector));
         when(serviceContainer.get<NotebookStarter>(NotebookStarter)).thenReturn(notebookStarter);

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -43,6 +43,7 @@ import { EXTENSION_ROOT_DIR } from '../../client/constants';
 import { Identifiers, PythonDaemonModule } from '../../client/datascience/constants';
 import { JupyterCommandFactory } from '../../client/datascience/jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder } from '../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
+import { JupyterCommandFinderInterpreterExecutionService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
 import { KernelSelector } from '../../client/datascience/jupyter/kernels/kernelSelector';
 import { LiveKernelModel } from '../../client/datascience/jupyter/kernels/types';
@@ -840,14 +841,13 @@ suite('Jupyter Execution', async () => {
             path: ''
         };
         when(kernelSelector.getKernelForLocalConnection(anything(), anything(), anything())).thenResolve({ kernelSpec });
-        notebookStarter = new NotebookStarter(
-            instance(executionFactory),
+        const jupyterCmdExecutionService = new JupyterCommandFinderInterpreterExecutionService(
             commandFinder,
-            instance(fileSystem),
-            instance(serviceContainer),
             instance(interpreterService),
-            instance(jupyterOutputChannel)
+            instance(fileSystem),
+            instance(executionFactory)
         );
+        notebookStarter = new NotebookStarter(jupyterCmdExecutionService, instance(fileSystem), instance(serviceContainer), instance(jupyterOutputChannel));
         when(serviceContainer.get<KernelSelector>(KernelSelector)).thenReturn(instance(kernelSelector));
         when(serviceContainer.get<NotebookStarter>(NotebookStarter)).thenReturn(notebookStarter);
         return {
@@ -855,7 +855,6 @@ suite('Jupyter Execution', async () => {
             jupyterExecutionFactory: new JupyterExecutionFactory(
                 instance(liveShare),
                 instance(interpreterService),
-                instance(logger),
                 disposableRegistry,
                 disposableRegistry,
                 instance(fileSystem),

--- a/src/test/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.unit.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { assert } from 'chai';
+import * as path from 'path';
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { PYTHON_LANGUAGE } from '../../../../client/common/constants';
+import { FileSystem } from '../../../../client/common/platform/fileSystem';
+import { IFileSystem } from '../../../../client/common/platform/types';
+import { PythonExecutionFactory } from '../../../../client/common/process/pythonExecutionFactory';
+import { PythonExecutionService } from '../../../../client/common/process/pythonProcess';
+import { IPythonExecutionService } from '../../../../client/common/process/types';
+import { JupyterCommands } from '../../../../client/datascience/constants';
+import { InterpreterJupyterNotebookCommand } from '../../../../client/datascience/jupyter/interpreter/jupyterCommand';
+import { JupyterCommandFinder, ModuleExistsStatus } from '../../../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
+import { JupyterCommandFinderInterpreterExecutionService } from '../../../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
+import { IJupyterCommand, IJupyterSubCommandExecutionService } from '../../../../client/datascience/types';
+import { IInterpreterService } from '../../../../client/interpreter/contracts';
+import { InterpreterService } from '../../../../client/interpreter/interpreterService';
+
+suite('Data Science - Jupyter CommandInterpreterExecutionService', () => {
+    let cmdFinder: JupyterCommandFinder;
+    let interperterService: IInterpreterService;
+    let fs: IFileSystem;
+    let kernelSpecCmd: IJupyterCommand;
+    let execService: IPythonExecutionService;
+    let jupyterInterpreterExecutionService: IJupyterSubCommandExecutionService;
+
+    setup(() => {
+        cmdFinder = mock(JupyterCommandFinder);
+        interperterService = mock(InterpreterService);
+        fs = mock(FileSystem);
+        kernelSpecCmd = mock(InterpreterJupyterNotebookCommand);
+        const execFactory = mock(PythonExecutionFactory);
+        execService = mock(PythonExecutionService);
+        jupyterInterpreterExecutionService = mock(JupyterCommandFinderInterpreterExecutionService);
+        when(execFactory.create(anything())).thenResolve(instance(execService));
+        // tslint:disable-next-line: no-any
+        (instance(execService) as any).then = undefined;
+        when(cmdFinder.findBestCommand(JupyterCommands.KernelSpecCommand)).thenResolve({ status: ModuleExistsStatus.Found, command: instance(kernelSpecCmd) });
+
+        jupyterInterpreterExecutionService = new JupyterCommandFinderInterpreterExecutionService(
+            instance(cmdFinder),
+            instance(interperterService),
+            instance(fs),
+            instance(execFactory)
+        );
+    });
+    test('Should not return any kernelspecs', async () => {
+        when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: '{}' });
+
+        const specs = await jupyterInterpreterExecutionService.getKernelSpecs();
+
+        assert.deepEqual(specs, []);
+    });
+    test('Should return a matching spec from a jupyter process for a given kernelspec', async () => {
+        const kernelSpecs = {
+            K1: {
+                resource_dir: 'dir1',
+                spec: { argv: [], display_name: 'disp1', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path', envName: 'MyEnvName' } } }
+            },
+            K2: {
+                resource_dir: 'dir2',
+                spec: { argv: [], display_name: 'disp2', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path2', envName: 'MyEnvName2' } } }
+            }
+        };
+        when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: JSON.stringify({ kernelspecs: kernelSpecs }) });
+        when(fs.fileExists(path.join('dir1', 'kernel.json'))).thenResolve(false);
+        when(fs.fileExists(path.join('dir2', 'kernel.json'))).thenResolve(true);
+        const specs = await jupyterInterpreterExecutionService.getKernelSpecs();
+
+        assert.equal(specs.length, 1);
+        verify(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).once();
+    });
+});

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -26,7 +26,7 @@ import { JupyterCommandFinderInterpreterExecutionService } from '../../../../cli
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
 import { JupyterKernelSpec } from '../../../../client/datascience/jupyter/kernels/jupyterKernelSpec';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
-import { IJupyterCommand, IJupyterInterpreterExecutionService, IJupyterKernelSpec, IJupyterSessionManager } from '../../../../client/datascience/types';
+import { IJupyterCommand, IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../../../client/datascience/types';
 import { EnvironmentActivationService } from '../../../../client/interpreter/activation/service';
 import { IEnvironmentActivationService } from '../../../../client/interpreter/activation/types';
 import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../../../client/interpreter/contracts';
@@ -45,7 +45,7 @@ suite('Data Science - KernelService', () => {
     let execService: IPythonExecutionService;
     let activationHelper: IEnvironmentActivationService;
     let installer: IInstaller;
-    let jupyterInterpreterExecutionService: IJupyterInterpreterExecutionService;
+    let jupyterInterpreterExecutionService: IJupyterSubCommandExecutionService;
 
     function initialize() {
         cmdFinder = mock(JupyterCommandFinder);

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -8,7 +8,7 @@ import { assert } from 'chai';
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { CancellationToken } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../../../client/common/constants';
 import { ProductInstaller } from '../../../../client/common/installer/productInstaller';
@@ -19,14 +19,11 @@ import { PythonExecutionService } from '../../../../client/common/process/python
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../../../client/common/process/types';
 import { IInstaller, InstallerResponse, Product, ReadWrite } from '../../../../client/common/types';
 import { Architecture } from '../../../../client/common/utils/platform';
-import { JupyterCommands } from '../../../../client/datascience/constants';
-import { InterpreterJupyterNotebookCommand } from '../../../../client/datascience/jupyter/interpreter/jupyterCommand';
-import { JupyterCommandFinder, ModuleExistsStatus } from '../../../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
 import { JupyterCommandFinderInterpreterExecutionService } from '../../../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
 import { JupyterKernelSpec } from '../../../../client/datascience/jupyter/kernels/jupyterKernelSpec';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
-import { IJupyterCommand, IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../../../client/datascience/types';
+import { IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../../../client/datascience/types';
 import { EnvironmentActivationService } from '../../../../client/interpreter/activation/service';
 import { IEnvironmentActivationService } from '../../../../client/interpreter/activation/types';
 import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../../../client/interpreter/contracts';
@@ -36,11 +33,9 @@ import { FakeClock } from '../../../common';
 // tslint:disable-next-line: max-func-body-length
 suite('Data Science - KernelService', () => {
     let kernelService: KernelService;
-    let cmdFinder: JupyterCommandFinder;
     let interperterService: IInterpreterService;
     let fs: IFileSystem;
     let sessionManager: IJupyterSessionManager;
-    let kernelSpecCmd: IJupyterCommand;
     let execFactory: IPythonExecutionFactory;
     let execService: IPythonExecutionService;
     let activationHelper: IEnvironmentActivationService;
@@ -48,11 +43,9 @@ suite('Data Science - KernelService', () => {
     let jupyterInterpreterExecutionService: IJupyterSubCommandExecutionService;
 
     function initialize() {
-        cmdFinder = mock(JupyterCommandFinder);
         interperterService = mock(InterpreterService);
         fs = mock(FileSystem);
         sessionManager = mock(JupyterSessionManager);
-        kernelSpecCmd = mock(InterpreterJupyterNotebookCommand);
         activationHelper = mock(EnvironmentActivationService);
         execFactory = mock(PythonExecutionFactory);
         execService = mock(PythonExecutionService);
@@ -61,7 +54,6 @@ suite('Data Science - KernelService', () => {
         when(execFactory.create(anything())).thenResolve(instance(execService));
         // tslint:disable-next-line: no-any
         (instance(execService) as any).then = undefined;
-        when(cmdFinder.findBestCommand(JupyterCommands.KernelSpecCommand)).thenResolve({ status: ModuleExistsStatus.Found, command: instance(kernelSpecCmd) });
 
         kernelService = new KernelService(
             instance(jupyterInterpreterExecutionService),
@@ -107,15 +99,14 @@ suite('Data Science - KernelService', () => {
         verify(sessionManager.getKernelSpecs()).once();
     });
     test('Should not return a matching spec from a jupyter process for a given kernelspec', async () => {
-        when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: '{}' });
+        when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve([]);
 
         const matchingKernel = await kernelService.findMatchingKernelSpec({ name: 'A', display_name: 'A' }, undefined);
 
         assert.isUndefined(matchingKernel);
-        verify(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).once();
     });
     test('Should not return a matching spec from a jupyter process for a given interpreter', async () => {
-        when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: '{}' });
+        when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve([]);
 
         const interpreter: PythonInterpreter = {
             path: 'some Path',
@@ -128,7 +119,6 @@ suite('Data Science - KernelService', () => {
         const matchingKernel = await kernelService.findMatchingKernelSpec(interpreter, undefined);
 
         assert.isUndefined(matchingKernel);
-        verify(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).once();
     });
     test('Should return a matching spec from a session for a given kernelspec', async () => {
         const activeKernelSpecs: IJupyterKernelSpec[] = [
@@ -174,18 +164,31 @@ suite('Data Science - KernelService', () => {
         verify(sessionManager.getKernelSpecs()).once();
     });
     test('Should return a matching spec from a jupyter process for a given kernelspec', async () => {
-        const kernelSpecs = {
-            K1: {
-                resource_dir: 'dir1',
-                spec: { argv: [], display_name: 'disp1', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path', envName: 'MyEnvName' } } }
-            },
-            K2: {
-                resource_dir: 'dir2',
-                spec: { argv: [], display_name: 'disp2', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path2', envName: 'MyEnvName2' } } }
-            }
-        };
-        when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: JSON.stringify({ kernelspecs: kernelSpecs }) });
-        when(fs.fileExists(path.join('dir2', 'kernel.json'))).thenResolve(true);
+        const kernelSpecs = [
+            new JupyterKernelSpec(
+                {
+                    name: 'K1',
+                    argv: [],
+                    display_name: 'disp1',
+                    language: PYTHON_LANGUAGE,
+                    resources: {},
+                    metadata: { interpreter: { path: 'Some Path', envName: 'MyEnvName' } }
+                },
+                path.join('dir1', 'kernel.json')
+            ),
+            new JupyterKernelSpec(
+                {
+                    name: 'K2',
+                    argv: [],
+                    display_name: 'disp2',
+                    language: PYTHON_LANGUAGE,
+                    resources: {},
+                    metadata: { interpreter: { path: 'Some Path2', envName: 'MyEnvName2' } }
+                },
+                path.join('dir2', 'kernel.json')
+            )
+        ];
+        when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve(kernelSpecs);
         const matchingKernel = await kernelService.findMatchingKernelSpec({ name: 'K2', display_name: 'disp2' }, undefined);
 
         assert.isOk(matchingKernel);
@@ -194,20 +197,33 @@ suite('Data Science - KernelService', () => {
         assert.equal(matchingKernel?.metadata?.interpreter?.path, 'Some Path2');
         assert.equal(matchingKernel?.metadata?.interpreter?.envName, 'MyEnvName2');
         assert.equal(matchingKernel?.language, PYTHON_LANGUAGE);
-        verify(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).once();
     });
     test('Should return a matching spec from a jupyter process for a given interpreter', async () => {
-        const kernelSpecs = {
-            K1: {
-                resource_dir: 'dir1',
-                spec: { argv: [], display_name: 'disp1', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path', envName: 'MyEnvName' } } }
-            },
-            K2: {
-                resource_dir: 'dir2',
-                spec: { argv: [], display_name: 'disp2', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path2', envName: 'MyEnvName2' } } }
-            }
-        };
-        when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: JSON.stringify({ kernelspecs: kernelSpecs }) });
+        const kernelSpecs = [
+            new JupyterKernelSpec(
+                {
+                    name: 'K1',
+                    argv: [],
+                    display_name: 'disp1',
+                    language: PYTHON_LANGUAGE,
+                    resources: {},
+                    metadata: { interpreter: { path: 'Some Path', envName: 'MyEnvName' } }
+                },
+                path.join('dir1', 'kernel.json')
+            ),
+            new JupyterKernelSpec(
+                {
+                    name: 'K2',
+                    argv: [],
+                    display_name: 'disp2',
+                    language: PYTHON_LANGUAGE,
+                    resources: {},
+                    metadata: { interpreter: { path: 'Some Path2', envName: 'MyEnvName2' } }
+                },
+                path.join('dir2', 'kernel.json')
+            )
+        ];
+        when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve(kernelSpecs);
         when(fs.arePathsSame('Some Path2', 'Some Path2')).thenReturn(true);
         when(fs.fileExists(path.join('dir2', 'kernel.json'))).thenResolve(true);
         const interpreter: PythonInterpreter = {
@@ -227,8 +243,7 @@ suite('Data Science - KernelService', () => {
         assert.equal(matchingKernel?.metadata?.interpreter?.path, 'Some Path2');
         assert.equal(matchingKernel?.metadata?.interpreter?.envName, 'MyEnvName2');
         assert.equal(matchingKernel?.language, PYTHON_LANGUAGE);
-        assert.deepEqual(matchingKernel?.metadata, kernelSpecs.K2.spec.metadata);
-        verify(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).once();
+        assert.deepEqual(matchingKernel?.metadata, kernelSpecs[1].metadata);
     });
     // tslint:disable-next-line: max-func-body-length
     suite('Registering Interpreters as Kernels', () => {

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -22,10 +22,11 @@ import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterCommands } from '../../../../client/datascience/constants';
 import { InterpreterJupyterNotebookCommand } from '../../../../client/datascience/jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder, ModuleExistsStatus } from '../../../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
+import { JupyterCommandFinderInterpreterExecutionService } from '../../../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
 import { JupyterKernelSpec } from '../../../../client/datascience/jupyter/kernels/jupyterKernelSpec';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
-import { IJupyterCommand, IJupyterKernelSpec, IJupyterSessionManager } from '../../../../client/datascience/types';
+import { IJupyterCommand, IJupyterInterpreterExecutionService, IJupyterKernelSpec, IJupyterSessionManager } from '../../../../client/datascience/types';
 import { EnvironmentActivationService } from '../../../../client/interpreter/activation/service';
 import { IEnvironmentActivationService } from '../../../../client/interpreter/activation/types';
 import { IInterpreterService, InterpreterType, PythonInterpreter } from '../../../../client/interpreter/contracts';
@@ -44,6 +45,7 @@ suite('Data Science - KernelService', () => {
     let execService: IPythonExecutionService;
     let activationHelper: IEnvironmentActivationService;
     let installer: IInstaller;
+    let jupyterInterpreterExecutionService: IJupyterInterpreterExecutionService;
 
     function initialize() {
         cmdFinder = mock(JupyterCommandFinder);
@@ -55,12 +57,20 @@ suite('Data Science - KernelService', () => {
         execFactory = mock(PythonExecutionFactory);
         execService = mock(PythonExecutionService);
         installer = mock(ProductInstaller);
+        jupyterInterpreterExecutionService = mock(JupyterCommandFinderInterpreterExecutionService);
         when(execFactory.create(anything())).thenResolve(instance(execService));
         // tslint:disable-next-line: no-any
         (instance(execService) as any).then = undefined;
         when(cmdFinder.findBestCommand(JupyterCommands.KernelSpecCommand)).thenResolve({ status: ModuleExistsStatus.Found, command: instance(kernelSpecCmd) });
 
-        kernelService = new KernelService(instance(cmdFinder), instance(execFactory), instance(interperterService), instance(installer), instance(fs), instance(activationHelper));
+        kernelService = new KernelService(
+            instance(jupyterInterpreterExecutionService),
+            instance(execFactory),
+            instance(interperterService),
+            instance(installer),
+            instance(fs),
+            instance(activationHelper)
+        );
     }
     setup(initialize);
     teardown(() => sinon.restore());


### PR DESCRIPTION
For #8623

@rchiodo @IanMatthewHuff @DavidKutu 
The changes here are a simple re-ractor.
* Move all Command finder related stuff behind a class.
* This allows us to then swap the code easily with the new jupyter interpreter
* Also allows us to keep the old command finder in place if the new one doesn't work (via some flag, so we don't break everyone without any fixes - **not sure this is required**, either way the refactor is required)

**Notes:**
* Not sure about the name of this new interface.
* Basically its a service that wraps jupyter stuff, then again we hvae a few of these. This is specifically geared towards **execution of sub commands against jupyter** (such as `python -m jupyter ...`).
* Please note, we can re-factor them into separate classes later. I prefer to keep it under one umbrella for now, as that makes it easier to swap the new global interpreter. When this old command stuff goes away we can refactor further.

Here's the new interface that hides all of the commands & command finder stuff:
```typescript
export interface IJupyterInterpreterExecutionService {
    isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean>;
    isExportSupported(cancelToken?: CancellationToken): Promise<boolean>;
    getReasonForJupyterNotebookNotBeingSupported(): Promise<string>;
    refreshCommands(): Promise<void>;
    getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined>;
    startNotebook(notebookArgs: string[], options: SpawnOptions): Promise<ObservableExecutionResult<string>>;
    getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined>;
    exportNotebookToPython(file: string, template?: string, token?: CancellationToken): Promise<string>;
    launchNotebook(notebookFile: string): Promise<void>;
    getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]>;
}
```