### PR TITLE
Use correct jedi function to generate signatures.

### DIFF
--- a/pythonFiles/completion.py
+++ b/pythonFiles/completion.py
@@ -85,15 +85,15 @@ class JediCompletion(object):
             return cls._get_top_level_module(_path)
         return path
 
-    def _generate_signature(self, completion):
+    def _generate_signature(self, definition):
         """Generate signature with function arguments.
         """
-        if completion.type in ["module"] or not hasattr(completion, "params"):
+        if completion.type in ["module"]:
             return ""
-        return "%s(%s)" % (
-            completion.name,
-            ", ".join(p.description[6:] for p in completion.params if p),
-        )
+        signatures = definition.get_signatures()
+        if len(signatures) == 0:
+            return ""
+        return signatures[0].to_string()
 
     def _get_call_signatures(self, script):
         """Extract call signatures from jedi.api.Script object in failsafe way.


### PR DESCRIPTION
For #185
Instead of generating the function signature concatenating strings it's now using the dedicated function from jedi.
The generated signature now contains the return type as well.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
