### PR TITLE
Capitalize Activate.ps1

### DIFF
--- a/news/2 Fixes/2607.md
+++ b/news/2 Fixes/2607.md
@@ -1,0 +1,1 @@
+Capitalize `Activate.ps1` in code for PowerShell Core on Linux.

--- a/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
+++ b/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
@@ -25,9 +25,9 @@ export class CommandPromptAndPowerShell extends BaseActivationCommandProvider {
 
         if (targetShell === TerminalShellType.commandPrompt && scriptFile.endsWith('activate.bat')) {
             return [scriptFile.fileToCommandArgument()];
-        } else if ((targetShell === TerminalShellType.powershell || targetShell === TerminalShellType.powershellCore) && scriptFile.endsWith('activate.ps1')) {
+        } else if ((targetShell === TerminalShellType.powershell || targetShell === TerminalShellType.powershellCore) && scriptFile.endsWith('Activate.ps1')) {
             return [`& ${scriptFile.fileToCommandArgument()}`];
-        } else if (targetShell === TerminalShellType.commandPrompt && scriptFile.endsWith('activate.ps1')) {
+        } else if (targetShell === TerminalShellType.commandPrompt && scriptFile.endsWith('Activate.ps1')) {
             // lets not try to run the powershell file from command prompt (user may not have powershell)
             return [];
         } else {
@@ -37,7 +37,7 @@ export class CommandPromptAndPowerShell extends BaseActivationCommandProvider {
 
     private getScriptsInOrderOfPreference(targetShell: TerminalShellType): string[] {
         const batchFiles = ['activate.bat', path.join('Scripts', 'activate.bat'), path.join('scripts', 'activate.bat')];
-        const powerShellFiles = ['activate.ps1', path.join('Scripts', 'activate.ps1'), path.join('scripts', 'activate.ps1')];
+        const powerShellFiles = ['Activate.ps1', path.join('Scripts', 'Activate.ps1'), path.join('scripts', 'Activate.ps1')];
         if (targetShell === TerminalShellType.commandPrompt) {
             return batchFiles.concat(powerShellFiles);
         } else {

--- a/src/test/common/terminals/activation.bash.unit.test.ts
+++ b/src/test/common/terminals/activation.bash.unit.test.ts
@@ -18,7 +18,7 @@ suite('Terminal Environment Activation (bash)', () => {
         const hasSpaces = pythonPath.indexOf(' ') > 0;
         const suiteTitle = hasSpaces ? 'and there are spaces in the script file (pythonpath),' : 'and there are no spaces in the script file (pythonpath),';
         suite(suiteTitle, () => {
-            ['activate', 'activate.sh', 'activate.csh', 'activate.fish', 'activate.bat', 'activate.ps1'].forEach(scriptFileName => {
+            ['activate', 'activate.sh', 'activate.csh', 'activate.fish', 'activate.bat', 'Activate.ps1'].forEach(scriptFileName => {
                 suite(`and script file is ${scriptFileName}`, () => {
                     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
                     let fileSystem: TypeMoq.IMock<IFileSystem>;

--- a/src/test/common/terminals/activation.commandPrompt.unit.test.ts
+++ b/src/test/common/terminals/activation.commandPrompt.unit.test.ts
@@ -21,7 +21,7 @@ suite('Terminal Environment Activation (cmd/powershell)', () => {
 
         const suiteTitle = hasSpaces ? 'and there are spaces in the script file (pythonpath),' : 'and there are no spaces in the script file (pythonpath),';
         suite(suiteTitle, () => {
-            ['activate', 'activate.sh', 'activate.csh', 'activate.fish', 'activate.bat', 'activate.ps1'].forEach(scriptFileName => {
+            ['activate', 'activate.sh', 'activate.csh', 'activate.fish', 'activate.bat', 'Activate.ps1'].forEach(scriptFileName => {
                 suite(`and script file is ${scriptFileName}`, () => {
                     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
                     let fileSystem: TypeMoq.IMock<IFileSystem>;
@@ -38,7 +38,7 @@ suite('Terminal Environment Activation (cmd/powershell)', () => {
                     });
 
                     getNamesAndValues<TerminalShellType>(TerminalShellType).forEach(shellType => {
-                        const isScriptFileSupported = ['activate.bat', 'activate.ps1'].indexOf(scriptFileName) >= 0;
+                        const isScriptFileSupported = ['activate.bat', 'Activate.ps1'].indexOf(scriptFileName) >= 0;
                         const titleTitle = isScriptFileSupported
                             ? `Ensure terminal type is supported (Shell: ${shellType.name})`
                             : `Ensure terminal type is not supported (Shell: ${shellType.name})`;
@@ -141,7 +141,7 @@ suite('Terminal Environment Activation (cmd/powershell)', () => {
                 });
             });
 
-            suite('and script file is activate.ps1', () => {
+            suite('and script file is Activate.ps1', () => {
                 let serviceContainer: TypeMoq.IMock<IServiceContainer>;
                 let fileSystem: TypeMoq.IMock<IFileSystem>;
                 let platform: TypeMoq.IMock<IPlatformService>;
@@ -163,7 +163,7 @@ suite('Terminal Environment Activation (cmd/powershell)', () => {
                     const bash = new CommandPromptAndPowerShell(serviceContainer.object);
 
                     platform.setup(p => p.isWindows).returns(() => true);
-                    const pathToScriptFile = path.join(path.dirname(pythonPath), 'activate.ps1');
+                    const pathToScriptFile = path.join(path.dirname(pythonPath), 'Activate.ps1');
                     fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pathToScriptFile))).returns(() => Promise.resolve(true));
                     const command = await bash.getActivationCommands(resource, TerminalShellType.commandPrompt);
 
@@ -174,7 +174,7 @@ suite('Terminal Environment Activation (cmd/powershell)', () => {
                     const bash = new CommandPromptAndPowerShell(serviceContainer.object);
 
                     platform.setup(p => p.isWindows).returns(() => true);
-                    const pathToScriptFile = path.join(path.dirname(pythonPath), 'activate.ps1');
+                    const pathToScriptFile = path.join(path.dirname(pythonPath), 'Activate.ps1');
                     fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pathToScriptFile))).returns(() => Promise.resolve(true));
                     const command = await bash.getActivationCommands(resource, TerminalShellType.powershell);
 
@@ -185,7 +185,7 @@ suite('Terminal Environment Activation (cmd/powershell)', () => {
                     const bash = new CommandPromptAndPowerShell(serviceContainer.object);
 
                     platform.setup(p => p.isWindows).returns(() => true);
-                    const pathToScriptFile = path.join(path.dirname(pythonPath), 'activate.ps1');
+                    const pathToScriptFile = path.join(path.dirname(pythonPath), 'Activate.ps1');
                     fileSystem.setup(fs => fs.fileExists(TypeMoq.It.isValue(pathToScriptFile))).returns(() => Promise.resolve(true));
                     const command = await bash.getActivationCommands(resource, TerminalShellType.powershellCore);
 


### PR DESCRIPTION
For #2607

This is to allow `Activate.ps1` to work appropriate on Linux for PowerShell Core.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [x] Appropriate comments and documentation strings in the code
- [x] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated
- [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
- [x] The wiki is updated with any design decisions/details.
