### PR TITLE
Clear variables when restarting regardless if visible or not

### DIFF
--- a/news/2 Fixes/9991.md
+++ b/news/2 Fixes/9991.md
@@ -1,0 +1,1 @@
+Clear variables in notebooks and interactive-window when restarting.

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -354,7 +354,12 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         return this.setDirty();
     }
 
-    protected addSysInfo(_reason: SysInfoReason): Promise<void> {
+    protected addSysInfo(reason: SysInfoReason): Promise<void> {
+        // We need to send a message when restarting
+        if (reason === SysInfoReason.Restart || reason === SysInfoReason.New) {
+            this.postMessage(InteractiveWindowMessages.RestartKernel).ignoreErrors();
+        }
+
         // These are not supported.
         return Promise.resolve();
     }

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -118,25 +118,21 @@ function handleResponse(arg: VariableReducerArg<IJupyterVariablesResponse>): IVa
 }
 
 function handleRestarted(arg: VariableReducerArg): IVariableState {
-    // If the variables are visible, refresh them
-    if (arg.prevState.visible) {
-        const result = handleRequest({
-            ...arg,
-            payload: {
-                executionCount: 0,
-                sortColumn: 'name',
-                sortAscending: true,
-                startIndex: 0,
-                pageSize: arg.prevState.pageSize
-            }
-        });
-        return {
-            ...result,
-            currentExecutionCount: 0,
-            variables: []
-        };
-    }
-    return arg.prevState;
+    const result = handleRequest({
+        ...arg,
+        payload: {
+            executionCount: 0,
+            sortColumn: 'name',
+            sortAscending: true,
+            startIndex: 0,
+            pageSize: arg.prevState.pageSize
+        }
+    });
+    return {
+        ...result,
+        currentExecutionCount: 0,
+        variables: []
+    };
 }
 
 function handleFinishCell(arg: VariableReducerArg<ICell>): IVariableState {


### PR DESCRIPTION
For #9991 

We should clear variables regardless of whether or not the variable explorer is open.

Also need to post a restart kernel message to the UI when restarting in the native editor.

