### PR TITLE
Ids of new cells must be provided to actions

### DIFF
--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -3,6 +3,7 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import { IServerState } from '../../../datascience-ui/interactive-common/mainState';
+import { IAddCellAction } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import { CssMessages, IGetCssRequest, IGetCssResponse, IGetMonacoThemeRequest } from '../messages';
 import { ICell, IInteractiveWindowInfo, IJupyterVariable, IJupyterVariablesRequest, IJupyterVariablesResponse } from '../types';
 
@@ -307,7 +308,7 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.GetAllCells]: ICell;
     public [InteractiveWindowMessages.ReturnAllCells]: ICell[];
     public [InteractiveWindowMessages.DeleteCell]: never | undefined;
-    public [InteractiveWindowMessages.DeleteAllCells]: never | undefined;
+    public [InteractiveWindowMessages.DeleteAllCells]: IAddCellAction;
     public [InteractiveWindowMessages.Undo]: never | undefined;
     public [InteractiveWindowMessages.Redo]: never | undefined;
     public [InteractiveWindowMessages.ExpandAll]: never | undefined;

--- a/src/datascience-ui/history-react/redux/mapping.ts
+++ b/src/datascience-ui/history-react/redux/mapping.ts
@@ -9,6 +9,7 @@ import { IMainState, IServerState } from '../../interactive-common/mainState';
 import { IncomingMessageActions } from '../../interactive-common/redux/postOffice';
 import {
     CommonActionType,
+    IAddCellAction,
     ICellAction,
     ICodeAction,
     IEditCellAction,
@@ -42,7 +43,7 @@ export class IInteractiveActionMapping {
     public [CommonActionType.GATHER_CELL]: InteractiveReducerFunc<ICellAction>;
     public [CommonActionType.EDIT_CELL]: InteractiveReducerFunc<IEditCellAction>;
     public [CommonActionType.SUBMIT_INPUT]: InteractiveReducerFunc<ICodeAction>;
-    public [CommonActionType.DELETE_ALL_CELLS]: InteractiveReducerFunc<never | undefined>;
+    public [CommonActionType.DELETE_ALL_CELLS]: InteractiveReducerFunc<IAddCellAction>;
     public [CommonActionType.EXPAND_ALL]: InteractiveReducerFunc<never | undefined>;
     public [CommonActionType.COLLAPSE_ALL]: InteractiveReducerFunc<never | undefined>;
     public [CommonActionType.EDITOR_LOADED]: InteractiveReducerFunc<never | undefined>;
@@ -63,7 +64,7 @@ export class IInteractiveActionMapping {
     public [IncomingMessageActions.GETALLCELLS]: InteractiveReducerFunc<never | undefined>;
     public [IncomingMessageActions.EXPANDALL]: InteractiveReducerFunc<never | undefined>;
     public [IncomingMessageActions.COLLAPSEALL]: InteractiveReducerFunc<never | undefined>;
-    public [IncomingMessageActions.DELETEALLCELLS]: InteractiveReducerFunc<never | undefined>;
+    public [IncomingMessageActions.DELETEALLCELLS]: InteractiveReducerFunc<IAddCellAction>;
     public [IncomingMessageActions.STARTPROGRESS]: InteractiveReducerFunc<never | undefined>;
     public [IncomingMessageActions.STOPPROGRESS]: InteractiveReducerFunc<never | undefined>;
     public [IncomingMessageActions.UPDATESETTINGS]: InteractiveReducerFunc<string>;

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -94,6 +94,17 @@ export interface ICellAction {
     cellId: string | undefined;
 }
 
+export interface IAddCellAction {
+    /**
+     * Id of the new cell that is to be added.
+     * If none provided, then generate a new id.
+     *
+     * @type {(string | undefined)}
+     * @memberof ICellAction
+     */
+    newCellId: string;
+}
+
 export interface ICodeAction extends ICellAction {
     code: string;
 }
@@ -103,9 +114,16 @@ export interface IEditCellAction extends ICodeAction {
     modelId: string;
 }
 
-export interface IExecuteAction extends ICodeAction {
-    moveOp: 'add' | 'select' | 'none';
-}
+// I.e. when using the operation `add`, we need the corresponding `IAddCellAction`.
+// They are mutually exclusive, if not `add`, then there's no `newCellId`.
+export type IExecuteAction =
+    | (ICodeAction & {
+          moveOp: 'select' | 'none';
+      })
+    | (ICodeAction &
+          IAddCellAction & {
+              moveOp: 'add';
+          });
 
 export interface ICodeCreatedAction extends ICellAction {
     modelId: string;

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -98,9 +98,6 @@ export interface IAddCellAction {
     /**
      * Id of the new cell that is to be added.
      * If none provided, then generate a new id.
-     *
-     * @type {(string | undefined)}
-     * @memberof ICellAction
      */
     newCellId: string;
 }

--- a/src/datascience-ui/native-editor/redux/mapping.ts
+++ b/src/datascience-ui/native-editor/redux/mapping.ts
@@ -9,6 +9,7 @@ import { IMainState, IServerState } from '../../interactive-common/mainState';
 import { IncomingMessageActions } from '../../interactive-common/redux/postOffice';
 import {
     CommonActionType,
+    IAddCellAction,
     ICellAction,
     ICellAndCursorAction,
     IChangeCellTypeAction,
@@ -27,12 +28,12 @@ type NativeEditorReducerFunc<T> = ReducerFunc<IMainState, CommonActionType, T>;
 export type NativeEditorReducerArg<T = never | undefined> = ReducerArg<IMainState, CommonActionType, T>;
 
 export class INativeEditorActionMapping {
-    public [CommonActionType.INSERT_ABOVE]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.INSERT_BELOW]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.INSERT_ABOVE_FIRST]: NativeEditorReducerFunc<never | undefined>;
+    public [CommonActionType.INSERT_ABOVE]: NativeEditorReducerFunc<ICellAction & IAddCellAction>;
+    public [CommonActionType.INSERT_BELOW]: NativeEditorReducerFunc<ICellAction & IAddCellAction>;
+    public [CommonActionType.INSERT_ABOVE_FIRST]: NativeEditorReducerFunc<IAddCellAction>;
     public [CommonActionType.FOCUS_CELL]: NativeEditorReducerFunc<ICellAndCursorAction>;
     public [CommonActionType.UNFOCUS_CELL]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.ADD_NEW_CELL]: NativeEditorReducerFunc<never | undefined>;
+    public [CommonActionType.ADD_NEW_CELL]: NativeEditorReducerFunc<IAddCellAction>;
     public [CommonActionType.EXECUTE_CELL]: NativeEditorReducerFunc<IExecuteAction>;
     public [CommonActionType.EXECUTE_ALL_CELLS]: NativeEditorReducerFunc<never | undefined>;
     public [CommonActionType.EXECUTE_ABOVE]: NativeEditorReducerFunc<ICellAction>;
@@ -74,9 +75,9 @@ export class INativeEditorActionMapping {
     public [IncomingMessageActions.LOADALLCELLS]: NativeEditorReducerFunc<ILoadAllCells>;
     public [IncomingMessageActions.NOTEBOOKRUNALLCELLS]: NativeEditorReducerFunc<never | undefined>;
     public [IncomingMessageActions.NOTEBOOKRUNSELECTEDCELL]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.NOTEBOOKADDCELLBELOW]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.NOTEBOOKADDCELLBELOW]: NativeEditorReducerFunc<IAddCellAction>;
     public [IncomingMessageActions.DOSAVE]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.DELETEALLCELLS]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.DELETEALLCELLS]: NativeEditorReducerFunc<IAddCellAction>;
     public [IncomingMessageActions.UNDO]: NativeEditorReducerFunc<never | undefined>;
     public [IncomingMessageActions.REDO]: NativeEditorReducerFunc<never | undefined>;
     public [IncomingMessageActions.STARTPROGRESS]: NativeEditorReducerFunc<never | undefined>;

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -69,6 +69,7 @@ export namespace Execution {
             const executeResult = executeRange(arg.prevState, index, index, [arg.payload.code], arg.queueAction);
 
             // Modify the execute result if moving
+            // Use `if` instead of `switch case` to ensure type safety.
             if (arg.payload.moveOp === 'add') {
                 // Add a new cell below
                 return Creation.insertBelow({ ...arg, prevState: executeResult, payload: { ...arg.payload } });

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -69,30 +69,27 @@ export namespace Execution {
             const executeResult = executeRange(arg.prevState, index, index, [arg.payload.code], arg.queueAction);
 
             // Modify the execute result if moving
-            switch (arg.payload.moveOp) {
-                case 'add':
-                    // Add a new cell below
-                    return Creation.insertBelow({ ...arg, prevState: executeResult });
-
-                case 'select':
-                    // Select the cell below this one, but don't focus it
-                    if (index < arg.prevState.cellVMs.length - 1) {
-                        return Effects.selectCell({
-                            ...arg,
-                            prevState: {
-                                ...executeResult
-                            },
-                            payload: {
-                                ...arg.payload,
-                                cellId: arg.prevState.cellVMs[index + 1].cell.id,
-                                cursorPos: CursorPos.Current
-                            }
-                        });
-                    }
-                    return executeResult;
-
-                default:
-                    return executeResult;
+            if (arg.payload.moveOp === 'add') {
+                // Add a new cell below
+                return Creation.insertBelow({ ...arg, prevState: executeResult, payload: { ...arg.payload } });
+            } else if (arg.payload.moveOp === 'select') {
+                // Select the cell below this one, but don't focus it
+                if (index < arg.prevState.cellVMs.length - 1) {
+                    return Effects.selectCell({
+                        ...arg,
+                        prevState: {
+                            ...executeResult
+                        },
+                        payload: {
+                            ...arg.payload,
+                            cellId: arg.prevState.cellVMs[index + 1].cell.id,
+                            cursorPos: CursorPos.Current
+                        }
+                    });
+                }
+                return executeResult;
+            } else {
+                return executeResult;
             }
         }
         return arg.prevState;


### PR DESCRIPTION
For #9340 (more PRs to come, this PR focuses on some minor refactoring).

* When adding a new cell, the ids must be provided to the redux store actions, instead of the actions generating their own ids.
* Any operation that results in creation of a cell will ensure a id for the cell is provided
* DeleteAllCells is an operation that has a side effect of creating a new cell, hence this must provide the id of the new cell that will be created.