### PR TITLE
Don't start two notebooks when interactive window starts

### DIFF
--- a/news/2 Fixes/9780.md
+++ b/news/2 Fixes/9780.md
@@ -1,0 +1,1 @@
+Fix debugging of Interactive Window cells. Don't start up a second notebook at Interactive Window startup.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -937,14 +937,20 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     };
 
     private async stopServer(): Promise<void> {
+        // Finish either of our notebook promises
         if (this.serverAndNotebookPromise) {
             await this.serverAndNotebookPromise;
             this.serverAndNotebookPromise = undefined;
-            if (this._notebook) {
-                const server = this._notebook;
-                this._notebook = undefined;
-                await server.dispose();
-            }
+        }
+        if (this.notebookPromise) {
+            await this.notebookPromise;
+            this.notebookPromise = undefined;
+        }
+        // If we have a notebook dispose of it
+        if (this._notebook) {
+            const server = this._notebook;
+            this._notebook = undefined;
+            await server.dispose();
         }
     }
 
@@ -1035,6 +1041,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             this._notebook = undefined;
         } finally {
             this.serverAndNotebookPromise = undefined;
+            this.notebookPromise = undefined;
         }
         await this.ensureServerAndNotebook();
     }


### PR DESCRIPTION
For #9780

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Appropriate comments and documentation strings in the code
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [ ] The wiki is updated with any design decisions/details.
