### PR TITLE
Fix open to work for non text documents

### DIFF
--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -86,6 +86,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     ['revealLine']: [{ lineNumber: number; at: 'top' | 'center' | 'bottom' }];
     ['python._loadLanguageServerExtension']: {}[];
     ['python.SelectAndInsertDebugConfiguration']: [TextDocument, Position, CancellationToken];
+    ['vscode.open']: [Uri];
     ['python.viewLanguageServerOutput']: [];
     [Commands.Build_Workspace_Symbols]: [boolean, CancellationToken];
     [Commands.Sort_Imports]: [undefined, Uri];

--- a/src/client/datascience/interactive-common/linkProvider.ts
+++ b/src/client/datascience/interactive-common/linkProvider.ts
@@ -6,7 +6,7 @@ import '../../common/extensions';
 import { inject, injectable } from 'inversify';
 import { Event, EventEmitter, Position, Range, TextEditorRevealType, Uri } from 'vscode';
 
-import { IApplicationShell, IDocumentManager } from '../../common/application/types';
+import { IApplicationShell, ICommandManager, IDocumentManager } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
@@ -22,7 +22,8 @@ export class LinkProvider implements IInteractiveWindowListener {
     constructor(
         @inject(IApplicationShell) private applicationShell: IApplicationShell,
         @inject(IFileSystem) private fileSystem: IFileSystem,
-        @inject(IDocumentManager) private documentManager: IDocumentManager
+        @inject(IDocumentManager) private documentManager: IDocumentManager,
+        @inject(ICommandManager) private commandManager: ICommandManager
     ) {
         noop();
     }
@@ -85,13 +86,19 @@ export class LinkProvider implements IInteractiveWindowListener {
         }
 
         // Show the matching editor if there is one
-        const editor = this.documentManager.visibleTextEditors.find(e => this.fileSystem.arePathsSame(e.document.fileName, uri.fsPath));
+        let editor = this.documentManager.visibleTextEditors.find(e => this.fileSystem.arePathsSame(e.document.fileName, uri.fsPath));
         if (editor) {
-            this.documentManager.showTextDocument(editor.document, { selection, viewColumn: editor.viewColumn }).then(() => {
-                editor.revealRange(selection, TextEditorRevealType.InCenter);
+            this.documentManager.showTextDocument(editor.document, { selection, viewColumn: editor.viewColumn }).then(e => {
+                e.revealRange(selection, TextEditorRevealType.InCenter);
             });
         } else {
-            this.documentManager.showTextDocument(uri, { selection });
+            this.commandManager.executeCommand('vscode.open', uri).then(() => {
+                // See if that opened a text document
+                editor = this.documentManager.visibleTextEditors.find(e => this.fileSystem.arePathsSame(e.document.fileName, uri.fsPath));
+                if (editor) {
+                    editor.revealRange(selection, TextEditorRevealType.InCenter);
+                }
+            });
         }
     }
 }

--- a/src/client/datascience/interactive-common/linkProvider.ts
+++ b/src/client/datascience/interactive-common/linkProvider.ts
@@ -4,7 +4,7 @@
 import '../../common/extensions';
 
 import { inject, injectable } from 'inversify';
-import { Event, EventEmitter, Position, Range, TextEditorRevealType, Uri } from 'vscode';
+import { Event, EventEmitter, Position, Range, Selection, TextEditorRevealType, Uri } from 'vscode';
 
 import { IApplicationShell, ICommandManager, IDocumentManager } from '../../common/application/types';
 import { IFileSystem } from '../../common/platform/types';
@@ -92,11 +92,14 @@ export class LinkProvider implements IInteractiveWindowListener {
                 e.revealRange(selection, TextEditorRevealType.InCenter);
             });
         } else {
+            // Not a visible editor, try opening otherwise
             this.commandManager.executeCommand('vscode.open', uri).then(() => {
                 // See if that opened a text document
                 editor = this.documentManager.visibleTextEditors.find(e => this.fileSystem.arePathsSame(e.document.fileName, uri.fsPath));
                 if (editor) {
-                    editor.revealRange(selection, TextEditorRevealType.InCenter);
+                    // Force the selection to change
+                    editor.revealRange(selection);
+                    editor.selection = new Selection(selection.start, selection.start);
                 }
             });
         }


### PR DESCRIPTION
@IanMatthewHuff had a good point on the error line change. Opening non text documents didn't work anymore because I switched it to use openTextDocument instead of openUrl.

This changes it such that VS code is always used to open a file link, but it will also work with non text documents.