### PR TITLE
Fix variable explorer when restarting a kernel

### DIFF
--- a/news/2 Fixes/9740.md
+++ b/news/2 Fixes/9740.md
@@ -1,0 +1,1 @@
+Make sure to clear variable list on restart kernel.

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -22,7 +22,7 @@ type VariableReducerFunc<T> = ReducerFunc<IVariableState, IncomingMessageActions
 type VariableReducerArg<T = never | undefined> = ReducerArg<IVariableState, IncomingMessageActions, T>;
 
 function handleRequest(arg: VariableReducerArg<IJupyterVariablesRequest>): IVariableState {
-    const newExecutionCount = arg.payload.executionCount ? arg.payload.executionCount : arg.prevState.currentExecutionCount;
+    const newExecutionCount = arg.payload.executionCount !== undefined ? arg.payload.executionCount : arg.prevState.currentExecutionCount;
     arg.queueAction(
         createPostableAction(InteractiveWindowMessages.GetVariablesRequest, {
             executionCount: newExecutionCount,
@@ -108,7 +108,12 @@ function handleResponse(arg: VariableReducerArg<IJupyterVariablesResponse>): IVa
 function handleRestarted(arg: VariableReducerArg): IVariableState {
     // If the variables are visible, refresh them
     if (arg.prevState.visible) {
-        return handleRequest({ ...arg, payload: { executionCount: 0, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize } });
+        const result = handleRequest({ ...arg, payload: { executionCount: 0, sortColumn: 'name', sortAscending: true, startIndex: 0, pageSize: arg.prevState.pageSize } });
+        return {
+            ...result,
+            currentExecutionCount: 0,
+            variables: []
+        };
     }
     return arg.prevState;
 }


### PR DESCRIPTION
For #9740 

Make sure to clear variables when restarting (or switching) a kernel.
