### PR TITLE
Skip having sources in our index_bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 !out/client/**/*.map
 **/*.map
+!out/datascience-ui/**/*.map
 *.vsix
 .appveyor.yml
 .editorconfig

--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -49,7 +49,7 @@ function buildConfiguration(folderName) {
         //  this seems to prevent chrome from downloading the source maps)
         devtool: 'eval-source-map',
         optimization: {
-            minimizer: [new TerserPlugin()]
+            minimizer: [new TerserPlugin({ sourceMap: true })]
         },
         node: {
             fs: 'empty'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ const os = require('os');
 
 const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined;
 
-const noop = function () { };
+const noop = function() {};
 /**
  * Hygiene works by creating cascading subsets of all our files and
  * passing them through a sequence of checks. Here are the current subsets,
@@ -80,7 +80,10 @@ gulp.task('hygiene-watch', () => gulp.watch(tsFilter, gulp.series('hygiene-modif
 
 gulp.task('hygiene', done => run({ mode: 'compile', skipFormatCheck: true, skipIndentationCheck: true }, done));
 
-gulp.task('hygiene-modified', gulp.series('compile', done => run({ mode: 'changes' }, done)));
+gulp.task(
+    'hygiene-modified',
+    gulp.series('compile', done => run({ mode: 'changes' }, done))
+);
 
 gulp.task('watch', gulp.parallel('hygiene-modified', 'hygiene-watch'));
 
@@ -110,7 +113,7 @@ gulp.task('checkNativeDependencies', done => {
 
 gulp.task('check-datascience-dependencies', () => checkDatascienceDependencies());
 
-const webpackEnv = { 'NODE_OPTIONS': '--max_old_space_size=9096' };
+const webpackEnv = { NODE_OPTIONS: '--max_old_space_size=9096' };
 
 gulp.task('compile-webviews', async () => {
     await spawnAsync('npm', ['run', 'webpack', '--', '--config', './build/webpack/webpack.datascience-ui-interactiveWindow.config.js', '--mode', 'production'], webpackEnv);
@@ -132,12 +135,12 @@ gulp.task('webpack', async () => {
     // Yes, console would print output from both, that's ok, we have a faster CI.
     // If things fail, we can run locally separately.
     if (isCI) {
-        const buildExtension = buildWebPack('extension', ['--config', './build/webpack/webpack.extension.config.js'], { 'NODE_OPTIONS': '--max_old_space_size=9096' });
-        const buildDebugAdapter = buildWebPack('debugAdapter', ['--config', './build/webpack/webpack.debugadapter.config.js'], { 'NODE_OPTIONS': '--max_old_space_size=9096' });
+        const buildExtension = buildWebPack('extension', ['--config', './build/webpack/webpack.extension.config.js'], { NODE_OPTIONS: '--max_old_space_size=9096' });
+        const buildDebugAdapter = buildWebPack('debugAdapter', ['--config', './build/webpack/webpack.debugadapter.config.js'], { NODE_OPTIONS: '--max_old_space_size=9096' });
         await Promise.all([buildExtension, buildDebugAdapter]);
     } else {
-        await buildWebPack('extension', ['--config', './build/webpack/webpack.extension.config.js'], { 'NODE_OPTIONS': '--max_old_space_size=9096' });
-        await buildWebPack('debugAdapter', ['--config', './build/webpack/webpack.debugadapter.config.js'], { 'NODE_OPTIONS': '--max_old_space_size=9096' });
+        await buildWebPack('extension', ['--config', './build/webpack/webpack.extension.config.js'], { NODE_OPTIONS: '--max_old_space_size=9096' });
+        await buildWebPack('debugAdapter', ['--config', './build/webpack/webpack.debugadapter.config.js'], { NODE_OPTIONS: '--max_old_space_size=9096' });
     }
 });
 
@@ -176,7 +179,7 @@ async function updateBuildNumber(args) {
 async function buildWebPack(webpackConfigName, args, env) {
     // Remember to perform a case insensitive search.
     const allowedWarnings = getAllowedWarningsForWebPack(webpackConfigName).map(item => item.toLowerCase());
-    const stdOut = await spawnAsync('npm', ['run', 'webpack', '--', ...args, ...['--mode', 'production']], env);
+    const stdOut = await spawnAsync('npm', ['run', 'webpack', '--', ...args, ...['--mode', 'production', '--devtool', 'source-map']], env);
     const stdOutLines = stdOut
         .split(os.EOL)
         .map(item => item.trim())
@@ -270,7 +273,6 @@ gulp.task('installPythonRequirements', async () => {
     );
 });
 
-
 // See https://github.com/microsoft/vscode-python/issues/7136
 gulp.task('installNewPtvsd', async () => {
     // Install new PTVSD with wheels for python 3.7
@@ -286,7 +288,20 @@ gulp.task('installNewPtvsd', async () => {
     }
 
     // Install source only version of new PTVSD for use with all other python versions.
-    const args = ['-m', 'pip', '--disable-pip-version-check', 'install', '-t', './pythonFiles/lib/python/new_ptvsd/no_wheels', '--no-cache-dir', '--implementation', 'py', '--no-deps', '--upgrade', 'ptvsd==5.0.0a11']
+    const args = [
+        '-m',
+        'pip',
+        '--disable-pip-version-check',
+        'install',
+        '-t',
+        './pythonFiles/lib/python/new_ptvsd/no_wheels',
+        '--no-cache-dir',
+        '--implementation',
+        'py',
+        '--no-deps',
+        '--upgrade',
+        'ptvsd==5.0.0a11'
+    ];
     const successWithoutWheels = await spawnAsync(process.env.CI_PYTHON_PATH || 'python3', args)
         .then(() => true)
         .catch(ex => {
@@ -303,7 +318,20 @@ gulp.task('installNewPtvsd', async () => {
 // until all users have migrated to the new debug adapter + new PTVSD (specified in requirements.txt)
 // See https://github.com/microsoft/vscode-python/issues/7136
 gulp.task('installOldPtvsd', async () => {
-    const args = ['-m', 'pip', '--disable-pip-version-check', 'install', '-t', './pythonFiles/lib/python/old_ptvsd', '--no-cache-dir', '--implementation', 'py', '--no-deps', '--upgrade', 'ptvsd==4.3.2']
+    const args = [
+        '-m',
+        'pip',
+        '--disable-pip-version-check',
+        'install',
+        '-t',
+        './pythonFiles/lib/python/old_ptvsd',
+        '--no-cache-dir',
+        '--implementation',
+        'py',
+        '--no-deps',
+        '--upgrade',
+        'ptvsd==4.3.2'
+    ];
     const success = await spawnAsync(process.env.CI_PYTHON_PATH || 'python3', args)
         .then(() => true)
         .catch(ex => {
@@ -507,7 +535,7 @@ const hygiene = (options, done) => {
     options = options || {};
     let errorCount = 0;
 
-    const indentation = es.through(function (file) {
+    const indentation = es.through(function(file) {
         file.contents
             .toString('utf8')
             .split(/\r\n|\r|\n/)
@@ -526,7 +554,7 @@ const hygiene = (options, done) => {
     });
 
     const formatOptions = { verify: true, tsconfig: true, tslint: true, editorconfig: true, tsfmt: true };
-    const formatting = es.map(function (file, cb) {
+    const formatting = es.map(function(file, cb) {
         tsfmt
             .processString(file.path, file.contents.toString('utf8'), formatOptions)
             .then(result => {
@@ -584,7 +612,7 @@ const hygiene = (options, done) => {
     }
 
     const { linter, configuration } = getLinter(options);
-    const tsl = es.through(function (file) {
+    const tsl = es.through(function(file) {
         const contents = file.contents.toString('utf8');
         if (isCI) {
             // Don't print anything to the console, we'll do that.
@@ -592,7 +620,7 @@ const hygiene = (options, done) => {
         }
         // Yes this is a hack, but tslinter doesn't provide an option to prevent this.
         const oldWarn = console.warn;
-        console.warn = () => { };
+        console.warn = () => {};
         linter.failures = [];
         linter.fixes = [];
         linter.lint(file.relative, contents, configuration.results);
@@ -611,7 +639,7 @@ const hygiene = (options, done) => {
     });
 
     const tsFiles = [];
-    const tscFilesTracker = es.through(function (file) {
+    const tscFilesTracker = es.through(function(file) {
         tsFiles.push(file.path.replace(/\\/g, '/'));
         tsFiles.push(file.path);
         this.emit('data', file);
@@ -619,10 +647,10 @@ const hygiene = (options, done) => {
 
     const tsProject = getTsProject(options);
 
-    const tsc = function () {
+    const tsc = function() {
         function customReporter() {
             return {
-                error: function (error, typescript) {
+                error: function(error, typescript) {
                     const fullFilename = error.fullFilename || '';
                     const relativeFilename = error.relativeFilename || '';
                     if (tsFiles.findIndex(file => fullFilename === file || relativeFilename === file) === -1) {
@@ -631,7 +659,7 @@ const hygiene = (options, done) => {
                     console.error(`Error: ${error.message}`);
                     errorCount += 1;
                 },
-                finish: function () {
+                finish: function() {
                     // forget the summary.
                     console.log('Finished compilation');
                 }
@@ -665,7 +693,7 @@ const hygiene = (options, done) => {
         .pipe(sourcemaps.init())
         .pipe(tsc())
         .pipe(
-            sourcemaps.mapSources(function (sourcePath, file) {
+            sourcemaps.mapSources(function(sourcePath, file) {
                 let tsFileName = path.basename(file.path).replace(/js$/, 'ts');
                 const qualifiedSourcePath = path
                     .dirname(file.path)
@@ -685,7 +713,7 @@ const hygiene = (options, done) => {
         .pipe(sourcemaps.write('.', { includeContent: false }))
         .pipe(gulp.dest(dest))
         .pipe(
-            es.through(null, function () {
+            es.through(null, function() {
                 if (errorCount > 0) {
                     const errorMessage = `Hygiene failed with errors 👎 . Check 'gulpfile.js' (completed in ${new Date().getTime() - started}ms).`;
                     console.error(colors.red(errorMessage));
@@ -895,5 +923,5 @@ exports.hygiene = hygiene;
 
 // this allows us to run hygiene via CLI (e.g. `node gulfile.js`).
 if (require.main === module) {
-    run({ exitOnError: true, mode: 'staged' }, () => { });
+    run({ exitOnError: true, mode: 'staged' }, () => {});
 }


### PR DESCRIPTION
For #8688

First step in making index_bundles load faster. Half the size by making source maps in production mode be external.
