### PR TITLE
Remove root level flags used to track cell selection and focus

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
             "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
-            ],
+            ]
         },
         {
             "name": "Extension inside container",

--- a/src/client/datascience/data-viewing/types.ts
+++ b/src/client/datascience/data-viewing/types.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { JSONObject } from '@phosphor/coreutils';
 
-import { CssMessages, IGetCssRequest, IGetCssResponse, SharedMessages } from '../messages';
+import { SharedMessages } from '../messages';
 import { IJupyterVariable } from '../types';
 
 export const CellFetchAllLimit = 100000;
@@ -40,15 +40,13 @@ export interface IGetRowsResponse {
 }
 
 // Map all messages to specific payloads
-export class IDataViewerMapping {
-    public [DataViewerMessages.Started]: never | undefined;
-    public [DataViewerMessages.UpdateSettings]: string;
-    public [DataViewerMessages.InitializeData]: IJupyterVariable;
-    public [DataViewerMessages.GetAllRowsRequest]: never | undefined;
-    public [DataViewerMessages.GetAllRowsResponse]: JSONObject;
-    public [DataViewerMessages.GetRowsRequest]: IGetRowsRequest;
-    public [DataViewerMessages.GetRowsResponse]: IGetRowsResponse;
-    public [DataViewerMessages.CompletedData]: never | undefined;
-    public [CssMessages.GetCssRequest]: IGetCssRequest;
-    public [CssMessages.GetCssResponse]: IGetCssResponse;
-}
+export type IDataViewerMapping = {
+    [DataViewerMessages.Started]: never | undefined;
+    [DataViewerMessages.UpdateSettings]: string;
+    [DataViewerMessages.InitializeData]: IJupyterVariable;
+    [DataViewerMessages.GetAllRowsRequest]: never | undefined;
+    [DataViewerMessages.GetAllRowsResponse]: JSONObject;
+    [DataViewerMessages.GetRowsRequest]: IGetRowsRequest;
+    [DataViewerMessages.GetRowsResponse]: IGetRowsResponse;
+    [DataViewerMessages.CompletedData]: never | undefined;
+};

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -3,8 +3,9 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import { IServerState } from '../../../datascience-ui/interactive-common/mainState';
-import { IAddCellAction } from '../../../datascience-ui/interactive-common/redux/reducers/types';
-import { CssMessages, IGetCssRequest, IGetCssResponse, IGetMonacoThemeRequest } from '../messages';
+import { IAddCellAction, ICellAction } from '../../../datascience-ui/interactive-common/redux/reducers/types';
+import { CssMessages, IGetCssRequest, IGetCssResponse, IGetMonacoThemeRequest, SharedMessages } from '../messages';
+import { IGetMonacoThemeResponse } from '../monacoMessages';
 import { ICell, IInteractiveWindowInfo, IJupyterVariable, IJupyterVariablesRequest, IJupyterVariablesResponse } from '../types';
 
 export enum InteractiveWindowMessages {
@@ -305,9 +306,9 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.SelectKernel]: IServerState | undefined;
     public [InteractiveWindowMessages.SelectJupyterServer]: never | undefined;
     public [InteractiveWindowMessages.Export]: ICell[];
-    public [InteractiveWindowMessages.GetAllCells]: ICell;
+    public [InteractiveWindowMessages.GetAllCells]: never | undefined;
     public [InteractiveWindowMessages.ReturnAllCells]: ICell[];
-    public [InteractiveWindowMessages.DeleteCell]: never | undefined;
+    public [InteractiveWindowMessages.DeleteCell]: ICellAction;
     public [InteractiveWindowMessages.DeleteAllCells]: IAddCellAction;
     public [InteractiveWindowMessages.Undo]: never | undefined;
     public [InteractiveWindowMessages.Redo]: never | undefined;
@@ -331,6 +332,7 @@ export class IInteractiveWindowMapping {
     public [CssMessages.GetCssRequest]: IGetCssRequest;
     public [CssMessages.GetCssResponse]: IGetCssResponse;
     public [CssMessages.GetMonacoThemeRequest]: IGetMonacoThemeRequest;
+    public [CssMessages.GetMonacoThemeResponse]: IGetMonacoThemeResponse;
     public [InteractiveWindowMessages.ProvideCompletionItemsRequest]: IProvideCompletionItemsRequest;
     public [InteractiveWindowMessages.CancelCompletionItemsRequest]: ICancelIntellisenseRequest;
     public [InteractiveWindowMessages.ProvideCompletionItemsResponse]: IProvideCompletionItemsResponse;
@@ -370,11 +372,14 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.VariablesComplete]: never | undefined;
     public [InteractiveWindowMessages.NotebookRunAllCells]: never | undefined;
     public [InteractiveWindowMessages.NotebookRunSelectedCell]: never | undefined;
-    public [InteractiveWindowMessages.NotebookAddCellBelow]: never | undefined;
+    public [InteractiveWindowMessages.NotebookAddCellBelow]: IAddCellAction;
+    public [InteractiveWindowMessages.DoSave]: never | undefined;
     public [InteractiveWindowMessages.ExecutionRendered]: IRenderComplete;
     public [InteractiveWindowMessages.FocusedCellEditor]: IFocusedCellEditor;
     public [InteractiveWindowMessages.UnfocusedCellEditor]: never | undefined;
     public [InteractiveWindowMessages.MonacoReady]: never | undefined;
     public [InteractiveWindowMessages.ClearAllOutputs]: never | undefined;
-    public [InteractiveWindowMessages.UpdateKernel]: IServerState | undefined;
+    public [InteractiveWindowMessages.UpdateKernel]: IServerState;
+    public [SharedMessages.UpdateSettings]: string;
+    public [SharedMessages.LocInit]: string;
 }

--- a/src/client/datascience/interactive-common/types.ts
+++ b/src/client/datascience/interactive-common/types.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// Stuff common to React and Extensions.
+
+// This forms the base content of every payload in all dispatchers.
+export type BaseReduxActionPayload = {
+    /**
+     * If this property exists, then this is an action that has been dispatched for the solve purpose of:
+     * 1. Synchronizing states across different editors (pointing to the same file).
+     * 2. Synchronizing states across different editors (pointing to the same file) in different sessions.
+     *
+     * @type {('syncEditors' | 'syncSessions')}
+     */
+    broadcastReason?: 'syncEditors' | 'syncSessions';
+};

--- a/src/client/datascience/interactive-common/types.ts
+++ b/src/client/datascience/interactive-common/types.ts
@@ -5,8 +5,7 @@
 
 // Stuff common to React and Extensions.
 
-// This forms the base content of every payload in all dispatchers.
-export type BaseReduxActionPayload = {
+type BaseData = {
     /**
      * If this property exists, then this is an action that has been dispatched for the solve purpose of:
      * 1. Synchronizing states across different editors (pointing to the same file).
@@ -15,4 +14,29 @@ export type BaseReduxActionPayload = {
      * @type {('syncEditors' | 'syncSessions')}
      */
     broadcastReason?: 'syncEditors' | 'syncSessions';
+    /**
+     * Tells us whether this message is incoming for reducer use or
+     * whether this is a message that needs to be sent out to extension (from reducer).
+     */
+    messageDirection?: 'incoming' | 'outgoing';
 };
+
+type BaseDataWithPayload<T> = {
+    /**
+     * If this property exists, then this is an action that has been dispatched for the solve purpose of:
+     * 1. Synchronizing states across different editors (pointing to the same file).
+     * 2. Synchronizing states across different editors (pointing to the same file) in different sessions.
+     *
+     * @type {('syncEditors' | 'syncSessions')}
+     */
+    broadcastReason?: 'syncEditors' | 'syncSessions';
+    /**
+     * Tells us whether this message is incoming for reducer use or
+     * whether this is a message that needs to be sent out to extension (from reducer).
+     */
+    messageDirection?: 'incoming' | 'outgoing';
+    data: T;
+};
+
+// This forms the base content of every payload in all dispatchers.
+export type BaseReduxActionPayload<T = never | undefined> = T extends never ? (T extends undefined ? BaseData : BaseDataWithPayload<T>) : BaseDataWithPayload<T>;

--- a/src/client/datascience/messages.ts
+++ b/src/client/datascience/messages.ts
@@ -2,18 +2,18 @@
 // Licensed under the MIT License.
 'use strict';
 
-export namespace CssMessages {
-    export const GetCssRequest = 'get_css_request';
-    export const GetCssResponse = 'get_css_response';
-    export const GetMonacoThemeRequest = 'get_monaco_theme_request';
-    export const GetMonacoThemeResponse = 'get_monaco_theme_response';
+export enum CssMessages {
+    GetCssRequest = 'get_css_request',
+    GetCssResponse = 'get_css_response',
+    GetMonacoThemeRequest = 'get_monaco_theme_request',
+    GetMonacoThemeResponse = 'get_monaco_theme_response'
 }
 
-export namespace SharedMessages {
-    export const UpdateSettings = 'update_settings';
-    export const Started = 'started';
-    export const LocInit = 'loc_init';
-    export const StyleUpdate = 'style_update';
+export enum SharedMessages {
+    UpdateSettings = 'update_settings',
+    Started = 'started',
+    LocInit = 'loc_init',
+    StyleUpdate = 'style_update'
 }
 
 export interface IGetCssRequest {

--- a/src/datascience-ui/data-explorer/mainPanel.tsx
+++ b/src/datascience-ui/data-explorer/mainPanel.tsx
@@ -94,7 +94,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         this.postOffice.addHandler(this);
 
         // Tell the dataviewer code we have started.
-        this.postOffice.sendMessage<IDataViewerMapping, 'started'>(DataViewerMessages.Started);
+        this.postOffice.sendMessage<IDataViewerMapping>(DataViewerMessages.Started);
     }
 
     public componentWillUnmount() {

--- a/src/datascience-ui/history-react/redux/actions.ts
+++ b/src/datascience-ui/history-react/redux/actions.ts
@@ -3,60 +3,57 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
-import { IRefreshVariablesRequest } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { InteractiveWindowMessages, IRefreshVariablesRequest } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterVariable, IJupyterVariablesRequest } from '../../../client/datascience/types';
 import {
     CommonAction,
     CommonActionType,
+    createIncomingAction,
+    createIncomingActionWithPayload,
     ICellAction,
     ICodeAction,
     ICodeCreatedAction,
     IEditCellAction,
     ILinkClickAction,
     IScrollAction,
-    IShowDataViewerAction,
-    IShowPlotAction
+    IShowDataViewerAction
 } from '../../interactive-common/redux/reducers/types';
 
 // See https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object
 export const actionCreators = {
-    refreshVariables: (newExecutionCount?: number): CommonAction<IRefreshVariablesRequest> => ({ type: CommonActionType.REFRESH_VARIABLES, payload: { newExecutionCount } }),
-    restartKernel: (): CommonAction<never | undefined> => ({ type: CommonActionType.RESTART_KERNEL }),
-    interruptKernel: (): CommonAction<never | undefined> => ({ type: CommonActionType.INTERRUPT_KERNEL }),
-    deleteAllCells: (): CommonAction<never | undefined> => ({ type: CommonActionType.DELETE_ALL_CELLS }),
-    deleteCell: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.DELETE_CELL, payload: { cellId } }),
-    undo: (): CommonAction<never | undefined> => ({ type: CommonActionType.UNDO }),
-    redo: (): CommonAction<never | undefined> => ({ type: CommonActionType.REDO }),
-    linkClick: (href: string): CommonAction<ILinkClickAction> => ({ type: CommonActionType.LINK_CLICK, payload: { href } }),
-    showPlot: (imageHtml: string): CommonAction<IShowPlotAction> => ({ type: CommonActionType.SHOW_PLOT, payload: { imageHtml } }),
-    toggleInputBlock: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.TOGGLE_INPUT_BLOCK, payload: { cellId } }),
-    gotoCell: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.GOTO_CELL, payload: { cellId } }),
-    copyCellCode: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.COPY_CELL_CODE, payload: { cellId } }),
-    gatherCell: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.GATHER_CELL, payload: { cellId } }),
-    clickCell: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.CLICK_CELL, payload: { cellId } }),
-    doubleClickCell: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.DOUBLE_CLICK_CELL, payload: { cellId } }),
-    editCell: (cellId: string, changes: monacoEditor.editor.IModelContentChange[], modelId: string, code: string): CommonAction<IEditCellAction> => ({
-        type: CommonActionType.EDIT_CELL,
-        payload: { cellId, changes, modelId, code }
-    }),
-    submitInput: (code: string, cellId: string): CommonAction<ICodeAction> => ({ type: CommonActionType.SUBMIT_INPUT, payload: { code, cellId } }),
-    toggleVariableExplorer: (): CommonAction<never | undefined> => ({ type: CommonActionType.TOGGLE_VARIABLE_EXPLORER }),
-    expandAll: (): CommonAction<never | undefined> => ({ type: CommonActionType.EXPAND_ALL }),
-    collapseAll: (): CommonAction<never | undefined> => ({ type: CommonActionType.COLLAPSE_ALL }),
-    export: (): CommonAction<never | undefined> => ({ type: CommonActionType.EXPORT }),
-    showDataViewer: (variable: IJupyterVariable, columnSize: number): CommonAction<IShowDataViewerAction> => ({
-        type: CommonActionType.SHOW_DATA_VIEWER,
-        payload: { variable, columnSize }
-    }),
-    editorLoaded: (): CommonAction<never | undefined> => ({ type: CommonActionType.EDITOR_LOADED }),
-    scroll: (isAtBottom: boolean): CommonAction<IScrollAction> => ({ type: CommonActionType.SCROLL, payload: { isAtBottom } }),
-    unfocus: (cellId: string | undefined): CommonAction<ICellAction> => ({ type: CommonActionType.UNFOCUS_CELL, payload: { cellId } }),
-    codeCreated: (cellId: string | undefined, modelId: string): CommonAction<ICodeCreatedAction> => ({ type: CommonActionType.CODE_CREATED, payload: { cellId, modelId } }),
-    editorUnmounted: (): CommonAction<never | undefined> => ({ type: CommonActionType.UNMOUNT }),
-    selectKernel: (): CommonAction<never | undefined> => ({ type: CommonActionType.SELECT_KERNEL }),
-    selectServer: (): CommonAction<never | undefined> => ({ type: CommonActionType.SELECT_SERVER }),
-    getVariableData: (newExecutionCount: number, startIndex: number = 0, pageSize: number = 100): CommonAction<IJupyterVariablesRequest> => ({
-        type: CommonActionType.GET_VARIABLE_DATA,
-        payload: { executionCount: newExecutionCount, sortColumn: 'name', sortAscending: true, startIndex, pageSize }
-    })
+    refreshVariables: (newExecutionCount?: number): CommonAction<IRefreshVariablesRequest> =>
+        createIncomingActionWithPayload(CommonActionType.REFRESH_VARIABLES, { newExecutionCount }),
+    restartKernel: (): CommonAction => createIncomingAction(CommonActionType.RESTART_KERNEL),
+    interruptKernel: (): CommonAction => createIncomingAction(CommonActionType.INTERRUPT_KERNEL),
+    deleteAllCells: (): CommonAction => createIncomingAction(InteractiveWindowMessages.DeleteAllCells),
+    deleteCell: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(InteractiveWindowMessages.DeleteCell, { cellId }),
+    undo: (): CommonAction => createIncomingAction(InteractiveWindowMessages.Undo),
+    redo: (): CommonAction => createIncomingAction(InteractiveWindowMessages.Redo),
+    linkClick: (href: string): CommonAction<ILinkClickAction> => createIncomingActionWithPayload(CommonActionType.LINK_CLICK, { href }),
+    showPlot: (imageHtml: string): CommonAction<string> => createIncomingActionWithPayload(InteractiveWindowMessages.ShowPlot, imageHtml),
+    toggleInputBlock: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.TOGGLE_INPUT_BLOCK, { cellId }),
+    gotoCell: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.GOTO_CELL, { cellId }),
+    copyCellCode: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.COPY_CELL_CODE, { cellId }),
+    gatherCell: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.GATHER_CELL, { cellId }),
+    clickCell: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.CLICK_CELL, { cellId }),
+    doubleClickCell: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.DOUBLE_CLICK_CELL, { cellId }),
+    editCell: (cellId: string, changes: monacoEditor.editor.IModelContentChange[], modelId: string, code: string): CommonAction<IEditCellAction> =>
+        createIncomingActionWithPayload(CommonActionType.EDIT_CELL, { cellId, changes, modelId, code }),
+    submitInput: (code: string, cellId: string): CommonAction<ICodeAction> => createIncomingActionWithPayload(CommonActionType.SUBMIT_INPUT, { code, cellId }),
+    toggleVariableExplorer: (): CommonAction => createIncomingAction(CommonActionType.TOGGLE_VARIABLE_EXPLORER),
+    expandAll: (): CommonAction => createIncomingAction(InteractiveWindowMessages.ExpandAll),
+    collapseAll: (): CommonAction => createIncomingAction(InteractiveWindowMessages.CollapseAll),
+    export: (): CommonAction => createIncomingAction(CommonActionType.EXPORT),
+    showDataViewer: (variable: IJupyterVariable, columnSize: number): CommonAction<IShowDataViewerAction> =>
+        createIncomingActionWithPayload(CommonActionType.SHOW_DATA_VIEWER, { variable, columnSize }),
+    editorLoaded: (): CommonAction => createIncomingAction(CommonActionType.EDITOR_LOADED),
+    scroll: (isAtBottom: boolean): CommonAction<IScrollAction> => createIncomingActionWithPayload(CommonActionType.SCROLL, { isAtBottom }),
+    unfocus: (cellId: string | undefined): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.UNFOCUS_CELL, { cellId }),
+    codeCreated: (cellId: string | undefined, modelId: string): CommonAction<ICodeCreatedAction> =>
+        createIncomingActionWithPayload(CommonActionType.CODE_CREATED, { cellId, modelId }),
+    editorUnmounted: (): CommonAction => createIncomingAction(CommonActionType.UNMOUNT),
+    selectKernel: (): CommonAction => createIncomingAction(InteractiveWindowMessages.SelectKernel),
+    selectServer: (): CommonAction => createIncomingAction(CommonActionType.SELECT_SERVER),
+    getVariableData: (newExecutionCount: number, startIndex: number = 0, pageSize: number = 100): CommonAction<IJupyterVariablesRequest> =>
+        createIncomingActionWithPayload(CommonActionType.GET_VARIABLE_DATA, { executionCount: newExecutionCount, sortColumn: 'name', sortAscending: true, startIndex, pageSize })
 };

--- a/src/datascience-ui/history-react/redux/mapping.ts
+++ b/src/datascience-ui/history-react/redux/mapping.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { IScrollToCell } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
 import { IGetCssResponse } from '../../../client/datascience/messages';
 import { IGetMonacoThemeResponse } from '../../../client/datascience/monacoMessages';
 import { ICell } from '../../../client/datascience/types';
@@ -16,23 +17,32 @@ import {
     ILinkClickAction,
     IScrollAction,
     IShowDataViewerAction,
-    IShowPlotAction
+    IShowPlotAction,
+    PrimitiveTypeInReduxActionPayload
 } from '../../interactive-common/redux/reducers/types';
 import { ReducerArg, ReducerFunc } from '../../react-common/reduxUtils';
 
-type InteractiveReducerFunc<T> = ReducerFunc<IMainState, CommonActionType, T>;
+type InteractiveReducerFunc<T = never | undefined> = T extends never | undefined
+    ? ReducerFunc<IMainState, CommonActionType, BaseReduxActionPayload>
+    : T extends PrimitiveTypeInReduxActionPayload
+    ? ReducerFunc<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
+    : ReducerFunc<IMainState, CommonActionType, T & BaseReduxActionPayload>;
 
-export type InteractiveReducerArg<T = never | undefined> = ReducerArg<IMainState, CommonActionType, T>;
+export type InteractiveReducerArg<T = never | undefined> = T extends never | undefined
+    ? ReducerArg<IMainState, CommonActionType, BaseReduxActionPayload>
+    : T extends PrimitiveTypeInReduxActionPayload
+    ? ReducerArg<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
+    : ReducerArg<IMainState, CommonActionType, T & BaseReduxActionPayload>;
 
 export class IInteractiveActionMapping {
-    public [CommonActionType.RESTART_KERNEL]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.SELECT_KERNEL]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.SELECT_SERVER]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.INTERRUPT_KERNEL]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.EXPORT]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.SAVE]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.UNDO]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.REDO]: InteractiveReducerFunc<never | undefined>;
+    public [CommonActionType.RESTART_KERNEL]: InteractiveReducerFunc;
+    public [CommonActionType.SELECT_KERNEL]: InteractiveReducerFunc;
+    public [CommonActionType.SELECT_SERVER]: InteractiveReducerFunc;
+    public [CommonActionType.INTERRUPT_KERNEL]: InteractiveReducerFunc;
+    public [CommonActionType.EXPORT]: InteractiveReducerFunc;
+    public [CommonActionType.SAVE]: InteractiveReducerFunc;
+    public [CommonActionType.UNDO]: InteractiveReducerFunc;
+    public [CommonActionType.REDO]: InteractiveReducerFunc;
     public [CommonActionType.SHOW_DATA_VIEWER]: InteractiveReducerFunc<IShowDataViewerAction>;
     public [CommonActionType.DELETE_CELL]: InteractiveReducerFunc<ICellAction>;
     public [CommonActionType.LINK_CLICK]: InteractiveReducerFunc<ILinkClickAction>;
@@ -44,32 +54,32 @@ export class IInteractiveActionMapping {
     public [CommonActionType.EDIT_CELL]: InteractiveReducerFunc<IEditCellAction>;
     public [CommonActionType.SUBMIT_INPUT]: InteractiveReducerFunc<ICodeAction>;
     public [CommonActionType.DELETE_ALL_CELLS]: InteractiveReducerFunc<IAddCellAction>;
-    public [CommonActionType.EXPAND_ALL]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.COLLAPSE_ALL]: InteractiveReducerFunc<never | undefined>;
-    public [CommonActionType.EDITOR_LOADED]: InteractiveReducerFunc<never | undefined>;
+    public [CommonActionType.EXPAND_ALL]: InteractiveReducerFunc;
+    public [CommonActionType.COLLAPSE_ALL]: InteractiveReducerFunc;
+    public [CommonActionType.EDITOR_LOADED]: InteractiveReducerFunc;
     public [CommonActionType.SCROLL]: InteractiveReducerFunc<IScrollAction>;
     public [CommonActionType.CLICK_CELL]: InteractiveReducerFunc<ICellAction>;
     public [CommonActionType.UNFOCUS_CELL]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.UNMOUNT]: InteractiveReducerFunc<never | undefined>;
+    public [CommonActionType.UNMOUNT]: InteractiveReducerFunc;
 
     // Messages from the extension
     public [IncomingMessageActions.STARTCELL]: InteractiveReducerFunc<ICell>;
     public [IncomingMessageActions.FINISHCELL]: InteractiveReducerFunc<ICell>;
     public [IncomingMessageActions.UPDATECELL]: InteractiveReducerFunc<ICell>;
-    public [IncomingMessageActions.ACTIVATE]: InteractiveReducerFunc<never | undefined>;
-    public [IncomingMessageActions.RESTARTKERNEL]: InteractiveReducerFunc<never | undefined>;
+    public [IncomingMessageActions.ACTIVATE]: InteractiveReducerFunc;
+    public [IncomingMessageActions.RESTARTKERNEL]: InteractiveReducerFunc;
     public [IncomingMessageActions.GETCSSRESPONSE]: InteractiveReducerFunc<IGetCssResponse>;
-    public [IncomingMessageActions.MONACOREADY]: InteractiveReducerFunc<never | undefined>;
+    public [IncomingMessageActions.MONACOREADY]: InteractiveReducerFunc;
     public [IncomingMessageActions.GETMONACOTHEMERESPONSE]: InteractiveReducerFunc<IGetMonacoThemeResponse>;
-    public [IncomingMessageActions.GETALLCELLS]: InteractiveReducerFunc<never | undefined>;
-    public [IncomingMessageActions.EXPANDALL]: InteractiveReducerFunc<never | undefined>;
-    public [IncomingMessageActions.COLLAPSEALL]: InteractiveReducerFunc<never | undefined>;
+    public [IncomingMessageActions.GETALLCELLS]: InteractiveReducerFunc;
+    public [IncomingMessageActions.EXPANDALL]: InteractiveReducerFunc;
+    public [IncomingMessageActions.COLLAPSEALL]: InteractiveReducerFunc;
     public [IncomingMessageActions.DELETEALLCELLS]: InteractiveReducerFunc<IAddCellAction>;
-    public [IncomingMessageActions.STARTPROGRESS]: InteractiveReducerFunc<never | undefined>;
-    public [IncomingMessageActions.STOPPROGRESS]: InteractiveReducerFunc<never | undefined>;
+    public [IncomingMessageActions.STARTPROGRESS]: InteractiveReducerFunc;
+    public [IncomingMessageActions.STOPPROGRESS]: InteractiveReducerFunc;
     public [IncomingMessageActions.UPDATESETTINGS]: InteractiveReducerFunc<string>;
-    public [IncomingMessageActions.STARTDEBUGGING]: InteractiveReducerFunc<never | undefined>;
-    public [IncomingMessageActions.STOPDEBUGGING]: InteractiveReducerFunc<never | undefined>;
+    public [IncomingMessageActions.STARTDEBUGGING]: InteractiveReducerFunc;
+    public [IncomingMessageActions.STOPDEBUGGING]: InteractiveReducerFunc;
     public [IncomingMessageActions.SCROLLTOCELL]: InteractiveReducerFunc<IScrollToCell>;
     public [IncomingMessageActions.UPDATEKERNEL]: InteractiveReducerFunc<IServerState>;
     public [IncomingMessageActions.LOCINIT]: InteractiveReducerFunc<string>;

--- a/src/datascience-ui/history-react/redux/mapping.ts
+++ b/src/datascience-ui/history-react/redux/mapping.ts
@@ -1,86 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import { IScrollToCell } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
-import { IGetCssResponse } from '../../../client/datascience/messages';
-import { IGetMonacoThemeResponse } from '../../../client/datascience/monacoMessages';
-import { ICell } from '../../../client/datascience/types';
-import { IMainState, IServerState } from '../../interactive-common/mainState';
-import { IncomingMessageActions } from '../../interactive-common/redux/postOffice';
-import {
-    CommonActionType,
-    IAddCellAction,
-    ICellAction,
-    ICodeAction,
-    IEditCellAction,
-    ILinkClickAction,
-    IScrollAction,
-    IShowDataViewerAction,
-    IShowPlotAction,
-    PrimitiveTypeInReduxActionPayload
-} from '../../interactive-common/redux/reducers/types';
+import { IMainState } from '../../interactive-common/mainState';
+import { CommonActionType, CommonActionTypeMapping } from '../../interactive-common/redux/reducers/types';
 import { ReducerArg, ReducerFunc } from '../../react-common/reduxUtils';
 
-type InteractiveReducerFunc<T = never | undefined> = T extends never | undefined
-    ? ReducerFunc<IMainState, CommonActionType, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerFunc<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
-    : ReducerFunc<IMainState, CommonActionType, T & BaseReduxActionPayload>;
+export type InteractiveReducerFunc<T = never | undefined> = ReducerFunc<IMainState, CommonActionType | InteractiveWindowMessages, BaseReduxActionPayload<T>>;
 
-export type InteractiveReducerArg<T = never | undefined> = T extends never | undefined
-    ? ReducerArg<IMainState, CommonActionType, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerArg<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
-    : ReducerArg<IMainState, CommonActionType, T & BaseReduxActionPayload>;
+export type InteractiveReducerArg<T = never | undefined> = ReducerArg<IMainState, CommonActionType | InteractiveWindowMessages, BaseReduxActionPayload<T>>;
 
-export class IInteractiveActionMapping {
-    public [CommonActionType.RESTART_KERNEL]: InteractiveReducerFunc;
-    public [CommonActionType.SELECT_KERNEL]: InteractiveReducerFunc;
-    public [CommonActionType.SELECT_SERVER]: InteractiveReducerFunc;
-    public [CommonActionType.INTERRUPT_KERNEL]: InteractiveReducerFunc;
-    public [CommonActionType.EXPORT]: InteractiveReducerFunc;
-    public [CommonActionType.SAVE]: InteractiveReducerFunc;
-    public [CommonActionType.UNDO]: InteractiveReducerFunc;
-    public [CommonActionType.REDO]: InteractiveReducerFunc;
-    public [CommonActionType.SHOW_DATA_VIEWER]: InteractiveReducerFunc<IShowDataViewerAction>;
-    public [CommonActionType.DELETE_CELL]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.LINK_CLICK]: InteractiveReducerFunc<ILinkClickAction>;
-    public [CommonActionType.SHOW_PLOT]: InteractiveReducerFunc<IShowPlotAction>;
-    public [CommonActionType.TOGGLE_INPUT_BLOCK]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.GOTO_CELL]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.COPY_CELL_CODE]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.GATHER_CELL]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.EDIT_CELL]: InteractiveReducerFunc<IEditCellAction>;
-    public [CommonActionType.SUBMIT_INPUT]: InteractiveReducerFunc<ICodeAction>;
-    public [CommonActionType.DELETE_ALL_CELLS]: InteractiveReducerFunc<IAddCellAction>;
-    public [CommonActionType.EXPAND_ALL]: InteractiveReducerFunc;
-    public [CommonActionType.COLLAPSE_ALL]: InteractiveReducerFunc;
-    public [CommonActionType.EDITOR_LOADED]: InteractiveReducerFunc;
-    public [CommonActionType.SCROLL]: InteractiveReducerFunc<IScrollAction>;
-    public [CommonActionType.CLICK_CELL]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.UNFOCUS_CELL]: InteractiveReducerFunc<ICellAction>;
-    public [CommonActionType.UNMOUNT]: InteractiveReducerFunc;
+type InteractiveWindowReducerFunctions<T> = {
+    [P in keyof T]: T[P] extends never | undefined ? InteractiveReducerFunc : InteractiveReducerFunc<T[P]>;
+};
 
-    // Messages from the extension
-    public [IncomingMessageActions.STARTCELL]: InteractiveReducerFunc<ICell>;
-    public [IncomingMessageActions.FINISHCELL]: InteractiveReducerFunc<ICell>;
-    public [IncomingMessageActions.UPDATECELL]: InteractiveReducerFunc<ICell>;
-    public [IncomingMessageActions.ACTIVATE]: InteractiveReducerFunc;
-    public [IncomingMessageActions.RESTARTKERNEL]: InteractiveReducerFunc;
-    public [IncomingMessageActions.GETCSSRESPONSE]: InteractiveReducerFunc<IGetCssResponse>;
-    public [IncomingMessageActions.MONACOREADY]: InteractiveReducerFunc;
-    public [IncomingMessageActions.GETMONACOTHEMERESPONSE]: InteractiveReducerFunc<IGetMonacoThemeResponse>;
-    public [IncomingMessageActions.GETALLCELLS]: InteractiveReducerFunc;
-    public [IncomingMessageActions.EXPANDALL]: InteractiveReducerFunc;
-    public [IncomingMessageActions.COLLAPSEALL]: InteractiveReducerFunc;
-    public [IncomingMessageActions.DELETEALLCELLS]: InteractiveReducerFunc<IAddCellAction>;
-    public [IncomingMessageActions.STARTPROGRESS]: InteractiveReducerFunc;
-    public [IncomingMessageActions.STOPPROGRESS]: InteractiveReducerFunc;
-    public [IncomingMessageActions.UPDATESETTINGS]: InteractiveReducerFunc<string>;
-    public [IncomingMessageActions.STARTDEBUGGING]: InteractiveReducerFunc;
-    public [IncomingMessageActions.STOPDEBUGGING]: InteractiveReducerFunc;
-    public [IncomingMessageActions.SCROLLTOCELL]: InteractiveReducerFunc<IScrollToCell>;
-    public [IncomingMessageActions.UPDATEKERNEL]: InteractiveReducerFunc<IServerState>;
-    public [IncomingMessageActions.LOCINIT]: InteractiveReducerFunc<string>;
-}
+export type IInteractiveActionMapping = InteractiveWindowReducerFunctions<IInteractiveWindowMapping> & InteractiveWindowReducerFunctions<CommonActionTypeMapping>;

--- a/src/datascience-ui/history-react/redux/reducers/creation.ts
+++ b/src/datascience-ui/history-react/redux/reducers/creation.ts
@@ -120,9 +120,7 @@ export namespace Creation {
         return {
             ...arg.prevState,
             cellVMs: [],
-            undoStack: Helpers.pushStack(arg.prevState.undoStack, arg.prevState.cellVMs),
-            selectedCellId: undefined,
-            focusedCellId: undefined
+            undoStack: Helpers.pushStack(arg.prevState.undoStack, arg.prevState.cellVMs)
         };
     }
 

--- a/src/datascience-ui/history-react/redux/reducers/creation.ts
+++ b/src/datascience-ui/history-react/redux/reducers/creation.ts
@@ -7,7 +7,7 @@ import { ICell, IDataScienceExtraSettings } from '../../../../client/datascience
 import { createCellVM, extractInputText, ICellViewModel, IMainState } from '../../../interactive-common/mainState';
 import { createPostableAction } from '../../../interactive-common/redux/postOffice';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
-import { ICellAction } from '../../../interactive-common/redux/reducers/types';
+import { IAddCellAction, ICellAction } from '../../../interactive-common/redux/reducers/types';
 import { InteractiveReducerArg } from '../mapping';
 
 export namespace Creation {
@@ -79,9 +79,9 @@ export namespace Creation {
     }
 
     export function startCell(arg: InteractiveReducerArg<ICell>): IMainState {
-        if (isCellSupported(arg.prevState, arg.payload)) {
+        if (isCellSupported(arg.prevState, arg.payload.data)) {
             const result = Helpers.updateOrAdd(arg, prepareCellVM);
-            if (result.cellVMs.length > arg.prevState.cellVMs.length && arg.payload.id !== Identifiers.EditCellId) {
+            if (result.cellVMs.length > arg.prevState.cellVMs.length && arg.payload.data.id !== Identifiers.EditCellId) {
                 const cellVM = result.cellVMs[result.cellVMs.length - 1];
 
                 // We're adding a new cell here. Tell the intellisense engine we have a new cell
@@ -100,20 +100,21 @@ export namespace Creation {
     }
 
     export function updateCell(arg: InteractiveReducerArg<ICell>): IMainState {
-        if (isCellSupported(arg.prevState, arg.payload)) {
+        if (isCellSupported(arg.prevState, arg.payload.data)) {
             return Helpers.updateOrAdd(arg, prepareCellVM);
         }
         return arg.prevState;
     }
 
     export function finishCell(arg: InteractiveReducerArg<ICell>): IMainState {
-        if (isCellSupported(arg.prevState, arg.payload)) {
+        if (isCellSupported(arg.prevState, arg.payload.data)) {
             return Helpers.updateOrAdd(arg, prepareCellVM);
         }
         return arg.prevState;
     }
 
-    export function deleteAllCells(arg: InteractiveReducerArg): IMainState {
+    export function deleteAllCells(arg: InteractiveReducerArg<IAddCellAction>): IMainState {
+        // TODO: In Native Editor, we create a new blank cell, don't we need that here?
         // Send messages to other side to indicate the deletes
         arg.queueAction(createPostableAction(InteractiveWindowMessages.DeleteAllCells));
 
@@ -127,11 +128,11 @@ export namespace Creation {
     }
 
     export function deleteCell(arg: InteractiveReducerArg<ICellAction>): IMainState {
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
-        if (index >= 0 && arg.payload.cellId) {
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
+        if (index >= 0 && arg.payload.data.cellId) {
             // Send messages to other side to indicate the delete
             arg.queueAction(createPostableAction(InteractiveWindowMessages.DeleteCell));
-            arg.queueAction(createPostableAction(InteractiveWindowMessages.RemoveCell, { id: arg.payload.cellId }));
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.RemoveCell, { id: arg.payload.data.cellId }));
 
             const newVMs = arg.prevState.cellVMs.filter((_c, i) => i !== index);
             return {

--- a/src/datascience-ui/history-react/redux/reducers/creation.ts
+++ b/src/datascience-ui/history-react/redux/reducers/creation.ts
@@ -114,7 +114,6 @@ export namespace Creation {
     }
 
     export function deleteAllCells(arg: InteractiveReducerArg<IAddCellAction>): IMainState {
-        // TODO: In Native Editor, we create a new blank cell, don't we need that here?
         // Send messages to other side to indicate the deletes
         arg.queueAction(createPostableAction(InteractiveWindowMessages.DeleteAllCells));
 

--- a/src/datascience-ui/history-react/redux/reducers/effects.ts
+++ b/src/datascience-ui/history-react/redux/reducers/effects.ts
@@ -52,7 +52,7 @@ export namespace Effects {
 
     export function updateSettings(arg: InteractiveReducerArg<string>): IMainState {
         // String arg should be the IDataScienceExtraSettings
-        const newSettingsJSON = JSON.parse(arg.payload);
+        const newSettingsJSON = JSON.parse(arg.payload.data);
         const newSettings = <IDataScienceExtraSettings>newSettingsJSON;
         const newEditorOptions = computeEditorOptions(newSettings);
         const newFontFamily = newSettings.extraSettings ? newSettings.extraSettings.fontFamily : arg.prevState.font.family;

--- a/src/datascience-ui/history-react/redux/reducers/effects.ts
+++ b/src/datascience-ui/history-react/redux/reducers/effects.ts
@@ -51,7 +51,6 @@ export namespace Effects {
     }
 
     export function updateSettings(arg: InteractiveReducerArg<string>): IMainState {
-        console.error(`Settings Message ${arg.payload}`);
         // String arg should be the IDataScienceExtraSettings
         const newSettingsJSON = JSON.parse(arg.payload.data);
         const newSettings = <IDataScienceExtraSettings>newSettingsJSON;

--- a/src/datascience-ui/history-react/redux/reducers/effects.ts
+++ b/src/datascience-ui/history-react/redux/reducers/effects.ts
@@ -37,9 +37,9 @@ export namespace Effects {
     }
 
     export function toggleInputBlock(arg: InteractiveReducerArg<ICellAction>): IMainState {
-        if (arg.payload.cellId) {
+        if (arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
-            const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+            const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
             const oldVM = arg.prevState.cellVMs[index];
             newVMs[index] = Creation.alterCellVM({ ...oldVM }, arg.prevState.settings, true, !oldVM.inputBlockOpen);
             return {
@@ -51,6 +51,7 @@ export namespace Effects {
     }
 
     export function updateSettings(arg: InteractiveReducerArg<string>): IMainState {
+        console.error(`Settings Message ${arg.payload}`);
         // String arg should be the IDataScienceExtraSettings
         const newSettingsJSON = JSON.parse(arg.payload.data);
         const newSettings = <IDataScienceExtraSettings>newSettingsJSON;
@@ -86,7 +87,7 @@ export namespace Effects {
 
     export function scrollToCell(arg: InteractiveReducerArg<IScrollToCell>): IMainState {
         // Up the scroll count on the necessary cell
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.id);
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.id);
         if (index >= 0) {
             const newVMs = [...arg.prevState.cellVMs];
 
@@ -105,12 +106,12 @@ export namespace Effects {
     export function scrolled(arg: InteractiveReducerArg<IScrollAction>): IMainState {
         return {
             ...arg.prevState,
-            isAtBottom: arg.payload.isAtBottom
+            isAtBottom: arg.payload.data.isAtBottom
         };
     }
 
     export function clickCell(arg: InteractiveReducerArg<ICellAction>): IMainState {
-        if (arg.payload.cellId === Identifiers.EditCellId && arg.prevState.editCellVM && !arg.prevState.editCellVM.focused) {
+        if (arg.payload.data.cellId === Identifiers.EditCellId && arg.prevState.editCellVM && !arg.prevState.editCellVM.focused) {
             return {
                 ...arg.prevState,
                 editCellVM: {
@@ -132,7 +133,7 @@ export namespace Effects {
     }
 
     export function unfocusCell(arg: InteractiveReducerArg<ICellAction>): IMainState {
-        if (arg.payload.cellId === Identifiers.EditCellId && arg.prevState.editCellVM && arg.prevState.editCellVM.focused) {
+        if (arg.payload.data.cellId === Identifiers.EditCellId && arg.prevState.editCellVM && arg.prevState.editCellVM.focused) {
             return {
                 ...arg.prevState,
                 editCellVM: {

--- a/src/datascience-ui/history-react/redux/reducers/execution.ts
+++ b/src/datascience-ui/history-react/redux/reducers/execution.ts
@@ -24,16 +24,13 @@ export namespace Execution {
             const cells = arg.prevState.undoStack[arg.prevState.undoStack.length - 1];
             const undoStack = arg.prevState.undoStack.slice(0, arg.prevState.undoStack.length - 1);
             const redoStack = Helpers.pushStack(arg.prevState.redoStack, arg.prevState.cellVMs);
-            const selected = cells.findIndex(c => c.selected);
             arg.queueAction(createPostableAction(InteractiveWindowMessages.Undo));
             return {
                 ...arg.prevState,
                 cellVMs: cells,
                 undoStack: undoStack,
                 redoStack: redoStack,
-                skipNextScroll: true,
-                selectedCellId: selected >= 0 ? cells[selected].cell.id : undefined,
-                focusedCellId: selected >= 0 && cells[selected].focused ? cells[selected].cell.id : undefined
+                skipNextScroll: true
             };
         }
 
@@ -46,16 +43,13 @@ export namespace Execution {
             const cells = arg.prevState.redoStack[arg.prevState.redoStack.length - 1];
             const redoStack = arg.prevState.redoStack.slice(0, arg.prevState.redoStack.length - 1);
             const undoStack = Helpers.pushStack(arg.prevState.undoStack, arg.prevState.cellVMs);
-            const selected = cells.findIndex(c => c.selected);
             arg.queueAction(createPostableAction(InteractiveWindowMessages.Redo));
             return {
                 ...arg.prevState,
                 cellVMs: cells,
                 undoStack: undoStack,
                 redoStack: redoStack,
-                skipNextScroll: true,
-                selectedCellId: selected >= 0 ? cells[selected].cell.id : undefined,
-                focusedCellId: selected >= 0 && cells[selected].focused ? cells[selected].cell.id : undefined
+                skipNextScroll: true
             };
         }
 

--- a/src/datascience-ui/history-react/redux/reducers/execution.ts
+++ b/src/datascience-ui/history-react/redux/reducers/execution.ts
@@ -79,16 +79,16 @@ export namespace Execution {
     export function submitInput(arg: InteractiveReducerArg<ICodeAction>): IMainState {
         // noop if the submitted code is just a cell marker
         const matcher = new CellMatcher(arg.prevState.settings);
-        if (matcher.stripFirstMarker(arg.payload.code).length > 0 && arg.prevState.editCellVM) {
+        if (matcher.stripFirstMarker(arg.payload.data.code).length > 0 && arg.prevState.editCellVM) {
             // This should be from the edit cell VM. Copy it and change the cell id
             let newCell = cloneDeep(arg.prevState.editCellVM);
 
             // Change this editable cell to not editable.
             newCell.cell.state = CellState.executing;
-            newCell.cell.data.source = arg.payload.code;
+            newCell.cell.data.source = arg.payload.data.code;
 
             // Change type to markdown if necessary
-            const split = arg.payload.code.splitLines({ trim: false });
+            const split = arg.payload.data.code.splitLines({ trim: false });
             const firstLine = split[0];
             if (matcher.isMarkdown(firstLine)) {
                 newCell.cell.data = createCellFrom(newCell.cell.data, 'markdown');
@@ -113,7 +113,7 @@ export namespace Execution {
 
             // Send a message to execute this code if necessary.
             if (newCell.cell.state !== CellState.finished) {
-                arg.queueAction(createPostableAction(InteractiveWindowMessages.SubmitNewCell, { code: arg.payload.code, id: newCell.cell.id }));
+                arg.queueAction(createPostableAction(InteractiveWindowMessages.SubmitNewCell, { code: arg.payload.data.code, id: newCell.cell.id }));
             }
 
             // Stick in a new cell at the bottom that's editable and update our state

--- a/src/datascience-ui/history-react/redux/reducers/index.ts
+++ b/src/datascience-ui/history-react/redux/reducers/index.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import { IncomingMessageActions } from '../../../interactive-common/redux/postOffice';
+import { InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { CssMessages, SharedMessages } from '../../../../client/datascience/messages';
 import { CommonEffects } from '../../../interactive-common/redux/reducers/commonEffects';
 import { Kernel } from '../../../interactive-common/redux/reducers/kernel';
 import { Transfer } from '../../../interactive-common/redux/reducers/transfer';
@@ -12,19 +13,17 @@ import { Effects } from './effects';
 import { Execution } from './execution';
 
 // The list of reducers. 1 per message/action.
-export const reducerMap: IInteractiveActionMapping = {
+export const reducerMap: Partial<IInteractiveActionMapping> = {
     // State updates
     [CommonActionType.RESTART_KERNEL]: Kernel.restartKernel,
     [CommonActionType.INTERRUPT_KERNEL]: Kernel.interruptKernel,
-    [CommonActionType.SELECT_KERNEL]: Kernel.selectKernel,
+    [InteractiveWindowMessages.SelectKernel]: Kernel.selectKernel,
     [CommonActionType.SELECT_SERVER]: Kernel.selectJupyterURI,
     [CommonActionType.EXPORT]: Transfer.exportCells,
     [CommonActionType.SAVE]: Transfer.save,
     [CommonActionType.SHOW_DATA_VIEWER]: Transfer.showDataViewer,
-    [CommonActionType.DELETE_CELL]: Creation.deleteCell,
-    [CommonActionType.UNDO]: Execution.undo,
-    [CommonActionType.REDO]: Execution.redo,
-    [CommonActionType.SHOW_PLOT]: Transfer.showPlot,
+    [InteractiveWindowMessages.DeleteCell]: Creation.deleteCell,
+    [InteractiveWindowMessages.ShowPlot]: Transfer.showPlot,
     [CommonActionType.LINK_CLICK]: Transfer.linkClick,
     [CommonActionType.GOTO_CELL]: Transfer.gotoCell,
     [CommonActionType.TOGGLE_INPUT_BLOCK]: Effects.toggleInputBlock,
@@ -32,9 +31,7 @@ export const reducerMap: IInteractiveActionMapping = {
     [CommonActionType.GATHER_CELL]: Transfer.gather,
     [CommonActionType.EDIT_CELL]: Transfer.editCell,
     [CommonActionType.SUBMIT_INPUT]: Execution.submitInput,
-    [CommonActionType.DELETE_ALL_CELLS]: Creation.deleteAllCells,
-    [CommonActionType.EXPAND_ALL]: Effects.expandAll,
-    [CommonActionType.COLLAPSE_ALL]: Effects.collapseAll,
+    [InteractiveWindowMessages.ExpandAll]: Effects.expandAll,
     [CommonActionType.EDITOR_LOADED]: Transfer.started,
     [CommonActionType.SCROLL]: Effects.scrolled,
     [CommonActionType.CLICK_CELL]: Effects.clickCell,
@@ -42,24 +39,24 @@ export const reducerMap: IInteractiveActionMapping = {
     [CommonActionType.UNMOUNT]: Creation.unmount,
 
     // Messages from the webview (some are ignored)
-    [IncomingMessageActions.STARTCELL]: Creation.startCell,
-    [IncomingMessageActions.FINISHCELL]: Creation.finishCell,
-    [IncomingMessageActions.UPDATECELL]: Creation.updateCell,
-    [IncomingMessageActions.ACTIVATE]: CommonEffects.activate,
-    [IncomingMessageActions.RESTARTKERNEL]: Kernel.handleRestarted,
-    [IncomingMessageActions.GETCSSRESPONSE]: CommonEffects.handleCss,
-    [IncomingMessageActions.MONACOREADY]: CommonEffects.monacoReady,
-    [IncomingMessageActions.GETMONACOTHEMERESPONSE]: CommonEffects.monacoThemeChange,
-    [IncomingMessageActions.GETALLCELLS]: Transfer.getAllCells,
-    [IncomingMessageActions.EXPANDALL]: Effects.expandAll,
-    [IncomingMessageActions.COLLAPSEALL]: Effects.collapseAll,
-    [IncomingMessageActions.DELETEALLCELLS]: Creation.deleteAllCells,
-    [IncomingMessageActions.STARTPROGRESS]: CommonEffects.startProgress,
-    [IncomingMessageActions.STOPPROGRESS]: CommonEffects.stopProgress,
-    [IncomingMessageActions.UPDATESETTINGS]: Effects.updateSettings,
-    [IncomingMessageActions.STARTDEBUGGING]: Execution.startDebugging,
-    [IncomingMessageActions.STOPDEBUGGING]: Execution.stopDebugging,
-    [IncomingMessageActions.SCROLLTOCELL]: Effects.scrollToCell,
-    [IncomingMessageActions.UPDATEKERNEL]: Kernel.updateStatus,
-    [IncomingMessageActions.LOCINIT]: CommonEffects.handleLocInit
+    [InteractiveWindowMessages.StartCell]: Creation.startCell,
+    [InteractiveWindowMessages.FinishCell]: Creation.finishCell,
+    [InteractiveWindowMessages.UpdateCell]: Creation.updateCell,
+    [InteractiveWindowMessages.Activate]: CommonEffects.activate,
+    [InteractiveWindowMessages.RestartKernel]: Kernel.handleRestarted,
+    [CssMessages.GetCssResponse]: CommonEffects.handleCss,
+    [InteractiveWindowMessages.MonacoReady]: CommonEffects.monacoReady,
+    [CssMessages.GetMonacoThemeResponse]: CommonEffects.monacoThemeChange,
+    [InteractiveWindowMessages.GetAllCells]: Transfer.getAllCells,
+    [InteractiveWindowMessages.ExpandAll]: Effects.expandAll,
+    [InteractiveWindowMessages.CollapseAll]: Effects.collapseAll,
+    [InteractiveWindowMessages.DeleteAllCells]: Creation.deleteAllCells,
+    [InteractiveWindowMessages.StartProgress]: CommonEffects.startProgress,
+    [InteractiveWindowMessages.StopProgress]: CommonEffects.stopProgress,
+    [SharedMessages.UpdateSettings]: Effects.updateSettings,
+    [InteractiveWindowMessages.StartDebugging]: Execution.startDebugging,
+    [InteractiveWindowMessages.StopDebugging]: Execution.stopDebugging,
+    [InteractiveWindowMessages.ScrollToCell]: Effects.scrollToCell,
+    [InteractiveWindowMessages.UpdateKernel]: Kernel.updateStatus,
+    [SharedMessages.LocInit]: CommonEffects.handleLocInit
 };

--- a/src/datascience-ui/history-react/redux/reducers/index.ts
+++ b/src/datascience-ui/history-react/redux/reducers/index.ts
@@ -39,6 +39,8 @@ export const reducerMap: Partial<IInteractiveActionMapping> = {
     [CommonActionType.UNMOUNT]: Creation.unmount,
 
     // Messages from the webview (some are ignored)
+    [InteractiveWindowMessages.Undo]: Execution.undo,
+    [InteractiveWindowMessages.Redo]: Execution.redo,
     [InteractiveWindowMessages.StartCell]: Creation.startCell,
     [InteractiveWindowMessages.FinishCell]: Creation.finishCell,
     [InteractiveWindowMessages.UpdateCell]: Creation.updateCell,

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -60,8 +60,6 @@ export type IMainState = {
     currentExecutionCount: number;
     debugging: boolean;
     dirty?: boolean;
-    selectedCellId?: string;
-    focusedCellId?: string;
     isAtBottom: boolean;
     newCellId?: string;
     loadTotal?: number;
@@ -74,6 +72,29 @@ export type IMainState = {
     loaded: boolean;
     kernel: IServerState;
 };
+
+/**
+ * Returns the cell id and index of selected and focused cells.
+ */
+export function getSelectedAndFocusedInfo(state: IMainState) {
+    const info: { selectedCellId?: string; selectedCellIndex?: number; focusedCellId?: string; focusedCellIndex?: number } = {};
+    for (let index = 0; index < state.cellVMs.length; index += 1) {
+        const cell = state.cellVMs[index];
+        if (cell.selected) {
+            info.selectedCellId = cell.cell.id;
+            info.selectedCellIndex = index;
+        }
+        if (cell.focused) {
+            info.focusedCellId = cell.cell.id;
+            info.focusedCellIndex = index;
+        }
+        if (info.selectedCellId && info.focusedCellId) {
+            break;
+        }
+    }
+
+    return info;
+}
 
 export interface IFont {
     size: number;

--- a/src/datascience-ui/interactive-common/redux/postOffice.ts
+++ b/src/datascience-ui/interactive-common/redux/postOffice.ts
@@ -7,6 +7,7 @@ import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../c
 import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
 import { CssMessages, SharedMessages } from '../../../client/datascience/messages';
 import { PostOffice } from '../../react-common/postOffice';
+import { CommonActionType } from './reducers/types';
 
 export const AllowedMessages = [...Object.values(InteractiveWindowMessages), ...Object.values(CssMessages), ...Object.values(SharedMessages)];
 
@@ -17,19 +18,22 @@ export function createPostableAction<M extends IInteractiveWindowMapping, T exte
         messageDirection: 'outgoing'
         // tslint:disable-next-line: no-any
     } as any) as BaseReduxActionPayload<M[T]>;
-    return { type: `${message}`, payload: newPayload };
+    return { type: CommonActionType.PostOutgoingMessage, payload: { payload: newPayload, type: message } };
 }
 
 export function generatePostOfficeSendReducer(postOffice: PostOffice): Redux.Reducer<{}, Redux.AnyAction> {
     // tslint:disable-next-line: no-function-expression
     return function(_state: {} | undefined, action: Redux.AnyAction): {} {
         // Make sure a valid message
-        // tslint:disable-next-line: no-any
-        const payload: BaseReduxActionPayload<{}> | undefined = action.payload;
-        if (AllowedMessages.find(k => k === action.type) && payload?.messageDirection === 'outgoing') {
-            // Just post this to the post office.
-            // tslint:disable-next-line: no-any
-            postOffice.sendMessage<IInteractiveWindowMapping>(action.type, payload.data as any);
+        if (action.type === CommonActionType.PostOutgoingMessage) {
+            // Unwrap the payload that was created in `createPostableAction`.
+            const type = action.payload.type;
+            const payload: BaseReduxActionPayload<{}> | undefined = action.payload.payload;
+            if (AllowedMessages.find(k => k === type) && payload?.messageDirection === 'outgoing') {
+                // Just post this to the post office.
+                // tslint:disable-next-line: no-any
+                postOffice.sendMessage<IInteractiveWindowMapping>(type, payload.data as any);
+            }
         }
 
         // We don't modify the state.

--- a/src/datascience-ui/interactive-common/redux/postOffice.ts
+++ b/src/datascience-ui/interactive-common/redux/postOffice.ts
@@ -4,113 +4,32 @@
 import * as Redux from 'redux';
 
 import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
 import { CssMessages, SharedMessages } from '../../../client/datascience/messages';
 import { PostOffice } from '../../react-common/postOffice';
-
-// Action types for Incoming messages. Basically all possible messages prefixed with the word 'action'
-// This allows us to have a reducer for an incoming message and a separate reducer for an outgoing message.
-// Note: Couldn't figure out a way to just generate this from the keys of the InteractiveWindowMessages.
-// String literals can't come from a concat of another
-export enum IncomingMessageActions {
-    // tslint:disable-next-line: prefer-template
-    STARTCELL = 'action.start_cell',
-    FINISHCELL = 'action.finish_cell',
-    UPDATECELL = 'action.update_cell',
-    GOTOCODECELL = 'action.gotocell_code',
-    COPYCODECELL = 'action.copycell_code',
-    RESTARTKERNEL = 'action.restart_kernel',
-    EXPORT = 'action.export_to_ipynb',
-    GETALLCELLS = 'action.get_all_cells',
-    RETURNALLCELLS = 'action.return_all_cells',
-    DELETECELL = 'action.delete_cell',
-    DELETEALLCELLS = 'action.delete_all_cells',
-    UNDO = 'action.undo',
-    REDO = 'action.redo',
-    EXPANDALL = 'action.expand_all',
-    COLLAPSEALL = 'action.collapse_all',
-    STARTPROGRESS = 'action.start_progress',
-    STOPPROGRESS = 'action.stop_progress',
-    INTERRUPT = 'action.interrupt',
-    SUBMITNEWCELL = 'action.submit_new_cell',
-    UPDATESETTINGS = 'action.update_settings',
-    DOSAVE = 'action.DoSave',
-    SENDINFO = 'action.send_info',
-    STARTED = 'action.started',
-    ADDEDSYSINFO = 'action.added_sys_info',
-    REMOTEADDCODE = 'action.remote_add_code',
-    REMOTEREEXECUTECODE = 'action.remote_reexecute_code',
-    ACTIVATE = 'action.activate',
-    SHOWDATAVIEWER = 'action.show_data_explorer',
-    GETVARIABLESREQUEST = 'ACTION.GET_VARIABLES_REQUEST',
-    GETVARIABLESRESPONSE = 'action.get_variables_response',
-    GETVARIABLEVALUEREQUEST = 'action.get_variable_value_request',
-    GETVARIABLEVALUERESPONSE = 'action.get_variable_value_response',
-    VARIABLEEXPLORERTOGGLE = 'action.variable_explorer_toggle',
-    PROVIDECOMPLETIONITEMSREQUEST = 'action.provide_completion_items_request',
-    CANCELCOMPLETIONITEMSREQUEST = 'action.cancel_completion_items_request',
-    PROVIDECOMPLETIONITEMSRESPONSE = 'action.provide_completion_items_response',
-    PROVIDEHOVERREQUEST = 'action.provide_hover_request',
-    CANCELHOVERREQUEST = 'action.cancel_hover_request',
-    PROVIDEHOVERRESPONSE = 'action.provide_hover_response',
-    PROVIDESIGNATUREHELPREQUEST = 'action.provide_signature_help_request',
-    CANCELSIGNATUREHELPREQUEST = 'action.cancel_signature_help_request',
-    PROVIDESIGNATUREHELPRESPONSE = 'action.provide_signature_help_response',
-    RESOLVECOMPLETIONITEMREQUEST = 'action.resolve_completion_item_request',
-    CANCELRESOLVECOMPLETIONITEMREQUEST = 'action.cancel_completion_items_request',
-    RESOLVECOMPLETIONITEMRESPONSE = 'action.resolve_completion_item_response',
-    ADDCELL = 'action.add_cell',
-    EDITCELL = 'action.edit_cell',
-    REMOVECELL = 'action.remove_cell',
-    SWAPCELLS = 'action.swap_cells',
-    INSERTCELL = 'action.insert_cell',
-    LOADONIGASMASSEMBLYREQUEST = 'action.load_onigasm_assembly_request',
-    LOADONIGASMASSEMBLYRESPONSE = 'action.load_onigasm_assembly_response',
-    LOADTMLANGUAGEREQUEST = 'action.load_tmlanguage_request',
-    LOADTMLANGUAGERESPONSE = 'action.load_tmlanguage_response',
-    OPENLINK = 'action.open_link',
-    SHOWPLOT = 'action.show_plot',
-    STARTDEBUGGING = 'action.start_debugging',
-    STOPDEBUGGING = 'action.stop_debugging',
-    GATHERCODE = 'action.gather_code',
-    LOADALLCELLS = 'action.load_all_cells',
-    LOADALLCELLSCOMPLETE = 'action.load_all_cells_complete',
-    SCROLLTOCELL = 'action.scroll_to_cell',
-    REEXECUTECELL = 'action.reexecute_cell',
-    NOTEBOOKIDENTITY = 'action.identity',
-    NOTEBOOKDIRTY = 'action.dirty',
-    NOTEBOOKCLEAN = 'action.clean',
-    SAVEALL = 'action.save_all',
-    NATIVECOMMAND = 'action.native_command',
-    VARIABLESCOMPLETE = 'action.variables_complete',
-    NOTEBOOKRUNALLCELLS = 'action.notebook_run_all_cells',
-    NOTEBOOKRUNSELECTEDCELL = 'action.notebook_run_selected_cell',
-    NOTEBOOKADDCELLBELOW = 'action.notebook_add_cell_below',
-    RENDERCOMPLETE = 'action.finished_rendering_cells',
-    FOCUSEDCELLEDITOR = 'action.focused_cell_editor',
-    MONACOREADY = 'action.monaco_ready',
-    GETCSSREQUEST = 'action.get_css_request',
-    GETCSSRESPONSE = 'action.get_css_response',
-    GETMONACOTHEMEREQUEST = 'action.get_monaco_theme_request',
-    GETMONACOTHEMERESPONSE = 'action.get_monaco_theme_response',
-    UPDATEKERNEL = 'action.update_kernel',
-    LOCINIT = 'action.loc_init'
-}
 
 export const AllowedMessages = [...Object.values(InteractiveWindowMessages), ...Object.values(CssMessages), ...Object.values(SharedMessages)];
 
 // Actions created from messages
 export function createPostableAction<M extends IInteractiveWindowMapping, T extends keyof M = keyof M>(message: T, payload?: M[T]): Redux.AnyAction {
-    return { type: `${message}`, payload };
+    const newPayload: BaseReduxActionPayload<M[T]> = ({
+        data: payload,
+        messageDirection: 'outgoing'
+        // tslint:disable-next-line: no-any
+    } as any) as BaseReduxActionPayload<M[T]>;
+    return { type: `${message}`, payload: newPayload };
 }
 
 export function generatePostOfficeSendReducer(postOffice: PostOffice): Redux.Reducer<{}, Redux.AnyAction> {
     // tslint:disable-next-line: no-function-expression
     return function(_state: {} | undefined, action: Redux.AnyAction): {} {
         // Make sure a valid message
-        if (AllowedMessages.find(k => k === action.type)) {
+        // tslint:disable-next-line: no-any
+        const payload: BaseReduxActionPayload<{}> | undefined = action.payload;
+        if (AllowedMessages.find(k => k === action.type) && payload?.messageDirection === 'outgoing') {
             // Just post this to the post office.
             // tslint:disable-next-line: no-any
-            postOffice.sendMessage<IInteractiveWindowMapping>(action.type, action.payload);
+            postOffice.sendMessage<IInteractiveWindowMapping>(action.type, payload.data as any);
         }
 
         // We don't modify the state.

--- a/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
@@ -47,7 +47,6 @@ export namespace CommonEffects {
 
     export function handleLocInit(arg: CommonReducerArg<CommonActionType, string>): IMainState {
         // Read in the loc strings
-        console.error(arg.payload);
         const locJSON = JSON.parse(arg.payload.data);
         storeLocStrings(locJSON);
         return arg.prevState;

--- a/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
@@ -47,7 +47,7 @@ export namespace CommonEffects {
 
     export function handleLocInit<T>(arg: CommonReducerArg<T, string>): IMainState {
         // Read in the loc strings
-        const locJSON = JSON.parse(arg.payload);
+        const locJSON = JSON.parse(arg.payload.data);
         storeLocStrings(locJSON);
         return arg.prevState;
     }

--- a/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/commonEffects.ts
@@ -7,52 +7,53 @@ import { IGetMonacoThemeResponse } from '../../../../client/datascience/monacoMe
 import { IMainState } from '../../../interactive-common/mainState';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { storeLocStrings } from '../../../react-common/locReactSide';
-import { CommonReducerArg } from './types';
+import { CommonActionType, CommonReducerArg } from './types';
 
 export namespace CommonEffects {
-    export function notebookDirty<T>(arg: CommonReducerArg<T>): IMainState {
+    export function notebookDirty(arg: CommonReducerArg): IMainState {
         return {
             ...arg.prevState,
             dirty: true
         };
     }
 
-    export function notebookClean<T>(arg: CommonReducerArg<T>): IMainState {
+    export function notebookClean(arg: CommonReducerArg): IMainState {
         return {
             ...arg.prevState,
             dirty: false
         };
     }
 
-    export function startProgress<T>(arg: CommonReducerArg<T>): IMainState {
+    export function startProgress(arg: CommonReducerArg): IMainState {
         return {
             ...arg.prevState,
             busy: true
         };
     }
 
-    export function stopProgress<T>(arg: CommonReducerArg<T>): IMainState {
+    export function stopProgress(arg: CommonReducerArg): IMainState {
         return {
             ...arg.prevState,
             busy: false
         };
     }
 
-    export function activate<T>(arg: CommonReducerArg<T>): IMainState {
+    export function activate(arg: CommonReducerArg): IMainState {
         return {
             ...arg.prevState,
             activateCount: arg.prevState.activateCount + 1
         };
     }
 
-    export function handleLocInit<T>(arg: CommonReducerArg<T, string>): IMainState {
+    export function handleLocInit(arg: CommonReducerArg<CommonActionType, string>): IMainState {
         // Read in the loc strings
+        console.error(arg.payload);
         const locJSON = JSON.parse(arg.payload.data);
         storeLocStrings(locJSON);
         return arg.prevState;
     }
 
-    export function handleCss<T>(arg: CommonReducerArg<T, IGetCssResponse>): IMainState {
+    export function handleCss(arg: CommonReducerArg<CommonActionType, IGetCssResponse>): IMainState {
         // Recompute our known dark value from the class name in the body
         // VS code should update this dynamically when the theme changes
         const computedKnownDark = Helpers.computeKnownDark(arg.prevState.settings);
@@ -66,27 +67,27 @@ export namespace CommonEffects {
         let fontFamily: string = "Consolas, 'Courier New', monospace";
         const sizeSetting = '--code-font-size: ';
         const familySetting = '--code-font-family: ';
-        const fontSizeIndex = arg.payload.css.indexOf(sizeSetting);
-        const fontFamilyIndex = arg.payload.css.indexOf(familySetting);
+        const fontSizeIndex = arg.payload.data.css.indexOf(sizeSetting);
+        const fontFamilyIndex = arg.payload.data.css.indexOf(familySetting);
 
         if (fontSizeIndex > -1) {
-            const fontSizeEndIndex = arg.payload.css.indexOf('px;', fontSizeIndex + sizeSetting.length);
-            fontSize = parseInt(arg.payload.css.substring(fontSizeIndex + sizeSetting.length, fontSizeEndIndex), 10);
+            const fontSizeEndIndex = arg.payload.data.css.indexOf('px;', fontSizeIndex + sizeSetting.length);
+            fontSize = parseInt(arg.payload.data.css.substring(fontSizeIndex + sizeSetting.length, fontSizeEndIndex), 10);
         }
 
         if (fontFamilyIndex > -1) {
-            const fontFamilyEndIndex = arg.payload.css.indexOf(';', fontFamilyIndex + familySetting.length);
-            fontFamily = arg.payload.css.substring(fontFamilyIndex + familySetting.length, fontFamilyEndIndex);
+            const fontFamilyEndIndex = arg.payload.data.css.indexOf(';', fontFamilyIndex + familySetting.length);
+            fontFamily = arg.payload.data.css.substring(fontFamilyIndex + familySetting.length, fontFamilyEndIndex);
         }
 
         return {
             ...arg.prevState,
-            rootCss: arg.payload.css,
+            rootCss: arg.payload.data.css,
             font: {
                 size: fontSize,
                 family: fontFamily
             },
-            vscodeThemeName: arg.payload.theme,
+            vscodeThemeName: arg.payload.data.theme,
             knownDark: computedKnownDark,
             baseTheme: newBaseTheme
         };

--- a/src/datascience-ui/interactive-common/redux/reducers/helpers.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/helpers.ts
@@ -9,7 +9,7 @@ import { ICell, IDataScienceExtraSettings } from '../../../../client/datascience
 import { arePathsSame } from '../../../react-common/arePathsSame';
 import { detectBaseTheme } from '../../../react-common/themeDetector';
 import { ICellViewModel, IMainState } from '../../mainState';
-import { CommonReducerArg } from './types';
+import { CommonActionType, CommonReducerArg } from './types';
 
 const StackLimit = 10;
 
@@ -44,14 +44,14 @@ export namespace Helpers {
         return cvm as ICellViewModel;
     }
 
-    export function updateOrAdd<T>(arg: CommonReducerArg<T, ICell>, generateVM: (cell: ICell, mainState: IMainState) => ICellViewModel): IMainState {
+    export function updateOrAdd(arg: CommonReducerArg<CommonActionType, ICell>, generateVM: (cell: ICell, mainState: IMainState) => ICellViewModel): IMainState {
         // First compute new execution count.
-        const newExecutionCount = arg.payload.data.execution_count
-            ? Math.max(arg.prevState.currentExecutionCount, parseInt(arg.payload.data.execution_count.toString(), 10))
+        const newExecutionCount = arg.payload.data.data.execution_count
+            ? Math.max(arg.prevState.currentExecutionCount, parseInt(arg.payload.data.data.execution_count.toString(), 10))
             : arg.prevState.currentExecutionCount;
 
         const index = arg.prevState.cellVMs.findIndex((c: ICellViewModel) => {
-            return c.cell.id === arg.payload.id && c.cell.line === arg.payload.line && arePathsSame(c.cell.file, arg.payload.file);
+            return c.cell.id === arg.payload.data.id && c.cell.line === arg.payload.data.line && arePathsSame(c.cell.file, arg.payload.data.file);
         });
         if (index >= 0) {
             // This means the cell existed already so it was actual executed code.
@@ -71,9 +71,9 @@ export namespace Helpers {
                 ...newVMs[index],
                 cell: {
                     ...newVMs[index].cell,
-                    state: arg.payload.state,
+                    state: arg.payload.data.state,
                     data: {
-                        ...arg.payload.data,
+                        ...arg.payload.data.data,
                         source: newVMs[index].cell.data.source
                     }
                 }
@@ -87,7 +87,7 @@ export namespace Helpers {
             };
         } else {
             // This is an entirely new cell (it may have started out as finished)
-            const newVM = generateVM(arg.payload, arg.prevState);
+            const newVM = generateVM(arg.payload.data, arg.prevState);
             const newVMs = [...arg.prevState.cellVMs, newVM];
             return {
                 ...arg.prevState,

--- a/src/datascience-ui/interactive-common/redux/reducers/kernel.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/kernel.ts
@@ -5,20 +5,21 @@ import { InteractiveWindowMessages } from '../../../../client/datascience/intera
 import { CellState } from '../../../../client/datascience/types';
 import { IMainState, IServerState } from '../../mainState';
 import { createPostableAction } from '../postOffice';
-import { CommonReducerArg } from './types';
+import { CommonActionType, CommonReducerArg } from './types';
 
 export namespace Kernel {
-    export function selectKernel<T>(arg: CommonReducerArg<T>): IMainState {
+    // tslint:disable-next-line: no-any
+    export function selectKernel(arg: CommonReducerArg<CommonActionType | InteractiveWindowMessages, IServerState | undefined>): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.SelectKernel));
 
         return arg.prevState;
     }
-    export function selectJupyterURI<T>(arg: CommonReducerArg<T>): IMainState {
+    export function selectJupyterURI(arg: CommonReducerArg): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.SelectJupyterServer));
 
         return arg.prevState;
     }
-    export function restartKernel<T>(arg: CommonReducerArg<T>): IMainState {
+    export function restartKernel(arg: CommonReducerArg): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.RestartKernel));
 
         // Set busy until kernel is restarted
@@ -28,7 +29,7 @@ export namespace Kernel {
         };
     }
 
-    export function interruptKernel<T>(arg: CommonReducerArg<T>): IMainState {
+    export function interruptKernel(arg: CommonReducerArg): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.Interrupt));
 
         // Set busy until kernel is finished interrupting
@@ -38,13 +39,13 @@ export namespace Kernel {
         };
     }
 
-    export function updateStatus<T>(arg: CommonReducerArg<T, IServerState>): IMainState {
+    export function updateStatus(arg: CommonReducerArg<CommonActionType | InteractiveWindowMessages, IServerState>): IMainState {
         return {
             ...arg.prevState,
             kernel: {
-                localizedUri: arg.payload.localizedUri,
-                jupyterServerStatus: arg.payload.jupyterServerStatus,
-                displayName: arg.payload.displayName
+                localizedUri: arg.payload.data.localizedUri,
+                jupyterServerStatus: arg.payload.data.jupyterServerStatus,
+                displayName: arg.payload.data.displayName
             }
         };
     }

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -6,11 +6,11 @@ import { CssMessages } from '../../../../client/datascience/messages';
 import { extractInputText, IMainState } from '../../mainState';
 import { createPostableAction } from '../postOffice';
 import { Helpers } from './helpers';
-import { CommonReducerArg, ICellAction, IEditCellAction, ILinkClickAction, ISendCommandAction, IShowDataViewerAction, IShowPlotAction } from './types';
+import { CommonActionType, CommonReducerArg, ICellAction, IEditCellAction, ILinkClickAction, ISendCommandAction, IShowDataViewerAction } from './types';
 
 // These are all reducers that don't actually change state. They merely dispatch a message to the other side.
 export namespace Transfer {
-    export function exportCells<T>(arg: CommonReducerArg<T>): IMainState {
+    export function exportCells(arg: CommonReducerArg): IMainState {
         const cellContents = arg.prevState.cellVMs.map(v => v.cell);
         arg.queueAction(createPostableAction(InteractiveWindowMessages.Export, cellContents));
 
@@ -21,7 +21,7 @@ export namespace Transfer {
         };
     }
 
-    export function save<T>(arg: CommonReducerArg<T>): IMainState {
+    export function save(arg: CommonReducerArg): IMainState {
         // Note: this is assuming editor contents have already been saved. That should happen as a result of focus change
 
         // Actually waiting for save results before marking as not dirty, so don't do it here.
@@ -29,47 +29,49 @@ export namespace Transfer {
         return arg.prevState;
     }
 
-    export function showDataViewer<T>(arg: CommonReducerArg<T, IShowDataViewerAction>): IMainState {
-        arg.queueAction(createPostableAction(InteractiveWindowMessages.ShowDataViewer, { variable: arg.payload.variable, columnSize: arg.payload.columnSize }));
+    export function showDataViewer(arg: CommonReducerArg<CommonActionType, IShowDataViewerAction>): IMainState {
+        arg.queueAction(createPostableAction(InteractiveWindowMessages.ShowDataViewer, { variable: arg.payload.data.variable, columnSize: arg.payload.data.columnSize }));
         return arg.prevState;
     }
 
-    export function sendCommand<T>(arg: CommonReducerArg<T, ISendCommandAction>): IMainState {
-        arg.queueAction(createPostableAction(InteractiveWindowMessages.NativeCommand, { command: arg.payload.command, source: arg.payload.commandType }));
+    export function sendCommand(arg: CommonReducerArg<CommonActionType, ISendCommandAction>): IMainState {
+        arg.queueAction(createPostableAction(InteractiveWindowMessages.NativeCommand, { command: arg.payload.data.command, source: arg.payload.data.commandType }));
         return arg.prevState;
     }
 
-    export function showPlot<T>(arg: CommonReducerArg<T, IShowPlotAction>): IMainState {
-        arg.queueAction(createPostableAction(InteractiveWindowMessages.ShowPlot, arg.payload.imageHtml));
-        return arg.prevState;
-    }
-
-    export function linkClick<T>(arg: CommonReducerArg<T, ILinkClickAction>): IMainState {
-        if (arg.payload.href.startsWith('data:image/png')) {
-            arg.queueAction(createPostableAction(InteractiveWindowMessages.SavePng, arg.payload.href));
-        } else {
-            arg.queueAction(createPostableAction(InteractiveWindowMessages.OpenLink, arg.payload.href));
+    export function showPlot(arg: CommonReducerArg<CommonActionType | InteractiveWindowMessages, string | undefined>): IMainState {
+        if (arg.payload.data) {
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.ShowPlot, arg.payload.data));
         }
         return arg.prevState;
     }
 
-    export function getAllCells<T>(arg: CommonReducerArg<T>): IMainState {
+    export function linkClick(arg: CommonReducerArg<CommonActionType, ILinkClickAction>): IMainState {
+        if (arg.payload.data.href.startsWith('data:image/png')) {
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.SavePng, arg.payload.data.href));
+        } else {
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.OpenLink, arg.payload.data.href));
+        }
+        return arg.prevState;
+    }
+
+    export function getAllCells(arg: CommonReducerArg): IMainState {
         const cells = arg.prevState.cellVMs.map(c => c.cell);
         arg.queueAction(createPostableAction(InteractiveWindowMessages.ReturnAllCells, cells));
         return arg.prevState;
     }
 
-    export function gotoCell<T>(arg: CommonReducerArg<T, ICellAction>): IMainState {
-        const cellVM = arg.prevState.cellVMs.find(c => c.cell.id === arg.payload.cellId);
+    export function gotoCell(arg: CommonReducerArg<CommonActionType, ICellAction>): IMainState {
+        const cellVM = arg.prevState.cellVMs.find(c => c.cell.id === arg.payload.data.cellId);
         if (cellVM && cellVM.cell.data.cell_type === 'code') {
             arg.queueAction(createPostableAction(InteractiveWindowMessages.GotoCodeCell, { file: cellVM.cell.file, line: cellVM.cell.line }));
         }
         return arg.prevState;
     }
 
-    export function copyCellCode<T>(arg: CommonReducerArg<T, ICellAction>): IMainState {
-        let cellVM = arg.prevState.cellVMs.find(c => c.cell.id === arg.payload.cellId);
-        if (!cellVM && arg.prevState.editCellVM && arg.payload.cellId === arg.prevState.editCellVM.cell.id) {
+    export function copyCellCode(arg: CommonReducerArg<CommonActionType, ICellAction>): IMainState {
+        let cellVM = arg.prevState.cellVMs.find(c => c.cell.id === arg.payload.data.cellId);
+        if (!cellVM && arg.prevState.editCellVM && arg.payload.data.cellId === arg.prevState.editCellVM.cell.id) {
             cellVM = arg.prevState.editCellVM;
         }
 
@@ -81,28 +83,28 @@ export namespace Transfer {
         return arg.prevState;
     }
 
-    export function gather<T>(arg: CommonReducerArg<T, ICellAction>): IMainState {
-        const cellVM = arg.prevState.cellVMs.find(c => c.cell.id === arg.payload.cellId);
+    export function gather(arg: CommonReducerArg<CommonActionType, ICellAction>): IMainState {
+        const cellVM = arg.prevState.cellVMs.find(c => c.cell.id === arg.payload.data.cellId);
         if (cellVM) {
             arg.queueAction(createPostableAction(InteractiveWindowMessages.GatherCodeRequest, cellVM.cell));
         }
         return arg.prevState;
     }
 
-    export function editCell<T>(arg: CommonReducerArg<T, IEditCellAction>): IMainState {
-        if (arg.payload.cellId) {
-            arg.queueAction(createPostableAction(InteractiveWindowMessages.EditCell, { changes: arg.payload.changes, id: arg.payload.cellId }));
+    export function editCell(arg: CommonReducerArg<CommonActionType, IEditCellAction>): IMainState {
+        if (arg.payload.data.cellId) {
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.EditCell, { changes: arg.payload.data.changes, id: arg.payload.data.cellId }));
 
             // Update the uncomitted text on the cell view model
             // We keep this saved here so we don't re-render and we put this code into the input / code data
             // when focus is lost
-            const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
-            if (index >= 0 && arg.prevState.focusedCellId === arg.payload.cellId) {
+            const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
+            if (index >= 0 && arg.prevState.focusedCellId === arg.payload.data.cellId) {
                 const newVMs = [...arg.prevState.cellVMs];
                 const current = arg.prevState.cellVMs[index];
                 const newCell = {
                     ...current,
-                    uncomittedText: arg.payload.code
+                    uncomittedText: arg.payload.data.code
                 };
 
                 // tslint:disable-next-line: no-any
@@ -116,7 +118,7 @@ export namespace Transfer {
         return arg.prevState;
     }
 
-    export function started<T>(arg: CommonReducerArg<T>): IMainState {
+    export function started(arg: CommonReducerArg): IMainState {
         // Send all of our initial requests
         arg.queueAction(createPostableAction(InteractiveWindowMessages.Started));
         arg.queueAction(createPostableAction(CssMessages.GetCssRequest, { isDark: arg.prevState.baseTheme !== 'vscode-light' }));
@@ -126,7 +128,7 @@ export namespace Transfer {
         return arg.prevState;
     }
 
-    export function loadedAllCells<T>(arg: CommonReducerArg<T>): IMainState {
+    export function loadedAllCells(arg: CommonReducerArg): IMainState {
         arg.queueAction(createPostableAction(InteractiveWindowMessages.LoadAllCellsComplete, { cells: arg.prevState.cellVMs.map(c => c.cell) }));
         return arg.prevState;
     }

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { CssMessages } from '../../../../client/datascience/messages';
-import { extractInputText, IMainState } from '../../mainState';
+import { extractInputText, getSelectedAndFocusedInfo, IMainState } from '../../mainState';
 import { createPostableAction } from '../postOffice';
 import { Helpers } from './helpers';
 import { CommonActionType, CommonReducerArg, ICellAction, IEditCellAction, ILinkClickAction, ISendCommandAction, IShowDataViewerAction } from './types';
@@ -99,7 +99,8 @@ export namespace Transfer {
             // We keep this saved here so we don't re-render and we put this code into the input / code data
             // when focus is lost
             const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-            if (index >= 0 && arg.prevState.focusedCellId === arg.payload.data.cellId) {
+            const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+            if (index >= 0 && selectionInfo.focusedCellId === arg.payload.data.cellId) {
                 const newVMs = [...arg.prevState.cellVMs];
                 const current = arg.prevState.cellVMs[index];
                 const newCell = {

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -4,6 +4,7 @@
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
 import { IShowDataViewer, NativeCommandType } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { BaseReduxActionPayload } from '../../../../client/datascience/interactive-common/types';
 import { ActionWithPayload, ReducerArg } from '../../../react-common/reduxUtils';
 import { CursorPos, IMainState } from '../../mainState';
 
@@ -88,7 +89,14 @@ export interface IShowPlotAction {
 export interface IScrollAction {
     isAtBottom: boolean;
 }
-export type CommonReducerArg<AT, T = never | undefined> = ReducerArg<IMainState, AT, T>;
+
+// tslint:disable-next-line: no-any
+export type PrimitiveTypeInReduxActionPayload = string | number | boolean | Buffer | any[];
+export type CommonReducerArg<AT, T = never | undefined> = T extends never | undefined
+    ? ReducerArg<IMainState, AT, BaseReduxActionPayload>
+    : T extends PrimitiveTypeInReduxActionPayload
+    ? ReducerArg<IMainState, AT, { data: T } & BaseReduxActionPayload>
+    : ReducerArg<IMainState, AT, T & BaseReduxActionPayload>;
 
 export interface ICellAction {
     cellId: string | undefined;

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -3,14 +3,15 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 
-import { IShowDataViewer, NativeCommandType } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { InteractiveWindowMessages, IShowDataViewer, NativeCommandType } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { BaseReduxActionPayload } from '../../../../client/datascience/interactive-common/types';
+import { IJupyterVariablesRequest } from '../../../../client/datascience/types';
 import { ActionWithPayload, ReducerArg } from '../../../react-common/reduxUtils';
 import { CursorPos, IMainState } from '../../mainState';
 
 /**
  * How to add a new state change:
- * 1) Add a new action.<name> to CommonActionType
+ * 1) Add a new <name> to CommonActionType (preferably `InteractiveWindowMessages` - to keep messages in the same place).
  * 2) Add a new interface (or reuse 1 below) if the action takes any parameters (ex: ICellAction)
  * 3) Add a new actionCreator function (this is how you use it from a react control) to the
  *    appropriate actionCreator list (one for native and one for interactive).
@@ -25,13 +26,9 @@ export enum CommonActionType {
     ARROW_DOWN = 'action.arrow_down',
     ARROW_UP = 'action.arrow_up',
     CHANGE_CELL_TYPE = 'action.change_cell_type',
-    CLEAR_ALL_OUTPUTS = 'action.clear_all_outputs',
     CLICK_CELL = 'action.click_cell',
     CODE_CREATED = 'action.code_created',
-    COLLAPSE_ALL = 'action.collapse_all',
     COPY_CELL_CODE = 'action.copy_cell_code',
-    DELETE_ALL_CELLS = 'action.delete_all_cells',
-    DELETE_CELL = 'action.delete_cell',
     DESELECT_CELL = 'action.deselect_cell',
     DOUBLE_CLICK_CELL = 'action.double_click_cell',
     EDITOR_LOADED = 'action.editor_loaded',
@@ -40,7 +37,6 @@ export enum CommonActionType {
     EXECUTE_ALL_CELLS = 'action.execute_all_cells',
     EXECUTE_CELL = 'action.execute_cell',
     EXECUTE_CELL_AND_BELOW = 'action.execute_cell_and_below',
-    EXPAND_ALL = 'action.expand_all',
     EXPORT = 'action.export',
     FOCUS_CELL = 'action.focus_cell',
     GATHER_CELL = 'action.gather_cell',
@@ -54,27 +50,65 @@ export enum CommonActionType {
     LINK_CLICK = 'action.link_click',
     MOVE_CELL_DOWN = 'action.move_cell_down',
     MOVE_CELL_UP = 'action.move_cell_up',
-    REDO = 'action.redo',
     REFRESH_VARIABLES = 'action.refresh_variables',
     RESTART_KERNEL = 'action.restart_kernel_action',
     SAVE = 'action.save',
     SCROLL = 'action.scroll',
     SELECT_CELL = 'action.select_cell',
-    SELECT_KERNEL = 'action.select_kernel',
     SELECT_SERVER = 'action.select_server',
     SEND_COMMAND = 'action.send_command',
     SHOW_DATA_VIEWER = 'action.show_data_viewer',
-    SHOW_PLOT = 'action.show_plot',
-    START_CELL = 'action.start_cell',
     SUBMIT_INPUT = 'action.submit_input',
     TOGGLE_INPUT_BLOCK = 'action.toggle_input_block',
     TOGGLE_LINE_NUMBERS = 'action.toggle_line_numbers',
     TOGGLE_OUTPUT = 'action.toggle_output',
     TOGGLE_VARIABLE_EXPLORER = 'action.toggle_variable_explorer',
-    UNDO = 'action.undo',
     UNFOCUS_CELL = 'action.unfocus_cell',
     UNMOUNT = 'action.unmount'
 }
+
+export type CommonActionTypeMapping = {
+    [CommonActionType.INSERT_ABOVE]: ICellAction & IAddCellAction;
+    [CommonActionType.INSERT_BELOW]: ICellAction & IAddCellAction;
+    [CommonActionType.INSERT_ABOVE_FIRST]: IAddCellAction;
+    [CommonActionType.FOCUS_CELL]: ICellAndCursorAction;
+    [CommonActionType.UNFOCUS_CELL]: ICodeAction;
+    [CommonActionType.ADD_NEW_CELL]: IAddCellAction;
+    [CommonActionType.EDIT_CELL]: IEditCellAction;
+    [CommonActionType.EXECUTE_CELL]: IExecuteAction;
+    [CommonActionType.EXECUTE_ALL_CELLS]: never | undefined;
+    [CommonActionType.EXECUTE_ABOVE]: ICellAction;
+    [CommonActionType.EXECUTE_CELL_AND_BELOW]: ICodeAction;
+    [CommonActionType.RESTART_KERNEL]: never | undefined;
+    [CommonActionType.INTERRUPT_KERNEL]: never | undefined;
+    [CommonActionType.EXPORT]: never | undefined;
+    [CommonActionType.SAVE]: never | undefined;
+    [CommonActionType.SHOW_DATA_VIEWER]: IShowDataViewerAction;
+    [CommonActionType.SEND_COMMAND]: ISendCommandAction;
+    [CommonActionType.SELECT_CELL]: ICellAndCursorAction;
+    [CommonActionType.MOVE_CELL_UP]: ICellAction;
+    [CommonActionType.MOVE_CELL_DOWN]: ICellAction;
+    [CommonActionType.TOGGLE_LINE_NUMBERS]: ICellAction;
+    [CommonActionType.TOGGLE_OUTPUT]: ICellAction;
+    [CommonActionType.ARROW_UP]: ICodeAction;
+    [CommonActionType.ARROW_DOWN]: ICodeAction;
+    [CommonActionType.CHANGE_CELL_TYPE]: IChangeCellTypeAction;
+    [CommonActionType.LINK_CLICK]: ILinkClickAction;
+    [CommonActionType.GOTO_CELL]: ICellAction;
+    [CommonActionType.TOGGLE_INPUT_BLOCK]: ICellAction;
+    [CommonActionType.SUBMIT_INPUT]: ICodeAction;
+    [CommonActionType.SCROLL]: IScrollAction;
+    [CommonActionType.CLICK_CELL]: ICellAction;
+    [CommonActionType.COPY_CELL_CODE]: ICellAction;
+    [CommonActionType.GATHER_CELL]: ICellAction;
+    [CommonActionType.EDITOR_LOADED]: never | undefined;
+    [CommonActionType.LOADED_ALL_CELLS]: never | undefined;
+    [CommonActionType.UNMOUNT]: never | undefined;
+    [CommonActionType.SELECT_SERVER]: never | undefined;
+    [CommonActionType.CODE_CREATED]: ICodeCreatedAction;
+    [CommonActionType.GET_VARIABLE_DATA]: IJupyterVariablesRequest;
+    [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: never | undefined;
+};
 
 export interface IShowDataViewerAction extends IShowDataViewer {}
 
@@ -82,21 +116,12 @@ export interface ILinkClickAction {
     href: string;
 }
 
-export interface IShowPlotAction {
-    imageHtml: string;
-}
-
 export interface IScrollAction {
     isAtBottom: boolean;
 }
 
 // tslint:disable-next-line: no-any
-export type PrimitiveTypeInReduxActionPayload = string | number | boolean | Buffer | any[];
-export type CommonReducerArg<AT, T = never | undefined> = T extends never | undefined
-    ? ReducerArg<IMainState, AT, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerArg<IMainState, AT, { data: T } & BaseReduxActionPayload>
-    : ReducerArg<IMainState, AT, T & BaseReduxActionPayload>;
+export type CommonReducerArg<AT = CommonActionType | InteractiveWindowMessages, T = never | undefined> = ReducerArg<IMainState, AT, BaseReduxActionPayload<T>>;
 
 export interface ICellAction {
     cellId: string | undefined;
@@ -153,4 +178,12 @@ export interface IChangeCellTypeAction {
     cellId: string;
     currentCode: string;
 }
-export type CommonAction<T> = ActionWithPayload<T, CommonActionType>;
+export type CommonAction<T = never | undefined> = ActionWithPayload<T, CommonActionType | InteractiveWindowMessages>;
+
+export function createIncomingActionWithPayload<T>(type: CommonActionType | InteractiveWindowMessages, data: T): CommonAction<T> {
+    // tslint:disable-next-line: no-any
+    return { type, payload: ({ data, messageDirection: 'incoming' } as any) as BaseReduxActionPayload<T> };
+}
+export function createIncomingAction(type: CommonActionType | InteractiveWindowMessages): CommonAction {
+    return { type, payload: { messageDirection: 'incoming', data: undefined } };
+}

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -50,6 +50,7 @@ export enum CommonActionType {
     LINK_CLICK = 'action.link_click',
     MOVE_CELL_DOWN = 'action.move_cell_down',
     MOVE_CELL_UP = 'action.move_cell_up',
+    PostOutgoingMessage = 'action.postOutgoingMessage',
     REFRESH_VARIABLES = 'action.refresh_variables',
     RESTART_KERNEL = 'action.restart_kernel_action',
     SAVE = 'action.save',

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 'use strict';
 import { Reducer } from 'redux';
-import { InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { BaseReduxActionPayload } from '../../../../client/datascience/interactive-common/types';
 import { ICell, IJupyterVariable, IJupyterVariablesRequest, IJupyterVariablesResponse } from '../../../../client/datascience/types';
 import { combineReducers, QueuableAction, ReducerArg, ReducerFunc } from '../../../react-common/reduxUtils';
-import { createPostableAction, IncomingMessageActions } from '../postOffice';
-import { CommonActionType, PrimitiveTypeInReduxActionPayload } from './types';
+import { createPostableAction } from '../postOffice';
+import { CommonActionType, CommonActionTypeMapping } from './types';
 
 export type IVariableState = {
     currentExecutionCount: number;
@@ -18,32 +18,23 @@ export type IVariableState = {
     pageSize: number;
 };
 
-type VariableReducerFunc<T = never | undefined> = T extends never | undefined
-    ? ReducerFunc<IVariableState, IncomingMessageActions, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerFunc<IVariableState, IncomingMessageActions, { data: T } & BaseReduxActionPayload>
-    : ReducerFunc<IVariableState, IncomingMessageActions, T & BaseReduxActionPayload>;
-
-type VariableReducerArg<T = never | undefined> = T extends never | undefined
-    ? ReducerArg<IVariableState, IncomingMessageActions, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerArg<IVariableState, IncomingMessageActions, { data: T } & BaseReduxActionPayload>
-    : ReducerArg<IVariableState, IncomingMessageActions, T & BaseReduxActionPayload>;
+type VariableReducerFunc<T = never | undefined> = ReducerFunc<IVariableState, InteractiveWindowMessages, BaseReduxActionPayload<T>>;
+type VariableReducerArg<T = never | undefined> = ReducerArg<IVariableState, InteractiveWindowMessages, BaseReduxActionPayload<T>>;
 
 function handleRequest(arg: VariableReducerArg<IJupyterVariablesRequest>): IVariableState {
-    const newExecutionCount = arg.payload.executionCount ? arg.payload.executionCount : arg.prevState.currentExecutionCount;
+    const newExecutionCount = arg.payload.data.executionCount ? arg.payload.data.executionCount : arg.prevState.currentExecutionCount;
     arg.queueAction(
         createPostableAction(InteractiveWindowMessages.GetVariablesRequest, {
             executionCount: newExecutionCount,
-            sortColumn: arg.payload.sortColumn,
-            startIndex: arg.payload.startIndex,
-            sortAscending: arg.payload.sortAscending,
-            pageSize: arg.payload.pageSize
+            sortColumn: arg.payload.data.sortColumn,
+            startIndex: arg.payload.data.startIndex,
+            sortAscending: arg.payload.data.sortAscending,
+            pageSize: arg.payload.data.pageSize
         })
     );
     return {
         ...arg.prevState,
-        pageSize: Math.max(arg.prevState.pageSize, arg.payload.pageSize)
+        pageSize: Math.max(arg.prevState.pageSize, arg.payload.data.pageSize)
     };
 }
 
@@ -60,7 +51,10 @@ function toggleVariableExplorer(arg: VariableReducerArg): IVariableState {
         return handleRequest({
             ...arg,
             prevState: newState,
-            payload: { executionCount: arg.prevState.currentExecutionCount, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize }
+            payload: {
+                ...arg.payload,
+                data: { executionCount: arg.prevState.currentExecutionCount, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize }
+            }
         });
     } else {
         return newState;
@@ -68,7 +62,7 @@ function toggleVariableExplorer(arg: VariableReducerArg): IVariableState {
 }
 
 function handleResponse(arg: VariableReducerArg<IJupyterVariablesResponse>): IVariableState {
-    const response = arg.payload;
+    const response = arg.payload.data;
 
     // Check to see if we have moved to a new execution count
     if (
@@ -117,17 +111,23 @@ function handleResponse(arg: VariableReducerArg<IJupyterVariablesResponse>): IVa
 function handleRestarted(arg: VariableReducerArg): IVariableState {
     // If the variables are visible, refresh them
     if (arg.prevState.visible) {
-        return handleRequest({ ...arg, payload: { executionCount: 0, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize } });
+        return handleRequest({
+            ...arg,
+            payload: { ...arg.payload, data: { executionCount: 0, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize } }
+        });
     }
     return arg.prevState;
 }
 
 function handleFinishCell(arg: VariableReducerArg<ICell>): IVariableState {
-    const executionCount = arg.payload.data.execution_count ? parseInt(arg.payload.data.execution_count.toString(), 10) : undefined;
+    const executionCount = arg.payload.data.data.execution_count ? parseInt(arg.payload.data.data.execution_count.toString(), 10) : undefined;
 
     // If the variables are visible, refresh them
     if (arg.prevState.visible && executionCount) {
-        return handleRequest({ ...arg, payload: { executionCount, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize } });
+        return handleRequest({
+            ...arg,
+            payload: { ...arg.payload, data: { executionCount, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize } }
+        });
     }
     return {
         ...arg.prevState,
@@ -135,25 +135,22 @@ function handleFinishCell(arg: VariableReducerArg<ICell>): IVariableState {
     };
 }
 
-// Create a mapping between message and reducer type
-class IVariableActionMapping {
-    public [IncomingMessageActions.RESTARTKERNEL]: VariableReducerFunc;
-    public [IncomingMessageActions.FINISHCELL]: VariableReducerFunc<ICell>;
-    public [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: VariableReducerFunc;
-    public [CommonActionType.GET_VARIABLE_DATA]: VariableReducerFunc<IJupyterVariablesRequest>;
-    public [IncomingMessageActions.GETVARIABLESRESPONSE]: VariableReducerFunc<IJupyterVariablesResponse>;
-}
-
-// Create the map between message type and the actual function to call to update state
-const reducerMap: IVariableActionMapping = {
-    [IncomingMessageActions.RESTARTKERNEL]: handleRestarted,
-    [IncomingMessageActions.FINISHCELL]: handleFinishCell,
-    [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: toggleVariableExplorer,
-    [CommonActionType.GET_VARIABLE_DATA]: handleRequest,
-    [IncomingMessageActions.GETVARIABLESRESPONSE]: handleResponse
+type VariableReducerFunctions<T> = {
+    [P in keyof T]: T[P] extends never | undefined ? VariableReducerFunc : VariableReducerFunc<T[P]>;
 };
 
-export function generateVariableReducer(): Reducer<IVariableState, QueuableAction<IVariableActionMapping>> {
+type VariableActionMapping = VariableReducerFunctions<IInteractiveWindowMapping> & VariableReducerFunctions<CommonActionTypeMapping>;
+
+// Create the map between message type and the actual function to call to update state
+const reducerMap: Partial<VariableActionMapping> = {
+    [InteractiveWindowMessages.RestartKernel]: handleRestarted,
+    [InteractiveWindowMessages.FinishCell]: handleFinishCell,
+    [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: toggleVariableExplorer,
+    [CommonActionType.GET_VARIABLE_DATA]: handleRequest,
+    [InteractiveWindowMessages.GetVariablesResponse]: handleResponse
+};
+
+export function generateVariableReducer(): Reducer<IVariableState, QueuableAction<Partial<VariableActionMapping>>> {
     // First create our default state.
     const defaultState: IVariableState = {
         currentExecutionCount: 0,
@@ -165,5 +162,5 @@ export function generateVariableReducer(): Reducer<IVariableState, QueuableActio
     };
 
     // Then combine that with our map of state change message to reducer
-    return combineReducers<IVariableState, IVariableActionMapping>(defaultState, reducerMap);
+    return combineReducers<IVariableState, Partial<VariableActionMapping>>(defaultState, reducerMap);
 }

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -201,18 +201,17 @@ function createMiddleWare(testMode: boolean): Redux.Middleware<{}, IStore>[] {
             return action;
         }
     });
-    // const loggerMiddleware = process.env.VSC_PYTHON_FORCE_LOGGING !== undefined || (process.env.NODE_ENV !== 'production' && !testMode) ? logger : undefined;
+    const loggerMiddleware = process.env.VSC_PYTHON_FORCE_LOGGING !== undefined || (process.env.NODE_ENV !== 'production' && !testMode) ? logger : undefined;
     // tslint:disable-next-line: no-console
-    console.log(logger);
     const results: Redux.Middleware<{}, IStore>[] = [];
     results.push(queueableActions);
     results.push(updateContext);
     if (testMiddleware) {
         results.push(testMiddleware);
     }
-    // if (loggerMiddleware) {
-    //     results.push(loggerMiddleware);
-    // }
+    if (loggerMiddleware) {
+        results.push(loggerMiddleware);
+    }
 
     return results;
 }

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -212,7 +212,9 @@ function createMiddleWare(testMode: boolean): Redux.Middleware<{}, IStore>[] {
         results.push(testMiddleware);
     }
     if (loggerMiddleware) {
-        results.push(loggerMiddleware);
+        // results.push(loggerMiddleware);
+        // tslint:disable-next-line: no-console
+        console.log(loggerMiddleware);
     }
 
     return results;

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -201,17 +201,18 @@ function createMiddleWare(testMode: boolean): Redux.Middleware<{}, IStore>[] {
             return action;
         }
     });
-    const loggerMiddleware = process.env.VSC_PYTHON_FORCE_LOGGING !== undefined || (process.env.NODE_ENV !== 'production' && !testMode) ? logger : undefined;
+    // const loggerMiddleware = process.env.VSC_PYTHON_FORCE_LOGGING !== undefined || (process.env.NODE_ENV !== 'production' && !testMode) ? logger : undefined;
     // tslint:disable-next-line: no-console
+    console.log(logger);
     const results: Redux.Middleware<{}, IStore>[] = [];
     results.push(queueableActions);
     results.push(updateContext);
     if (testMiddleware) {
         results.push(testMiddleware);
     }
-    if (loggerMiddleware) {
-        results.push(loggerMiddleware);
-    }
+    // if (loggerMiddleware) {
+    //     results.push(loggerMiddleware);
+    // }
 
     return results;
 }

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -3,12 +3,14 @@
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import * as uuid from 'uuid/v4';
-import { NativeCommandType } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { InteractiveWindowMessages, NativeCommandType } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterVariable, IJupyterVariablesRequest } from '../../../client/datascience/types';
 import { CursorPos } from '../../interactive-common/mainState';
 import {
     CommonAction,
     CommonActionType,
+    createIncomingAction,
+    createIncomingActionWithPayload,
     IAddCellAction,
     ICellAction,
     ICellAndCursorAction,
@@ -20,81 +22,67 @@ import {
     ILinkClickAction,
     IRefreshVariablesAction,
     ISendCommandAction,
-    IShowDataViewerAction,
-    IShowPlotAction
+    IShowDataViewerAction
 } from '../../interactive-common/redux/reducers/types';
 
 // See https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object
 export const actionCreators = {
-    insertAbove: (cellId: string | undefined): CommonAction<ICellAction & IAddCellAction> => ({ type: CommonActionType.INSERT_ABOVE, payload: { cellId, newCellId: uuid() } }),
-    insertAboveFirst: (): CommonAction<IAddCellAction> => ({ type: CommonActionType.INSERT_ABOVE_FIRST, payload: { newCellId: uuid() } }),
-    insertBelow: (cellId: string | undefined): CommonAction<ICellAction & IAddCellAction> => ({ type: CommonActionType.INSERT_BELOW, payload: { cellId, newCellId: uuid() } }),
-    focusCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> => ({
-        type: CommonActionType.FOCUS_CELL,
-        payload: { cellId, cursorPos }
-    }),
-    unfocusCell: (cellId: string, code: string): CommonAction<ICodeAction> => ({ type: CommonActionType.UNFOCUS_CELL, payload: { cellId, code } }),
-    selectCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> => ({
-        type: CommonActionType.SELECT_CELL,
-        payload: { cellId, cursorPos }
-    }),
-    addCell: (): CommonAction<IAddCellAction> => ({ type: CommonActionType.ADD_NEW_CELL, payload: { newCellId: uuid() } }),
+    insertAbove: (cellId: string | undefined): CommonAction<ICellAction & IAddCellAction> =>
+        createIncomingActionWithPayload(CommonActionType.INSERT_ABOVE, { cellId, newCellId: uuid() }),
+    insertAboveFirst: (): CommonAction<IAddCellAction> => createIncomingActionWithPayload(CommonActionType.INSERT_ABOVE_FIRST, { newCellId: uuid() }),
+    insertBelow: (cellId: string | undefined): CommonAction<ICellAction & IAddCellAction> =>
+        createIncomingActionWithPayload(CommonActionType.INSERT_BELOW, { cellId, newCellId: uuid() }),
+    focusCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> =>
+        createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId, cursorPos }),
+    unfocusCell: (cellId: string, code: string): CommonAction<ICodeAction> => createIncomingActionWithPayload(CommonActionType.UNFOCUS_CELL, { cellId, code }),
+    selectCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> =>
+        createIncomingActionWithPayload(CommonActionType.SELECT_CELL, { cellId, cursorPos }),
+    addCell: (): CommonAction<IAddCellAction> => createIncomingActionWithPayload(CommonActionType.ADD_NEW_CELL, { newCellId: uuid() }),
     executeCell: (cellId: string, code: string, moveOp: 'add' | 'select' | 'none'): CommonAction<IExecuteAction> => {
         if (moveOp === 'add') {
-            return {
-                type: CommonActionType.EXECUTE_CELL,
-                payload: { cellId, code, moveOp, newCellId: uuid() }
-            };
+            return createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL, { cellId, code, moveOp, newCellId: uuid() });
         } else {
-            return {
-                type: CommonActionType.EXECUTE_CELL,
-                payload: { cellId, code, moveOp }
-            };
+            return createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL, { cellId, code, moveOp });
         }
     },
-    executeAllCells: (): CommonAction<never | undefined> => ({ type: CommonActionType.EXECUTE_ALL_CELLS }),
-    executeAbove: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.EXECUTE_ABOVE, payload: { cellId } }),
-    executeCellAndBelow: (cellId: string, code: string): CommonAction<ICodeAction> => ({ type: CommonActionType.EXECUTE_CELL_AND_BELOW, payload: { cellId, code } }),
-    toggleVariableExplorer: (): CommonAction<never | undefined> => ({ type: CommonActionType.TOGGLE_VARIABLE_EXPLORER }),
-    refreshVariables: (newExecutionCount?: number): CommonAction<IRefreshVariablesAction> => ({ type: CommonActionType.REFRESH_VARIABLES, payload: { newExecutionCount } }),
-    restartKernel: (): CommonAction<never | undefined> => ({ type: CommonActionType.RESTART_KERNEL }),
-    interruptKernel: (): CommonAction<never | undefined> => ({ type: CommonActionType.INTERRUPT_KERNEL }),
-    clearAllOutputs: (): CommonAction<never | undefined> => ({ type: CommonActionType.CLEAR_ALL_OUTPUTS }),
-    export: (): CommonAction<never | undefined> => ({ type: CommonActionType.EXPORT }),
-    save: (): CommonAction<never | undefined> => ({ type: CommonActionType.SAVE }),
-    showDataViewer: (variable: IJupyterVariable, columnSize: number): CommonAction<IShowDataViewerAction> => ({
-        type: CommonActionType.SHOW_DATA_VIEWER,
-        payload: { variable, columnSize }
-    }),
-    sendCommand: (command: NativeCommandType, commandType: 'mouse' | 'keyboard'): CommonAction<ISendCommandAction> => ({
-        type: CommonActionType.SEND_COMMAND,
-        payload: { command, commandType }
-    }),
-    moveCellUp: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.MOVE_CELL_UP, payload: { cellId } }),
-    moveCellDown: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.MOVE_CELL_DOWN, payload: { cellId } }),
-    changeCellType: (cellId: string, currentCode: string): CommonAction<IChangeCellTypeAction> => ({ type: CommonActionType.CHANGE_CELL_TYPE, payload: { cellId, currentCode } }),
-    toggleLineNumbers: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.TOGGLE_LINE_NUMBERS, payload: { cellId } }),
-    toggleOutput: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.TOGGLE_OUTPUT, payload: { cellId } }),
-    deleteCell: (cellId: string): CommonAction<ICellAction> => ({ type: CommonActionType.DELETE_CELL, payload: { cellId } }),
-    undo: (): CommonAction<never | undefined> => ({ type: CommonActionType.UNDO }),
-    redo: (): CommonAction<never | undefined> => ({ type: CommonActionType.REDO }),
-    arrowUp: (cellId: string, code: string): CommonAction<ICodeAction> => ({ type: CommonActionType.ARROW_UP, payload: { cellId, code } }),
-    arrowDown: (cellId: string, code: string): CommonAction<ICodeAction> => ({ type: CommonActionType.ARROW_DOWN, payload: { cellId, code } }),
-    editCell: (cellId: string, changes: monacoEditor.editor.IModelContentChange[], modelId: string, code: string): CommonAction<IEditCellAction> => ({
-        type: CommonActionType.EDIT_CELL,
-        payload: { cellId, changes, modelId, code }
-    }),
-    linkClick: (href: string): CommonAction<ILinkClickAction> => ({ type: CommonActionType.LINK_CLICK, payload: { href } }),
-    showPlot: (imageHtml: string): CommonAction<IShowPlotAction> => ({ type: CommonActionType.SHOW_PLOT, payload: { imageHtml } }),
-    gatherCell: (cellId: string | undefined): CommonAction<ICellAction> => ({ type: CommonActionType.GATHER_CELL, payload: { cellId } }),
-    editorLoaded: (): CommonAction<never | undefined> => ({ type: CommonActionType.EDITOR_LOADED }),
-    codeCreated: (cellId: string | undefined, modelId: string): CommonAction<ICodeCreatedAction> => ({ type: CommonActionType.CODE_CREATED, payload: { cellId, modelId } }),
-    loadedAllCells: (): CommonAction<never | undefined> => ({ type: CommonActionType.LOADED_ALL_CELLS }),
-    editorUnmounted: (): CommonAction<never | undefined> => ({ type: CommonActionType.UNMOUNT }),
-    selectKernel: (): CommonAction<never | undefined> => ({ type: CommonActionType.SELECT_KERNEL }),
-    selectServer: (): CommonAction<never | undefined> => ({ type: CommonActionType.SELECT_SERVER }),
-    getVariableData: (newExecutionCount: number, startIndex: number = 0, pageSize: number = 100): CommonAction<IJupyterVariablesRequest> => ({
-        type: CommonActionType.GET_VARIABLE_DATA,
-        payload: { executionCount: newExecutionCount, sortColumn: 'name', sortAscending: true, startIndex, pageSize }
-    })
+    executeAllCells: (): CommonAction => createIncomingAction(CommonActionType.EXECUTE_ALL_CELLS),
+    executeAbove: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.EXECUTE_ABOVE, { cellId }),
+    executeCellAndBelow: (cellId: string, code: string): CommonAction<ICodeAction> => createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_BELOW, { cellId, code }),
+    toggleVariableExplorer: (): CommonAction => createIncomingAction(CommonActionType.TOGGLE_VARIABLE_EXPLORER),
+    refreshVariables: (newExecutionCount?: number): CommonAction<IRefreshVariablesAction> =>
+        createIncomingActionWithPayload(CommonActionType.REFRESH_VARIABLES, { newExecutionCount }),
+    restartKernel: (): CommonAction => createIncomingAction(CommonActionType.RESTART_KERNEL),
+    interruptKernel: (): CommonAction => createIncomingAction(CommonActionType.INTERRUPT_KERNEL),
+    clearAllOutputs: (): CommonAction => createIncomingAction(InteractiveWindowMessages.ClearAllOutputs),
+    export: (): CommonAction => createIncomingAction(CommonActionType.EXPORT),
+    save: (): CommonAction => createIncomingAction(CommonActionType.SAVE),
+    showDataViewer: (variable: IJupyterVariable, columnSize: number): CommonAction<IShowDataViewerAction> =>
+        createIncomingActionWithPayload(CommonActionType.SHOW_DATA_VIEWER, { variable, columnSize }),
+    sendCommand: (command: NativeCommandType, commandType: 'mouse' | 'keyboard'): CommonAction<ISendCommandAction> =>
+        createIncomingActionWithPayload(CommonActionType.SEND_COMMAND, { command, commandType }),
+    moveCellUp: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.MOVE_CELL_UP, { cellId }),
+    moveCellDown: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.MOVE_CELL_DOWN, { cellId }),
+    changeCellType: (cellId: string, currentCode: string): CommonAction<IChangeCellTypeAction> =>
+        createIncomingActionWithPayload(CommonActionType.CHANGE_CELL_TYPE, { cellId, currentCode }),
+    toggleLineNumbers: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.TOGGLE_LINE_NUMBERS, { cellId }),
+    toggleOutput: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.TOGGLE_OUTPUT, { cellId }),
+    deleteCell: (cellId: string): CommonAction<ICellAction> => createIncomingActionWithPayload(InteractiveWindowMessages.DeleteCell, { cellId }),
+    undo: (): CommonAction => createIncomingAction(InteractiveWindowMessages.Undo),
+    redo: (): CommonAction => createIncomingAction(InteractiveWindowMessages.Redo),
+    arrowUp: (cellId: string, code: string): CommonAction<ICodeAction> => createIncomingActionWithPayload(CommonActionType.ARROW_UP, { cellId, code }),
+    arrowDown: (cellId: string, code: string): CommonAction<ICodeAction> => createIncomingActionWithPayload(CommonActionType.ARROW_DOWN, { cellId, code }),
+    editCell: (cellId: string, changes: monacoEditor.editor.IModelContentChange[], modelId: string, code: string): CommonAction<IEditCellAction> =>
+        createIncomingActionWithPayload(CommonActionType.EDIT_CELL, { cellId, changes, modelId, code }),
+    linkClick: (href: string): CommonAction<ILinkClickAction> => createIncomingActionWithPayload(CommonActionType.LINK_CLICK, { href }),
+    showPlot: (imageHtml: string): CommonAction<string> => createIncomingActionWithPayload(InteractiveWindowMessages.ShowPlot, imageHtml),
+    gatherCell: (cellId: string | undefined): CommonAction<ICellAction> => createIncomingActionWithPayload(CommonActionType.GATHER_CELL, { cellId }),
+    editorLoaded: (): CommonAction => createIncomingAction(CommonActionType.EDITOR_LOADED),
+    codeCreated: (cellId: string | undefined, modelId: string): CommonAction<ICodeCreatedAction> =>
+        createIncomingActionWithPayload(CommonActionType.CODE_CREATED, { cellId, modelId }),
+    loadedAllCells: (): CommonAction => createIncomingAction(CommonActionType.LOADED_ALL_CELLS),
+    editorUnmounted: (): CommonAction => createIncomingAction(CommonActionType.UNMOUNT),
+    selectKernel: (): CommonAction => createIncomingAction(InteractiveWindowMessages.SelectKernel),
+    selectServer: (): CommonAction => createIncomingAction(CommonActionType.SELECT_SERVER),
+    getVariableData: (newExecutionCount: number, startIndex: number = 0, pageSize: number = 100): CommonAction<IJupyterVariablesRequest> =>
+        createIncomingActionWithPayload(CommonActionType.GET_VARIABLE_DATA, { executionCount: newExecutionCount, sortColumn: 'name', sortAscending: true, startIndex, pageSize })
 };

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -27,7 +27,7 @@ import {
 // See https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object
 export const actionCreators = {
     insertAbove: (cellId: string | undefined): CommonAction<ICellAction & IAddCellAction> => ({ type: CommonActionType.INSERT_ABOVE, payload: { cellId, newCellId: uuid() } }),
-    insertAboveFirst: (): CommonAction<never | undefined> => ({ type: CommonActionType.INSERT_ABOVE_FIRST, payload: { newCellId: uuid() } }),
+    insertAboveFirst: (): CommonAction<IAddCellAction> => ({ type: CommonActionType.INSERT_ABOVE_FIRST, payload: { newCellId: uuid() } }),
     insertBelow: (cellId: string | undefined): CommonAction<ICellAction & IAddCellAction> => ({ type: CommonActionType.INSERT_BELOW, payload: { cellId, newCellId: uuid() } }),
     focusCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> => ({
         type: CommonActionType.FOCUS_CELL,
@@ -38,7 +38,7 @@ export const actionCreators = {
         type: CommonActionType.SELECT_CELL,
         payload: { cellId, cursorPos }
     }),
-    addCell: (): CommonAction<never | undefined> => ({ type: CommonActionType.ADD_NEW_CELL, payload: { newCellId: uuid() } }),
+    addCell: (): CommonAction<IAddCellAction> => ({ type: CommonActionType.ADD_NEW_CELL, payload: { newCellId: uuid() } }),
     executeCell: (cellId: string, code: string, moveOp: 'add' | 'select' | 'none'): CommonAction<IExecuteAction> => {
         if (moveOp === 'add') {
             return {

--- a/src/datascience-ui/native-editor/redux/mapping.ts
+++ b/src/datascience-ui/native-editor/redux/mapping.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { ILoadAllCells } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
 import { IGetCssResponse } from '../../../client/datascience/messages';
 import { IGetMonacoThemeResponse } from '../../../client/datascience/monacoMessages';
 import { ICell } from '../../../client/datascience/types';
@@ -19,13 +20,22 @@ import {
     ILinkClickAction,
     ISendCommandAction,
     IShowDataViewerAction,
-    IShowPlotAction
+    IShowPlotAction,
+    PrimitiveTypeInReduxActionPayload
 } from '../../interactive-common/redux/reducers/types';
 import { ReducerArg, ReducerFunc } from '../../react-common/reduxUtils';
 
-type NativeEditorReducerFunc<T> = ReducerFunc<IMainState, CommonActionType, T>;
+type NativeEditorReducerFunc<T = never | undefined> = T extends never | undefined
+    ? ReducerFunc<IMainState, CommonActionType, BaseReduxActionPayload>
+    : T extends PrimitiveTypeInReduxActionPayload
+    ? ReducerFunc<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
+    : ReducerFunc<IMainState, CommonActionType, T & BaseReduxActionPayload>;
 
-export type NativeEditorReducerArg<T = never | undefined> = ReducerArg<IMainState, CommonActionType, T>;
+export type NativeEditorReducerArg<T = never | undefined> = T extends never | undefined
+    ? ReducerArg<IMainState, CommonActionType, BaseReduxActionPayload>
+    : T extends PrimitiveTypeInReduxActionPayload
+    ? ReducerArg<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
+    : ReducerArg<IMainState, CommonActionType, T & BaseReduxActionPayload>;
 
 export class INativeEditorActionMapping {
     public [CommonActionType.INSERT_ABOVE]: NativeEditorReducerFunc<ICellAction & IAddCellAction>;
@@ -35,16 +45,16 @@ export class INativeEditorActionMapping {
     public [CommonActionType.UNFOCUS_CELL]: NativeEditorReducerFunc<ICodeAction>;
     public [CommonActionType.ADD_NEW_CELL]: NativeEditorReducerFunc<IAddCellAction>;
     public [CommonActionType.EXECUTE_CELL]: NativeEditorReducerFunc<IExecuteAction>;
-    public [CommonActionType.EXECUTE_ALL_CELLS]: NativeEditorReducerFunc<never | undefined>;
+    public [CommonActionType.EXECUTE_ALL_CELLS]: NativeEditorReducerFunc;
     public [CommonActionType.EXECUTE_ABOVE]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.EXECUTE_CELL_AND_BELOW]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.RESTART_KERNEL]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.INTERRUPT_KERNEL]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.CLEAR_ALL_OUTPUTS]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.EXPORT]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.SAVE]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.UNDO]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.REDO]: NativeEditorReducerFunc<never | undefined>;
+    public [CommonActionType.RESTART_KERNEL]: NativeEditorReducerFunc;
+    public [CommonActionType.INTERRUPT_KERNEL]: NativeEditorReducerFunc;
+    public [CommonActionType.CLEAR_ALL_OUTPUTS]: NativeEditorReducerFunc;
+    public [CommonActionType.EXPORT]: NativeEditorReducerFunc;
+    public [CommonActionType.SAVE]: NativeEditorReducerFunc;
+    public [CommonActionType.UNDO]: NativeEditorReducerFunc;
+    public [CommonActionType.REDO]: NativeEditorReducerFunc;
     public [CommonActionType.SHOW_DATA_VIEWER]: NativeEditorReducerFunc<IShowDataViewerAction>;
     public [CommonActionType.SEND_COMMAND]: NativeEditorReducerFunc<ISendCommandAction>;
     public [CommonActionType.SELECT_CELL]: NativeEditorReducerFunc<ICellAndCursorAction>;
@@ -60,33 +70,33 @@ export class INativeEditorActionMapping {
     public [CommonActionType.LINK_CLICK]: NativeEditorReducerFunc<ILinkClickAction>;
     public [CommonActionType.SHOW_PLOT]: NativeEditorReducerFunc<IShowPlotAction>;
     public [CommonActionType.GATHER_CELL]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.EDITOR_LOADED]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.LOADED_ALL_CELLS]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.UNMOUNT]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.SELECT_KERNEL]: NativeEditorReducerFunc<never | undefined>;
-    public [CommonActionType.SELECT_SERVER]: NativeEditorReducerFunc<never | undefined>;
+    public [CommonActionType.EDITOR_LOADED]: NativeEditorReducerFunc;
+    public [CommonActionType.LOADED_ALL_CELLS]: NativeEditorReducerFunc;
+    public [CommonActionType.UNMOUNT]: NativeEditorReducerFunc;
+    public [CommonActionType.SELECT_KERNEL]: NativeEditorReducerFunc;
+    public [CommonActionType.SELECT_SERVER]: NativeEditorReducerFunc;
 
     // Messages from the extension
     public [IncomingMessageActions.STARTCELL]: NativeEditorReducerFunc<ICell>;
     public [IncomingMessageActions.FINISHCELL]: NativeEditorReducerFunc<ICell>;
     public [IncomingMessageActions.UPDATECELL]: NativeEditorReducerFunc<ICell>;
-    public [IncomingMessageActions.NOTEBOOKDIRTY]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.NOTEBOOKCLEAN]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.NOTEBOOKDIRTY]: NativeEditorReducerFunc;
+    public [IncomingMessageActions.NOTEBOOKCLEAN]: NativeEditorReducerFunc;
     public [IncomingMessageActions.LOADALLCELLS]: NativeEditorReducerFunc<ILoadAllCells>;
-    public [IncomingMessageActions.NOTEBOOKRUNALLCELLS]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.NOTEBOOKRUNSELECTEDCELL]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.NOTEBOOKRUNALLCELLS]: NativeEditorReducerFunc;
+    public [IncomingMessageActions.NOTEBOOKRUNSELECTEDCELL]: NativeEditorReducerFunc;
     public [IncomingMessageActions.NOTEBOOKADDCELLBELOW]: NativeEditorReducerFunc<IAddCellAction>;
-    public [IncomingMessageActions.DOSAVE]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.DOSAVE]: NativeEditorReducerFunc;
     public [IncomingMessageActions.DELETEALLCELLS]: NativeEditorReducerFunc<IAddCellAction>;
-    public [IncomingMessageActions.UNDO]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.REDO]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.STARTPROGRESS]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.STOPPROGRESS]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.UNDO]: NativeEditorReducerFunc;
+    public [IncomingMessageActions.REDO]: NativeEditorReducerFunc;
+    public [IncomingMessageActions.STARTPROGRESS]: NativeEditorReducerFunc;
+    public [IncomingMessageActions.STOPPROGRESS]: NativeEditorReducerFunc;
     public [IncomingMessageActions.UPDATESETTINGS]: NativeEditorReducerFunc<string>;
-    public [IncomingMessageActions.ACTIVATE]: NativeEditorReducerFunc<never | undefined>;
-    public [IncomingMessageActions.RESTARTKERNEL]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.ACTIVATE]: NativeEditorReducerFunc;
+    public [IncomingMessageActions.RESTARTKERNEL]: NativeEditorReducerFunc;
     public [IncomingMessageActions.GETCSSRESPONSE]: NativeEditorReducerFunc<IGetCssResponse>;
-    public [IncomingMessageActions.MONACOREADY]: NativeEditorReducerFunc<never | undefined>;
+    public [IncomingMessageActions.MONACOREADY]: NativeEditorReducerFunc;
     public [IncomingMessageActions.GETMONACOTHEMERESPONSE]: NativeEditorReducerFunc<IGetMonacoThemeResponse>;
     public [IncomingMessageActions.UPDATEKERNEL]: NativeEditorReducerFunc<IServerState>;
     public [IncomingMessageActions.LOCINIT]: NativeEditorReducerFunc<string>;

--- a/src/datascience-ui/native-editor/redux/mapping.ts
+++ b/src/datascience-ui/native-editor/redux/mapping.ts
@@ -1,103 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import { ILoadAllCells } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
-import { IGetCssResponse } from '../../../client/datascience/messages';
-import { IGetMonacoThemeResponse } from '../../../client/datascience/monacoMessages';
-import { ICell } from '../../../client/datascience/types';
-import { IMainState, IServerState } from '../../interactive-common/mainState';
-import { IncomingMessageActions } from '../../interactive-common/redux/postOffice';
-import {
-    CommonActionType,
-    IAddCellAction,
-    ICellAction,
-    ICellAndCursorAction,
-    IChangeCellTypeAction,
-    ICodeAction,
-    IEditCellAction,
-    IExecuteAction,
-    ILinkClickAction,
-    ISendCommandAction,
-    IShowDataViewerAction,
-    IShowPlotAction,
-    PrimitiveTypeInReduxActionPayload
-} from '../../interactive-common/redux/reducers/types';
+import { IMainState } from '../../interactive-common/mainState';
+import { CommonActionType, CommonActionTypeMapping } from '../../interactive-common/redux/reducers/types';
 import { ReducerArg, ReducerFunc } from '../../react-common/reduxUtils';
 
-type NativeEditorReducerFunc<T = never | undefined> = T extends never | undefined
-    ? ReducerFunc<IMainState, CommonActionType, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerFunc<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
-    : ReducerFunc<IMainState, CommonActionType, T & BaseReduxActionPayload>;
+type NativeEditorReducerFunc<T = never | undefined> = ReducerFunc<IMainState, CommonActionType | InteractiveWindowMessages, BaseReduxActionPayload<T>>;
 
-export type NativeEditorReducerArg<T = never | undefined> = T extends never | undefined
-    ? ReducerArg<IMainState, CommonActionType, BaseReduxActionPayload>
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? ReducerArg<IMainState, CommonActionType, { data: T } & BaseReduxActionPayload>
-    : ReducerArg<IMainState, CommonActionType, T & BaseReduxActionPayload>;
+export type NativeEditorReducerArg<T = never | undefined> = ReducerArg<IMainState, CommonActionType | InteractiveWindowMessages, BaseReduxActionPayload<T>>;
 
-export class INativeEditorActionMapping {
-    public [CommonActionType.INSERT_ABOVE]: NativeEditorReducerFunc<ICellAction & IAddCellAction>;
-    public [CommonActionType.INSERT_BELOW]: NativeEditorReducerFunc<ICellAction & IAddCellAction>;
-    public [CommonActionType.INSERT_ABOVE_FIRST]: NativeEditorReducerFunc<IAddCellAction>;
-    public [CommonActionType.FOCUS_CELL]: NativeEditorReducerFunc<ICellAndCursorAction>;
-    public [CommonActionType.UNFOCUS_CELL]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.ADD_NEW_CELL]: NativeEditorReducerFunc<IAddCellAction>;
-    public [CommonActionType.EXECUTE_CELL]: NativeEditorReducerFunc<IExecuteAction>;
-    public [CommonActionType.EXECUTE_ALL_CELLS]: NativeEditorReducerFunc;
-    public [CommonActionType.EXECUTE_ABOVE]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.EXECUTE_CELL_AND_BELOW]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.RESTART_KERNEL]: NativeEditorReducerFunc;
-    public [CommonActionType.INTERRUPT_KERNEL]: NativeEditorReducerFunc;
-    public [CommonActionType.CLEAR_ALL_OUTPUTS]: NativeEditorReducerFunc;
-    public [CommonActionType.EXPORT]: NativeEditorReducerFunc;
-    public [CommonActionType.SAVE]: NativeEditorReducerFunc;
-    public [CommonActionType.UNDO]: NativeEditorReducerFunc;
-    public [CommonActionType.REDO]: NativeEditorReducerFunc;
-    public [CommonActionType.SHOW_DATA_VIEWER]: NativeEditorReducerFunc<IShowDataViewerAction>;
-    public [CommonActionType.SEND_COMMAND]: NativeEditorReducerFunc<ISendCommandAction>;
-    public [CommonActionType.SELECT_CELL]: NativeEditorReducerFunc<ICellAndCursorAction>;
-    public [CommonActionType.MOVE_CELL_UP]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.MOVE_CELL_DOWN]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.TOGGLE_LINE_NUMBERS]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.TOGGLE_OUTPUT]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.DELETE_CELL]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.ARROW_UP]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.ARROW_DOWN]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.CHANGE_CELL_TYPE]: NativeEditorReducerFunc<IChangeCellTypeAction>;
-    public [CommonActionType.EDIT_CELL]: NativeEditorReducerFunc<IEditCellAction>;
-    public [CommonActionType.LINK_CLICK]: NativeEditorReducerFunc<ILinkClickAction>;
-    public [CommonActionType.SHOW_PLOT]: NativeEditorReducerFunc<IShowPlotAction>;
-    public [CommonActionType.GATHER_CELL]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.EDITOR_LOADED]: NativeEditorReducerFunc;
-    public [CommonActionType.LOADED_ALL_CELLS]: NativeEditorReducerFunc;
-    public [CommonActionType.UNMOUNT]: NativeEditorReducerFunc;
-    public [CommonActionType.SELECT_KERNEL]: NativeEditorReducerFunc;
-    public [CommonActionType.SELECT_SERVER]: NativeEditorReducerFunc;
+type NativeEditorReducerFunctions<T> = {
+    [P in keyof T]: T[P] extends never | undefined ? NativeEditorReducerFunc : NativeEditorReducerFunc<T[P]>;
+};
 
-    // Messages from the extension
-    public [IncomingMessageActions.STARTCELL]: NativeEditorReducerFunc<ICell>;
-    public [IncomingMessageActions.FINISHCELL]: NativeEditorReducerFunc<ICell>;
-    public [IncomingMessageActions.UPDATECELL]: NativeEditorReducerFunc<ICell>;
-    public [IncomingMessageActions.NOTEBOOKDIRTY]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.NOTEBOOKCLEAN]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.LOADALLCELLS]: NativeEditorReducerFunc<ILoadAllCells>;
-    public [IncomingMessageActions.NOTEBOOKRUNALLCELLS]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.NOTEBOOKRUNSELECTEDCELL]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.NOTEBOOKADDCELLBELOW]: NativeEditorReducerFunc<IAddCellAction>;
-    public [IncomingMessageActions.DOSAVE]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.DELETEALLCELLS]: NativeEditorReducerFunc<IAddCellAction>;
-    public [IncomingMessageActions.UNDO]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.REDO]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.STARTPROGRESS]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.STOPPROGRESS]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.UPDATESETTINGS]: NativeEditorReducerFunc<string>;
-    public [IncomingMessageActions.ACTIVATE]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.RESTARTKERNEL]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.GETCSSRESPONSE]: NativeEditorReducerFunc<IGetCssResponse>;
-    public [IncomingMessageActions.MONACOREADY]: NativeEditorReducerFunc;
-    public [IncomingMessageActions.GETMONACOTHEMERESPONSE]: NativeEditorReducerFunc<IGetMonacoThemeResponse>;
-    public [IncomingMessageActions.UPDATEKERNEL]: NativeEditorReducerFunc<IServerState>;
-    public [IncomingMessageActions.LOCINIT]: NativeEditorReducerFunc<string>;
-}
+export type INativeEditorActionMapping = NativeEditorReducerFunctions<IInteractiveWindowMapping> & NativeEditorReducerFunctions<CommonActionTypeMapping>;

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { CssMessages } from '../../../../client/datascience/messages';
 import { IDataScienceExtraSettings } from '../../../../client/datascience/types';
-import { IMainState } from '../../../interactive-common/mainState';
+import { getSelectedAndFocusedInfo, IMainState } from '../../../interactive-common/mainState';
 import { createPostableAction } from '../../../interactive-common/redux/postOffice';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { ICellAction, ICellAndCursorAction, ICodeAction } from '../../../interactive-common/redux/reducers/types';
@@ -13,20 +13,25 @@ import { NativeEditorReducerArg } from '../mapping';
 export namespace Effects {
     export function focusCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
         // Do nothing if already the focused cell.
-        if (arg.prevState.focusedCellId !== arg.payload.data.cellId) {
+        let selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (selectionInfo.focusedCellId !== arg.payload.data.cellId) {
             let prevState = arg.prevState;
 
-            // First find the old focused cell and unfocus it
-            let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.focusedCellId);
-            if (removeFocusIndex < 0) {
-                removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.selectedCellId);
-            }
+            // Ensure we unfocus & unselect all cells.
+            while (selectionInfo.focusedCellId || selectionInfo.selectedCellId) {
+                selectionInfo = getSelectedAndFocusedInfo(prevState);
+                // First find the old focused cell and unfocus it
+                let removeFocusIndex = selectionInfo.focusedCellIndex;
+                if (typeof removeFocusIndex !== 'number') {
+                    removeFocusIndex = selectionInfo.selectedCellIndex;
+                }
 
-            if (removeFocusIndex >= 0) {
-                const oldFocusCell = prevState.cellVMs[removeFocusIndex];
-                const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
-                prevState = unfocusCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } } });
-                prevState = deselectCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } } });
+                if (typeof removeFocusIndex === 'number') {
+                    const oldFocusCell = prevState.cellVMs[removeFocusIndex];
+                    const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
+                    prevState = unfocusCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } } });
+                    prevState = deselectCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } } });
+                }
             }
 
             const newVMs = [...prevState.cellVMs];
@@ -39,9 +44,7 @@ export namespace Effects {
 
             return {
                 ...prevState,
-                cellVMs: newVMs,
-                focusedCellId: arg.payload.data.cellId,
-                selectedCellId: arg.payload.data.cellId
+                cellVMs: newVMs
             };
         }
 
@@ -51,7 +54,8 @@ export namespace Effects {
     export function unfocusCell(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
         // Unfocus the cell
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-        if (index >= 0 && arg.prevState.focusedCellId === arg.payload.data.cellId) {
+        const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (index >= 0 && selectionInfo.focusedCellId === arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
             const current = arg.prevState.cellVMs[index];
             const newCell = {
@@ -72,8 +76,7 @@ export namespace Effects {
 
             return {
                 ...arg.prevState,
-                cellVMs: newVMs,
-                focusedCellId: undefined
+                cellVMs: newVMs
             };
         } else if (index >= 0) {
             // Dont change focus state if not the focused cell. Just update the code.
@@ -105,7 +108,8 @@ export namespace Effects {
 
     export function deselectCell(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-        if (index >= 0 && arg.prevState.selectedCellId === arg.payload.data.cellId) {
+        const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (index >= 0 && selectionInfo.selectedCellId === arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
             const target = arg.prevState.cellVMs[index];
             const newCell = {
@@ -118,8 +122,7 @@ export namespace Effects {
 
             return {
                 ...arg.prevState,
-                cellVMs: newVMs,
-                selectedCellId: undefined
+                cellVMs: newVMs
             };
         }
 
@@ -128,14 +131,15 @@ export namespace Effects {
 
     export function selectCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
         // Skip doing anything if already selected.
-        if (arg.payload.data.cellId !== arg.prevState.selectedCellId) {
+        const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (arg.payload.data.cellId !== selectionInfo.selectedCellId) {
             let prevState = arg.prevState;
             const addIndex = prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
 
             // First find the old focused cell and unfocus it
-            let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.focusedCellId);
+            let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === selectionInfo.focusedCellId);
             if (removeFocusIndex < 0) {
-                removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.selectedCellId);
+                removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === selectionInfo.selectedCellId);
             }
 
             if (removeFocusIndex >= 0) {
@@ -146,10 +150,10 @@ export namespace Effects {
             }
 
             const newVMs = [...prevState.cellVMs];
-            if (addIndex >= 0 && arg.payload.data.cellId !== prevState.selectedCellId) {
+            if (addIndex >= 0 && arg.payload.data.cellId !== selectionInfo.selectedCellId) {
                 newVMs[addIndex] = {
                     ...newVMs[addIndex],
-                    focused: prevState.focusedCellId !== undefined && prevState.focusedCellId === prevState.selectedCellId,
+                    focused: selectionInfo.focusedCellId !== undefined && selectionInfo.focusedCellId === selectionInfo.selectedCellId,
                     selected: true,
                     cursorPos: arg.payload.data.cursorPos
                 };
@@ -157,9 +161,7 @@ export namespace Effects {
 
             return {
                 ...prevState,
-                cellVMs: newVMs,
-                focusedCellId: prevState.focusedCellId !== undefined ? arg.payload.data.cellId : undefined,
-                selectedCellId: arg.payload.data.cellId
+                cellVMs: newVMs
             };
         }
         return arg.prevState;

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -193,7 +193,7 @@ export namespace Effects {
 
     export function updateSettings(arg: NativeEditorReducerArg<string>): IMainState {
         // String arg should be the IDataScienceExtraSettings
-        const newSettingsJSON = JSON.parse(arg.payload);
+        const newSettingsJSON = JSON.parse(arg.payload.data);
         const newSettings = <IDataScienceExtraSettings>newSettingsJSON;
         const newEditorOptions = computeEditorOptions(newSettings);
         const newFontFamily = newSettings.extraSettings ? newSettings.extraSettings.fontFamily : arg.prevState.font.family;

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -13,7 +13,7 @@ import { NativeEditorReducerArg } from '../mapping';
 export namespace Effects {
     export function focusCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
         // Do nothing if already the focused cell.
-        if (arg.prevState.focusedCellId !== arg.payload.cellId) {
+        if (arg.prevState.focusedCellId !== arg.payload.data.cellId) {
             let prevState = arg.prevState;
 
             // First find the old focused cell and unfocus it
@@ -25,23 +25,23 @@ export namespace Effects {
             if (removeFocusIndex >= 0) {
                 const oldFocusCell = prevState.cellVMs[removeFocusIndex];
                 const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
-                prevState = unfocusCell({ ...arg, prevState, payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } });
-                prevState = deselectCell({ ...arg, prevState, payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } });
+                prevState = unfocusCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } } });
+                prevState = deselectCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } } });
             }
 
             const newVMs = [...prevState.cellVMs];
 
             // Add focus on new cell
-            const addFocusIndex = newVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+            const addFocusIndex = newVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
             if (addFocusIndex >= 0) {
-                newVMs[addFocusIndex] = { ...newVMs[addFocusIndex], focused: true, selected: true, cursorPos: arg.payload.cursorPos };
+                newVMs[addFocusIndex] = { ...newVMs[addFocusIndex], focused: true, selected: true, cursorPos: arg.payload.data.cursorPos };
             }
 
             return {
                 ...prevState,
                 cellVMs: newVMs,
-                focusedCellId: arg.payload.cellId,
-                selectedCellId: arg.payload.cellId
+                focusedCellId: arg.payload.data.cellId,
+                selectedCellId: arg.payload.data.cellId
             };
         }
 
@@ -50,19 +50,19 @@ export namespace Effects {
 
     export function unfocusCell(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
         // Unfocus the cell
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
-        if (index >= 0 && arg.prevState.focusedCellId === arg.payload.cellId) {
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
+        if (index >= 0 && arg.prevState.focusedCellId === arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
             const current = arg.prevState.cellVMs[index];
             const newCell = {
                 ...current,
-                inputBlockText: arg.payload.code,
+                inputBlockText: arg.payload.data.code,
                 focused: false,
                 cell: {
                     ...current.cell,
                     data: {
                         ...current.cell.data,
-                        source: arg.payload.code
+                        source: arg.payload.data.code
                     }
                 }
             };
@@ -81,12 +81,12 @@ export namespace Effects {
             const current = arg.prevState.cellVMs[index];
             const newCell = {
                 ...current,
-                inputBlockText: arg.payload.code,
+                inputBlockText: arg.payload.data.code,
                 cell: {
                     ...current.cell,
                     data: {
                         ...current.cell.data,
-                        source: arg.payload.code
+                        source: arg.payload.data.code
                     }
                 }
             };
@@ -104,8 +104,8 @@ export namespace Effects {
     }
 
     export function deselectCell(arg: NativeEditorReducerArg<ICellAction>): IMainState {
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
-        if (index >= 0 && arg.prevState.selectedCellId === arg.payload.cellId) {
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
+        if (index >= 0 && arg.prevState.selectedCellId === arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
             const target = arg.prevState.cellVMs[index];
             const newCell = {
@@ -128,9 +128,9 @@ export namespace Effects {
 
     export function selectCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
         // Skip doing anything if already selected.
-        if (arg.payload.cellId !== arg.prevState.selectedCellId) {
+        if (arg.payload.data.cellId !== arg.prevState.selectedCellId) {
             let prevState = arg.prevState;
-            const addIndex = prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+            const addIndex = prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
 
             // First find the old focused cell and unfocus it
             let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.focusedCellId);
@@ -141,32 +141,32 @@ export namespace Effects {
             if (removeFocusIndex >= 0) {
                 const oldFocusCell = prevState.cellVMs[removeFocusIndex];
                 const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
-                prevState = unfocusCell({ ...arg, prevState, payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } });
-                prevState = deselectCell({ ...arg, prevState, payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } });
+                prevState = unfocusCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } } });
+                prevState = deselectCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } } });
             }
 
             const newVMs = [...prevState.cellVMs];
-            if (addIndex >= 0 && arg.payload.cellId !== prevState.selectedCellId) {
+            if (addIndex >= 0 && arg.payload.data.cellId !== prevState.selectedCellId) {
                 newVMs[addIndex] = {
                     ...newVMs[addIndex],
                     focused: prevState.focusedCellId !== undefined && prevState.focusedCellId === prevState.selectedCellId,
                     selected: true,
-                    cursorPos: arg.payload.cursorPos
+                    cursorPos: arg.payload.data.cursorPos
                 };
             }
 
             return {
                 ...prevState,
                 cellVMs: newVMs,
-                focusedCellId: prevState.focusedCellId !== undefined ? arg.payload.cellId : undefined,
-                selectedCellId: arg.payload.cellId
+                focusedCellId: prevState.focusedCellId !== undefined ? arg.payload.data.cellId : undefined,
+                selectedCellId: arg.payload.data.cellId
             };
         }
         return arg.prevState;
     }
 
     export function toggleLineNumbers(arg: NativeEditorReducerArg<ICellAction>): IMainState {
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         if (index >= 0) {
             const newVMs = [...arg.prevState.cellVMs];
             newVMs[index] = { ...newVMs[index], showLineNumbers: !newVMs[index].showLineNumbers };
@@ -179,7 +179,7 @@ export namespace Effects {
     }
 
     export function toggleOutput(arg: NativeEditorReducerArg<ICellAction>): IMainState {
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         if (index >= 0) {
             const newVMs = [...arg.prevState.cellVMs];
             newVMs[index] = { ...newVMs[index], hideOutput: !newVMs[index].hideOutput };

--- a/src/datascience-ui/native-editor/redux/reducers/index.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/index.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import { IncomingMessageActions } from '../../../interactive-common/redux/postOffice';
+import { InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { CssMessages, SharedMessages } from '../../../../client/datascience/messages';
 import { CommonEffects } from '../../../interactive-common/redux/reducers/commonEffects';
 import { Kernel } from '../../../interactive-common/redux/reducers/kernel';
 import { Transfer } from '../../../interactive-common/redux/reducers/transfer';
@@ -13,7 +14,7 @@ import { Execution } from './execution';
 import { Movement } from './movement';
 
 // The list of reducers. 1 per message/action.
-export const reducerMap: INativeEditorActionMapping = {
+export const reducerMap: Partial<INativeEditorActionMapping> = {
     // State updates
     [CommonActionType.INSERT_ABOVE]: Creation.insertAbove,
     [CommonActionType.INSERT_ABOVE_FIRST]: Creation.insertAboveFirst,
@@ -27,26 +28,26 @@ export const reducerMap: INativeEditorActionMapping = {
     [CommonActionType.EXECUTE_CELL_AND_BELOW]: Execution.executeCellAndBelow,
     [CommonActionType.RESTART_KERNEL]: Kernel.restartKernel,
     [CommonActionType.INTERRUPT_KERNEL]: Kernel.interruptKernel,
-    [CommonActionType.CLEAR_ALL_OUTPUTS]: Execution.clearAllOutputs,
+    [InteractiveWindowMessages.ClearAllOutputs]: Execution.clearAllOutputs,
     [CommonActionType.EXPORT]: Transfer.exportCells,
     [CommonActionType.SAVE]: Transfer.save,
     [CommonActionType.SHOW_DATA_VIEWER]: Transfer.showDataViewer,
     [CommonActionType.SEND_COMMAND]: Transfer.sendCommand,
     [CommonActionType.SELECT_CELL]: Effects.selectCell,
-    [CommonActionType.SELECT_KERNEL]: Kernel.selectKernel,
+    [InteractiveWindowMessages.SelectKernel]: Kernel.selectKernel,
     [CommonActionType.SELECT_SERVER]: Kernel.selectJupyterURI,
     [CommonActionType.MOVE_CELL_UP]: Movement.moveCellUp,
     [CommonActionType.MOVE_CELL_DOWN]: Movement.moveCellDown,
-    [CommonActionType.DELETE_CELL]: Creation.deleteCell,
+    [InteractiveWindowMessages.DeleteCell]: Creation.deleteCell,
     [CommonActionType.TOGGLE_LINE_NUMBERS]: Effects.toggleLineNumbers,
     [CommonActionType.TOGGLE_OUTPUT]: Effects.toggleOutput,
     [CommonActionType.CHANGE_CELL_TYPE]: Execution.changeCellType,
-    [CommonActionType.UNDO]: Execution.undo,
-    [CommonActionType.REDO]: Execution.redo,
+    [InteractiveWindowMessages.Undo]: Execution.undo,
+    [InteractiveWindowMessages.Redo]: Execution.redo,
     [CommonActionType.ARROW_UP]: Movement.arrowUp,
     [CommonActionType.ARROW_DOWN]: Movement.arrowDown,
     [CommonActionType.EDIT_CELL]: Transfer.editCell,
-    [CommonActionType.SHOW_PLOT]: Transfer.showPlot,
+    [InteractiveWindowMessages.ShowPlot]: Transfer.showPlot,
     [CommonActionType.LINK_CLICK]: Transfer.linkClick,
     [CommonActionType.GATHER_CELL]: Transfer.gather,
     [CommonActionType.EDITOR_LOADED]: Transfer.started,
@@ -54,27 +55,27 @@ export const reducerMap: INativeEditorActionMapping = {
     [CommonActionType.UNMOUNT]: Creation.unmount,
 
     // Messages from the webview (some are ignored)
-    [IncomingMessageActions.STARTCELL]: Creation.startCell,
-    [IncomingMessageActions.FINISHCELL]: Creation.finishCell,
-    [IncomingMessageActions.UPDATECELL]: Creation.updateCell,
-    [IncomingMessageActions.NOTEBOOKDIRTY]: CommonEffects.notebookDirty,
-    [IncomingMessageActions.NOTEBOOKCLEAN]: CommonEffects.notebookClean,
-    [IncomingMessageActions.LOADALLCELLS]: Creation.loadAllCells,
-    [IncomingMessageActions.NOTEBOOKRUNALLCELLS]: Execution.executeAllCells,
-    [IncomingMessageActions.NOTEBOOKRUNSELECTEDCELL]: Execution.executeSelectedCell,
-    [IncomingMessageActions.NOTEBOOKADDCELLBELOW]: Creation.addNewCell,
-    [IncomingMessageActions.DOSAVE]: Transfer.save,
-    [IncomingMessageActions.DELETEALLCELLS]: Creation.deleteAllCells,
-    [IncomingMessageActions.UNDO]: Execution.undo,
-    [IncomingMessageActions.REDO]: Execution.redo,
-    [IncomingMessageActions.STARTPROGRESS]: CommonEffects.startProgress,
-    [IncomingMessageActions.STOPPROGRESS]: CommonEffects.stopProgress,
-    [IncomingMessageActions.UPDATESETTINGS]: Effects.updateSettings,
-    [IncomingMessageActions.ACTIVATE]: CommonEffects.activate,
-    [IncomingMessageActions.RESTARTKERNEL]: Kernel.handleRestarted,
-    [IncomingMessageActions.GETCSSRESPONSE]: CommonEffects.handleCss,
-    [IncomingMessageActions.MONACOREADY]: CommonEffects.monacoReady,
-    [IncomingMessageActions.GETMONACOTHEMERESPONSE]: CommonEffects.monacoThemeChange,
-    [IncomingMessageActions.UPDATEKERNEL]: Kernel.updateStatus,
-    [IncomingMessageActions.LOCINIT]: CommonEffects.handleLocInit
+    [InteractiveWindowMessages.StartCell]: Creation.startCell,
+    [InteractiveWindowMessages.FinishCell]: Creation.finishCell,
+    [InteractiveWindowMessages.UpdateCell]: Creation.updateCell,
+    [InteractiveWindowMessages.NotebookDirty]: CommonEffects.notebookDirty,
+    [InteractiveWindowMessages.NotebookClean]: CommonEffects.notebookClean,
+    [InteractiveWindowMessages.LoadAllCells]: Creation.loadAllCells,
+    [InteractiveWindowMessages.NotebookRunAllCells]: Execution.executeAllCells,
+    [InteractiveWindowMessages.NotebookRunSelectedCell]: Execution.executeSelectedCell,
+    [InteractiveWindowMessages.NotebookAddCellBelow]: Creation.addNewCell,
+    [InteractiveWindowMessages.DoSave]: Transfer.save,
+    [InteractiveWindowMessages.DeleteAllCells]: Creation.deleteAllCells,
+    [InteractiveWindowMessages.Undo]: Execution.undo,
+    [InteractiveWindowMessages.Redo]: Execution.redo,
+    [InteractiveWindowMessages.StartProgress]: CommonEffects.startProgress,
+    [InteractiveWindowMessages.StopProgress]: CommonEffects.stopProgress,
+    [SharedMessages.UpdateSettings]: Effects.updateSettings,
+    [InteractiveWindowMessages.Activate]: CommonEffects.activate,
+    [InteractiveWindowMessages.RestartKernel]: Kernel.handleRestarted,
+    [CssMessages.GetCssResponse]: CommonEffects.handleCss,
+    [InteractiveWindowMessages.MonacoReady]: CommonEffects.monacoReady,
+    [CssMessages.GetMonacoThemeResponse]: CommonEffects.monacoThemeChange,
+    [InteractiveWindowMessages.UpdateKernel]: Kernel.updateStatus,
+    [SharedMessages.LocInit]: CommonEffects.handleLocInit
 };

--- a/src/datascience-ui/native-editor/redux/reducers/movement.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/movement.ts
@@ -12,10 +12,10 @@ import { Effects } from './effects';
 export namespace Movement {
     export function moveCellUp(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         const newVMs = [...arg.prevState.cellVMs];
-        const index = newVMs.findIndex(cvm => cvm.cell.id === arg.payload.cellId);
+        const index = newVMs.findIndex(cvm => cvm.cell.id === arg.payload.data.cellId);
         if (index > 0) {
             [newVMs[index - 1], newVMs[index]] = [newVMs[index], newVMs[index - 1]];
-            arg.queueAction(createPostableAction(InteractiveWindowMessages.SwapCells, { firstCellId: arg.payload.cellId!, secondCellId: newVMs[index].cell.id }));
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.SwapCells, { firstCellId: arg.payload.data.cellId!, secondCellId: newVMs[index].cell.id }));
             return {
                 ...arg.prevState,
                 cellVMs: newVMs,
@@ -28,10 +28,10 @@ export namespace Movement {
 
     export function moveCellDown(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         const newVMs = [...arg.prevState.cellVMs];
-        const index = newVMs.findIndex(cvm => cvm.cell.id === arg.payload.cellId);
+        const index = newVMs.findIndex(cvm => cvm.cell.id === arg.payload.data.cellId);
         if (index < newVMs.length - 1) {
             [newVMs[index + 1], newVMs[index]] = [newVMs[index], newVMs[index + 1]];
-            arg.queueAction(createPostableAction(InteractiveWindowMessages.SwapCells, { firstCellId: arg.payload.cellId!, secondCellId: newVMs[index].cell.id }));
+            arg.queueAction(createPostableAction(InteractiveWindowMessages.SwapCells, { firstCellId: arg.payload.data.cellId!, secondCellId: newVMs[index].cell.id }));
             return {
                 ...arg.prevState,
                 cellVMs: newVMs,
@@ -43,14 +43,14 @@ export namespace Movement {
     }
 
     export function arrowUp(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         if (index > 0) {
-            const newState = Effects.selectCell({ ...arg, payload: { cellId: arg.prevState.cellVMs[index - 1].cell.id, cursorPos: CursorPos.Bottom } });
+            const newState = Effects.selectCell({ ...arg, payload: { ...arg.payload, data: { cellId: arg.prevState.cellVMs[index - 1].cell.id, cursorPos: CursorPos.Bottom } } });
             const newVMs = [...newState.cellVMs];
             newVMs[index] = Helpers.asCellViewModel({
                 ...newVMs[index],
-                inputBlockText: arg.payload.code,
-                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data, source: arg.payload.code } }
+                inputBlockText: arg.payload.data.code,
+                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data, source: arg.payload.data.code } }
             });
             return {
                 ...newState,
@@ -62,14 +62,14 @@ export namespace Movement {
     }
 
     export function arrowDown(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
-        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
+        const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         if (index < arg.prevState.cellVMs.length - 1) {
-            const newState = Effects.selectCell({ ...arg, payload: { cellId: arg.prevState.cellVMs[index + 1].cell.id, cursorPos: CursorPos.Top } });
+            const newState = Effects.selectCell({ ...arg, payload: { ...arg.payload, data: { cellId: arg.prevState.cellVMs[index + 1].cell.id, cursorPos: CursorPos.Top } } });
             const newVMs = [...newState.cellVMs];
             newVMs[index] = Helpers.asCellViewModel({
                 ...newVMs[index],
-                inputBlockText: arg.payload.code,
-                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data, source: arg.payload.code } }
+                inputBlockText: arg.payload.data.code,
+                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data, source: arg.payload.data.code } }
             });
             return {
                 ...newState,

--- a/src/datascience-ui/plot/mainPanel.tsx
+++ b/src/datascience-ui/plot/mainPanel.tsx
@@ -80,7 +80,7 @@ export class MainPanel extends React.Component<IMainPanelProps, IMainPanelState>
         this.postOffice.addHandler(this);
 
         // Tell the plot viewer code we have started.
-        this.postOffice.sendMessage<IPlotViewerMapping, 'started'>(PlotViewerMessages.Started);
+        this.postOffice.sendMessage<IPlotViewerMapping>(PlotViewerMessages.Started);
 
         // Listen to key events
         window.addEventListener('keydown', this.onKeyDown);

--- a/src/datascience-ui/react-common/postOffice.ts
+++ b/src/datascience-ui/react-common/postOffice.ts
@@ -3,7 +3,6 @@
 'use strict';
 import { WebPanelMessage } from '../../client/common/application/types';
 import { IDisposable } from '../../client/common/types';
-import { noop } from '../../client/common/utils/misc';
 import { logMessage } from './logger';
 
 export interface IVsCodeApi {
@@ -69,58 +68,10 @@ export class PostOffice implements IDisposable {
         if (!this.vscodeApi && typeof acquireVsCodeApi !== 'undefined') {
             this.vscodeApi = acquireVsCodeApi(); // NOSONAR
         }
-        let rewireConsole = false;
         if (!this.registered) {
-            rewireConsole = true;
+            // rewireConsole = true;
             this.registered = true;
             window.addEventListener('message', this.baseHandler);
-        }
-
-        if (this.vscodeApi && rewireConsole) {
-            const originalConsole = window.console;
-            const vscodeApi = this.vscodeApi;
-            // Replace console.log with sending a message
-            const customConsole = {
-                ...originalConsole,
-                // tslint:disable-next-line: no-any no-function-expression
-                log: function(message?: any, ..._optionalParams: any[]) {
-                    try {
-                        originalConsole.log.apply(arguments);
-                        vscodeApi?.postMessage({ type: 'console_log', payload: message });
-                    } catch {
-                        noop();
-                    }
-                },
-                // tslint:disable-next-line: no-any no-function-expression
-                info: function(message?: any, ..._optionalParams: any[]) {
-                    try {
-                        originalConsole.info.apply(arguments);
-                        vscodeApi?.postMessage({ type: 'console_info', payload: message });
-                    } catch {
-                        noop();
-                    }
-                },
-                // tslint:disable-next-line: no-any no-function-expression
-                error: function(message?: any, ..._optionalParams: any[]) {
-                    try {
-                        originalConsole.error.apply(arguments);
-                        vscodeApi?.postMessage({ type: 'console_error', payload: message });
-                    } catch {
-                        noop();
-                    }
-                },
-                // tslint:disable-next-line: no-any no-function-expression
-                warn: function(message?: any, ..._optionalParams: any[]) {
-                    try {
-                        originalConsole.warn.apply(arguments);
-                        vscodeApi?.postMessage({ type: 'console_warn', payload: message });
-                    } catch {
-                        noop();
-                    }
-                }
-            };
-            // tslint:disable-next-line: no-any
-            (window as any).console = customConsole;
         }
 
         return this.vscodeApi;

--- a/src/datascience-ui/react-common/reduxUtils.ts
+++ b/src/datascience-ui/react-common/reduxUtils.ts
@@ -3,7 +3,6 @@
 'use strict';
 import { Action, AnyAction, Middleware, Reducer } from 'redux';
 import { BaseReduxActionPayload } from '../../client/datascience/interactive-common/types';
-import { PrimitiveTypeInReduxActionPayload } from '../interactive-common/redux/reducers/types';
 
 // tslint:disable-next-line: interface-name
 interface TypedAnyAction<T> extends Action<T> {
@@ -13,7 +12,7 @@ interface TypedAnyAction<T> extends Action<T> {
 }
 export type QueueAnotherFunc<T> = (nextAction: Action<T>) => void;
 export type QueuableAction<M> = TypedAnyAction<keyof M> & { queueAction: QueueAnotherFunc<keyof M> };
-export type ReducerArg<S, AT, T> = T extends never | undefined
+export type ReducerArg<S, AT = AnyAction, T = BaseReduxActionPayload> = T extends never | undefined
     ? {
           prevState: S;
           queueAction: QueueAnotherFunc<AT>;
@@ -26,11 +25,8 @@ export type ReducerArg<S, AT, T> = T extends never | undefined
       };
 
 export type ReducerFunc<S, AT, T> = (args: ReducerArg<S, AT, T>) => S;
-export type ActionWithPayload<T, K> = T extends never | undefined
-    ? TypedAnyAction<K> & { payload?: BaseReduxActionPayload }
-    : T extends PrimitiveTypeInReduxActionPayload
-    ? TypedAnyAction<K> & { payload: { data: T } & BaseReduxActionPayload }
-    : TypedAnyAction<K> & { payload: T & BaseReduxActionPayload };
+export type ActionWithPayload<T, K> = TypedAnyAction<K> & { payload: BaseReduxActionPayload<T> };
+export type ActionWithOutPayloadData<K> = TypedAnyAction<K> & { payload: BaseReduxActionPayload };
 
 /**
  * CombineReducers takes in a map of action.type to func and creates a reducer that will call the appropriate function for

--- a/src/datascience-ui/react-common/reduxUtils.ts
+++ b/src/datascience-ui/react-common/reduxUtils.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 'use strict';
 import { Action, AnyAction, Middleware, Reducer } from 'redux';
+import { BaseReduxActionPayload } from '../../client/datascience/interactive-common/types';
+import { PrimitiveTypeInReduxActionPayload } from '../interactive-common/redux/reducers/types';
 
 // tslint:disable-next-line: interface-name
 interface TypedAnyAction<T> extends Action<T> {
@@ -11,10 +13,11 @@ interface TypedAnyAction<T> extends Action<T> {
 }
 export type QueueAnotherFunc<T> = (nextAction: Action<T>) => void;
 export type QueuableAction<M> = TypedAnyAction<keyof M> & { queueAction: QueueAnotherFunc<keyof M> };
-export type ReducerArg<S, AT, T> = T extends null | undefined
+export type ReducerArg<S, AT, T> = T extends never | undefined
     ? {
           prevState: S;
           queueAction: QueueAnotherFunc<AT>;
+          payload: BaseReduxActionPayload;
       }
     : {
           prevState: S;
@@ -23,8 +26,11 @@ export type ReducerArg<S, AT, T> = T extends null | undefined
       };
 
 export type ReducerFunc<S, AT, T> = (args: ReducerArg<S, AT, T>) => S;
-
-export type ActionWithPayload<T, K> = T extends null | undefined ? TypedAnyAction<K> : TypedAnyAction<K> & { payload: T };
+export type ActionWithPayload<T, K> = T extends never | undefined
+    ? TypedAnyAction<K> & { payload?: BaseReduxActionPayload }
+    : T extends PrimitiveTypeInReduxActionPayload
+    ? TypedAnyAction<K> & { payload: { data: T } & BaseReduxActionPayload }
+    : TypedAnyAction<K> & { payload: T & BaseReduxActionPayload };
 
 /**
  * CombineReducers takes in a map of action.type to func and creates a reducer that will call the appropriate function for


### PR DESCRIPTION
For #9340
To be merged after https://github.com/microsoft/vscode-python/pull/9840

Basically I got rid of the root level state info that keeps track of the cell that's selected and focused.
This required us to keep the two in sync along with the state at the cell level.
When syncing information between multiple editors this got messy. removing this removes the issues where things could go out of sync, i.e. two ways to storing the same thing. Now we get selected information from the cells directly - single source of truth.