### PR TITLE
Disable the terminal activation experiment

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -82,12 +82,12 @@
         "name": "UseTerminalToGetActivatedEnvVars - experiment",
         "salt": "UseTerminalToGetActivatedEnvVars",
         "min": 0,
-        "max": 20
+        "max": 0
     },
     {
         "name": "UseTerminalToGetActivatedEnvVars - control",
         "salt": "UseTerminalToGetActivatedEnvVars",
-        "min": 20,
+        "min": 0,
         "max": 100
     },
     {


### PR DESCRIPTION
Disable until next release of VSC (for hidden terminals).
Disabled because a terminal gets displayed to the user and then hidden (doesn't happen in insiders, we will need to wait for their new API to hide terms)