### PR TITLE
Include interpreter name in message

### DIFF
--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -92,7 +92,7 @@ export class JupyterInterpreterSubCommandExecutionService
         }
 
         if (productsNotInstalled.length === 1 && productsNotInstalled[0] === Product.kernelspec) {
-            return DataScience.jupyterKernelSpecModuleNotFound();
+            return DataScience.jupyterKernelSpecModuleNotFound().format(interpreter.path);
         }
 
         return getMessageForLibrariesNotInstalled(productsNotInstalled, interpreter.displayName);

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -281,7 +281,7 @@ suite('Data Science - Jupyter InterpreterSubCommandExecutionService', () => {
                 undefined
             );
 
-            assert.equal(reason, DataScience.jupyterKernelSpecModuleNotFound());
+            assert.equal(reason, DataScience.jupyterKernelSpecModuleNotFound().format(selectedJupyterInterpreter.path));
         });
         test('Can start jupyer notebook', async () => {
             const output = await jupyterInterpreterExecutionService.startNotebook([], {});


### PR DESCRIPTION
For #10071
Fix to ensure interpreter is included in message, here's the actual message seen by the user.

`Error: Jupyter cannot be started. Error attempting to locate jupyter: 'Kernelspec' module not installed in the selected interpreter ({0}).
`

Note the `{0}`