### PR TITLE
Ensure environment variables are always strings in launch.json

### DIFF
--- a/news/2 Fixes/9568.md
+++ b/news/2 Fixes/9568.md
@@ -1,0 +1,1 @@
+Ensure environment variables are always strings in `launch.json`.

--- a/package.json
+++ b/package.json
@@ -1155,7 +1155,10 @@
                             "env": {
                                 "type": "object",
                                 "description": "Environment variables defined as a key value pair. Property ends up being the Environment Variable and the value of the property ends up being the value of the Env Variable.",
-                                "default": {}
+                                "default": {},
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
                             },
                             "envFile": {
                                 "type": "string",
@@ -1282,7 +1285,10 @@
                             "env": {
                                 "type": "object",
                                 "description": "Environment variables defined as a key value pair. Property ends up being the Environment Variable and the value of the property ends up being the value of the Env Variable.",
-                                "default": {}
+                                "default": {},
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
                             },
                             "envFile": {
                                 "type": "string",


### PR DESCRIPTION
For #9568

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
