### PR TITLE
Complete refactoring of creation and queueing of actions

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -11,7 +11,6 @@ import { CancellationToken, ConfigurationTarget, Event, EventEmitter, Memento, P
 import { Disposable } from 'vscode-jsonrpc';
 
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
-import { CommonActionType } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import { IApplicationShell, ICommandManager, IDocumentManager, ILiveShareApi, IWebPanelProvider, IWorkspaceService } from '../../common/application/types';
 import { CancellationError } from '../../common/cancellation';
 import { EXTENSION_ROOT_DIR, PYTHON_LANGUAGE } from '../../common/constants';
@@ -44,7 +43,7 @@ import { JupyterInstallError } from '../jupyter/jupyterInstallError';
 import { JupyterSelfCertsError } from '../jupyter/jupyterSelfCertsError';
 import { JupyterKernelPromiseFailedError } from '../jupyter/kernels/jupyterKernelPromiseFailedError';
 import { LiveKernelModel } from '../jupyter/kernels/types';
-import { CssMessages, SharedMessages } from '../messages';
+import { CssMessages } from '../messages';
 import { ProgressReporter } from '../progress/progressReporter';
 import {
     CellState,
@@ -74,7 +73,6 @@ import {
 } from '../types';
 import { WebViewHost } from '../webViewHost';
 import { InteractiveWindowMessageListener } from './interactiveWindowMessageListener';
-import { BaseReduxActionPayload } from './types';
 
 @injectable()
 export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapping> implements IInteractiveBase {
@@ -178,11 +176,6 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     // tslint:disable-next-line: no-any no-empty cyclomatic-complexity max-func-body-length
     public onMessage(message: string, payload: any) {
         switch (message) {
-            case InteractiveWindowMessages.Sync:
-                // tslint:disable-next-line: no-any
-                const syncPayload = payload as { type: InteractiveWindowMessages | SharedMessages | CommonActionType; payload: BaseReduxActionPayload<any> };
-                this.postMessageInternal(syncPayload.type, syncPayload.payload).ignoreErrors();
-                break;
             case InteractiveWindowMessages.GotoCodeCell:
                 this.handleMessage(message, payload, this.gotoCode);
                 break;

--- a/src/client/datascience/interactive-common/interactiveWindowMessageListener.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowMessageListener.ts
@@ -15,7 +15,6 @@ import { InteractiveWindowMessages, InteractiveWindowRemoteMessages } from './in
 
 // This class listens to messages that come from the local Python Interactive window
 export class InteractiveWindowMessageListener implements IWebPanelMessageListener {
-    private static handlers = new Map<InteractiveWindowMessageListener, (message: string, payload: any) => void>();
     private postOffice: PostOffice;
     private disposedCallback: () => void;
     private callback: (message: string, payload: any) => void;
@@ -41,7 +40,6 @@ export class InteractiveWindowMessageListener implements IWebPanelMessageListene
         this.interactiveWindowMessages.forEach(m => {
             this.postOffice.registerCallback(m, a => callback(m, a)).ignoreErrors();
         });
-        InteractiveWindowMessageListener.handlers.set(this, callback);
     }
 
     public async dispose() {
@@ -50,20 +48,6 @@ export class InteractiveWindowMessageListener implements IWebPanelMessageListene
     }
 
     public onMessage(message: string, payload: any) {
-        if (message === InteractiveWindowMessages.Sync) {
-            // const syncPayload = payload as BaseReduxActionPayload;
-            Array.from(InteractiveWindowMessageListener.handlers.keys()).forEach(item => {
-                if (item === this) {
-                    return;
-                }
-                // Temporarily disabled.
-                // const cb = InteractiveWindowMessageListener.handlers.get(item);
-                // if (cb) {
-                //     cb(InteractiveWindowMessages.Sync, { type: message, payload: syncPayload });
-                // }
-            });
-            return;
-        }
         // We received a message from the local webview. Broadcast it to everybody if it's a remote message
         if (InteractiveWindowRemoteMessages.indexOf(message) >= 0) {
             this.postOffice.postCommand(message, payload).ignoreErrors();

--- a/src/client/datascience/interactive-common/synchronization.ts
+++ b/src/client/datascience/interactive-common/synchronization.ts
@@ -194,7 +194,6 @@ export function checkToPostBasedOnOriginalMessageType(messageType?: MessageType)
 }
 
 export function shouldRebroadcast(message: keyof IInteractiveWindowMapping): [boolean, MessageType] {
-    console.error(messageWithMessageTypes);
     // Get the configured type for this message (whether it should be re-broadcasted or not).
     const messageType: MessageType | undefined = messageWithMessageTypes[message];
     // Support for liveshare is turned off for now, we can enable that later.

--- a/src/client/datascience/interactive-common/synchronization.ts
+++ b/src/client/datascience/interactive-common/synchronization.ts
@@ -1,7 +1,6 @@
 import { CommonActionType, CommonActionTypeMapping } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import { CssMessages, SharedMessages } from '../messages';
 import { IInteractiveWindowMapping, InteractiveWindowMessages } from './interactiveWindowTypes';
-import { BaseReduxActionPayload } from './types';
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
@@ -172,11 +171,31 @@ const messageWithMessageTypes: MessageMapping<IInteractiveWindowMapping> & Messa
     [SharedMessages.UpdateSettings]: MessageType.userAction
 };
 
-export function isActionPerformedByUser(action: BaseReduxActionPayload<{}> | BaseReduxActionPayload<never>) {
-    return action.messageType === undefined;
+/**
+ * If the original message was a sync message, then do not send messages to extension.
+ *  We allow messages to be sent to extension ONLY when the original message was triggered by the user.
+ *
+ * @export
+ * @param {MessageType} [messageType]
+ * @returns
+ */
+export function checkToPostBasedOnOriginalMessageType(messageType?: MessageType): boolean {
+    if (!messageType) {
+        return true;
+    }
+    if (
+        (messageType & MessageType.syncAcrossSameNotebooks) === MessageType.syncAcrossSameNotebooks ||
+        (messageType & MessageType.syncWithLiveShare) === MessageType.syncWithLiveShare
+    ) {
+        return false;
+    }
+
+    return true;
 }
 
 export function shouldRebroadcast(message: keyof IInteractiveWindowMapping): [boolean, MessageType] {
+    console.error(messageWithMessageTypes);
+    // Get the configured type for this message (whether it should be re-broadcasted or not).
     const messageType: MessageType | undefined = messageWithMessageTypes[message];
     // Support for liveshare is turned off for now, we can enable that later.
     // I.e. we only support synchronizing across editors in the same session.

--- a/src/datascience-ui/history-react/redux/actions.ts
+++ b/src/datascience-ui/history-react/redux/actions.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IInteractiveWindowMapping, InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterVariable, IJupyterVariablesRequest } from '../../../client/datascience/types';
-import { createIncomingAction, createIncomingActionWithPayload } from '../../interactive-common/redux/helpers';
 import {
     CommonAction,
     CommonActionType,
+    CommonActionTypeMapping,
     ICellAction,
     ICodeAction,
     ICodeCreatedAction,
@@ -17,6 +17,16 @@ import {
     IShowDataViewerAction
 } from '../../interactive-common/redux/reducers/types';
 import { IMonacoModelContentChangeEvent } from '../../react-common/monacoHelpers';
+
+// This function isn't made common and not exported, to ensure it isn't used elsewhere.
+function createIncomingActionWithPayload<M extends IInteractiveWindowMapping & CommonActionTypeMapping, K extends keyof M>(type: K, data: M[K]): CommonAction<M[K]> {
+    // tslint:disable-next-line: no-any
+    return { type, payload: { data, messageDirection: 'incoming' } as any } as any;
+}
+// This function isn't made common and not exported, to ensure it isn't used elsewhere.
+function createIncomingAction(type: CommonActionType | InteractiveWindowMessages): CommonAction {
+    return { type, payload: { messageDirection: 'incoming', data: undefined } };
+}
 
 // See https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object
 export const actionCreators = {

--- a/src/datascience-ui/interactive-common/redux/postOffice.ts
+++ b/src/datascience-ui/interactive-common/redux/postOffice.ts
@@ -23,7 +23,7 @@ export function generatePostOfficeSendReducer(postOffice: PostOffice): Redux.Red
                 const payload: BaseReduxActionPayload<{}> | undefined = action.payload;
                 // Do not rebroadcast messages that have been sent through as part of a synchronization packet.
                 // If `messageType` is a number, then its some part of a synchronization packet.
-                if (payload?.messageDirection === 'incoming' && typeof payload?.messageType !== 'number') {
+                if (payload?.messageDirection === 'incoming') {
                     // We can delay this, first focus on UX perf.
                     setTimeout(() => {
                         reBroadcastMessageIfRequired(postOffice.sendMessage.bind(postOffice), action.type, action?.payload);

--- a/src/datascience-ui/interactive-common/redux/reducers/monaco.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/monaco.ts
@@ -20,7 +20,7 @@ import { PostOffice } from '../../../react-common/postOffice';
 import { combineReducers, QueuableAction, ReducerArg, ReducerFunc } from '../../../react-common/reduxUtils';
 import { IntellisenseProvider } from '../../intellisenseProvider';
 import { initializeTokenizer, registerMonacoLanguage } from '../../tokenizer';
-import { createIncomingAction } from '../helpers';
+import { queueIncomingAction } from '../helpers';
 import { CommonActionType, ICodeCreatedAction, IEditCellAction } from './types';
 
 export interface IMonacoState {
@@ -63,7 +63,7 @@ function finishTokenizer<T>(buffer: ArrayBuffer, tmJson: string, arg: MonacoRedu
         if (e) {
             logMessage(`ERROR from onigasm: ${e}`);
         }
-        arg.queueAction(createIncomingAction(InteractiveWindowMessages.MonacoReady));
+        queueIncomingAction(arg, InteractiveWindowMessages.MonacoReady);
     }).ignoreErrors();
 }
 

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -6,6 +6,7 @@ import * as Redux from 'redux';
 import { createLogger } from 'redux-logger';
 import { Identifiers } from '../../../client/datascience/constants';
 import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { MessageType } from '../../../client/datascience/interactive-common/synchronization';
 import { BaseReduxActionPayload } from '../../../client/datascience/interactive-common/types';
 import { CssMessages } from '../../../client/datascience/messages';
 import { CellState } from '../../../client/datascience/types';
@@ -294,12 +295,17 @@ export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode
         handleMessage(message: string, payload?: any): boolean {
             // Double check this is one of our messages. React will actually post messages here too during development
             if (isAllowedMessage(message)) {
+                debugger;
                 const basePayload: BaseReduxActionPayload = { data: payload };
                 if (message === InteractiveWindowMessages.Sync) {
+                    // This is a message that has been sent from extension purely for synchronization purposes.
                     // Unwrap the message.
                     message = payload.type;
-                    basePayload.messageType = payload.payload.messageType;
+                    basePayload.messageType = payload.payload.messageType ?? MessageType.syncAcrossSameNotebooks;
                     basePayload.data = payload.payload.data;
+                } else {
+                    // Messages result of some user action.
+                    basePayload.messageType = basePayload.messageType ?? MessageType.userAction;
                 }
                 store.dispatch({ type: message, payload: basePayload });
             }

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -295,7 +295,6 @@ export function createStore<M>(skipDefault: boolean, baseTheme: string, testMode
         handleMessage(message: string, payload?: any): boolean {
             // Double check this is one of our messages. React will actually post messages here too during development
             if (isAllowedMessage(message)) {
-                debugger;
                 const basePayload: BaseReduxActionPayload = { data: payload };
                 if (message === InteractiveWindowMessages.Sync) {
                     // This is a message that has been sent from extension purely for synchronization purposes.

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -76,7 +76,11 @@ function createSendInfoMiddleware(): Redux.Middleware<{}, IStore> {
         const afterState = store.getState();
 
         // If the action is part of a sync message, then do not send it to the extension.
-        if (action.payload && typeof (action.payload as BaseReduxActionPayload).messageType === 'number') {
+        const messageType = (action?.payload as BaseReduxActionPayload).messageType ?? MessageType.userAction;
+        const isSyncMessage =
+            (messageType & MessageType.syncAcrossSameNotebooks) === MessageType.syncAcrossSameNotebooks &&
+            (messageType & MessageType.syncAcrossSameNotebooks) === MessageType.syncWithLiveShare;
+        if (isSyncMessage) {
             return res;
         }
 

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 'use strict';
 import * as uuid from 'uuid/v4';
-import { InteractiveWindowMessages, NativeCommandType } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { IInteractiveWindowMapping, InteractiveWindowMessages, NativeCommandType } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterVariable, IJupyterVariablesRequest } from '../../../client/datascience/types';
 import { CursorPos } from '../../interactive-common/mainState';
-import { createIncomingAction, createIncomingActionWithPayload } from '../../interactive-common/redux/helpers';
 import {
     CommonAction,
     CommonActionType,
+    CommonActionTypeMapping,
     ICellAction,
     ICellAndCursorAction,
     ICodeAction,
@@ -19,6 +19,16 @@ import {
     IShowDataViewerAction
 } from '../../interactive-common/redux/reducers/types';
 import { IMonacoModelContentChangeEvent } from '../../react-common/monacoHelpers';
+
+// This function isn't made common and not exported, to ensure it isn't used elsewhere.
+function createIncomingActionWithPayload<M extends IInteractiveWindowMapping & CommonActionTypeMapping, K extends keyof M>(type: K, data: M[K]): CommonAction<M[K]> {
+    // tslint:disable-next-line: no-any
+    return { type, payload: { data, messageDirection: 'incoming' } as any } as any;
+}
+// This function isn't made common and not exported, to ensure it isn't used elsewhere.
+function createIncomingAction(type: CommonActionType | InteractiveWindowMessages): CommonAction {
+    return { type, payload: { messageDirection: 'incoming', data: undefined } };
+}
 
 // See https://react-redux.js.org/using-react-redux/connect-mapdispatch#defining-mapdispatchtoprops-as-an-object
 export const actionCreators = {

--- a/src/datascience-ui/native-editor/redux/reducers/creation.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/creation.ts
@@ -6,7 +6,7 @@ import { noop } from '../../../../client/common/utils/misc';
 import { IEditorContentChange, ILoadAllCells, NotebookModelChange } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { ICell, IDataScienceExtraSettings } from '../../../../client/datascience/types';
 import { createCellVM, createEmptyCell, CursorPos, extractInputText, getSelectedAndFocusedInfo, ICellViewModel, IMainState } from '../../../interactive-common/mainState';
-import { createIncomingActionWithPayload } from '../../../interactive-common/redux/helpers';
+import { queueIncomingActionWithPayload } from '../../../interactive-common/redux/helpers';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { Transfer } from '../../../interactive-common/redux/reducers/transfer';
 import { CommonActionType, IAddCellAction, ICellAction } from '../../../interactive-common/redux/reducers/types';
@@ -41,26 +41,26 @@ export namespace Creation {
     }
 
     export function addAndFocusCell(arg: NativeEditorReducerArg<IAddCellAction>): IMainState {
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.ADD_NEW_CELL, { newCellId: arg.payload.data.newCellId }));
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current }));
+        queueIncomingActionWithPayload(arg, CommonActionType.ADD_NEW_CELL, { newCellId: arg.payload.data.newCellId });
+        queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current });
         return arg.prevState;
     }
 
     export function insertAboveAndFocusCell(arg: NativeEditorReducerArg<IAddCellAction & ICellAction>): IMainState {
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.INSERT_ABOVE, { cellId: arg.payload.data.cellId, newCellId: arg.payload.data.newCellId }));
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current }));
+        queueIncomingActionWithPayload(arg, CommonActionType.INSERT_ABOVE, { cellId: arg.payload.data.cellId, newCellId: arg.payload.data.newCellId });
+        queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current });
         return arg.prevState;
     }
 
     export function insertBelowAndFocusCell(arg: NativeEditorReducerArg<IAddCellAction & ICellAction>): IMainState {
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.INSERT_BELOW, { cellId: arg.payload.data.cellId, newCellId: arg.payload.data.newCellId }));
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current }));
+        queueIncomingActionWithPayload(arg, CommonActionType.INSERT_BELOW, { cellId: arg.payload.data.cellId, newCellId: arg.payload.data.newCellId });
+        queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current });
         return arg.prevState;
     }
 
     export function insertAboveFirstAndFocusCell(arg: NativeEditorReducerArg<IAddCellAction>): IMainState {
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.INSERT_ABOVE_FIRST, { newCellId: arg.payload.data.newCellId }));
-        arg.queueAction(createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current }));
+        queueIncomingActionWithPayload(arg, CommonActionType.INSERT_ABOVE_FIRST, { newCellId: arg.payload.data.newCellId });
+        queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, { cellId: arg.payload.data.newCellId, cursorPos: CursorPos.Current });
         return arg.prevState;
     }
 

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -10,7 +10,7 @@ import { CellState } from '../../../../client/datascience/types';
 import { concatMultilineStringInput } from '../../../common';
 import { createCellFrom } from '../../../common/cellFactory';
 import { CursorPos, getSelectedAndFocusedInfo, ICellViewModel, IMainState } from '../../../interactive-common/mainState';
-import { createIncomingActionWithPayload, postActionToExtension } from '../../../interactive-common/redux/helpers';
+import { postActionToExtension, queueIncomingActionWithPayload } from '../../../interactive-common/redux/helpers';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { Transfer } from '../../../interactive-common/redux/reducers/transfer';
 import { CommonActionType, ICellAction, IChangeCellTypeAction, ICodeAction, IExecuteAction } from '../../../interactive-common/redux/reducers/types';
@@ -64,13 +64,11 @@ export namespace Execution {
     }
 
     export function executeCellAndAdvance(arg: NativeEditorReducerArg<IExecuteAction>): IMainState {
-        arg.queueAction(
-            createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL, { cellId: arg.payload.data.cellId, code: arg.payload.data.code, moveOp: arg.payload.data.moveOp })
-        );
+        queueIncomingActionWithPayload(arg, CommonActionType.EXECUTE_CELL, { cellId: arg.payload.data.cellId, code: arg.payload.data.code, moveOp: arg.payload.data.moveOp });
         if (arg.payload.data.moveOp === 'add') {
             const newCellId = uuid();
-            arg.queueAction(createIncomingActionWithPayload(CommonActionType.INSERT_BELOW, { cellId: arg.payload.data.cellId, newCellId }));
-            arg.queueAction(createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId: newCellId, cursorPos: CursorPos.Current }));
+            queueIncomingActionWithPayload(arg, CommonActionType.INSERT_BELOW, { cellId: arg.payload.data.cellId, newCellId });
+            queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, { cellId: newCellId, cursorPos: CursorPos.Current });
         }
         return arg.prevState;
     }

--- a/src/datascience-ui/native-editor/redux/reducers/movement.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/movement.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { CursorPos, IMainState } from '../../../interactive-common/mainState';
-import { createIncomingActionWithPayload } from '../../../interactive-common/redux/helpers';
+import { queueIncomingActionWithPayload } from '../../../interactive-common/redux/helpers';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
 import { Transfer } from '../../../interactive-common/redux/reducers/transfer';
 import { CommonActionType, ICellAction, ICodeAction } from '../../../interactive-common/redux/reducers/types';
@@ -50,7 +50,7 @@ export namespace Movement {
     export function arrowUp(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         if (index > 0) {
-            arg.queueAction(createIncomingActionWithPayload(CommonActionType.SELECT_CELL, { cellId: arg.prevState.cellVMs[index - 1].cell.id, cursorPos: CursorPos.Bottom }));
+            queueIncomingActionWithPayload(arg, CommonActionType.SELECT_CELL, { cellId: arg.prevState.cellVMs[index - 1].cell.id, cursorPos: CursorPos.Bottom });
         }
 
         return arg.prevState;
@@ -59,7 +59,7 @@ export namespace Movement {
     export function arrowDown(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         if (index < arg.prevState.cellVMs.length - 1) {
-            arg.queueAction(createIncomingActionWithPayload(CommonActionType.SELECT_CELL, { cellId: arg.prevState.cellVMs[index + 1].cell.id, cursorPos: CursorPos.Bottom }));
+            queueIncomingActionWithPayload(arg, CommonActionType.SELECT_CELL, { cellId: arg.prevState.cellVMs[index + 1].cell.id, cursorPos: CursorPos.Bottom });
         }
 
         return arg.prevState;


### PR DESCRIPTION
Some how I had not included some of the other remaining `arg.queueAction` into the original 
PR https://github.com/microsoft/vscode-python/pull/10019

This PR merely brings them from (I had these in the same branch, but failed to include them).
Same as #10019, just a refactor to use a common function to create an action and dispatch it in one step. & removed some of the old syncing stuff.