### PR TITLE
Don't crash jupyter startup if liveshare fails

### DIFF
--- a/news/2 Fixes/10097.md
+++ b/news/2 Fixes/10097.md
@@ -1,0 +1,1 @@
+LiveShare can prevent the jupyter server from starting if it crashes.

--- a/src/client/datascience/liveshare/liveshare.ts
+++ b/src/client/datascience/liveshare/liveshare.ts
@@ -50,7 +50,10 @@ export class LiveShareApi implements ILiveShareApi {
             this.supported = supported ? true : false;
             const liveShareTimeout = this.configService.getSettings().datascience.liveShareConnectionTimeout;
             this.apiPromise = supported
-                ? vsls.getApi().then(a => (a ? new LiveShareProxy(this.appShell, liveShareTimeout, a) : a))
+                ? vsls
+                      .getApi()
+                      .then(a => (a ? new LiveShareProxy(this.appShell, liveShareTimeout, a) : a))
+                      .catch(_e => null)
                 : Promise.resolve(null);
         } else if (!this.apiPromise) {
             this.apiPromise = Promise.resolve(null);


### PR DESCRIPTION
For #10097 

Live share crashing can break our server startup