### PR TITLE
Increase timeout for often failing test hooks

### DIFF
--- a/src/test/interpreters/locators/interpreterLocatorService.testvirtualenvs.ts
+++ b/src/test/interpreters/locators/interpreterLocatorService.testvirtualenvs.ts
@@ -51,7 +51,7 @@ suite('Python interpreter locator service', () => {
         const filteredInterpreters = interpreters.filter(i => i.envName === 'test_env1' && i.type === InterpreterType.Conda);
         expect(filteredInterpreters.length).to.be.greaterThan(0, 'Environment test_env1 not found');
     });
-    test('Ensure we are getting conda environment created using command `conda create -p "./test_env2`', async () => {
+    test('Ensure we are getting conda environment created using command `conda create -p "./test_env2`"', async () => {
         // Created in CI using command `conda create -p "./test_env2" -y python`
         const filteredInterpreters = interpreters.filter(i => {
             let dirName = path.dirname(i.path);

--- a/src/test/testing/debugger.test.ts
+++ b/src/test/testing/debugger.test.ts
@@ -22,7 +22,7 @@ import { IArgumentsHelper, IArgumentsService, ITestManagerRunner, IUnitTestHelpe
 import { UnitTestHelper } from '../../client/testing/unittest/helper';
 import { ArgumentsService as UnitTestArgumentsService } from '../../client/testing/unittest/services/argsService';
 import { deleteDirectory, rootWorkspaceUri, updateSetting } from '../common';
-import { initialize, initializeTest, IS_MULTI_ROOT_TEST } from './../initialize';
+import { initialize, initializeTest, IS_MULTI_ROOT_TEST, TEST_TIMEOUT } from './../initialize';
 import { MockDebugLauncher } from './mocks';
 import { UnitTestIocContainer } from './serviceRegistry';
 
@@ -42,7 +42,9 @@ suite('Unit Tests - debugging', () => {
         await updateSetting('testing.nosetestArgs', [], rootWorkspaceUri, configTarget);
         await updateSetting('testing.pytestArgs', [], rootWorkspaceUri, configTarget);
     });
-    setup(async () => {
+    setup(async function() {
+        // tslint:disable-next-line:no-invalid-this
+        this.timeout(TEST_TIMEOUT * 2); // This hook requires more timeout as we're deleting files as well
         await deleteDirectory(path.join(testFilesPath, '.cache'));
         await initializeTest();
         initializeDI();

--- a/src/test/testing/rediscover.test.ts
+++ b/src/test/testing/rediscover.test.ts
@@ -9,7 +9,7 @@ import { CondaService } from '../../client/interpreter/locators/services/condaSe
 import { CommandSource } from '../../client/testing/common/constants';
 import { ITestManagerFactory, TestProvider } from '../../client/testing/common/types';
 import { deleteDirectory, deleteFile, rootWorkspaceUri, updateSetting } from '../common';
-import { initialize, initializeTest, IS_MULTI_ROOT_TEST } from './../initialize';
+import { initialize, initializeTest, IS_MULTI_ROOT_TEST, TEST_TIMEOUT } from './../initialize';
 import { UnitTestIocContainer } from './serviceRegistry';
 
 const testFilesPath = path.join(__dirname, '..', '..', '..', 'src', 'test', 'pythonFiles', 'testFiles', 'debuggerTest');
@@ -25,7 +25,9 @@ suite('Unit Tests re-discovery', () => {
     suiteSetup(async () => {
         await initialize();
     });
-    setup(async () => {
+    setup(async function() {
+        // tslint:disable-next-line:no-invalid-this
+        this.timeout(TEST_TIMEOUT * 2); // This hook requires more timeout as we're dealing with files as well
         await fs.copy(testFileWithFewTests, testFile, { overwrite: true });
         await deleteDirectory(path.join(testFilesPath, '.cache'));
         await resetSettings();


### PR DESCRIPTION
The hooks are doing more than just dependency injection, deserving greater timeouts.