### PR TITLE
When starting Jupyter activate conda env

### DIFF
--- a/src/client/common/terminal/helper.ts
+++ b/src/client/common/terminal/helper.ts
@@ -93,7 +93,7 @@ export class TerminalHelper implements ITerminalHelper {
         }
 
         // If we have a conda environment, then use that.
-        const isCondaEnvironment = await this.condaService.isCondaEnvironment(settings.pythonPath);
+        const isCondaEnvironment = interpreter ? interpreter.type === InterpreterType.Conda : await this.condaService.isCondaEnvironment(settings.pythonPath);
         if (isCondaEnvironment) {
             const activationCommands = interpreter
                 ? await this.conda.getActivationCommandsForInterpreter(interpreter.path, terminalShellType)

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -327,8 +327,8 @@ suite('Terminal Service helpers', () => {
 
                             expect(cmd).to.equal(undefined, 'Command must be undefined');
                             verify(pythonSettings.terminal).once();
-                            verify(pythonSettings.pythonPath).once();
-                            verify(condaService.isCondaEnvironment(pythonPath)).once();
+                            verify(pythonSettings.pythonPath).times(interpreter ? 0 : 1);
+                            verify(condaService.isCondaEnvironment(pythonPath)).times(interpreter ? 0 : 1);
                             verify(bashActivationProvider.isShellSupported(shellToExpect)).atLeast(1);
                             verify(pyenvActivationProvider.isShellSupported(anything())).never();
                             verify(pipenvActivationProvider.isShellSupported(anything())).never();


### PR DESCRIPTION
For #9973
Currently `conda` isn't getting activated when auto starting Jupyter server.