### PR TITLE
Remove root level flags used to track cell selection and focus

### DIFF
--- a/src/datascience-ui/history-react/redux/reducers/creation.ts
+++ b/src/datascience-ui/history-react/redux/reducers/creation.ts
@@ -120,9 +120,7 @@ export namespace Creation {
         return {
             ...arg.prevState,
             cellVMs: [],
-            undoStack: Helpers.pushStack(arg.prevState.undoStack, arg.prevState.cellVMs),
-            selectedCellId: undefined,
-            focusedCellId: undefined
+            undoStack: Helpers.pushStack(arg.prevState.undoStack, arg.prevState.cellVMs)
         };
     }
 

--- a/src/datascience-ui/history-react/redux/reducers/execution.ts
+++ b/src/datascience-ui/history-react/redux/reducers/execution.ts
@@ -24,16 +24,13 @@ export namespace Execution {
             const cells = arg.prevState.undoStack[arg.prevState.undoStack.length - 1];
             const undoStack = arg.prevState.undoStack.slice(0, arg.prevState.undoStack.length - 1);
             const redoStack = Helpers.pushStack(arg.prevState.redoStack, arg.prevState.cellVMs);
-            const selected = cells.findIndex(c => c.selected);
             arg.queueAction(createPostableAction(InteractiveWindowMessages.Undo));
             return {
                 ...arg.prevState,
                 cellVMs: cells,
                 undoStack: undoStack,
                 redoStack: redoStack,
-                skipNextScroll: true,
-                selectedCellId: selected >= 0 ? cells[selected].cell.id : undefined,
-                focusedCellId: selected >= 0 && cells[selected].focused ? cells[selected].cell.id : undefined
+                skipNextScroll: true
             };
         }
 
@@ -46,16 +43,13 @@ export namespace Execution {
             const cells = arg.prevState.redoStack[arg.prevState.redoStack.length - 1];
             const redoStack = arg.prevState.redoStack.slice(0, arg.prevState.redoStack.length - 1);
             const undoStack = Helpers.pushStack(arg.prevState.undoStack, arg.prevState.cellVMs);
-            const selected = cells.findIndex(c => c.selected);
             arg.queueAction(createPostableAction(InteractiveWindowMessages.Redo));
             return {
                 ...arg.prevState,
                 cellVMs: cells,
                 undoStack: undoStack,
                 redoStack: redoStack,
-                skipNextScroll: true,
-                selectedCellId: selected >= 0 ? cells[selected].cell.id : undefined,
-                focusedCellId: selected >= 0 && cells[selected].focused ? cells[selected].cell.id : undefined
+                skipNextScroll: true
             };
         }
 

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -60,8 +60,6 @@ export type IMainState = {
     currentExecutionCount: number;
     debugging: boolean;
     dirty?: boolean;
-    selectedCellId?: string;
-    focusedCellId?: string;
     isAtBottom: boolean;
     newCellId?: string;
     loadTotal?: number;
@@ -74,6 +72,29 @@ export type IMainState = {
     loaded: boolean;
     kernel: IServerState;
 };
+
+/**
+ * Returns the cell id and index of selected and focused cells.
+ */
+export function getSelectedAndFocusedInfo(state: IMainState) {
+    const info: { selectedCellId?: string; selectedCellIndex?: number; focusedCellId?: string; focusedCellIndex?: number } = {};
+    for (let index = 0; index < state.cellVMs.length; index += 1) {
+        const cell = state.cellVMs[index];
+        if (cell.selected) {
+            info.selectedCellId = cell.cell.id;
+            info.selectedCellIndex = index;
+        }
+        if (cell.focused) {
+            info.focusedCellId = cell.cell.id;
+            info.focusedCellIndex = index;
+        }
+        if (info.selectedCellId && info.focusedCellId) {
+            break;
+        }
+    }
+
+    return info;
+}
 
 export interface IFont {
     size: number;

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { CssMessages } from '../../../../client/datascience/messages';
-import { extractInputText, IMainState } from '../../mainState';
+import { extractInputText, getSelectedAndFocusedInfo, IMainState } from '../../mainState';
 import { createPostableAction } from '../postOffice';
 import { Helpers } from './helpers';
 import { CommonActionType, CommonReducerArg, ICellAction, IEditCellAction, ILinkClickAction, ISendCommandAction, IShowDataViewerAction } from './types';
@@ -99,7 +99,8 @@ export namespace Transfer {
             // We keep this saved here so we don't re-render and we put this code into the input / code data
             // when focus is lost
             const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-            if (index >= 0 && arg.prevState.focusedCellId === arg.payload.data.cellId) {
+            const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+            if (index >= 0 && selectionInfo.focusedCellId === arg.payload.data.cellId) {
                 const newVMs = [...arg.prevState.cellVMs];
                 const current = arg.prevState.cellVMs[index];
                 const newCell = {

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { CssMessages } from '../../../../client/datascience/messages';
 import { IDataScienceExtraSettings } from '../../../../client/datascience/types';
-import { IMainState } from '../../../interactive-common/mainState';
+import { getSelectedAndFocusedInfo, IMainState } from '../../../interactive-common/mainState';
 import { createPostableAction } from '../../../interactive-common/redux/postOffice';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { ICellAction, ICellAndCursorAction, ICodeAction } from '../../../interactive-common/redux/reducers/types';
@@ -13,20 +13,25 @@ import { NativeEditorReducerArg } from '../mapping';
 export namespace Effects {
     export function focusCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
         // Do nothing if already the focused cell.
-        if (arg.prevState.focusedCellId !== arg.payload.data.cellId) {
+        let selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (selectionInfo.focusedCellId !== arg.payload.data.cellId) {
             let prevState = arg.prevState;
 
-            // First find the old focused cell and unfocus it
-            let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.focusedCellId);
-            if (removeFocusIndex < 0) {
-                removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.selectedCellId);
-            }
+            // Ensure we unfocus & unselect all cells.
+            while (selectionInfo.focusedCellId || selectionInfo.selectedCellId) {
+                selectionInfo = getSelectedAndFocusedInfo(prevState);
+                // First find the old focused cell and unfocus it
+                let removeFocusIndex = selectionInfo.focusedCellIndex;
+                if (typeof removeFocusIndex !== 'number') {
+                    removeFocusIndex = selectionInfo.selectedCellIndex;
+                }
 
-            if (removeFocusIndex >= 0) {
-                const oldFocusCell = prevState.cellVMs[removeFocusIndex];
-                const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
-                prevState = unfocusCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } } });
-                prevState = deselectCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } } });
+                if (typeof removeFocusIndex === 'number') {
+                    const oldFocusCell = prevState.cellVMs[removeFocusIndex];
+                    const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
+                    prevState = unfocusCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode } } });
+                    prevState = deselectCell({ ...arg, prevState, payload: { ...arg.payload, data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id } } });
+                }
             }
 
             const newVMs = [...prevState.cellVMs];
@@ -39,9 +44,7 @@ export namespace Effects {
 
             return {
                 ...prevState,
-                cellVMs: newVMs,
-                focusedCellId: arg.payload.data.cellId,
-                selectedCellId: arg.payload.data.cellId
+                cellVMs: newVMs
             };
         }
 
@@ -51,7 +54,8 @@ export namespace Effects {
     export function unfocusCell(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
         // Unfocus the cell
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-        if (index >= 0 && arg.prevState.focusedCellId === arg.payload.data.cellId) {
+        const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (index >= 0 && selectionInfo.focusedCellId === arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
             const current = arg.prevState.cellVMs[index];
             const newCell = {
@@ -72,8 +76,7 @@ export namespace Effects {
 
             return {
                 ...arg.prevState,
-                cellVMs: newVMs,
-                focusedCellId: undefined
+                cellVMs: newVMs
             };
         } else if (index >= 0) {
             // Dont change focus state if not the focused cell. Just update the code.
@@ -105,7 +108,8 @@ export namespace Effects {
 
     export function deselectCell(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-        if (index >= 0 && arg.prevState.selectedCellId === arg.payload.data.cellId) {
+        const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (index >= 0 && selectionInfo.selectedCellId === arg.payload.data.cellId) {
             const newVMs = [...arg.prevState.cellVMs];
             const target = arg.prevState.cellVMs[index];
             const newCell = {
@@ -118,8 +122,7 @@ export namespace Effects {
 
             return {
                 ...arg.prevState,
-                cellVMs: newVMs,
-                selectedCellId: undefined
+                cellVMs: newVMs
             };
         }
 
@@ -128,14 +131,15 @@ export namespace Effects {
 
     export function selectCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
         // Skip doing anything if already selected.
-        if (arg.payload.data.cellId !== arg.prevState.selectedCellId) {
+        const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
+        if (arg.payload.data.cellId !== selectionInfo.selectedCellId) {
             let prevState = arg.prevState;
             const addIndex = prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
 
             // First find the old focused cell and unfocus it
-            let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.focusedCellId);
+            let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === selectionInfo.focusedCellId);
             if (removeFocusIndex < 0) {
-                removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.prevState.selectedCellId);
+                removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === selectionInfo.selectedCellId);
             }
 
             if (removeFocusIndex >= 0) {
@@ -146,10 +150,10 @@ export namespace Effects {
             }
 
             const newVMs = [...prevState.cellVMs];
-            if (addIndex >= 0 && arg.payload.data.cellId !== prevState.selectedCellId) {
+            if (addIndex >= 0 && arg.payload.data.cellId !== selectionInfo.selectedCellId) {
                 newVMs[addIndex] = {
                     ...newVMs[addIndex],
-                    focused: prevState.focusedCellId !== undefined && prevState.focusedCellId === prevState.selectedCellId,
+                    focused: selectionInfo.focusedCellId !== undefined && selectionInfo.focusedCellId === selectionInfo.selectedCellId,
                     selected: true,
                     cursorPos: arg.payload.data.cursorPos
                 };
@@ -157,9 +161,7 @@ export namespace Effects {
 
             return {
                 ...prevState,
-                cellVMs: newVMs,
-                focusedCellId: prevState.focusedCellId !== undefined ? arg.payload.data.cellId : undefined,
-                selectedCellId: arg.payload.data.cellId
+                cellVMs: newVMs
             };
         }
         return arg.prevState;

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -129,13 +129,18 @@ export namespace Effects {
         return arg.prevState;
     }
 
-    export function selectCell(arg: NativeEditorReducerArg<ICellAndCursorAction>): IMainState {
+    /**
+     * Select a cell.
+     *
+     * @param {boolean} [shouldFocusCell] If provided, then will control the focus behavior of the cell. (defaults to focus state of previously selected cell).
+     */
+    export function selectCell(arg: NativeEditorReducerArg<ICellAndCursorAction>, shouldFocusCell?: boolean): IMainState {
         // Skip doing anything if already selected.
         const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
         if (arg.payload.data.cellId !== selectionInfo.selectedCellId) {
             let prevState = arg.prevState;
             const addIndex = prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
-
+            const someOtherCellWasFocusedAndSelected = selectionInfo.focusedCellId === selectionInfo.selectedCellId && !!selectionInfo.focusedCellId;
             // First find the old focused cell and unfocus it
             let removeFocusIndex = arg.prevState.cellVMs.findIndex(c => c.cell.id === selectionInfo.focusedCellId);
             if (removeFocusIndex < 0) {
@@ -153,7 +158,7 @@ export namespace Effects {
             if (addIndex >= 0 && arg.payload.data.cellId !== selectionInfo.selectedCellId) {
                 newVMs[addIndex] = {
                     ...newVMs[addIndex],
-                    focused: selectionInfo.focusedCellId !== undefined && selectionInfo.focusedCellId === selectionInfo.selectedCellId,
+                    focused: typeof shouldFocusCell === 'boolean' ? shouldFocusCell : someOtherCellWasFocusedAndSelected,
                     selected: true,
                     cursorPos: arg.payload.data.cursorPos
                 };

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -76,20 +76,24 @@ export namespace Execution {
             } else if (arg.payload.data.moveOp === 'select') {
                 // Select the cell below this one, but don't focus it
                 if (index < arg.prevState.cellVMs.length - 1) {
-                    return Effects.selectCell({
-                        ...arg,
-                        prevState: {
-                            ...executeResult
-                        },
-                        payload: {
-                            ...arg.payload,
-                            data: {
-                                ...arg.payload.data,
-                                cellId: arg.prevState.cellVMs[index + 1].cell.id,
-                                cursorPos: CursorPos.Current
+                    return Effects.selectCell(
+                        {
+                            ...arg,
+                            prevState: {
+                                ...executeResult
+                            },
+                            payload: {
+                                ...arg.payload,
+                                data: {
+                                    ...arg.payload.data,
+                                    cellId: arg.prevState.cellVMs[index + 1].cell.id,
+                                    cursorPos: CursorPos.Current
+                                }
                             }
-                        }
-                    });
+                        },
+                        // Select the next cell, but do not set focus to it.
+                        false
+                    );
                 }
                 return executeResult;
             } else {


### PR DESCRIPTION
For #9340
To be merged after #9840

Basically I got rid of the root level state info that keeps track of the cell that's selected and focused.
This required us to keep the two in sync along with the state at the cell level.
When syncing information between multiple editors this got messy. removing this removes the issues where things could go out of sync, i.e. two ways to storing the same thing. Now we get selected information from the cells directly - single source of truth.