### PR TITLE
Fix problem with undoing entire stack

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -34,7 +34,7 @@ interface INativeEditorStorageState {
 @injectable()
 export class NativeEditorStorage implements INotebookModel, INotebookStorage {
     public get isDirty(): boolean {
-        return this._state.changeCount !== this._state.saveChangeCount && this._state.changeCount !== 0;
+        return this._state.changeCount !== this._state.saveChangeCount;
     }
     public get changed(): Event<NotebookModelChange> {
         return this._changedEmitter.event;


### PR DESCRIPTION
If you save a file, then undo back to when the undo stack is empty, the file should be dirty.

VS code will show the dirty icon on the file, but we won't enable the save button on the UI.