### PR TITLE
Do not open the output panel when building workspace symbols

### DIFF
--- a/news/2 Fixes/9603.md
+++ b/news/2 Fixes/9603.md
@@ -1,1 +1,1 @@
-Don't open output panel after each save when rebuilding on save.
+Do not open the output panel when building workspace symbols.

--- a/src/client/workspaceSymbols/main.ts
+++ b/src/client/workspaceSymbols/main.ts
@@ -72,7 +72,7 @@ export class WorkspaceSymbols implements Disposable {
     private registerCommands() {
         this.disposables.push(
             this.commandMgr.registerCommand(Commands.Build_Workspace_Symbols, async (rebuild: boolean = true, token?: CancellationToken) => {
-                const promises = this.buildWorkspaceSymbols(rebuild, token, true);
+                const promises = this.buildWorkspaceSymbols(rebuild, token);
                 return Promise.all(promises);
             })
         );
@@ -88,7 +88,7 @@ export class WorkspaceSymbols implements Disposable {
     }
 
     // tslint:disable-next-line:no-any
-    private buildWorkspaceSymbols(rebuild: boolean = true, token?: CancellationToken, show = false): Promise<any>[] {
+    private buildWorkspaceSymbols(rebuild: boolean = true, token?: CancellationToken): Promise<any>[] {
         if (token && token.isCancellationRequested) {
             return [];
         }
@@ -114,9 +114,6 @@ export class WorkspaceSymbols implements Disposable {
                     return;
                 } catch (error) {
                     if (!isNotInstalledError(error)) {
-                        if (show) {
-                            this.outputChannel.show();
-                        }
                         return;
                     }
                 }


### PR DESCRIPTION
For #9782

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
