### PR TITLE
Fix run all cells to wait for the previous cell

### DIFF
--- a/news/2 Fixes/10016.md
+++ b/news/2 Fixes/10016.md
@@ -1,0 +1,1 @@
+Fix run all cells to force each cell to finish before running the next one.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1410,7 +1410,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                 this.postMessage(InteractiveWindowMessages.LoadTmLanguageResponse, s).ignoreErrors();
             })
             .catch(_e => {
-                this.postMessage(InteractiveWindowMessages.LoadTmLanguageResponse, undefined).ignoreErrors();
+                this.postMessage(InteractiveWindowMessages.LoadTmLanguageResponse).ignoreErrors();
             });
     }
 
@@ -1431,13 +1431,13 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                     this.postMessage(InteractiveWindowMessages.LoadOnigasmAssemblyResponse, contents).ignoreErrors();
                 } else {
                     traceWarning('Onigasm file not found. Colorization will not be available.');
-                    this.postMessage(InteractiveWindowMessages.LoadOnigasmAssemblyResponse, undefined).ignoreErrors();
+                    this.postMessage(InteractiveWindowMessages.LoadOnigasmAssemblyResponse).ignoreErrors();
                 }
             }
         } else {
             // This happens during testing. Onigasm not needed as we're not testing colorization.
             traceWarning('File system not found. Colorization will not be available.');
-            this.postMessage(InteractiveWindowMessages.LoadOnigasmAssemblyResponse, undefined).ignoreErrors();
+            this.postMessage(InteractiveWindowMessages.LoadOnigasmAssemblyResponse).ignoreErrors();
         }
     }
 

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -460,7 +460,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     // Submits a new cell to the window
     protected abstract submitNewCell(info: ISubmitNewCell): void;
 
-    // Re-executes a cell already in the window
+    // Re-executes cells already in the window
     protected reexecuteCells(_info: IReExecuteCells): void {
         // Default is not to do anything. This only works in the native editor
     }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -54,7 +54,7 @@ import {
     IGotoCode,
     IInteractiveWindowMapping,
     InteractiveWindowMessages,
-    IReExecuteCell,
+    IReExecuteCells,
     IRemoteAddCode,
     IRemoteReexecuteCode,
     IShowDataViewer,
@@ -228,8 +228,8 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                 this.handleMessage(message, payload, this.submitNewCell);
                 break;
 
-            case InteractiveWindowMessages.ReExecuteCell:
-                this.handleMessage(message, payload, this.reexecuteCell);
+            case InteractiveWindowMessages.ReExecuteCells:
+                this.handleMessage(message, payload, this.reexecuteCells);
                 break;
 
             case InteractiveWindowMessages.DeleteAllCells:
@@ -461,7 +461,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     protected abstract submitNewCell(info: ISubmitNewCell): void;
 
     // Re-executes a cell already in the window
-    protected reexecuteCell(_info: IReExecuteCell): void {
+    protected reexecuteCells(_info: IReExecuteCells): void {
         // Default is not to do anything. This only works in the native editor
     }
 

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -497,7 +497,8 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         line: number,
         id?: string,
         data?: nbformat.ICodeCell | nbformat.IRawCell | nbformat.IMarkdownCell,
-        debug?: boolean
+        debug?: boolean,
+        cancelToken?: CancellationToken
     ): Promise<boolean> {
         traceInfo(`Submitting code for ${this.id}`);
         let result = true;
@@ -564,7 +565,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                         file,
                         line,
                         uuid(),
-                        undefined,
+                        cancelToken,
                         true
                     );
                 }

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -76,7 +76,7 @@ export enum InteractiveWindowMessages {
     LoadAllCells = 'load_all_cells',
     LoadAllCellsComplete = 'load_all_cells_complete',
     ScrollToCell = 'scroll_to_cell',
-    ReExecuteCell = 'reexecute_cell',
+    ReExecuteCells = 'reexecute_cells',
     NotebookIdentity = 'identity',
     NotebookDirty = 'dirty',
     NotebookClean = 'clean',
@@ -177,9 +177,8 @@ export interface ISubmitNewCell {
     id: string;
 }
 
-export interface IReExecuteCell {
-    newCode: string;
-    cell: ICell;
+export interface IReExecuteCells {
+    entries: { cell: ICell; code: string }[];
 }
 
 export interface IProvideCompletionItemsRequest {
@@ -372,7 +371,7 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.LoadAllCells]: ILoadAllCells;
     public [InteractiveWindowMessages.LoadAllCellsComplete]: ILoadAllCells;
     public [InteractiveWindowMessages.ScrollToCell]: IScrollToCell;
-    public [InteractiveWindowMessages.ReExecuteCell]: IReExecuteCell;
+    public [InteractiveWindowMessages.ReExecuteCells]: IReExecuteCells;
     public [InteractiveWindowMessages.NotebookIdentity]: INotebookIdentity;
     public [InteractiveWindowMessages.NotebookDirty]: never | undefined;
     public [InteractiveWindowMessages.NotebookClean]: never | undefined;

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -21,7 +21,7 @@ import {
     IWorkspaceService
 } from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
-import { traceError } from '../../common/logger';
+import { traceError, traceInfo } from '../../common/logger';
 import { IFileSystem, TemporaryFile } from '../../common/platform/types';
 import {
     GLOBAL_MEMENTO,
@@ -574,6 +574,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         try {
             // If there's any payload, it has the code and the id
             if (entry.code && entry.cell.id && entry.cell.data.cell_type !== 'messages') {
+                traceInfo(`Executing cell ${entry.cell.id}`);
+
                 // Clear the result if we've run before
                 await this.clearResult(entry.cell.id);
 
@@ -615,6 +617,10 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             ]);
 
             throw exc;
+        } finally {
+            if (entry && entry.cell.id) {
+                traceInfo(`Finished executing cell ${entry.cell.id}`);
+            }
         }
     }
 

--- a/src/datascience-ui/interactive-common/redux/postOffice.ts
+++ b/src/datascience-ui/interactive-common/redux/postOffice.ts
@@ -78,7 +78,7 @@ export enum IncomingMessageActions {
     LOADALLCELLS = 'action.load_all_cells',
     LOADALLCELLSCOMPLETE = 'action.load_all_cells_complete',
     SCROLLTOCELL = 'action.scroll_to_cell',
-    REEXECUTECELL = 'action.reexecute_cell',
+    REEXECUTECELLS = 'action.reexecute_cells',
     NOTEBOOKIDENTITY = 'action.identity',
     NOTEBOOKDIRTY = 'action.dirty',
     NOTEBOOKCLEAN = 'action.clean',

--- a/src/datascience-ui/interactive-common/tokenizer.ts
+++ b/src/datascience-ui/interactive-common/tokenizer.ts
@@ -67,26 +67,27 @@ export async function initializeTokenizer(
         // Register the language first
         registerMonacoLanguage();
 
-        // Load the web assembly
-        await loadWASM(onigasm);
+        // Load the web assembly if necessary
+        if (onigasm && onigasm.byteLength > 0) {
+            await loadWASM(onigasm);
 
-        // Setup our registry of different
-        const registry = new Registry({
-            getGrammarDefinition: async _scopeName => {
-                return {
-                    format: 'json',
-                    content: tmlanguageJSON
-                };
-            }
-        });
+            // Setup our registry of different
+            const registry = new Registry({
+                getGrammarDefinition: async _scopeName => {
+                    return {
+                        format: 'json',
+                        content: tmlanguageJSON
+                    };
+                }
+            });
 
-        // map of monaco "language id's" to TextMate scopeNames
-        const grammars = new Map();
-        grammars.set('python', 'source.python');
+            // map of monaco "language id's" to TextMate scopeNames
+            const grammars = new Map();
+            grammars.set('python', 'source.python');
 
-        // Wire everything together.
-        await wireTmGrammars(monacoEditor, registry, grammars);
-
+            // Wire everything together.
+            await wireTmGrammars(monacoEditor, registry, grammars);
+        }
         // Indicate to the callback that we're done.
         loadingFinished();
     } catch (e) {

--- a/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditor.unit.test.ts
@@ -33,12 +33,14 @@ import {
 import { WebPanel } from '../../../client/common/application/webPanels/webPanel';
 import { WebPanelProvider } from '../../../client/common/application/webPanels/webPanelProvider';
 import { WorkspaceService } from '../../../client/common/application/workspace';
+import { AsyncDisposableRegistry } from '../../../client/common/asyncDisposableRegistry';
 import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { CryptoUtils } from '../../../client/common/crypto';
 import { ExperimentsManager } from '../../../client/common/experiments';
 import { IFileSystem } from '../../../client/common/platform/types';
 import {
+    IAsyncDisposableRegistry,
     IConfigurationService,
     ICryptoUtils,
     IExperimentsManager,
@@ -154,6 +156,7 @@ suite('Data Science - Native Editor', () => {
     let testIndex = 0;
     let reporter: ProgressReporter;
     let experimentsManager: IExperimentsManager;
+    let asyncRegistry: IAsyncDisposableRegistry;
     const baseFile = `{
  "cells": [
   {
@@ -341,6 +344,7 @@ suite('Data Science - Native Editor', () => {
             .returns(_a1 => {
                 return Promise.resolve(lastWriteFileValue);
             });
+        asyncRegistry = mock(AsyncDisposableRegistry);
     });
 
     teardown(() => {
@@ -377,7 +381,8 @@ suite('Data Science - Native Editor', () => {
             instance(crypto),
             context.object,
             instance(reporter),
-            instance(experimentsManager)
+            instance(experimentsManager),
+            instance(asyncRegistry)
         );
     }
 

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -454,13 +454,14 @@ for _ in range(50):
         runMountedTest(
             'RunAllCells',
             async wrapper => {
-                addMockData(ioc, 'b=2\nb', 2);
-                addMockData(ioc, 'c=3\nc', 3);
+                addMockData(ioc, 'a3=1', '');
+                addMockData(ioc, 'a3=2', '');
+                addMockData(ioc, 'a3', 2);
 
                 const baseFile = [
-                    { id: 'NotebookImport#0', data: { source: 'a=1\na' } },
-                    { id: 'NotebookImport#1', data: { source: 'b=2\nb' } },
-                    { id: 'NotebookImport#2', data: { source: 'c=3\nc' } }
+                    { id: 'NotebookImport#0', data: { source: 'a3=1' } },
+                    { id: 'NotebookImport#1', data: { source: 'a3=2' } },
+                    { id: 'NotebookImport#2', data: { source: 'a3' } }
                 ];
                 const runAllCells = baseFile.map(cell => {
                     return createFileCell(cell, cell.data);
@@ -478,9 +479,7 @@ for _ in range(50):
                 await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
                 await threeCellsUpdated;
 
-                verifyHtmlOnCell(wrapper, 'NativeCell', `1`, 0);
-                verifyHtmlOnCell(wrapper, 'NativeCell', `2`, 1);
-                verifyHtmlOnCell(wrapper, 'NativeCell', `3`, 2);
+                verifyHtmlOnCell(wrapper, 'NativeCell', `2`, 2);
             },
             () => {
                 return ioc;

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -454,14 +454,14 @@ for _ in range(50):
         runMountedTest(
             'RunAllCells',
             async wrapper => {
-                addMockData(ioc, 'a3=1', '');
-                addMockData(ioc, 'a3=2', '');
-                addMockData(ioc, 'a3', 2);
+                addMockData(ioc, 'print(1)\na=1', 1);
+                addMockData(ioc, 'a=a+1\nprint(a)', 2);
+                addMockData(ioc, 'print(a+1)', 3);
 
                 const baseFile = [
-                    { id: 'NotebookImport#0', data: { source: 'a3=1' } },
-                    { id: 'NotebookImport#1', data: { source: 'a3=2' } },
-                    { id: 'NotebookImport#2', data: { source: 'a3' } }
+                    { id: 'NotebookImport#0', data: { source: 'print(1)\na=1' } },
+                    { id: 'NotebookImport#1', data: { source: 'a=a+1\nprint(a)' } },
+                    { id: 'NotebookImport#2', data: { source: 'print(a+1)' } }
                 ];
                 const runAllCells = baseFile.map(cell => {
                     return createFileCell(cell, cell.data);
@@ -479,7 +479,9 @@ for _ in range(50):
                 await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
                 await threeCellsUpdated;
 
-                verifyHtmlOnCell(wrapper, 'NativeCell', `2`, 2);
+                verifyHtmlOnCell(wrapper, 'NativeCell', `1`, 0);
+                verifyHtmlOnCell(wrapper, 'NativeCell', `2`, 1);
+                verifyHtmlOnCell(wrapper, 'NativeCell', `3`, 2);
             },
             () => {
                 return ioc;


### PR DESCRIPTION
For #10016

Notebooks when executing cells were sending a message for each cell. It wasn't guaranteed that any one cell would start or finish before another. 

This changes all of the cells to be sent in a group.
