### PR TITLE
Fix interrupts from always indicating restart

### DIFF
--- a/news/2 Fixes/10050.md
+++ b/news/2 Fixes/10050.md
@@ -1,0 +1,1 @@
+Fix interrupts from always thinking a restart occurred.

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -463,8 +463,8 @@ export class JupyterNotebookBase implements INotebook {
             const restarted = createDeferred<CellState[]>();
 
             // Listen to status change events so we can tell if we're restarting
-            const restartHandler = () => {
-                if (status === ServerStatus.Restarting) {
+            const restartHandler = (e: ServerStatus) => {
+                if (e === ServerStatus.Restarting) {
                     // We restarted the kernel.
                     this.sessionStartTime = Date.now();
                     traceWarning('Kernel restarting during interrupt');
@@ -483,13 +483,10 @@ export class JupyterNotebookBase implements INotebook {
             const restartHandlerToken = this.session.onSessionStatusChanged(restartHandler);
 
             // Start our interrupt. If it fails, indicate a restart
-            this.session
-                .interrupt(timeoutMs)
-                .then(() => restarted.resolve([]))
-                .catch(exc => {
-                    traceWarning(`Error during interrupt: ${exc}`);
-                    restarted.resolve([]);
-                });
+            this.session.interrupt(timeoutMs).catch(exc => {
+                traceWarning(`Error during interrupt: ${exc}`);
+                restarted.resolve([]);
+            });
 
             try {
                 // Wait for all of the pending cells to finish or the timeout to fire

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -984,8 +984,8 @@ suite('DataScience notebook tests', () => {
         assert.equal(finishedBefore, false, 'Finished before the interruption');
         assert.equal(error, undefined, 'Error thrown during interrupt');
         assert.ok(
-            finishedPromise.completed || result === InterruptResult.TimedOut || result === InterruptResult.Restarted,
-            `Timed out before interrupt for result: ${result}: ${code}`
+            finishedPromise.completed || result === InterruptResult.TimedOut || result === InterruptResult.Success,
+            `Interrupt restarted ${result} for: ${code}`
         );
 
         return result;


### PR DESCRIPTION
For #10050

Interrupt is always indicating a restart even when a restart doesn't occur.