### PR TITLE
Changes to add support for global interpreter for jupyter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -238,10 +238,11 @@
                 "--timeout=300000"
             ],
             "env": {
-                // Remove `X_` prefix to test with real python (for DS functional tests).
-                "X_VSCODE_PYTHON_ROLLING": "1",
-                // Remove `X_` prefix and update path to test with real python interpreter (for DS functional tests).
-                "X_CI_PYTHON_PATH": "<Python Path>"
+                // Remove `X` prefix to test with real python (for DS functional tests).
+                "XVSCODE_PYTHON_ROLLING": "1",
+                // Remove `X` prefix and update path to test with real python interpreter (for DS functional tests).
+                // Do not use a conda environment (as it needs to be activated and the like).
+                "XCI_PYTHON_PATH": "<Python Path>"
             },
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -237,6 +237,12 @@
                 //"--grep", "<suite name>",
                 "--timeout=300000"
             ],
+            "env": {
+                // Remove `X_` prefix to test with real python (for DS functional tests).
+                "X_VSCODE_PYTHON_ROLLING": "1",
+                // Remove `X_` prefix and update path to test with real python interpreter (for DS functional tests).
+                "X_CI_PYTHON_PATH": "<Python Path>"
+            },
             "outFiles": [
                 "${workspaceFolder}/out/**/*.js"
             ],

--- a/news/1 Enhancements/8623.md
+++ b/news/1 Enhancements/8623.md
@@ -1,0 +1,2 @@
+Use a dedicated Python Interpreter for starting `Jupyter Notebook Server`.
+This can be changed using the command `Select Interpreter to start Jupyter server` from the `Command Palette`.

--- a/package.nls.json
+++ b/package.nls.json
@@ -190,6 +190,7 @@
     "Installer.noPipInstaller": "There is no Pip installer available in the selected environment.",
     "Installer.searchForHelp": "Search for help",
     "DataScience.libraryNotInstalled": "Data Science library {0} is not installed. Install?",
+    "DataScience.libraryRequiredToLaunchJupyterNotInstalled": "Data Science library {0} is not installed.",
     "DataScience.jupyterInstall": "Install",
     "DataScience.jupyterSelectURIPrompt": "Enter the URI of the running Jupyter server",
     "DataScience.jupyterSelectURIInvalidURI": "Invalid URI specified",
@@ -416,6 +417,7 @@
     "DataScience.selectKernel": "Select a Kernel",
     "DataScience.selectDifferentKernel": "Select a different Kernel",
     "DataScience.selectDifferentJupyterInterpreter": "Select a different Interpreter",
+    "DataScience.selectJupyterInterpreter": "Select an Interpreter to start Jupyter",
     "products.installingModule": "Installing {0}",
     "DataScience.switchingKernelProgress": "Switching kernel to '{0}'",
     "DataScience.sessionStartFailedWithKernel": "Failed to start a session for the Kernel '{0}'. \nView Jupyter [log](command:{1}) for further details."

--- a/package.nls.json
+++ b/package.nls.json
@@ -124,6 +124,7 @@
     "DataScience.jupyterSelfCertClose": "No, close the connection",
     "DataScience.jupyterServerCrashed": "Jupyter server crashed. Unable to connect. \r\nError code from jupyter: {0}",
     "DataScience.pythonInteractiveHelpLink": "Get more help",
+    "DataScience.markdownHelpInstallingMissingDependencies": "See [https://aka.ms/pyaiinstall](https://aka.ms/pyaiinstall) for help on installing jupyter.",
     "DataScience.importingFormat": "Importing {0}",
     "DataScience.startingJupyter": "Starting Jupyter server",
     "DataScience.connectingToJupyter": "Connecting to Jupyter server",

--- a/package.nls.json
+++ b/package.nls.json
@@ -238,6 +238,7 @@
     "DataScience.pythonInterruptFailedHeader": "Keyboard interrupt crashed the kernel. Kernel restarted.",
     "DataScience.sysInfoURILabel": "Jupyter Server URI: ",
     "DataScience.jupyterStartTimedout": "Starting Jupyter has timedout. Please check the 'Jupyter' output panel for further details.",
+    "DataScience.startingJupyterLogMessage": "Starting Jupyter from {0}",
     "Common.loadingPythonExtension": "Python extension loading...",
     "debug.selectConfigurationTitle": "Select a debug configuration",
     "debug.selectConfigurationPlaceholder": "Debug Configuration",

--- a/package.nls.json
+++ b/package.nls.json
@@ -200,7 +200,6 @@
     "DataScience.jupyterNotebookRemoteConnectFailed": "Failed to connect to remote Jupyter notebook.\r\nCheck that the Jupyter Server URI setting has a valid running server specified.\r\n{0}\r\n{1}",
     "DataScience.jupyterNotebookRemoteConnectSelfCertsFailed": "Failed to connect to remote Jupyter notebook.\r\nSpecified server is using self signed certs. Enable Allow Unauthorized Remote Connection setting to connect anyways\r\n{0}\r\n{1}",
     "DataScience.notebookVersionFormat": "Jupyter Notebook Version: {0}",
-    "DataScience.jupyterKernelNotSupportedOnActive": "Jupyter kernel cannot be started from '{0}'. Using closest match {1} instead.\r\nError starting original kernel: {2}",
     "DataScience.jupyterKernelSpecNotFound": "Cannot create a Jupyter kernel spec and none are available for use",
     "DataScience.jupyterKernelSpecModuleNotFound": "'Kernelspec' module not installed in the selected interpreter ({0}).\n Please re-install or update 'jupyter'.",
     "DataScience.jupyterGetVariablesBadResults": "Failed to fetch variable info from the Jupyter server.",

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -327,6 +327,7 @@ export class ProductInstaller implements IInstaller {
     }
 }
 
+// tslint:disable-next-line: cyclomatic-complexity
 function translateProductToModule(product: Product, purpose: ModuleNamePurpose): string {
     switch (product) {
         case Product.mypy:
@@ -366,6 +367,10 @@ function translateProductToModule(product: Product, purpose: ModuleNamePurpose):
             return 'notebook';
         case Product.ipykernel:
             return 'ipykernel';
+        case Product.nbconvert:
+            return 'ipykernel';
+        case Product.kernelspec:
+            return 'kernelspec';
         default: {
             throw new Error(`Product ${product} cannot be installed as a Python Module.`);
         }

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -74,7 +74,7 @@ export abstract class BaseInstaller {
     }
 
     public async isInstalled(product: Product, resource?: InterpreterUri): Promise<boolean | undefined> {
-        if (product === Product.unittest || product === Product.jupyter || product === Product.notebook) {
+        if (product === Product.unittest) {
             return true;
         }
         // User may have customized the module name or provided the fully qualified path.
@@ -368,7 +368,7 @@ function translateProductToModule(product: Product, purpose: ModuleNamePurpose):
         case Product.ipykernel:
             return 'ipykernel';
         case Product.nbconvert:
-            return 'ipykernel';
+            return 'nbconvert';
         case Product.kernelspec:
             return 'kernelspec';
         default: {

--- a/src/client/common/installer/productNames.ts
+++ b/src/client/common/installer/productNames.ts
@@ -22,3 +22,5 @@ ProductNames.set(Product.rope, 'rope');
 ProductNames.set(Product.jupyter, 'jupyter');
 ProductNames.set(Product.notebook, 'notebook');
 ProductNames.set(Product.ipykernel, 'ipykernel');
+ProductNames.set(Product.nbconvert, 'nbconvert');
+ProductNames.set(Product.kernelspec, 'kernelspec');

--- a/src/client/common/installer/productPath.ts
+++ b/src/client/common/installer/productPath.ts
@@ -28,6 +28,9 @@ export abstract class BaseProductPathsService implements IProductPathService {
         if (product === Product.ipykernel) {
             return true;
         }
+        if (product === Product.kernelspec) {
+            return false;
+        }
         let moduleName: string | undefined;
         try {
             moduleName = this.productInstaller.translateProductToModuleName(product, ModuleNamePurpose.run);

--- a/src/client/common/installer/productPath.ts
+++ b/src/client/common/installer/productPath.ts
@@ -25,9 +25,6 @@ export abstract class BaseProductPathsService implements IProductPathService {
     }
     public abstract getExecutableNameFromSettings(product: Product, resource?: Uri): string;
     public isExecutableAModule(product: Product, resource?: Uri): Boolean {
-        if (product === Product.ipykernel) {
-            return true;
-        }
         if (product === Product.kernelspec) {
             return false;
         }

--- a/src/client/common/installer/productService.ts
+++ b/src/client/common/installer/productService.ts
@@ -31,6 +31,8 @@ export class ProductService implements IProductService {
         this.ProductTypes.set(Product.jupyter, ProductType.DataScience);
         this.ProductTypes.set(Product.notebook, ProductType.DataScience);
         this.ProductTypes.set(Product.ipykernel, ProductType.DataScience);
+        this.ProductTypes.set(Product.nbconvert, ProductType.DataScience);
+        this.ProductTypes.set(Product.kernelspec, ProductType.DataScience);
     }
     public getProductType(product: Product): ProductType {
         return this.ProductTypes.get(product)!;

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -117,7 +117,9 @@ export enum Product {
     bandit = 17,
     jupyter = 18,
     ipykernel = 19,
-    notebook = 20
+    notebook = 20,
+    kernelspec = 21,
+    nbconvert = 22
 }
 
 export enum ModuleNamePurpose {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -207,6 +207,8 @@ export namespace DataScience {
     export const notebookCheckForImportNo = localize('DataScience.notebookCheckForImportNo', 'Later');
     export const notebookCheckForImportDontAskAgain = localize('DataScience.notebookCheckForImportDontAskAgain', "Don't Ask Again");
     export const libraryNotInstalled = localize('DataScience.libraryNotInstalled', 'Data Science library {0} is not installed. Install?');
+    export const libraryRequiredToLaunchJupyterNotInstalled = localize('DataScience.libraryRequiredToLaunchJupyterNotInstalled', 'Data Science library {0} is not installed.');
+    export const selectJupyterInterpreter = localize('DataScience.selectJupyterInterpreter', 'Select an Interpreter to start Jupyter');
     export const jupyterInstall = localize('DataScience.jupyterInstall', 'Install');
     export const currentlySelectedJupyterInterpreterForPlaceholder = localize('Datascience.currentlySelectedJupyterInterpreterForPlaceholder', 'current: {0}');
     export const jupyterNotSupported = localize('DataScience.jupyterNotSupported', 'Jupyter cannot be started. Error attempting to locate jupyter: {0}');

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -473,6 +473,7 @@ export namespace DataScience {
         'DataScience.fallBackToPromptToUseActiveInterpreterOrSelectAKernel',
         "Couldn't find kernel '{0}' that the notebook was created with."
     );
+    export const startingJupyterLogMessage = localize('DataScience.startingJupyterLogMessage', 'Starting Jupyter from {0}');
     export const jupyterStartTimedout = localize('DataScience.jupyterStartTimedout', "Starting Jupyter has timedout. Please check the 'Jupyter' output panel for further details.");
     export const switchingKernelProgress = localize('DataScience.switchingKernelProgress', "Switching Kenel to '{0}'");
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -290,11 +290,6 @@ export namespace DataScience {
     );
     export const jupyterServerCrashed = localize('DataScience.jupyterServerCrashed', 'Jupyter server crashed. Unable to connect. \r\nError code from jupyter: {0}');
     export const notebookVersionFormat = localize('DataScience.notebookVersionFormat', 'Jupyter Notebook Version: {0}');
-    //tslint:disable-next-line:no-multiline-string
-    export const jupyterKernelNotSupportedOnActive = localize(
-        'DataScience.jupyterKernelNotSupportedOnActive',
-        `IPython kernel cannot be started from '{0}'. Using closest match {1} instead.`
-    );
     export const jupyterKernelSpecNotFound = localize('DataScience.jupyterKernelSpecNotFound', 'Cannot create a IPython kernel spec and none are available for use');
     export const jupyterKernelSpecModuleNotFound = localize(
         'DataScience.jupyterKernelSpecModuleNotFound',

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -223,6 +223,10 @@ export namespace DataScience {
     export const jupyterSelfCertEnable = localize('DataScience.jupyterSelfCertEnable', 'Yes, connect anyways');
     export const jupyterSelfCertClose = localize('DataScience.jupyterSelfCertClose', 'No, close the connection');
     export const pythonInteractiveHelpLink = localize('DataScience.pythonInteractiveHelpLink', 'See [https://aka.ms/pyaiinstall] for help on installing jupyter.');
+    export const markdownHelpInstallingMissingDependencies = localize(
+        'DataScience.markdownHelpInstallingMissingDependencies',
+        'See [https://aka.ms/pyaiinstall](https://aka.ms/pyaiinstall) for help on installing jupyter.'
+    );
     export const importingFormat = localize('DataScience.importingFormat', 'Importing {0}');
     export const startingJupyter = localize('DataScience.startingJupyter', 'Starting Jupyter server');
     export const connectingToJupyter = localize('DataScience.connectingToJupyter', 'Connecting to Jupyter server');

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -9,10 +9,10 @@ import '../common/extensions';
 import { IPythonExecutionFactory } from '../common/process/types';
 import { IDisposableRegistry } from '../common/types';
 import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
-import { IInterpreterService } from '../interpreter/contracts';
 import { sendTelemetryEvent } from '../telemetry';
 import { PythonDaemonModule, Telemetry } from './constants';
 import { ActiveEditorContextService } from './context/activeEditorContext';
+import { JupyterInterpreterService } from './jupyter/interpreter/jupyterInterpreterService';
 import { INotebookEditor, INotebookEditorProvider } from './types';
 
 @injectable()
@@ -20,14 +20,14 @@ export class Activation implements IExtensionSingleActivationService {
     private notebookOpened = false;
     constructor(
         @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
-        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        @inject(JupyterInterpreterService) private readonly jupyterInterpreterService: JupyterInterpreterService,
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService
     ) {}
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
-        this.disposables.push(this.interpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
+        this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
         await this.contextService.activate();
     }
 
@@ -44,12 +44,12 @@ export class Activation implements IExtensionSingleActivationService {
     }
 
     @debounceAsync(500)
-    @swallowExceptions('Failed to create daemon when notebook opened')
+    @swallowExceptions('Failed to pre-warm daemon pool')
     private async PreWarmDaemonPool() {
-        const activeInterpreter = await this.interpreterService.getActiveInterpreter(undefined);
-        if (!activeInterpreter) {
+        const interpreter = await this.jupyterInterpreterService.getSelectedInterpreter();
+        if (!interpreter) {
             return;
         }
-        await this.factory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: activeInterpreter.path });
+        await this.factory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
     }
 }

--- a/src/client/datascience/errorHandler/errorHandler.ts
+++ b/src/client/datascience/errorHandler/errorHandler.ts
@@ -2,54 +2,22 @@
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
 import { IApplicationShell } from '../../common/application/types';
-import { ProductNames } from '../../common/installer/productNames';
-import { IInstallationChannelManager } from '../../common/installer/types';
-import { ILogger, Product } from '../../common/types';
-import * as localize from '../../common/utils/localize';
+import { traceError } from '../../common/logger';
 import { noop } from '../../common/utils/misc';
-import { sendTelemetryEvent } from '../../telemetry';
-import { Telemetry } from '../constants';
 import { JupyterInstallError } from '../jupyter/jupyterInstallError';
 import { JupyterSelfCertsError } from '../jupyter/jupyterSelfCertsError';
-import { IDataScienceErrorHandler } from '../types';
+import { IDataScienceErrorHandler, IJupyterInterpreterDependencyManager } from '../types';
 
 @injectable()
 export class DataScienceErrorHandler implements IDataScienceErrorHandler {
     constructor(
         @inject(IApplicationShell) private applicationShell: IApplicationShell,
-        @inject(ILogger) private logger: ILogger,
-        @inject(IInstallationChannelManager) protected channels: IInstallationChannelManager
+        @inject(IJupyterInterpreterDependencyManager) protected dependencyManager: IJupyterInterpreterDependencyManager
     ) {}
 
     public async handleError(err: Error): Promise<void> {
         if (err instanceof JupyterInstallError) {
-            sendTelemetryEvent(Telemetry.JupyterNotInstalledErrorShown);
-            const response = await this.applicationShell.showInformationMessage(
-                err.message,
-                localize.DataScience.jupyterInstall(),
-                localize.DataScience.notebookCheckForImportNo(),
-                err.actionTitle
-            );
-            if (response === localize.DataScience.jupyterInstall()) {
-                const installers = await this.channels.getInstallationChannels();
-                if (installers) {
-                    // If Conda is available, always pick it as the user must have a Conda Environment
-                    const installer = installers.find(ins => ins.name === 'Conda');
-                    const product = ProductNames.get(Product.jupyter);
-
-                    if (installer && product) {
-                        sendTelemetryEvent(Telemetry.UserInstalledJupyter);
-                        installer.installModule(product).catch(e => this.applicationShell.showErrorMessage(e.message, localize.DataScience.pythonInteractiveHelpLink()));
-                    } else if (installers[0] && product) {
-                        installers[0].installModule(product).catch(e => this.applicationShell.showErrorMessage(e.message, localize.DataScience.pythonInteractiveHelpLink()));
-                    }
-                }
-            } else if (response === localize.DataScience.notebookCheckForImportNo()) {
-                sendTelemetryEvent(Telemetry.UserDidNotInstallJupyter);
-            } else if (response === err.actionTitle) {
-                // This is a special error that shows a link to open for more help
-                this.applicationShell.openUrl(err.action);
-            }
+            await this.dependencyManager.installMissingDependencies(err);
         } else if (err instanceof JupyterSelfCertsError) {
             // Don't show the message for self cert errors
             noop();
@@ -58,6 +26,6 @@ export class DataScienceErrorHandler implements IDataScienceErrorHandler {
         } else {
             this.applicationShell.showErrorMessage(err.toString());
         }
-        this.logger.logError(err);
+        traceError('DataScience Error', err);
     }
 }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { ConfigurationTarget, Event, EventEmitter, Memento, Position, Range, Selection, TextEditor, Uri, ViewColumn } from 'vscode';
 import { Disposable } from 'vscode-jsonrpc';
-import * as vsls from 'vsls/vscode';
 
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 import { IApplicationShell, ICommandManager, IDocumentManager, ILiveShareApi, IWebPanelProvider, IWorkspaceService } from '../../common/application/types';
@@ -92,7 +91,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
 
     constructor(
         @unmanaged() private readonly listeners: IInteractiveWindowListener[],
-        @unmanaged() private liveShare: ILiveShareApi,
+        @unmanaged() liveShare: ILiveShareApi,
         @unmanaged() protected applicationShell: IApplicationShell,
         @unmanaged() protected documentManager: IDocumentManager,
         @unmanaged() private interpreterService: IInterpreterService,

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1178,24 +1178,6 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             if (options && !options.uri) {
                 activeInterpreter = await this.interpreterService.getActiveInterpreter();
                 const usableInterpreter = await this.jupyterExecution.getUsableJupyterPython();
-                if (usableInterpreter) {
-                    // See if the usable interpreter is not our active one. If so, show a warning
-                    // Only do this if not the guest in a liveshare session
-                    const api = await this.liveShare.getApi();
-                    if (!api || (api.session && api.session.role !== vsls.Role.Guest)) {
-                        const active = await this.interpreterService.getActiveInterpreter();
-                        const activeDisplayName = active ? active.displayName : undefined;
-                        const activePath = active ? active.path : undefined;
-                        const usableDisplayName = usableInterpreter ? usableInterpreter.displayName : undefined;
-                        const usablePath = usableInterpreter ? usableInterpreter.path : undefined;
-                        const notebookError = await this.jupyterExecution.getNotebookError();
-                        if (activePath && usablePath && !this.fileSystem.arePathsSame(activePath, usablePath) && activeDisplayName && usableDisplayName) {
-                            this.applicationShell.showWarningMessage(
-                                localize.DataScience.jupyterKernelNotSupportedOnActive().format(activeDisplayName, usableDisplayName, notebookError)
-                            );
-                        }
-                    }
-                }
                 return usableInterpreter ? true : false;
             } else {
                 return true;

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject } from 'inversify';
+import { IApplicationShell } from '../../../common/application/types';
+import { ProductNames } from '../../../common/installer/productNames';
+import { IInstallationChannelManager } from '../../../common/installer/types';
+import { Product } from '../../../common/types';
+import { DataScience } from '../../../common/utils/localize';
+import { sendTelemetryEvent } from '../../../telemetry';
+import { Telemetry } from '../../constants';
+import { IJupyterInterpreterDependencyManager } from '../../types';
+import { JupyterInstallError } from '../jupyterInstallError';
+
+export class JupyterCommandInterpreterDependencyService implements IJupyterInterpreterDependencyManager {
+    constructor(@inject(IApplicationShell) private applicationShell: IApplicationShell, @inject(IInstallationChannelManager) protected channels: IInstallationChannelManager) {}
+    public async installMissingDependencies(err?: JupyterInstallError): Promise<void> {
+        if (!err) {
+            return;
+        }
+        sendTelemetryEvent(Telemetry.JupyterNotInstalledErrorShown);
+        const response = await this.applicationShell.showInformationMessage(err.message, DataScience.jupyterInstall(), DataScience.notebookCheckForImportNo(), err.actionTitle);
+        if (response === DataScience.jupyterInstall()) {
+            const installers = await this.channels.getInstallationChannels();
+            if (installers) {
+                // If Conda is available, always pick it as the user must have a Conda Environment
+                const installer = installers.find(ins => ins.name === 'Conda');
+                const product = ProductNames.get(Product.jupyter);
+
+                if (installer && product) {
+                    sendTelemetryEvent(Telemetry.UserInstalledJupyter);
+                    installer.installModule(product).catch(e => this.applicationShell.showErrorMessage(e.message, DataScience.pythonInteractiveHelpLink()));
+                } else if (installers[0] && product) {
+                    installers[0].installModule(product).catch(e => this.applicationShell.showErrorMessage(e.message, DataScience.pythonInteractiveHelpLink()));
+                }
+            }
+        } else if (response === DataScience.notebookCheckForImportNo()) {
+            sendTelemetryEvent(Telemetry.UserDidNotInstallJupyter);
+        } else if (response === err.actionTitle) {
+            // This is a special error that shows a link to open for more help
+            this.applicationShell.openUrl(err.action);
+        }
+    }
+}

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { IApplicationShell } from '../../../common/application/types';
 import { ProductNames } from '../../../common/installer/productNames';
 import { IInstallationChannelManager } from '../../../common/installer/types';
@@ -14,6 +14,7 @@ import { Telemetry } from '../../constants';
 import { IJupyterInterpreterDependencyManager } from '../../types';
 import { JupyterInstallError } from '../jupyterInstallError';
 
+@injectable()
 export class JupyterCommandInterpreterDependencyService implements IJupyterInterpreterDependencyManager {
     constructor(@inject(IApplicationShell) private applicationShell: IApplicationShell, @inject(IInstallationChannelManager) protected channels: IInstallationChannelManager) {}
     public async installMissingDependencies(err?: JupyterInstallError): Promise<void> {

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -107,7 +107,7 @@ export class JupyterCommandFinderInterpreterExecutionService implements IJupyter
         const args = template ? [file, '--to', 'python', '--stdout', '--template', template] : [file, '--to', 'python', '--stdout'];
         return convert.command.exec(args, { throwOnStdErr: false, encoding: 'utf8', token }).then(output => output.stdout);
     }
-    public async launchNotebook(notebookFile: string): Promise<void> {
+    public async openNotebook(notebookFile: string): Promise<void> {
         // First we find a way to start a notebook server
         const notebookCommand = await this.commandFinder.findBestCommand(JupyterCommands.NotebookCommand);
         this.checkNotebookCommand(notebookCommand);

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -105,7 +105,7 @@ export class JupyterCommandFinderInterpreterExecutionService implements IJupyter
 
         // Wait for the nbconvert to finish
         const args = template ? [file, '--to', 'python', '--stdout', '--template', template] : [file, '--to', 'python', '--stdout'];
-        return convert.command.exec(args, { throwOnStdErr: true, encoding: 'utf8', token }).then(output => output.stdout);
+        return convert.command.exec(args, { throwOnStdErr: false, encoding: 'utf8', token }).then(output => output.stdout);
     }
     public async launchNotebook(notebookFile: string): Promise<void> {
         // First we find a way to start a notebook server

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -19,7 +19,7 @@ import { JupyterCommands, PythonDaemonModule } from '../../constants';
 import { IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterServerInfo } from '../jupyterConnection';
 import { JupyterInstallError } from '../jupyterInstallError';
-import { JupyterKernelSpec } from '../kernels/jupyterKernelSpec';
+import { JupyterKernelSpec, parseKernelSpecs } from '../kernels/jupyterKernelSpec';
 import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder';
 
 /**
@@ -135,31 +135,11 @@ export class JupyterCommandFinderInterpreterExecutionService implements IJupyter
             // Ask for our current list.
             const output = await kernelSpecCommand.command.exec(['list', '--json'], { throwOnStdErr: true, encoding: 'utf8' });
 
-            traceInfo('Parsing kernelspecs from jupyter');
-            // This should give us back a key value pair we can parse
-            const jsOut = JSON.parse(output.stdout.trim()) as { kernelspecs: Record<string, { resource_dir: string; spec: Omit<Kernel.ISpecModel, 'name'> }> };
-            const kernelSpecs = jsOut.kernelspecs;
-            const specs = await Promise.race([
-                Promise.all(
-                    Object.keys(kernelSpecs).map(async kernelName => {
-                        const specFile = path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json');
-                        const spec = kernelSpecs[kernelName].spec;
-                        // Add the missing name property.
-                        const model = {
-                            ...spec,
-                            name: kernelName
-                        };
-                        // Check if the spec file exists.
-                        if (await this.fs.fileExists(specFile)) {
-                            return new JupyterKernelSpec(model as Kernel.ISpecModel, specFile);
-                        } else {
-                            return;
-                        }
-                    })
-                ),
-                createPromiseFromCancellation({ cancelAction: 'resolve', defaultValue: [], token })
-            ]);
-            return specs.filter(item => !!item).map(item => item as JupyterKernelSpec);
+            return parseKernelSpecs(output.stdout, this.fs, token).catch(parserError => {
+                traceError('Failed to parse kernelspecs', parserError);
+                // This is failing for some folks. In that case return nothing
+                return [];
+            });
         } catch (ex) {
             traceError('Failed to list kernels', ex);
             // This is failing for some folks. In that case return nothing

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -3,11 +3,10 @@
 
 'use strict';
 
-import { Kernel } from '@jupyterlab/services';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { CancellationToken } from 'vscode';
-import { Cancellation, createPromiseFromCancellation } from '../../../common/cancellation';
+import { Cancellation } from '../../../common/cancellation';
 import { traceError, traceInfo, traceWarning } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import { IPythonExecutionFactory, ObservableExecutionResult, SpawnOptions } from '../../../common/process/types';

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -83,7 +83,7 @@ export class JupyterInterpreterDependencyService {
             .map(product => ProductNames.get(product))
             .filter(name => !!name)
             .map(name => name as string);
-        const message = DataScience.libraryNotInstalled().format(names.join(` ${Common.and} `));
+        const message = DataScience.libraryNotInstalled().format(names.join(` ${Common.and()} `));
 
         sendTelemetryEvent(Telemetry.JupyterNotInstalledErrorShown);
         const selection = await this.applicationShell.showErrorMessage(

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -83,7 +83,7 @@ export class JupyterInterpreterDependencyService {
         sendTelemetryEvent(Telemetry.JupyterNotInstalledErrorShown);
         const selection = await this.applicationShell.showErrorMessage(
             // tslint:disable-next-line: messages-must-be-localized
-            `${message}\n${error?.actionTitle || DataScience.pythonInteractiveHelpLink().format(HelpLinks.PythonInteractiveHelpLink)}`,
+            `${message}\r\n${DataScience.markdownHelpInstallingMissingDependencies()}`,
             DataScience.jupyterInstall(),
             DataScience.selectDifferentJupyterInterpreter(),
             Common.cancel()

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -14,7 +14,7 @@ import { Common, DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { PythonInterpreter } from '../../../interpreter/contracts';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { HelpLinks, Telemetry } from '../../constants';
+import { Telemetry } from '../../constants';
 import { JupyterInstallError } from '../jupyterInstallError';
 
 export enum JupyterInterpreterDependencyResponse {
@@ -59,11 +59,16 @@ export class JupyterInterpreterDependencyService {
      * If user opts not to isntall they can opt to select another interpreter.
      *
      * @param {PythonInterpreter} interpreter
+     * @param {JupyterInstallError} [_error]
      * @param {CancellationToken} [token]
      * @returns {Promise<JupyterInterpreterDependencyResponse>}
      * @memberof JupyterInterpreterDependencyService
      */
-    public async installMissingDependencies(interpreter: PythonInterpreter, error?: JupyterInstallError, token?: CancellationToken): Promise<JupyterInterpreterDependencyResponse> {
+    public async installMissingDependencies(
+        interpreter: PythonInterpreter,
+        _error?: JupyterInstallError,
+        token?: CancellationToken
+    ): Promise<JupyterInterpreterDependencyResponse> {
         const productsToInstall = await this.getDependenciesNotInstalled(interpreter, token);
         if (Cancellation.isCanceled(token)) {
             return JupyterInterpreterDependencyResponse.cancel;

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -136,24 +136,7 @@ export class JupyterInterpreterDependencyService {
      * @memberof JupyterInterpreterConfigurationService
      */
     public async areDependenciesInstalled(interpreter: PythonInterpreter, token?: CancellationToken): Promise<boolean> {
-        const installedPromise = this.getDependenciesNotInstalled(interpreter, token)
-            .then(items => items.length === 0)
-            .then(installed => {
-                if (installed) {
-                    this.dependenciesInstalledInInterpreter.add(interpreter.path);
-                } else {
-                    // If modules are not installed, then don't cache it.
-                    this.dependenciesInstalledInInterpreter.delete(interpreter.path);
-                }
-                return installed;
-            });
-
-        if (this.dependenciesInstalledInInterpreter.has(interpreter.path)) {
-            installedPromise.ignoreErrors();
-            return true;
-        }
-
-        return installedPromise;
+        return this.getDependenciesNotInstalled(interpreter, token).then(items => items.length === 0);
     }
 
     /**

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts
@@ -11,13 +11,14 @@ import '../../../common/extensions';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
-import { JupyterInterpreterConfigurationResponse, JupyterInterpreterConfigurationService } from './jupyterInterpreterConfiguration';
+import { JupyterInterpreterDependencyResponse, JupyterInterpreterDependencyService } from './jupyterInterpreterDependencyService';
 import { JupyterInterpreterOldCacheStateStore } from './jupyterInterpreterOldCacheStateStore';
 import { JupyterInterpreterSelector } from './jupyterInterpreterSelector';
 import { JupyterInterpreterStateStore } from './jupyterInterpreterStateStore';
 
 @injectable()
 export class JupyterInterpreterService {
+    private _selectedInterpreter?: PythonInterpreter;
     private _selectedInterpreterPath?: string;
     private _onDidChangeInterpreter = new EventEmitter<PythonInterpreter>();
     public get onDidChangeInterpreter(): Event<PythonInterpreter> {
@@ -28,7 +29,7 @@ export class JupyterInterpreterService {
         @inject(JupyterInterpreterOldCacheStateStore) private readonly oldVersionCacheStateStore: JupyterInterpreterOldCacheStateStore,
         @inject(JupyterInterpreterStateStore) private readonly interpreterSelectionState: JupyterInterpreterStateStore,
         @inject(JupyterInterpreterSelector) private readonly jupyterInterpreterSelector: JupyterInterpreterSelector,
-        @inject(JupyterInterpreterConfigurationService) private readonly interpreterConfiguration: JupyterInterpreterConfigurationService,
+        @inject(JupyterInterpreterDependencyService) private readonly interpreterConfiguration: JupyterInterpreterDependencyService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService
     ) {}
     /**
@@ -39,20 +40,39 @@ export class JupyterInterpreterService {
      * @memberof JupyterInterpreterService
      */
     public async getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined> {
+        if (this._selectedInterpreter) {
+            return this._selectedInterpreter;
+        }
+
         const resolveToUndefinedWhenCancelled = createPromiseFromCancellation({ cancelAction: 'resolve', defaultValue: undefined, token });
         // For backwards compatiblity check if we have a cached interpreter (older version of extension).
         // If that interpreter has everything we need then use that.
-        const interpreter = await Promise.race([this.getInterpreterFromChangeOfOlderVersionOfExtension(), resolveToUndefinedWhenCancelled]);
+        let interpreter = await Promise.race([this.getInterpreterFromChangeOfOlderVersionOfExtension(), resolveToUndefinedWhenCancelled]);
         if (interpreter) {
             return interpreter;
         }
 
         const pythonPath = this._selectedInterpreterPath || this.interpreterSelectionState.selectedPythonPath;
         if (!pythonPath) {
+            // Check if current interpreter has all of the required dependencies.
+            // If yes, then use that.
+            interpreter = await this.interpreterService.getActiveInterpreter(undefined);
+            if (!interpreter) {
+                return;
+            }
+            // Use this interpreter going forward.
+            if (await this.interpreterConfiguration.areDependenciesInstalled(interpreter)) {
+                this.setAsSelectedInterpreter(interpreter);
+                return interpreter;
+            }
             return;
         }
 
-        return Promise.race([this.interpreterService.getInterpreterDetails(pythonPath, undefined), resolveToUndefinedWhenCancelled]);
+        const interpreterDetails = await Promise.race([this.interpreterService.getInterpreterDetails(pythonPath, undefined), resolveToUndefinedWhenCancelled]);
+        if (interpreterDetails) {
+            this._selectedInterpreter = interpreterDetails;
+        }
+        return interpreterDetails;
     }
     /**
      * Selects and interpreter to run jupyter server.
@@ -71,13 +91,13 @@ export class JupyterInterpreterService {
             return;
         }
 
-        const result = await this.interpreterConfiguration.configureInterpreter(interpreter, token);
+        const result = await this.interpreterConfiguration.installMissingDependencies(interpreter, undefined, token);
         switch (result) {
-            case JupyterInterpreterConfigurationResponse.ok: {
+            case JupyterInterpreterDependencyResponse.ok: {
                 this.setAsSelectedInterpreter(interpreter);
                 return interpreter;
             }
-            case JupyterInterpreterConfigurationResponse.cancel:
+            case JupyterInterpreterDependencyResponse.cancel:
                 sendTelemetryEvent(Telemetry.SelectJupyterInterpreter, undefined, { result: 'installationCancelled' });
                 return;
             default:
@@ -106,6 +126,7 @@ export class JupyterInterpreterService {
     }
     private setAsSelectedInterpreter(interpreter: PythonInterpreter): void {
         this._onDidChangeInterpreter.fire(interpreter);
+        this._selectedInterpreter = interpreter;
         this.interpreterSelectionState.updateSelectedPythonPath((this._selectedInterpreterPath = interpreter.path));
         sendTelemetryEvent(Telemetry.SelectJupyterInterpreter, undefined, { result: 'selected' });
     }

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts
@@ -125,8 +125,8 @@ export class JupyterInterpreterService {
         }
     }
     private setAsSelectedInterpreter(interpreter: PythonInterpreter): void {
-        this._onDidChangeInterpreter.fire(interpreter);
         this._selectedInterpreter = interpreter;
+        this._onDidChangeInterpreter.fire(interpreter);
         this.interpreterSelectionState.updateSelectedPythonPath((this._selectedInterpreterPath = interpreter.path));
         sendTelemetryEvent(Telemetry.SelectJupyterInterpreter, undefined, { result: 'selected' });
     }

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -1,0 +1,220 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Kernel } from '@jupyterlab/services';
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { CancellationToken } from 'vscode';
+import { Cancellation, createPromiseFromCancellation } from '../../../common/cancellation';
+import { ProductNames } from '../../../common/installer/productNames';
+import { traceError, traceInfo, traceWarning } from '../../../common/logger';
+import { IFileSystem } from '../../../common/platform/types';
+import { IPythonExecutionFactory, ObservableExecutionResult, SpawnOptions } from '../../../common/process/types';
+import { Product } from '../../../common/types';
+import { Common, DataScience } from '../../../common/utils/localize';
+import { noop } from '../../../common/utils/misc';
+import { EXTENSION_ROOT_DIR } from '../../../constants';
+import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
+import { PythonDaemonModule } from '../../constants';
+import { IJupyterInterpreterDependencyManager, IJupyterSubCommandExecutionService } from '../../types';
+import { JupyterServerInfo } from '../jupyterConnection';
+import { JupyterInstallError } from '../jupyterInstallError';
+import { JupyterKernelSpec } from '../kernels/jupyterKernelSpec';
+import { JupyterInterpreterDependencyService } from './jupyterInterpreterDependencyService';
+import { JupyterInterpreterService } from './jupyterInterpreterService';
+
+/**
+ * Responsible for execution of jupyter sub commands using a single/global interpreter set aside for launching jupyter server.
+ *
+ * @export
+ * @class JupyterCommandFinderInterpreterExecutionService
+ * @implements {IJupyterSubCommandExecutionService}
+ */
+@injectable()
+export class JupyterInterpreterSubCommandExecutionService implements IJupyterSubCommandExecutionService, IJupyterInterpreterDependencyManager {
+    constructor(
+        @inject(JupyterInterpreterService) private readonly jupyterInterpreter: JupyterInterpreterService,
+        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
+        @inject(JupyterInterpreterDependencyService) private readonly jupyterConfigurationService: JupyterInterpreterDependencyService,
+        @inject(IFileSystem) private readonly fs: IFileSystem,
+        @inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory
+    ) {}
+
+    /**
+     * This is a noop, implemented for backwards compatibility.
+     *
+     * @returns {Promise<void>}
+     * @memberof JupyterInterpreterSubCommandExecutionService
+     */
+    public async refreshCommands(): Promise<void> {
+        noop();
+    }
+    public async isNotebookSupported(token?: CancellationToken): Promise<boolean> {
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(token);
+        if (!interpreter) {
+            return false;
+        }
+        return this.jupyterConfigurationService.areDependenciesInstalled(interpreter, token);
+    }
+    public async isExportSupported(token?: CancellationToken): Promise<boolean> {
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(token);
+        if (!interpreter) {
+            return false;
+        }
+        return this.jupyterConfigurationService.isExportSupported(interpreter, token);
+    }
+    public async getReasonForJupyterNotebookNotBeingSupported(token?: CancellationToken): Promise<string> {
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(token);
+        if (!interpreter) {
+            return DataScience.selectJupyterInterpreter();
+        }
+        const productsNotInstalled = await this.jupyterConfigurationService.getDependenciesNotInstalled(interpreter, token);
+        if (productsNotInstalled.length === 0) {
+            return '';
+        }
+
+        if (productsNotInstalled.length === 1 && productsNotInstalled[0] === Product.kernelspec) {
+            return DataScience.jupyterKernelSpecModuleNotFound();
+        }
+
+        const names = productsNotInstalled
+            .map(product => ProductNames.get(product))
+            .filter(name => !!name)
+            .map(name => name as string);
+        return DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(names.join(` ${Common.and} `));
+    }
+    public async getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined> {
+        return this.jupyterInterpreter.getSelectedInterpreter(token);
+    }
+    public async startNotebook(notebookArgs: string[], options: SpawnOptions): Promise<ObservableExecutionResult<string>> {
+        await this.checkNotebookCommand(options.token);
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(options.token);
+        if (!interpreter) {
+            throw new JupyterInstallError(DataScience.selectJupyterInterpreter(), DataScience.pythonInteractiveHelpLink());
+        }
+        const executionService = await this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
+        return executionService.execModuleObservable('jupyter', ['notebook'].concat(notebookArgs), options);
+    }
+
+    public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(token);
+        if (!interpreter) {
+            throw new JupyterInstallError(DataScience.selectJupyterInterpreter(), DataScience.pythonInteractiveHelpLink());
+        }
+        const daemon = await this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
+
+        // We have a small python file here that we will execute to get the server info from all running Jupyter instances
+        const newOptions: SpawnOptions = { mergeStdOutErr: true, token: token };
+        const file = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'datascience', 'getServerInfo.py');
+        const serverInfoString = await daemon.exec([file], newOptions);
+
+        let serverInfos: JupyterServerInfo[];
+        try {
+            // Parse out our results, return undefined if we can't suss it out
+            serverInfos = JSON.parse(serverInfoString.stdout.trim()) as JupyterServerInfo[];
+        } catch (err) {
+            traceWarning('Failed to parse JSON when getting server info out from getServerInfo.py', err);
+            return;
+        }
+        return serverInfos;
+    }
+    public async exportNotebookToPython(file: string, template?: string, token?: CancellationToken): Promise<string> {
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(token);
+        if (!interpreter) {
+            throw new JupyterInstallError(DataScience.selectJupyterInterpreter(), DataScience.pythonInteractiveHelpLink());
+        }
+        if (!(await this.jupyterConfigurationService.isExportSupported(interpreter, token))) {
+            throw new Error(DataScience.jupyterNbConvertNotSupported());
+        }
+
+        const daemon = await this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
+        // Wait for the nbconvert to finish
+        const args = template ? [file, '--to', 'python', '--stdout', '--template', template] : [file, '--to', 'python', '--stdout'];
+        return daemon.execModule('jupyter', ['nbconvert'].concat(args), { throwOnStdErr: true, encoding: 'utf8', token }).then(output => output.stdout);
+    }
+    public async launchNotebook(notebookFile: string): Promise<void> {
+        await this.checkNotebookCommand();
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter();
+        if (!interpreter) {
+            throw new JupyterInstallError(DataScience.selectJupyterInterpreter(), DataScience.pythonInteractiveHelpLink());
+        }
+        const executionService = await this.pythonExecutionFactory.createActivatedEnvironment({ interpreter, bypassCondaExecution: true, allowEnvironmentFetchExceptions: true });
+        const args: string[] = [`--NotebookApp.file_to_run=${notebookFile}`];
+
+        // Don't wait for the exec to finish and don't dispose. It's up to the user to kill the process
+        executionService.execModule('jupyter', ['notebook'].concat(args), { throwOnStdErr: false, encoding: 'utf8' }).ignoreErrors();
+    }
+
+    public async getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]> {
+        await this.checkNotebookCommand();
+        const interpreter = await this.jupyterInterpreter.getSelectedInterpreter(token);
+        if (!interpreter) {
+            throw new JupyterInstallError(DataScience.selectJupyterInterpreter(), DataScience.pythonInteractiveHelpLink());
+        }
+        const daemon = await this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
+        if (Cancellation.isCanceled(token)) {
+            return [];
+        }
+        try {
+            traceInfo('Asking for kernelspecs from jupyter');
+
+            // Ask for our current list.
+            const output = await daemon.execModule('jupyter', ['kernelspec', 'list', '--json'], { throwOnStdErr: true, encoding: 'utf8' });
+
+            traceInfo('Parsing kernelspecs from jupyter');
+            // This should give us back a key value pair we can parse
+            const jsOut = JSON.parse(output.stdout.trim()) as { kernelspecs: Record<string, { resource_dir: string; spec: Omit<Kernel.ISpecModel, 'name'> }> };
+            const kernelSpecs = jsOut.kernelspecs;
+            const specs = await Promise.race([
+                Promise.all(
+                    Object.keys(kernelSpecs).map(async kernelName => {
+                        const specFile = path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json');
+                        const spec = kernelSpecs[kernelName].spec;
+                        // Add the missing name property.
+                        const model = {
+                            ...spec,
+                            name: kernelName
+                        };
+                        // Check if the spec file exists.
+                        if (await this.fs.fileExists(specFile)) {
+                            return new JupyterKernelSpec(model as Kernel.ISpecModel, specFile);
+                        } else {
+                            return;
+                        }
+                    })
+                ),
+                createPromiseFromCancellation({ cancelAction: 'resolve', defaultValue: [], token })
+            ]);
+            return specs.filter(item => !!item).map(item => item as JupyterKernelSpec);
+        } catch (ex) {
+            traceError('Failed to list kernels', ex);
+            // This is failing for some folks. In that case return nothing
+            return [];
+        }
+    }
+
+    public async installMissingDependencies(err?: JupyterInstallError): Promise<void> {
+        let interpreter = await this.jupyterInterpreter.getSelectedInterpreter();
+        if (!interpreter) {
+            // Use current interpreter.
+            interpreter = await this.interpreterService.getActiveInterpreter(undefined);
+            if (!interpreter) {
+                // Unlikely scenario, user hasn't selected python, python extension will fall over.
+                // Get user to select something.
+                await this.jupyterInterpreter.selectInterpreter();
+                return;
+            }
+        }
+
+        await this.jupyterConfigurationService.installMissingDependencies(interpreter, err);
+    }
+
+    private async checkNotebookCommand(token?: CancellationToken): Promise<void> {
+        const reason = await this.getReasonForJupyterNotebookNotBeingSupported(token);
+        if (reason) {
+            throw new JupyterInstallError(reason, DataScience.pythonInteractiveHelpLink());
+        }
+    }
+}

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -102,7 +102,7 @@ export class JupyterInterpreterSubCommandExecutionService implements IJupyterSub
         if (!interpreter) {
             throw new JupyterInstallError(DataScience.selectJupyterInterpreter(), DataScience.pythonInteractiveHelpLink());
         }
-        // this.jupyterOutputChannel.appendLine(DataScience.startingJupyterLogMessage().format(this.pathUtils.getDisplayName(interpreter.path)));
+        this.jupyterOutputChannel.appendLine(DataScience.startingJupyterLogMessage().format(this.pathUtils.getDisplayName(interpreter.path)));
         const executionService = await this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
         return executionService.execModuleObservable('jupyter', ['notebook'].concat(notebookArgs), options);
     }

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -79,6 +79,8 @@ export class JupyterInterpreterSubCommandExecutionService implements IJupyterSub
         }
 
         const names = productsNotInstalled
+            // kernelspec is not a module that can be installed.
+            .filter(product => product !== Product.kernelspec)
             .map(product => ProductNames.get(product))
             .filter(name => !!name)
             .map(name => name as string);

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -3,15 +3,14 @@
 
 'use strict';
 
-import { Kernel } from '@jupyterlab/services';
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { CancellationToken } from 'vscode';
-import { Cancellation, createPromiseFromCancellation } from '../../../common/cancellation';
+import { Cancellation } from '../../../common/cancellation';
 import { ProductNames } from '../../../common/installer/productNames';
 import { traceError, traceInfo, traceWarning } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
-import { IPythonExecutionFactory, IPythonExecutionService, ObservableExecutionResult, SpawnOptions } from '../../../common/process/types';
+import { IPythonExecutionFactory, ObservableExecutionResult, SpawnOptions } from '../../../common/process/types';
 import { Product } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -131,7 +131,9 @@ export class JupyterInterpreterSubCommandExecutionService implements IJupyterSub
         const daemon = await this.pythonExecutionFactory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
         // Wait for the nbconvert to finish
         const args = template ? [file, '--to', 'python', '--stdout', '--template', template] : [file, '--to', 'python', '--stdout'];
-        return daemon.execModule('jupyter', ['nbconvert'].concat(args), { throwOnStdErr: true, encoding: 'utf8', token }).then(output => output.stdout);
+        // Ignore stderr, as nbconvert writes conversion result to stderr.
+        // stdout contains the generated python code.
+        return daemon.execModule('jupyter', ['nbconvert'].concat(args), { throwOnStdErr: false, encoding: 'utf8', token }).then(output => output.stdout);
     }
     public async launchNotebook(notebookFile: string): Promise<void> {
         await this.checkNotebookCommand();

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -248,7 +248,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
     }
 
     public async spawnNotebook(file: string): Promise<void> {
-        return this.jupyterInterpreterService.launchNotebook(file);
+        return this.jupyterInterpreterService.openNotebook(file);
     }
 
     public async importNotebook(file: string, template: string | undefined): Promise<string> {

--- a/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
@@ -30,6 +30,15 @@ export class JupyterKernelSpec implements IJupyterKernelSpec {
     }
 }
 
+/**
+ * Given the stdout contents from the command `python -m jupyter kernelspec list --json` this will parser that and build a list of kernelspecs.
+ *
+ * @export
+ * @param {string} stdout
+ * @param {IFileSystem} fs
+ * @param {CancellationToken} [token]
+ * @returns
+ */
 export async function parseKernelSpecs(stdout: string, fs: IFileSystem, token?: CancellationToken) {
     traceInfo('Parsing kernelspecs from jupyter');
     // This should give us back a key value pair we can parse

--- a/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 'use strict';
 import { Kernel } from '@jupyterlab/services';
+import * as path from 'path';
+import { CancellationToken } from 'vscode';
+import { createPromiseFromCancellation } from '../../../common/cancellation';
+import { traceInfo } from '../../../common/logger';
+import { IFileSystem } from '../../../common/platform/types';
 import { PythonInterpreter } from '../../../interpreter/contracts';
 import { IJupyterKernelSpec } from '../../types';
 
@@ -23,4 +28,33 @@ export class JupyterKernelSpec implements IJupyterKernelSpec {
         this.display_name = specModel.display_name;
         this.metadata = specModel.metadata;
     }
+}
+
+export async function parseKernelSpecs(stdout: string, fs: IFileSystem, token?: CancellationToken) {
+    traceInfo('Parsing kernelspecs from jupyter');
+    // This should give us back a key value pair we can parse
+    const jsOut = JSON.parse(stdout.trim()) as { kernelspecs: Record<string, { resource_dir: string; spec: Omit<Kernel.ISpecModel, 'name'> }> };
+    const kernelSpecs = jsOut.kernelspecs;
+
+    const specs = await Promise.race([
+        Promise.all(
+            Object.keys(kernelSpecs).map(async kernelName => {
+                const specFile = path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json');
+                const spec = kernelSpecs[kernelName].spec;
+                // Add the missing name property.
+                const model = {
+                    ...spec,
+                    name: kernelName
+                };
+                // Check if the spec file exists.
+                if (await fs.fileExists(specFile)) {
+                    return new JupyterKernelSpec(model as Kernel.ISpecModel, specFile);
+                } else {
+                    return;
+                }
+            })
+        ),
+        createPromiseFromCancellation({ cancelAction: 'resolve', defaultValue: [], token })
+    ]);
+    return specs.filter(item => !!item).map(item => item as JupyterKernelSpec);
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -15,6 +15,7 @@ import { StopWatch } from '../common/utils/stopWatch';
 import { PythonInterpreter } from '../interpreter/contracts';
 import { JupyterCommands } from './constants';
 import { JupyterServerInfo } from './jupyter/jupyterConnection';
+import { JupyterInstallError } from './jupyter/jupyterInstallError';
 import { JupyterKernelSpec } from './jupyter/kernels/jupyterKernelSpec';
 import { LiveKernelModel } from './jupyter/kernels/types';
 
@@ -613,7 +614,21 @@ export const IJupyterSubCommandExecutionService = Symbol('IJupyterSubCommandExec
  * @interface IJupyterSubCommandExecutionService
  */
 export interface IJupyterSubCommandExecutionService {
+    /**
+     * Checks whether notebook is supported.
+     *
+     * @param {CancellationToken} [cancelToken]
+     * @returns {Promise<boolean>}
+     * @memberof IJupyterSubCommandExecutionService
+     */
     isNotebookSupported(cancelToken?: CancellationToken): Promise<boolean>;
+    /**
+     * Checks whether exporting of ipynb is supported.
+     *
+     * @param {CancellationToken} [cancelToken]
+     * @returns {Promise<boolean>}
+     * @memberof IJupyterSubCommandExecutionService
+     */
     isExportSupported(cancelToken?: CancellationToken): Promise<boolean>;
     /**
      * Error message indicating why jupyter notebook isn't supported.
@@ -672,5 +687,24 @@ export interface IJupyterSubCommandExecutionService {
      * @memberof IJupyterSubCommandExecutionService
      */
     launchNotebook(notebookFile: string): Promise<void>;
+    /**
+     * Gets the kernelspecs.
+     *
+     * @param {CancellationToken} [token]
+     * @returns {Promise<JupyterKernelSpec[]>}
+     * @memberof IJupyterSubCommandExecutionService
+     */
     getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]>;
+}
+
+export const IJupyterInterpreterDependencyManager = Symbol('IJupyterInterpreterDependencyManager');
+export interface IJupyterInterpreterDependencyManager {
+    /**
+     * Installs the dependencies required to launch jupyter.
+     *
+     * @param {JupyterInstallError} [err]
+     * @returns {Promise<void>}
+     * @memberof IJupyterInterpreterDependencyManager
+     */
+    installMissingDependencies(err?: JupyterInstallError): Promise<void>;
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -686,7 +686,7 @@ export interface IJupyterSubCommandExecutionService {
      * @returns {Promise<void>}
      * @memberof IJupyterSubCommandExecutionService
      */
-    launchNotebook(notebookFile: string): Promise<void>;
+    openNotebook(notebookFile: string): Promise<void>;
     /**
      * Gets the kernelspecs.
      *

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -138,6 +138,8 @@ suite('Installer', () => {
                 prod.value === Product.isort ||
                 prod.value === Product.jupyter ||
                 prod.value === Product.notebook ||
+                prod.value === Product.kernelspec ||
+                prod.value === Product.nbconvert ||
                 prod.value === Product.ipykernel
             ) {
                 return;

--- a/src/test/common/installer/installer.invalidPath.unit.test.ts
+++ b/src/test/common/installer/installer.invalidPath.unit.test.ts
@@ -57,6 +57,8 @@ suite('Module Installer - Invalid Paths', () => {
                     case Product.rope:
                     case Product.unittest:
                     case Product.ipykernel:
+                    case Product.kernelspec:
+                    case Product.nbconvert:
                     case Product.notebook:
                     case Product.jupyter: {
                         return;

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -464,7 +464,7 @@ suite('Module Installer only', () => {
                         });
                 }
                 // Test isInstalled()
-                if (product.value === Product.unittest || product.value === Product.jupyter || product.value === Product.notebook) {
+                if (product.value === Product.unittest) {
                     test(`Method isInstalled() returns true for module installer ${product.name} (${resource ? 'With a resource' : 'without a resource'})`, async () => {
                         const result = await installer.isInstalled(product.value, resource);
                         expect(result).to.equal(true, 'Should be true');

--- a/src/test/common/installer/productPath.unit.test.ts
+++ b/src/test/common/installer/productPath.unit.test.ts
@@ -84,6 +84,16 @@ suite('Product Path', () => {
                         const productPathService = new TestBaseProductPathsService(serviceContainer.object);
                         expect(productPathService.isExecutableAModule(product.value)).to.equal(true, 'Should be true');
                     });
+                } else if (product.value === Product.nbconvert) {
+                    test('Returns true if product is nbconvert', () => {
+                        const productPathService = new TestBaseProductPathsService(serviceContainer.object);
+                        expect(productPathService.isExecutableAModule(product.value)).to.equal(true, 'Should be true');
+                    });
+                } else if (product.value === Product.kernelspec) {
+                    test('Returns true if product is kernelspec', () => {
+                        const productPathService = new TestBaseProductPathsService(serviceContainer.object);
+                        expect(productPathService.isExecutableAModule(product.value)).to.equal(false, 'Should be false');
+                    });
                 } else {
                     test('Returns true if User has customized the executable name', () => {
                         productInstaller.translateProductToModuleName = () => 'moduleName';

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -142,7 +142,7 @@ import { InteractiveWindowCommandListener } from '../../client/datascience/inter
 import { JupyterCommandFactory } from '../../client/datascience/jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder } from '../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
 import { JupyterCommandFinderInterpreterExecutionService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
-import { JupyterInterpreterConfigurationService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterConfiguration';
+import { JupyterInterpreterDependencyService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
 import { JupyterInterpreterOldCacheStateStore } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore';
 import { JupyterInterpreterSelectionCommand } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterSelectionCommand';
 import { JupyterInterpreterSelector } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterSelector';
@@ -667,7 +667,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<JupyterInterpreterStateStore>(JupyterInterpreterStateStore, JupyterInterpreterStateStore);
         this.serviceManager.addSingleton<IExtensionSingleActivationService>(IExtensionSingleActivationService, JupyterInterpreterSelectionCommand);
         this.serviceManager.addSingleton<JupyterInterpreterSelector>(JupyterInterpreterSelector, JupyterInterpreterSelector);
-        this.serviceManager.addSingleton<JupyterInterpreterConfigurationService>(JupyterInterpreterConfigurationService, JupyterInterpreterConfigurationService);
+        this.serviceManager.addSingleton<JupyterInterpreterDependencyService>(JupyterInterpreterDependencyService, JupyterInterpreterDependencyService);
         this.serviceManager.addSingleton<JupyterInterpreterService>(JupyterInterpreterService, JupyterInterpreterService);
         this.serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
         this.serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -141,6 +141,7 @@ import { InteractiveWindow } from '../../client/datascience/interactive-window/i
 import { InteractiveWindowCommandListener } from '../../client/datascience/interactive-window/interactiveWindowCommandListener';
 import { JupyterCommandFactory } from '../../client/datascience/jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder } from '../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
+import { JupyterCommandInterpreterDependencyService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService';
 import { JupyterCommandFinderInterpreterExecutionService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService';
 import { JupyterInterpreterDependencyService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
 import { JupyterInterpreterOldCacheStateStore } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore';
@@ -184,6 +185,7 @@ import {
     IJupyterCommandFactory,
     IJupyterDebugger,
     IJupyterExecution,
+    IJupyterInterpreterDependencyManager,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
@@ -672,6 +674,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<JupyterInterpreterOldCacheStateStore>(JupyterInterpreterOldCacheStateStore, JupyterInterpreterOldCacheStateStore);
         this.serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
         this.serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterCommandFinderInterpreterExecutionService);
+        this.serviceManager.addSingleton<IJupyterInterpreterDependencyManager>(IJupyterInterpreterDependencyManager, JupyterCommandInterpreterDependencyService);
 
         // Don't use conda at all during functional tests.
         const condaService = TypeMoq.Mock.ofType<ICondaService>();

--- a/src/test/datascience/errorHandler.unit.test.ts
+++ b/src/test/datascience/errorHandler.unit.test.ts
@@ -4,24 +4,23 @@
 import * as typemoq from 'typemoq';
 import { IApplicationShell } from '../../client/common/application/types';
 import { IInstallationChannelManager, IModuleInstaller } from '../../client/common/installer/types';
-import { ILogger } from '../../client/common/types';
 import * as localize from '../../client/common/utils/localize';
 import { DataScienceErrorHandler } from '../../client/datascience/errorHandler/errorHandler';
+import { JupyterCommandInterpreterDependencyService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService';
 import { JupyterInstallError } from '../../client/datascience/jupyter/jupyterInstallError';
 import { JupyterSelfCertsError } from '../../client/datascience/jupyter/jupyterSelfCertsError';
 
 suite('DataScience Error Handler Unit Tests', () => {
     let applicationShell: typemoq.IMock<IApplicationShell>;
-    let logger: typemoq.IMock<ILogger>;
     let channels: typemoq.IMock<IInstallationChannelManager>;
+    let dependencyManager: JupyterCommandInterpreterDependencyService;
     let dataScienceErrorHandler: DataScienceErrorHandler;
 
     setup(() => {
         applicationShell = typemoq.Mock.ofType<IApplicationShell>();
-        logger = typemoq.Mock.ofType<ILogger>();
         channels = typemoq.Mock.ofType<IInstallationChannelManager>();
-
-        dataScienceErrorHandler = new DataScienceErrorHandler(applicationShell.object, logger.object, channels.object);
+        dependencyManager = new JupyterCommandInterpreterDependencyService(applicationShell.object, channels.object);
+        dataScienceErrorHandler = new DataScienceErrorHandler(applicationShell.object, dependencyManager);
     });
     const message = 'Test error message.';
 
@@ -31,22 +30,22 @@ suite('DataScience Error Handler Unit Tests', () => {
             .returns(() => Promise.resolve(message))
             .verifiable(typemoq.Times.once());
 
-        logger.setup(log => log.logError(typemoq.It.isAny())).verifiable(typemoq.Times.once());
-
         const err = new Error(message);
         await dataScienceErrorHandler.handleError(err);
 
         applicationShell.verifyAll();
-        logger.verifyAll();
     });
 
     test('Jupyter Self Certificates Error', async () => {
-        logger.setup(log => log.logError(typemoq.It.isAny())).verifiable(typemoq.Times.once());
+        applicationShell
+            .setup(app => app.showErrorMessage(typemoq.It.isAny()))
+            .returns(() => Promise.resolve(message))
+            .verifiable(typemoq.Times.never());
 
         const err = new JupyterSelfCertsError(message);
         await dataScienceErrorHandler.handleError(err);
 
-        logger.verifyAll();
+        applicationShell.verifyAll();
     });
 
     test('Jupyter Install Error', async () => {
@@ -61,8 +60,6 @@ suite('DataScience Error Handler Unit Tests', () => {
             )
             .returns(() => Promise.resolve(localize.DataScience.jupyterInstall()))
             .verifiable(typemoq.Times.once());
-
-        logger.setup(log => log.logError(typemoq.It.isAny())).verifiable(typemoq.Times.once());
 
         const installers: IModuleInstaller[] = [
             {
@@ -90,7 +87,6 @@ suite('DataScience Error Handler Unit Tests', () => {
         await dataScienceErrorHandler.handleError(err);
 
         applicationShell.verifyAll();
-        logger.verifyAll();
         channels.verifyAll();
     });
 });

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterService.unit.test.ts
@@ -7,10 +7,7 @@ import { assert } from 'chai';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Memento } from 'vscode';
 import { Architecture } from '../../../../client/common/utils/platform';
-import {
-    JupyterInterpreterConfigurationResponse,
-    JupyterInterpreterConfigurationService
-} from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterConfiguration';
+import { JupyterInterpreterDependencyResponse, JupyterInterpreterDependencyService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
 import { JupyterInterpreterOldCacheStateStore } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterOldCacheStateStore';
 import { JupyterInterpreterSelector } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterSelector';
 import { JupyterInterpreterService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterService';
@@ -22,7 +19,7 @@ import { MockMemento } from '../../../mocks/mementos';
 suite('Data Science - Jupyter Interpreter Service', () => {
     let jupyterInterpreterService: JupyterInterpreterService;
     let interpreterSelector: JupyterInterpreterSelector;
-    let interpreterConfiguration: JupyterInterpreterConfigurationService;
+    let interpreterConfiguration: JupyterInterpreterDependencyService;
     let interpreterService: IInterpreterService;
     let selectedInterpreterEventArgs: PythonInterpreter | undefined;
     let memento: Memento;
@@ -45,7 +42,7 @@ suite('Data Science - Jupyter Interpreter Service', () => {
 
     setup(() => {
         interpreterSelector = mock(JupyterInterpreterSelector);
-        interpreterConfiguration = mock(JupyterInterpreterConfigurationService);
+        interpreterConfiguration = mock(JupyterInterpreterDependencyService);
         interpreterService = mock(InterpreterService);
         memento = mock(MockMemento);
         interpreterSelectionState = mock(JupyterInterpreterStateStore);
@@ -65,20 +62,20 @@ suite('Data Science - Jupyter Interpreter Service', () => {
     });
 
     test('Cancelling interpreter configuration is same as cancelling selection of an interpreter', async () => {
-        when(interpreterConfiguration.configureInterpreter(pythonInterpreter, anything())).thenResolve(JupyterInterpreterConfigurationResponse.cancel);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.cancel);
 
         const response = await jupyterInterpreterService.selectInterpreter();
 
-        verify(interpreterConfiguration.configureInterpreter(pythonInterpreter, anything())).once();
+        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).once();
         assert.equal(response, undefined);
         assert.isUndefined(selectedInterpreterEventArgs);
     });
     test('Once selected interpreter must be stored in settings and event fired', async () => {
-        when(interpreterConfiguration.configureInterpreter(pythonInterpreter, anything())).thenResolve(JupyterInterpreterConfigurationResponse.ok);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
 
         const response = await jupyterInterpreterService.selectInterpreter();
 
-        verify(interpreterConfiguration.configureInterpreter(pythonInterpreter, anything())).once();
+        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).once();
         assert.equal(response, pythonInterpreter);
         assert.equal(selectedInterpreterEventArgs, pythonInterpreter);
 
@@ -88,8 +85,8 @@ suite('Data Science - Jupyter Interpreter Service', () => {
         assert.equal(selectedInterpreter, pythonInterpreter);
     });
     test('Select another interpreter if user opts to not install dependencies', async () => {
-        when(interpreterConfiguration.configureInterpreter(pythonInterpreter, anything())).thenResolve(JupyterInterpreterConfigurationResponse.selectAnotherInterpreter);
-        when(interpreterConfiguration.configureInterpreter(secondPythonInterpreter, anything())).thenResolve(JupyterInterpreterConfigurationResponse.ok);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.selectAnotherInterpreter);
+        when(interpreterConfiguration.installMissingDependencies(secondPythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
         let interpreterSelection = 0;
         when(interpreterSelector.selectInterpreter()).thenCall(() => {
             // When selecting intererpter for first time, return first interpreter
@@ -101,8 +98,8 @@ suite('Data Science - Jupyter Interpreter Service', () => {
         const response = await jupyterInterpreterService.selectInterpreter();
 
         verify(interpreterSelector.selectInterpreter()).twice();
-        verify(interpreterConfiguration.configureInterpreter(pythonInterpreter, anything())).once();
-        verify(interpreterConfiguration.configureInterpreter(secondPythonInterpreter, anything())).once();
+        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).once();
+        verify(interpreterConfiguration.installMissingDependencies(secondPythonInterpreter, anything())).once();
         assert.equal(response, secondPythonInterpreter);
         assert.equal(selectedInterpreterEventArgs, secondPythonInterpreter);
 

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterService.unit.test.ts
@@ -84,7 +84,9 @@ suite('Data Science - Jupyter Interpreter Service', () => {
         assert.equal(selectedInterpreter, pythonInterpreter);
     });
     test('Select another interpreter if user opts to not install dependencies', async () => {
-        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything(), anything())).thenResolve(JupyterInterpreterDependencyResponse.selectAnotherInterpreter);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything(), anything())).thenResolve(
+            JupyterInterpreterDependencyResponse.selectAnotherInterpreter
+        );
         when(interpreterConfiguration.installMissingDependencies(secondPythonInterpreter, anything(), anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
         let interpreterSelection = 0;
         when(interpreterSelector.selectInterpreter()).thenCall(() => {

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterService.unit.test.ts
@@ -62,20 +62,19 @@ suite('Data Science - Jupyter Interpreter Service', () => {
     });
 
     test('Cancelling interpreter configuration is same as cancelling selection of an interpreter', async () => {
-        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.cancel);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything(), anything())).thenResolve(JupyterInterpreterDependencyResponse.cancel);
 
         const response = await jupyterInterpreterService.selectInterpreter();
 
-        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).once();
         assert.equal(response, undefined);
         assert.isUndefined(selectedInterpreterEventArgs);
     });
     test('Once selected interpreter must be stored in settings and event fired', async () => {
-        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything(), anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
 
         const response = await jupyterInterpreterService.selectInterpreter();
 
-        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).once();
+        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything(), anything())).once();
         assert.equal(response, pythonInterpreter);
         assert.equal(selectedInterpreterEventArgs, pythonInterpreter);
 
@@ -85,8 +84,8 @@ suite('Data Science - Jupyter Interpreter Service', () => {
         assert.equal(selectedInterpreter, pythonInterpreter);
     });
     test('Select another interpreter if user opts to not install dependencies', async () => {
-        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.selectAnotherInterpreter);
-        when(interpreterConfiguration.installMissingDependencies(secondPythonInterpreter, anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
+        when(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything(), anything())).thenResolve(JupyterInterpreterDependencyResponse.selectAnotherInterpreter);
+        when(interpreterConfiguration.installMissingDependencies(secondPythonInterpreter, anything(), anything())).thenResolve(JupyterInterpreterDependencyResponse.ok);
         let interpreterSelection = 0;
         when(interpreterSelector.selectInterpreter()).thenCall(() => {
             // When selecting intererpter for first time, return first interpreter
@@ -98,8 +97,6 @@ suite('Data Science - Jupyter Interpreter Service', () => {
         const response = await jupyterInterpreterService.selectInterpreter();
 
         verify(interpreterSelector.selectInterpreter()).twice();
-        verify(interpreterConfiguration.installMissingDependencies(pythonInterpreter, anything())).once();
-        verify(interpreterConfiguration.installMissingDependencies(secondPythonInterpreter, anything())).once();
         assert.equal(response, secondPythonInterpreter);
         assert.equal(selectedInterpreterEventArgs, secondPythonInterpreter);
 

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -125,7 +125,7 @@ suite('xData Science - Jupyter InterpreterSubCommandExecutionService', () => {
             await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
         });
         test('Cannot launch notebook file in jupyter notebook', async () => {
-            const promise = jupyterInterpreterExecutionService.launchNotebook('some.ipynb');
+            const promise = jupyterInterpreterExecutionService.openNotebook('some.ipynb');
             when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
 
             await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
@@ -216,7 +216,7 @@ suite('xData Science - Jupyter InterpreterSubCommandExecutionService', () => {
             const file = 'somefile.ipynb';
             when(execService.execModule('jupyter', anything(), anything())).thenResolve();
 
-            await jupyterInterpreterExecutionService.launchNotebook(file);
+            await jupyterInterpreterExecutionService.openNotebook(file);
 
             verify(execService.execModule('jupyter', deepEqual(['notebook', `--NotebookApp.file_to_run=${file}`]), anything())).once();
         });

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { assert, expect, use } from 'chai';
+import * as chaiPromise from 'chai-as-promised';
+import { Subject } from 'rxjs/Subject';
+import { anything, capture, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { ProductNames } from '../../../../client/common/installer/productNames';
+import { FileSystem } from '../../../../client/common/platform/fileSystem';
+import { PathUtils } from '../../../../client/common/platform/pathUtils';
+import { IFileSystem } from '../../../../client/common/platform/types';
+import { PythonExecutionFactory } from '../../../../client/common/process/pythonExecutionFactory';
+import { PythonExecutionService } from '../../../../client/common/process/pythonProcess';
+import { IPythonExecutionService, ObservableExecutionResult, Output } from '../../../../client/common/process/types';
+import { Product } from '../../../../client/common/types';
+import { DataScience } from '../../../../client/common/utils/localize';
+import { noop } from '../../../../client/common/utils/misc';
+import { PythonDaemonModule } from '../../../../client/datascience/constants';
+import { JupyterInterpreterDependencyService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
+import { JupyterInterpreterService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterService';
+import { JupyterInterpreterSubCommandExecutionService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService';
+import { IInterpreterService } from '../../../../client/interpreter/contracts';
+import { InterpreterService } from '../../../../client/interpreter/interpreterService';
+import { MockOutputChannel } from '../../../mockClasses';
+import { createPythonInterpreter } from '../../../utils/interpreters';
+use(chaiPromise);
+
+// tslint:disable-next-line: max-func-body-length
+suite('xData Science - Jupyter InterpreterSubCommandExecutionService', () => {
+    let jupyterInterpreter: JupyterInterpreterService;
+    let interperterService: IInterpreterService;
+    let jupyterDependencyService: JupyterInterpreterDependencyService;
+    let fs: IFileSystem;
+    let execService: IPythonExecutionService;
+    let jupyterInterpreterExecutionService: JupyterInterpreterSubCommandExecutionService;
+    const selectedJupyterInterpreter = createPythonInterpreter({ displayName: 'JupyterInterpreter' });
+    const activePythonInterpreter = createPythonInterpreter({ displayName: 'activePythonInterpreter' });
+    let notebookStartResult: ObservableExecutionResult<string>;
+    setup(() => {
+        interperterService = mock(InterpreterService);
+        jupyterInterpreter = mock(JupyterInterpreterService);
+        jupyterDependencyService = mock(JupyterInterpreterDependencyService);
+        fs = mock(FileSystem);
+        const execFactory = mock(PythonExecutionFactory);
+        execService = mock(PythonExecutionService);
+        when(execFactory.createDaemon(deepEqual({ daemonModule: PythonDaemonModule, pythonPath: selectedJupyterInterpreter.path }))).thenResolve(instance(execService));
+        when(execFactory.createActivatedEnvironment(anything())).thenResolve(instance(execService));
+        // tslint:disable-next-line: no-any
+        (instance(execService) as any).then = undefined;
+        const output = new MockOutputChannel('');
+        const pathUtils = mock(PathUtils);
+        notebookStartResult = {
+            dispose: noop,
+            proc: undefined,
+            out: new Subject<Output<string>>().asObservable()
+        };
+        jupyterInterpreterExecutionService = new JupyterInterpreterSubCommandExecutionService(
+            instance(jupyterInterpreter),
+            instance(interperterService),
+            instance(jupyterDependencyService),
+            instance(fs),
+            instance(execFactory),
+            output,
+            instance(pathUtils)
+        );
+
+        // tslint:disable-next-line: no-any
+        when(execService.execModuleObservable('jupyter', anything(), anything())).thenResolve(notebookStartResult as any);
+        when(interperterService.getActiveInterpreter()).thenResolve(activePythonInterpreter);
+        when(interperterService.getActiveInterpreter(undefined)).thenResolve(activePythonInterpreter);
+    });
+    suite('Interpreter is not selected', () => {
+        setup(() => {
+            when(jupyterInterpreter.getSelectedInterpreter()).thenResolve(undefined);
+            when(jupyterInterpreter.getSelectedInterpreter(anything())).thenResolve(undefined);
+        });
+        test('Returns selected interpreter', async () => {
+            const interpreter = await jupyterInterpreterExecutionService.getSelectedInterpreter(undefined);
+            assert.isUndefined(interpreter);
+        });
+        test('Notebook is not supported', async () => {
+            const isSupported = await jupyterInterpreterExecutionService.isNotebookSupported(undefined);
+            assert.isFalse(isSupported);
+        });
+        test('Export is not supported', async () => {
+            const isSupported = await jupyterInterpreterExecutionService.isExportSupported(undefined);
+            assert.isFalse(isSupported);
+        });
+        test('Install missing dependencies into active interpreter', async () => {
+            await jupyterInterpreterExecutionService.installMissingDependencies(undefined);
+            verify(jupyterDependencyService.installMissingDependencies(activePythonInterpreter, undefined)).once();
+        });
+        test('Display picker if no interpreters are seleced', async () => {
+            when(interperterService.getActiveInterpreter(undefined)).thenResolve(undefined);
+            await jupyterInterpreterExecutionService.installMissingDependencies(undefined);
+            verify(jupyterInterpreter.selectInterpreter()).once();
+        });
+        test('Jupyter cannot be started because no interpreter has been selected', async () => {
+            when(interperterService.getActiveInterpreter(undefined)).thenResolve(undefined);
+            const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(undefined);
+            assert.equal(reason, DataScience.selectJupyterInterpreter());
+        });
+        test('Jupyter cannot be started because jupyter is not installed', async () => {
+            const expectedReason = DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.jupyter)!);
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.jupyter]);
+            const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(undefined);
+            assert.equal(reason, expectedReason);
+        });
+        test('Jupyter cannot be started because notebook is not installed', async () => {
+            const expectedReason = DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!);
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
+            const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(undefined);
+            assert.equal(reason, expectedReason);
+        });
+        test('Cannot start notebook', async () => {
+            const promise = jupyterInterpreterExecutionService.startNotebook([], {});
+
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+        });
+        test('Cannot launch notebook file in jupyter notebook', async () => {
+            const promise = jupyterInterpreterExecutionService.launchNotebook('some.ipynb');
+
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+        });
+        test('Cannot export notebook to python', async () => {
+            const promise = jupyterInterpreterExecutionService.exportNotebookToPython('somefile.ipynb');
+
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+        });
+    });
+    suite('Interpreter is selected', () => {
+        setup(() => {
+            when(jupyterInterpreter.getSelectedInterpreter()).thenResolve(selectedJupyterInterpreter);
+            when(jupyterInterpreter.getSelectedInterpreter(anything())).thenResolve(selectedJupyterInterpreter);
+        });
+        test('Returns selected interpreter', async () => {
+            const interpreter = await jupyterInterpreterExecutionService.getSelectedInterpreter(undefined);
+
+            assert.deepEqual(interpreter, selectedJupyterInterpreter);
+        });
+        test('If ds dependencies are not installed, then notebook is not supported', async () => {
+            when(jupyterDependencyService.areDependenciesInstalled(selectedJupyterInterpreter, anything())).thenResolve(false);
+
+            const isSupported = await jupyterInterpreterExecutionService.isNotebookSupported(undefined);
+
+            assert.isFalse(isSupported);
+        });
+        test('If ds dependencies are installed, then notebook is supported', async () => {
+            when(jupyterInterpreter.getSelectedInterpreter(anything())).thenResolve(selectedJupyterInterpreter);
+            when(jupyterDependencyService.areDependenciesInstalled(selectedJupyterInterpreter, anything())).thenResolve(true);
+
+            const isSupported = await jupyterInterpreterExecutionService.isNotebookSupported(undefined);
+
+            assert.isOk(isSupported);
+        });
+        test('Install missing dependencies into jupyter interpreter', async () => {
+            await jupyterInterpreterExecutionService.installMissingDependencies(undefined);
+
+            verify(jupyterDependencyService.installMissingDependencies(selectedJupyterInterpreter, undefined)).once();
+        });
+        test('Jupyter cannot be started because jupyter is not installed', async () => {
+            const expectedReason = DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.jupyter)!);
+            when(jupyterDependencyService.getDependenciesNotInstalled(selectedJupyterInterpreter, undefined)).thenResolve([Product.jupyter]);
+
+            const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(undefined);
+
+            assert.equal(reason, expectedReason);
+        });
+        test('Jupyter cannot be started because notebook is not installed', async () => {
+            const expectedReason = DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!);
+            when(jupyterDependencyService.getDependenciesNotInstalled(selectedJupyterInterpreter, undefined)).thenResolve([Product.notebook]);
+
+            const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(undefined);
+
+            assert.equal(reason, expectedReason);
+        });
+        test('Jupyter cannot be started because kernelspec is not available', async () => {
+            when(jupyterDependencyService.getDependenciesNotInstalled(selectedJupyterInterpreter, undefined)).thenResolve([Product.kernelspec]);
+
+            const reason = await jupyterInterpreterExecutionService.getReasonForJupyterNotebookNotBeingSupported(undefined);
+
+            assert.equal(reason, DataScience.jupyterKernelSpecModuleNotFound());
+        });
+        test('Can start jupyer notebook', async () => {
+            const output = await jupyterInterpreterExecutionService.startNotebook([], {});
+
+            assert.isOk(output === notebookStartResult);
+            const moduleName = capture(execService.execModuleObservable).first()[0];
+            const args = capture(execService.execModuleObservable).first()[1];
+            assert.equal(moduleName, 'jupyter');
+            assert.equal(args[0], 'notebook');
+        });
+        test('Can launch notebook file in jupyter notebook', async () => {
+            const file = 'somefile.ipynb';
+            when(execService.execModule('jupyter', anything(), anything())).thenResolve();
+
+            await jupyterInterpreterExecutionService.launchNotebook(file);
+
+            verify(execService.execModule('jupyter', deepEqual(['notebook', `--NotebookApp.file_to_run=${file}`]), anything())).once();
+        });
+        test('Cannot export notebook to python if module is not installed', async () => {
+            const file = 'somefile.ipynb';
+            when(jupyterDependencyService.isExportSupported(selectedJupyterInterpreter, anything())).thenResolve(false);
+
+            const promise = jupyterInterpreterExecutionService.exportNotebookToPython(file);
+
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.jupyterNbConvertNotSupported());
+        });
+        test('Export notebook to python', async () => {
+            const file = 'somefile.ipynb';
+            const convertOutput = 'converted';
+            when(jupyterDependencyService.isExportSupported(selectedJupyterInterpreter, anything())).thenResolve(true);
+            when(execService.execModule('jupyter', deepEqual(['nbconvert', file, '--to', 'python', '--stdout']), anything())).thenResolve({ stdout: convertOutput });
+
+            const output = await jupyterInterpreterExecutionService.exportNotebookToPython(file);
+
+            assert.equal(output, convertOutput);
+        });
+    });
+    // test('Should return a matching spec from a jupyter process for a given kernelspec', async () => {
+    //     const kernelSpecs = {
+    //         K1: {
+    //             resource_dir: 'dir1',
+    //             spec: { argv: [], display_name: 'disp1', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path', envName: 'MyEnvName' } } }
+    //         },
+    //         K2: {
+    //             resource_dir: 'dir2',
+    //             spec: { argv: [], display_name: 'disp2', language: PYTHON_LANGUAGE, metadata: { interpreter: { path: 'Some Path2', envName: 'MyEnvName2' } } }
+    //         }
+    //     };
+    //     when(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).thenResolve({ stdout: JSON.stringify({ kernelspecs: kernelSpecs }) });
+    //     when(fs.fileExists(path.join('dir1', 'kernel.json'))).thenResolve(false);
+    //     when(fs.fileExists(path.join('dir2', 'kernel.json'))).thenResolve(true);
+    //     const specs = await jupyterInterpreterExecutionService.getKernelSpecs();
+
+    //     assert.equal(specs.length, 1);
+    //     verify(kernelSpecCmd.exec(deepEqual(['list', '--json']), anything())).once();
+    // });
+});

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -32,7 +32,7 @@ import { createPythonInterpreter } from '../../../utils/interpreters';
 use(chaiPromise);
 
 // tslint:disable-next-line: max-func-body-length
-suite('xData Science - Jupyter InterpreterSubCommandExecutionService', () => {
+suite('Data Science - Jupyter InterpreterSubCommandExecutionService', () => {
     let jupyterInterpreter: JupyterInterpreterService;
     let interperterService: IInterpreterService;
     let jupyterDependencyService: JupyterInterpreterDependencyService;

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -32,7 +32,7 @@ import { createPythonInterpreter } from '../../../utils/interpreters';
 use(chaiPromise);
 
 // tslint:disable-next-line: max-func-body-length
-suite('Data Science - Jupyter InterpreterSubCommandExecutionService', () => {
+suite('xData Science - Jupyter InterpreterSubCommandExecutionService', () => {
     let jupyterInterpreter: JupyterInterpreterService;
     let interperterService: IInterpreterService;
     let jupyterDependencyService: JupyterInterpreterDependencyService;
@@ -120,28 +120,33 @@ suite('Data Science - Jupyter InterpreterSubCommandExecutionService', () => {
         });
         test('Cannot start notebook', async () => {
             const promise = jupyterInterpreterExecutionService.startNotebook([], {});
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
 
-            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
         });
         test('Cannot launch notebook file in jupyter notebook', async () => {
             const promise = jupyterInterpreterExecutionService.launchNotebook('some.ipynb');
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
 
-            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
         });
         test('Cannot export notebook to python', async () => {
             const promise = jupyterInterpreterExecutionService.exportNotebookToPython('somefile.ipynb');
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
 
-            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
         });
         test('Cannot get a list of running jupyter servers', async () => {
             const promise = jupyterInterpreterExecutionService.getRunningJupyterServers(undefined);
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
 
-            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
         });
         test('Cannot get kernelspecs', async () => {
             const promise = jupyterInterpreterExecutionService.getKernelSpecs(undefined);
+            when(jupyterDependencyService.getDependenciesNotInstalled(activePythonInterpreter, undefined)).thenResolve([Product.notebook]);
 
-            await expect(promise).to.eventually.be.rejectedWith(DataScience.selectJupyterInterpreter());
+            await expect(promise).to.eventually.be.rejectedWith(DataScience.libraryRequiredToLaunchJupyterNotInstalled().format(ProductNames.get(Product.notebook)!));
         });
     });
     // tslint:disable-next-line: max-func-body-length

--- a/src/test/utils/interpreters.ts
+++ b/src/test/utils/interpreters.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { Architecture } from '../../client/common/utils/platform';
+import { InterpreterType, PythonInterpreter } from '../../client/interpreter/contracts';
+
+/**
+ * Creates a PythonInterpreter object for testing purposes, with unique name, version and path.
+ * If required a custom name, version and the like can be provided.
+ *
+ * @export
+ * @param {Partial<PythonInterpreter>} [info]
+ * @returns {PythonInterpreter}
+ */
+export function createPythonInterpreter(info?: Partial<PythonInterpreter>): PythonInterpreter {
+    const rnd = new Date().getTime().toString();
+    return {
+        displayName: `Something${rnd}`,
+        architecture: Architecture.Unknown,
+        path: `somePath${rnd}`,
+        sysPrefix: `someSysPrefix${rnd}`,
+        sysVersion: `1.1.1`,
+        type: InterpreterType.Unknown,
+        ...(info || {})
+    };
+}


### PR DESCRIPTION
For #8623 

**Note:**
* One more PR
I thought I could make the switch with this PR. Unfortunately I'll need another PR.
The next PR will make the switch to the new global interpreter.
I need to ensure the functional tests pass for the change. However I also need to ensure the changes do not break the old approach. **Hence leaving this PR will not change to the new approach but focus more on refactoring an other fixes.** 
Here's the next PR, its still a WIP - https://github.com/microsoft/vscode-python/pull/9625
* Setting for backwards compatibility
I've added a setting `python.dataScience.useOldJupyterServer` (not in package.json) that would allow users to revert to the old behavior if things don't work.
This way when we release this we can revert to old behavior.
Note: This setting is NOT in `package.json`, hence users will not see this.

@rchiodo @IanMatthewHuff @DavidKutu /cc