### PR TITLE
Use the autoStart server if it matches when starting a new server

### DIFF
--- a/news/2 Fixes/9926.md
+++ b/news/2 Fixes/9926.md
@@ -1,0 +1,1 @@
+Use the autoStart server when available.

--- a/src/client/datascience/jupyter/liveshare/serverCache.ts
+++ b/src/client/datascience/jupyter/liveshare/serverCache.ts
@@ -17,6 +17,7 @@ interface IServerData {
     options: INotebookServerOptions;
     promise: Promise<INotebookServer | undefined>;
     cancelSource: CancellationTokenSource;
+    resolved: boolean;
 }
 
 export class ServerCache implements IAsyncDisposable {
@@ -43,7 +44,7 @@ export class ServerCache implements IAsyncDisposable {
 
         // See if the old options had the same UI setting. If not,
         // cancel the old
-        if (data && data.options.disableUI !== fixedOptions.disableUI) {
+        if (data && !data.resolved && data.options.disableUI !== fixedOptions.disableUI) {
             traceInfo('Cancelling server create as UI state has changed');
             data.cancelSource.cancel();
             data = undefined;
@@ -55,7 +56,8 @@ export class ServerCache implements IAsyncDisposable {
             data = {
                 promise: createFunction(options, cancelSource.token),
                 options: fixedOptions,
-                cancelSource
+                cancelSource,
+                resolved: false
             };
             this.cache.set(key, data);
         }
@@ -74,6 +76,12 @@ export class ServerCache implements IAsyncDisposable {
                     this.cache.delete(key);
                     return oldDispose();
                 };
+
+                // We've resolved the promise at this point
+                const resolvedData = this.cache.get(key);
+                if (resolvedData) {
+                    resolvedData.resolved = true;
+                }
 
                 return server;
             })

--- a/src/client/datascience/jupyter/liveshare/serverCache.ts
+++ b/src/client/datascience/jupyter/liveshare/serverCache.ts
@@ -78,9 +78,8 @@ export class ServerCache implements IAsyncDisposable {
                 };
 
                 // We've resolved the promise at this point
-                const resolvedData = this.cache.get(key);
-                if (resolvedData) {
-                    resolvedData.resolved = true;
+                if (data) {
+                    data.resolved = true;
                 }
 
                 return server;


### PR DESCRIPTION

For #9926 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
