### PR TITLE
Check our saved jupyter interpreters before allowing any of them to be used as active interpreters

### DIFF
--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -113,8 +113,8 @@ export interface IPythonExecutionFactory {
     create(options: ExecutionFactoryCreationOptions): Promise<IPythonExecutionService>;
     /**
      * Creates a daemon Python Process.
-     * On windows its cheapter to create a daemon and use that than spin up Python Processes everytime.
-     * If something cannot be executed within the daemin, it will resort to using the stanard IPythonExecutionService.
+     * On windows it's cheaper to create a daemon and use that than spin up Python Processes everytime.
+     * If something cannot be executed within the daemon, it will resort to using the standard IPythonExecutionService.
      * Note: The returned execution service is always using an activated environment.
      *
      * @param {ExecutionFactoryCreationOptions} options

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -28,6 +28,7 @@ export class Activation implements IExtensionSingleActivationService {
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
+        this.testSavedInterpreter();
         await this.contextService.activate();
     }
 
@@ -41,6 +42,11 @@ export class Activation implements IExtensionSingleActivationService {
         if (this.notebookOpened) {
             this.PreWarmDaemonPool().ignoreErrors();
         }
+    }
+
+    private testSavedInterpreter(): void {
+        // Do we have a saved interpreter? If so check it out to see if it's still valid
+        this.jupyterInterpreterService.checkSavedInterpreter().ignoreErrors();
     }
 
     @debounceAsync(500)

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -28,7 +28,7 @@ export class Activation implements IExtensionSingleActivationService {
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
-        this.testSavedInterpreter();
+        this.jupyterInterpreterService.validateSavedInterpreter().ignoreErrors();
         await this.contextService.activate();
     }
 
@@ -42,11 +42,6 @@ export class Activation implements IExtensionSingleActivationService {
         if (this.notebookOpened) {
             this.PreWarmDaemonPool().ignoreErrors();
         }
-    }
-
-    private testSavedInterpreter(): void {
-        // Do we have a saved interpreter? If so check it out to see if it's still valid
-        this.jupyterInterpreterService.checkSavedInterpreter().ignoreErrors();
     }
 
     @debounceAsync(500)

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -28,7 +28,8 @@ export class Activation implements IExtensionSingleActivationService {
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
-        this.jupyterInterpreterService.validateSavedInterpreter().ignoreErrors();
+        // Warm up our selected interpreter for the extension
+        this.jupyterInterpreterService.setInitialInterpreter().ignoreErrors();
         await this.contextService.activate();
     }
 

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterStateStore.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterStateStore.ts
@@ -11,11 +11,11 @@ import { noop } from '../../../common/utils/misc';
 const key = 'INTERPRETER_PATH_SELECTED_FOR_JUPYTER_SERVER';
 const keySelected = 'INTERPRETER_PATH_WAS_SELECTED_FOR_JUPYTER_SERVER';
 /**
- * Keeps track of whether the user ever selected an interpreter to be used as the gloabl jupyter interpreter.
+ * Keeps track of whether the user ever selected an interpreter to be used as the global jupyter interpreter.
  * Keeps track of the interpreter path of the interpreter used as the global jupyter interpreter.
  *
  * @export
- * @class JupyterInterpreterFinderEverSet
+ * @class JupyterInterpreterStateStore
  */
 @injectable()
 export class JupyterInterpreterStateStore {
@@ -27,7 +27,6 @@ export class JupyterInterpreterStateStore {
      *
      * @readonly
      * @type {Promise<boolean>}
-     * @memberof JupyterInterpreterFinderEverSet
      */
     public get interpreterSetAtleastOnce(): boolean {
         return !!this.selectedPythonPath || this.memento.get<boolean>(keySelected, false);
@@ -35,7 +34,7 @@ export class JupyterInterpreterStateStore {
     public get selectedPythonPath(): string | undefined {
         return this._interpreterPath || this.memento.get<string | undefined>(key, undefined);
     }
-    public updateSelectedPythonPath(value: string) {
+    public updateSelectedPythonPath(value: string | undefined) {
         this._interpreterPath = value;
         this.memento.update(key, value).then(noop, noop);
         this.memento.update(keySelected, true).then(noop, noop);

--- a/src/test/datascience/activation.unit.test.ts
+++ b/src/test/datascience/activation.unit.test.ts
@@ -53,6 +53,7 @@ suite('Data Science - Activation', () => {
         );
         when(jupyterInterpreterService.getSelectedInterpreter()).thenResolve(interpreter);
         when(jupyterInterpreterService.getSelectedInterpreter(anything())).thenResolve(interpreter);
+        when(jupyterInterpreterService.setInitialInterpreter()).thenResolve(interpreter);
         await activator.activate();
     });
     teardown(() => fakeTimer.uninstall());


### PR DESCRIPTION
For #9904 

Skip news as this is the second PR for this item.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
