### PR TITLE
Reduce the number of build agents used by CI.

### DIFF
--- a/build/ci/vscode-python-ci-manual.yaml
+++ b/build/ci/vscode-python-ci-manual.yaml
@@ -1,0 +1,292 @@
+# manual CI build
+
+name: '$(Year:yyyy).$(Month).0.$(BuildID)-manual'
+
+trigger: none
+pr: none
+
+# Variables that are available for the entire pipeline.
+variables:
+- template: templates/globals.yml
+
+stages:
+- stage: Build
+  jobs:
+  - template: templates/jobs/build_compile.yml
+
+# Each item in each matrix has a number of possible values it may
+# define.  They are detailed in templates/test_phases.yml.  The only
+# required value is "TestsToRun".
+
+- stage: Linux
+  dependsOn: []
+  jobs:
+  - job: 'Py3x'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          # with mocks
+          # focused on small units (i.e. functions)
+          # and tightly controlled dependencies
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          # no mocks, no vscode
+          # focused on integration
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          # no mocks, with vscode
+          # focused on integration
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+        'Multi Workspace':
+          # no mocks, with vscode
+          # focused on integration
+          TestsToRun: 'testMultiWorkspace'
+          NeedsPythonTestReqs: true
+        'Venv':
+          TestsToRun: 'venvTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+          # This is for the venvTests to use, not needed if you don't run venv tests...
+          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+        'Debugger':
+          TestsToRun: 'testDebugger'
+          NeedsPythonTestReqs: true
+        'Smoke':
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - template: templates/test_phases.yml
+
+  # This is the oldest Python 3 version we support.
+  - job: 'Py36'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          PythonVersion: '3.6'
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          PythonVersion: '3.6'
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          PythonVersion: '3.6'
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - template: templates/test_phases.yml
+
+  # This is the oldest Python 3 version we support.
+  - job: 'Py35'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          PythonVersion: '3.5'
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          PythonVersion: '3.5'
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          PythonVersion: '3.5'
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+        'Venv':
+          PythonVersion: '3.5'
+          TestsToRun: 'venvTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+        'Debugger':
+          PythonVersion: '3.5'
+          TestsToRun: 'testDebugger'
+          NeedsPythonTestReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - template: templates/test_phases.yml
+
+- stage: Mac
+  dependsOn: []
+  jobs:
+  - job: 'Py3x'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+        'Multi Workspace':
+          TestsToRun: 'testMultiWorkspace'
+          NeedsPythonTestReqs: true
+        'Venv':
+          TestsToRun: 'venvTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+        'Debugger':
+          TestsToRun: 'testDebugger'
+          NeedsPythonTestReqs: true
+        'Smoke':
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'macos-10.13'
+    steps:
+      - template: templates/test_phases.yml
+
+  # This is the oldest Python 3 version we support.
+  - job: 'Py35'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          PythonVersion: '3.5'
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          PythonVersion: '3.5'
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          PythonVersion: '3.5'
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+        'Venv':
+          PythonVersion: '3.5'
+          TestsToRun: 'venvTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+        'Debugger':
+          PythonVersion: '3.5'
+          TestsToRun: 'testDebugger'
+          NeedsPythonTestReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'macos-10.13'
+    steps:
+      - template: templates/test_phases.yml
+
+- stage: Windows
+  dependsOn: []
+  jobs:
+  - job: 'Py3x'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+        'Multi Workspace':
+          TestsToRun: 'testMultiWorkspace'
+          NeedsPythonTestReqs: true
+        'Venv':
+          TestsToRun: 'venvTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+        'Debugger':
+          TestsToRun: 'testDebugger'
+          NeedsPythonTestReqs: true
+        'Smoke':
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - template: templates/test_phases.yml
+
+  # This is the oldest Python 3 version we support.
+  - job: 'Py35'
+    dependsOn: []
+    timeoutInMinutes: 120
+    strategy:
+      matrix:
+        'Unit':
+          PythonVersion: '3.5'
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+        'Functional':
+          PythonVersion: '3.5'
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
+        'Single Workspace':
+          PythonVersion: '3.5'
+          TestsToRun: 'testSingleWorkspace'
+          NeedsPythonTestReqs: true
+        'Venv':
+          PythonVersion: '3.5'
+          TestsToRun: 'venvTests'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
+        'Debugger':
+          PythonVersion: '3.5'
+          TestsToRun: 'testDebugger'
+          NeedsPythonTestReqs: true
+      #maxParallel: 3
+    pool:
+      vmImage: 'vs2017-win2016'
+    steps:
+      - template: templates/test_phases.yml
+
+- stage: Reports
+  dependsOn:
+  - Linux
+  - Mac
+  - Windows
+  condition: always()
+  jobs:
+  - template: templates/jobs/coverage.yml

--- a/build/ci/vscode-python-ci-manual.yaml
+++ b/build/ci/vscode-python-ci-manual.yaml
@@ -76,7 +76,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.6'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -102,7 +103,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -178,7 +180,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -254,7 +257,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':

--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -1,5 +1,7 @@
+# CI build (PR merge)
+
 name: '$(Year:yyyy).$(Month).0.$(BuildID)-ci'
-# CI build.
+
 # Notes: Only trigger a commit for master and release, and skip build/rebuild
 #        on changes in the news and .vscode folders.
 trigger:
@@ -82,7 +84,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Venv':

--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -68,6 +68,7 @@ stages:
           TestsToRun: 'testSmoke'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
+      maxParallel: 2
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -94,6 +95,7 @@ stages:
           PythonVersion: '3.5'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
+      maxParallel: 2
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -133,6 +135,7 @@ stages:
           TestsToRun: 'testSmoke'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
+      maxParallel: 2
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -172,6 +175,7 @@ stages:
           TestsToRun: 'testSmoke'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
+      maxParallel: 2
     pool:
       vmImage: 'vs2017-win2016'
     steps:

--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -65,45 +65,33 @@ stages:
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
         'Smoke':
-            TestsToRun: 'testSmoke'
-            NeedsPythonTestReqs: true
-            NeedsIPythonReqs: true
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
       - template: templates/test_phases.yml
 
-  - job: 'Py36'
+  # This is the oldest Python 3 version we support.
+  - job: 'Py35'
     dependsOn: []
     timeoutInMinutes: 120
     strategy:
       matrix:
         'Unit':
-          PythonVersion: '3.6'
+          PythonVersion: '3.5'
           TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
-        'Functional':
-          PythonVersion: '3.6'
-          TestsToRun: 'testfunctional'
-          NeedsPythonTestReqs: true
-          NeedsPythonFunctionalReqs: true
-        'Single Workspace':
-          PythonVersion: '3.6'
-          TestsToRun: 'testSingleWorkspace'
-          NeedsPythonTestReqs: true
-        'Multi Workspace':
-          PythonVersion: '3.6'
-          TestsToRun: 'testMultiWorkspace'
-          NeedsPythonTestReqs: true
         'Venv':
-          PythonVersion: '3.6'
+          PythonVersion: '3.5'
           TestsToRun: 'venvTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         'Debugger':
-          PythonVersion: '3.6'
+          PythonVersion: '3.5'
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
     pool:
@@ -142,47 +130,9 @@ stages:
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
         'Smoke':
-            TestsToRun: 'testSmoke'
-            NeedsPythonTestReqs: true
-            NeedsIPythonReqs: true
-    pool:
-      vmImage: 'macos-10.13'
-    steps:
-      - template: templates/test_phases.yml
-
-  - job: 'Py36'
-    dependsOn: []
-    timeoutInMinutes: 120
-    strategy:
-      matrix:
-        'Unit':
-          PythonVersion: '3.6'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          TestsToRun: 'testSmoke'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
-        'Functional':
-          PythonVersion: '3.6'
-          TestsToRun: 'testfunctional'
-          NeedsPythonTestReqs: true
-          NeedsPythonFunctionalReqs: true
-        'Single Workspace':
-          PythonVersion: '3.6'
-          TestsToRun: 'testSingleWorkspace'
-          NeedsPythonTestReqs: true
-        'Multi Workspace':
-          PythonVersion: '3.6'
-          TestsToRun: 'testMultiWorkspace'
-          NeedsPythonTestReqs: true
-        'Venv':
-          PythonVersion: '3.6'
-          TestsToRun: 'venvTests'
-          NeedsPythonTestReqs: true
-          NeedsIPythonReqs: true
-          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-        'Debugger':
-          PythonVersion: '3.6'
-          TestsToRun: 'testDebugger'
-          NeedsPythonTestReqs: true
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -219,47 +169,9 @@ stages:
           TestsToRun: 'testDebugger'
           NeedsPythonTestReqs: true
         'Smoke':
-            TestsToRun: 'testSmoke'
-            NeedsPythonTestReqs: true
-            NeedsIPythonReqs: true
-    pool:
-      vmImage: 'vs2017-win2016'
-    steps:
-      - template: templates/test_phases.yml
-
-  - job: 'Py36'
-    dependsOn: []
-    timeoutInMinutes: 120
-    strategy:
-      matrix:
-        'Unit':
-          PythonVersion: '3.6'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          TestsToRun: 'testSmoke'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
-        'Functional':
-          PythonVersion: '3.6'
-          TestsToRun: 'testfunctional'
-          NeedsPythonTestReqs: true
-          NeedsPythonFunctionalReqs: true
-        'Single Workspace':
-          PythonVersion: '3.6'
-          TestsToRun: 'testSingleWorkspace'
-          NeedsPythonTestReqs: true
-        'Multi Workspace':
-          PythonVersion: '3.6'
-          TestsToRun: 'testMultiWorkspace'
-          NeedsPythonTestReqs: true
-        'Venv':
-          PythonVersion: '3.6'
-          TestsToRun: 'venvTests'
-          NeedsPythonTestReqs: true
-          NeedsIPythonReqs: true
-          PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
-        'Debugger':
-          PythonVersion: '3.6'
-          TestsToRun: 'testDebugger'
-          NeedsPythonTestReqs: true
     pool:
       vmImage: 'vs2017-win2016'
     steps:

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -63,9 +63,10 @@ stages:
           # This is for the venvTests to use, not needed if you don't run venv tests...
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         'Smoke':
-            TestsToRun: 'testSmoke'
-            NeedsPythonTestReqs: true
-            NeedsIPythonReqs: true
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+      maxParallel: 1
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -104,6 +105,7 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -142,6 +144,7 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -176,6 +179,7 @@ stages:
           NeedsPythonTestReqs: true
         # Note: Virtual env tests use `venv` and won't currently work with Python 2.7
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -212,9 +216,10 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         'Smoke':
-            TestsToRun: 'testSmoke'
-            NeedsPythonTestReqs: true
-            NeedsIPythonReqs: true
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+      maxParallel: 1
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -253,6 +258,7 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -291,6 +297,7 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -325,6 +332,7 @@ stages:
           NeedsPythonTestReqs: true
         # Note: Virtual env tests use `venv` and won't currently work with Python 2.7
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -361,9 +369,10 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         'Smoke':
-            TestsToRun: 'testSmoke'
-            NeedsPythonTestReqs: true
-            NeedsIPythonReqs: true
+          TestsToRun: 'testSmoke'
+          NeedsPythonTestReqs: true
+          NeedsIPythonReqs: true
+      maxParallel: 1
     pool:
       vmImage: 'vs2017-win2016'
     steps:
@@ -402,6 +411,7 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'vs2017-win2016'
     steps:
@@ -440,6 +450,7 @@ stages:
           NeedsPythonTestReqs: true
           PYTHON_VIRTUAL_ENVS_LOCATION: './src/tmp/envPaths.json'
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'vs2017-win2016'
     steps:
@@ -474,6 +485,7 @@ stages:
           NeedsPythonTestReqs: true
         # Note: Virtual env tests use `venv` and won't currently work with Python 2.7
         # Note: We only run the smoke tests with the latest Python release.
+      maxParallel: 1
     pool:
       vmImage: 'vs2017-win2016'
     steps:

--- a/build/ci/vscode-python-nightly-ci.yaml
+++ b/build/ci/vscode-python-nightly-ci.yaml
@@ -79,7 +79,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.6'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -118,7 +119,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -157,7 +159,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '2.7'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -232,7 +235,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.6'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -271,7 +275,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -310,7 +315,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '2.7'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -385,7 +391,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.6'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -424,7 +431,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '3.5'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':
@@ -463,7 +471,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '2.7'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonIPythonTests'
           NeedsPythonTestReqs: true
           NeedsIPythonReqs: true
         'Functional':

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -60,7 +60,8 @@ stages:
       matrix:
         'Unit':
           PythonVersion: '2.7'
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools'
+          # Note: "pythonInternalTools" tests are 3.7+.
+          TestsToRun: 'testUnitTests, pythonUnitTests'
           NeedsPythonTestReqs: true
         'Functional':
           PythonVersion: '2.7'

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -57,10 +57,15 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        'Unit+Single':
+        'Unit':
           PythonVersion: '2.7'
-          TestsToRun: 'pythonUnitTests, testSingleWorkspace'
+          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools'
           NeedsPythonTestReqs: true
+        'Functional':
+          PythonVersion: '2.7'
+          TestsToRun: 'testfunctional'
+          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -73,30 +78,11 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        'Unit':
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+        # This gives us our best functional coverage for the OS.
+        'Functional+Single':
+          TestsToRun: 'testfunctional, testSingleWorkspace'
           NeedsPythonTestReqs: true
-          NeedsIPythonReqs: true
-        'Single Workspace':
-          TestsToRun: 'testSingleWorkspace'
-          NeedsPythonTestReqs: true
-        'Smoke':
-          TestsToRun: 'testSmoke'
-          NeedsPythonTestReqs: true
-          NeedsIPythonReqs: true
-    pool:
-      vmImage: 'macos-10.13'
-    steps:
-      - template: templates/test_phases.yml
-
-  - job: 'Py27'
-    dependsOn: []
-    strategy:
-      matrix:
-        'Unit+Single':
-          PythonVersion: '2.7'
-          TestsToRun: 'pythonUnitTests, testSingleWorkspace'
-          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
     pool:
       vmImage: 'macos-10.13'
     steps:
@@ -109,27 +95,11 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        'Unit':
-          TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+        # This gives us our best functional coverage for the OS.
+        'Functional+Single':
+          TestsToRun: 'testfunctional, testSingleWorkspace'
           NeedsPythonTestReqs: true
-          NeedsIPythonReqs: true
-        'Smoke':
-          TestsToRun: 'testSmoke'
-          NeedsPythonTestReqs: true
-          NeedsIPythonReqs: true
-    pool:
-      vmImage: 'vs2017-win2016'
-    steps:
-      - template: templates/test_phases.yml
-
-  - job: 'Py27'
-    dependsOn: []
-    strategy:
-      matrix:
-        'Unit':
-          PythonVersion: '2.7'
-          TestsToRun: 'pythonUnitTests'
-          NeedsPythonTestReqs: true
+          NeedsPythonFunctionalReqs: true
     pool:
       vmImage: 'vs2017-win2016'
     steps:

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -114,25 +114,3 @@ stages:
   condition: always()
   jobs:
   - template: templates/jobs/coverage.yml
-
-# The following is a temporary workaround for transitioning the
-# job names for 2 jobs set as required checks in GitHub.  It will
-# be removed once we adjust the GitHub configuration.
-
-- stage: Tests
-  dependsOn: []
-  jobs:
-  - job: 'Test'
-    dependsOn: []
-    strategy:
-      matrix:
-        'Linux-Py3.7 Functional':
-            noop: true
-        'Linux-Py3.7 Unit':
-            noop: true
-    # Essentially, this is a noop.
-    steps:
-      - task: Delay@1
-        inputs:
-          delayForMinutes: '0'
-    pool: server

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -1,6 +1,7 @@
+# PR Validation build.
+
 name: '$(Year:yyyy).$(Month).0.$(BuildID)-pr'
 
-# PR Validation build.
 # Notes: Only trigger a PR build for master and release, and skip build/rebuild
 #        on changes in the news and .vscode folders.
 pr:


### PR DESCRIPTION
(for #9939)

This change reduces the number of agents required by the following pipelines:

* "PR Validation"
   + jobs:  13 -> 8
   + agents:  same
* "CI" (PR-merge)
   + jobs:  39 -> 24
   + agents:  24 -> 8 (2 agents per job matrix)
* "Nightly Build"
   + jobs: same (84)
   + agents: 84 -> 12 (1 agent per job matrix)

So the total number of jobs drops from 136 to 116 and max agents from 116 to 28.  We can adjust if we find that too limiting.

(FYI, I've manually started CI runs in the "CI" and "Nightly Build" pipelines.)