### PR TITLE
Closes the file stream once the tracker is done

### DIFF
--- a/src/client/debugger/extension/adapter/logging.ts
+++ b/src/client/debugger/extension/adapter/logging.ts
@@ -13,7 +13,7 @@ import { EXTENSION_ROOT_DIR } from '../../../constants';
 
 class DebugSessionLoggingTracker implements DebugAdapterTracker {
     private readonly enabled: boolean = false;
-    private stream: WriteStream | undefined;
+    private stream?: WriteStream;
     private timer = new StopWatch();
 
     constructor(private readonly session: DebugSession, fileSystem: IFileSystem) {
@@ -47,6 +47,7 @@ class DebugSessionLoggingTracker implements DebugAdapterTracker {
 
     public onExit(code: number | undefined, signal: string | undefined) {
         this.log(`Exit:\nExit-Code: ${code ? code : 0}\nSignal: ${signal ? signal : 'none'}\n`);
+        this.stream?.close();
     }
 
     private log(message: string) {


### PR DESCRIPTION
Currently the file stream is left opened.
This PR closes the log file stream opened for logging purposes.

Can file an issue and create a news entry if required. Though I don't see the point.