### PR TITLE
Rchiodo/latex on execute

### DIFF
--- a/news/2 Fixes/8742.md
+++ b/news/2 Fixes/8742.md
@@ -1,0 +1,1 @@
+Fix latex output from a code cell to render correctly.

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -237,6 +237,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             isText = true;
             isError = false;
             renderWithScrollbars = true;
+            // NOSONAR - Sonar is wrong, TS won't compile without this AS
             const stream = output as nbformat.IStream;
             const formatted = concatMultilineStringOutput(stream.text);
             input = {
@@ -261,6 +262,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             isText = true;
             isError = true;
             renderWithScrollbars = true;
+            // NOSONAR - Sonar is wrong, TS won't compile without this AS
             const error = output as nbformat.IError;
             try {
                 const converter = new CellOutput.ansiToHtmlClass(CellOutput.getAnsiToHtmlOptions());

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -237,8 +237,8 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             isText = true;
             isError = false;
             renderWithScrollbars = true;
-            // NOSONAR - Sonar is wrong, TS won't compile without this AS
-            const stream = output as nbformat.IStream;
+            // Sonar is wrong, TS won't compile without this AS
+            const stream = output as nbformat.IStream; // NOSONAR
             const formatted = concatMultilineStringOutput(stream.text);
             input = {
                 'text/html': formatted.includes('<') ? `<xmp>${formatted}</xmp>` : `<div>${formatted}</div>`
@@ -262,8 +262,8 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             isText = true;
             isError = true;
             renderWithScrollbars = true;
-            // NOSONAR - Sonar is wrong, TS won't compile without this AS
-            const error = output as nbformat.IError;
+            // Sonar is wrong, TS won't compile without this AS
+            const error = output as nbformat.IError; // NOSONAR
             try {
                 const converter = new CellOutput.ansiToHtmlClass(CellOutput.getAnsiToHtmlOptions());
                 const trace = converter.toHtml(error.traceback.join('\n'));
@@ -283,7 +283,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
         }
 
         // Then parse the mime type
-        const mimeBundle = input as nbformat.IMimeBundle;
+        const mimeBundle = input as nbformat.IMimeBundle; // NOSONAR
         let data: nbformat.MultilineString | JSONObject = mimeBundle[mimeType];
 
         // For un-executed output we might get text or svg output as multiline string arrays

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -33,12 +33,17 @@ interface ICellOutputProps {
     expandImage(imageHtml: string): void;
 }
 
-interface ICellOutput {
+interface ICellOutputData {
     mimeType: string;
     data: nbformat.MultilineString | JSONObject;
+    mimeBundle: nbformat.IMimeBundle;
     renderWithScrollbars: boolean;
     isText: boolean;
     isError: boolean;
+}
+
+interface ICellOutput {
+    output: ICellOutputData;
     extraButton: JSX.Element | null; // Extra button for plot viewing is stored here
     outputSpanClassName?: string; // Wrap this output in a span with the following className, undefined to not wrap
     doubleClick(): void; // Double click handler for plot viewing is stored here
@@ -213,32 +218,28 @@ export class CellOutput extends React.Component<ICellOutputProps> {
         ];
     };
 
-    // tslint:disable-next-line: max-func-body-length
-    private transformOutput(output: nbformat.IOutput): ICellOutput {
-        // First make a copy of the outputs.
-        const copy = cloneDeep(output);
-
+    private computeOutputData(output: nbformat.IOutput): ICellOutputData {
         let isText = false;
         let isError = false;
         let mimeType = 'text/plain';
+        let input = output.data;
         let renderWithScrollbars = false;
-        let extraButton: JSX.Element | null = null;
 
         // Special case for json. Just turn into a string
-        if (copy.data && copy.data.hasOwnProperty('application/json')) {
-            copy.data = JSON.stringify(copy.data);
+        if (input && input.hasOwnProperty('application/json')) {
+            input = JSON.stringify(output.data);
             renderWithScrollbars = true;
             isText = true;
-        } else if (copy.output_type === 'stream') {
+        } else if (output.output_type === 'stream') {
             // Stream output needs to be wrapped in xmp so it
             // show literally. Otherwise < chars start a new html element.
             mimeType = 'text/html';
             isText = true;
             isError = false;
             renderWithScrollbars = true;
-            const stream = copy as nbformat.IStream;
+            const stream = output as nbformat.IStream;
             const formatted = concatMultilineStringOutput(stream.text);
-            copy.data = {
+            input = {
                 'text/html': formatted.includes('<') ? `<xmp>${formatted}</xmp>` : `<div>${formatted}</div>`
             };
 
@@ -248,64 +249,85 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                 if (ansiRegex().test(formatted)) {
                     const converter = new CellOutput.ansiToHtmlClass(CellOutput.getAnsiToHtmlOptions());
                     const html = converter.toHtml(formatted);
-                    copy.data = {
+                    input = {
                         'text/html': html
                     };
                 }
             } catch {
                 noop();
             }
-        } else if (copy.output_type === 'error') {
+        } else if (output.output_type === 'error') {
             mimeType = 'text/html';
             isText = true;
             isError = true;
             renderWithScrollbars = true;
-            const error = copy as nbformat.IError;
+            const error = output as nbformat.IError;
             try {
                 const converter = new CellOutput.ansiToHtmlClass(CellOutput.getAnsiToHtmlOptions());
                 const trace = converter.toHtml(error.traceback.join('\n'));
-                copy.data = {
+                input = {
                     'text/html': trace
                 };
             } catch {
                 // This can fail during unit tests, just use the raw data
-                copy.data = {
+                input = {
                     'text/html': error.evalue
                 };
             }
-        } else if (copy.data) {
+        } else if (input) {
             // Compute the mime type
-            mimeType = getRichestMimetype(copy.data);
+            mimeType = getRichestMimetype(input);
             isText = mimeType === 'text/plain';
         }
 
         // Then parse the mime type
-        try {
-            const mimeBundle = copy.data as nbformat.IMimeBundle;
-            let data: nbformat.MultilineString | JSONObject = mimeBundle[mimeType];
-            // For un-executed output we might get text or svg output as multiline string arrays
-            // we want to concat those so we don't display a bunch of weird commas as we expect
-            // Single strings in our output
-            if (Array.isArray(data)) {
-                data = concatMultilineStringOutput(data as nbformat.MultilineString);
-            }
+        const mimeBundle = input as nbformat.IMimeBundle;
+        let data: nbformat.MultilineString | JSONObject = mimeBundle[mimeType];
 
+        // For un-executed output we might get text or svg output as multiline string arrays
+        // we want to concat those so we don't display a bunch of weird commas as we expect
+        // Single strings in our output
+        if (Array.isArray(data)) {
+            data = concatMultilineStringOutput(data as nbformat.MultilineString);
+        }
+
+        // Fixup latex to make sure it has the requisite $$ around it
+        if (mimeType === 'text/latex') {
+            data = fixLatexEquations(concatMultilineStringOutput(data as nbformat.MultilineString), true);
+        }
+
+        return {
+            isText,
+            isError,
+            renderWithScrollbars,
+            data: data,
+            mimeType,
+            mimeBundle
+        };
+    }
+
+    private transformOutput(output: nbformat.IOutput): ICellOutput {
+        // First make a copy of the outputs.
+        const copy = cloneDeep(output);
+
+        // Then compute the data
+        const data = this.computeOutputData(copy);
+        let extraButton: JSX.Element | null = null;
+
+        // Then parse the mime type
+        try {
             // Text based mimeTypes don't get a white background
-            if (/^text\//.test(mimeType)) {
+            if (/^text\//.test(data.mimeType)) {
                 return {
-                    mimeType,
-                    data,
-                    isText,
-                    isError,
-                    renderWithScrollbars: true,
+                    output: data,
                     extraButton,
                     doubleClick: noop
                 };
-            } else if (mimeType === 'image/svg+xml' || mimeType === 'image/png') {
+            } else if (data.mimeType === 'image/svg+xml' || data.mimeType === 'image/png') {
                 // If we have a png or svg enable the plot viewer button
                 // There should be two mime bundles. Well if enablePlotViewer is turned on. See if we have both
-                const svg = mimeBundle['image/svg+xml'];
-                const png = mimeBundle['image/png'];
+                const svg = data.mimeBundle['image/svg+xml'];
+                const png = data.mimeBundle['image/png'];
                 const buttonTheme = this.props.themeMatplotlibPlots ? this.props.baseTheme : 'vscode-light';
                 let doubleClick: () => void = noop;
                 if (svg && png) {
@@ -322,8 +344,8 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                     );
 
                     // Switch the data to the png
-                    data = png;
-                    mimeType = 'image/png';
+                    data.data = png;
+                    data.mimeType = 'image/png';
 
                     // Switch double click to do the same thing as the extra button
                     doubleClick = openClick;
@@ -332,11 +354,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                 // return the image
                 // If not theming plots then wrap in a span
                 return {
-                    mimeType,
-                    data,
-                    isText,
-                    isError,
-                    renderWithScrollbars,
+                    output: data,
                     extraButton,
                     doubleClick,
                     outputSpanClassName: this.props.themeMatplotlibPlots ? undefined : 'cell-output-plot-background'
@@ -345,11 +363,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                 // For anything else just return it with a white plot background. This lets stuff like vega look good in
                 // dark mode
                 return {
-                    mimeType,
-                    data,
-                    isText,
-                    isError,
-                    renderWithScrollbars,
+                    output: data,
                     extraButton,
                     doubleClick: noop,
                     outputSpanClassName: this.props.themeMatplotlibPlots ? undefined : 'cell-output-plot-background'
@@ -357,12 +371,15 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             }
         } catch (e) {
             return {
-                data: e.toString(),
-                isText: true,
-                isError: false,
+                output: {
+                    data: e.toString(),
+                    isText: true,
+                    isError: false,
+                    renderWithScrollbars: false,
+                    mimeType: 'text/plain',
+                    mimeBundle: {}
+                },
                 extraButton: null,
-                renderWithScrollbars: false,
-                mimeType: 'text/plain',
                 doubleClick: noop
             };
         }
@@ -378,15 +395,15 @@ export class CellOutput extends React.Component<ICellOutputProps> {
         const transformedList = outputs.map(this.transformOutput.bind(this));
 
         transformedList.forEach((transformed, index) => {
-            let mimetype = transformed.mimeType;
+            let mimetype = transformed.output.mimeType;
 
             // If that worked, use the transform
             if (mimetype && isMimeTypeSupported(mimetype)) {
                 // Get the matching React.Component for that mimetype
                 const Transform = getTransform(mimetype);
 
-                let className = transformed.isText ? 'cell-output-text' : 'cell-output-html';
-                className = transformed.isError ? `${className} cell-output-error` : className;
+                let className = transformed.output.isText ? 'cell-output-text' : 'cell-output-html';
+                className = transformed.output.isError ? `${className} cell-output-error` : className;
 
                 // If we are not theming plots then wrap them in a white span
                 if (transformed.outputSpanClassName) {
@@ -394,7 +411,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                         <div role="group" key={index} onDoubleClick={transformed.doubleClick} className={className}>
                             <span className={transformed.outputSpanClassName}>
                                 {transformed.extraButton}
-                                <Transform data={transformed.data} />
+                                <Transform data={transformed.output.data} />
                             </span>
                         </div>
                     );
@@ -402,7 +419,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                     buffer.push(
                         <div role="group" key={index} onDoubleClick={transformed.doubleClick} className={className}>
                             {transformed.extraButton}
-                            <Transform data={transformed.data} />
+                            <Transform data={transformed.output.data} />
                         </div>
                     );
                 }
@@ -410,8 +427,8 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                 // Silently skip rendering of these mime types, render an empty div so the user sees the cell was executed.
                 buffer.push(<div key={index}></div>);
             } else {
-                if (transformed.data) {
-                    const keys = Object.keys(transformed.data);
+                if (transformed.output.data) {
+                    const keys = Object.keys(transformed.output.data);
                     mimetype = keys.length > 0 ? keys[0] : 'unknown';
                 } else {
                     mimetype = 'unknown';
@@ -425,7 +442,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
         const style: React.CSSProperties = {};
 
         // Create a scrollbar style if necessary
-        if (transformedList.some(transformed => transformed.renderWithScrollbars) && this.props.maxTextSize) {
+        if (transformedList.some(transformed => transformed.output.renderWithScrollbars) && this.props.maxTextSize) {
             style.overflowY = 'auto';
             style.maxHeight = `${this.props.maxTextSize}px`;
         }

--- a/src/datascience-ui/interactive-common/latexManipulation.ts
+++ b/src/datascience-ui/interactive-common/latexManipulation.ts
@@ -13,7 +13,7 @@ const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/es
 //
 // LaTeX seems to follow the pattern of \begin{name} or is escaped with $$ or $. See here for a bunch of examples:
 // https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Typesetting%20Equations.html
-export function fixLatexEquations(input: string): string {
+export function fixLatexEquations(input: string, wrapSingles: boolean = false): string {
     const output: string[] = [];
 
     // Search for begin/end pairs, outputting as we go
@@ -64,21 +64,25 @@ export function fixLatexEquations(input: string): string {
                 const offset = match.index + 2 + start;
                 const endDollar = endRegex.exec(input.substr(offset));
                 if (endDollar) {
-                    const length = endDollar.index + 2 + offset;
-                    output.push(input.substr(start, length));
-                    start = start + length;
+                    const length = endDollar.index + 2;
+                    const before = input.substr(start, offset - start);
+                    const after = input.substr(offset, length);
+                    output.push(`${before}${after}`);
+                    start = offset + length;
                 } else {
                     // Invalid, just return
                     return input;
                 }
             } else {
-                // Output till the next $
+                // Output till the next $ (wrapping in an extra $ so it works with latex cells too)
                 const offset = match.index + 1 + start;
                 const endDollar = endRegex.exec(input.substr(offset));
                 if (endDollar) {
-                    const length = endDollar.index + 1 + offset;
-                    output.push(input.substr(start, length));
-                    start = start + length;
+                    const length = endDollar.index + 1;
+                    const before = input.substr(start, offset - start);
+                    const after = input.substr(offset, length);
+                    output.push(wrapSingles ? `${before}$${after}$` : `${before}${after}`);
+                    start = offset + length;
                 } else {
                     // Invalid, just return
                     return input;

--- a/src/test/datascience/latexManipulation.unit.test.ts
+++ b/src/test/datascience/latexManipulation.unit.test.ts
@@ -152,6 +152,42 @@ $$
 X^TX\\omega = X^TT
 $$`;
 
+    const output6 = `$$
+\\begin{aligned}
+\\frac{\\partial}{\\partial\\omega_j}C(\\omega) &= \\frac1m\\sum_{i=1}^m\\varphi_j\\left(x^i\\right)\\left(\\varphi^T\\left(x^i\\right)\\omega-t^i\\right)
+= 0
+\\end{aligned}
+$$
+$$
+\\begin{pmatrix}
+\\varphi_j\\left(x^1\\right) & \\dots & \\varphi_j\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+\\varphi_1\\left(x^1\\right) & \\dots & \\varphi_n\\left(x^1\\right)\\\\
+\\vdots & \\ddots & \\vdots\\\\
+\\varphi_1\\left(x^m\\right) & \\dots & \\varphi_n\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+\\omega_1\\\\
+\\vdots\\\\
+\\omega_n
+\\end{pmatrix}
+=
+\\begin{pmatrix}
+\\varphi_j\\left(x^1\\right) & \\dots & \\varphi_j\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+t^1\\\\
+\\vdots\\\\
+t^m
+\\end{pmatrix}
+$$
+
+Assuming that $$T = (t^1, t^2, ..., t^m)^T$$，$$X = \\left(\\varphi(x^1), \\varphi(x^2), ..., \\varphi(x^m)\\right)^T$$, then
+$$
+X^TX\\omega = X^TT
+$$`;
+
     test("Latex - Equations don't have $$", () => {
         const result = fixLatexEquations(markdown1);
         expect(result).to.be.equal(output1, 'Result is incorrect');
@@ -191,7 +227,7 @@ $$`;
     });
 
     test('Latex - Multiple /begins inside $$', () => {
-        const result = fixLatexEquations(markdown6);
-        expect(result).to.be.equal(markdown6, 'Result should not have changed');
+        const result = fixLatexEquations(markdown6, true);
+        expect(result).to.be.equal(output6, 'Result is incorrect');
     });
 });

--- a/src/test/datascience/latexManipulation.unit.test.ts
+++ b/src/test/datascience/latexManipulation.unit.test.ts
@@ -188,6 +188,42 @@ $$
 X^TX\\omega = X^TT
 $$`;
 
+    const output6_nonSingle = `$$
+\\begin{aligned}
+\\frac{\\partial}{\\partial\\omega_j}C(\\omega) &= \\frac1m\\sum_{i=1}^m\\varphi_j\\left(x^i\\right)\\left(\\varphi^T\\left(x^i\\right)\\omega-t^i\\right)
+= 0
+\\end{aligned}
+$$
+$$
+\\begin{pmatrix}
+\\varphi_j\\left(x^1\\right) & \\dots & \\varphi_j\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+\\varphi_1\\left(x^1\\right) & \\dots & \\varphi_n\\left(x^1\\right)\\\\
+\\vdots & \\ddots & \\vdots\\\\
+\\varphi_1\\left(x^m\\right) & \\dots & \\varphi_n\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+\\omega_1\\\\
+\\vdots\\\\
+\\omega_n
+\\end{pmatrix}
+=
+\\begin{pmatrix}
+\\varphi_j\\left(x^1\\right) & \\dots & \\varphi_j\\left(x^m\\right)
+\\end{pmatrix}
+\\begin{pmatrix}
+t^1\\\\
+\\vdots\\\\
+t^m
+\\end{pmatrix}
+$$
+
+Assuming that $T = (t^1, t^2, ..., t^m)^T$，$X = \\left(\\varphi(x^1), \\varphi(x^2), ..., \\varphi(x^m)\\right)^T$, then
+$$
+X^TX\\omega = X^TT
+$$`;
+
     test("Latex - Equations don't have $$", () => {
         const result = fixLatexEquations(markdown1);
         expect(result).to.be.equal(output1, 'Result is incorrect');
@@ -229,5 +265,7 @@ $$`;
     test('Latex - Multiple /begins inside $$', () => {
         const result = fixLatexEquations(markdown6, true);
         expect(result).to.be.equal(output6, 'Result is incorrect');
+        const result2 = fixLatexEquations(markdown6, false);
+        expect(result2).to.be.equal(output6_nonSingle, 'Result is incorrect');
     });
 });


### PR DESCRIPTION
For #8742

Mimetype ```text/latex``` requires all equations to be surrounded with ```$$```, unlike markdown which supports a single ```$```.

Modify the latex manipulation equation to support turning '$' into '$$' and use it when outputting type 'text/latex'