### PR TITLE
Fix the return value for FileSystem.isReadOnly().

### DIFF
--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -45,7 +45,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                     await terminalService.sendCommand(pythonPath, args, token);
                 } else if (settings.globalModuleInstallation) {
                     const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
-                    if (await fs.isDirReadonly(path.dirname(pythonPath))) {
+                    if (await fs.isDirReadonly(path.dirname(pythonPath)).catch(_err => true)) {
                         this.elevatedInstall(pythonPath, args);
                     } else {
                         await terminalService.sendCommand(pythonPath, args, token);

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -1279,7 +1279,7 @@ suite('FileSystem', () => {
 
                     const isReadonly = await fileSystem.isDirReadonly(dirname);
 
-                    expect(isReadonly).to.equal(false);
+                    expect(isReadonly).to.equal(true);
                 });
             });
 
@@ -1288,15 +1288,13 @@ suite('FileSystem', () => {
 
                 const isReadonly = await fileSystem.isDirReadonly(dirname);
 
-                expect(isReadonly).to.equal(true);
+                expect(isReadonly).to.equal(false);
             });
 
-            // Failing may be more sensible, but for now we are sticking
-            // with the existing behavior.
-            test('false if the directory does not exist', async () => {
-                const isReadonly = await fileSystem.isDirReadonly(DOES_NOT_EXIST);
+            test('fail if the directory does not exist', async () => {
+                const promise = fileSystem.isDirReadonly(DOES_NOT_EXIST);
 
-                expect(isReadonly).to.equal(false);
+                await expect(promise).to.eventually.be.rejected;
             });
         });
 


### PR DESCRIPTION
(for #8995)

The return value didn't get fixed when we changed `isPathWritableAsync()` to `FileSystem.isDirReadonly()`.  Here we fix that and update the test.  We now also fail for any errors except errno EACCES.  The one consumer of `isDirReadonly()` has been adjusted accordingly, maintaining its does-not-fail behavior.