### PR TITLE
Disables the use of a terminal to activate an environment

### DIFF
--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -9,7 +9,6 @@ import { PreWarmActivatedEnvironmentVariables } from './activation/preWarmVariab
 import { EnvironmentActivationService } from './activation/service';
 import { TerminalEnvironmentActivationService } from './activation/terminalEnvironmentActivationService';
 import { IEnvironmentActivationService } from './activation/types';
-import { WrapperEnvironmentActivationService } from './activation/wrapperEnvironmentActivationService';
 import { InterpreterAutoSelectionService } from './autoSelection/index';
 import { InterpreterAutoSeletionProxyService } from './autoSelection/proxy';
 import { CachedInterpretersAutoSelectionRule } from './autoSelection/rules/cached';
@@ -155,5 +154,5 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IInterpreterAutoSeletionProxyService>(IInterpreterAutoSeletionProxyService, InterpreterAutoSeletionProxyService);
     serviceManager.addSingleton<IEnvironmentActivationService>(EnvironmentActivationService, EnvironmentActivationService);
     serviceManager.addSingleton<IEnvironmentActivationService>(TerminalEnvironmentActivationService, TerminalEnvironmentActivationService);
-    serviceManager.addSingleton<IEnvironmentActivationService>(IEnvironmentActivationService, WrapperEnvironmentActivationService);
+    serviceManager.addSingleton<IEnvironmentActivationService>(IEnvironmentActivationService, EnvironmentActivationService);
 }

--- a/src/test/interpreters/activation/service.unit.test.ts
+++ b/src/test/interpreters/activation/service.unit.test.ts
@@ -18,6 +18,7 @@ import { IProcessService, IProcessServiceFactory } from '../../../client/common/
 import { TerminalHelper } from '../../../client/common/terminal/helper';
 import { ITerminalHelper } from '../../../client/common/terminal/types';
 import { ICurrentProcess } from '../../../client/common/types';
+import { clearCache } from '../../../client/common/utils/cacheUtils';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
 import { EnvironmentVariablesProvider } from '../../../client/common/variables/environmentVariablesProvider';
@@ -26,7 +27,6 @@ import { EXTENSION_ROOT_DIR } from '../../../client/constants';
 import { EnvironmentActivationService } from '../../../client/interpreter/activation/service';
 import { InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
 import { mockedVSCodeNamespaces } from '../../vscode-mock';
-import { clearCache } from '../../../client/common/utils/cacheUtils';
 
 const getEnvironmentPrefix = 'e8b39361-0157-4923-80e1-22d70d46dee6';
 const defaultShells = {

--- a/src/test/interpreters/activation/service.unit.test.ts
+++ b/src/test/interpreters/activation/service.unit.test.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { SemVer } from 'semver';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
-import { Uri, workspace as workspaceType, WorkspaceConfiguration } from 'vscode';
+import { EventEmitter, Uri, workspace as workspaceType, WorkspaceConfiguration } from 'vscode';
 import { PlatformService } from '../../../client/common/platform/platformService';
 import { IPlatformService } from '../../../client/common/platform/types';
 import { CurrentProcess } from '../../../client/common/process/currentProcess';
@@ -26,6 +26,7 @@ import { EXTENSION_ROOT_DIR } from '../../../client/constants';
 import { EnvironmentActivationService } from '../../../client/interpreter/activation/service';
 import { InterpreterType, PythonInterpreter } from '../../../client/interpreter/contracts';
 import { mockedVSCodeNamespaces } from '../../vscode-mock';
+import { clearCache } from '../../../client/common/utils/cacheUtils';
 
 const getEnvironmentPrefix = 'e8b39361-0157-4923-80e1-22d70d46dee6';
 const defaultShells = {
@@ -63,6 +64,7 @@ suite('Interpreters Activation - Python Environment Variables', () => {
         currentProcess = mock(CurrentProcess);
         envVarsService = mock(EnvironmentVariablesProvider);
         workspace = mockedVSCodeNamespaces.workspace!;
+        when(envVarsService.onDidEnvironmentVariablesChange).thenReturn(new EventEmitter<Uri | undefined>().event);
         service = new EnvironmentActivationService(instance(helper), instance(platform), instance(processServiceFactory), instance(currentProcess), instance(envVarsService));
 
         const cfg = typemoq.Mock.ofType<WorkspaceConfiguration>();
@@ -71,6 +73,7 @@ suite('Interpreters Activation - Python Environment Variables', () => {
         cfg.setup(c => c.inspect(typemoq.It.isValue('pythonPath'))).returns(() => {
             return { globalValue: 'GlobalValuepython' } as any;
         });
+        clearCache();
     }
     teardown(() => {
         mockedVSCodeNamespaces.workspace!.reset();

--- a/src/test/interpreters/serviceRegistry.unit.test.ts
+++ b/src/test/interpreters/serviceRegistry.unit.test.ts
@@ -10,7 +10,6 @@ import { IExtensionActivationService, IExtensionSingleActivationService } from '
 import { EnvironmentActivationService } from '../../client/interpreter/activation/service';
 import { TerminalEnvironmentActivationService } from '../../client/interpreter/activation/terminalEnvironmentActivationService';
 import { IEnvironmentActivationService } from '../../client/interpreter/activation/types';
-import { WrapperEnvironmentActivationService } from '../../client/interpreter/activation/wrapperEnvironmentActivationService';
 import { InterpreterAutoSelectionService } from '../../client/interpreter/autoSelection';
 import { InterpreterAutoSeletionProxyService } from '../../client/interpreter/autoSelection/proxy';
 import { CachedInterpretersAutoSelectionRule } from '../../client/interpreter/autoSelection/rules/cached';
@@ -146,7 +145,7 @@ suite('Interpreters - Service Registry', () => {
 
             [EnvironmentActivationService, EnvironmentActivationService],
             [TerminalEnvironmentActivationService, TerminalEnvironmentActivationService],
-            [IEnvironmentActivationService, WrapperEnvironmentActivationService],
+            [IEnvironmentActivationService, EnvironmentActivationService],
             [IExtensionActivationService, CondaInheritEnvPrompt],
 
             [WindowsStoreInterpreter, WindowsStoreInterpreter],


### PR DESCRIPTION
Temporarily disabled until we update to use the latest VSC API.
(also reading files unnecessarily instead of caching it)
Basically this code restores the old behaviour.