### PR TITLE
Fix magics to work by handling page return data.

### DIFF
--- a/news/2 Fixes/6900.md
+++ b/news/2 Fixes/6900.md
@@ -1,0 +1,1 @@
+Fix magic commands that return 'paged' output. 

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -289,6 +289,17 @@ for _ in range(50):
 
             await addCode(ioc, wrapper, spinningCursor);
             verifyHtmlOnCell(wrapper, 'InteractiveCell', '<div>', CellPosition.Last);
+
+            addContinuousMockData(ioc, 'len?', async _c => {
+                return Promise.resolve({
+                    result: `Signature: len(obj, /)
+Docstring: Return the number of items in a container.
+Type:      builtin_function_or_method`,
+                    haveMore: false
+                });
+            });
+            await addCode(ioc, wrapper, 'len?');
+            verifyHtmlOnCell(wrapper, 'InteractiveCell', 'len', CellPosition.Last);
         },
         () => {
             return ioc;


### PR DESCRIPTION
For #6900

This fixes all magic commands that return 'paged' output (like %%prun or <var>? or %%pinfo)

We were never listening to the execute reply response, which seems is always sent whenever a request is executed (it also indicates the request is done). 

Part of the reply can have a payload that contains additional data. I move this data into the stream output for the cell (Jupyter actually has a separate UI for it).

Here's a screen shot for ```len?```

![image](https://user-images.githubusercontent.com/19672699/74188193-cfe8af80-4c02-11ea-81a7-dd8246347b0f.png)


