### PR TITLE
Trigger formatting if interpreter is changed and formatOnSave is enabled

### DIFF
--- a/news/2 Fixes/7750.md
+++ b/news/2 Fixes/7750.md
@@ -1,0 +1,1 @@
+Don't show any install product prompts if interpreter is not selected

--- a/news/2 Fixes/9613.md
+++ b/news/2 Fixes/9613.md
@@ -1,1 +1,0 @@
-Don't show linter prompt if interpreter is not selected

--- a/src/client/providers/formatProvider.ts
+++ b/src/client/providers/formatProvider.ts
@@ -4,6 +4,7 @@
 import * as vscode from 'vscode';
 import { ICommandManager, IDocumentManager, IWorkspaceService } from '../common/application/types';
 import { IConfigurationService } from '../common/types';
+import { IInterpreterService } from '../interpreter/contracts';
 import { IServiceContainer } from '../ioc/types';
 import { AutoPep8Formatter } from './../formatters/autoPep8Formatter';
 import { BaseFormatter } from './../formatters/baseFormatter';
@@ -38,7 +39,15 @@ export class PythonFormattingEditProvider implements vscode.DocumentFormattingEd
         this.workspace = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
         this.documentManager = serviceContainer.get<IDocumentManager>(IDocumentManager);
         this.config = serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
         this.disposables.push(this.documentManager.onDidSaveTextDocument(async document => this.onSaveDocument(document)));
+        this.disposables.push(
+            interpreterService.onDidChangeInterpreter(async () => {
+                if (this.documentManager.activeTextEditor) {
+                    return this.onSaveDocument(this.documentManager.activeTextEditor.document);
+                }
+            })
+        );
     }
 
     public dispose() {


### PR DESCRIPTION
For #9612 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
