### PR TITLE
Save metadata when executing a cell

### DIFF
--- a/news/2 Fixes/9997.md
+++ b/news/2 Fixes/9997.md
@@ -1,0 +1,1 @@
+Make sure metadata in a cell survives execution.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -22,6 +22,7 @@ import {
 } from 'vscode';
 import { Disposable } from 'vscode-jsonrpc';
 
+import { nbformat } from '@jupyterlab/coreutils';
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 import {
     IApplicationShell,
@@ -52,6 +53,7 @@ import {
     IGotoCode,
     IInteractiveWindowMapping,
     InteractiveWindowMessages,
+    IReExecuteCell,
     IRemoteAddCode,
     IRemoteReexecuteCode,
     IShowDataViewer,
@@ -455,7 +457,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     protected abstract submitNewCell(info: ISubmitNewCell): void;
 
     // Re-executes a cell already in the window
-    protected reexecuteCell(_info: ISubmitNewCell): void {
+    protected reexecuteCell(_info: IReExecuteCell): void {
         // Default is not to do anything. This only works in the native editor
     }
 
@@ -490,7 +492,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         file: string,
         line: number,
         id?: string,
-        _editor?: TextEditor,
+        data?: nbformat.ICodeCell | nbformat.IRawCell | nbformat.IMarkdownCell,
         debug?: boolean
     ): Promise<boolean> {
         traceInfo(`Submitting code for ${this.id}`);
@@ -571,7 +573,11 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                 // Sign up for cell changes
                 observable.subscribe(
                     (cells: ICell[]) => {
-                        this.sendCellsToWebView(cells);
+                        // Combine the cell data with the possible input data (so we don't lose anything that might have already been in the cells)
+                        const combined = cells.map(this.combineData.bind(undefined, data));
+
+                        // Then send the combined output to the UI
+                        this.sendCellsToWebView(combined);
 
                         // Any errors will move our result to false (if allowed)
                         if (this.configuration.getSettings().datascience.stopOnError) {
@@ -773,6 +779,30 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             this.serverAndNotebookPromise = undefined;
             throw e;
         }
+    }
+
+    private combineData(
+        oldData: nbformat.ICodeCell | nbformat.IRawCell | nbformat.IMarkdownCell | undefined,
+        cell: ICell
+    ): ICell {
+        if (oldData) {
+            const result = {
+                ...cell,
+                data: {
+                    ...oldData,
+                    ...cell.data,
+                    metadata: {
+                        ...oldData.metadata,
+                        ...cell.data.metadata
+                    }
+                }
+            };
+            // Workaround the nyc compiler problem.
+            // tslint:disable-next-line: no-any
+            return (result as any) as ICell;
+        }
+        // tslint:disable-next-line: no-any
+        return (cell as any) as ICell;
     }
 
     private async ensureServerAndNotebookImpl(): Promise<void> {

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -176,6 +176,11 @@ export interface ISubmitNewCell {
     id: string;
 }
 
+export interface IReExecuteCell {
+    newCode: string;
+    cell: ICell;
+}
+
 export interface IProvideCompletionItemsRequest {
     position: monacoEditor.Position;
     context: monacoEditor.languages.CompletionContext;
@@ -365,7 +370,7 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.LoadAllCells]: ILoadAllCells;
     public [InteractiveWindowMessages.LoadAllCellsComplete]: ILoadAllCells;
     public [InteractiveWindowMessages.ScrollToCell]: IScrollToCell;
-    public [InteractiveWindowMessages.ReExecuteCell]: ISubmitNewCell;
+    public [InteractiveWindowMessages.ReExecuteCell]: IReExecuteCell;
     public [InteractiveWindowMessages.NotebookIdentity]: INotebookIdentity;
     public [InteractiveWindowMessages.NotebookDirty]: never | undefined;
     public [InteractiveWindowMessages.NotebookClean]: never | undefined;

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -8,7 +8,7 @@ import * as detectIndent from 'detect-indent';
 import { inject, injectable, multiInject, named } from 'inversify';
 import * as path from 'path';
 import * as uuid from 'uuid/v4';
-import { Event, EventEmitter, Memento, TextEditor, Uri, ViewColumn } from 'vscode';
+import { Event, EventEmitter, Memento, Uri, ViewColumn } from 'vscode';
 
 import { concatMultilineStringInput, splitMultilineString } from '../../../datascience-ui/common';
 import { createCodeCell, createErrorOutput } from '../../../datascience-ui/common/cellFactory';
@@ -54,6 +54,7 @@ import {
     IInsertCell,
     INativeCommand,
     InteractiveWindowMessages,
+    IReExecuteCell,
     IRemoveCell,
     ISaveAll,
     ISubmitNewCell,
@@ -394,11 +395,11 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         file: string,
         line: number,
         id?: string,
-        editor?: TextEditor,
+        data?: nbformat.ICodeCell | nbformat.IRawCell | nbformat.IMarkdownCell,
         debug?: boolean
     ): Promise<boolean> {
         // When code is executed, update the version number in the metadata.
-        return super.submitCode(code, file, line, id, editor, debug).then(value => {
+        return super.submitCode(code, file, line, id, data, debug).then(value => {
             this.updateVersionInfoInNotebook()
                 .then(() => {
                     this.metadataUpdatedEvent.fire(this);
@@ -440,23 +441,23 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
     @captureTelemetry(Telemetry.ExecuteNativeCell, undefined, true)
     // tslint:disable-next-line:no-any
-    protected async reexecuteCell(info: ISubmitNewCell): Promise<void> {
+    protected async reexecuteCell(info: IReExecuteCell): Promise<void> {
         try {
             // If there's any payload, it has the code and the id
-            if (info && info.code && info.id) {
+            if (info && info.newCode && info.cell.id && info.cell.data.cell_type !== 'messages') {
                 // Clear the result if we've run before
-                await this.clearResult(info.id);
+                await this.clearResult(info.cell.id);
 
                 // Send to ourselves.
-                await this.submitCode(info.code, Identifiers.EmptyFileName, 0, info.id);
+                await this.submitCode(info.newCode, Identifiers.EmptyFileName, 0, info.cell.id, info.cell.data);
 
                 // Activate the other side, and send as if came from a file
                 await this.ipynbProvider.show(this.file);
                 this.shareMessage(InteractiveWindowMessages.RemoteReexecuteCode, {
-                    code: info.code,
+                    code: info.newCode,
                     file: Identifiers.EmptyFileName,
                     line: 0,
-                    id: info.id,
+                    id: info.cell.id,
                     originator: this.id,
                     debug: false
                 });
@@ -465,8 +466,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             // Make this error our cell output
             this.sendCellsToWebView([
                 {
-                    data: createCodeCell([info.code], [createErrorOutput(exc)]),
-                    id: info.id,
+                    data: { ...info.cell.data, outputs: [createErrorOutput(exc)] },
+                    id: info.cell.id,
                     file: Identifiers.EmptyFileName,
                     line: 0,
                     state: CellState.error

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -466,7 +466,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             // Make this error our cell output
             this.sendCellsToWebView([
                 {
-                    data: { ...info.cell.data, outputs: [createErrorOutput(exc)] },
+                    // tslint:disable-next-line: no-any
+                    data: { ...info.cell.data, outputs: [createErrorOutput(exc)] } as any, // nyc compiler issue
                     id: info.cell.id,
                     file: Identifiers.EmptyFileName,
                     line: 0,

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { inject, injectable, multiInject, named } from 'inversify';
 import * as path from 'path';
-import { Event, EventEmitter, Memento, TextEditor, Uri, ViewColumn } from 'vscode';
+import { Event, EventEmitter, Memento, Uri, ViewColumn } from 'vscode';
 import {
     IApplicationShell,
     ICommandManager,
@@ -172,7 +172,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         return super.show();
     }
 
-    public async addCode(code: string, file: string, line: number, editor?: TextEditor): Promise<boolean> {
+    public async addCode(code: string, file: string, line: number): Promise<boolean> {
         // Save the last file we ran with.
         this.lastFile = file;
 
@@ -183,7 +183,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         this.updateCwd(path.dirname(file));
 
         // Call the internal method.
-        return this.submitCode(code, file, line, undefined, editor, false);
+        return this.submitCode(code, file, line);
     }
 
     public exportCells() {
@@ -212,7 +212,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         }
     }
 
-    public async debugCode(code: string, file: string, line: number, editor?: TextEditor): Promise<boolean> {
+    public async debugCode(code: string, file: string, line: number): Promise<boolean> {
         let saved = true;
         // Make sure the file is saved before debugging
         const doc = this.documentManager.textDocuments.find(d => this.fileSystem.arePathsSame(d.fileName, file));
@@ -231,16 +231,13 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
 
                     // Open the new document
                     await this.documentManager.openTextDocument(file);
-
-                    // Change the editor to the new file
-                    editor = this.documentManager.visibleTextEditors.find(e => e.document.fileName === file);
                 }
             }
         }
 
         // Call the internal method if we were able to save
         if (saved) {
-            return this.submitCode(code, file, line, undefined, editor, true);
+            return this.submitCode(code, file, line, undefined, undefined, true);
         }
 
         return false;
@@ -271,7 +268,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         // If there's any payload, it has the code and the id
         if (info && info.code && info.id) {
             // Send to ourselves.
-            this.submitCode(info.code, Identifiers.EmptyFileName, 0, info.id, undefined).ignoreErrors();
+            this.submitCode(info.code, Identifiers.EmptyFileName, 0, info.id).ignoreErrors();
 
             // Activate the other side, and send as if came from a file
             this.interactiveWindowProvider

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -52,7 +52,10 @@ export namespace Execution {
 
                     // Send a message if a code cell
                     queueAction(
-                        createPostableAction(InteractiveWindowMessages.ReExecuteCell, { code, id: orig.cell.id })
+                        createPostableAction(InteractiveWindowMessages.ReExecuteCell, {
+                            newCode: code,
+                            cell: orig.cell
+                        })
                     );
                 } else {
                     // Update our input to be our new code

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1871,6 +1871,9 @@ for _ in range(50):
                 const fileContent = await fs.readFile(notebookFile.filePath, 'utf8');
                 const fileObject = JSON.parse(fileContent);
 
+                // First cell should still have the 'collapsed' metadata
+                assert.ok(fileObject.cells[0].metadata.collapsed, 'Metadata erased during execution');
+
                 // The version should be updated to something not "1.2.3"
                 assert.notEqual(fileObject.metadata.language_info.version, '1.2.3');
 


### PR DESCRIPTION
For #9997

Recombine data with output from execution so that metadata isn't lost.