### PR TITLE
Use different method for checking if kernelspec is available

### DIFF
--- a/pythonFiles/datascience/getJupyterKernelspecVersion.py
+++ b/pythonFiles/datascience/getJupyterKernelspecVersion.py
@@ -1,0 +1,7 @@
+# Check whether kernelspec module exists.
+import sys
+import jupyter_client
+import jupyter_client.kernelspec
+
+sys.stdout.write(jupyter_client.__version__)
+sys.stdout.flush()

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -8,13 +8,13 @@ import { CancellationToken } from 'vscode';
 import { IApplicationShell } from '../../../common/application/types';
 import { Cancellation, createPromiseFromCancellation, wrapCancellationTokens } from '../../../common/cancellation';
 import { ProductNames } from '../../../common/installer/productNames';
-import { IPythonExecutionFactory } from '../../../common/process/types';
 import { IInstaller, InstallerResponse, Product } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { PythonInterpreter } from '../../../interpreter/contracts';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { HelpLinks, Telemetry } from '../../constants';
+import { HelpLinks, JupyterCommands, Telemetry } from '../../constants';
+import { IJupyterCommandFactory } from '../../types';
 import { JupyterInstallError } from '../jupyterInstallError';
 
 export enum JupyterInterpreterDependencyResponse {
@@ -113,7 +113,7 @@ export class JupyterInterpreterDependencyService {
     constructor(
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(IInstaller) private readonly installer: IInstaller,
-        @inject(IPythonExecutionFactory) private readonly pythonExecFactory: IPythonExecutionFactory
+        @inject(IJupyterCommandFactory) private readonly commandFactory: IJupyterCommandFactory
     ) {}
     /**
      * Configures the python interpreter to ensure it can run Jupyter server by installing any missing dependencies.
@@ -291,17 +291,16 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<boolean>}
      * @memberof JupyterInterpreterConfigurationService
      */
-    private async isKernelSpecAvailable(interpreter: PythonInterpreter, token?: CancellationToken): Promise<boolean> {
-        const execService = await this.pythonExecFactory.createActivatedEnvironment({
+    private async isKernelSpecAvailable(interpreter: PythonInterpreter, _token?: CancellationToken): Promise<boolean> {
+        const command = this.commandFactory.createInterpreterCommand(
+            JupyterCommands.KernelSpecCommand,
+            'jupyter',
+            ['-m', 'jupyter', 'kernelspec'],
             interpreter,
-            allowEnvironmentFetchExceptions: true,
-            bypassCondaExecution: true
-        });
-        if (Cancellation.isCanceled(token)) {
-            return false;
-        }
-        return execService
-            .execModule('jupyter', ['kernelspec', '--version'], { throwOnStdErr: true })
+            false
+        );
+        return command
+            .exec(['--version'], { throwOnStdErr: true })
             .then(() => true)
             .catch(() => false);
     }
@@ -323,9 +322,10 @@ export class JupyterInterpreterDependencyService {
         token?: CancellationToken
     ): Promise<JupyterInterpreterDependencyResponse> {
         if (await this.isKernelSpecAvailable(interpreter)) {
-            sendTelemetryEvent(Telemetry.JupyterInstalledButNotKernelSpecModule);
             return JupyterInterpreterDependencyResponse.ok;
         }
+        // Indicate no kernel spec module.
+        sendTelemetryEvent(Telemetry.JupyterInstalledButNotKernelSpecModule);
         if (Cancellation.isCanceled(token)) {
             return JupyterInterpreterDependencyResponse.cancel;
         }

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.unit.test.ts
@@ -14,10 +14,12 @@ import { IPythonExecutionService } from '../../../../client/common/process/types
 import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
 import { DataScience } from '../../../../client/common/utils/localize';
 import { Architecture } from '../../../../client/common/utils/platform';
+import { JupyterCommandFactory } from '../../../../client/datascience/jupyter/interpreter/jupyterCommand';
 import {
     JupyterInterpreterDependencyResponse,
     JupyterInterpreterDependencyService
 } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
+import { IJupyterCommandFactory } from '../../../../client/datascience/types';
 import { InterpreterType, PythonInterpreter } from '../../../../client/interpreter/contracts';
 
 // tslint:disable: max-func-body-length
@@ -26,6 +28,7 @@ suite('Data Science - Jupyter Interpreter Configuration', () => {
     let configuration: JupyterInterpreterDependencyService;
     let appShell: IApplicationShell;
     let installer: IInstaller;
+    let commandFactory: IJupyterCommandFactory;
     let pythonExecService: IPythonExecutionService;
     const pythonInterpreter: PythonInterpreter = {
         path: '',
@@ -37,6 +40,7 @@ suite('Data Science - Jupyter Interpreter Configuration', () => {
     setup(() => {
         appShell = mock(ApplicationShell);
         installer = mock(ProductInstaller);
+        commandFactory = mock(JupyterCommandFactory);
         pythonExecService = mock(PythonExecutionService);
         const pythonExecFactory = mock(PythonExecutionFactory);
         when(pythonExecFactory.createActivatedEnvironment(anything())).thenResolve(instance(pythonExecService));
@@ -49,7 +53,7 @@ suite('Data Science - Jupyter Interpreter Configuration', () => {
         configuration = new JupyterInterpreterDependencyService(
             instance(appShell),
             instance(installer),
-            instance(pythonExecFactory)
+            instance(commandFactory)
         );
     });
     test('Return ok if all dependencies are installed', async () => {

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.unit.test.ts
@@ -4,32 +4,32 @@
 'use strict';
 
 import { assert } from 'chai';
-import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { ApplicationShell } from '../../../../client/common/application/applicationShell';
 import { IApplicationShell } from '../../../../client/common/application/types';
 import { ProductInstaller } from '../../../../client/common/installer/productInstaller';
-import { PythonExecutionFactory } from '../../../../client/common/process/pythonExecutionFactory';
-import { PythonExecutionService } from '../../../../client/common/process/pythonProcess';
-import { IPythonExecutionService } from '../../../../client/common/process/types';
 import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
 import { DataScience } from '../../../../client/common/utils/localize';
 import { Architecture } from '../../../../client/common/utils/platform';
-import { JupyterCommandFactory } from '../../../../client/datascience/jupyter/interpreter/jupyterCommand';
+import {
+    InterpreterJupyterKernelSpecCommand,
+    JupyterCommandFactory
+} from '../../../../client/datascience/jupyter/interpreter/jupyterCommand';
 import {
     JupyterInterpreterDependencyResponse,
     JupyterInterpreterDependencyService
 } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
-import { IJupyterCommandFactory } from '../../../../client/datascience/types';
+import { IJupyterCommand, IJupyterCommandFactory } from '../../../../client/datascience/types';
 import { InterpreterType, PythonInterpreter } from '../../../../client/interpreter/contracts';
 
-// tslint:disable: max-func-body-length
+// tslint:disable: max-func-body-length no-any
 
 suite('Data Science - Jupyter Interpreter Configuration', () => {
     let configuration: JupyterInterpreterDependencyService;
     let appShell: IApplicationShell;
     let installer: IInstaller;
     let commandFactory: IJupyterCommandFactory;
-    let pythonExecService: IPythonExecutionService;
+    let command: IJupyterCommand;
     const pythonInterpreter: PythonInterpreter = {
         path: '',
         architecture: Architecture.Unknown,
@@ -41,14 +41,13 @@ suite('Data Science - Jupyter Interpreter Configuration', () => {
         appShell = mock(ApplicationShell);
         installer = mock(ProductInstaller);
         commandFactory = mock(JupyterCommandFactory);
-        pythonExecService = mock(PythonExecutionService);
-        const pythonExecFactory = mock(PythonExecutionFactory);
-        when(pythonExecFactory.createActivatedEnvironment(anything())).thenResolve(instance(pythonExecService));
-        // tslint:disable-next-line: no-any
-        instance(pythonExecService as any).then = undefined;
-        when(pythonExecService.execModule('jupyter', deepEqual(['kernelspec', '--version']), anything())).thenResolve({
-            stdout: ''
-        });
+        command = mock(InterpreterJupyterKernelSpecCommand);
+        instance(commandFactory as any).then = undefined;
+        instance(command as any).then = undefined;
+        when(
+            commandFactory.createInterpreterCommand(anything(), anything(), anything(), anything(), anything())
+        ).thenReturn(instance(command));
+        when(command.exec(anything(), anything())).thenResolve({ stdout: '' });
 
         configuration = new JupyterInterpreterDependencyService(
             instance(appShell),
@@ -95,9 +94,7 @@ suite('Data Science - Jupyter Interpreter Configuration', () => {
             // tslint:disable-next-line: no-any
             DataScience.jupyterInstall() as any
         );
-        when(pythonExecService.execModule('jupyter', deepEqual(['kernelspec', '--version']), anything())).thenReject(
-            new Error('Not found')
-        );
+        when(command.exec(anything(), anything())).thenReject(new Error('Not found'));
         when(installer.install(anything(), anything(), anything())).thenResolve(InstallerResponse.Installed);
 
         const response = await configuration.installMissingDependencies(pythonInterpreter);


### PR DESCRIPTION
For  https://github.com/microsoft/vscode-python/issues/10071

Instead of using 'python -m jupyter kernelspec --version', run some python code to do the same thing.

Hopefully this will make it work when the python command line doesn't.