### PR TITLE
Update code as user types into the editor

### DIFF
--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -178,7 +178,7 @@ export interface ISubmitNewCell {
 }
 
 export interface IReExecuteCells {
-    entries: { cell: ICell; code: string }[];
+    cellIds: string[];
 }
 
 export interface IProvideCompletionItemsRequest {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -470,11 +470,15 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     protected async reexecuteCells(info: IReExecuteCells): Promise<void> {
         const tokenSource = new CancellationTokenSource();
         this.executeCancelTokens.add(tokenSource);
-        let finishedPos = info && info.entries ? info.entries.length : -1;
+        let finishedPos = info && info.cellIds ? info.cellIds.length : -1;
         try {
-            if (info && info.entries) {
-                for (let i = 0; i < info.entries.length && !tokenSource.token.isCancellationRequested; i += 1) {
-                    await this.reexecuteCell(info.entries[i], tokenSource.token);
+            if (info && info.cellIds) {
+                for (let i = 0; i < info.cellIds.length && !tokenSource.token.isCancellationRequested; i += 1) {
+                    const cell = this.cells.find(item => item.id === info.cellIds[i]);
+                    if (!cell) {
+                        continue;
+                    }
+                    await this.reexecuteCell(cell, tokenSource.token);
                     if (!tokenSource.token.isCancellationRequested) {
                         finishedPos = i;
                     }
@@ -491,9 +495,13 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
             // Make sure everything is marked as finished or error after the final finished
             // position
-            if (info && info.entries) {
-                for (let i = finishedPos + 1; i < info.entries.length; i += 1) {
-                    this.finishCell(info.entries[i]);
+            if (info && info.cellIds) {
+                for (let i = finishedPos + 1; i < info.cellIds.length; i += 1) {
+                    const cell = this.cells.find(item => item.id === info.cellIds[i]);
+                    if (!cell) {
+                        continue;
+                    }
+                    this.finishCell(cell);
                 }
             }
         }
@@ -572,45 +580,36 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         this.executeCancelTokens.forEach(t => t.cancel());
     }
 
-    private finishCell(entry: { cell: ICell; code: string }) {
+    private finishCell(cell: ICell) {
         this.sendCellsToWebView([
             {
-                ...entry.cell,
-                // tslint:disable-next-line: no-any
-                data: { ...entry.cell.data, source: entry.code } as any, // nyc compiler issue
+                ...cell,
                 state: CellState.finished
             }
         ]);
     }
 
-    private async reexecuteCell(entry: { cell: ICell; code: string }, cancelToken: CancellationToken): Promise<void> {
+    private async reexecuteCell(cell: ICell, cancelToken: CancellationToken): Promise<void> {
         try {
             // If there's any payload, it has the code and the id
-            if (entry.code && entry.cell.id && entry.cell.data.cell_type !== 'messages') {
-                traceInfo(`Executing cell ${entry.cell.id}`);
+            if (cell.id && cell.data.cell_type !== 'messages') {
+                traceInfo(`Executing cell ${cell.id}`);
 
                 // Clear the result if we've run before
-                await this.clearResult(entry.cell.id);
+                await this.clearResult(cell.id);
 
+                const code = concatMultilineStringInput(cell.data.source);
                 // Send to ourselves.
-                await this.submitCode(
-                    entry.code,
-                    Identifiers.EmptyFileName,
-                    0,
-                    entry.cell.id,
-                    entry.cell.data,
-                    false,
-                    cancelToken
-                );
+                await this.submitCode(code, Identifiers.EmptyFileName, 0, cell.id, cell.data, false, cancelToken);
 
                 if (!cancelToken.isCancellationRequested) {
                     // Activate the other side, and send as if came from a file
                     await this.ipynbProvider.show(this.file);
                     this.shareMessage(InteractiveWindowMessages.RemoteReexecuteCode, {
-                        code: entry.code,
+                        code,
                         file: Identifiers.EmptyFileName,
                         line: 0,
-                        id: entry.cell.id,
+                        id: cell.id,
                         originator: this.id,
                         debug: false
                     });
@@ -621,8 +620,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             this.sendCellsToWebView([
                 {
                     // tslint:disable-next-line: no-any
-                    data: { ...entry.cell.data, outputs: [createErrorOutput(exc)] } as any, // nyc compiler issue
-                    id: entry.cell.id,
+                    data: { ...cell.data, outputs: [createErrorOutput(exc)] } as any, // nyc compiler issue
+                    id: cell.id,
                     file: Identifiers.EmptyFileName,
                     line: 0,
                     state: CellState.error
@@ -631,8 +630,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
             throw exc;
         } finally {
-            if (entry && entry.cell.id) {
-                traceInfo(`Finished executing cell ${entry.cell.id}`);
+            if (cell.id) {
+                traceInfo(`Finished executing cell ${cell.id}`);
             }
         }
     }

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -78,26 +78,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
 
     public shouldComponentUpdate(nextProps: IInteractiveCellProps): boolean {
         // if something other than cellvm has changed, then update.
-        if (!fastDeepEqual({ ...this.props, cellVM: undefined }, { ...nextProps, cellVM: undefined })) {
-            return true;
-        }
-        // If anything but cell source|modelId has changed, then update.
-        const previousCell = this.props.cellVM;
-        const nextCell = nextProps.cellVM;
-        if (
-            !fastDeepEqual(
-                { ...previousCell, cell: { ...previousCell.cell, data: { ...previousCell.cell.data, source: '' } } },
-                { ...nextCell, cell: { ...nextCell.cell, data: { ...nextCell.cell.data, source: '' } } }
-            )
-        ) {
-            return true;
-        }
-
-        // Possible source has changed.
-        if (nextProps.cellVM.modelId && this.codeRef.current?.getModelId() === nextProps.cellVM.modelId) {
-            return false;
-        }
-        return previousCell.cell.data.source !== nextCell.cell.data.source;
+        return !fastDeepEqual(this.props, nextProps);
     }
 
     private scrollAndFlash() {

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -77,7 +77,27 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
     }
 
     public shouldComponentUpdate(nextProps: IInteractiveCellProps): boolean {
-        return !fastDeepEqual(this.props, nextProps);
+        // if something other than cellvm has changed, then update.
+        if (!fastDeepEqual({ ...this.props, cellVM: undefined }, { ...nextProps, cellVM: undefined })) {
+            return true;
+        }
+        // If anything but cell source|modelId has changed, then update.
+        const previousCell = this.props.cellVM;
+        const nextCell = nextProps.cellVM;
+        if (
+            !fastDeepEqual(
+                { ...previousCell, cell: { ...previousCell.cell, data: { ...previousCell.cell.data, source: '' } } },
+                { ...nextCell, cell: { ...nextCell.cell, data: { ...nextCell.cell.data, source: '' } } }
+            )
+        ) {
+            return true;
+        }
+
+        // Possible source has changed.
+        if (nextProps.cellVM.modelId && this.codeRef.current?.getModelId() === nextProps.cellVM.modelId) {
+            return false;
+        }
+        return previousCell.cell.data.source !== nextCell.cell.data.source;
     }
 
     private scrollAndFlash() {

--- a/src/datascience-ui/interactive-common/cellInput.tsx
+++ b/src/datascience-ui/interactive-common/cellInput.tsx
@@ -59,7 +59,13 @@ export class CellInput extends React.Component<ICellInputProps> {
             return this.markdownRef.current.getContents();
         }
     }
-
+    public getModelId(): string | undefined {
+        if (this.codeRef.current) {
+            return this.codeRef.current.getModelId();
+        } else if (this.markdownRef.current) {
+            return this.markdownRef.current.getModelId();
+        }
+    }
     private isCodeCell = () => {
         return this.props.cellVM.cell.data.cell_type === 'code';
     };
@@ -104,6 +110,7 @@ export class CellInput extends React.Component<ICellInputProps> {
                         openLink={this.props.openLink}
                         hasFocus={this.props.cellVM.focused}
                         cursorPos={this.props.cellVM.cursorPos}
+                        modelId={this.props.cellVM.modelId}
                         editorMeasureClassName={this.props.editorMeasureClassName}
                         focused={this.onCodeFocused}
                         unfocused={this.onCodeUnfocused}

--- a/src/datascience-ui/interactive-common/code.tsx
+++ b/src/datascience-ui/interactive-common/code.tsx
@@ -18,6 +18,7 @@ export interface ICodeProps {
     history: InputHistory | undefined;
     showWatermark: boolean;
     monacoTheme: string | undefined;
+    modelId?: string;
     outermostParentClass: string;
     editorOptions?: monacoEditor.editor.IEditorOptions;
     editorMeasureClassName?: string;
@@ -96,6 +97,10 @@ export class Code extends React.Component<ICodeProps, ICodeState> {
         if (this.editorRef.current) {
             return this.editorRef.current.getContents();
         }
+    }
+
+    public getModelId(): string | undefined {
+        return this.editorRef.current?.getModelId();
     }
 
     private giveFocus(cursorPos: CursorPos) {

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -90,6 +90,10 @@ export class Editor extends React.Component<IEditorProps, IEditorState> {
         return '';
     }
 
+    public getModelId(): string | undefined {
+        return this.state.model?.id;
+    }
+
     private renderQuickEditor = (): JSX.Element => {
         const readOnly = this.props.readOnly;
         return (

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -38,7 +38,7 @@ export interface ICellViewModel {
     cursorPos: CursorPos;
     hasBeenRun: boolean;
     runDuringDebug?: boolean;
-    uncomittedText?: string;
+    modelId?: string;
 }
 
 export type IMainState = {

--- a/src/datascience-ui/interactive-common/markdown.tsx
+++ b/src/datascience-ui/interactive-common/markdown.tsx
@@ -75,6 +75,10 @@ export class Markdown extends React.Component<IMarkdownProps> {
         }
     }
 
+    public getModelId(): string | undefined {
+        return this.editorRef.current?.getModelId();
+    }
+
     private onModelChanged = (
         changes: monacoEditor.editor.IModelContentChange[],
         model: monacoEditor.editor.ITextModel

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { InteractiveWindowMessages } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { CssMessages } from '../../../../client/datascience/messages';
-import { extractInputText, IMainState } from '../../mainState';
+import { extractInputText, ICellViewModel, IMainState } from '../../mainState';
 import { createPostableAction } from '../postOffice';
 import { Helpers } from './helpers';
 import {
@@ -136,9 +136,16 @@ export namespace Transfer {
             if (index >= 0 && arg.prevState.focusedCellId === arg.payload.cellId) {
                 const newVMs = [...arg.prevState.cellVMs];
                 const current = arg.prevState.cellVMs[index];
-                const newCell = {
+                const newCell: ICellViewModel = {
                     ...current,
-                    uncomittedText: arg.payload.code
+                    cell: {
+                        ...current.cell,
+                        data: {
+                            ...current.cell.data,
+                            source: arg.payload.code
+                        }
+                    },
+                    modelId: arg.payload.modelId
                 };
 
                 // tslint:disable-next-line: no-any

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -138,6 +138,7 @@ export namespace Transfer {
                 const current = arg.prevState.cellVMs[index];
                 const newCell: ICellViewModel = {
                     ...current,
+                    inputBlockText: arg.payload.code,
                     cell: {
                         ...current.cell,
                         data: {

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -133,6 +133,5 @@ export interface ISendCommandAction {
 
 export interface IChangeCellTypeAction {
     cellId: string;
-    currentCode: string;
 }
 export type CommonAction<T> = ActionWithPayload<T, CommonActionType>;

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -108,7 +108,7 @@ export interface IEditCellAction extends ICodeAction {
     modelId: string;
 }
 
-export interface IExecuteAction extends ICodeAction {
+export interface IExecuteAction extends ICellAction {
     moveOp: 'add' | 'select' | 'none';
 }
 

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -268,7 +268,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 if (!this.isFocused() && this.isSelected() && this.isMarkdownCell()) {
                     e.stopPropagation();
                     e.preventDefault();
-                    this.props.changeCellType(cellId, this.getCurrentCode());
+                    this.props.changeCellType(cellId);
                     this.props.sendCommand(NativeCommandType.ChangeToCode, 'keyboard');
                 }
                 break;
@@ -276,7 +276,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 if (!this.isFocused() && this.isSelected() && this.isCodeCell()) {
                     e.stopPropagation();
                     e.preventDefault();
-                    this.props.changeCellType(cellId, this.getCurrentCode());
+                    this.props.changeCellType(cellId);
                     this.props.sendCommand(NativeCommandType.ChangeToMarkdown, 'keyboard');
                 }
                 break;
@@ -554,7 +554,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
             // can give focus to the cell input.
             event.stopPropagation();
             event.preventDefault();
-            this.props.changeCellType(cellId, this.getCurrentCode());
+            this.props.changeCellType(cellId);
             this.props.sendCommand(otherCellTypeCommand, 'mouse');
         };
         const toolbarClassName = this.props.cellVM.cell.data.cell_type === 'code' ? '' : 'markdown-toolbar';

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -75,7 +75,27 @@ export class NativeCell extends React.Component<INativeCellProps> {
     }
 
     public shouldComponentUpdate(nextProps: INativeCellProps): boolean {
-        return !fastDeepEqual(this.props, nextProps);
+        // if something other than cellvm has changed, then update.
+        if (!fastDeepEqual({ ...this.props, cellVM: undefined }, { ...nextProps, cellVM: undefined })) {
+            return true;
+        }
+        // If anything but cell source|modelId has changed, then update.
+        const previousCell = this.props.cellVM;
+        const nextCell = nextProps.cellVM;
+        if (
+            !fastDeepEqual(
+                { ...previousCell, cell: { ...previousCell.cell, data: { ...previousCell.cell.data, source: '' } } },
+                { ...nextCell, cell: { ...nextCell.cell, data: { ...nextCell.cell.data, source: '' } } }
+            )
+        ) {
+            return true;
+        }
+
+        // Possible source has changed.
+        if (nextProps.cellVM.modelId && this.inputRef.current?.getModelId() === nextProps.cellVM.modelId) {
+            return false;
+        }
+        return previousCell.cell.data.source !== nextCell.cell.data.source;
     }
 
     // Public for testing

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -365,14 +365,14 @@ export class NativeCell extends React.Component<INativeCellProps> {
     private arrowUpFromCell = (e: IKeyboardEvent) => {
         e.stopPropagation();
         e.preventDefault();
-        this.props.arrowUp(this.cellId, this.getCurrentCode());
+        this.props.arrowUp(this.cellId);
         this.props.sendCommand(NativeCommandType.ArrowUp, 'keyboard');
     };
 
     private arrowDownFromCell = (e: IKeyboardEvent) => {
         e.stopPropagation();
         e.preventDefault();
-        this.props.arrowDown(this.cellId, this.getCurrentCode());
+        this.props.arrowDown(this.cellId);
         this.props.sendCommand(NativeCommandType.ArrowDown, 'keyboard');
     };
 
@@ -440,7 +440,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
         // Send to jupyter
         if (content) {
-            this.props.executeCell(this.cellId, content, moveOp);
+            this.props.executeCell(this.cellId, moveOp);
         }
     };
 
@@ -658,7 +658,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
     private onCodeUnfocused = () => {
         // Make sure to save the code from the editor into the cell
-        this.props.unfocusCell(this.cellId, this.getCurrentCode());
+        this.props.unfocusCell(this.cellId);
     };
 
     private onCodeChange = (changes: monacoEditor.editor.IModelContentChange[], cellId: string, modelId: string) => {

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { OSType } from '../../client/common/utils/platform';
 import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
-import { concatMultilineStringInput } from '../common';
 import { buildSettingsCss } from '../interactive-common/buildSettingsCss';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
 import { handleLinkClick } from '../interactive-common/handlers';
@@ -151,10 +150,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             if (this.props.selectedCellId) {
                 // tslint:disable-next-line: no-suspicious-comment
                 // TODO: Is the source going to be up to date during run below?
-                this.props.executeCellAndBelow(
-                    this.props.selectedCellId,
-                    concatMultilineStringInput(this.props.cellVMs[selectedIndex].cell.data.source)
-                );
+                this.props.executeCellAndBelow(this.props.selectedCellId);
                 this.props.sendCommand(NativeCommandType.RunBelow, 'mouse');
             }
         };

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -12,7 +12,6 @@ import {
     ICellAction,
     ICellAndCursorAction,
     IChangeCellTypeAction,
-    ICodeAction,
     ICodeCreatedAction,
     IEditCellAction,
     IExecuteAction,
@@ -38,27 +37,27 @@ export const actionCreators = {
         type: CommonActionType.FOCUS_CELL,
         payload: { cellId, cursorPos }
     }),
-    unfocusCell: (cellId: string, code: string): CommonAction<ICodeAction> => ({
+    unfocusCell: (cellId: string): CommonAction<ICellAction> => ({
         type: CommonActionType.UNFOCUS_CELL,
-        payload: { cellId, code }
+        payload: { cellId }
     }),
     selectCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> => ({
         type: CommonActionType.SELECT_CELL,
         payload: { cellId, cursorPos }
     }),
     addCell: (): CommonAction<never | undefined> => ({ type: CommonActionType.ADD_NEW_CELL }),
-    executeCell: (cellId: string, code: string, moveOp: 'add' | 'select' | 'none'): CommonAction<IExecuteAction> => ({
+    executeCell: (cellId: string, moveOp: 'add' | 'select' | 'none'): CommonAction<IExecuteAction> => ({
         type: CommonActionType.EXECUTE_CELL,
-        payload: { cellId, code, moveOp }
+        payload: { cellId, moveOp }
     }),
     executeAllCells: (): CommonAction<never | undefined> => ({ type: CommonActionType.EXECUTE_ALL_CELLS }),
     executeAbove: (cellId: string): CommonAction<ICellAction> => ({
         type: CommonActionType.EXECUTE_ABOVE,
         payload: { cellId }
     }),
-    executeCellAndBelow: (cellId: string, code: string): CommonAction<ICodeAction> => ({
+    executeCellAndBelow: (cellId: string): CommonAction<ICellAction> => ({
         type: CommonActionType.EXECUTE_CELL_AND_BELOW,
-        payload: { cellId, code }
+        payload: { cellId }
     }),
     toggleVariableExplorer: (): CommonAction<never | undefined> => ({
         type: CommonActionType.TOGGLE_VARIABLE_EXPLORER
@@ -106,13 +105,13 @@ export const actionCreators = {
     }),
     undo: (): CommonAction<never | undefined> => ({ type: CommonActionType.UNDO }),
     redo: (): CommonAction<never | undefined> => ({ type: CommonActionType.REDO }),
-    arrowUp: (cellId: string, code: string): CommonAction<ICodeAction> => ({
+    arrowUp: (cellId: string): CommonAction<ICellAction> => ({
         type: CommonActionType.ARROW_UP,
-        payload: { cellId, code }
+        payload: { cellId }
     }),
-    arrowDown: (cellId: string, code: string): CommonAction<ICodeAction> => ({
+    arrowDown: (cellId: string): CommonAction<ICellAction> => ({
         type: CommonActionType.ARROW_DOWN,
-        payload: { cellId, code }
+        payload: { cellId }
     }),
     editCell: (
         cellId: string,

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -87,9 +87,9 @@ export const actionCreators = {
         type: CommonActionType.MOVE_CELL_DOWN,
         payload: { cellId }
     }),
-    changeCellType: (cellId: string, currentCode: string): CommonAction<IChangeCellTypeAction> => ({
+    changeCellType: (cellId: string): CommonAction<IChangeCellTypeAction> => ({
         type: CommonActionType.CHANGE_CELL_TYPE,
-        payload: { cellId, currentCode }
+        payload: { cellId }
     }),
     toggleLineNumbers: (cellId: string): CommonAction<ICellAction> => ({
         type: CommonActionType.TOGGLE_LINE_NUMBERS,

--- a/src/datascience-ui/native-editor/redux/mapping.ts
+++ b/src/datascience-ui/native-editor/redux/mapping.ts
@@ -12,7 +12,6 @@ import {
     ICellAction,
     ICellAndCursorAction,
     IChangeCellTypeAction,
-    ICodeAction,
     IEditCellAction,
     IExecuteAction,
     ILinkClickAction,
@@ -31,12 +30,12 @@ export class INativeEditorActionMapping {
     public [CommonActionType.INSERT_BELOW]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.INSERT_ABOVE_FIRST]: NativeEditorReducerFunc<never | undefined>;
     public [CommonActionType.FOCUS_CELL]: NativeEditorReducerFunc<ICellAndCursorAction>;
-    public [CommonActionType.UNFOCUS_CELL]: NativeEditorReducerFunc<ICodeAction>;
+    public [CommonActionType.UNFOCUS_CELL]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.ADD_NEW_CELL]: NativeEditorReducerFunc<never | undefined>;
     public [CommonActionType.EXECUTE_CELL]: NativeEditorReducerFunc<IExecuteAction>;
     public [CommonActionType.EXECUTE_ALL_CELLS]: NativeEditorReducerFunc<never | undefined>;
     public [CommonActionType.EXECUTE_ABOVE]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.EXECUTE_CELL_AND_BELOW]: NativeEditorReducerFunc<ICodeAction>;
+    public [CommonActionType.EXECUTE_CELL_AND_BELOW]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.RESTART_KERNEL]: NativeEditorReducerFunc<never | undefined>;
     public [CommonActionType.INTERRUPT_KERNEL]: NativeEditorReducerFunc<never | undefined>;
     public [CommonActionType.CLEAR_ALL_OUTPUTS]: NativeEditorReducerFunc<never | undefined>;
@@ -52,8 +51,8 @@ export class INativeEditorActionMapping {
     public [CommonActionType.TOGGLE_LINE_NUMBERS]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.TOGGLE_OUTPUT]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.DELETE_CELL]: NativeEditorReducerFunc<ICellAction>;
-    public [CommonActionType.ARROW_UP]: NativeEditorReducerFunc<ICodeAction>;
-    public [CommonActionType.ARROW_DOWN]: NativeEditorReducerFunc<ICodeAction>;
+    public [CommonActionType.ARROW_UP]: NativeEditorReducerFunc<ICellAction>;
+    public [CommonActionType.ARROW_DOWN]: NativeEditorReducerFunc<ICellAction>;
     public [CommonActionType.CHANGE_CELL_TYPE]: NativeEditorReducerFunc<IChangeCellTypeAction>;
     public [CommonActionType.EDIT_CELL]: NativeEditorReducerFunc<IEditCellAction>;
     public [CommonActionType.LINK_CLICK]: NativeEditorReducerFunc<ILinkClickAction>;

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -6,7 +6,7 @@ import { IDataScienceExtraSettings } from '../../../../client/datascience/types'
 import { IMainState } from '../../../interactive-common/mainState';
 import { createPostableAction } from '../../../interactive-common/redux/postOffice';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
-import { ICellAction, ICellAndCursorAction, ICodeAction } from '../../../interactive-common/redux/reducers/types';
+import { ICellAction, ICellAndCursorAction } from '../../../interactive-common/redux/reducers/types';
 import { computeEditorOptions } from '../../../react-common/settingsReactSide';
 import { NativeEditorReducerArg } from '../mapping';
 
@@ -23,12 +23,10 @@ export namespace Effects {
             }
 
             if (removeFocusIndex >= 0) {
-                const oldFocusCell = prevState.cellVMs[removeFocusIndex];
-                const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
                 prevState = unfocusCell({
                     ...arg,
                     prevState,
-                    payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode }
+                    payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id }
                 });
                 prevState = deselectCell({
                     ...arg,
@@ -61,7 +59,7 @@ export namespace Effects {
         return arg.prevState;
     }
 
-    export function unfocusCell(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
+    export function unfocusCell(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         // Unfocus the cell
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
         if (index >= 0 && arg.prevState.focusedCellId === arg.payload.cellId) {
@@ -69,15 +67,7 @@ export namespace Effects {
             const current = arg.prevState.cellVMs[index];
             const newCell = {
                 ...current,
-                inputBlockText: arg.payload.code,
-                focused: false,
-                cell: {
-                    ...current.cell,
-                    data: {
-                        ...current.cell.data,
-                        source: arg.payload.code
-                    }
-                }
+                focused: false
             };
 
             // tslint:disable-next-line: no-any
@@ -93,15 +83,7 @@ export namespace Effects {
             const newVMs = [...arg.prevState.cellVMs];
             const current = arg.prevState.cellVMs[index];
             const newCell = {
-                ...current,
-                inputBlockText: arg.payload.code,
-                cell: {
-                    ...current.cell,
-                    data: {
-                        ...current.cell.data,
-                        source: arg.payload.code
-                    }
-                }
+                ...current
             };
 
             // tslint:disable-next-line: no-any
@@ -163,12 +145,10 @@ export namespace Effects {
             }
 
             if (removeFocusIndex >= 0) {
-                const oldFocusCell = prevState.cellVMs[removeFocusIndex];
-                const oldCode = oldFocusCell.uncomittedText || oldFocusCell.inputBlockText;
                 prevState = unfocusCell({
                     ...arg,
                     prevState,
-                    payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode }
+                    payload: { cellId: prevState.cellVMs[removeFocusIndex].cell.id }
                 });
                 prevState = deselectCell({
                     ...arg,

--- a/src/datascience-ui/native-editor/redux/reducers/movement.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/movement.ts
@@ -60,10 +60,6 @@ export namespace Movement {
                 payload: { cellId: arg.prevState.cellVMs[index - 1].cell.id, cursorPos: CursorPos.Bottom }
             });
             const newVMs = [...newState.cellVMs];
-            newVMs[index] = Helpers.asCellViewModel({
-                ...newVMs[index],
-                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data } }
-            });
             return {
                 ...newState,
                 cellVMs: newVMs
@@ -81,10 +77,6 @@ export namespace Movement {
                 payload: { cellId: arg.prevState.cellVMs[index + 1].cell.id, cursorPos: CursorPos.Top }
             });
             const newVMs = [...newState.cellVMs];
-            newVMs[index] = Helpers.asCellViewModel({
-                ...newVMs[index],
-                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data } }
-            });
             return {
                 ...newState,
                 cellVMs: newVMs

--- a/src/datascience-ui/native-editor/redux/reducers/movement.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/movement.ts
@@ -5,7 +5,7 @@ import { InteractiveWindowMessages } from '../../../../client/datascience/intera
 import { CursorPos, IMainState } from '../../../interactive-common/mainState';
 import { createPostableAction } from '../../../interactive-common/redux/postOffice';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
-import { ICellAction, ICodeAction } from '../../../interactive-common/redux/reducers/types';
+import { ICellAction } from '../../../interactive-common/redux/reducers/types';
 import { NativeEditorReducerArg } from '../mapping';
 import { Effects } from './effects';
 
@@ -52,7 +52,7 @@ export namespace Movement {
         return arg.prevState;
     }
 
-    export function arrowUp(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
+    export function arrowUp(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
         if (index > 0) {
             const newState = Effects.selectCell({
@@ -62,8 +62,7 @@ export namespace Movement {
             const newVMs = [...newState.cellVMs];
             newVMs[index] = Helpers.asCellViewModel({
                 ...newVMs[index],
-                inputBlockText: arg.payload.code,
-                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data, source: arg.payload.code } }
+                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data } }
             });
             return {
                 ...newState,
@@ -74,7 +73,7 @@ export namespace Movement {
         return arg.prevState;
     }
 
-    export function arrowDown(arg: NativeEditorReducerArg<ICodeAction>): IMainState {
+    export function arrowDown(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.cellId);
         if (index < arg.prevState.cellVMs.length - 1) {
             const newState = Effects.selectCell({
@@ -84,8 +83,7 @@ export namespace Movement {
             const newVMs = [...newState.cellVMs];
             newVMs[index] = Helpers.asCellViewModel({
                 ...newVMs[index],
-                inputBlockText: arg.payload.code,
-                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data, source: arg.payload.code } }
+                cell: { ...newVMs[index].cell, data: { ...newVMs[index].cell.data } }
             });
             return {
                 ...newState,


### PR DESCRIPTION
For #8589
For #9870

* Code is kept upto date as user types into the editor/cell
* Hence when running a cell, we only pass the cell id
* When moving a cell up/down we only need the cell id
* When changing focus we no longer attempt to update the cell source
* When changing cell types from markdown to code, we use code in current state instead of passing it.

**Basically the expectation is that the cells in extension and state will always be up to date with latest code**
We'll always strive to keep the cells updated with the latest source upon typing text as per issue requirement.

**Note:**
I think i found why some of the case we were getting weird behaviour. When running a cell, the user could be in the edtior & they could hit the `shift+enter` key. Even when focus fires, its possible that that triggers the dispatcher to update the state with latest source, however, when running a cell we're dealing with the old previous state, which contains old code. I know we've tried to work around this in some places to get the latest source, but I found some places were not using this even though it was being passed around. It would compile because we added new properties but we weren't using them.

Then again, this is exactly what we're trying to solve. 😄 

**Again, WIP**
* [ ] Add functional tests
* [ ] Review issues where code was lost (when changing cell types), ensure this still works
