### PR TITLE
Fix latex manipulation case with multiple formulas inside a single '$$' block

### DIFF
--- a/news/2 Fixes/9766.md
+++ b/news/2 Fixes/9766.md
@@ -1,0 +1,1 @@
+Changed the latex manipulation to only fix single formulas. Otherwise the user must input '$' or '$$' as intended.

--- a/news/2 Fixes/9766.md
+++ b/news/2 Fixes/9766.md
@@ -1,1 +1,1 @@
-Changed the latex manipulation to only fix single formulas. Otherwise the user must input '$' or '$$' as intended.
+Fixed an issue with multiple latex formulas in the same '$$' block.

--- a/src/datascience-ui/interactive-common/latexManipulation.ts
+++ b/src/datascience-ui/interactive-common/latexManipulation.ts
@@ -4,21 +4,91 @@
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp');
 
-// Adds '$$' to single latex formulas that don't have a '$', allowing users to input the formula directly.
-
+// Adds '$$' to latex formulas that don't have a '$', allowing users to input the formula directly.
+//
+// The general algorithm here is:
+// Search for either $$ or $ or a \begin{name} item.
+// If a $$ or $ is found, output up to the next dollar sign
+// If a \begin{name} is found, find the matching \end{name}, wrap the section in $$ and output up to the \end.
+//
+// LaTeX seems to follow the pattern of \begin{name} or is escaped with $$ or $. See here for a bunch of examples:
+// https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Typesetting%20Equations.html
 export function fixLatexEquations(input: string): string {
-    const begin = /\\begin\{([a-z,\*]+)\}/.exec(input);
+    const output: string[] = [];
 
-    if (begin && begin.index === 0) {
-        const endRegex = new RegExp(`\\\\end\\{${_escapeRegExp(begin[1])}\\}`);
-        const end = endRegex.exec(input);
+    // Search for begin/end pairs, outputting as we go
+    let start = 0;
 
-        if (end && end.index + end[0].length === input.length) {
-            const prefix = '$$\n';
-            const postfix = '\n$$';
-            return prefix + input + postfix;
+    // Loop until we run out string
+    while (start < input.length) {
+        // Check $$, $ and begin
+        const dollars = /\$\$/.exec(input.substr(start));
+        const dollar = /\$/.exec(input.substr(start));
+        const begin = /\\begin\{([a-z,\*]+)\}/.exec(input.substr(start));
+        let endRegex = /\$\$/;
+        let endRegexLength = 2;
+
+        // Pick the first that matches
+        let match = dollars;
+        let isBeginMatch = false;
+        const isDollarsMatch = dollars?.index === dollar?.index;
+        if (!match || (dollar && dollar.index < match.index)) {
+            match = dollar;
+            endRegex = /\$/;
+            endRegexLength = 1;
+        }
+        if (!match || (begin && begin.index < match.index)) {
+            match = begin;
+            endRegex = begin ? new RegExp(`\\\\end\\{${_escapeRegExp(begin[1])}\\}`) : /\$/;
+            endRegexLength = begin ? `\\end{${begin[1]}}`.length : 1;
+            isBeginMatch = true;
+        }
+
+        // Output this match
+        if (match) {
+            if (isBeginMatch) {
+                // Begin match is a little more complicated.
+                const offset = match.index + start;
+                const end = endRegex.exec(input.substr(start));
+                if (end) {
+                    const prefix = input.substr(start, match.index);
+                    const wrapped = input.substr(offset, endRegexLength + end.index - match.index);
+                    output.push(`${prefix}\n$$\n${wrapped}\n$$\n`);
+                    start = start + prefix.length + wrapped.length;
+                } else {
+                    // Invalid, just return
+                    return input;
+                }
+            } else if (isDollarsMatch) {
+                // Output till the next $$
+                const offset = match.index + 2 + start;
+                const endDollar = endRegex.exec(input.substr(offset));
+                if (endDollar) {
+                    const length = endDollar.index + 2 + offset;
+                    output.push(input.substr(start, length));
+                    start = start + length;
+                } else {
+                    // Invalid, just return
+                    return input;
+                }
+            } else {
+                // Output till the next $
+                const offset = match.index + 1 + start;
+                const endDollar = endRegex.exec(input.substr(offset));
+                if (endDollar) {
+                    const length = endDollar.index + 1 + offset;
+                    output.push(input.substr(start, length));
+                    start = start + length;
+                } else {
+                    // Invalid, just return
+                    return input;
+                }
+            }
+        } else {
+            // No more matches
+            output.push(input.substr(start));
+            start = input.length;
         }
     }
-
-    return input;
+    return output.join('');
 }

--- a/src/datascience-ui/interactive-common/latexManipulation.ts
+++ b/src/datascience-ui/interactive-common/latexManipulation.ts
@@ -4,78 +4,21 @@
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp');
 
-// Adds '$$' to latex formulas that don't have a '$', allowing users to input the formula directly.
-//
-// The general algorithm here is:
-// Search for either $$ or $ or a \begin{name} item.
-// If a $$ or $ is found, output up to the next dollar sign
-// If a \begin{name} is found, find the matching \end{name}, wrap the section in $$ and output up to the \end.
-//
-// LaTeX seems to follow the pattern of \begin{name} or is escaped with $$ or $. See here for a bunch of examples:
-// https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Typesetting%20Equations.html
+// Adds '$$' to single latex formulas that don't have a '$', allowing users to input the formula directly.
+
 export function fixLatexEquations(input: string): string {
-    const output: string[] = [];
+    const begin = /\\begin\{([a-z,\*]+)\}/.exec(input);
 
-    // Search for begin/end pairs, outputting as we go
-    let start = 0;
+    if (begin && begin.index === 0) {
+        const endRegex = new RegExp(`\\\\end\\{${_escapeRegExp(begin[1])}\\}`);
+        const end = endRegex.exec(input);
 
-    // Loop until we run out string
-    while (start < input.length) {
-        // Check $$, $ and begin
-        const dollars = /\$\$/.exec(input.substr(start));
-        const dollar = /\$/.exec(input.substr(start));
-        const begin = /\\begin\{([a-z,\*]+)\}/.exec(input.substr(start));
-        let endRegex = /\$\$/;
-        let endRegexLength = 2;
-
-        // Pick the first that matches
-        let match = dollars;
-        let isBeginMatch = false;
-        if (!match || (dollar && dollar.index < match.index)) {
-            match = dollar;
-            endRegex = /\$/;
-            endRegexLength = 1;
-        }
-        if (!match || (begin && begin.index < match.index)) {
-            match = begin;
-            endRegex = begin ? new RegExp(`\\\\end\\{${_escapeRegExp(begin[1])}\\}`) : /\$/;
-            endRegexLength = begin ? `\\end{${begin[1]}}`.length : 1;
-            isBeginMatch = true;
-        }
-
-        // Output this match
-        if (match) {
-            if (isBeginMatch) {
-                // Begin match is a little more complicated.
-                const offset = match.index + start;
-                const end = endRegex.exec(input.substr(start));
-                if (end) {
-                    const prefix = input.substr(start, match.index);
-                    const wrapped = input.substr(offset, endRegexLength + end.index - match.index);
-                    output.push(`${prefix}\n$$\n${wrapped}\n$$\n`);
-                    start = start + prefix.length + wrapped.length;
-                } else {
-                    // Invalid, just return
-                    return input;
-                }
-            } else {
-                // Output till the next $ or $$
-                const offset = match.index + 1 + start;
-                const endDollar = endRegex.exec(input.substr(offset));
-                if (endDollar) {
-                    const length = endDollar.index + 1 + offset;
-                    output.push(input.substr(start, length));
-                    start = start + length;
-                } else {
-                    // Invalid, just return
-                    return input;
-                }
-            }
-        } else {
-            // No more matches
-            output.push(input.substr(start));
-            start = input.length;
+        if (end && end.index + end[0].length === input.length) {
+            const prefix = '$$\n';
+            const postfix = '\n$$';
+            return prefix + input + postfix;
         }
     }
-    return output.join('');
+
+    return input;
 }

--- a/src/test/datascience/latexManipulation.unit.test.ts
+++ b/src/test/datascience/latexManipulation.unit.test.ts
@@ -10,19 +10,15 @@ suite('Data Science - LaTeX Manipulation', () => {
 \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\
 \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\
 \\nabla \\cdot \\vec{\\mathbf{B}} & = 0
-\\end{align}
-sample text`;
+\\end{align}`;
 
-    const output1 = `
-$$
+    const output1 = `$$
 \\begin{align}
 \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\
 \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\
 \\nabla \\cdot \\vec{\\mathbf{B}} & = 0
 \\end{align}
-$$
-
-sample text`;
+$$`;
 
     const markdown2 = `$\\begin{align*}
 (a+b)^2 = a^2+2ab+b^2
@@ -51,40 +47,6 @@ sample text
 (a+b)^2 = a^2+2ab+b^2
 \\end{align*}`;
 
-    const output3 = `
-$$
-\\begin{align*}
-(a+b)^2 = a^2+2ab+b^2
-\\end{align*}
-$$
-
-sample text
-
-$$
-\\begin{align*}
-(a+b)^2 = a^2+2ab+b^2
-\\end{align*}
-$$
-
-sample text
-
-$$
-\\begin{align*}
-(a+b)^2 = a^2+2ab+b^2
-\\end{align*}
-$$
-
-sample text
-
-sample text
-
-$$
-\\begin{align*}
-(a+b)^2 = a^2+2ab+b^2
-\\end{align*}
-$$
-`;
-
     const markdown4 = `
 $$
 \\begin{equation*}
@@ -104,17 +66,6 @@ P(E)   = {n \\choose k} p^k (1-p)^{ n-k}
 
 This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](https://daringfireball.net/projects/markdown/) sentence.
 `;
-    const output5 = `
-
-$$
-\\begin{equation*}
-P(E)   = {n \\choose k} p^k (1-p)^{ n-k}
-\\end{equation*}
-$$
-
-
-This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](https://daringfireball.net/projects/markdown/) sentence.
-`;
 
     test("Latex - Equations don't have $$", () => {
         const result = fixLatexEquations(markdown1);
@@ -123,17 +74,17 @@ This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in
 
     test('Latex - Equations have $', () => {
         const result = fixLatexEquations(markdown2);
-        expect(result).to.be.equal(markdown2, 'Result is incorrect');
+        expect(result).to.be.equal(markdown2, 'Result should not have changed');
     });
 
     test("Latex - Multiple equations don't have $$", () => {
         const result = fixLatexEquations(markdown3);
-        expect(result).to.be.equal(output3, 'Result is incorrect');
+        expect(result).to.be.equal(markdown3, 'Result should not have changed');
     });
 
     test('Latex - All on the same line', () => {
         const line = '\\begin{matrix}1 & 0\\0 & 1\\end{matrix}';
-        const after = '\n$$\n\\begin{matrix}1 & 0\\0 & 1\\end{matrix}\n$$\n';
+        const after = '$$\n\\begin{matrix}1 & 0\\0 & 1\\end{matrix}\n$$';
         const result = fixLatexEquations(line);
         expect(result).to.be.equal(after, 'Result is incorrect');
     });
@@ -151,6 +102,6 @@ This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in
 
     test('Latex - Multiple types', () => {
         const result = fixLatexEquations(markdown5);
-        expect(result).to.be.equal(output5, 'Result is incorrect');
+        expect(result).to.be.equal(markdown5, 'Result should not have changed');
     });
 });

--- a/src/test/datascience/latexManipulation.unit.test.ts
+++ b/src/test/datascience/latexManipulation.unit.test.ts
@@ -45,6 +45,7 @@ sample text
 (a+b)^2 = a^2+2ab+b^2
 \\end{align*}
 sample text
+
 sample text
 \\begin{align*}
 (a+b)^2 = a^2+2ab+b^2
@@ -74,6 +75,7 @@ $$
 $$
 
 sample text
+
 sample text
 
 $$
@@ -95,17 +97,21 @@ $$
 $$
 `;
 
-    const markdown5 = `\\begin{equation*}
+    const markdown5 = `
+\\begin{equation*}
 P(E)   = {n \\choose k} p^k (1-p)^{ n-k}
 \\end{equation*}
+
 This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](https://daringfireball.net/projects/markdown/) sentence.
 `;
     const output5 = `
+
 $$
 \\begin{equation*}
 P(E)   = {n \\choose k} p^k (1-p)^{ n-k}
 \\end{equation*}
 $$
+
 
 This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](https://daringfireball.net/projects/markdown/) sentence.
 `;

--- a/src/test/datascience/latexManipulation.unit.test.ts
+++ b/src/test/datascience/latexManipulation.unit.test.ts
@@ -10,15 +10,19 @@ suite('Data Science - LaTeX Manipulation', () => {
 \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\
 \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\
 \\nabla \\cdot \\vec{\\mathbf{B}} & = 0
-\\end{align}`;
+\\end{align}
+sample text`;
 
-    const output1 = `$$
+    const output1 = `
+$$
 \\begin{align}
 \\nabla \\cdot \\vec{\\mathbf{E}} & = 4 \\pi \\rho \\\\
 \\nabla \\times \\vec{\\mathbf{E}}\\, +\\, \\frac1c\\, \\frac{\\partial\\vec{\\mathbf{B}}}{\\partial t} & = \\vec{\\mathbf{0}} \\\\
 \\nabla \\cdot \\vec{\\mathbf{B}} & = 0
 \\end{align}
-$$`;
+$$
+
+sample text`;
 
     const markdown2 = `$\\begin{align*}
 (a+b)^2 = a^2+2ab+b^2
@@ -41,31 +45,106 @@ sample text
 (a+b)^2 = a^2+2ab+b^2
 \\end{align*}
 sample text
-
 sample text
 \\begin{align*}
 (a+b)^2 = a^2+2ab+b^2
 \\end{align*}`;
 
+    const output3 = `
+$$
+\\begin{align*}
+(a+b)^2 = a^2+2ab+b^2
+\\end{align*}
+$$
+
+sample text
+
+$$
+\\begin{align*}
+(a+b)^2 = a^2+2ab+b^2
+\\end{align*}
+$$
+
+sample text
+
+$$
+\\begin{align*}
+(a+b)^2 = a^2+2ab+b^2
+\\end{align*}
+$$
+
+sample text
+sample text
+
+$$
+\\begin{align*}
+(a+b)^2 = a^2+2ab+b^2
+\\end{align*}
+$$
+`;
+
     const markdown4 = `
 $$
 \\begin{equation*}
 \\mathbf{V}_1 \\times \\mathbf{V}_2 = \\begin{vmatrix}
-\\mathbf{i} & \\mathbf{j} & \\mathbf{k} \\
-\\frac{\partial X}{\\partial u} & \\frac{\\partial Y}{\\partial u} & 0 \\\\
-\\frac{\partial X}{\\partial v} & \\frac{\\partial Y}{\\partial v} & 0
+\\mathbf{i} & \\mathbf{j} & \\mathbf{k} \\\\
+\\frac{\\partial X}{\\partial u} & \\frac{\\partial Y}{\\partial u} & 0 \\\\
+\\frac{\\partial X}{\\partial v} & \\frac{\\partial Y}{\\partial v} & 0
 \\end{vmatrix}
 \\end{equation*}
 $$
 `;
 
-    const markdown5 = `
+    const markdown5 = `\\begin{equation*}
+P(E)   = {n \\choose k} p^k (1-p)^{ n-k}
+\\end{equation*}
+This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](https://daringfireball.net/projects/markdown/) sentence.
+`;
+    const output5 = `
+$$
 \\begin{equation*}
 P(E)   = {n \\choose k} p^k (1-p)^{ n-k}
 \\end{equation*}
+$$
 
 This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in a [Markdown-formatted](https://daringfireball.net/projects/markdown/) sentence.
 `;
+
+    const markdown6 = `$$
+\\begin{aligned}
+\\frac{\\partial}{\\partial\\omega_j}C(\\omega) &= \\frac1m\\sum_{i=1}^m\\varphi_j\\left(x^i\\right)\\left(\\varphi^T\\left(x^i\\right)\\omega-t^i\\right)
+= 0
+\\end{aligned}
+$$
+$$
+\\begin{pmatrix}
+\\varphi_j\\left(x^1\\right) & \\dots & \\varphi_j\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+\\varphi_1\\left(x^1\\right) & \\dots & \\varphi_n\\left(x^1\\right)\\\\
+\\vdots & \\ddots & \\vdots\\\\
+\\varphi_1\\left(x^m\\right) & \\dots & \\varphi_n\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+\\omega_1\\\\
+\\vdots\\\\
+\\omega_n
+\\end{pmatrix}
+=
+\\begin{pmatrix}
+\\varphi_j\\left(x^1\\right) & \\dots & \\varphi_j\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+t^1\\\\
+\\vdots\\\\
+t^m
+\\end{pmatrix}
+$$
+
+Assuming that $T = (t^1, t^2, ..., t^m)^T$，$X = \\left(\\varphi(x^1), \\varphi(x^2), ..., \\varphi(x^m)\\right)^T$, then
+$$
+X^TX\\omega = X^TT
+$$`;
 
     test("Latex - Equations don't have $$", () => {
         const result = fixLatexEquations(markdown1);
@@ -74,17 +153,17 @@ This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in
 
     test('Latex - Equations have $', () => {
         const result = fixLatexEquations(markdown2);
-        expect(result).to.be.equal(markdown2, 'Result should not have changed');
+        expect(result).to.be.equal(markdown2, 'Result is incorrect');
     });
 
     test("Latex - Multiple equations don't have $$", () => {
         const result = fixLatexEquations(markdown3);
-        expect(result).to.be.equal(markdown3, 'Result should not have changed');
+        expect(result).to.be.equal(output3, 'Result is incorrect');
     });
 
     test('Latex - All on the same line', () => {
         const line = '\\begin{matrix}1 & 0\\0 & 1\\end{matrix}';
-        const after = '$$\n\\begin{matrix}1 & 0\\0 & 1\\end{matrix}\n$$';
+        const after = '\n$$\n\\begin{matrix}1 & 0\\0 & 1\\end{matrix}\n$$\n';
         const result = fixLatexEquations(line);
         expect(result).to.be.equal(after, 'Result is incorrect');
     });
@@ -102,6 +181,11 @@ This expression $\\sqrt{3x-1}+(1+x)^2$ is an example of a TeX inline equation in
 
     test('Latex - Multiple types', () => {
         const result = fixLatexEquations(markdown5);
-        expect(result).to.be.equal(markdown5, 'Result should not have changed');
+        expect(result).to.be.equal(output5, 'Result is incorrect');
+    });
+
+    test('Latex - Multiple /begins inside $$', () => {
+        const result = fixLatexEquations(markdown6);
+        expect(result).to.be.equal(markdown6, 'Result should not have changed');
     });
 });


### PR DESCRIPTION
For #9766, #7992, #8673

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
