### PR TITLE
Fix variables on mac and linux

### DIFF
--- a/src/client/datascience/jupyter/jupyterVariables.ts
+++ b/src/client/datascience/jupyter/jupyterVariables.ts
@@ -45,7 +45,7 @@ export class JupyterVariables implements IJupyterVariables {
     private languageToQueryMap = new Map<string, { query: string; parser: RegExp }>();
     private notebookState = new Map<Uri, INotebookState>();
 
-    constructor(@inject(IFileSystem) private fileSystem: IFileSystem, @inject(IConfigurationService) private configService: IConfigurationService) { }
+    constructor(@inject(IFileSystem) private fileSystem: IFileSystem, @inject(IConfigurationService) private configService: IConfigurationService) {}
 
     // IJupyterVariables implementation
     public async getVariables(notebook: INotebook, request: IJupyterVariablesRequest): Promise<IJupyterVariablesResponse> {
@@ -256,7 +256,7 @@ export class JupyterVariables implements IJupyterVariables {
             result.pageStartIndex = startPos;
 
             // Do one at a time. All at once doesn't work as they all have to wait for each other anyway
-            for (let i = startPos; i < startPos + chunkSize && i < list.variables.length;) {
+            for (let i = startPos; i < startPos + chunkSize && i < list.variables.length; ) {
                 const fullVariable = list.variables[i].value ? list.variables[i] : await this.getVariableValueFromKernel(list.variables[i], notebook);
 
                 // See if this is excluded or not.

--- a/src/datascience-ui/data-explorer/globalJQueryImports.ts
+++ b/src/datascience-ui/data-explorer/globalJQueryImports.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+/*
+This file exists for the sole purpose of ensuring jQuery and slickgrid load in the right sequence.
+We need to first load jquery into window.jQuery.
+After that we need to load slickgrid, and then the jQuery plugin from slickgrid event.drag.
+*/
+
+// Slickgrid requires jquery to be defined. Globally. So we do some hacks here.
+// We need to manipulate the grid with the same jquery that it uses
+// use slickgridJQ instead of the usual $ to make it clear that we need that JQ and not
+// the one currently in node-modules
+
+// tslint:disable-next-line: no-var-requires no-require-imports
+require('expose-loader?jQuery!slickgrid/lib/jquery-1.11.2.min');
+
+// tslint:disable-next-line: no-var-requires no-require-imports
+require('slickgrid/lib/jquery-1.11.2.min');
+
+// tslint:disable-next-line: no-var-requires no-require-imports
+require('expose-loader?jQuery.fn.drag!slickgrid/lib/jquery.event.drag-2.3.0');

--- a/src/datascience-ui/data-explorer/reactSlickGrid.tsx
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.tsx
@@ -7,29 +7,39 @@ import * as ReactDOM from 'react-dom';
 import { MaxStringCompare } from '../../client/datascience/data-viewing/types';
 import { KeyCodes } from '../react-common/constants';
 import { measureText } from '../react-common/textMeasure';
+import './globalJQueryImports';
 import { ReactSlickGridFilterBox } from './reactSlickGridFilterBox';
 
-// Slickgrid requires jquery to be defined. Globally. So we do some hacks here.
-// We need to manipulate the grid with the same jquery that it uses
-// use slickgridJQ instead of the usual $ to make it clear that we need that JQ and not
-// the one currently in node-modules
-// tslint:disable-next-line: no-var-requires no-require-imports
-require('expose-loader?jQuery!slickgrid/lib/jquery-1.11.2.min');
+/*
+WARNING: Do not change the order of these imports.
+Slick grid MUST be imported after we load jQuery and other stuff from `./globalJQueryImports`
+*/
 // tslint:disable-next-line: no-var-requires no-require-imports
 const slickgridJQ = require('slickgrid/lib/jquery-1.11.2.min');
-// tslint:disable-next-line: no-var-requires no-require-imports
-require('expose-loader?jQuery.fn.drag!slickgrid/lib/jquery.event.drag-2.3.0');
 
+// Adding comments to ensure order of imports does not change due to auto formatters.
+// tslint:disable-next-line: ordered-imports
 import 'slickgrid/slick.core';
+// Adding comments to ensure order of imports does not change due to auto formatters.
+// tslint:disable-next-line: ordered-imports
 import 'slickgrid/slick.dataview';
+// Adding comments to ensure order of imports does not change due to auto formatters.
+// tslint:disable-next-line: ordered-imports
 import 'slickgrid/slick.grid';
-
+// Adding comments to ensure order of imports does not change due to auto formatters.
+// tslint:disable-next-line: ordered-imports
 import 'slickgrid/plugins/slick.autotooltips';
-
+// Adding comments to ensure order of imports does not change due to auto formatters.
+// tslint:disable-next-line: ordered-imports
 import 'slickgrid/slick.grid.css';
-
 // Make sure our css comes after the slick grid css. We override some of its styles.
+// tslint:disable-next-line: ordered-imports
 import './reactSlickGrid.css';
+/*
+WARNING: Do not change the order of these imports.
+Slick grid MUST be imported after we load jQuery and other stuff from `./globalJQueryImports`
+*/
+
 
 const MinColumnWidth = 70;
 const MaxColumnWidth = 500;

--- a/src/datascience-ui/data-explorer/reactSlickGrid.tsx
+++ b/src/datascience-ui/data-explorer/reactSlickGrid.tsx
@@ -40,7 +40,6 @@ WARNING: Do not change the order of these imports.
 Slick grid MUST be imported after we load jQuery and other stuff from `./globalJQueryImports`
 */
 
-
 const MinColumnWidth = 70;
 const MaxColumnWidth = 500;
 


### PR DESCRIPTION
Nightly flake tests caught this and we ignored it :(

Essentially the regex for parsing results from jupyter doesn't work on linux as the unicode char is different.

Fix the regex

Also found that jquery was busted. Don figured out a way to get it back so that the DataViewers would work again.