### PR TITLE
CI: Update to Python 3.8.

### DIFF
--- a/build/ci/performance/strategy.yaml
+++ b/build/ci/performance/strategy.yaml
@@ -4,24 +4,34 @@ parameters:
       # All scenarios tagged with `@noNeedToTestInAllPython`, will run in the latest version of Python.
       # When using other versions of Python, ignore `@noNeedToTestInAllPython`.
       {
+          "version": "3.9",
+          "displayName": "39",
+          "excludeTags": "not @python3.8 and not @python3.7 and not @python3.6 and not @python3.5 and not @python2"
+      },
+      {
+          "version": "3.8",
+          "displayName": "38",
+          "excludeTags": "not @python3.9 and not @python3.7 and not @python3.6 and not @python3.5 and not @python2"
+      },
+      {
           "version": "3.7",
           "displayName": "37",
-          "excludeTags": "not @python3.6 and not @python3.5 and not @python2"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.6 and not @python3.5 and not @python2"
       },
       {
           "version": "3.6",
           "displayName": "36",
-          "excludeTags": "not @python3.7 and not @python3.5 and not @python2 and not @noNeedToTestInAllPython"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.7 and not @python3.5 and not @python2 and not @noNeedToTestInAllPython"
       },
       {
           "version": "3.5",
           "displayName": "35",
-          "excludeTags": "not @python3.7 and not @python3.6 and not @python2 and not @noNeedToTestInAllPython"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.7 and not @python3.6 and not @python2 and not @noNeedToTestInAllPython"
       },
       {
           "version": "2.7",
           "displayName": "27",
-          "excludeTags": "not @python3.7 and not @python3.6 and not @python3.5 and not @python3 and not @noNeedToTestInAllPython"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.7 and not @python3.6 and not @python3.5 and not @python3 and not @noNeedToTestInAllPython"
       }
     ]
 

--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  PythonVersion: '3.7' # Always use latest version.
+  PythonVersion: '3.8' # Always use latest version.
   NodeVersion: '12.4.0' # Check version of node used in VS Code.
   NpmVersion: '6.13.4'
   MOCHA_FILE: '$(Build.ArtifactStagingDirectory)/test-junit.xml' # All test files will write their JUnit xml output to this file, clobbering the last time it was written.

--- a/build/ci/templates/jobs/uitest.yml
+++ b/build/ci/templates/jobs/uitest.yml
@@ -6,7 +6,7 @@
 #   list of jobs for each permutation.
 # I.e. we generate permutations of Jobs for each of the following:
 # - OS: Windows, Linux, Mac
-# - Python Version: 2.7, 3.5, 3.6, 3.7
+# - Python Version: 2.7, 3.5, 3.6, latest
 # - VSC Version: Stable, Insiders
 # Using this approach, we can add tests for PipEnv, PyEnv, Conda, etc and ensure we test in all possible combinations.
 # When using this template we can also, ignore testing against specific permutations by
@@ -43,7 +43,7 @@
 # 2. ignorePythonVersions
 #   Comma delimited list of Python versions not to be tested against.
 #   E.g. = 3.7,3.6
-#   Possible values 3.7, 3.6, 3.5, 2.7
+#   Possible values 2.7, 3.5, ..., latest
 #   Any OS provided in this string will not be tested against.
 #
 #   Sample:
@@ -95,24 +95,34 @@ parameters:
       # All scenarios tagged with `@noNeedToTestInAllPython`, will run in the latest version of Python.
       # When using other versions of Python, ignore `@noNeedToTestInAllPython`.
       {
+          "version": "3.9",
+          "displayName": "39",
+          "excludeTags": "not @python3.8 and not @python3.7 and not @python3.6 and not @python3.5 and not @python2"
+      },
+      {
+          "version": "3.8",
+          "displayName": "38",
+          "excludeTags": "not @python3.9 and not @python3.7 and not @python3.6 and not @python3.5 and not @python2"
+      },
+      {
           "version": "3.7",
           "displayName": "37",
-          "excludeTags": "not @python3.6 and not @python3.5 and not @python2"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.6 and not @python3.5 and not @python2"
       },
       {
           "version": "3.6",
           "displayName": "36",
-          "excludeTags": "not @python3.7 and not @python3.5 and not @python2 and not @noNeedToTestInAllPython"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.7 and not @python3.5 and not @python2 and not @noNeedToTestInAllPython"
       },
       {
           "version": "3.5",
           "displayName": "35",
-          "excludeTags": "not @python3.7 and not @python3.6 and not @python2 and not @noNeedToTestInAllPython"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.7 and not @python3.6 and not @python2 and not @noNeedToTestInAllPython"
       },
       {
           "version": "2.7",
           "displayName": "27",
-          "excludeTags": "not @python3.7 and not @python3.6 and not @python3.5 and not @python3 and not @noNeedToTestInAllPython"
+          "excludeTags": "not @python3.9 and not @python3.8 and not @python3.7 and not @python3.6 and not @python3.5 and not @python3 and not @noNeedToTestInAllPython"
       }
     ]
 

--- a/build/ci/templates/steps/uitest.yml
+++ b/build/ci/templates/steps/uitest.yml
@@ -8,7 +8,7 @@
 # 4. Setup CI_PYTHON_PATH for extension       - Export Env variable that'll be used by a seprate step.
 #                                               Note: This env variable is NOT used by any Code (used purely in the Azdo step further below).
 # 5. Use Python 2.7                           - Ensure minimum version of Python (2.7) is available on CI for Python Extension.
-# 6. Use Python 3.7                           - Ensure latest version of Python (3.7) is available on CI for Python Extension.
+# 6. Use Python 3.8                           - Ensure latest version of Python (3.8) is available on CI for Python Extension.
 # 7. npm ci                                   - Install npm packages for some JS scripts used in testing (NOT for extension).
 # 8. Show Dependency Versions                 - Logging.
 # 9. Start xvfb                               - Start in-memory display server (for launching VSC).
@@ -41,16 +41,16 @@
 #   VM Image to be used (standard Azure Devops variable).
 
 steps:
-    # Some tests need to have both 2.7 & 3.7 available.
+    # Some tests need to have both 2.7 & 3.8 available.
     - task: UsePythonVersion@0
       displayName: 'Use Python 2.7'
       inputs:
           versionSpec: 2.7
 
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.7'
+      displayName: 'Use Python 3.8'
       inputs:
-          versionSpec: 3.7
+          versionSpec: 3.8
 
     # Setup python environment in current path for extension to use.
     - template: initialization.yml

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -126,6 +126,7 @@ steps:
     # Downgrade pywin32 on Windows due to bug https://github.com/jupyter/notebook/issues/4909
     #
     # This task will only run if variable `NeedsPythonFunctionalReqs` is true.
+    # TODO: Why only Python 3.6?
     - bash: |
           python -m pip install --upgrade pywin32==224
       displayName: 'Downgrade pywin32 on Windows / Python 3.6'
@@ -151,13 +152,15 @@ steps:
       displayName: 'pip install jupyter'
       condition: and(succeeded(), eq(variables['NeedsIPythonReqs'], 'true'), contains(variables['TestsToRun'], 'testSmoke'))
 
+    # This matters for 3.7+ because that's the version the script
+    # was written against.
     - task: PythonScript@0
       displayName: 'Install PTVSD wheels'
       inputs:
           scriptSource: 'filePath'
           scriptPath: './pythonFiles/install_ptvsd.py'
           failOnStderr: true
-      condition: and(eq(variables['NeedsPythonTestReqs'], 'true'), eq(variables['PythonVersion'], '3.7'))
+      condition: and(eq(variables['NeedsPythonTestReqs'], 'true'), or(eq(variables['PythonVersion'], '3.7'), eq(variables['PythonVersion'], '3.8')))
 
     # Run the Python unit tests in our codebase. Produces a JUnit-style log file that
     # will be uploaded after all tests are complete.

--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -42,20 +42,17 @@ stages:
 
         ## Virtual Environment Tests:
 
-        'Win-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Win-Py3.x Unit':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
-        'Linux-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Unit':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
-        'Mac-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Unit':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
@@ -79,24 +76,21 @@ stages:
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
 
-        'Win-Py3.7 Venv':
+        'Win-Py3.x Venv':
           VMImageName: 'vs2017-win2016'
-          PythonVersion: '3.7'
           TestsToRun: 'venvTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
           # This is for the venvTests to use, not needed if you don't run venv tests...
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-        'Linux-Py3.7 Venv':
+        'Linux-Py3.x Venv':
           VMImageName: 'ubuntu-16.04'
-          PythonVersion: '3.7'
           TestsToRun: 'venvTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-        'Mac-Py3.7 Venv':
+        'Mac-Py3.x Venv':
           VMImageName: 'macos-10.13'
-          PythonVersion: '3.7'
           TestsToRun: 'venvTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
@@ -124,18 +118,15 @@ stages:
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
 
         # SingleWorkspace Tests
-        'Win-Py3.7 Single':
-          PythonVersion: '3.7'
+        'Win-Py3.x Single':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Single':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Single':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Single':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Single':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
@@ -156,18 +147,15 @@ stages:
           NeedsPythonTestReqs: true
 
         # MultiWorkspace Tests
-        'Win-Py3.7 Multi':
-          PythonVersion: '3.7'
+        'Win-Py3.x Multi':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testMultiWorkspace'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Multi':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Multi':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testMultiWorkspace'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Multi':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Multi':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testMultiWorkspace'
           NeedsPythonTestReqs: true
@@ -188,18 +176,15 @@ stages:
           NeedsPythonTestReqs: true
 
         # Debugger integration Tests
-        'Win-Py3.7 Debugger':
-          PythonVersion: '3.7'
+        'Win-Py3.x Debugger':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Debugger':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Debugger':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Debugger':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Debugger':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
@@ -220,20 +205,17 @@ stages:
           NeedsPythonTestReqs: true
 
         # Functional tests (not mocked Jupyter)
-        'Windows-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Windows-Py3.x Functional':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
           NeedsPythonFunctionalReqs: true
-        'Linux-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Functional':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
           NeedsPythonFunctionalReqs: true
-        'Mac-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Functional':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
@@ -271,20 +253,17 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        'Mac-Py3.7':
-            PythonVersion: '3.7'
+        'Mac-Py3.x':
             VMImageName: 'macos-10.13'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
             NeedsIPythonReqs: true
-        'Linux-Py3.7':
-            PythonVersion: '3.7'
+        'Linux-Py3.x':
             VMImageName: 'ubuntu-16.04'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
             NeedsIPythonReqs: true
-        'Win-Py3.7':
-            PythonVersion: '3.7'
+        'Win-Py3.x':
             VMImageName: 'vs2017-win2016'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -49,18 +49,15 @@ stages:
 
         ## Virtual Environment Tests:
 
-        'Win-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Win-Py3.x Unit':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testUnitTests, pythonUnitTests'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Unit':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testUnitTests, pythonUnitTests'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Unit':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testUnitTests, pythonUnitTests'
           NeedsPythonTestReqs: true
@@ -110,22 +107,19 @@ stages:
           TestsToRun: 'pythonUnitTests'
           NeedsPythonTestReqs: true
 
-        'Win-Py3.7 Venv':
+        'Win-Py3.x Venv':
           VMImageName: 'vs2017-win2016'
-          PythonVersion: '3.7'
           TestsToRun: 'venvTests'
           NeedsPythonTestReqs: true
           # This is for the venvTests to use, not needed if you don't run venv tests...
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-        'Linux-Py3.7 Venv':
+        'Linux-Py3.x Venv':
           VMImageName: 'ubuntu-16.04'
-          PythonVersion: '3.7'
           TestsToRun: 'venvTests'
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-        'Mac-Py3.7 Venv':
+        'Mac-Py3.x Venv':
           VMImageName: 'macos-10.13'
-          PythonVersion: '3.7'
           TestsToRun: 'venvTests'
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
@@ -168,18 +162,15 @@ stages:
         # Note: Virtual env tests use `venv` and won't currently work with Python 2.7
 
         # SingleWorkspace Tests
-        'Win-Py3.7 Single':
-          PythonVersion: '3.7'
+        'Win-Py3.x Single':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Single':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Single':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Single':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Single':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
@@ -230,18 +221,15 @@ stages:
           NeedsPythonTestReqs: true
 
         # MultiWorkspace Tests
-        'Win-Py3.7 Multi':
-          PythonVersion: '3.7'
+        'Win-Py3.x Multi':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testMultiWorkspace'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Multi':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Multi':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testMultiWorkspace'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Multi':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Multi':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testMultiWorkspace'
           NeedsPythonTestReqs: true
@@ -292,18 +280,15 @@ stages:
           NeedsPythonTestReqs: true
 
         # Debugger integration Tests
-        'Win-Py3.7 Debugger':
-          PythonVersion: '3.7'
+        'Win-Py3.x Debugger':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Debugger':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Debugger':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Debugger':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Debugger':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
@@ -354,20 +339,17 @@ stages:
           NeedsPythonTestReqs: true
 
         # Functional tests (mocked Jupyter)
-        'Windows-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Windows-Py3.x Functional':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
           NeedsPythonFunctionalReqs: true
-        'Linux-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Functional':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
           NeedsPythonFunctionalReqs: true
-        'Mac-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Functional':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
@@ -442,20 +424,17 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        'Mac-Py3.7':
-            PythonVersion: '3.7'
+        'Mac-Py3.x':
             VMImageName: 'macos-10.13'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
             NeedsIPythonReqs: true
-        'Linux-Py3.7':
-            PythonVersion: '3.7'
+        'Linux-Py3.x':
             VMImageName: 'ubuntu-16.04'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
             NeedsIPythonReqs: true
-        'Win-Py3.7':
-            PythonVersion: '3.7'
+        'Win-Py3.x':
             VMImageName: 'vs2017-win2016'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true

--- a/build/ci/vscode-python-nightly-flake-ci.yaml
+++ b/build/ci/vscode-python-nightly-flake-ci.yaml
@@ -55,8 +55,7 @@ stages:
         ## Virtual Environment Tests:
 
         # Functional tests (not mocked Jupyter)
-        'Windows-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Windows-Py3.x Functional':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
@@ -64,16 +63,14 @@ stages:
           # This tells the functional tests to not mock out Jupyter...
           VSCODE_PYTHON_ROLLING: true
           VSC_PYTHON_LOG_TELEMETRY: true
-        'Linux-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Functional':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
           NeedsPythonFunctionalReqs: true
           VSCODE_PYTHON_ROLLING: true
           VSC_PYTHON_LOG_TELEMETRY: true
-        'Mac-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Functional':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true

--- a/build/ci/vscode-python-nightly-uitest.yaml
+++ b/build/ci/vscode-python-nightly-uitest.yaml
@@ -50,19 +50,19 @@ stages:
         # No need to run tests against all versions.
         # This is faster/cheaper, besides activation of terminals is generic enough
         # not to warrant testing against all versions.
-        ignorePythonVersions: "3.6,3.5"
+        ignorePythonVersions: "3.7,3.6,3.5"
       - test: "Debugging"
         tags: "@debugging"
         # No need to run tests against all versions.
         # This is faster/cheaper, and these are external packages.
         # We expect them to work (or 3rd party packages to test against all PY versions).
-        ignorePythonVersions: "3.6,3.5"
+        ignorePythonVersions: "3.7,3.6,3.5"
       - test: "Jedi_Language_Server"
         tags: "@ls"
         # No need to run tests against all versions.
         # This is faster/cheaper, and these are external packages.
         # We expect them to work (or 3rd party packages to test against all PY versions).
-        ignorePythonVersions: "3.6,3.5"
+        ignorePythonVersions: "3.7,3.6,3.5"
 
 - stage: Reports
   dependsOn:

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -39,8 +39,7 @@ stages:
         # NodeVersion: 'x.y.z' - Node version to use. DefaultNodeVersion if not set.
         # SkipXvfb: [true|false] - skip initialization of xvfb prior to running system tests on Linux. False if not set
         # UploadBinary: [true|false] - upload test binaries to Azure if true. False if not set.
-        'Win-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Win-Py3.x Unit':
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools'
           NeedsPythonTestReqs: true
@@ -49,13 +48,11 @@ stages:
           VMImageName: 'vs2017-win2016'
           TestsToRun: 'pythonUnitTests'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Unit':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools'
           NeedsPythonTestReqs: true
-        'Mac-Py3.7 Single Workspace':
-          PythonVersion: '3.7'
+        'Mac-Py3.x Single Workspace':
           VMImageName: 'macos-10.13'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
@@ -64,13 +61,11 @@ stages:
           VMImageName: 'macos-10.13'
           TestsToRun: 'pythonUnitTests, testSingleWorkspace'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Unit':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Unit':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Single Workspace':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Single Workspace':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testSingleWorkspace'
           NeedsPythonTestReqs: true
@@ -79,8 +74,7 @@ stages:
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'pythonUnitTests, testSingleWorkspace'
           NeedsPythonTestReqs: true
-        'Linux-Py3.7 Functional':
-          PythonVersion: '3.7'
+        'Linux-Py3.x Functional':
           VMImageName: 'ubuntu-16.04'
           TestsToRun: 'testfunctional'
           NeedsPythonTestReqs: true
@@ -99,20 +93,17 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        'Mac-Py3.7':
-            PythonVersion: '3.7'
+        'Mac-Py3.x':
             VMImageName: 'macos-10.13'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
             NeedsIPythonReqs: true
-        'Linux-Py3.7':
-            PythonVersion: '3.7'
+        'Linux-Py3.x':
             VMImageName: 'ubuntu-16.04'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true
             NeedsIPythonReqs: true
-        'Win-Py3.7':
-            PythonVersion: '3.7'
+        'Win-Py3.x':
             VMImageName: 'vs2017-win2016'
             TestsToRun: 'testSmoke'
             NeedsPythonTestReqs: true


### PR DESCRIPTION
(for #9939)

We want to be testing against the most recent version of Python supported by Azure Pipelines.  This is a prerequisite for reducing the number of Python versions in our test matrix.