### PR TITLE
Ignore display name when searching kernels matching an interpreter

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -104,9 +104,6 @@ export class KernelService {
                 if (item.language.toLowerCase() !== PYTHON_LANGUAGE.toLowerCase()) {
                     return false;
                 }
-                if (item.display_name !== option.displayName) {
-                    return false;
-                }
                 return (
                     this.fileSystem.arePathsSame(item.argv[0], option.path) ||
                     this.fileSystem.arePathsSame(item.metadata?.interpreter?.path || '', option.path)


### PR DESCRIPTION
Partial fix for #10173
Comparing against path of interpreter alone is sufficient.

Figured there's no harm in trying to minimise occurrences of dup kernels (basically just compare against python executable path, as thats sufficient and always accurate)

Display name:
* Can change from version to version of Python extension (**i.e. it shouldn't have been used as a unique identifier**)
* Display name can change after extension loads and more information about interpreter is available.