### PR TITLE
Run tests against insiders

### DIFF
--- a/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
+++ b/src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
@@ -99,7 +99,10 @@ suite('Insiders Extension Service - Activation', () => {
     let handleEdgeCases: sinon.SinonStub<any>;
     let insidersInstaller: IExtensionBuildInstaller;
     let insidersExtensionService: InsidersExtensionService;
+    let envUITEST_DISABLE_INSIDERSExists = false;
     setup(() => {
+        envUITEST_DISABLE_INSIDERSExists = process.env.UITEST_DISABLE_INSIDERS !== undefined;
+        delete process.env.UITEST_DISABLE_INSIDERS;
         extensionChannelService = mock(ExtensionChannelService);
         insidersInstaller = mock(InsidersBuildInstaller);
         appEnvironment = mock(ApplicationEnvironment);
@@ -112,6 +115,9 @@ suite('Insiders Extension Service - Activation', () => {
     });
 
     teardown(() => {
+        if (envUITEST_DISABLE_INSIDERSExists) {
+            process.env.UITEST_DISABLE_INSIDERS = '1';
+        }
         sinon.restore();
     });
 

--- a/src/test/debuggerTest.ts
+++ b/src/test/debuggerTest.ts
@@ -18,7 +18,8 @@ function start() {
         extensionDevelopmentPath: EXTENSION_ROOT_DIR_FOR_TESTS,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
         launchArgs: [workspacePath],
-        version: 'stable'
+        version: 'insiders',
+        extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' }
     }).catch(ex => {
         console.error('End Debugger tests (with errors)', ex);
         process.exit(1);

--- a/src/test/multiRootTest.ts
+++ b/src/test/multiRootTest.ts
@@ -14,7 +14,8 @@ function start() {
         extensionDevelopmentPath: EXTENSION_ROOT_DIR_FOR_TESTS,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
         launchArgs: [workspacePath, '--enable-proposed-api', 'ms-python.python'],
-        version: 'insiders'
+        version: 'insiders',
+        extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' }
     }).catch(ex => {
         console.error('End Multiroot tests (with errors)', ex);
         process.exit(1);

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -16,7 +16,8 @@ function start() {
         extensionDevelopmentPath: extensionDevelopmentPath,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
         launchArgs: [workspacePath, '--enable-proposed-api', 'ms-python.python'],
-        version: 'insiders'
+        version: 'insiders',
+        extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' }
     }).catch(ex => {
         console.error('End Standard tests (with errors)', ex);
         process.exit(1);


### PR DESCRIPTION
We have code in extension that displays a dialog (preventing extension from loading) in insiders version of VSC.