### PR TITLE
Eliminate variable value when computing data frame info

### DIFF
--- a/news/2 Fixes/10075.md
+++ b/news/2 Fixes/10075.md
@@ -1,0 +1,1 @@
+Fix data viewer not opening on certain data frames.

--- a/src/client/datascience/jupyter/jupyterVariables.ts
+++ b/src/client/datascience/jupyter/jupyterVariables.ts
@@ -120,8 +120,9 @@ export class JupyterVariables implements IJupyterVariables {
             return defaultValue;
         }
 
-        // Prep our targetVariable to send over
-        const variableString = JSON.stringify(targetVariable).replace(/\\n/g, '\\\\n');
+        // Prep our targetVariable to send over. Remove the 'value' as it's not necessary for getting df info and can have invalid data in it
+        const pruned = { ...targetVariable, value: '' };
+        const variableString = JSON.stringify(pruned);
 
         // Setup a regex
         const regexPattern =


### PR DESCRIPTION
For #100075

DF values as returned from the new Jupyter inspect command can have invalid json in them. 

Since we don't need the value when computing the DF information, just remove it.