### PR TITLE
Fix nightly flake tests

### DIFF
--- a/build/ci/vscode-python-nightly-flake-ci.yaml
+++ b/build/ci/vscode-python-nightly-flake-ci.yaml
@@ -128,30 +128,6 @@ stages:
           NeedsPythonFunctionalReqs: true
           VSCODE_PYTHON_ROLLING: true
           VSC_PYTHON_LOG_TELEMETRY: true
-        'Windows-Py2.7 Functional':
-          PythonVersion: '2.7'
-          VMImageName: 'vs2017-win2016'
-          TestsToRun: 'testfunctional'
-          NeedsPythonTestReqs: true
-          NeedsPythonFunctionalReqs: true
-          VSCODE_PYTHON_ROLLING: true
-          VSC_PYTHON_LOG_TELEMETRY: true
-        'Linux-Py2.7 Functional':
-          PythonVersion: '2.7'
-          VMImageName: 'ubuntu-16.04'
-          TestsToRun: 'testfunctional'
-          NeedsPythonTestReqs: true
-          NeedsPythonFunctionalReqs: true
-          VSCODE_PYTHON_ROLLING: true
-          VSC_PYTHON_LOG_TELEMETRY: true
-        'Mac-Py2.7 Functional':
-          PythonVersion: '2.7'
-          VMImageName: 'macos-10.13'
-          TestsToRun: 'testfunctional'
-          NeedsPythonTestReqs: true
-          NeedsPythonFunctionalReqs: true
-          VSCODE_PYTHON_ROLLING: true
-          VSC_PYTHON_LOG_TELEMETRY: true
 
     pool:
       vmImage: $(VMImageName)

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -74,8 +74,8 @@ suite('DataScience DataViewer tests', () => {
         // asyncDump();
     });
 
-    async function createDataViewer(variable: string): Promise<IDataViewer> {
-        return dataProvider.create({ name: variable, value: '', supportsDataExplorer: true, type: 'test', size: 0, truncated: true, shape: '', count: 0 }, notebook!);
+    async function createDataViewer(variable: string, type: string): Promise<IDataViewer> {
+        return dataProvider.create({ name: variable, value: '', supportsDataExplorer: true, type, size: 0, truncated: true, shape: '', count: 0 }, notebook!);
     }
 
     async function injectCode(code: string): Promise<void> {
@@ -155,7 +155,7 @@ suite('DataScience DataViewer tests', () => {
     runMountedTest('Data Frame', async wrapper => {
         await injectCode('import pandas as pd\r\ndf = pd.DataFrame([0, 1, 2, 3])');
         const gotAllRows = getCompletedPromise();
-        const dv = await createDataViewer('df');
+        const dv = await createDataViewer('df', 'DataFrame');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
@@ -165,7 +165,7 @@ suite('DataScience DataViewer tests', () => {
     runMountedTest('List', async wrapper => {
         await injectCode('ls = [0, 1, 2, 3]');
         const gotAllRows = getCompletedPromise();
-        const dv = await createDataViewer('ls');
+        const dv = await createDataViewer('ls', 'list');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
@@ -175,7 +175,7 @@ suite('DataScience DataViewer tests', () => {
     runMountedTest('Series', async wrapper => {
         await injectCode('import pandas as pd\r\ns = pd.Series([0, 1, 2, 3])');
         const gotAllRows = getCompletedPromise();
-        const dv = await createDataViewer('s');
+        const dv = await createDataViewer('s', 'Series');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
@@ -185,7 +185,7 @@ suite('DataScience DataViewer tests', () => {
     runMountedTest('np.array', async wrapper => {
         await injectCode('import numpy as np\r\nx = np.array([0, 1, 2, 3])');
         const gotAllRows = getCompletedPromise();
-        const dv = await createDataViewer('x');
+        const dv = await createDataViewer('x', 'ndarray');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 
@@ -195,7 +195,7 @@ suite('DataScience DataViewer tests', () => {
     runMountedTest('Failure', async _wrapper => {
         await injectCode('import numpy as np\r\nx = np.array([0, 1, 2, 3])');
         try {
-            await createDataViewer('unknown variable');
+            await createDataViewer('unknown variable', 'ndarray');
             assert.fail('Exception should have been thrown');
         } catch {
             noop();
@@ -205,7 +205,7 @@ suite('DataScience DataViewer tests', () => {
     runMountedTest('Sorting', async wrapper => {
         await injectCode('import numpy as np\r\nx = np.array([0, 1, 2, 3])');
         const gotAllRows = getCompletedPromise();
-        const dv = await createDataViewer('x');
+        const dv = await createDataViewer('x', 'ndarray');
         assert.ok(dv, 'DataViewer not created');
         await gotAllRows;
 

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -292,12 +292,13 @@ suite('DataScience notebook tests', () => {
 
     runTest('Remote Self Certs', async (_this: Mocha.Context) => {
         const python = await getNotebookCapableInterpreter(ioc, processFactory);
-        const procService = await processFactory.create();
 
-        // We will only connect if we allow for self signed cert connections
-        ioc.getSettings().datascience.allowUnauthorizedRemoteConnection = true;
+        if (python && python.version?.major && python.version?.major > 2) {
+            const procService = await processFactory.create();
 
-        if (procService && python && python.version?.major && python.version?.major > 2) {
+            // We will only connect if we allow for self signed cert connections
+            ioc.getSettings().datascience.allowUnauthorizedRemoteConnection = true;
+
             const connectionFound = createDeferred();
             const configFile = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience', 'serverConfigFiles', 'selfCert.py');
             const pemFile = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience', 'serverConfigFiles', 'jcert.pem');


### PR DESCRIPTION
The variable changes broke the data viewer tests (as they don't run from an actual variable list so there's no type information).

Also eliminating the 2.7 tests from the nightly flake test. Other tests are only failing on 2.7 and I don't think we'd care if 2.7 didn't work anymore.