### PR TITLE
Restore old webview provider

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*"
             ],
-            // "preLaunchTask": "Compile",
+            "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*"
             ],
-            "preLaunchTask": "Compile",
+            // "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
             ],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "2020.3.0-dev",
     "languageServerVersion": "0.5.30",
     "publisher": "ms-python",
-    "enableProposedApi": true,
+    "enableProposedApi": false,
     "author": {
         "name": "Microsoft Corporation"
     },
@@ -2836,15 +2836,6 @@
             ]
         },
         "webviewEditors": [
-            {
-                "viewType": "NativeEditorProvider.ipynb",
-                "displayName": "Jupyter Notebook",
-                "selector": [
-                    {
-                        "filenamePattern": "*.ipynb"
-                    }
-                ]
-            }
         ]
     },
     "scripts": {

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -157,4 +157,6 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.ViewJupyterOutput]: [];
     [DSCommands.SwitchJupyterKernel]: [INotebook | undefined];
     [DSCommands.SelectJupyterCommandLine]: [undefined | Uri];
+    [DSCommands.SaveNotebookNonCustomEditor]: [Uri];
+    [DSCommands.SaveAsNotebookNonCustomEditor]: [Uri, Uri];
 }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -159,4 +159,5 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.SelectJupyterCommandLine]: [undefined | Uri];
     [DSCommands.SaveNotebookNonCustomEditor]: [Uri];
     [DSCommands.SaveAsNotebookNonCustomEditor]: [Uri, Uri];
+    [DSCommands.OpenNotebookNonCustomEditor]: [Uri];
 }

--- a/src/client/common/application/customEditorService.ts
+++ b/src/client/common/application/customEditorService.ts
@@ -4,14 +4,15 @@
 import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 
+import { UseCustomEditorApi } from '../constants';
 import { noop } from '../utils/misc';
-import { IApplicationEnvironment, ICommandManager, ICustomEditorService, WebviewCustomEditorProvider } from './types';
+import { ICommandManager, ICustomEditorService, WebviewCustomEditorProvider } from './types';
 
 @injectable()
 export class CustomEditorService implements ICustomEditorService {
     constructor(
         @inject(ICommandManager) private commandManager: ICommandManager,
-        @inject(IApplicationEnvironment) private readonly appEnv: IApplicationEnvironment
+        @inject(UseCustomEditorApi) private readonly useCustomEditorApi: boolean
     ) {}
 
     public registerWebviewCustomEditorProvider(
@@ -19,7 +20,7 @@ export class CustomEditorService implements ICustomEditorService {
         provider: WebviewCustomEditorProvider,
         options?: vscode.WebviewPanelOptions
     ): vscode.Disposable {
-        if (this.appEnv.packageJson.enableProposedApi) {
+        if (this.useCustomEditorApi) {
             // tslint:disable-next-line: no-any
             return (vscode.window as any).registerWebviewCustomEditorProvider(viewType, provider, options);
         } else {
@@ -28,7 +29,7 @@ export class CustomEditorService implements ICustomEditorService {
     }
 
     public async openEditor(file: vscode.Uri): Promise<void> {
-        if (this.appEnv.packageJson.enableProposedApi) {
+        if (this.useCustomEditorApi) {
             await this.commandManager.executeCommand('vscode.open', file);
         }
     }

--- a/src/client/common/application/customEditorService.ts
+++ b/src/client/common/application/customEditorService.ts
@@ -4,22 +4,32 @@
 import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 
-import { ICommandManager, ICustomEditorService, WebviewCustomEditorProvider } from './types';
+import { noop } from '../utils/misc';
+import { IApplicationEnvironment, ICommandManager, ICustomEditorService, WebviewCustomEditorProvider } from './types';
 
 @injectable()
 export class CustomEditorService implements ICustomEditorService {
-    constructor(@inject(ICommandManager) private commandManager: ICommandManager) {}
+    constructor(
+        @inject(ICommandManager) private commandManager: ICommandManager,
+        @inject(IApplicationEnvironment) private readonly appEnv: IApplicationEnvironment
+    ) {}
 
     public registerWebviewCustomEditorProvider(
         viewType: string,
         provider: WebviewCustomEditorProvider,
         options?: vscode.WebviewPanelOptions
     ): vscode.Disposable {
-        // tslint:disable-next-line: no-any
-        return (vscode.window as any).registerWebviewCustomEditorProvider(viewType, provider, options);
+        if (this.appEnv.packageJson.enableProposedApi) {
+            // tslint:disable-next-line: no-any
+            return (vscode.window as any).registerWebviewCustomEditorProvider(viewType, provider, options);
+        } else {
+            return { dispose: noop };
+        }
     }
 
     public async openEditor(file: vscode.Uri): Promise<void> {
-        await this.commandManager.executeCommand('vscode.open', file);
+        if (this.appEnv.packageJson.enableProposedApi) {
+            await this.commandManager.executeCommand('vscode.open', file);
+        }
     }
 }

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -100,4 +100,7 @@ export function isUnitTestExecution(): boolean {
     return process.env.VSC_PYTHON_UNIT_TEST === '1';
 }
 
+// Temporary constant, used to indicate whether we're using custom editor api or not.
+export const UseCustomEditorApi = Symbol('USE_CUSTOM_EDITOR');
+
 export * from '../constants';

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -78,6 +78,8 @@ export namespace Commands {
     export const ScrollToCell = 'python.datascience.scrolltocell';
     export const CreateNewNotebook = 'python.datascience.createnewnotebook';
     export const ViewJupyterOutput = 'python.datascience.viewJupyterOutput';
+    export const SaveNotebookNonCustomEditor = 'python.datascience.notebookeditor.save';
+    export const SaveAsNotebookNonCustomEditor = 'python.datascience.notebookeditor.saveAs';
 }
 
 export namespace CodeLensCommands {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -80,6 +80,7 @@ export namespace Commands {
     export const ViewJupyterOutput = 'python.datascience.viewJupyterOutput';
     export const SaveNotebookNonCustomEditor = 'python.datascience.notebookeditor.save';
     export const SaveAsNotebookNonCustomEditor = 'python.datascience.notebookeditor.saveAs';
+    export const OpenNotebookNonCustomEditor = 'python.datascience.notebookeditor.open';
 }
 
 export namespace CodeLensCommands {

--- a/src/client/datascience/interactive-ipynb/autoSaveService.ts
+++ b/src/client/datascience/interactive-ipynb/autoSaveService.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { ConfigurationChangeEvent, Event, EventEmitter, TextEditor, Uri } from 'vscode';
+import { IApplicationShell, IDocumentManager, IWorkspaceService } from '../../common/application/types';
+import '../../common/extensions';
+import { traceError } from '../../common/logger';
+import { IFileSystem } from '../../common/platform/types';
+import { IDisposable } from '../../common/types';
+import { INotebookIdentity, InteractiveWindowMessages } from '../interactive-common/interactiveWindowTypes';
+import { FileSettings, IInteractiveWindowListener, INotebookEditor, INotebookEditorProvider } from '../types';
+
+// tslint:disable: no-any
+
+/**
+ * Sends notifications to Notebooks to save the notebook.
+ * Based on auto save settings, this class will regularly check for changes and send a save requet.
+ * If window state changes or active editor changes, then notify notebooks (if auto save is configured to do so).
+ * Monitor save and modified events on editor to determine its current dirty state.
+ *
+ * @export
+ * @class AutoSaveService
+ * @implements {IInteractiveWindowListener}
+ */
+@injectable()
+export class AutoSaveService implements IInteractiveWindowListener {
+    private postEmitter: EventEmitter<{ message: string; payload: any }> = new EventEmitter<{
+        message: string;
+        payload: any;
+    }>();
+    private disposables: IDisposable[] = [];
+    private notebookUri?: Uri;
+    private timeout?: ReturnType<typeof setTimeout>;
+    constructor(
+        @inject(IApplicationShell) appShell: IApplicationShell,
+        @inject(IDocumentManager) documentManager: IDocumentManager,
+        @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
+        @inject(IFileSystem) private readonly fileSystem: IFileSystem,
+        @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
+    ) {
+        this.workspace.onDidChangeConfiguration(this.onSettingsChanded.bind(this), this, this.disposables);
+        this.disposables.push(appShell.onDidChangeWindowState(this.onDidChangeWindowState.bind(this)));
+        this.disposables.push(documentManager.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditor.bind(this)));
+    }
+
+    public get postMessage(): Event<{ message: string; payload: any }> {
+        return this.postEmitter.event;
+    }
+
+    public onMessage(message: string, payload?: any): void {
+        if (message === InteractiveWindowMessages.NotebookIdentity) {
+            this.notebookUri = Uri.parse((payload as INotebookIdentity).resource);
+        }
+        if (message === InteractiveWindowMessages.LoadAllCellsComplete) {
+            const notebook = this.getNotebook();
+            if (!notebook) {
+                traceError(
+                    `Received message ${message}, but there is no notebook for ${
+                        this.notebookUri ? this.notebookUri.fsPath : undefined
+                    }`
+                );
+                return;
+            }
+            this.disposables.push(notebook.modified(this.onNotebookModified, this, this.disposables));
+            this.disposables.push(notebook.saved(this.onNotebookSaved, this, this.disposables));
+        }
+    }
+    public dispose(): void | undefined {
+        this.disposables.filter(item => !!item).forEach(item => item.dispose());
+        this.clearTimeout();
+    }
+    private onNotebookModified(_: INotebookEditor) {
+        // If we haven't started a timer, then start if necessary.
+        if (!this.timeout) {
+            this.setTimer();
+        }
+    }
+    private onNotebookSaved(_: INotebookEditor) {
+        // If we haven't started a timer, then start if necessary.
+        if (!this.timeout) {
+            this.setTimer();
+        }
+    }
+    private getNotebook(): INotebookEditor | undefined {
+        const uri = this.notebookUri;
+        if (!uri) {
+            return;
+        }
+        return this.notebookProvider.editors.find(item => this.fileSystem.arePathsSame(item.file.fsPath, uri.fsPath));
+    }
+    private getAutoSaveSettings(): FileSettings {
+        const filesConfig = this.workspace.getConfiguration('files', this.notebookUri);
+        return {
+            autoSave: filesConfig.get('autoSave', 'off'),
+            autoSaveDelay: filesConfig.get('autoSaveDelay', 1000)
+        };
+    }
+    private onSettingsChanded(e: ConfigurationChangeEvent) {
+        if (
+            e.affectsConfiguration('files.autoSave', this.notebookUri) ||
+            e.affectsConfiguration('files.autoSaveDelay', this.notebookUri)
+        ) {
+            // Reset the timer, as we may have increased it, turned it off or other.
+            this.clearTimeout();
+            this.setTimer();
+        }
+    }
+    private setTimer() {
+        const settings = this.getAutoSaveSettings();
+        if (!settings || settings.autoSave === 'off') {
+            return;
+        }
+        if (settings && settings.autoSave === 'afterDelay') {
+            // Add a timeout to save after n milli seconds.
+            // Do not use setInterval, as that will cause all handlers to queue up.
+            this.timeout = setTimeout(() => {
+                this.save();
+            }, settings.autoSaveDelay);
+        }
+    }
+    private clearTimeout() {
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+            this.timeout = undefined;
+        }
+    }
+    private save() {
+        this.clearTimeout();
+        const notebook = this.getNotebook();
+        if (notebook && notebook.isDirty && !notebook.isUntitled) {
+            // Notify webview to perform a save.
+            this.postEmitter.fire({ message: InteractiveWindowMessages.DoSave, payload: undefined });
+        } else {
+            this.setTimer();
+        }
+    }
+    private onDidChangeWindowState() {
+        const settings = this.getAutoSaveSettings();
+        if (settings && settings.autoSave === 'onWindowChange') {
+            this.save();
+        }
+    }
+    private onDidChangeActiveTextEditor(_e?: TextEditor) {
+        const settings = this.getAutoSaveSettings();
+        if (settings && settings.autoSave === 'onFocusChange') {
+            this.save();
+        }
+    }
+}

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -493,7 +493,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
         // Restart our kernel so that execution counts are reset
         let oldAsk: boolean | undefined = false;
-        const settings = this.configuration.getSettings();
+        const settings = this.configuration.getSettings(await this.getOwningResource());
         if (settings && settings.datascience) {
             oldAsk = settings.datascience.askForKernelRestart;
             settings.datascience.askForKernelRestart = false;

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -520,9 +520,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         }
 
         // Use the current state of the model to indicate dirty (not the message itself)
-        if (this._model && change.newDirty !== change.oldDirty) {
+        if (this.model && change.newDirty !== change.oldDirty) {
             this.modifiedEvent.fire();
-            if (this._model.isDirty) {
+            if (this.model.isDirty) {
                 await this.postMessage(InteractiveWindowMessages.NotebookDirty);
             } else {
                 // Then tell the UI

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -641,10 +641,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         if (this.isUntitled) {
             this.commandManager.executeCommand('workbench.action.files.saveAs', this.file);
         } else {
-            this.commandManager.executeCommand('workbench.action.files.save', this.file).then(
-                () => this.savedEvent.fire(this),
-                () => this.savedEvent.fire(this)
-            );
+            this.commandManager
+                .executeCommand('workbench.action.files.save', this.file)
+                .then(() => this.savedEvent.fire(this));
         }
     }
 

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import '../../common/extensions';
+
+import { inject, injectable, multiInject, named } from 'inversify';
+import * as path from 'path';
+import { Memento, WebviewPanel } from 'vscode';
+
+import {
+    IApplicationShell,
+    ICommandManager,
+    IDocumentManager,
+    ILiveShareApi,
+    IWebPanelProvider,
+    IWorkspaceService
+} from '../../common/application/types';
+import { IFileSystem } from '../../common/platform/types';
+import {
+    GLOBAL_MEMENTO,
+    IAsyncDisposableRegistry,
+    IConfigurationService,
+    IDisposableRegistry,
+    IExperimentsManager,
+    IMemento
+} from '../../common/types';
+import * as localize from '../../common/utils/localize';
+import { IInterpreterService } from '../../interpreter/contracts';
+import { ProgressReporter } from '../progress/progressReporter';
+import {
+    ICodeCssGenerator,
+    IDataScienceErrorHandler,
+    IDataViewerProvider,
+    IInteractiveWindowListener,
+    IJupyterDebugger,
+    IJupyterExecution,
+    IJupyterVariables,
+    INotebookEditorProvider,
+    INotebookExporter,
+    INotebookImporter,
+    INotebookModel,
+    IStatusProvider,
+    IThemeFinder
+} from '../types';
+import { NativeEditor } from './nativeEditor';
+
+@injectable()
+export class NativeEditorOldWebView extends NativeEditor {
+    public get visible(): boolean {
+        return this.viewState.visible;
+    }
+    public get active(): boolean {
+        return this.viewState.active;
+    }
+    public get isUntitled(): boolean {
+        const baseName = path.basename(this.file.fsPath);
+        return baseName.includes(localize.DataScience.untitledNotebookFileName());
+    }
+    constructor(
+        @multiInject(IInteractiveWindowListener) listeners: IInteractiveWindowListener[],
+        @inject(ILiveShareApi) liveShare: ILiveShareApi,
+        @inject(IApplicationShell) applicationShell: IApplicationShell,
+        @inject(IDocumentManager) documentManager: IDocumentManager,
+        @inject(IInterpreterService) interpreterService: IInterpreterService,
+        @inject(IWebPanelProvider) provider: IWebPanelProvider,
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
+        @inject(ICodeCssGenerator) cssGenerator: ICodeCssGenerator,
+        @inject(IThemeFinder) themeFinder: IThemeFinder,
+        @inject(IStatusProvider) statusProvider: IStatusProvider,
+        @inject(IJupyterExecution) jupyterExecution: IJupyterExecution,
+        @inject(IFileSystem) fileSystem: IFileSystem,
+        @inject(IConfigurationService) configuration: IConfigurationService,
+        @inject(ICommandManager) commandManager: ICommandManager,
+        @inject(INotebookExporter) jupyterExporter: INotebookExporter,
+        @inject(IWorkspaceService) workspaceService: IWorkspaceService,
+        @inject(INotebookEditorProvider) editorProvider: INotebookEditorProvider,
+        @inject(IDataViewerProvider) dataExplorerProvider: IDataViewerProvider,
+        @inject(IJupyterVariables) jupyterVariables: IJupyterVariables,
+        @inject(IJupyterDebugger) jupyterDebugger: IJupyterDebugger,
+        @inject(INotebookImporter) importer: INotebookImporter,
+        @inject(IDataScienceErrorHandler) errorHandler: IDataScienceErrorHandler,
+        @inject(IMemento) @named(GLOBAL_MEMENTO) globalStorage: Memento,
+        @inject(ProgressReporter) progressReporter: ProgressReporter,
+        @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
+        @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry
+    ) {
+        super(
+            listeners,
+            liveShare,
+            applicationShell,
+            documentManager,
+            interpreterService,
+            provider,
+            disposables,
+            cssGenerator,
+            themeFinder,
+            statusProvider,
+            jupyterExecution,
+            fileSystem,
+            configuration,
+            commandManager,
+            jupyterExporter,
+            workspaceService,
+            editorProvider,
+            dataExplorerProvider,
+            jupyterVariables,
+            jupyterDebugger,
+            importer,
+            errorHandler,
+            globalStorage,
+            progressReporter,
+            experimentsManager,
+            asyncRegistry
+        );
+        asyncRegistry.push(this);
+    }
+    public async load(model: INotebookModel, webViewPanel: WebviewPanel): Promise<void> {
+        await super.load(model, webViewPanel);
+
+        // Update our title to match
+        this.setTitle(path.basename(model.file.fsPath));
+
+        // Show ourselves
+        await this.show();
+
+        // // See if this file was stored in storage prior to shutdown
+        // const dirtyContents = await model.getContent();
+        // if (dirtyContents) {
+        //     // This means we're dirty. Indicate dirty and load from this content
+        //     return this.loadContents(dirtyContents, true);
+        // } else {
+        //     // Load without setting dirty
+        //     return this.loadContents(contents, false);
+        // }
+    }
+
+    // protected async reopen(cells: ICell[]): Promise<void> {
+    //     try {
+    //         // Reload the web panel too.
+    //         await super.loadWebPanel(path.basename(this._file.fsPath));
+    //         await this.show();
+
+    //         // Indicate we have our identity
+    //         this.loadedPromise.resolve();
+
+    //         // Update our title to match
+    //         if (this._dirty) {
+    //             this._dirty = false;
+    //             await this.setDirty();
+    //         } else {
+    //             this.setTitle(path.basename(this._file.fsPath));
+    //         }
+
+    //         // If that works, send the cells to the web view
+    //         return this.postMessage(InteractiveWindowMessages.LoadAllCells, { cells });
+    //     } catch (e) {
+    //         return this.errorHandler.handleError(e);
+    //     }
+    // }
+
+    //     private async askForSave(): Promise<AskForSaveResult> {
+    //         const message1 = localize.DataScience.dirtyNotebookMessage1().format(`${path.basename(this.file.fsPath)}`);
+    //         const message2 = localize.DataScience.dirtyNotebookMessage2();
+    //         const yes = localize.DataScience.dirtyNotebookYes();
+    //         const no = localize.DataScience.dirtyNotebookNo();
+    //         const result = await this.applicationShell.showInformationMessage(
+    //             // tslint:disable-next-line: messages-must-be-localized
+    //             `${message1}\n${message2}`,
+    //             { modal: true },
+    //             yes,
+    //             no
+    //         );
+    //         switch (result) {
+    //             case yes:
+    //                 return AskForSaveResult.Yes;
+
+    //             case no:
+    //                 return AskForSaveResult.No;
+
+    //             default:
+    //                 return AskForSaveResult.Cancel;
+    //         }
+    //     }
+
+    //     private async setDirty(): Promise<void> {
+    //         // Update storage if not untitled. Don't wait for results.
+    //         if (!this.isUntitled) {
+    //             this.generateNotebookConten; this.storeContents(c).catch(ex => traceError('Failed to generate notebook content to store in state', ex));te;', ex);
+    //                     )
+    //                 )
+    //                 .ignoreErrors();
+    //         }
+
+    //         // Then update dirty flag.
+    //         if (!this._dirty) {
+    //             this._dirty = true;
+    //             this.setTitle(`${path.basename(this.file.fsPath)}*`);
+
+    //             // Tell the webview we're dirty
+    //             await this.postMessage(InteractiveWindowMessages.NotebookDirty);
+
+    //             // Tell listeners we're dirty
+    //             this.modifiedEvent.fire(this);
+    //         }
+    //     }
+
+    //     private async setClean(): Promise<void> {
+    //         // Always update storage
+    //         this.storeContents(undefined).catch(ex => traceError('Failed to clear notebook store', ex));
+
+    //         if (this._dirty) {
+    //             this._dirty = false;
+    //             this.setTitle(`${path.basename(this.file.fsPath)}`);
+    //             await this.postMessage(InteractiveWindowMessages.NotebookClean);
+    //         }
+    //     }
+
+    //     private async viewDocument(contents: string): Promise<void> {
+    //         const doc = await this.documentManager.openTextDocument({ language: 'python', content: contents });
+    //         await this.documentManager.showTextDocument(doc, ViewColumn.One);
+    //     }
+
+    //     @captureTelemetry(Telemetry.Save, undefined, true)
+    //     private async saveToDisk(): Promise<void> {
+    //         // If we're already in the middle of prompting the user to save, then get out of here.
+    //         // We could add a debounce decorator, unfortunately that slows saving (by waiting for no more save events to get sent).
+    //         if (this.isPromptingToSaveToDisc && this.isUntitled) {
+    //             return;
+    //         }
+    //         try {
+    //             let fileToSaveTo: Uri | undefined = this.file;
+    //             let isDirty = this._dirty;
+
+    //             // Ask user for a save as dialog if no title
+    //             if (this.isUntitled) {
+    //                 this.isPromptingToSaveToDisc = true;
+    //                 const filtersKey = localize.DataScience.dirtyNotebookDialogFilter();
+    //                 const filtersObject: { [name: string]: string[] } = {};
+    //                 filtersObject[filtersKey] = ['ipynb'];
+    //                 isDirty = true;
+
+    //                 const defaultUri =
+    //                     Array.isAervice.workspaceFolders); &&
+    //                     this.workspaceService.workspaceFolders.length > 0
+    //                         ? this.workspaceService.workspaceFolders[0].uri
+    //                         : undefined;
+    //                 fileToSaveTo = await this.applicationShell.showSaveDialog({
+    //                     saveLabel: localize.DataScience.dirtyNotebookDialogTitle(),
+    //                     filters: filtersObject,
+    //                     defaultUri
+    //                 });
+    //             }
+
+    //             if (fileToSaveTo && isDirty) {
+    //                 // Write out our visible cells
+    //  fileToSaveTo.fsPath, await this.generateNotebookContent(this.visibleCells);bookContent(this.visibleCells);
+    //                 )
+
+    //                 // Update our file name and dirty state
+    //                 this._file = fileToSaveTo;
+    //                 await this.setClean();
+    //                 this.savedEvent.fire(this);
+    //             }
+    //         } catch (e) {
+    //             traceError(e);
+    //         } finally {
+    //             this.isPromptingToSaveToDisc = false;
+    //         }
+    //     }
+
+    //     private saveAll(args: ISaveAll) {
+    //         this.visibleCells = args.cells;
+    //         this.saveToDisk().ignoreErrors();
+    //     }
+
+    //     private loadCellsComplete(); {
+    //         if (!this.loadedAllCells) {
+    //             this.loadedAllCells = true;
+    //             sendTelemetryEvent(Telemetry.NotebookOpenTime, this.startupTimer.elapsedTime);
+    //         }
+    //     }
+
+    //     private async; clearAllOutputs(); {
+    //         this.visibleCells.forEach(cell => {
+    //             cell.data.execution_count = null;
+    //             cell.data.outputs = [];
+    //         });
+
+    //         await this.setDirty();
+    //     }
+}

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -188,7 +188,7 @@ export class NativeEditorOldWebView extends NativeEditor {
             const autoSave = filesConfig.get('autoSave', 'off');
             if (autoSave === 'off') {
                 const model = this.model as NativeEditorStorage;
-                await model.storeContentsInHotExitFile(await model.getContent());
+                await model.storeContentsInHotExitFile();
             }
             this.commandManager.executeCommand(Commands.OpenNotebookNonCustomEditor, this.model.file).then(noop, noop);
         }

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -260,7 +260,7 @@ export class NativeEditorOldWebView extends NativeEditor {
 
             const defaultUri =
                 Array.isArray(this.workspaceService.workspaceFolders) &&
-                    this.workspaceService.workspaceFolders.length > 0
+                this.workspaceService.workspaceFolders.length > 0
                     ? this.workspaceService.workspaceFolders[0].uri
                     : undefined;
             fileToSaveTo = await this.applicationShell.showSaveDialog({

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -28,7 +28,7 @@ import {
 import * as localize from '../../common/utils/localize';
 import { IInterpreterService } from '../../interpreter/contracts';
 import { captureTelemetry } from '../../telemetry';
-import { Telemetry } from '../constants';
+import { Commands, Telemetry } from '../constants';
 import { InteractiveWindowMessages } from '../interactive-common/interactiveWindowTypes';
 import { ProgressReporter } from '../progress/progressReporter';
 import {
@@ -246,7 +246,7 @@ export class NativeEditorOldWebView extends NativeEditor {
         }
         try {
             if (!this.isUntitled) {
-                await this.commandManager.executeCommand('save.Notebook', this.model?.file);
+                await this.commandManager.executeCommand(Commands.SaveNotebookNonCustomEditor, this.model?.file);
                 this.savedEvent.fire(this);
                 return;
             }
@@ -260,7 +260,7 @@ export class NativeEditorOldWebView extends NativeEditor {
 
             const defaultUri =
                 Array.isArray(this.workspaceService.workspaceFolders) &&
-                this.workspaceService.workspaceFolders.length > 0
+                    this.workspaceService.workspaceFolders.length > 0
                     ? this.workspaceService.workspaceFolders[0].uri
                     : undefined;
             fileToSaveTo = await this.applicationShell.showSaveDialog({
@@ -270,7 +270,11 @@ export class NativeEditorOldWebView extends NativeEditor {
             });
 
             if (fileToSaveTo) {
-                await this.commandManager.executeCommand('saveAs.Notebook', this.model.file, fileToSaveTo);
+                await this.commandManager.executeCommand(
+                    Commands.SaveAsNotebookNonCustomEditor,
+                    this.model.file,
+                    fileToSaveTo
+                );
                 this.savedEvent.fire(this);
             }
         } catch (e) {

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -142,23 +142,6 @@ export class NativeEditorOldWebView extends NativeEditor {
         });
     }
     protected async close(): Promise<void> {
-        const actuallyClose = async () => {
-            // Tell listeners.
-            this.closedEvent.fire(this);
-
-            // Restart our kernel so that execution counts are reset
-            let oldAsk: boolean | undefined = false;
-            const settings = this.configuration.getSettings(await this.getOwningResource());
-            if (settings && settings.datascience) {
-                oldAsk = settings.datascience.askForKernelRestart;
-                settings.datascience.askForKernelRestart = false;
-            }
-            await this.restartKernel();
-            if (oldAsk && settings && settings.datascience) {
-                settings.datascience.askForKernelRestart = true;
-            }
-        };
-
         // Ask user if they want to save. It seems hotExit has no bearing on
         // whether or not we should ask
         if (this.isDirty) {
@@ -169,23 +152,23 @@ export class NativeEditorOldWebView extends NativeEditor {
                     await this.saveToDisk();
 
                     // Close it
-                    await actuallyClose();
+                    await super.close();
                     break;
 
                 case AskForSaveResult.No:
                     // Close it
-                    await actuallyClose();
+                    await super.close();
                     break;
 
                 default: {
-                    await actuallyClose();
+                    await super.close();
                     await this.reopen();
                     break;
                 }
             }
         } else {
             // Not dirty, just close normally.
-            return actuallyClose();
+            await super.close();
         }
     }
 

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -107,28 +107,28 @@ export class NativeEditorProvider
         });
     }
 
-    public save(resource: Uri): Thenable<void> {
+    public save(resource: Uri): Promise<void> {
         return this.loadStorage(resource).then(async s => {
             if (s) {
                 await s.save();
             }
         });
     }
-    public saveAs(resource: Uri, targetResource: Uri): Thenable<void> {
+    public saveAs(resource: Uri, targetResource: Uri): Promise<void> {
         return this.loadStorage(resource).then(async s => {
             if (s) {
                 await s.saveAs(targetResource);
             }
         });
     }
-    public applyEdits(resource: Uri, edits: readonly NotebookModelChange[]): Thenable<void> {
+    public applyEdits(resource: Uri, edits: readonly NotebookModelChange[]): Promise<void> {
         return this.loadModel(resource).then(s => {
             if (s) {
                 edits.forEach(e => s.update({ ...e, source: 'redo' }));
             }
         });
     }
-    public undoEdits(resource: Uri, edits: readonly NotebookModelChange[]): Thenable<void> {
+    public undoEdits(resource: Uri, edits: readonly NotebookModelChange[]): Promise<void> {
         return this.loadModel(resource).then(s => {
             if (s) {
                 edits.forEach(e => s.update({ ...e, source: 'undo' }));

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -71,23 +71,14 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
             })
         );
 
-        // // Since we may have activated after a document was opened, also run open document for all documents.
-        // // This needs to be async though. Iterating over all of these in the .ctor is crashing the extension
-        // // host, so postpone till after the ctor is finished.
-        // setTimeout(() => {
-        //     if (this.documentManager.textDocuments && this.documentManager.textDocuments.forEach) {
-        //         this.documentManager.textDocuments.forEach(doc => this.openNotebookAndCloseEditor(doc, false));
-        //     }
-        // }, 0);
-
-        // // Reopen our list of files that were open during shutdown. Actually not doing this for now. The files
-        // don't open until the extension loads and all they all steal focus.
-        // const uriList = this.workspaceStorage.get<Uri[]>(NotebookUriListStorageKey);
-        // if (uriList && uriList.length) {
-        //     uriList.forEach(u => {
-        //         this.fileSystem.readFile(u.fsPath).then(c => this.open(u, c).ignoreErrors()).ignoreErrors();
-        //     });
-        // }
+        // Since we may have activated after a document was opened, also run open document for all documents.
+        // This needs to be async though. Iterating over all of these in the .ctor is crashing the extension
+        // host, so postpone till after the ctor is finished.
+        setTimeout(() => {
+            if (this.documentManager.textDocuments && this.documentManager.textDocuments.forEach) {
+                this.documentManager.textDocuments.forEach(doc => this.openNotebookAndCloseEditor(doc, false));
+            }
+        }, 0);
     }
 
     public async open(file: Uri): Promise<INotebookEditor> {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -65,6 +65,12 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
             )
         );
 
+        this.disposables.push(
+            this.cmdManager.registerCommand(Commands.OpenNotebookNonCustomEditor, async (resource: Uri) => {
+                await this.open(resource);
+            })
+        );
+
         // // Since we may have activated after a document was opened, also run open document for all documents.
         // // This needs to be async though. Iterating over all of these in the .ctor is crashing the extension
         // // host, so postpone till after the ctor is finished.

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -52,15 +52,15 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
             this.documentManager.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditorHandler.bind(this))
         );
         this.disposables.push(
-            this.cmdManager.registerCommand(Commands.SaveNotebookNonCustomEditor, (resource: Uri) => {
-                this.save(resource);
+            this.cmdManager.registerCommand(Commands.SaveNotebookNonCustomEditor, async (resource: Uri) => {
+                await this.save(resource);
             })
         );
         this.disposables.push(
             this.cmdManager.registerCommand(
                 Commands.SaveAsNotebookNonCustomEditor,
-                (resource: Uri, targetResource: Uri) => {
-                    this.saveAs(resource, targetResource);
+                async (resource: Uri, targetResource: Uri) => {
+                    await this.saveAs(resource, targetResource);
                 }
             )
         );

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -51,6 +51,16 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
         this.disposables.push(
             this.documentManager.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditorHandler.bind(this))
         );
+        this.disposables.push(
+            this.cmdManager.registerCommand('save.Notebook', (resource: Uri) => {
+                this.save(resource);
+            })
+        );
+        this.disposables.push(
+            this.cmdManager.registerCommand('saveAs.Notebook', (resource: Uri, targetResource: Uri) => {
+                this.saveAs(resource, targetResource);
+            })
+        );
 
         // // Since we may have activated after a document was opened, also run open document for all documents.
         // // This needs to be async though. Iterating over all of these in the .ctor is crashing the extension

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -15,7 +15,7 @@ import { JUPYTER_LANGUAGE } from '../../common/constants';
 import { IFileSystem } from '../../common/platform/types';
 import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
-import { Identifiers, Settings } from '../constants';
+import { Commands, Identifiers, Settings } from '../constants';
 import { IDataScienceErrorHandler, INotebookEditor, INotebookServerOptions } from '../types';
 import { NativeEditorProvider } from './nativeEditorProvider';
 
@@ -52,14 +52,17 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
             this.documentManager.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditorHandler.bind(this))
         );
         this.disposables.push(
-            this.cmdManager.registerCommand('save.Notebook', (resource: Uri) => {
+            this.cmdManager.registerCommand(Commands.SaveNotebookNonCustomEditor, (resource: Uri) => {
                 this.save(resource);
             })
         );
         this.disposables.push(
-            this.cmdManager.registerCommand('saveAs.Notebook', (resource: Uri, targetResource: Uri) => {
-                this.saveAs(resource, targetResource);
-            })
+            this.cmdManager.registerCommand(
+                Commands.SaveAsNotebookNonCustomEditor,
+                (resource: Uri, targetResource: Uri) => {
+                    this.saveAs(resource, targetResource);
+                }
+            )
         );
 
         // // Since we may have activated after a document was opened, also run open document for all documents.

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { TextDocument, TextEditor, Uri } from 'vscode';
+
+import {
+    ICommandManager,
+    ICustomEditorService,
+    IDocumentManager,
+    IWorkspaceService
+} from '../../common/application/types';
+import { JUPYTER_LANGUAGE } from '../../common/constants';
+import { IFileSystem } from '../../common/platform/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
+import { IServiceContainer } from '../../ioc/types';
+import { Identifiers, Settings } from '../constants';
+import { IDataScienceErrorHandler, INotebookEditor, INotebookServerOptions } from '../types';
+import { NativeEditorProvider } from './nativeEditorProvider';
+
+@injectable()
+export class NativeEditorProviderOld extends NativeEditorProvider {
+    public get activeEditor(): INotebookEditor | undefined {
+        const active = [...this.activeEditors.entries()].find(e => e[1].active);
+        if (active) {
+            return active[1];
+        }
+    }
+
+    public get editors(): INotebookEditor[] {
+        return [...this.activeEditors.values()];
+    }
+    private activeEditors: Map<string, INotebookEditor> = new Map<string, INotebookEditor>();
+    constructor(
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
+        @inject(IWorkspaceService) workspace: IWorkspaceService,
+        @inject(IConfigurationService) configuration: IConfigurationService,
+        @inject(ICustomEditorService) customEditorService: ICustomEditorService,
+        @inject(IFileSystem) private fileSystem: IFileSystem,
+        @inject(IDocumentManager) private documentManager: IDocumentManager,
+        @inject(ICommandManager) private readonly cmdManager: ICommandManager,
+        @inject(IDataScienceErrorHandler) private dataScienceErrorHandler: IDataScienceErrorHandler
+    ) {
+        super(serviceContainer, asyncRegistry, disposables, workspace, configuration, customEditorService);
+
+        // No live share sync required as open document from vscode will give us our contents.
+
+        this.disposables.push(
+            this.documentManager.onDidChangeActiveTextEditor(this.onDidChangeActiveTextEditorHandler.bind(this))
+        );
+
+        // // Since we may have activated after a document was opened, also run open document for all documents.
+        // // This needs to be async though. Iterating over all of these in the .ctor is crashing the extension
+        // // host, so postpone till after the ctor is finished.
+        // setTimeout(() => {
+        //     if (this.documentManager.textDocuments && this.documentManager.textDocuments.forEach) {
+        //         this.documentManager.textDocuments.forEach(doc => this.openNotebookAndCloseEditor(doc, false));
+        //     }
+        // }, 0);
+
+        // // Reopen our list of files that were open during shutdown. Actually not doing this for now. The files
+        // don't open until the extension loads and all they all steal focus.
+        // const uriList = this.workspaceStorage.get<Uri[]>(NotebookUriListStorageKey);
+        // if (uriList && uriList.length) {
+        //     uriList.forEach(u => {
+        //         this.fileSystem.readFile(u.fsPath).then(c => this.open(u, c).ignoreErrors()).ignoreErrors();
+        //     });
+        // }
+    }
+
+    public async open(file: Uri): Promise<INotebookEditor> {
+        // See if this file is open or not already
+        let editor = this.activeEditors.get(file.fsPath);
+        if (!editor) {
+            editor = await this.create(file);
+            this.onOpenedEditor(editor);
+        } else {
+            await this.showEditor(editor);
+        }
+        return editor;
+    }
+
+    public async show(file: Uri): Promise<INotebookEditor | undefined> {
+        // See if this file is open or not already
+        const editor = this.activeEditors.get(file.fsPath);
+        if (editor) {
+            await this.showEditor(editor);
+        }
+        return editor;
+    }
+
+    public async getNotebookOptions(resource: Resource): Promise<INotebookServerOptions> {
+        const settings = this.configuration.getSettings(resource);
+        let serverURI: string | undefined = settings.datascience.jupyterServerURI;
+        const useDefaultConfig: boolean | undefined = settings.datascience.useDefaultConfigForJupyter;
+
+        // For the local case pass in our URI as undefined, that way connect doesn't have to check the setting
+        if (serverURI.toLowerCase() === Settings.JupyterServerLocalLaunch) {
+            serverURI = undefined;
+        }
+
+        return {
+            enableDebugging: true,
+            uri: serverURI,
+            useDefaultConfig,
+            purpose: Identifiers.HistoryPurpose // Share the same one as the interactive window. Just need a new session
+        };
+    }
+
+    protected onOpenedEditor(e: INotebookEditor) {
+        super.openedEditor(e);
+        this.activeEditors.set(e.file.fsPath, e);
+        this.disposables.push(e.saved(this.onSavedEditor.bind(this, e.file.fsPath)));
+        this._onDidChangeActiveNotebookEditor.fire(this.activeEditor);
+    }
+
+    /**
+     * Open ipynb files when user opens an ipynb file.
+     *
+     * @private
+     * @memberof NativeEditorProvider
+     */
+    private onDidChangeActiveTextEditorHandler(editor?: TextEditor) {
+        // I we're a source control diff view, then ignore this editor.
+        if (!editor || this.isEditorPartOfDiffView(editor)) {
+            return;
+        }
+        this.openNotebookAndCloseEditor(editor.document, true).ignoreErrors();
+    }
+
+    private async showEditor(editor: INotebookEditor) {
+        await editor.show();
+        this._onDidChangeActiveNotebookEditor.fire(this.activeEditor);
+    }
+
+    private async create(file: Uri): Promise<INotebookEditor> {
+        const editor = await this.createNotebookEditor(file);
+        this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
+        await this.showEditor(editor);
+        return editor;
+    }
+
+    private onClosedEditor(e: INotebookEditor) {
+        this.activeEditors.delete(e.file.fsPath);
+        this._onDidChangeActiveNotebookEditor.fire(this.activeEditor);
+    }
+    private onSavedEditor(oldPath: string, e: INotebookEditor) {
+        // Switch our key for this editor
+        if (this.activeEditors.has(oldPath)) {
+            this.activeEditors.delete(oldPath);
+        }
+        this.activeEditors.set(e.file.fsPath, e);
+    }
+
+    private openNotebookAndCloseEditor = async (
+        document: TextDocument,
+        closeDocumentBeforeOpeningNotebook: boolean
+    ) => {
+        // See if this is an ipynb file
+        if (this.isNotebook(document) && this.configuration.getSettings(document.uri).datascience.useNotebookEditor) {
+            const closeActiveEditorCommand = 'workbench.action.closeActiveEditor';
+            try {
+                const uri = document.uri;
+
+                if (closeDocumentBeforeOpeningNotebook) {
+                    if (
+                        !this.documentManager.activeTextEditor ||
+                        this.documentManager.activeTextEditor.document !== document
+                    ) {
+                        await this.documentManager.showTextDocument(document);
+                    }
+                    await this.cmdManager.executeCommand(closeActiveEditorCommand);
+                }
+
+                // Open our own editor.
+                await this.open(uri);
+
+                if (!closeDocumentBeforeOpeningNotebook) {
+                    // Then switch back to the ipynb and close it.
+                    // If we don't do it in this order, the close will switch to the wrong item
+                    await this.documentManager.showTextDocument(document);
+                    await this.cmdManager.executeCommand(closeActiveEditorCommand);
+                }
+            } catch (e) {
+                return this.dataScienceErrorHandler.handleError(e);
+            }
+        }
+    };
+    /**
+     * Check if user is attempting to compare two ipynb files.
+     * If yes, then return `true`, else `false`.
+     *
+     * @private
+     * @param {TextEditor} editor
+     * @memberof NativeEditorProvider
+     */
+    private isEditorPartOfDiffView(editor?: TextEditor) {
+        if (!editor) {
+            return false;
+        }
+        // There's no easy way to determine if the user is openeing a diff view.
+        // One simple way is to check if there are 2 editor opened, and if both editors point to the same file
+        // One file with the `file` scheme and the other with the `git` scheme.
+        if (this.documentManager.visibleTextEditors.length <= 1) {
+            return false;
+        }
+
+        // If we have both `git` & `file` schemes for the same file, then we're most likely looking at a diff view.
+        // Also ensure both editors are in the same view column.
+        // Possible we have a git diff view (with two editors git and file scheme), and we open the file view
+        // on the side (different view column).
+        const gitSchemeEditor = this.documentManager.visibleTextEditors.find(
+            editorUri =>
+                editorUri.document.uri.scheme === 'git' &&
+                this.fileSystem.arePathsSame(editorUri.document.uri.fsPath, editor.document.uri.fsPath)
+        );
+
+        if (!gitSchemeEditor) {
+            return false;
+        }
+
+        const fileSchemeEditor = this.documentManager.visibleTextEditors.find(
+            editorUri =>
+                editorUri.document.uri.scheme === 'file' &&
+                this.fileSystem.arePathsSame(editorUri.document.uri.fsPath, editor.document.uri.fsPath) &&
+                editorUri.viewColumn === gitSchemeEditor.viewColumn
+        );
+        if (!fileSchemeEditor) {
+            return false;
+        }
+
+        // Also confirm the document we have passed in, belongs to one of the editors.
+        // If its not, then its another document (that is not in the diff view).
+        return gitSchemeEditor === editor || fileSchemeEditor === editor;
+    }
+    private isNotebook(document: TextDocument) {
+        // Only support file uris (we don't want to automatically open any other ipynb file from another resource as a notebook).
+        // E.g. when opening a document for comparison, the scheme is `git`, in live share the scheme is `vsls`.
+        const validUriScheme = document.uri.scheme === 'file' || document.uri.scheme === 'vsls';
+        return (
+            validUriScheme &&
+            (document.languageId === JUPYTER_LANGUAGE ||
+                path.extname(document.fileName).toLocaleLowerCase() === '.ipynb')
+        );
+    }
+}

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -113,7 +113,8 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
      * Also keep track of the current time. This way we can check whether changes were
      * made to the file since the last time uncommitted changes were stored.
      */
-    public async storeContentsInHotExitFile(contents: string): Promise<void> {
+    public async storeContentsInHotExitFile(): Promise<void> {
+        const contents = await this.getContent();
         const key = this.getStorageKey();
         const filePath = this.getHashedFileName(key);
 

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -108,6 +108,35 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
         return this.generateNotebookContent(cells ? cells : this.cells);
     }
 
+    /**
+     * Stores the uncommitted notebook changes into a temporary location.
+     * Also keep track of the current time. This way we can check whether changes were
+     * made to the file since the last time uncommitted changes were stored.
+     */
+    public async storeContentsInHotExitFile(contents: string): Promise<void> {
+        const key = this.getStorageKey();
+        const filePath = this.getHashedFileName(key);
+
+        // Keep track of the time when this data was saved.
+        // This way when we retrieve the data we can compare it against last modified date of the file.
+        const specialContents = contents ? JSON.stringify({ contents, lastModifiedTimeMs: Date.now() }) : undefined;
+
+        // Write but debounced (wait at least 250 ms)
+        return this.writeToStorage(filePath, specialContents);
+    }
+    private async writeToStorage(filePath: string, contents?: string): Promise<void> {
+        try {
+            if (contents) {
+                await this.fileSystem.createDirectory(path.dirname(filePath));
+                return this.fileSystem.writeFile(filePath, contents);
+            } else {
+                return this.fileSystem.deleteFile(filePath);
+            }
+        } catch (exc) {
+            traceError(`Error writing storage for ${filePath}: `, exc);
+        }
+    }
+
     private sendLanguageTelemetry(notebookJson: Partial<nbformat.INotebookContent>) {
         try {
             // See if we have a language

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -3,6 +3,7 @@
 'use strict';
 import { IExtensionSingleActivationService } from '../activation/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../common/application/types';
+import { UseCustomEditorApi } from '../common/constants';
 import { IServiceManager } from '../ioc/types';
 import { Activation } from './activation';
 import { CodeCssGenerator } from './codeCssGenerator';
@@ -110,6 +111,10 @@ import {
 
 // tslint:disable-next-line: max-func-body-length
 export function registerTypes(serviceManager: IServiceManager) {
+    const useCustomEditorApi = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment).packageJson
+        .enableProposedApi;
+    serviceManager.addSingletonInstance<boolean>(UseCustomEditorApi, useCustomEditorApi);
+
     serviceManager.addSingleton<IDataScienceCodeLensProvider>(
         IDataScienceCodeLensProvider,
         DataScienceCodeLensProvider
@@ -155,16 +160,12 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addBinding(ICellHashProvider, IInteractiveWindowListener);
     serviceManager.addBinding(ICellHashProvider, INotebookExecutionLogger);
     serviceManager.addBinding(IJupyterDebugger, ICellHashListener);
-    const app = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
     serviceManager.addSingleton<INotebookEditorProvider>(
         INotebookEditorProvider,
-        app.packageJson.enableProposedApi ? NativeEditorProvider : NativeEditorProviderOld
+        useCustomEditorApi ? NativeEditorProvider : NativeEditorProviderOld
     );
     serviceManager.add<INotebookStorage>(INotebookStorage, NativeEditorStorage);
-    serviceManager.add<INotebookEditor>(
-        INotebookEditor,
-        app.packageJson.enableProposedApi ? NativeEditor : NativeEditorOldWebView
-    );
+    serviceManager.add<INotebookEditor>(INotebookEditor, useCustomEditorApi ? NativeEditor : NativeEditorOldWebView);
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NativeEditorCommandListener);
     serviceManager.addBinding(ICodeLensFactory, IInteractiveWindowListener);
     serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, DebugLocationTrackerFactory);

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import { IExtensionSingleActivationService } from '../activation/types';
-import { IWorkspaceService } from '../common/application/types';
+import { IApplicationEnvironment, IWorkspaceService } from '../common/application/types';
 import { IServiceManager } from '../ioc/types';
 import { Activation } from './activation';
 import { CodeCssGenerator } from './codeCssGenerator';
@@ -29,7 +29,9 @@ import { LinkProvider } from './interactive-common/linkProvider';
 import { ShowPlotListener } from './interactive-common/showPlotListener';
 import { NativeEditor } from './interactive-ipynb/nativeEditor';
 import { NativeEditorCommandListener } from './interactive-ipynb/nativeEditorCommandListener';
+import { NativeEditorOldWebView } from './interactive-ipynb/nativeEditorOldWebView';
 import { NativeEditorProvider } from './interactive-ipynb/nativeEditorProvider';
+import { NativeEditorProviderOld } from './interactive-ipynb/nativeEditorProviderOld';
 import { NativeEditorStorage } from './interactive-ipynb/nativeEditorStorage';
 import { InteractiveWindow } from './interactive-window/interactiveWindow';
 import { InteractiveWindowCommandListener } from './interactive-window/interactiveWindowCommandListener';
@@ -151,9 +153,16 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addBinding(ICellHashProvider, IInteractiveWindowListener);
     serviceManager.addBinding(ICellHashProvider, INotebookExecutionLogger);
     serviceManager.addBinding(IJupyterDebugger, ICellHashListener);
-    serviceManager.addSingleton<INotebookEditorProvider>(INotebookEditorProvider, NativeEditorProvider);
+    const app = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
+    serviceManager.addSingleton<INotebookEditorProvider>(
+        INotebookEditorProvider,
+        app.packageJson.enableProposedApi ? NativeEditorProvider : NativeEditorProviderOld
+    );
     serviceManager.add<INotebookStorage>(INotebookStorage, NativeEditorStorage);
-    serviceManager.add<INotebookEditor>(INotebookEditor, NativeEditor);
+    serviceManager.add<INotebookEditor>(
+        INotebookEditor,
+        app.packageJson.enableProposedApi ? NativeEditor : NativeEditorOldWebView
+    );
     serviceManager.addSingleton<IDataScienceCommandListener>(IDataScienceCommandListener, NativeEditorCommandListener);
     serviceManager.addBinding(ICodeLensFactory, IInteractiveWindowListener);
     serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, DebugLocationTrackerFactory);

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -27,6 +27,7 @@ import { DebugListener } from './interactive-common/debugListener';
 import { IntellisenseProvider } from './interactive-common/intellisense/intellisenseProvider';
 import { LinkProvider } from './interactive-common/linkProvider';
 import { ShowPlotListener } from './interactive-common/showPlotListener';
+import { AutoSaveService } from './interactive-ipynb/autoSaveService';
 import { NativeEditor } from './interactive-ipynb/nativeEditor';
 import { NativeEditorCommandListener } from './interactive-ipynb/nativeEditorCommandListener';
 import { NativeEditorOldWebView } from './interactive-ipynb/nativeEditorOldWebView';
@@ -141,6 +142,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, IntellisenseProvider);
     serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, LinkProvider);
     serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, ShowPlotListener);
+    serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, AutoSaveService);
     serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, DebugListener);
     serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, GatherListener);
     serviceManager.addSingleton<IPlotViewerProvider>(IPlotViewerProvider, PlotViewerProvider);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -375,6 +375,7 @@ export interface INotebookEditor extends IInteractiveBase {
     readonly closed: Event<INotebookEditor>;
     readonly executed: Event<INotebookEditor>;
     readonly modified: Event<INotebookEditor>;
+    readonly saved: Event<INotebookEditor>;
     /**
      * Is this notebook representing an untitled file which has never been saved yet.
      */
@@ -386,7 +387,7 @@ export interface INotebookEditor extends IInteractiveBase {
     readonly file: Uri;
     readonly visible: boolean;
     readonly active: boolean;
-    load(storage: INotebookModel, webViewPanel: WebviewPanel): Promise<void>;
+    load(storage: INotebookModel, webViewPanel?: WebviewPanel): Promise<void>;
     runAllCells(): void;
     runSelectedCell(): void;
     addCellBelow(): void;

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1755,7 +1755,6 @@ export interface IEventNamePropertyMapping {
     [Telemetry.StartSessionFailedJupyter]: undefined | never;
     /**
      * Telemetry event fired if a failure occurs loading a notebook
-     * message param is the exception message string.
      */
     [Telemetry.OpenNotebookFailure]: undefined | never;
     /**

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -335,7 +335,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 break;
             case 'z':
             case 'Z':
-                if (!this.isFocused() && UseCustomEditor) {
+                if (!this.isFocused() && !UseCustomEditor) {
                     if (e.shiftKey && !e.ctrlKey && !e.altKey) {
                         e.stopPropagation();
                         this.props.redo();

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -333,6 +333,20 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     this.props.sendCommand(NativeCommandType.InsertBelow, 'keyboard');
                 }
                 break;
+            case 'z':
+            case 'Z':
+                if (!this.isFocused()) {
+                    if (e.shiftKey && !e.ctrlKey && !e.altKey) {
+                        e.stopPropagation();
+                        this.props.redo();
+                        this.props.sendCommand(NativeCommandType.Redo, 'keyboard');
+                    } else if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
+                        e.stopPropagation();
+                        this.props.undo();
+                        this.props.sendCommand(NativeCommandType.Undo, 'keyboard');
+                    }
+                }
+                break;
             default:
                 break;
         }

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -19,7 +19,7 @@ import { CellOutput } from '../interactive-common/cellOutput';
 import { ExecutionCount } from '../interactive-common/executionCount';
 import { InformationMessages } from '../interactive-common/informationMessages';
 import { CursorPos, ICellViewModel, IFont } from '../interactive-common/mainState';
-import { getOSType } from '../react-common/constants';
+import { getOSType, UseCustomEditor } from '../react-common/constants';
 import { IKeyboardEvent } from '../react-common/event';
 import { Image, ImageName } from '../react-common/image';
 import { ImageButton } from '../react-common/imageButton';
@@ -335,7 +335,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 break;
             case 'z':
             case 'Z':
-                if (!this.isFocused()) {
+                if (!this.isFocused() && UseCustomEditor) {
                     if (e.shiftKey && !e.ctrlKey && !e.altKey) {
                         e.stopPropagation();
                         this.props.redo();
@@ -649,7 +649,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                         keyDown={this.keyDownInput}
                         showLineNumbers={this.props.cellVM.showLineNumbers}
                         font={this.props.font}
-                        disableUndoStack={true}
+                        disableUndoStack={UseCustomEditor}
                         codeVersion={this.props.cellVM.codeVersion ? this.props.cellVM.codeVersion : 1}
                         focusPending={this.props.focusPending}
                     />

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -13,7 +13,7 @@ import { KernelSelection } from '../interactive-common/kernelSelection';
 import { getSelectedAndFocusedInfo, ICellViewModel, IMainState } from '../interactive-common/mainState';
 import { IMainWithVariables, IStore } from '../interactive-common/redux/store';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
-import { getOSType } from '../react-common/constants';
+import { getOSType, UseCustomEditor } from '../react-common/constants';
 import { ErrorBoundary } from '../react-common/errorBoundary';
 import { Image, ImageName } from '../react-common/image';
 import { ImageButton } from '../react-common/imageButton';
@@ -392,7 +392,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             }
             case 'z':
             case 'Z':
-                if (!getSelectedAndFocusedInfo(this.props).focusedCellId) {
+                if (!getSelectedAndFocusedInfo(this.props).focusedCellId && UseCustomEditor) {
                     if (event.shiftKey && !event.ctrlKey && !event.altKey) {
                         event.stopPropagation();
                         this.props.redo();

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -390,6 +390,20 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                 }
                 break;
             }
+            case 'z':
+            case 'Z':
+                if (!getSelectedAndFocusedInfo(this.props).focusedCellId) {
+                    if (event.shiftKey && !event.ctrlKey && !event.altKey) {
+                        event.stopPropagation();
+                        this.props.redo();
+                        this.props.sendCommand(NativeCommandType.Redo, 'keyboard');
+                    } else if (!event.shiftKey && !event.altKey && !event.ctrlKey) {
+                        event.stopPropagation();
+                        this.props.undo();
+                        this.props.sendCommand(NativeCommandType.Undo, 'keyboard');
+                    }
+                }
+                break;
             default:
                 break;
         }

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -392,7 +392,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             }
             case 'z':
             case 'Z':
-                if (!getSelectedAndFocusedInfo(this.props).focusedCellId && UseCustomEditor) {
+                if (!getSelectedAndFocusedInfo(this.props).focusedCellId && !UseCustomEditor) {
                     if (event.shiftKey && !event.ctrlKey && !event.altKey) {
                         event.stopPropagation();
                         this.props.redo();

--- a/src/datascience-ui/react-common/constants.ts
+++ b/src/datascience-ui/react-common/constants.ts
@@ -23,3 +23,5 @@ export function getOSType() {
         return OSType.Unknown;
     }
 }
+
+export const UseCustomEditor = false;

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -171,6 +171,7 @@ import { DataScienceErrorHandler } from '../../client/datascience/errorHandler/e
 import { GatherExecution } from '../../client/datascience/gather/gather';
 import { GatherListener } from '../../client/datascience/gather/gatherListener';
 import { IntellisenseProvider } from '../../client/datascience/interactive-common/intellisense/intellisenseProvider';
+import { AutoSaveService } from '../../client/datascience/interactive-ipynb/autoSaveService';
 import { NativeEditor } from '../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorCommandListener } from '../../client/datascience/interactive-ipynb/nativeEditorCommandListener';
 import { NativeEditorStorage } from '../../client/datascience/interactive-ipynb/nativeEditorStorage';
@@ -598,6 +599,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         }
 
         this.serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, IntellisenseProvider);
+        this.serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, AutoSaveService);
         this.serviceManager.add<IProtocolParser>(IProtocolParser, ProtocolParser);
         this.serviceManager.addSingleton<IDebugService>(IDebugService, MockDebuggerService);
         this.serviceManager.addSingleton<ICellHashProvider>(ICellHashProvider, CellHashProvider);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -84,7 +84,7 @@ import {
 import { WorkspaceService } from '../../client/common/application/workspace';
 import { AsyncDisposableRegistry } from '../../client/common/asyncDisposableRegistry';
 import { PythonSettings } from '../../client/common/configSettings';
-import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
+import { EXTENSION_ROOT_DIR, UseCustomEditorApi } from '../../client/common/constants';
 import { CryptoUtils } from '../../client/common/crypto';
 import { DotNetCompatibilityService } from '../../client/common/dotnet/compatibilityService';
 import { IDotNetCompatibilityService } from '../../client/common/dotnet/types';
@@ -464,7 +464,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             IInteractiveWindowProvider,
             TestInteractiveWindowProvider
         );
-        this.serviceManager.addSingletonInstance('USE_CUSTOM_EDITOR', useCustomEditor);
+        this.serviceManager.addSingletonInstance(UseCustomEditorApi, useCustomEditor);
         this.serviceManager.addSingleton<IDataViewerProvider>(IDataViewerProvider, DataViewerProvider);
         this.serviceManager.addSingleton<IPlotViewerProvider>(IPlotViewerProvider, PlotViewerProvider);
         this.serviceManager.add<IInteractiveWindow>(IInteractiveWindow, InteractiveWindow);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -174,6 +174,7 @@ import { IntellisenseProvider } from '../../client/datascience/interactive-commo
 import { AutoSaveService } from '../../client/datascience/interactive-ipynb/autoSaveService';
 import { NativeEditor } from '../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorCommandListener } from '../../client/datascience/interactive-ipynb/nativeEditorCommandListener';
+import { NativeEditorOldWebView } from '../../client/datascience/interactive-ipynb/nativeEditorOldWebView';
 import { NativeEditorStorage } from '../../client/datascience/interactive-ipynb/nativeEditorStorage';
 import { InteractiveWindow } from '../../client/datascience/interactive-window/interactiveWindow';
 import { InteractiveWindowCommandListener } from '../../client/datascience/interactive-window/interactiveWindowCommandListener';
@@ -453,7 +454,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
     }
 
     //tslint:disable:max-func-body-length
-    public registerDataScienceTypes() {
+    public registerDataScienceTypes(useCustomEditor: boolean = false) {
         const testWorkspaceFolder = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience');
 
         this.registerFileSystemTypes();
@@ -463,6 +464,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             IInteractiveWindowProvider,
             TestInteractiveWindowProvider
         );
+        this.serviceManager.addSingletonInstance('USE_CUSTOM_EDITOR', useCustomEditor);
         this.serviceManager.addSingleton<IDataViewerProvider>(IDataViewerProvider, DataViewerProvider);
         this.serviceManager.addSingleton<IPlotViewerProvider>(IPlotViewerProvider, PlotViewerProvider);
         this.serviceManager.add<IInteractiveWindow>(IInteractiveWindow, InteractiveWindow);
@@ -509,7 +511,11 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<IJupyterDebugger>(IJupyterDebugger, JupyterDebugger);
         this.serviceManager.addSingleton<IDebugLocationTracker>(IDebugLocationTracker, DebugLocationTrackerFactory);
         this.serviceManager.addSingleton<INotebookEditorProvider>(INotebookEditorProvider, TestNativeEditorProvider);
-        this.serviceManager.add<INotebookEditor>(INotebookEditor, NativeEditor);
+        this.serviceManager.add<INotebookEditor>(
+            INotebookEditor,
+            useCustomEditor ? NativeEditor : NativeEditorOldWebView
+        );
+
         this.serviceManager.add<INotebookStorage>(INotebookStorage, NativeEditorStorage);
         this.serviceManager.addSingletonInstance<ICustomEditorService>(
             ICustomEditorService,

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1345,12 +1345,11 @@ df.head()`;
                 wrapper.update();
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
-                // const secondCell = wrapper.find('NativeCell').at(1);
-
                 clickCell(0);
+                const addedCell = waitForMessage(ioc, CommonActionType.INSERT_ABOVE_AND_FOCUS_NEW_CELL);
                 const update = waitForUpdate(wrapper, NativeEditor, 1);
                 simulateKeyPressOnCell(0, { code: 'a' });
-                await update;
+                await Promise.all([update, addedCell]);
 
                 // There should be 4 cells.
                 assert.equal(wrapper.find('NativeCell').length, 4);

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -77,109 +77,142 @@ import {
 } from './testHelpers';
 
 use(chaiAsPromised);
-
-//import { asyncDump } from '../common/asyncDump';
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
-suite('DataScience Native Editor', () => {
-    function createFileCell(cell: any, data: any): ICell {
-        const newCell = { type: 'preview', id: 'FakeID', file: Identifiers.EmptyFileName, line: 0, state: 2, ...cell };
-        newCell.data = { cell_type: 'code', execution_count: null, metadata: {}, outputs: [], source: '', ...data };
+// tslint:disable:no-any no-multiline-string max-func-body-length no-console max-classes-per-file trailing-comma
 
-        return newCell;
-    }
-    suite('Editor tests', () => {
-        const disposables: Disposable[] = [];
-        let ioc: DataScienceIocContainer;
-        let tempNotebookFile: {
-            filePath: string;
-            cleanupCallback: Function;
-        };
+suite('xDataScience Native Editor', () => {
+    const originalPlatform = window.navigator.platform;
+    Object.defineProperty(
+        window.navigator,
+        'platform',
+        ((value: string) => {
+            return {
+                get: () => value,
+                set: (v: string) => (value = v)
+            };
+        })(originalPlatform)
+    );
 
-        setup(async () => {
-            ioc = new DataScienceIocContainer();
-            ioc.registerDataScienceTypes();
+    [false, true].forEach(useCustomEditorApi => {
+        //import { asyncDump } from '../common/asyncDump';
+        suite(`${useCustomEditorApi ? 'With' : 'Without'} Custom Editor API`, () => {
+            function createFileCell(cell: any, data: any): ICell {
+                const newCell = {
+                    type: 'preview',
+                    id: 'FakeID',
+                    file: Identifiers.EmptyFileName,
+                    line: 0,
+                    state: 2,
+                    ...cell
+                };
+                newCell.data = {
+                    cell_type: 'code',
+                    execution_count: null,
+                    metadata: {},
+                    outputs: [],
+                    source: '',
+                    ...data
+                };
 
-            const appShell = TypeMoq.Mock.ofType<IApplicationShell>();
-            appShell.setup(a => a.showErrorMessage(TypeMoq.It.isAnyString())).returns(_e => Promise.resolve(''));
-            appShell
-                .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                .returns(() => Promise.resolve(''));
-            appShell
-                .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                .returns((_a1: string, a2: string, _a3: string) => Promise.resolve(a2));
-            appShell
-                .setup(a =>
-                    a.showInformationMessage(
-                        TypeMoq.It.isAny(),
-                        TypeMoq.It.isAny(),
-                        TypeMoq.It.isAny(),
-                        TypeMoq.It.isAny()
-                    )
-                )
-                .returns((_a1: string, _a2: any, _a3: string, a4: string) => Promise.resolve(a4));
-            appShell
-                .setup(a => a.showSaveDialog(TypeMoq.It.isAny()))
-                .returns(() => Promise.resolve(Uri.file('foo.ipynb')));
-            ioc.serviceManager.rebindInstance<IApplicationShell>(IApplicationShell, appShell.object);
-            tempNotebookFile = await createTemporaryFile('.ipynb');
-        });
-
-        teardown(async () => {
-            for (const disposable of disposables) {
-                if (!disposable) {
-                    continue;
-                }
-                // tslint:disable-next-line:no-any
-                const promise = disposable.dispose() as Promise<any>;
-                if (promise) {
-                    await promise;
-                }
+                return newCell;
             }
-            await ioc.dispose();
-            try {
-                tempNotebookFile.cleanupCallback();
-            } catch {
-                noop();
-            }
-        });
+            suite('Editor tests', () => {
+                const disposables: Disposable[] = [];
+                let ioc: DataScienceIocContainer;
+                let tempNotebookFile: {
+                    filePath: string;
+                    cleanupCallback: Function;
+                };
 
-        // Uncomment this to debug hangs on exit
-        // suiteTeardown(() => {
-        //      asyncDump();
-        // });
+                setup(async () => {
+                    ioc = new DataScienceIocContainer();
+                    ioc.registerDataScienceTypes(useCustomEditorApi);
 
-        runMountedTest(
-            'Simple text',
-            async wrapper => {
-                // Create an editor so something is listening to messages
-                await createNewEditor(ioc);
+                    const appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+                    appShell
+                        .setup(a => a.showErrorMessage(TypeMoq.It.isAnyString()))
+                        .returns(_e => Promise.resolve(''));
+                    appShell
+                        .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve(''));
+                    appShell
+                        .setup(a =>
+                            a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())
+                        )
+                        .returns((_a1: string, a2: string, _a3: string) => Promise.resolve(a2));
+                    appShell
+                        .setup(a =>
+                            a.showInformationMessage(
+                                TypeMoq.It.isAny(),
+                                TypeMoq.It.isAny(),
+                                TypeMoq.It.isAny(),
+                                TypeMoq.It.isAny()
+                            )
+                        )
+                        .returns((_a1: string, _a2: any, _a3: string, a4: string) => Promise.resolve(a4));
+                    appShell
+                        .setup(a => a.showSaveDialog(TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve(Uri.file('foo.ipynb')));
+                    ioc.serviceManager.rebindInstance<IApplicationShell>(IApplicationShell, appShell.object);
+                    tempNotebookFile = await createTemporaryFile('.ipynb');
+                });
 
-                // Add a cell into the UI and wait for it to render
-                await addCell(wrapper, ioc, 'a=1\na');
+                teardown(async () => {
+                    for (const disposable of disposables) {
+                        if (!disposable) {
+                            continue;
+                        }
+                        // tslint:disable-next-line:no-any
+                        const promise = disposable.dispose() as Promise<any>;
+                        if (promise) {
+                            await promise;
+                        }
+                    }
+                    await ioc.dispose();
+                    try {
+                        tempNotebookFile.cleanupCallback();
+                    } catch {
+                        noop();
+                    }
+                });
 
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<span>1</span>', 1);
-            },
-            () => {
-                return ioc;
-            }
-        );
+                // Uncomment this to debug hangs on exit
+                // suiteTeardown(() => {
+                //      asyncDump();
+                // });
 
-        runMountedTest(
-            'Mime Types',
-            async wrapper => {
-                // Create an editor so something is listening to messages
-                await createNewEditor(ioc);
+                runMountedTest(
+                    'Simple text',
+                    async wrapper => {
+                        // Create an editor so something is listening to messages
+                        await createNewEditor(ioc);
 
-                const badPanda = `import pandas as pd
+                        // Add a cell into the UI and wait for it to render
+                        await addCell(wrapper, ioc, 'a=1\na');
+
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>1</span>', 1);
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
+                    'Mime Types',
+                    async wrapper => {
+                        // Create an editor so something is listening to messages
+                        await createNewEditor(ioc);
+
+                        const badPanda = `import pandas as pd
 df = pd.read("${escapePath(path.join(srcDirectory(), 'DefaultSalesReport.csv'))}")
 df.head()`;
-                const goodPanda = `import pandas as pd
+                        const goodPanda = `import pandas as pd
 df = pd.read_csv("${escapePath(path.join(srcDirectory(), 'DefaultSalesReport.csv'))}")
 df.head()`;
-                const matPlotLib =
-                    'import matplotlib.pyplot as plt\r\nimport numpy as np\r\nx = np.linspace(0,20,100)\r\nplt.plot(x, np.sin(x))\r\nplt.show()';
-                const matPlotLibResults = 'img';
-                const spinningCursor = dedent`import sys
+                        const matPlotLib =
+                            'import matplotlib.pyplot as plt\r\nimport numpy as np\r\nx = np.linspace(0,20,100)\r\nplt.plot(x, np.sin(x))\r\nplt.show()';
+                        const matPlotLibResults = 'img';
+                        const spinningCursor = dedent`import sys
                     import time
                     def spinning_cursor():
                         while True:
@@ -191,481 +224,496 @@ df.head()`;
                         sys.stdout.flush()
                         time.sleep(0.1)
                         sys.stdout.write('\\r')`;
-                const alternating = `from IPython.display import display\r\nprint('foo')\r\ndisplay('foo')\r\nprint('bar')\r\ndisplay('bar')`;
-                const alternatingResults = ['foo\n', 'foo', 'bar\n', 'bar'];
+                        const alternating = `from IPython.display import display\r\nprint('foo')\r\ndisplay('foo')\r\nprint('bar')\r\ndisplay('bar')`;
+                        const alternatingResults = ['foo\n', 'foo', 'bar\n', 'bar'];
 
-                const clearalternating = `from IPython.display import display, clear_output\r\nprint('foo')\r\ndisplay('foo')\r\nclear_output(True)\r\nprint('bar')\r\ndisplay('bar')`;
-                const clearalternatingResults = ['foo\n', 'foo', '', 'bar\n', 'bar'];
+                        const clearalternating = `from IPython.display import display, clear_output\r\nprint('foo')\r\ndisplay('foo')\r\nclear_output(True)\r\nprint('bar')\r\ndisplay('bar')`;
+                        const clearalternatingResults = ['foo\n', 'foo', '', 'bar\n', 'bar'];
 
-                addMockData(ioc, badPanda, `pandas has no attribute 'read'`, 'text/html', 'error');
-                addMockData(ioc, goodPanda, `<td>A table</td>`, 'text/html');
-                addMockData(ioc, matPlotLib, matPlotLibResults, 'text/html');
-                addMockData(ioc, alternating, alternatingResults, ['text/plain', 'stream', 'text/plain', 'stream']);
-                addMockData(ioc, clearalternating, clearalternatingResults, [
-                    'text/plain',
-                    'stream',
-                    'clear_true',
-                    'text/plain',
-                    'stream'
-                ]);
-                const cursors = ['|', '/', '-', '\\'];
-                let cursorPos = 0;
-                let loops = 3;
-                addContinuousMockData(ioc, spinningCursor, async _c => {
-                    const result = `${cursors[cursorPos]}\r`;
-                    cursorPos += 1;
-                    if (cursorPos >= cursors.length) {
-                        cursorPos = 0;
-                        loops -= 1;
-                    }
-                    return Promise.resolve({ result: result, haveMore: loops > 0 });
-                });
+                        addMockData(ioc, badPanda, `pandas has no attribute 'read'`, 'text/html', 'error');
+                        addMockData(ioc, goodPanda, `<td>A table</td>`, 'text/html');
+                        addMockData(ioc, matPlotLib, matPlotLibResults, 'text/html');
+                        addMockData(ioc, alternating, alternatingResults, [
+                            'text/plain',
+                            'stream',
+                            'text/plain',
+                            'stream'
+                        ]);
+                        addMockData(ioc, clearalternating, clearalternatingResults, [
+                            'text/plain',
+                            'stream',
+                            'clear_true',
+                            'text/plain',
+                            'stream'
+                        ]);
+                        const cursors = ['|', '/', '-', '\\'];
+                        let cursorPos = 0;
+                        let loops = 3;
+                        addContinuousMockData(ioc, spinningCursor, async _c => {
+                            const result = `${cursors[cursorPos]}\r`;
+                            cursorPos += 1;
+                            if (cursorPos >= cursors.length) {
+                                cursorPos = 0;
+                                loops -= 1;
+                            }
+                            return Promise.resolve({ result: result, haveMore: loops > 0 });
+                        });
 
-                await addCell(wrapper, ioc, badPanda, true);
-                verifyHtmlOnCell(wrapper, 'NativeCell', `has no attribute 'read'`, CellPosition.Last);
+                        await addCell(wrapper, ioc, badPanda, true);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', `has no attribute 'read'`, CellPosition.Last);
 
-                await addCell(wrapper, ioc, goodPanda, true);
-                verifyHtmlOnCell(wrapper, 'NativeCell', `<td>`, CellPosition.Last);
+                        await addCell(wrapper, ioc, goodPanda, true);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', `<td>`, CellPosition.Last);
 
-                await addCell(wrapper, ioc, matPlotLib, true);
-                verifyHtmlOnCell(wrapper, 'NativeCell', /img|Figure/, CellPosition.Last);
+                        await addCell(wrapper, ioc, matPlotLib, true);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', /img|Figure/, CellPosition.Last);
 
-                await addCell(wrapper, ioc, spinningCursor, true);
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<div>', CellPosition.Last);
+                        await addCell(wrapper, ioc, spinningCursor, true);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<div>', CellPosition.Last);
 
-                await addCell(wrapper, ioc, alternating, true);
-                verifyHtmlOnCell(wrapper, 'NativeCell', /.*foo\n.*foo.*bar\n.*bar/m, CellPosition.Last);
-                await addCell(wrapper, ioc, clearalternating, true);
-                verifyHtmlOnCell(wrapper, 'NativeCell', /.*bar\n.*bar/m, CellPosition.Last);
-            },
-            () => {
-                return ioc;
-            }
-        );
-
-        runMountedTest(
-            'Click buttons',
-            async wrapper => {
-                // Goto source should cause the visible editor to be picked as long as its filename matches
-                const showedEditor = createDeferred();
-                const textEditors: TextEditor[] = [];
-                const docManager = TypeMoq.Mock.ofType<IDocumentManager>();
-                const visibleEditor = TypeMoq.Mock.ofType<TextEditor>();
-                const dummyDocument = TypeMoq.Mock.ofType<TextDocument>();
-                dummyDocument.setup(d => d.fileName).returns(() => Uri.file('foo.py').fsPath);
-                visibleEditor.setup(v => v.show()).returns(() => showedEditor.resolve());
-                visibleEditor.setup(v => v.revealRange(TypeMoq.It.isAny())).returns(noop);
-                visibleEditor.setup(v => v.document).returns(() => dummyDocument.object);
-                textEditors.push(visibleEditor.object);
-                docManager.setup(a => a.visibleTextEditors).returns(() => textEditors);
-                ioc.serviceManager.rebindInstance<IDocumentManager>(IDocumentManager, docManager.object);
-                // Create an editor so something is listening to messages
-                await createNewEditor(ioc);
-
-                // Get a cell into the list
-                await addCell(wrapper, ioc, 'a=1\na');
-
-                // find the buttons on the cell itself
-                let cell = getLastOutputCell(wrapper, 'NativeCell');
-                let ImageButtons = cell.find(ImageButton);
-                assert.equal(ImageButtons.length, 6, 'Cell buttons not found');
-                let deleteButton = ImageButtons.at(5);
-
-                // Make sure delete works
-                let afterDelete = await getNativeCellResults(ioc, wrapper, async () => {
-                    deleteButton.simulate('click');
-                    return Promise.resolve();
-                });
-                assert.equal(afterDelete.length, 1, `Delete should remove a cell`);
-
-                // Secondary delete should NOT delete the cell as there should ALWAYS be at
-                // least one cell in the file.
-                cell = getLastOutputCell(wrapper, 'NativeCell');
-                ImageButtons = cell.find(ImageButton);
-                assert.equal(ImageButtons.length, 6, 'Cell buttons not found');
-                deleteButton = ImageButtons.at(5);
-
-                afterDelete = await getNativeCellResults(
-                    ioc,
-                    wrapper,
-                    async () => {
-                        deleteButton.simulate('click');
-                        return Promise.resolve();
+                        await addCell(wrapper, ioc, alternating, true);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', /.*foo\n.*foo.*bar\n.*bar/m, CellPosition.Last);
+                        await addCell(wrapper, ioc, clearalternating, true);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', /.*bar\n.*bar/m, CellPosition.Last);
                     },
-                    () => waitForUpdate(wrapper, NativeEditor, 1)
+                    () => {
+                        return ioc;
+                    }
                 );
-                assert.equal(afterDelete.length, 1, `Delete should NOT remove the last cell`);
-            },
-            () => {
-                return ioc;
-            }
-        );
 
-        runMountedTest(
-            'Select Jupyter Server',
-            async _wrapper => {
-                // tslint:disable-next-line: no-console
-                console.log('Test skipped until user can change jupyter server selection again');
-                // let selectorCalled = false;
+                runMountedTest(
+                    'Click buttons',
+                    async wrapper => {
+                        // Goto source should cause the visible editor to be picked as long as its filename matches
+                        const showedEditor = createDeferred();
+                        const textEditors: TextEditor[] = [];
+                        const docManager = TypeMoq.Mock.ofType<IDocumentManager>();
+                        const visibleEditor = TypeMoq.Mock.ofType<TextEditor>();
+                        const dummyDocument = TypeMoq.Mock.ofType<TextDocument>();
+                        dummyDocument.setup(d => d.fileName).returns(() => Uri.file('foo.py').fsPath);
+                        visibleEditor.setup(v => v.show()).returns(() => showedEditor.resolve());
+                        visibleEditor.setup(v => v.revealRange(TypeMoq.It.isAny())).returns(noop);
+                        visibleEditor.setup(v => v.document).returns(() => dummyDocument.object);
+                        textEditors.push(visibleEditor.object);
+                        docManager.setup(a => a.visibleTextEditors).returns(() => textEditors);
+                        ioc.serviceManager.rebindInstance<IDocumentManager>(IDocumentManager, docManager.object);
+                        // Create an editor so something is listening to messages
+                        await createNewEditor(ioc);
 
-                // ioc.datascience.setup(ds => ds.selectJupyterURI()).returns(() => {
-                //     selectorCalled = true;
-                //     return Promise.resolve();
-                // });
+                        // Get a cell into the list
+                        await addCell(wrapper, ioc, 'a=1\na');
 
-                // await createNewEditor(ioc);
-                // const editor = wrapper.find(NativeEditor);
-                // const kernelSelectionUI = editor.find(KernelSelection);
-                // const buttons = kernelSelectionUI.find('div');
-                // buttons!.at(1).simulate('click');
+                        // find the buttons on the cell itself
+                        let cell = getLastOutputCell(wrapper, 'NativeCell');
+                        let ImageButtons = cell.find(ImageButton);
+                        assert.equal(ImageButtons.length, 6, 'Cell buttons not found');
+                        let deleteButton = ImageButtons.at(5);
 
-                // assert.equal(selectorCalled, true, 'Server Selector should have been called');
-            },
-            () => {
-                return ioc;
-            }
-        );
+                        // Make sure delete works
+                        let afterDelete = await getNativeCellResults(ioc, wrapper, async () => {
+                            deleteButton.simulate('click');
+                            return Promise.resolve();
+                        });
+                        assert.equal(afterDelete.length, 1, `Delete should remove a cell`);
 
-        runMountedTest(
-            'Select Jupyter Kernel',
-            async _wrapper => {
-                // tslint:disable-next-line: no-console
-                console.log('Tests skipped, as we need better tests');
-                // let selectorCalled = false;
+                        // Secondary delete should NOT delete the cell as there should ALWAYS be at
+                        // least one cell in the file.
+                        cell = getLastOutputCell(wrapper, 'NativeCell');
+                        ImageButtons = cell.find(ImageButton);
+                        assert.equal(ImageButtons.length, 6, 'Cell buttons not found');
+                        deleteButton = ImageButtons.at(5);
 
-                // ioc.datascience.setup(ds => ds.selectLocalJupyterKernel()).returns(() => {
-                //     selectorCalled = true;
-                //     const spec: KernelSpecInterpreter = {};
-                //     return Promise.resolve(spec);
-                // });
-
-                // await createNewEditor(ioc);
-                // // Create an editor so something is listening to messages
-                // await createNewEditor(ioc);
-
-                // // Add a cell into the UI and wait for it to render
-                // await addCell(wrapper, ioc, 'a=1\na');
-
-                // const editor = wrapper.find(NativeEditor);
-                // const kernelSelectionUI = editor.find(KernelSelection);
-                // const buttons = kernelSelectionUI.find('div');
-                // buttons!.at(4).simulate('click');
-
-                // assert.equal(selectorCalled, true, 'Kernel Selector should have been called');
-            },
-            () => {
-                return ioc;
-            }
-        );
-
-        runMountedTest(
-            'Server already loaded',
-            async (_wrapper, context) => {
-                if (ioc.mockJupyter) {
-                    await ioc.activate();
-
-                    // Create an editor so something is listening to messages
-                    const editor = await createNewEditor(ioc);
-
-                    // Wait a bit to let async activation to work
-                    await sleep(500);
-
-                    // Make sure it has a server
-                    assert.ok(editor.notebook, 'Notebook did not start with a server');
-                } else {
-                    context.skip();
-                }
-                // Do the same thing again, but disable auto start
-                ioc.getSettings().datascience.disableJupyterAutoStart = true;
-            },
-            () => {
-                return ioc;
-            }
-        );
-
-        runMountedTest(
-            'Server load skipped',
-            async (_wrapper, context) => {
-                if (ioc.mockJupyter) {
-                    ioc.getSettings().datascience.disableJupyterAutoStart = true;
-                    await ioc.activate();
-
-                    // Create an editor so something is listening to messages
-                    const editor = await createNewEditor(ioc);
-
-                    // Wait a bit to let async activation to work
-                    await sleep(500);
-
-                    // Make sure it does not have a server
-                    assert.notOk(editor.notebook, 'Notebook should not start with a server');
-                } else {
-                    context.skip();
-                }
-            },
-            () => {
-                return ioc;
-            }
-        );
-
-        runMountedTest(
-            'Convert to python',
-            async wrapper => {
-                // Export should cause the export dialog to come up. Remap appshell so we can check
-                const dummyDisposable = {
-                    dispose: () => {
-                        return;
+                        afterDelete = await getNativeCellResults(
+                            ioc,
+                            wrapper,
+                            async () => {
+                                deleteButton.simulate('click');
+                                return Promise.resolve();
+                            },
+                            () => waitForUpdate(wrapper, NativeEditor, 1)
+                        );
+                        assert.equal(afterDelete.length, 1, `Delete should NOT remove the last cell`);
+                    },
+                    () => {
+                        return ioc;
                     }
-                };
-                const appShell = TypeMoq.Mock.ofType<IApplicationShell>();
-                appShell
-                    .setup(a => a.showErrorMessage(TypeMoq.It.isAnyString()))
-                    .returns(e => {
-                        throw e;
-                    });
-                appShell
-                    .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve(''));
-                appShell
-                    .setup(a => a.showSaveDialog(TypeMoq.It.isAny()))
-                    .returns(() => {
-                        return Promise.resolve(Uri.file(tempNotebookFile.filePath));
-                    });
-                appShell.setup(a => a.setStatusBarMessage(TypeMoq.It.isAny())).returns(() => dummyDisposable);
-                ioc.serviceManager.rebindInstance<IApplicationShell>(IApplicationShell, appShell.object);
+                );
 
-                // Make sure to create the interactive window after the rebind or it gets the wrong application shell.
-                await createNewEditor(ioc);
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                await addCell(wrapper, ioc, 'a=1\na');
-                await dirtyPromise;
+                runMountedTest(
+                    'Select Jupyter Server',
+                    async _wrapper => {
+                        // tslint:disable-next-line: no-console
+                        console.log('Test skipped until user can change jupyter server selection again');
+                        // let selectorCalled = false;
 
-                // Export should cause exportCalled to change to true
-                const saveButton = findButton(wrapper, NativeEditor, 8);
-                const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
-                await saved;
+                        // ioc.datascience.setup(ds => ds.selectJupyterURI()).returns(() => {
+                        //     selectorCalled = true;
+                        //     return Promise.resolve();
+                        // });
 
-                // Click export and wait for a document to change
-                const activeTextEditorChange = createDeferred();
-                const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
-                docManager.onDidChangeActiveTextEditor(() => activeTextEditorChange.resolve());
-                const exportButton = findButton(wrapper, NativeEditor, 9);
-                await waitForMessageResponse(ioc, () => exportButton!.simulate('click'));
+                        // await createNewEditor(ioc);
+                        // const editor = wrapper.find(NativeEditor);
+                        // const kernelSelectionUI = editor.find(KernelSelection);
+                        // const buttons = kernelSelectionUI.find('div');
+                        // buttons!.at(1).simulate('click');
 
-                // This can be slow, hence wait for a max of 60.
-                await waitForPromise(activeTextEditorChange.promise, 60_000);
-
-                // Verify the new document is valid python
-                const newDoc = docManager.activeTextEditor;
-                assert.ok(newDoc, 'New doc not created');
-                assert.ok(newDoc!.document.getText().includes('a=1'), 'Export did not create a python file');
-            },
-            () => {
-                return ioc;
-            }
-        );
-
-        runMountedTest(
-            'Save As',
-            async wrapper => {
-                const initialFileContents = (await fs.readFile(tempNotebookFile.filePath, 'utf8')).toString();
-                // Export should cause the export dialog to come up. Remap appshell so we can check
-                const dummyDisposable = {
-                    dispose: () => {
-                        return;
+                        // assert.equal(selectorCalled, true, 'Server Selector should have been called');
+                    },
+                    () => {
+                        return ioc;
                     }
-                };
-                const appShell = TypeMoq.Mock.ofType<IApplicationShell>();
-                appShell
-                    .setup(a => a.showErrorMessage(TypeMoq.It.isAnyString()))
-                    .returns(e => {
-                        throw e;
-                    });
-                appShell
-                    .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve(''));
-                appShell
-                    .setup(a => a.showSaveDialog(TypeMoq.It.isAny()))
-                    .returns(() => {
-                        return Promise.resolve(Uri.file(tempNotebookFile.filePath));
-                    });
-                appShell.setup(a => a.setStatusBarMessage(TypeMoq.It.isAny())).returns(() => dummyDisposable);
-                ioc.serviceManager.rebindInstance<IApplicationShell>(IApplicationShell, appShell.object);
+                );
 
-                // Make sure to create the interactive window after the rebind or it gets the wrong application shell.
-                await createNewEditor(ioc);
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                await addCell(wrapper, ioc, 'a=1\na');
-                await dirtyPromise;
+                runMountedTest(
+                    'Select Jupyter Kernel',
+                    async _wrapper => {
+                        // tslint:disable-next-line: no-console
+                        console.log('Tests skipped, as we need better tests');
+                        // let selectorCalled = false;
 
-                // Export should cause exportCalled to change to true
-                const saveButton = findButton(wrapper, NativeEditor, 8);
-                const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
-                await saved;
+                        // ioc.datascience.setup(ds => ds.selectLocalJupyterKernel()).returns(() => {
+                        //     selectorCalled = true;
+                        //     const spec: KernelSpecInterpreter = {};
+                        //     return Promise.resolve(spec);
+                        // });
 
-                const newFileContents = (await fs.readFile(tempNotebookFile.filePath, 'utf8')).toString();
-                // File should have been modified.
-                assert.notEqual(initialFileContents, newFileContents);
-                // Should be a valid json with 2 cells.
-                const nbContent = JSON.parse(newFileContents) as nbformat.INotebookContent;
-                assert.equal(nbContent.cells.length, 2);
-            },
-            () => {
-                return ioc;
-            }
-        );
+                        // await createNewEditor(ioc);
+                        // // Create an editor so something is listening to messages
+                        // await createNewEditor(ioc);
 
-        runMountedTest(
-            'RunAllCells',
-            async wrapper => {
-                addMockData(ioc, 'print(1)\na=1', 1);
-                addMockData(ioc, 'a=a+1\nprint(a)', 2);
-                addMockData(ioc, 'print(a+1)', 3);
+                        // // Add a cell into the UI and wait for it to render
+                        // await addCell(wrapper, ioc, 'a=1\na');
 
-                const baseFile = [
-                    { id: 'NotebookImport#0', data: { source: 'print(1)\na=1' } },
-                    { id: 'NotebookImport#1', data: { source: 'a=a+1\nprint(a)' } },
-                    { id: 'NotebookImport#2', data: { source: 'print(a+1)' } }
-                ];
-                const runAllCells = baseFile.map(cell => {
-                    return createFileCell(cell, cell.data);
-                });
-                const notebook = await ioc
-                    .get<INotebookExporter>(INotebookExporter)
-                    .translateToNotebook(runAllCells, undefined);
-                await openEditor(ioc, JSON.stringify(notebook));
+                        // const editor = wrapper.find(NativeEditor);
+                        // const kernelSelectionUI = editor.find(KernelSelection);
+                        // const buttons = kernelSelectionUI.find('div');
+                        // buttons!.at(4).simulate('click');
 
-                const runAllButton = findButton(wrapper, NativeEditor, 0);
-                // The render method needs to be executed 3 times for three cells.
-                const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                    numberOfTimes: 3
-                });
-                await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
-                await threeCellsUpdated;
-
-                verifyHtmlOnCell(wrapper, 'NativeCell', `1`, 0);
-                verifyHtmlOnCell(wrapper, 'NativeCell', `2`, 1);
-                verifyHtmlOnCell(wrapper, 'NativeCell', `3`, 2);
-            },
-            () => {
-                return ioc;
-            }
-        );
-
-        runMountedTest(
-            'Startup and shutdown',
-            async wrapper => {
-                // Stub the `stat` method to return a dummy value.
-                try {
-                    sinon
-                        .stub(ioc.serviceContainer.get<IFileSystem>(IFileSystem), 'stat')
-                        .resolves({ mtime: 0 } as any);
-                } catch (e) {
-                    // tslint:disable-next-line: no-console
-                    console.log(`Stub failure ${e}`);
-                }
-
-                addMockData(ioc, 'b=2\nb', 2);
-                addMockData(ioc, 'c=3\nc', 3);
-
-                const baseFile = [
-                    { id: 'NotebookImport#0', data: { source: 'a=1\na' } },
-                    { id: 'NotebookImport#1', data: { source: 'b=2\nb' } },
-                    { id: 'NotebookImport#2', data: { source: 'c=3\nc' } }
-                ];
-                const runAllCells = baseFile.map(cell => {
-                    return createFileCell(cell, cell.data);
-                });
-                const notebook = await ioc
-                    .get<INotebookExporter>(INotebookExporter)
-                    .translateToNotebook(runAllCells, undefined);
-                let editor = await openEditor(ioc, JSON.stringify(notebook));
-
-                // Run everything
-                let threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                    numberOfTimes: 3
-                });
-                let runAllButton = findButton(wrapper, NativeEditor, 0);
-                await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
-                await threeCellsUpdated;
-
-                // Close editor. Should still have the server up
-                await closeNotebook(editor, wrapper);
-                const jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
-                const editorProvider = ioc.serviceManager.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const server = await jupyterExecution.getServer(await editorProvider.getNotebookOptions(undefined));
-                assert.ok(server, 'Server was destroyed on notebook shutdown');
-
-                // Reopen, and rerun
-                const newWrapper = await setupWebview(ioc);
-                assert.ok(newWrapper, 'Could not mount a second time');
-                editor = await openEditor(ioc, JSON.stringify(notebook));
-
-                threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                    numberOfTimes: 3
-                });
-                runAllButton = findButton(newWrapper!, NativeEditor, 0);
-                await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
-                await threeCellsUpdated;
-                verifyHtmlOnCell(newWrapper!, 'NativeCell', `1`, 0);
-            },
-            () => {
-                // Disable the warning displayed by nodejs when there are too many listeners.
-                EventEmitter.defaultMaxListeners = 15;
-                return ioc;
-            }
-        );
-
-        test('Failure', async () => {
-            let fail = true;
-            const errorThrownDeferred = createDeferred<Error>();
-            // Make a dummy class that will fail during launch
-            class FailedProcess extends JupyterExecutionFactory {
-                public getUsableJupyterPython(): Promise<PythonInterpreter | undefined> {
-                    if (fail) {
-                        return Promise.resolve(undefined);
+                        // assert.equal(selectorCalled, true, 'Kernel Selector should have been called');
+                    },
+                    () => {
+                        return ioc;
                     }
-                    return super.getUsableJupyterPython();
-                }
-            }
+                );
 
-            class CustomErrorHandler extends DataScienceErrorHandler {
-                public handleError(exc: Error): Promise<void> {
-                    errorThrownDeferred.resolve(exc);
-                    return Promise.resolve();
-                }
-            }
-            ioc.serviceManager.rebind<IJupyterExecution>(IJupyterExecution, FailedProcess);
-            ioc.serviceManager.rebind<IDataScienceErrorHandler>(IDataScienceErrorHandler, CustomErrorHandler);
-            ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
-            addMockData(ioc, 'a=1\na', 1);
-            const wrapper = mountNativeWebView(ioc);
-            await createNewEditor(ioc);
-            const result = await Promise.race([addCell(wrapper, ioc, 'a=1\na', true), errorThrownDeferred.promise]);
-            assert.ok(result, 'Error not found');
-            assert.ok(result instanceof Error, 'Error not found');
+                runMountedTest(
+                    'Server already loaded',
+                    async (_wrapper, context) => {
+                        if (ioc.mockJupyter) {
+                            await ioc.activate();
 
-            // Fix failure and try again
-            fail = false;
-            const cell = getOutputCell(wrapper, 'NativeCell', 1);
-            assert.ok(cell, 'Cannot find the first cell');
-            const imageButtons = cell!.find(ImageButton);
-            assert.equal(imageButtons.length, 6, 'Cell buttons not found');
-            const runButton = imageButtons.findWhere(w => w.props().tooltip === 'Run cell');
-            assert.equal(runButton.length, 1, 'No run button found');
-            const update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, { numberOfTimes: 2 });
-            runButton.simulate('click');
-            await update;
-            verifyHtmlOnCell(wrapper, 'NativeCell', `1`, 1);
-        });
-    });
+                            // Create an editor so something is listening to messages
+                            const editor = await createNewEditor(ioc);
 
-    suite('Editor tests', () => {
-        let wrapper: ReactWrapper<any, Readonly<{}>, React.Component>;
-        const disposables: Disposable[] = [];
-        let ioc: DataScienceIocContainer;
-        const baseFile = `
+                            // Wait a bit to let async activation to work
+                            await sleep(500);
+
+                            // Make sure it has a server
+                            assert.ok(editor.notebook, 'Notebook did not start with a server');
+                        } else {
+                            context.skip();
+                        }
+                        // Do the same thing again, but disable auto start
+                        ioc.getSettings().datascience.disableJupyterAutoStart = true;
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
+                    'Server load skipped',
+                    async (_wrapper, context) => {
+                        if (ioc.mockJupyter) {
+                            ioc.getSettings().datascience.disableJupyterAutoStart = true;
+                            await ioc.activate();
+
+                            // Create an editor so something is listening to messages
+                            const editor = await createNewEditor(ioc);
+
+                            // Wait a bit to let async activation to work
+                            await sleep(500);
+
+                            // Make sure it does not have a server
+                            assert.notOk(editor.notebook, 'Notebook should not start with a server');
+                        } else {
+                            context.skip();
+                        }
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
+                    'Convert to python',
+                    async wrapper => {
+                        // Export should cause the export dialog to come up. Remap appshell so we can check
+                        const dummyDisposable = {
+                            dispose: () => {
+                                return;
+                            }
+                        };
+                        const appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+                        appShell
+                            .setup(a => a.showErrorMessage(TypeMoq.It.isAnyString()))
+                            .returns(e => {
+                                throw e;
+                            });
+                        appShell
+                            .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                            .returns(() => Promise.resolve(''));
+                        appShell
+                            .setup(a => a.showSaveDialog(TypeMoq.It.isAny()))
+                            .returns(() => {
+                                return Promise.resolve(Uri.file(tempNotebookFile.filePath));
+                            });
+                        appShell.setup(a => a.setStatusBarMessage(TypeMoq.It.isAny())).returns(() => dummyDisposable);
+                        ioc.serviceManager.rebindInstance<IApplicationShell>(IApplicationShell, appShell.object);
+
+                        // Make sure to create the interactive window after the rebind or it gets the wrong application shell.
+                        await createNewEditor(ioc);
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        await addCell(wrapper, ioc, 'a=1\na');
+                        await dirtyPromise;
+
+                        // Export should cause exportCalled to change to true
+                        const saveButton = findButton(wrapper, NativeEditor, 8);
+                        const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
+                        await saved;
+
+                        // Click export and wait for a document to change
+                        const activeTextEditorChange = createDeferred();
+                        const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
+                        docManager.onDidChangeActiveTextEditor(() => activeTextEditorChange.resolve());
+                        const exportButton = findButton(wrapper, NativeEditor, 9);
+                        await waitForMessageResponse(ioc, () => exportButton!.simulate('click'));
+
+                        // This can be slow, hence wait for a max of 60.
+                        await waitForPromise(activeTextEditorChange.promise, 60_000);
+
+                        // Verify the new document is valid python
+                        const newDoc = docManager.activeTextEditor;
+                        assert.ok(newDoc, 'New doc not created');
+                        assert.ok(newDoc!.document.getText().includes('a=1'), 'Export did not create a python file');
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
+                    'Save As',
+                    async wrapper => {
+                        if (useCustomEditorApi) {
+                            return;
+                        }
+                        const initialFileContents = (await fs.readFile(tempNotebookFile.filePath, 'utf8')).toString();
+                        // Export should cause the export dialog to come up. Remap appshell so we can check
+                        const dummyDisposable = {
+                            dispose: () => {
+                                return;
+                            }
+                        };
+                        const appShell = TypeMoq.Mock.ofType<IApplicationShell>();
+                        appShell
+                            .setup(a => a.showErrorMessage(TypeMoq.It.isAnyString()))
+                            .returns(e => {
+                                throw e;
+                            });
+                        appShell
+                            .setup(a => a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                            .returns(() => Promise.resolve(''));
+                        appShell
+                            .setup(a => a.showSaveDialog(TypeMoq.It.isAny()))
+                            .returns(() => {
+                                return Promise.resolve(Uri.file(tempNotebookFile.filePath));
+                            });
+                        appShell.setup(a => a.setStatusBarMessage(TypeMoq.It.isAny())).returns(() => dummyDisposable);
+                        ioc.serviceManager.rebindInstance<IApplicationShell>(IApplicationShell, appShell.object);
+
+                        // Make sure to create the interactive window after the rebind or it gets the wrong application shell.
+                        await createNewEditor(ioc);
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        await addCell(wrapper, ioc, 'a=1\na');
+                        await dirtyPromise;
+
+                        // Export should cause exportCalled to change to true
+                        const saveButton = findButton(wrapper, NativeEditor, 8);
+                        const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
+                        await saved;
+
+                        const newFileContents = (await fs.readFile(tempNotebookFile.filePath, 'utf8')).toString();
+                        // File should have been modified.
+                        assert.notEqual(initialFileContents, newFileContents);
+                        // Should be a valid json with 2 cells.
+                        const nbContent = JSON.parse(newFileContents) as nbformat.INotebookContent;
+                        assert.equal(nbContent.cells.length, 2);
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
+                    'RunAllCells',
+                    async wrapper => {
+                        addMockData(ioc, 'print(1)\na=1', 1);
+                        addMockData(ioc, 'a=a+1\nprint(a)', 2);
+                        addMockData(ioc, 'print(a+1)', 3);
+
+                        const baseFile = [
+                            { id: 'NotebookImport#0', data: { source: 'print(1)\na=1' } },
+                            { id: 'NotebookImport#1', data: { source: 'a=a+1\nprint(a)' } },
+                            { id: 'NotebookImport#2', data: { source: 'print(a+1)' } }
+                        ];
+                        const runAllCells = baseFile.map(cell => {
+                            return createFileCell(cell, cell.data);
+                        });
+                        const notebook = await ioc
+                            .get<INotebookExporter>(INotebookExporter)
+                            .translateToNotebook(runAllCells, undefined);
+                        await openEditor(ioc, JSON.stringify(notebook));
+
+                        const runAllButton = findButton(wrapper, NativeEditor, 0);
+                        // The render method needs to be executed 3 times for three cells.
+                        const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
+                        await threeCellsUpdated;
+
+                        verifyHtmlOnCell(wrapper, 'NativeCell', `1`, 0);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', `2`, 1);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', `3`, 2);
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
+                    'Startup and shutdown',
+                    async wrapper => {
+                        // Stub the `stat` method to return a dummy value.
+                        try {
+                            sinon
+                                .stub(ioc.serviceContainer.get<IFileSystem>(IFileSystem), 'stat')
+                                .resolves({ mtime: 0 } as any);
+                        } catch (e) {
+                            // tslint:disable-next-line: no-console
+                            console.log(`Stub failure ${e}`);
+                        }
+
+                        addMockData(ioc, 'b=2\nb', 2);
+                        addMockData(ioc, 'c=3\nc', 3);
+
+                        const baseFile = [
+                            { id: 'NotebookImport#0', data: { source: 'a=1\na' } },
+                            { id: 'NotebookImport#1', data: { source: 'b=2\nb' } },
+                            { id: 'NotebookImport#2', data: { source: 'c=3\nc' } }
+                        ];
+                        const runAllCells = baseFile.map(cell => {
+                            return createFileCell(cell, cell.data);
+                        });
+                        const notebook = await ioc
+                            .get<INotebookExporter>(INotebookExporter)
+                            .translateToNotebook(runAllCells, undefined);
+                        let editor = await openEditor(ioc, JSON.stringify(notebook));
+
+                        // Run everything
+                        let threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        let runAllButton = findButton(wrapper, NativeEditor, 0);
+                        await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
+                        await threeCellsUpdated;
+
+                        // Close editor. Should still have the server up
+                        await closeNotebook(editor, wrapper);
+                        const jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
+                        const editorProvider = ioc.serviceManager.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const server = await jupyterExecution.getServer(
+                            await editorProvider.getNotebookOptions(undefined)
+                        );
+                        assert.ok(server, 'Server was destroyed on notebook shutdown');
+
+                        // Reopen, and rerun
+                        const newWrapper = await setupWebview(ioc);
+                        assert.ok(newWrapper, 'Could not mount a second time');
+                        editor = await openEditor(ioc, JSON.stringify(notebook));
+
+                        threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        runAllButton = findButton(newWrapper!, NativeEditor, 0);
+                        await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
+                        await threeCellsUpdated;
+                        verifyHtmlOnCell(newWrapper!, 'NativeCell', `1`, 0);
+                    },
+                    () => {
+                        // Disable the warning displayed by nodejs when there are too many listeners.
+                        EventEmitter.defaultMaxListeners = 15;
+                        return ioc;
+                    }
+                );
+
+                test('Failure', async () => {
+                    let fail = true;
+                    const errorThrownDeferred = createDeferred<Error>();
+                    // Make a dummy class that will fail during launch
+                    class FailedProcess extends JupyterExecutionFactory {
+                        public getUsableJupyterPython(): Promise<PythonInterpreter | undefined> {
+                            if (fail) {
+                                return Promise.resolve(undefined);
+                            }
+                            return super.getUsableJupyterPython();
+                        }
+                    }
+
+                    class CustomErrorHandler extends DataScienceErrorHandler {
+                        public handleError(exc: Error): Promise<void> {
+                            errorThrownDeferred.resolve(exc);
+                            return Promise.resolve();
+                        }
+                    }
+                    ioc.serviceManager.rebind<IJupyterExecution>(IJupyterExecution, FailedProcess);
+                    ioc.serviceManager.rebind<IDataScienceErrorHandler>(IDataScienceErrorHandler, CustomErrorHandler);
+                    ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
+                    addMockData(ioc, 'a=1\na', 1);
+                    const wrapper = mountNativeWebView(ioc);
+                    await createNewEditor(ioc);
+                    const result = await Promise.race([
+                        addCell(wrapper, ioc, 'a=1\na', true),
+                        errorThrownDeferred.promise
+                    ]);
+                    assert.ok(result, 'Error not found');
+                    assert.ok(result instanceof Error, 'Error not found');
+
+                    // Fix failure and try again
+                    fail = false;
+                    const cell = getOutputCell(wrapper, 'NativeCell', 1);
+                    assert.ok(cell, 'Cannot find the first cell');
+                    const imageButtons = cell!.find(ImageButton);
+                    assert.equal(imageButtons.length, 6, 'Cell buttons not found');
+                    const runButton = imageButtons.findWhere(w => w.props().tooltip === 'Run cell');
+                    assert.equal(runButton.length, 1, 'No run button found');
+                    const update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                        numberOfTimes: 2
+                    });
+                    runButton.simulate('click');
+                    await update;
+                    verifyHtmlOnCell(wrapper, 'NativeCell', `1`, 1);
+                });
+            });
+
+            suite('Editor tests', () => {
+                let wrapper: ReactWrapper<any, Readonly<{}>, React.Component>;
+                const disposables: Disposable[] = [];
+                let ioc: DataScienceIocContainer;
+                const baseFile = `
 {
  "cells": [
   {
@@ -762,1405 +810,1461 @@ df.head()`;
  "nbformat": 4,
  "nbformat_minor": 2
 }`;
-        const addedJSON = JSON.parse(baseFile);
-        addedJSON.cells.splice(3, 0, {
-            cell_type: 'code',
-            execution_count: null,
-            metadata: {},
-            outputs: [],
-            source: []
-        });
-
-        const addedJSONFile = JSON.stringify(addedJSON, null, ' ');
-
-        let notebookFile: {
-            filePath: string;
-            cleanupCallback: Function;
-        };
-        function initIoc() {
-            ioc = new DataScienceIocContainer();
-            ioc.registerDataScienceTypes();
-        }
-        async function setupFunction(this: Mocha.Context, fileContents?: any) {
-            const wrapperPossiblyUndefined = await setupWebview(ioc);
-            if (wrapperPossiblyUndefined) {
-                wrapper = wrapperPossiblyUndefined;
-
-                addMockData(ioc, 'b=2\nb', 2);
-                addMockData(ioc, 'c=3\nc', 3);
-                // Use a real file so we can save notebook to a file.
-                // This is used in some tests (saving).
-                notebookFile = await createTemporaryFile('.ipynb');
-                await fs.writeFile(notebookFile.filePath, fileContents ? fileContents : baseFile);
-                await Promise.all([
-                    waitForUpdate(wrapper, NativeEditor, 1),
-                    openEditor(ioc, fileContents ? fileContents : baseFile, notebookFile.filePath)
-                ]);
-            } else {
-                // tslint:disable-next-line: no-invalid-this
-                this.skip();
-            }
-        }
-
-        teardown(async () => {
-            for (const disposable of disposables) {
-                if (!disposable) {
-                    continue;
-                }
-                // tslint:disable-next-line:no-any
-                const promise = disposable.dispose() as Promise<any>;
-                if (promise) {
-                    await promise;
-                }
-            }
-            await ioc.dispose();
-            try {
-                notebookFile.cleanupCallback();
-            } catch {
-                noop();
-            }
-        });
-
-        function clickCell(cellIndex: number) {
-            wrapper.update();
-            wrapper
-                .find(NativeCell)
-                .at(cellIndex)
-                .simulate('click');
-            wrapper.update();
-        }
-
-        function simulateKeyPressOnCell(cellIndex: number, keyboardEvent: Partial<IKeyboardEvent> & { code: string }) {
-            // Check to see if we have an active focused editor
-            const editor = getNativeFocusedEditor(wrapper);
-
-            // If we do have one, send the input there, otherwise send it to the outer cell
-            if (editor) {
-                simulateKeyPressOnEditor(editor, keyboardEvent);
-            } else {
-                simulateKeyPressOnCellInner(cellIndex, keyboardEvent);
-            }
-        }
-
-        function simulateKeyPressOnEditor(
-            editorControl: ReactWrapper<any, Readonly<{}>, React.Component> | undefined,
-            keyboardEvent: Partial<IKeyboardEvent> & { code: string }
-        ) {
-            enterEditorKey(editorControl, keyboardEvent);
-        }
-
-        function simulateKeyPressOnCellInner(
-            cellIndex: number,
-            keyboardEvent: Partial<IKeyboardEvent> & { code: string }
-        ) {
-            wrapper.update();
-            let nativeCell = wrapper.find(NativeCell).at(cellIndex);
-            if (nativeCell.exists()) {
-                nativeCell.simulate('keydown', {
-                    key: keyboardEvent.code,
-                    shiftKey: keyboardEvent.shiftKey,
-                    ctrlKey: keyboardEvent.ctrlKey,
-                    altKey: keyboardEvent.altKey,
-                    metaKey: keyboardEvent.metaKey
-                });
-            }
-            wrapper.update();
-            // Requery for our cell as something like a 'dd' keydown command can delete it before the press and up
-            nativeCell = wrapper.find(NativeCell).at(cellIndex);
-            if (nativeCell.exists()) {
-                nativeCell.simulate('keypress', {
-                    key: keyboardEvent.code,
-                    shiftKey: keyboardEvent.shiftKey,
-                    ctrlKey: keyboardEvent.ctrlKey,
-                    altKey: keyboardEvent.altKey,
-                    metaKey: keyboardEvent.metaKey
-                });
-            }
-            nativeCell = wrapper.find(NativeCell).at(cellIndex);
-            wrapper.update();
-            if (nativeCell.exists()) {
-                nativeCell.simulate('keyup', {
-                    key: keyboardEvent.code,
-                    shiftKey: keyboardEvent.shiftKey,
-                    ctrlKey: keyboardEvent.ctrlKey,
-                    altKey: keyboardEvent.altKey,
-                    metaKey: keyboardEvent.metaKey
-                });
-            }
-            wrapper.update();
-        }
-
-        suite('Selection/Focus', () => {
-            setup(async function() {
-                initIoc();
-                // tslint:disable-next-line: no-invalid-this
-                await setupFunction.call(this);
-            });
-            test('None of the cells are selected by default', async () => {
-                assert.ok(!isCellSelected(wrapper, 'NativeCell', 0));
-                assert.ok(!isCellSelected(wrapper, 'NativeCell', 1));
-                assert.ok(!isCellSelected(wrapper, 'NativeCell', 2));
-            });
-
-            test('None of the cells are not focused by default', async () => {
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 0));
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 1));
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 2));
-            });
-
-            test('Select cells by clicking them', async () => {
-                // Click first cell, then second, then third.
-                clickCell(0);
-                assert.ok(isCellSelected(wrapper, 'NativeCell', 0));
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 2), false);
-
-                clickCell(1);
-                assert.ok(isCellSelected(wrapper, 'NativeCell', 1));
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 2), false);
-
-                clickCell(2);
-                assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-            });
-
-            test('Markdown saved when selecting another cell', async () => {
-                clickCell(0);
-
-                // Switch to markdown
-                let update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
-                simulateKeyPressOnCell(0, { code: 'm' });
-                await update;
-
-                // Monaco editor should be rendered and the cell should be markdown
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 0));
-                assert.ok(isCellMarkdown(wrapper, 'NativeCell', 0));
-
-                // Focus the cell.
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                simulateKeyPressOnCell(0, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 0));
-                assert.equal(
-                    wrapper
-                        .find(NativeCell)
-                        .at(0)
-                        .find(MonacoEditor).length,
-                    1
-                );
-
-                // Verify cell content
-                const currentEditor = getNativeFocusedEditor(wrapper);
-                const reactEditor = currentEditor!.instance() as MonacoEditor;
-                const editor = reactEditor.state.editor;
-                if (editor) {
-                    assert.equal(editor.getModel()!.getValue(), 'a=1\na', 'Incorrect editor text in markdown cell');
-                }
-
-                typeCode(currentEditor, 'world');
-
-                if (editor) {
-                    assert.equal(
-                        editor.getModel()!.getValue(),
-                        'worlda=1\na',
-                        'Incorrect editor text in markdown cell'
-                    );
-                }
-
-                // Now get the editor for the next cell and click it
-                update = waitForUpdate(wrapper, NativeEditor, 1);
-                clickCell(1);
-                await update;
-
-                // Look back at the output for the first cell, not focused, not selected, text saved in output
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
-                assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
-
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<p>worlda=1\na</p>', 0);
-            });
-        });
-
-        suite('Model updates', () => {
-            setup(async function() {
-                initIoc();
-                // tslint:disable-next-line: no-invalid-this
-                await setupFunction.call(this);
-            });
-            async function undo(): Promise<void> {
-                const uri = Uri.file(notebookFile.filePath);
-                const update = waitForMessage(ioc, InteractiveWindowMessages.ReceivedUpdateModel);
-                const editorService = ioc.serviceManager.get<ICustomEditorService>(
-                    ICustomEditorService
-                ) as MockCustomEditorService;
-                editorService.undo(uri);
-                return update;
-            }
-            async function redo(): Promise<void> {
-                const uri = Uri.file(notebookFile.filePath);
-                const update = waitForMessage(ioc, InteractiveWindowMessages.ReceivedUpdateModel);
-                const editorService = ioc.serviceManager.get<ICustomEditorService>(
-                    ICustomEditorService
-                ) as MockCustomEditorService;
-                editorService.redo(uri);
-                return update;
-            }
-            test('Add a cell and undo', async () => {
-                addMockData(ioc, 'c=4\nc', '4');
-                await addCell(wrapper, ioc, 'c=4\nc', false);
-
-                // Should have 4 cells
-                assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
-
-                // Send undo through the custom editor
-                await undo();
-
-                // Should have 3
-                assert.equal(wrapper.find('NativeCell').length, 3, 'Cell not removed');
-            });
-            test('Edit a cell and undo', async () => {
-                await addCell(wrapper, ioc, '', false);
-
-                // Should have 4 cells
-                assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
-
-                // Change the contents of the cell
-                const editorEnzyme = getNativeFocusedEditor(wrapper);
-
-                // Type in something with brackets
-                typeCode(editorEnzyme, 'some more');
-
-                // Verify cell content
-                const reactEditor = editorEnzyme!.instance() as MonacoEditor;
-                const editor = reactEditor.state.editor;
-                if (editor) {
-                    assert.equal(editor.getModel()!.getValue(), 'some more', 'Text does not match');
-                }
-
-                // Add a new cell
-                await addCell(wrapper, ioc, '', false);
-
-                // Send undo a bunch of times. Should undo the add and the edits
-                await undo();
-                await undo();
-                await undo();
-
-                // Should have four again
-                assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not removed on undo');
-
-                // Should have different content
-                if (editor) {
-                    assert.equal(editor.getModel()!.getValue(), 'some mo', 'Text does not match after undo');
-                }
-
-                // Send redo to see if goes back
-                await redo();
-                if (editor) {
-                    assert.equal(editor.getModel()!.getValue(), 'some mor', 'Text does not match');
-                }
-
-                // Send redo to see if goes back
-                await redo();
-                await redo();
-                assert.equal(wrapper.find('NativeCell').length, 5, 'Cell not readded on redo');
-            });
-            test('Remove, move, and undo', async () => {
-                await addCell(wrapper, ioc, '', false);
-
-                // Should have 4 cells
-                assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
-
-                // Delete the cell
-                let cell = getLastOutputCell(wrapper, 'NativeCell');
-                let imageButtons = cell.find(ImageButton);
-                assert.equal(imageButtons.length, 6, 'Cell buttons not found');
-                const deleteButton = imageButtons.at(5);
-                await getNativeCellResults(ioc, wrapper, async () => {
-                    deleteButton.simulate('click');
-                    return Promise.resolve();
-                });
-                // Should have 3 cells
-                assert.equal(wrapper.find('NativeCell').length, 3, 'Cell not deleted');
-
-                // Undo the delete
-                await undo();
-
-                // Should have 4 cells again
-                assert.equal(wrapper.find('NativeCell').length, 4, 'Cell delete not undone');
-
-                // Redo the delete
-                await redo();
-
-                // Should have 3 cells again
-                assert.equal(wrapper.find('NativeCell').length, 3, 'Cell delete not redone');
-
-                // Move some cells around
-                cell = getLastOutputCell(wrapper, 'NativeCell');
-                imageButtons = cell.find(ImageButton);
-                assert.equal(imageButtons.length, 6, 'Cell buttons not found');
-                const moveUpButton = imageButtons.at(0);
-                await getNativeCellResults(ioc, wrapper, async () => {
-                    moveUpButton.simulate('click');
-                    return Promise.resolve();
-                });
-
-                let foundCell = getOutputCell(wrapper, 'NativeCell', 2)?.instance() as NativeCell;
-                assert.equal(foundCell.props.cellVM.cell.id, 'NotebookImport#1', 'Cell did not move');
-                await undo();
-                foundCell = getOutputCell(wrapper, 'NativeCell', 2)?.instance() as NativeCell;
-                assert.equal(foundCell.props.cellVM.cell.id, 'NotebookImport#2', 'Cell did not move back');
-            });
-        });
-
-        suite('Keyboard Shortcuts', () => {
-            const originalPlatform = window.navigator.platform;
-            Object.defineProperty(
-                window.navigator,
-                'platform',
-                ((value: string) => {
-                    return {
-                        get: () => value,
-                        set: (v: string) => (value = v)
-                    };
-                })(originalPlatform)
-            );
-            setup(async function() {
-                (window.navigator as any).platform = originalPlatform;
-                initIoc();
-                // tslint:disable-next-line: no-invalid-this
-                await setupFunction.call(this);
-            });
-            teardown(() => ((window.navigator as any).platform = originalPlatform));
-            test('Traverse cells by using ArrowUp and ArrowDown, k and j', async () => {
-                const keyCodesAndPositions = [
-                    // When we press arrow down in the first cell, then second cell gets selected.
-                    { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 0, expectedSelectedCell: 1 },
-                    { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 1, expectedSelectedCell: 2 },
-                    // Arrow down on last cell is a noop.
-                    { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 2, expectedSelectedCell: 2 },
-                    // When we press arrow up in the last cell, then second cell (from bottom) gets selected.
-                    { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 2, expectedSelectedCell: 1 },
-                    { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 1, expectedSelectedCell: 0 },
-                    // Arrow up on last cell is a noop.
-                    { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 0, expectedSelectedCell: 0 },
-
-                    // Same tests as above with k and j.
-                    { keyCode: 'j', cellIndexToPressKeysOn: 0, expectedSelectedCell: 1 },
-                    { keyCode: 'j', cellIndexToPressKeysOn: 1, expectedSelectedCell: 2 },
-                    // Arrow down on last cell is a noop.
-                    { keyCode: 'j', cellIndexToPressKeysOn: 2, expectedSelectedCell: 2 },
-                    { keyCode: 'k', cellIndexToPressKeysOn: 2, expectedSelectedCell: 1 },
-                    { keyCode: 'k', cellIndexToPressKeysOn: 1, expectedSelectedCell: 0 },
-                    // Arrow up on last cell is a noop.
-                    { keyCode: 'k', cellIndexToPressKeysOn: 0, expectedSelectedCell: 0 }
-                ];
-
-                // keypress on first cell, then second, then third.
-                // Test navigation through all cells, by traversing up and down.
-                for (const testItem of keyCodesAndPositions) {
-                    simulateKeyPressOnCell(testItem.cellIndexToPressKeysOn, { code: testItem.keyCode });
-
-                    // Check if it is selected.
-                    // Only the cell at the index should be selected, as that's what we click.
-                    assert.ok(isCellSelected(wrapper, 'NativeCell', testItem.expectedSelectedCell) === true);
-                }
-            });
-
-            test('Traverse cells by using ArrowUp and ArrowDown, k and j', async () => {
-                const keyCodesAndPositions = [
-                    // When we press arrow down in the first cell, then second cell gets selected.
-                    { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 0, expectedIndex: 1 },
-                    { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 1, expectedIndex: 2 },
-                    // Arrow down on last cell is a noop.
-                    { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 2, expectedIndex: 2 },
-                    // When we press arrow up in the last cell, then second cell (from bottom) gets selected.
-                    { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 2, expectedIndex: 1 },
-                    { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 1, expectedIndex: 0 },
-                    // Arrow up on last cell is a noop.
-                    { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 0, expectedIndex: 0 }
-                ];
-
-                // keypress on first cell, then second, then third.
-                // Test navigation through all cells, by traversing up and down.
-                for (const testItem of keyCodesAndPositions) {
-                    simulateKeyPressOnCell(testItem.cellIndexToPressKeysOn, { code: testItem.keyCode });
-
-                    // Check if it is selected.
-                    // Only the cell at the index should be selected, as that's what we click.
-                    assert.ok(isCellSelected(wrapper, 'NativeCell', testItem.expectedIndex) === true);
-                }
-            });
-
-            test("Pressing 'Enter' on a selected cell, results in focus being set to the code", async () => {
-                // For some reason we cannot allow setting focus to monaco editor.
-                // Tests are known to fall over if allowed.
-                wrapper.update();
-                const editor = wrapper
-                    .find(NativeCell)
-                    .at(1)
-                    .find(Editor)
-                    .first();
-                (editor.instance() as Editor).giveFocus = () => editor.props().focused!();
-
-                const update = waitForUpdate(wrapper, NativeEditor, 1);
-                clickCell(1);
-                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                // The second cell should be selected.
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
-            });
-
-            test("Pressing 'Escape' on a focused cell results in the cell being selected", async () => {
-                // First focus the cell.
-                let update = waitForUpdate(wrapper, NativeEditor, 1);
-                clickCell(1);
-                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                // The second cell should be selected.
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                assert.equal(isCellFocused(wrapper, 'NativeCell', 1), true);
-
-                // Now hit escape.
-                update = waitForUpdate(wrapper, NativeEditor, 1);
-                simulateKeyPressOnCell(1, { code: 'Escape' });
-                await update;
-
-                // Confirm it is no longer focused, and it is selected.
-                assert.equal(isCellSelected(wrapper, 'NativeCell', 1), true);
-                assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
-            }).retries(3);
-
-            test("Pressing 'Shift+Enter' on a selected cell executes the cell and advances to the next cell", async () => {
-                let update = waitForUpdate(wrapper, NativeEditor, 1);
-                clickCell(1);
-                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                // The 2nd cell should be focused
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
-
-                update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
-                simulateKeyPressOnCell(1, { code: 'Enter', shiftKey: true, editorInfo: undefined });
-                await update;
-                wrapper.update();
-
-                // Ensure cell was executed.
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1);
-
-                // The third cell should be selected.
-                assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
-
-                // The third cell should not be focused
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 2));
-
-                // Shift+enter on the last cell, it should behave differently. It should be selected and focused
-
-                // First focus the cell.
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                clickCell(2);
-                simulateKeyPressOnCell(2, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                // The 3rd cell should be focused
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
-
-                update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
-                simulateKeyPressOnCell(2, { code: 'Enter', shiftKey: true, editorInfo: undefined });
-                await update;
-                wrapper.update();
-
-                // The fourth cell should be focused and not selected.
-                assert.ok(!isCellSelected(wrapper, 'NativeCell', 3));
-
-                // The fourth cell should be focused
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 3));
-            });
-
-            test("Pressing 'Ctrl+Enter' on a selected cell executes the cell and cell selection is not changed", async () => {
-                const update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
-                clickCell(1);
-                simulateKeyPressOnCell(1, { code: 'Enter', ctrlKey: true, editorInfo: undefined });
-                await update;
-
-                // Ensure cell was executed.
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1);
-
-                // The first cell should be selected.
-                assert.ok(isCellSelected(wrapper, 'NativeCell', 1));
-            });
-
-            test("Pressing 'Alt+Enter' on a selected cell adds a new cell below it", async () => {
-                // Initially 3 cells.
-                wrapper.update();
-                assert.equal(wrapper.find('NativeCell').length, 3);
-
-                const update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                clickCell(1);
-                simulateKeyPressOnCell(1, { code: 'Enter', altKey: true, editorInfo: undefined });
-                await update;
-
-                // The second cell should be focused.
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
-                // There should be 4 cells.
-                assert.equal(wrapper.find('NativeCell').length, 4);
-            });
-
-            test('Auto brackets work', async () => {
-                wrapper.update();
-                // Initially 3 cells.
-                assert.equal(wrapper.find('NativeCell').length, 3);
-
-                // Give focus
-                let update = waitForUpdate(wrapper, NativeEditor, 1);
-                clickCell(1);
-                await update;
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                // The first cell should be focused.
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
-
-                // Add cell
-                await addCell(wrapper, ioc, '', false);
-                assert.equal(wrapper.find('NativeCell').length, 4);
-
-                // New cell should have focus
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
-
-                const editorEnzyme = getNativeFocusedEditor(wrapper);
-
-                // Type in something with brackets
-                typeCode(editorEnzyme, 'a(');
-
-                // Verify cell content
-                const reactEditor = editorEnzyme!.instance() as MonacoEditor;
-                const editor = reactEditor.state.editor;
-                if (editor) {
-                    assert.equal(editor.getModel()!.getValue(), 'a()', 'Text does not have brackets');
-                }
-            });
-
-            test('Navigating cells using up/down keys while focus is set to editor', async () => {
-                wrapper.update();
-
-                const firstCell = 0;
-                const secondCell = 1;
-
-                // Set focus to the first cell.
-                let update = waitForUpdate(wrapper, NativeEditor, 1);
-                clickCell(firstCell);
-                await update;
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                simulateKeyPressOnCell(firstCell, { code: 'Enter' });
-                await update;
-                assert.ok(isCellFocused(wrapper, 'NativeCell', firstCell));
-
-                // Now press the down arrow, and focus should go to the next cell.
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                let monacoEditor = getNativeFocusedEditor(wrapper)!.instance() as MonacoEditor;
-                monacoEditor.getCurrentVisibleLine = () => 0;
-                monacoEditor.getVisibleLineCount = () => 1;
-                simulateKeyPressOnCell(firstCell, { code: 'ArrowDown' });
-                await update;
-
-                // The next cell must be focused, but not selected.
-                assert.isFalse(isCellFocused(wrapper, 'NativeCell', firstCell), 'First new cell must not be focused');
-                assert.isTrue(isCellFocused(wrapper, 'NativeCell', secondCell), 'Second new cell must be focused');
-                assert.isFalse(isCellSelected(wrapper, 'NativeCell', firstCell), 'First new cell must not be selected');
-                assert.isFalse(
-                    isCellSelected(wrapper, 'NativeCell', secondCell),
-                    'Second new cell must not be selected'
-                );
-
-                // Now press the up arrow, and focus should go back to the first cell.
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                monacoEditor = getNativeFocusedEditor(wrapper)!.instance() as MonacoEditor;
-                monacoEditor.getCurrentVisibleLine = () => 0;
-                monacoEditor.getVisibleLineCount = () => 1;
-                simulateKeyPressOnCell(firstCell, { code: 'ArrowUp' });
-                await update;
-
-                // The first cell must be focused, but not selected.
-                assert.isTrue(isCellFocused(wrapper, 'NativeCell', firstCell), 'First new cell must not be focused');
-                assert.isFalse(isCellFocused(wrapper, 'NativeCell', secondCell), 'Second new cell must be focused');
-                assert.isFalse(isCellSelected(wrapper, 'NativeCell', firstCell), 'First new cell must not be selected');
-                assert.isFalse(
-                    isCellSelected(wrapper, 'NativeCell', secondCell),
-                    'Second new cell must not be selected'
-                );
-            });
-
-            test("Pressing 'd' on a selected cell twice deletes the cell", async () => {
-                // Initially 3 cells.
-                wrapper.update();
-                assert.equal(wrapper.find('NativeCell').length, 3);
-
-                clickCell(2);
-                simulateKeyPressOnCell(2, { code: 'd' });
-                simulateKeyPressOnCell(2, { code: 'd' });
-
-                // There should be 2 cells.
-                assert.equal(wrapper.find('NativeCell').length, 2);
-            });
-
-            test("Pressing 'a' on a selected cell adds a cell at the current position", async () => {
-                // Initially 3 cells.
-                wrapper.update();
-                assert.equal(wrapper.find('NativeCell').length, 3);
-
-                clickCell(0);
-                const addedCell = waitForMessage(ioc, CommonActionType.INSERT_ABOVE_AND_FOCUS_NEW_CELL);
-                const update = waitForUpdate(wrapper, NativeEditor, 1);
-                simulateKeyPressOnCell(0, { code: 'a' });
-                await Promise.all([update, addedCell]);
-
-                // There should be 4 cells.
-                assert.equal(wrapper.find('NativeCell').length, 4);
-
-                // Verify cell indexes of old items.
-                verifyCellIndex(wrapper, 'div[id="NotebookImport#0"]', 1);
-                verifyCellIndex(wrapper, 'div[id="NotebookImport#1"]', 2);
-                verifyCellIndex(wrapper, 'div[id="NotebookImport#2"]', 3);
-            });
-
-            test("Pressing 'b' on a selected cell adds a cell after the current position", async () => {
-                // Initially 3 cells.
-                wrapper.update();
-                assert.equal(wrapper.find('NativeCell').length, 3);
-
-                clickCell(1);
-                const addedCell = waitForMessage(ioc, CommonActionType.INSERT_BELOW_AND_FOCUS_NEW_CELL);
-                const update = waitForUpdate(wrapper, NativeEditor, 1);
-                simulateKeyPressOnCell(1, { code: 'b' });
-                await Promise.all([update, addedCell]);
-
-                // There should be 4 cells.
-                assert.equal(wrapper.find('NativeCell').length, 4);
-
-                // Verify cell indexes of old items.
-                verifyCellIndex(wrapper, 'div[id="NotebookImport#0"]', 0);
-                verifyCellIndex(wrapper, 'div[id="NotebookImport#1"]', 1);
-                verifyCellIndex(wrapper, 'div[id="NotebookImport#2"]', 3);
-            });
-
-            test('Toggle visibility of output', async () => {
-                // First execute contents of last cell.
-                let update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
-                clickCell(2);
-                simulateKeyPressOnCell(2, { code: 'Enter', ctrlKey: true, editorInfo: undefined });
-                await update;
-
-                // Ensure cell was executed.
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2);
-
-                // Hide the output
-                update = waitForUpdate(wrapper, NativeEditor, 1);
-                simulateKeyPressOnCell(2, { code: 'o' });
-                await update;
-
-                // Ensure cell output is hidden (looking for cell results will throw an exception).
-                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2));
-
-                // Display the output
-                update = waitForUpdate(wrapper, NativeEditor, 1);
-                simulateKeyPressOnCell(2, { code: 'o' });
-                await update;
-
-                // Ensure cell output is visible again.
-                verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2);
-            });
-
-            test("Toggle line numbers using the 'l' key", async () => {
-                clickCell(1);
-
-                const monacoEditorComponent = wrapper
-                    .find(NativeCell)
-                    .at(1)
-                    .find(MonacoEditor)
-                    .first();
-                const editor = (monacoEditorComponent.instance().state as IMonacoEditorState).editor!;
-                const optionsUpdated = sinon.spy(editor, 'updateOptions');
-
-                // Display line numbers.
-                simulateKeyPressOnCell(1, { code: 'l' });
-                // Confirm monaco editor got updated with line numbers set to turned on.
-                assert.equal(optionsUpdated.lastCall.args[0].lineNumbers, 'on');
-
-                // toggle the display of line numbers.
-                simulateKeyPressOnCell(1, { code: 'l' });
-                // Confirm monaco editor got updated with line numbers set to turned ff.
-                assert.equal(optionsUpdated.lastCall.args[0].lineNumbers, 'off');
-            });
-
-            test("Toggle markdown and code modes using 'y' and 'm' keys (cells should not be focused)", async () => {
-                clickCell(1);
-                // Switch to markdown
-                let update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
-                simulateKeyPressOnCell(1, { code: 'm' });
-                await update;
-
-                // Monaco editor should be rendered and the cell should be markdown
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused');
-                assert.ok(isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is not markdown');
-
-                // Switch to code
-                update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
-                simulateKeyPressOnCell(1, { code: 'y' });
-                await update;
-
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused 2nd time');
-                assert.ok(!isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is markdown second time');
-            });
-
-            test("Toggle markdown and code modes using 'y' and 'm' keys & ensure changes to cells is preserved", async () => {
-                clickCell(1);
-                // Switch to markdown
-                let update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
-                simulateKeyPressOnCell(1, { code: 'm' });
-                await update;
-
-                // Monaco editor should be rendered and the cell should be markdown
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused');
-                assert.ok(isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is not markdown');
-
-                // Focus the cell.
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
-                assert.equal(
-                    wrapper
-                        .find(NativeCell)
-                        .at(1)
-                        .find(MonacoEditor).length,
-                    1
-                );
-
-                // Change the markdown
-                let editor = getNativeFocusedEditor(wrapper);
-                injectCode(editor, 'foo');
-
-                // Switch back to code mode.
-                // First lose focus
-                update = waitForMessage(ioc, InteractiveWindowMessages.UnfocusedCellEditor);
-                simulateKeyPressOnCell(1, { code: 'Escape' });
-                await update;
-
-                // Confirm markdown output is rendered
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is focused');
-                assert.ok(isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is not markdown');
-                assert.equal(
-                    wrapper
-                        .find(NativeCell)
-                        .at(1)
-                        .find(MonacoEditor).length,
-                    0
-                );
-
-                // Switch to code
-                update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
-                simulateKeyPressOnCell(1, { code: 'y' });
-                await update;
-
-                assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused 2nd time');
-                assert.ok(!isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is markdown second time');
-
-                // Focus the cell.
-                update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
-                await update;
-
-                // Confirm editor still has the same text
-                editor = getNativeFocusedEditor(wrapper);
-                const monacoEditor = editor!.instance() as MonacoEditor;
-                assert.equal('foo', monacoEditor.state.editor!.getValue(), 'Changing cell type lost input');
-            });
-
-            test("Test undo using the key 'z'", async () => {
-                clickCell(0);
-
-                // Add, then undo, keep doing at least 3 times and confirm it works as expected.
-                for (let i = 0; i < 3; i += 1) {
-                    // Add a new cell
-                    let update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
-                    simulateKeyPressOnCell(0, { code: 'a' });
-                    await update;
-
-                    // Wait a bit for the time out to try and set focus a second time (this will be
-                    // fixed when we switch to redux)
-                    await sleep(100);
-
-                    // There should be 4 cells and first cell is focused.
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 0), true);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
-                    assert.equal(wrapper.find('NativeCell').length, 4);
-
-                    // Unfocus the cell
-                    update = waitForUpdate(wrapper, NativeEditor, 1);
-                    simulateKeyPressOnCell(0, { code: 'Escape' });
-                    await update;
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
-
-                    // Press 'ctrl+z'. This should do nothing
-                    update = waitForUpdate(wrapper, NativeEditor, 1);
-                    simulateKeyPressOnCell(0, { code: 'z', ctrlKey: true });
-                    await waitForPromise(update, 100);
-
-                    // There should be 4 cells and first cell is selected.
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
-                    assert.equal(wrapper.find('NativeCell').length, 4);
-
-                    // Press 'z' to undo.
-                    update = waitForUpdate(wrapper, NativeEditor, 1);
-                    simulateKeyPressOnCell(0, { code: 'z' });
-                    await update;
-
-                    // There should be 3 cells and first cell is selected & nothing focused.
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                    assert.equal(wrapper.find('NativeCell').length, 3);
-
-                    // Press 'shift+z' to redo
-                    update = waitForUpdate(wrapper, NativeEditor, 1);
-                    simulateKeyPressOnCell(0, { code: 'z', shiftKey: true });
-                    await update;
-
-                    // There should be 4 cells and first cell is selected.
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
-                    assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
-                    assert.equal(wrapper.find('NativeCell').length, 4);
-
-                    // Press 'z' to undo.
-                    update = waitForUpdate(wrapper, NativeEditor, 1);
-                    simulateKeyPressOnCell(0, { code: 'z' });
-                    await update;
-
-                    // There should be 3 cells and first cell is selected & nothing focused.
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
-                    assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                    assert.equal(wrapper.find('NativeCell').length, 3);
-                }
-            });
-
-            test("Test save using the key 'ctrl+s' on Windows", async () => {
-                (window.navigator as any).platform = 'Win';
-                clickCell(0);
-
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                await addCell(wrapper, ioc, 'a=1\na', true);
-                await dirtyPromise;
-
-                const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const editor = notebookProvider.editors[0];
-                assert.ok(editor, 'No editor when saving');
-                const savedPromise = createDeferred();
-                editor.saved(() => savedPromise.resolve());
-
-                const clean = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                simulateKeyPressOnCell(1, { code: 's', ctrlKey: true });
-                await waitForCondition(
-                    () => savedPromise.promise.then(() => true).catch(() => false),
-                    10_000,
-                    'Timedout'
-                );
-                await clean;
-                assert.ok(!editor!.isDirty, 'Editor should not be dirty after saving');
-            });
-
-            test("Test save using the key 'ctrl+s' on Mac", async () => {
-                (window.navigator as any).platform = 'Mac';
-                clickCell(0);
-
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                await addCell(wrapper, ioc, 'a=1\na', true);
-                await dirtyPromise;
-
-                const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const editor = notebookProvider.editors[0];
-                assert.ok(editor, 'No editor when saving');
-                const savedPromise = createDeferred();
-                editor.saved(() => savedPromise.resolve());
-
-                simulateKeyPressOnCell(1, { code: 's', ctrlKey: true });
-
-                await expect(
-                    waitForCondition(() => savedPromise.promise.then(() => true).catch(() => false), 1_000, 'Timedout')
-                ).to.eventually.be.rejected;
-
-                assert.ok(editor!.isDirty, 'Editor be dirty as nothing got saved');
-            });
-
-            test("Test save using the key 'cmd+s' on a Mac", async () => {
-                (window.navigator as any).platform = 'Mac';
-
-                clickCell(0);
-
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                await addCell(wrapper, ioc, 'a=1\na', true);
-                await dirtyPromise;
-
-                const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const editor = notebookProvider.editors[0];
-                assert.ok(editor, 'No editor when saving');
-                const savedPromise = createDeferred();
-                editor.saved(() => savedPromise.resolve());
-
-                simulateKeyPressOnCell(1, { code: 's', metaKey: true });
-
-                const clean = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                await waitForCondition(
-                    () => savedPromise.promise.then(() => true).catch(() => false),
-                    1_000,
-                    'Timedout'
-                );
-                await clean;
-
-                assert.ok(!editor!.isDirty, 'Editor should not be dirty after saving');
-            });
-            test("Test save using the key 'cmd+s' on a Windows", async () => {
-                (window.navigator as any).platform = 'Win';
-
-                clickCell(0);
-
-                await addCell(wrapper, ioc, 'a=1\na', true);
-
-                const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const editor = notebookProvider.editors[0];
-                assert.ok(editor, 'No editor when saving');
-                const savedPromise = createDeferred();
-                editor.saved(() => savedPromise.resolve());
-
-                // CMD+s won't work on Windows.
-                simulateKeyPressOnCell(1, { code: 's', metaKey: true });
-
-                await expect(
-                    waitForCondition(() => savedPromise.promise.then(() => true).catch(() => false), 1_000, 'Timedout')
-                ).to.eventually.be.rejected;
-
-                assert.ok(editor!.isDirty, 'Editor be dirty as nothing got saved');
-            });
-        });
-
-        suite('Auto Save', () => {
-            let windowStateChangeHandlers: ((e: WindowState) => any)[] = [];
-            setup(async function() {
-                initIoc();
-
-                windowStateChangeHandlers = [];
-                // Keep track of all handlers for the onDidChangeWindowState event.
-                ioc.applicationShell
-                    .setup(app => app.onDidChangeWindowState(TypeMoq.It.isAny()))
-                    .callback(cb => windowStateChangeHandlers.push(cb));
-
-                // tslint:disable-next-line: no-invalid-this
-                await setupFunction.call(this);
-            });
-            teardown(() => sinon.restore());
-
-            /**
-             * Make some kind of a change to the notebook.
-             *
-             * @param {number} cellIndex
-             */
-            async function modifyNotebook() {
-                // (Add a cell into the UI)
-                await addCell(wrapper, ioc, 'a', false);
-            }
-
-            test('Auto save notebook every 1s', async () => {
-                // Configure notebook to save automatically ever 1s.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('afterDelay');
-                when(ioc.mockedWorkspaceConfig.get<number>('autoSaveDelay', anything())).thenReturn(1_000);
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
-
-                /**
-                 * Make some changes to a cell of a notebook, then verify the notebook is auto saved.
-                 *
-                 * @param {number} cellIndex
-                 */
-                async function makeChangesAndConfirmFileIsUpdated() {
-                    const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                    const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                    const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-
-                    await modifyNotebook();
-                    await dirtyPromise;
-
-                    // At this point a message should be sent to extension asking it to save.
-                    // After the save, the extension should send a message to react letting it know that it was saved successfully.
-                    await cleanPromise;
-
-                    // Confirm file has been updated as well.
-                    const newFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                    assert.notEqual(newFileContents, notebookFileContents);
-                }
-
-                // Make changes & validate (try a couple of times).
-                await makeChangesAndConfirmFileIsUpdated();
-                await makeChangesAndConfirmFileIsUpdated();
-                await makeChangesAndConfirmFileIsUpdated();
-            });
-
-            test('File saved with same format', async () => {
-                // Configure notebook to save automatically ever 1s.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('afterDelay');
-                when(ioc.mockedWorkspaceConfig.get<number>('autoSaveDelay', anything())).thenReturn(2_000);
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
-                const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-
-                await modifyNotebook();
-                await dirtyPromise;
-
-                // At this point a message should be sent to extension asking it to save.
-                // After the save, the extension should send a message to react letting it know that it was saved successfully.
-                await cleanPromise;
-
-                // Confirm file is not the same. There should be a single cell that's been added
-                const newFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                assert.notEqual(newFileContents, notebookFileContents);
-                assert.equal(newFileContents, addedJSONFile);
-            });
-
-            test('Should not auto save notebook, ever', async () => {
-                const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-
-                // Configure notebook to to never save.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('off');
-                when(ioc.mockedWorkspaceConfig.get<number>('autoSaveDelay', anything())).thenReturn(1000);
-                // Update the settings and wait for the component to receive it and process it.
-                const promise = waitForMessage(ioc, InteractiveWindowMessages.SettingsUpdated);
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath, {
-                    ...defaultDataScienceSettings(),
-                    showCellInputCode: false
-                });
-                await promise;
-
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, { timeoutMs: 5_000 });
-
-                await modifyNotebook();
-                await dirtyPromise;
-
-                // Now that the notebook is dirty, change the active editor.
-                const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
-                docManager.didChangeActiveTextEditorEmitter.fire();
-                // Also, send notification about changes to window state.
-                windowStateChangeHandlers.forEach(item => item({ focused: false }));
-                windowStateChangeHandlers.forEach(item => item({ focused: true }));
-
-                // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
-                await expect(cleanPromise).to.eventually.be.rejected;
-                // Confirm file has not been updated as well.
-                assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
-            }).timeout(10_000);
-
-            async function testAutoSavingWhenEditorFocusChanges(newEditor: TextEditor | undefined) {
-                const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-
-                await modifyNotebook();
-                await dirtyPromise;
-
-                // Configure notebook to save when active editor changes.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onFocusChange');
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
-
-                // Now that the notebook is dirty, change the active editor.
-                const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
-                docManager.didChangeActiveTextEditorEmitter.fire(newEditor);
-
-                // At this point a message should be sent to extension asking it to save.
-                // After the save, the extension should send a message to react letting it know that it was saved successfully.
-                await cleanPromise;
-
-                // Confirm file has been updated as well.
-                assert.notEqual(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
-            }
-
-            test('Auto save notebook when focus changes from active editor to none', () =>
-                testAutoSavingWhenEditorFocusChanges(undefined));
-
-            test('Auto save notebook when focus changes from active editor to something else', () =>
-                testAutoSavingWhenEditorFocusChanges(TypeMoq.Mock.ofType<TextEditor>().object));
-
-            test('Should not auto save notebook when active editor changes', async () => {
-                const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, { timeoutMs: 5_000 });
-
-                await modifyNotebook();
-                await dirtyPromise;
-
-                // Configure notebook to save when window state changes.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onWindowChange');
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
-
-                // Now that the notebook is dirty, change the active editor.
-                // This should not trigger a save of notebook (as its configured to save only when window state changes).
-                const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
-                docManager.didChangeActiveTextEditorEmitter.fire();
-
-                // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
-                await expect(cleanPromise).to.eventually.be.rejected;
-                // Confirm file has not been updated as well.
-                assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
-            }).timeout(10_000);
-
-            async function testAutoSavingWithChangesToWindowState(focused: boolean) {
-                const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-
-                await modifyNotebook();
-                await dirtyPromise;
-
-                // Configure notebook to save when active editor changes.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onWindowChange');
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
-
-                // Now that the notebook is dirty, send notification about changes to window state.
-                windowStateChangeHandlers.forEach(item => item({ focused }));
-
-                // At this point a message should be sent to extension asking it to save.
-                // After the save, the extension should send a message to react letting it know that it was saved successfully.
-                await cleanPromise;
-
-                // Confirm file has been updated as well.
-                assert.notEqual(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
-            }
-
-            test('Auto save notebook when window state changes to being not focused', async () =>
-                testAutoSavingWithChangesToWindowState(false));
-            test('Auto save notebook when window state changes to being focused', async () =>
-                testAutoSavingWithChangesToWindowState(true));
-
-            test('Should not auto save notebook when window state changes', async () => {
-                const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, { timeoutMs: 5_000 });
-
-                await modifyNotebook();
-                await dirtyPromise;
-
-                // Configure notebook to save when active editor changes.
-                when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onFocusChange');
-                ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
-
-                // Now that the notebook is dirty, change window state.
-                // This should not trigger a save of notebook (as its configured to save only when focus is changed).
-                windowStateChangeHandlers.forEach(item => item({ focused: false }));
-                windowStateChangeHandlers.forEach(item => item({ focused: true }));
-
-                // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
-                await expect(cleanPromise).to.eventually.be.rejected;
-                // Confirm file has not been updated as well.
-                assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
-            }).timeout(10_000);
-        });
-
-        const oldJson: nbformat.INotebookContent = {
-            nbformat: 4,
-            nbformat_minor: 2,
-            cells: [
-                {
+                const addedJSON = JSON.parse(baseFile);
+                addedJSON.cells.splice(3, 0, {
                     cell_type: 'code',
-                    execution_count: 1,
-                    metadata: {
-                        collapsed: true
-                    },
-                    outputs: [
-                        {
-                            data: {
-                                'text/plain': ['1']
-                            },
-                            output_type: 'execute_result',
-                            execution_count: 1,
-                            metadata: {}
-                        }
-                    ],
-                    source: ['a=1\n', 'a']
-                },
-                {
-                    cell_type: 'code',
-                    execution_count: 2,
+                    execution_count: null,
                     metadata: {},
-                    outputs: [
-                        {
-                            data: {
-                                'text/plain': ['2']
-                            },
-                            output_type: 'execute_result',
-                            execution_count: 2,
-                            metadata: {}
-                        }
-                    ],
-                    source: ['b=2\n', 'b']
-                },
-                {
-                    cell_type: 'code',
-                    execution_count: 3,
-                    metadata: {},
-                    outputs: [
-                        {
-                            data: {
-                                'text/plain': ['3']
-                            },
-                            output_type: 'execute_result',
-                            execution_count: 3,
-                            metadata: {}
-                        }
-                    ],
-                    source: ['c=3\n', 'c']
-                }
-            ],
-            metadata: {
-                orig_nbformat: 4,
-                kernelspec: {
-                    display_name: 'JUNK',
-                    name: 'JUNK'
-                },
-                language_info: {
-                    name: 'python',
-                    version: '1.2.3'
-                }
-            }
-        };
-
-        suite('Update Metadata', () => {
-            setup(async function() {
-                initIoc();
-                // tslint:disable-next-line: no-invalid-this
-                await setupFunction.call(this, JSON.stringify(oldJson));
-            });
-
-            test('Update notebook metadata on execution', async () => {
-                const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const editor = notebookProvider.editors[0];
-                assert.ok(editor, 'No editor when saving');
-
-                // add cells, run them and save
-                await addCell(wrapper, ioc, 'a=1\na');
-                const runAllButton = findButton(wrapper, NativeEditor, 0);
-                const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                    numberOfTimes: 3
+                    outputs: [],
+                    source: []
                 });
-                await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
-                await threeCellsUpdated;
 
-                const saveButton = findButton(wrapper, NativeEditor, 8);
-                const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
-                await saved;
+                const addedJSONFile = JSON.stringify(addedJSON, null, ' ');
 
-                // the file has output and execution count
-                const fileContent = await fs.readFile(notebookFile.filePath, 'utf8');
-                const fileObject = JSON.parse(fileContent);
-
-                // First cell should still have the 'collapsed' metadata
-                assert.ok(fileObject.cells[0].metadata.collapsed, 'Metadata erased during execution');
-
-                // The version should be updated to something not "1.2.3"
-                assert.notEqual(fileObject.metadata.language_info.version, '1.2.3');
-
-                // Some tests don't have a kernelspec, in which case we should remove it
-                // If there is a spec, we should update the name and display name
-                const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
-                if (isRollingBuild && fileObject.metadata.kernelspec) {
-                    assert.notEqual(fileObject.metadata.kernelspec.display_name, 'JUNK');
-                    assert.notEqual(fileObject.metadata.kernelspec.name, 'JUNK');
+                let notebookFile: {
+                    filePath: string;
+                    cleanupCallback: Function;
+                };
+                function initIoc() {
+                    ioc = new DataScienceIocContainer();
+                    ioc.registerDataScienceTypes(useCustomEditorApi);
                 }
-            });
-        });
+                async function setupFunction(this: Mocha.Context, fileContents?: any) {
+                    const wrapperPossiblyUndefined = await setupWebview(ioc);
+                    if (wrapperPossiblyUndefined) {
+                        wrapper = wrapperPossiblyUndefined;
 
-        suite('Clear Outputs', () => {
-            setup(async function() {
-                initIoc();
-                // tslint:disable-next-line: no-invalid-this
-                await setupFunction.call(this, JSON.stringify(oldJson));
-            });
+                        addMockData(ioc, 'b=2\nb', 2);
+                        addMockData(ioc, 'c=3\nc', 3);
+                        // Use a real file so we can save notebook to a file.
+                        // This is used in some tests (saving).
+                        notebookFile = await createTemporaryFile('.ipynb');
+                        await fs.writeFile(notebookFile.filePath, fileContents ? fileContents : baseFile);
+                        await Promise.all([
+                            waitForUpdate(wrapper, NativeEditor, 1),
+                            openEditor(ioc, fileContents ? fileContents : baseFile, notebookFile.filePath)
+                        ]);
+                    } else {
+                        // tslint:disable-next-line: no-invalid-this
+                        this.skip();
+                    }
+                }
 
-            function verifyExecutionCount(cellIndex: number, executionCountContent: string) {
-                assert.equal(
+                teardown(async () => {
+                    for (const disposable of disposables) {
+                        if (!disposable) {
+                            continue;
+                        }
+                        // tslint:disable-next-line:no-any
+                        const promise = disposable.dispose() as Promise<any>;
+                        if (promise) {
+                            await promise;
+                        }
+                    }
+                    await ioc.dispose();
+                    try {
+                        notebookFile.cleanupCallback();
+                    } catch {
+                        noop();
+                    }
+                });
+
+                function clickCell(cellIndex: number) {
+                    wrapper.update();
                     wrapper
-                        .find(ExecutionCount)
+                        .find(NativeCell)
                         .at(cellIndex)
-                        .props().count,
-                    executionCountContent
-                );
-            }
+                        .simulate('click');
+                    wrapper.update();
+                }
 
-            test('Clear Outputs in WebView', async () => {
-                const runAllButton = findButton(wrapper, NativeEditor, 0);
-                const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                    numberOfTimes: 3
+                function simulateKeyPressOnCell(
+                    cellIndex: number,
+                    keyboardEvent: Partial<IKeyboardEvent> & { code: string }
+                ) {
+                    // Check to see if we have an active focused editor
+                    const editor = getNativeFocusedEditor(wrapper);
+
+                    // If we do have one, send the input there, otherwise send it to the outer cell
+                    if (editor) {
+                        simulateKeyPressOnEditor(editor, keyboardEvent);
+                    } else {
+                        simulateKeyPressOnCellInner(cellIndex, keyboardEvent);
+                    }
+                }
+
+                function simulateKeyPressOnEditor(
+                    editorControl: ReactWrapper<any, Readonly<{}>, React.Component> | undefined,
+                    keyboardEvent: Partial<IKeyboardEvent> & { code: string }
+                ) {
+                    enterEditorKey(editorControl, keyboardEvent);
+                }
+
+                function simulateKeyPressOnCellInner(
+                    cellIndex: number,
+                    keyboardEvent: Partial<IKeyboardEvent> & { code: string }
+                ) {
+                    wrapper.update();
+                    let nativeCell = wrapper.find(NativeCell).at(cellIndex);
+                    if (nativeCell.exists()) {
+                        nativeCell.simulate('keydown', {
+                            key: keyboardEvent.code,
+                            shiftKey: keyboardEvent.shiftKey,
+                            ctrlKey: keyboardEvent.ctrlKey,
+                            altKey: keyboardEvent.altKey,
+                            metaKey: keyboardEvent.metaKey
+                        });
+                    }
+                    wrapper.update();
+                    // Requery for our cell as something like a 'dd' keydown command can delete it before the press and up
+                    nativeCell = wrapper.find(NativeCell).at(cellIndex);
+                    if (nativeCell.exists()) {
+                        nativeCell.simulate('keypress', {
+                            key: keyboardEvent.code,
+                            shiftKey: keyboardEvent.shiftKey,
+                            ctrlKey: keyboardEvent.ctrlKey,
+                            altKey: keyboardEvent.altKey,
+                            metaKey: keyboardEvent.metaKey
+                        });
+                    }
+                    nativeCell = wrapper.find(NativeCell).at(cellIndex);
+                    wrapper.update();
+                    if (nativeCell.exists()) {
+                        nativeCell.simulate('keyup', {
+                            key: keyboardEvent.code,
+                            shiftKey: keyboardEvent.shiftKey,
+                            ctrlKey: keyboardEvent.ctrlKey,
+                            altKey: keyboardEvent.altKey,
+                            metaKey: keyboardEvent.metaKey
+                        });
+                    }
+                    wrapper.update();
+                }
+
+                suite('Selection/Focus', () => {
+                    setup(async function() {
+                        initIoc();
+                        // tslint:disable-next-line: no-invalid-this
+                        await setupFunction.call(this);
+                    });
+                    test('None of the cells are selected by default', async () => {
+                        assert.ok(!isCellSelected(wrapper, 'NativeCell', 0));
+                        assert.ok(!isCellSelected(wrapper, 'NativeCell', 1));
+                        assert.ok(!isCellSelected(wrapper, 'NativeCell', 2));
+                    });
+
+                    test('None of the cells are not focused by default', async () => {
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 0));
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 1));
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 2));
+                    });
+
+                    test('Select cells by clicking them', async () => {
+                        // Click first cell, then second, then third.
+                        clickCell(0);
+                        assert.ok(isCellSelected(wrapper, 'NativeCell', 0));
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 2), false);
+
+                        clickCell(1);
+                        assert.ok(isCellSelected(wrapper, 'NativeCell', 1));
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 2), false);
+
+                        clickCell(2);
+                        assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                    });
+
+                    test('Markdown saved when selecting another cell', async () => {
+                        clickCell(0);
+
+                        // Switch to markdown
+                        let update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
+                        simulateKeyPressOnCell(0, { code: 'm' });
+                        await update;
+
+                        // Monaco editor should be rendered and the cell should be markdown
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 0));
+                        assert.ok(isCellMarkdown(wrapper, 'NativeCell', 0));
+
+                        // Focus the cell.
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        simulateKeyPressOnCell(0, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 0));
+                        assert.equal(
+                            wrapper
+                                .find(NativeCell)
+                                .at(0)
+                                .find(MonacoEditor).length,
+                            1
+                        );
+
+                        // Verify cell content
+                        const currentEditor = getNativeFocusedEditor(wrapper);
+                        const reactEditor = currentEditor!.instance() as MonacoEditor;
+                        const editor = reactEditor.state.editor;
+                        if (editor) {
+                            assert.equal(
+                                editor.getModel()!.getValue(),
+                                'a=1\na',
+                                'Incorrect editor text in markdown cell'
+                            );
+                        }
+
+                        typeCode(currentEditor, 'world');
+
+                        if (editor) {
+                            assert.equal(
+                                editor.getModel()!.getValue(),
+                                'worlda=1\na',
+                                'Incorrect editor text in markdown cell'
+                            );
+                        }
+
+                        // Now get the editor for the next cell and click it
+                        update = waitForUpdate(wrapper, NativeEditor, 1);
+                        clickCell(1);
+                        await update;
+
+                        // Look back at the output for the first cell, not focused, not selected, text saved in output
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
+                        assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
+
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<p>worlda=1\na</p>', 0);
+                    });
                 });
-                await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
-                await threeCellsUpdated;
 
-                verifyExecutionCount(0, '1');
-                verifyExecutionCount(1, '2');
-                verifyExecutionCount(2, '3');
+                suite('Model updates', () => {
+                    setup(async function() {
+                        initIoc();
+                        // tslint:disable-next-line: no-invalid-this
+                        await setupFunction.call(this);
+                    });
+                    async function undo(): Promise<void> {
+                        const uri = Uri.file(notebookFile.filePath);
+                        const update = waitForMessage(ioc, InteractiveWindowMessages.ReceivedUpdateModel);
+                        const editorService = ioc.serviceManager.get<ICustomEditorService>(
+                            ICustomEditorService
+                        ) as MockCustomEditorService;
+                        editorService.undo(uri);
+                        return update;
+                    }
+                    async function redo(): Promise<void> {
+                        const uri = Uri.file(notebookFile.filePath);
+                        const update = waitForMessage(ioc, InteractiveWindowMessages.ReceivedUpdateModel);
+                        const editorService = ioc.serviceManager.get<ICustomEditorService>(
+                            ICustomEditorService
+                        ) as MockCustomEditorService;
+                        editorService.redo(uri);
+                        return update;
+                    }
+                    test('Add a cell and undo', async () => {
+                        addMockData(ioc, 'c=4\nc', '4');
+                        await addCell(wrapper, ioc, 'c=4\nc', false);
 
-                // Press clear all outputs
-                const clearAllOutput = waitForMessage(ioc, InteractiveWindowMessages.ClearAllOutputs);
-                const clearAllOutputButton = findButton(wrapper, NativeEditor, 6);
-                await waitForMessageResponse(ioc, () => clearAllOutputButton!.simulate('click'));
-                await clearAllOutput;
+                        // Should have 4 cells
+                        assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
 
-                verifyExecutionCount(0, '-');
-                verifyExecutionCount(1, '-');
-                verifyExecutionCount(2, '-');
-            });
+                        // Send undo through the custom editor
+                        await undo();
 
-            test('Clear execution_count and outputs in notebook', async () => {
-                const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                const editor = notebookProvider.editors[0];
-                assert.ok(editor, 'No editor when saving');
-                // add cells, run them and save
-                // await addCell(wrapper, ioc, 'a=1\na');
-                const runAllButton = findButton(wrapper, NativeEditor, 0);
-                const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                    numberOfTimes: 3
+                        // Should have 3
+                        assert.equal(wrapper.find('NativeCell').length, 3, 'Cell not removed');
+                    });
+                    test('Edit a cell and undo', async () => {
+                        await addCell(wrapper, ioc, '', false);
+
+                        // Should have 4 cells
+                        assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
+
+                        // Change the contents of the cell
+                        const editorEnzyme = getNativeFocusedEditor(wrapper);
+
+                        // Type in something with brackets
+                        typeCode(editorEnzyme, 'some more');
+
+                        // Verify cell content
+                        const reactEditor = editorEnzyme!.instance() as MonacoEditor;
+                        const editor = reactEditor.state.editor;
+                        if (editor) {
+                            assert.equal(editor.getModel()!.getValue(), 'some more', 'Text does not match');
+                        }
+
+                        // Add a new cell
+                        await addCell(wrapper, ioc, '', false);
+
+                        // Send undo a bunch of times. Should undo the add and the edits
+                        await undo();
+                        await undo();
+                        await undo();
+
+                        // Should have four again
+                        assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not removed on undo');
+
+                        // Should have different content
+                        if (editor) {
+                            assert.equal(editor.getModel()!.getValue(), 'some mo', 'Text does not match after undo');
+                        }
+
+                        // Send redo to see if goes back
+                        await redo();
+                        if (editor) {
+                            assert.equal(editor.getModel()!.getValue(), 'some mor', 'Text does not match');
+                        }
+
+                        // Send redo to see if goes back
+                        await redo();
+                        await redo();
+                        assert.equal(wrapper.find('NativeCell').length, 5, 'Cell not readded on redo');
+                    });
+                    test('Remove, move, and undo', async () => {
+                        await addCell(wrapper, ioc, '', false);
+
+                        // Should have 4 cells
+                        assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
+
+                        // Delete the cell
+                        let cell = getLastOutputCell(wrapper, 'NativeCell');
+                        let imageButtons = cell.find(ImageButton);
+                        assert.equal(imageButtons.length, 6, 'Cell buttons not found');
+                        const deleteButton = imageButtons.at(5);
+                        await getNativeCellResults(ioc, wrapper, async () => {
+                            deleteButton.simulate('click');
+                            return Promise.resolve();
+                        });
+                        // Should have 3 cells
+                        assert.equal(wrapper.find('NativeCell').length, 3, 'Cell not deleted');
+
+                        // Undo the delete
+                        await undo();
+
+                        // Should have 4 cells again
+                        assert.equal(wrapper.find('NativeCell').length, 4, 'Cell delete not undone');
+
+                        // Redo the delete
+                        await redo();
+
+                        // Should have 3 cells again
+                        assert.equal(wrapper.find('NativeCell').length, 3, 'Cell delete not redone');
+
+                        // Move some cells around
+                        cell = getLastOutputCell(wrapper, 'NativeCell');
+                        imageButtons = cell.find(ImageButton);
+                        assert.equal(imageButtons.length, 6, 'Cell buttons not found');
+                        const moveUpButton = imageButtons.at(0);
+                        await getNativeCellResults(ioc, wrapper, async () => {
+                            moveUpButton.simulate('click');
+                            return Promise.resolve();
+                        });
+
+                        let foundCell = getOutputCell(wrapper, 'NativeCell', 2)?.instance() as NativeCell;
+                        assert.equal(foundCell.props.cellVM.cell.id, 'NotebookImport#1', 'Cell did not move');
+                        await undo();
+                        foundCell = getOutputCell(wrapper, 'NativeCell', 2)?.instance() as NativeCell;
+                        assert.equal(foundCell.props.cellVM.cell.id, 'NotebookImport#2', 'Cell did not move back');
+                    });
                 });
-                await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
-                await threeCellsUpdated;
 
-                const saveButton = findButton(wrapper, NativeEditor, 8);
-                let saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
-                await saved;
+                suite('Keyboard Shortcuts', () => {
+                    setup(async function() {
+                        (window.navigator as any).platform = originalPlatform;
+                        initIoc();
+                        // tslint:disable-next-line: no-invalid-this
+                        await setupFunction.call(this);
+                    });
+                    teardown(() => ((window.navigator as any).platform = originalPlatform));
+                    test('Traverse cells by using ArrowUp and ArrowDown, k and j', async () => {
+                        const keyCodesAndPositions = [
+                            // When we press arrow down in the first cell, then second cell gets selected.
+                            { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 0, expectedSelectedCell: 1 },
+                            { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 1, expectedSelectedCell: 2 },
+                            // Arrow down on last cell is a noop.
+                            { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 2, expectedSelectedCell: 2 },
+                            // When we press arrow up in the last cell, then second cell (from bottom) gets selected.
+                            { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 2, expectedSelectedCell: 1 },
+                            { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 1, expectedSelectedCell: 0 },
+                            // Arrow up on last cell is a noop.
+                            { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 0, expectedSelectedCell: 0 },
 
-                // press clear all outputs, and save
-                const clearAllOutputButton = findButton(wrapper, NativeEditor, 6);
-                await waitForMessageResponse(ioc, () => clearAllOutputButton!.simulate('click'));
+                            // Same tests as above with k and j.
+                            { keyCode: 'j', cellIndexToPressKeysOn: 0, expectedSelectedCell: 1 },
+                            { keyCode: 'j', cellIndexToPressKeysOn: 1, expectedSelectedCell: 2 },
+                            // Arrow down on last cell is a noop.
+                            { keyCode: 'j', cellIndexToPressKeysOn: 2, expectedSelectedCell: 2 },
+                            { keyCode: 'k', cellIndexToPressKeysOn: 2, expectedSelectedCell: 1 },
+                            { keyCode: 'k', cellIndexToPressKeysOn: 1, expectedSelectedCell: 0 },
+                            // Arrow up on last cell is a noop.
+                            { keyCode: 'k', cellIndexToPressKeysOn: 0, expectedSelectedCell: 0 }
+                        ];
 
-                saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
-                await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
-                await saved;
+                        // keypress on first cell, then second, then third.
+                        // Test navigation through all cells, by traversing up and down.
+                        for (const testItem of keyCodesAndPositions) {
+                            simulateKeyPressOnCell(testItem.cellIndexToPressKeysOn, { code: testItem.keyCode });
 
-                const nb = JSON.parse(await fs.readFile(notebookFile.filePath, 'utf8')) as nbformat.INotebookContent;
-                assert.equal(nb.cells[0].execution_count, null);
-                assert.equal(nb.cells[1].execution_count, null);
-                assert.equal(nb.cells[2].execution_count, null);
-                expect(nb.cells[0].outputs).to.be.lengthOf(0);
-                expect(nb.cells[1].outputs).to.be.lengthOf(0);
-                expect(nb.cells[2].outputs).to.be.lengthOf(0);
+                            // Check if it is selected.
+                            // Only the cell at the index should be selected, as that's what we click.
+                            assert.ok(isCellSelected(wrapper, 'NativeCell', testItem.expectedSelectedCell) === true);
+                        }
+                    });
+
+                    test('Traverse cells by using ArrowUp and ArrowDown, k and j', async () => {
+                        const keyCodesAndPositions = [
+                            // When we press arrow down in the first cell, then second cell gets selected.
+                            { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 0, expectedIndex: 1 },
+                            { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 1, expectedIndex: 2 },
+                            // Arrow down on last cell is a noop.
+                            { keyCode: 'ArrowDown', cellIndexToPressKeysOn: 2, expectedIndex: 2 },
+                            // When we press arrow up in the last cell, then second cell (from bottom) gets selected.
+                            { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 2, expectedIndex: 1 },
+                            { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 1, expectedIndex: 0 },
+                            // Arrow up on last cell is a noop.
+                            { keyCode: 'ArrowUp', cellIndexToPressKeysOn: 0, expectedIndex: 0 }
+                        ];
+
+                        // keypress on first cell, then second, then third.
+                        // Test navigation through all cells, by traversing up and down.
+                        for (const testItem of keyCodesAndPositions) {
+                            simulateKeyPressOnCell(testItem.cellIndexToPressKeysOn, { code: testItem.keyCode });
+
+                            // Check if it is selected.
+                            // Only the cell at the index should be selected, as that's what we click.
+                            assert.ok(isCellSelected(wrapper, 'NativeCell', testItem.expectedIndex) === true);
+                        }
+                    });
+
+                    test("Pressing 'Enter' on a selected cell, results in focus being set to the code", async () => {
+                        // For some reason we cannot allow setting focus to monaco editor.
+                        // Tests are known to fall over if allowed.
+                        wrapper.update();
+                        const editor = wrapper
+                            .find(NativeCell)
+                            .at(1)
+                            .find(Editor)
+                            .first();
+                        (editor.instance() as Editor).giveFocus = () => editor.props().focused!();
+
+                        const update = waitForUpdate(wrapper, NativeEditor, 1);
+                        clickCell(1);
+                        simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        // The second cell should be selected.
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
+                    });
+
+                    test("Pressing 'Escape' on a focused cell results in the cell being selected", async () => {
+                        // First focus the cell.
+                        let update = waitForUpdate(wrapper, NativeEditor, 1);
+                        clickCell(1);
+                        simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        // The second cell should be selected.
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                        assert.equal(isCellFocused(wrapper, 'NativeCell', 1), true);
+
+                        // Now hit escape.
+                        update = waitForUpdate(wrapper, NativeEditor, 1);
+                        simulateKeyPressOnCell(1, { code: 'Escape' });
+                        await update;
+
+                        // Confirm it is no longer focused, and it is selected.
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', 1), true);
+                        assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
+                    }).retries(3);
+
+                    test("Pressing 'Shift+Enter' on a selected cell executes the cell and advances to the next cell", async () => {
+                        let update = waitForUpdate(wrapper, NativeEditor, 1);
+                        clickCell(1);
+                        simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        // The 2nd cell should be focused
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
+
+                        update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
+                        simulateKeyPressOnCell(1, { code: 'Enter', shiftKey: true, editorInfo: undefined });
+                        await update;
+                        wrapper.update();
+
+                        // Ensure cell was executed.
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1);
+
+                        // The third cell should be selected.
+                        assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
+
+                        // The third cell should not be focused
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 2));
+
+                        // Shift+enter on the last cell, it should behave differently. It should be selected and focused
+
+                        // First focus the cell.
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        clickCell(2);
+                        simulateKeyPressOnCell(2, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        // The 3rd cell should be focused
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
+
+                        update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
+                        simulateKeyPressOnCell(2, { code: 'Enter', shiftKey: true, editorInfo: undefined });
+                        await update;
+                        wrapper.update();
+
+                        // The fourth cell should be focused and not selected.
+                        assert.ok(!isCellSelected(wrapper, 'NativeCell', 3));
+
+                        // The fourth cell should be focused
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 3));
+                    });
+
+                    test("Pressing 'Ctrl+Enter' on a selected cell executes the cell and cell selection is not changed", async () => {
+                        const update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
+                        clickCell(1);
+                        simulateKeyPressOnCell(1, { code: 'Enter', ctrlKey: true, editorInfo: undefined });
+                        await update;
+
+                        // Ensure cell was executed.
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1);
+
+                        // The first cell should be selected.
+                        assert.ok(isCellSelected(wrapper, 'NativeCell', 1));
+                    });
+
+                    test("Pressing 'Alt+Enter' on a selected cell adds a new cell below it", async () => {
+                        // Initially 3 cells.
+                        wrapper.update();
+                        assert.equal(wrapper.find('NativeCell').length, 3);
+
+                        const update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        clickCell(1);
+                        simulateKeyPressOnCell(1, { code: 'Enter', altKey: true, editorInfo: undefined });
+                        await update;
+
+                        // The second cell should be focused.
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
+                        // There should be 4 cells.
+                        assert.equal(wrapper.find('NativeCell').length, 4);
+                    });
+
+                    test('Auto brackets work', async () => {
+                        wrapper.update();
+                        // Initially 3 cells.
+                        assert.equal(wrapper.find('NativeCell').length, 3);
+
+                        // Give focus
+                        let update = waitForUpdate(wrapper, NativeEditor, 1);
+                        clickCell(1);
+                        await update;
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        // The first cell should be focused.
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
+
+                        // Add cell
+                        await addCell(wrapper, ioc, '', false);
+                        assert.equal(wrapper.find('NativeCell').length, 4);
+
+                        // New cell should have focus
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 2));
+
+                        const editorEnzyme = getNativeFocusedEditor(wrapper);
+
+                        // Type in something with brackets
+                        typeCode(editorEnzyme, 'a(');
+
+                        // Verify cell content
+                        const reactEditor = editorEnzyme!.instance() as MonacoEditor;
+                        const editor = reactEditor.state.editor;
+                        if (editor) {
+                            assert.equal(editor.getModel()!.getValue(), 'a()', 'Text does not have brackets');
+                        }
+                    });
+
+                    test('Navigating cells using up/down keys while focus is set to editor', async () => {
+                        wrapper.update();
+
+                        const firstCell = 0;
+                        const secondCell = 1;
+
+                        // Set focus to the first cell.
+                        let update = waitForUpdate(wrapper, NativeEditor, 1);
+                        clickCell(firstCell);
+                        await update;
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        simulateKeyPressOnCell(firstCell, { code: 'Enter' });
+                        await update;
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', firstCell));
+
+                        // Now press the down arrow, and focus should go to the next cell.
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        let monacoEditor = getNativeFocusedEditor(wrapper)!.instance() as MonacoEditor;
+                        monacoEditor.getCurrentVisibleLine = () => 0;
+                        monacoEditor.getVisibleLineCount = () => 1;
+                        simulateKeyPressOnCell(firstCell, { code: 'ArrowDown' });
+                        await update;
+
+                        // The next cell must be focused, but not selected.
+                        assert.isFalse(
+                            isCellFocused(wrapper, 'NativeCell', firstCell),
+                            'First new cell must not be focused'
+                        );
+                        assert.isTrue(
+                            isCellFocused(wrapper, 'NativeCell', secondCell),
+                            'Second new cell must be focused'
+                        );
+                        assert.isFalse(
+                            isCellSelected(wrapper, 'NativeCell', firstCell),
+                            'First new cell must not be selected'
+                        );
+                        assert.isFalse(
+                            isCellSelected(wrapper, 'NativeCell', secondCell),
+                            'Second new cell must not be selected'
+                        );
+
+                        // Now press the up arrow, and focus should go back to the first cell.
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        monacoEditor = getNativeFocusedEditor(wrapper)!.instance() as MonacoEditor;
+                        monacoEditor.getCurrentVisibleLine = () => 0;
+                        monacoEditor.getVisibleLineCount = () => 1;
+                        simulateKeyPressOnCell(firstCell, { code: 'ArrowUp' });
+                        await update;
+
+                        // The first cell must be focused, but not selected.
+                        assert.isTrue(
+                            isCellFocused(wrapper, 'NativeCell', firstCell),
+                            'First new cell must not be focused'
+                        );
+                        assert.isFalse(
+                            isCellFocused(wrapper, 'NativeCell', secondCell),
+                            'Second new cell must be focused'
+                        );
+                        assert.isFalse(
+                            isCellSelected(wrapper, 'NativeCell', firstCell),
+                            'First new cell must not be selected'
+                        );
+                        assert.isFalse(
+                            isCellSelected(wrapper, 'NativeCell', secondCell),
+                            'Second new cell must not be selected'
+                        );
+                    });
+
+                    test("Pressing 'd' on a selected cell twice deletes the cell", async () => {
+                        // Initially 3 cells.
+                        wrapper.update();
+                        assert.equal(wrapper.find('NativeCell').length, 3);
+
+                        clickCell(2);
+                        simulateKeyPressOnCell(2, { code: 'd' });
+                        simulateKeyPressOnCell(2, { code: 'd' });
+
+                        // There should be 2 cells.
+                        assert.equal(wrapper.find('NativeCell').length, 2);
+                    });
+
+                    test("Pressing 'a' on a selected cell adds a cell at the current position", async () => {
+                        // Initially 3 cells.
+                        wrapper.update();
+                        assert.equal(wrapper.find('NativeCell').length, 3);
+
+                        clickCell(0);
+                        const addedCell = waitForMessage(ioc, CommonActionType.INSERT_ABOVE_AND_FOCUS_NEW_CELL);
+                        const update = waitForUpdate(wrapper, NativeEditor, 1);
+                        simulateKeyPressOnCell(0, { code: 'a' });
+                        await Promise.all([update, addedCell]);
+
+                        // There should be 4 cells.
+                        assert.equal(wrapper.find('NativeCell').length, 4);
+
+                        // Verify cell indexes of old items.
+                        verifyCellIndex(wrapper, 'div[id="NotebookImport#0"]', 1);
+                        verifyCellIndex(wrapper, 'div[id="NotebookImport#1"]', 2);
+                        verifyCellIndex(wrapper, 'div[id="NotebookImport#2"]', 3);
+                    });
+
+                    test("Pressing 'b' on a selected cell adds a cell after the current position", async () => {
+                        // Initially 3 cells.
+                        wrapper.update();
+                        assert.equal(wrapper.find('NativeCell').length, 3);
+
+                        clickCell(1);
+                        const addedCell = waitForMessage(ioc, CommonActionType.INSERT_BELOW_AND_FOCUS_NEW_CELL);
+                        const update = waitForUpdate(wrapper, NativeEditor, 1);
+                        simulateKeyPressOnCell(1, { code: 'b' });
+                        await Promise.all([update, addedCell]);
+
+                        // There should be 4 cells.
+                        assert.equal(wrapper.find('NativeCell').length, 4);
+
+                        // Verify cell indexes of old items.
+                        verifyCellIndex(wrapper, 'div[id="NotebookImport#0"]', 0);
+                        verifyCellIndex(wrapper, 'div[id="NotebookImport#1"]', 1);
+                        verifyCellIndex(wrapper, 'div[id="NotebookImport#2"]', 3);
+                    });
+
+                    test('Toggle visibility of output', async () => {
+                        // First execute contents of last cell.
+                        let update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered);
+                        clickCell(2);
+                        simulateKeyPressOnCell(2, { code: 'Enter', ctrlKey: true, editorInfo: undefined });
+                        await update;
+
+                        // Ensure cell was executed.
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2);
+
+                        // Hide the output
+                        update = waitForUpdate(wrapper, NativeEditor, 1);
+                        simulateKeyPressOnCell(2, { code: 'o' });
+                        await update;
+
+                        // Ensure cell output is hidden (looking for cell results will throw an exception).
+                        assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2));
+
+                        // Display the output
+                        update = waitForUpdate(wrapper, NativeEditor, 1);
+                        simulateKeyPressOnCell(2, { code: 'o' });
+                        await update;
+
+                        // Ensure cell output is visible again.
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2);
+                    });
+
+                    test("Toggle line numbers using the 'l' key", async () => {
+                        clickCell(1);
+
+                        const monacoEditorComponent = wrapper
+                            .find(NativeCell)
+                            .at(1)
+                            .find(MonacoEditor)
+                            .first();
+                        const editor = (monacoEditorComponent.instance().state as IMonacoEditorState).editor!;
+                        const optionsUpdated = sinon.spy(editor, 'updateOptions');
+
+                        // Display line numbers.
+                        simulateKeyPressOnCell(1, { code: 'l' });
+                        // Confirm monaco editor got updated with line numbers set to turned on.
+                        assert.equal(optionsUpdated.lastCall.args[0].lineNumbers, 'on');
+
+                        // toggle the display of line numbers.
+                        simulateKeyPressOnCell(1, { code: 'l' });
+                        // Confirm monaco editor got updated with line numbers set to turned ff.
+                        assert.equal(optionsUpdated.lastCall.args[0].lineNumbers, 'off');
+                    });
+
+                    test("Toggle markdown and code modes using 'y' and 'm' keys (cells should not be focused)", async () => {
+                        clickCell(1);
+                        // Switch to markdown
+                        let update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
+                        simulateKeyPressOnCell(1, { code: 'm' });
+                        await update;
+
+                        // Monaco editor should be rendered and the cell should be markdown
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused');
+                        assert.ok(isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is not markdown');
+
+                        // Switch to code
+                        update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
+                        simulateKeyPressOnCell(1, { code: 'y' });
+                        await update;
+
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused 2nd time');
+                        assert.ok(!isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is markdown second time');
+                    });
+
+                    test("Toggle markdown and code modes using 'y' and 'm' keys & ensure changes to cells is preserved", async () => {
+                        clickCell(1);
+                        // Switch to markdown
+                        let update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
+                        simulateKeyPressOnCell(1, { code: 'm' });
+                        await update;
+
+                        // Monaco editor should be rendered and the cell should be markdown
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused');
+                        assert.ok(isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is not markdown');
+
+                        // Focus the cell.
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', 1));
+                        assert.equal(
+                            wrapper
+                                .find(NativeCell)
+                                .at(1)
+                                .find(MonacoEditor).length,
+                            1
+                        );
+
+                        // Change the markdown
+                        let editor = getNativeFocusedEditor(wrapper);
+                        injectCode(editor, 'foo');
+
+                        // Switch back to code mode.
+                        // First lose focus
+                        update = waitForMessage(ioc, InteractiveWindowMessages.UnfocusedCellEditor);
+                        simulateKeyPressOnCell(1, { code: 'Escape' });
+                        await update;
+
+                        // Confirm markdown output is rendered
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is focused');
+                        assert.ok(isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is not markdown');
+                        assert.equal(
+                            wrapper
+                                .find(NativeCell)
+                                .at(1)
+                                .find(MonacoEditor).length,
+                            0
+                        );
+
+                        // Switch to code
+                        update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
+                        simulateKeyPressOnCell(1, { code: 'y' });
+                        await update;
+
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', 1), '1st cell is not focused 2nd time');
+                        assert.ok(!isCellMarkdown(wrapper, 'NativeCell', 1), '1st cell is markdown second time');
+
+                        // Focus the cell.
+                        update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                        simulateKeyPressOnCell(1, { code: 'Enter', editorInfo: undefined });
+                        await update;
+
+                        // Confirm editor still has the same text
+                        editor = getNativeFocusedEditor(wrapper);
+                        const monacoEditor = editor!.instance() as MonacoEditor;
+                        assert.equal('foo', monacoEditor.state.editor!.getValue(), 'Changing cell type lost input');
+                    });
+
+                    test("Test undo using the key 'z'", async function() {
+                        if (useCustomEditorApi) {
+                            // tslint:disable-next-line: no-invalid-this
+                            return this.skip();
+                        }
+                        clickCell(0);
+
+                        // Add, then undo, keep doing at least 3 times and confirm it works as expected.
+                        for (let i = 0; i < 3; i += 1) {
+                            // Add a new cell
+                            let update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                            simulateKeyPressOnCell(0, { code: 'a' });
+                            await update;
+
+                            // Wait a bit for the time out to try and set focus a second time (this will be
+                            // fixed when we switch to redux)
+                            await sleep(100);
+
+                            // There should be 4 cells and first cell is focused.
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 0), true);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
+                            assert.equal(wrapper.find('NativeCell').length, 4);
+
+                            // Unfocus the cell
+                            update = waitForUpdate(wrapper, NativeEditor, 1);
+                            simulateKeyPressOnCell(0, { code: 'Escape' });
+                            await update;
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
+
+                            // Press 'ctrl+z'. This should do nothing
+                            update = waitForUpdate(wrapper, NativeEditor, 1);
+                            simulateKeyPressOnCell(0, { code: 'z', ctrlKey: true });
+                            await waitForPromise(update, 100);
+
+                            // There should be 4 cells and first cell is selected.
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
+                            assert.equal(wrapper.find('NativeCell').length, 4);
+
+                            // Press 'z' to undo.
+                            update = waitForUpdate(wrapper, NativeEditor, 1);
+                            simulateKeyPressOnCell(0, { code: 'z' });
+                            await update;
+
+                            // There should be 3 cells and first cell is selected & nothing focused.
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                            assert.equal(wrapper.find('NativeCell').length, 3);
+
+                            // Press 'shift+z' to redo
+                            update = waitForUpdate(wrapper, NativeEditor, 1);
+                            simulateKeyPressOnCell(0, { code: 'z', shiftKey: true });
+                            await update;
+
+                            // There should be 4 cells and first cell is selected.
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
+                            assert.equal(wrapper.find('NativeCell').length, 4);
+
+                            // Press 'z' to undo.
+                            update = waitForUpdate(wrapper, NativeEditor, 1);
+                            simulateKeyPressOnCell(0, { code: 'z' });
+                            await update;
+
+                            // There should be 3 cells and first cell is selected & nothing focused.
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
+                            assert.equal(wrapper.find('NativeCell').length, 3);
+                        }
+                    });
+
+                    test("Test save using the key 'ctrl+s' on Windows", async function() {
+                        if (useCustomEditorApi) {
+                            // tslint:disable-next-line: no-invalid-this
+                            return this.skip();
+                        }
+                        (window.navigator as any).platform = 'Win';
+                        clickCell(0);
+
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        await addCell(wrapper, ioc, 'a=1\na', true);
+                        await dirtyPromise;
+
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookProvider.editors[0];
+                        assert.ok(editor, 'No editor when saving');
+                        const savedPromise = createDeferred();
+                        editor.saved(() => savedPromise.resolve());
+
+                        const clean = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        simulateKeyPressOnCell(1, { code: 's', ctrlKey: true });
+                        await waitForCondition(
+                            () => savedPromise.promise.then(() => true).catch(() => false),
+                            10_000,
+                            'Timedout'
+                        );
+                        await clean;
+                        assert.ok(!editor!.isDirty, 'Editor should not be dirty after saving');
+                    });
+
+                    test("Test save using the key 'ctrl+s' on Mac", async function() {
+                        if (useCustomEditorApi) {
+                            // tslint:disable-next-line: no-invalid-this
+                            return this.skip();
+                        }
+                        (window.navigator as any).platform = 'Mac';
+                        clickCell(0);
+
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        await addCell(wrapper, ioc, 'a=1\na', true);
+                        await dirtyPromise;
+
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookProvider.editors[0];
+                        assert.ok(editor, 'No editor when saving');
+                        const savedPromise = createDeferred();
+                        editor.saved(() => savedPromise.resolve());
+
+                        simulateKeyPressOnCell(1, { code: 's', ctrlKey: true });
+
+                        await expect(
+                            waitForCondition(
+                                () => savedPromise.promise.then(() => true).catch(() => false),
+                                1_000,
+                                'Timedout'
+                            )
+                        ).to.eventually.be.rejected;
+
+                        assert.ok(editor!.isDirty, 'Editor be dirty as nothing got saved');
+                    });
+
+                    test("Test save using the key 'cmd+s' on a Mac", async function() {
+                        if (useCustomEditorApi) {
+                            // tslint:disable-next-line: no-invalid-this
+                            return this.skip();
+                        }
+                        (window.navigator as any).platform = 'Mac';
+
+                        clickCell(0);
+
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        await addCell(wrapper, ioc, 'a=1\na', true);
+                        await dirtyPromise;
+
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookProvider.editors[0];
+                        assert.ok(editor, 'No editor when saving');
+                        const savedPromise = createDeferred();
+                        editor.saved(() => savedPromise.resolve());
+
+                        simulateKeyPressOnCell(1, { code: 's', metaKey: true });
+
+                        const clean = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        await waitForCondition(
+                            () => savedPromise.promise.then(() => true).catch(() => false),
+                            1_000,
+                            'Timedout'
+                        );
+                        await clean;
+
+                        assert.ok(!editor!.isDirty, 'Editor should not be dirty after saving');
+                    });
+                    test("Test save using the key 'cmd+s' on a Windows", async function() {
+                        if (useCustomEditorApi) {
+                            // tslint:disable-next-line: no-invalid-this
+                            return this.skip();
+                        }
+                        (window.navigator as any).platform = 'Win';
+
+                        clickCell(0);
+
+                        await addCell(wrapper, ioc, 'a=1\na', true);
+
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookProvider.editors[0];
+                        assert.ok(editor, 'No editor when saving');
+                        const savedPromise = createDeferred();
+                        editor.saved(() => savedPromise.resolve());
+
+                        // CMD+s won't work on Windows.
+                        simulateKeyPressOnCell(1, { code: 's', metaKey: true });
+
+                        await expect(
+                            waitForCondition(
+                                () => savedPromise.promise.then(() => true).catch(() => false),
+                                1_000,
+                                'Timedout'
+                            )
+                        ).to.eventually.be.rejected;
+
+                        assert.ok(editor!.isDirty, 'Editor be dirty as nothing got saved');
+                    });
+                });
+
+                suite('Auto Save', () => {
+                    let windowStateChangeHandlers: ((e: WindowState) => any)[] = [];
+                    setup(async function() {
+                        if (useCustomEditorApi) {
+                            // tslint:disable-next-line: no-invalid-this
+                            return this.skip();
+                        }
+                        initIoc();
+
+                        windowStateChangeHandlers = [];
+                        // Keep track of all handlers for the onDidChangeWindowState event.
+                        ioc.applicationShell
+                            .setup(app => app.onDidChangeWindowState(TypeMoq.It.isAny()))
+                            .callback(cb => windowStateChangeHandlers.push(cb));
+
+                        // tslint:disable-next-line: no-invalid-this
+                        await setupFunction.call(this);
+                    });
+                    teardown(() => sinon.restore());
+
+                    /**
+                     * Make some kind of a change to the notebook.
+                     *
+                     * @param {number} cellIndex
+                     */
+                    async function modifyNotebook() {
+                        // (Add a cell into the UI)
+                        await addCell(wrapper, ioc, 'a', false);
+                    }
+
+                    test('Auto save notebook every 1s', async () => {
+                        // Configure notebook to save automatically ever 1s.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('afterDelay');
+                        when(ioc.mockedWorkspaceConfig.get<number>('autoSaveDelay', anything())).thenReturn(1_000);
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
+
+                        /**
+                         * Make some changes to a cell of a notebook, then verify the notebook is auto saved.
+                         *
+                         * @param {number} cellIndex
+                         */
+                        async function makeChangesAndConfirmFileIsUpdated() {
+                            const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                            const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                            const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+
+                            await modifyNotebook();
+                            await dirtyPromise;
+
+                            // At this point a message should be sent to extension asking it to save.
+                            // After the save, the extension should send a message to react letting it know that it was saved successfully.
+                            await cleanPromise;
+
+                            // Confirm file has been updated as well.
+                            const newFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                            assert.notEqual(newFileContents, notebookFileContents);
+                        }
+
+                        // Make changes & validate (try a couple of times).
+                        await makeChangesAndConfirmFileIsUpdated();
+                        await makeChangesAndConfirmFileIsUpdated();
+                        await makeChangesAndConfirmFileIsUpdated();
+                    });
+
+                    test('File saved with same format', async () => {
+                        // Configure notebook to save automatically ever 1s.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('afterDelay');
+                        when(ioc.mockedWorkspaceConfig.get<number>('autoSaveDelay', anything())).thenReturn(2_000);
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
+                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+
+                        await modifyNotebook();
+                        await dirtyPromise;
+
+                        // At this point a message should be sent to extension asking it to save.
+                        // After the save, the extension should send a message to react letting it know that it was saved successfully.
+                        await cleanPromise;
+
+                        // Confirm file is not the same. There should be a single cell that's been added
+                        const newFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                        assert.notEqual(newFileContents, notebookFileContents);
+                        assert.equal(newFileContents, addedJSONFile);
+                    });
+
+                    test('Should not auto save notebook, ever', async () => {
+                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+
+                        // Configure notebook to to never save.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('off');
+                        when(ioc.mockedWorkspaceConfig.get<number>('autoSaveDelay', anything())).thenReturn(1000);
+                        // Update the settings and wait for the component to receive it and process it.
+                        const promise = waitForMessage(ioc, InteractiveWindowMessages.SettingsUpdated);
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath, {
+                            ...defaultDataScienceSettings(),
+                            showCellInputCode: false
+                        });
+                        await promise;
+
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, {
+                            timeoutMs: 5_000
+                        });
+
+                        await modifyNotebook();
+                        await dirtyPromise;
+
+                        // Now that the notebook is dirty, change the active editor.
+                        const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
+                        docManager.didChangeActiveTextEditorEmitter.fire();
+                        // Also, send notification about changes to window state.
+                        windowStateChangeHandlers.forEach(item => item({ focused: false }));
+                        windowStateChangeHandlers.forEach(item => item({ focused: true }));
+
+                        // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
+                        await expect(cleanPromise).to.eventually.be.rejected;
+                        // Confirm file has not been updated as well.
+                        assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
+                    }).timeout(10_000);
+
+                    async function testAutoSavingWhenEditorFocusChanges(newEditor: TextEditor | undefined) {
+                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+
+                        await modifyNotebook();
+                        await dirtyPromise;
+
+                        // Configure notebook to save when active editor changes.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onFocusChange');
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
+
+                        // Now that the notebook is dirty, change the active editor.
+                        const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
+                        docManager.didChangeActiveTextEditorEmitter.fire(newEditor);
+
+                        // At this point a message should be sent to extension asking it to save.
+                        // After the save, the extension should send a message to react letting it know that it was saved successfully.
+                        await cleanPromise;
+
+                        // Confirm file has been updated as well.
+                        assert.notEqual(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
+                    }
+
+                    test('Auto save notebook when focus changes from active editor to none', () =>
+                        testAutoSavingWhenEditorFocusChanges(undefined));
+
+                    test('Auto save notebook when focus changes from active editor to something else', () =>
+                        testAutoSavingWhenEditorFocusChanges(TypeMoq.Mock.ofType<TextEditor>().object));
+
+                    test('Should not auto save notebook when active editor changes', async () => {
+                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, {
+                            timeoutMs: 5_000
+                        });
+
+                        await modifyNotebook();
+                        await dirtyPromise;
+
+                        // Configure notebook to save when window state changes.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onWindowChange');
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
+
+                        // Now that the notebook is dirty, change the active editor.
+                        // This should not trigger a save of notebook (as its configured to save only when window state changes).
+                        const docManager = ioc.get<IDocumentManager>(IDocumentManager) as MockDocumentManager;
+                        docManager.didChangeActiveTextEditorEmitter.fire();
+
+                        // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
+                        await expect(cleanPromise).to.eventually.be.rejected;
+                        // Confirm file has not been updated as well.
+                        assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
+                    }).timeout(10_000);
+
+                    async function testAutoSavingWithChangesToWindowState(focused: boolean) {
+                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+
+                        await modifyNotebook();
+                        await dirtyPromise;
+
+                        // Configure notebook to save when active editor changes.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onWindowChange');
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
+
+                        // Now that the notebook is dirty, send notification about changes to window state.
+                        windowStateChangeHandlers.forEach(item => item({ focused }));
+
+                        // At this point a message should be sent to extension asking it to save.
+                        // After the save, the extension should send a message to react letting it know that it was saved successfully.
+                        await cleanPromise;
+
+                        // Confirm file has been updated as well.
+                        assert.notEqual(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
+                    }
+
+                    test('Auto save notebook when window state changes to being not focused', async () =>
+                        testAutoSavingWithChangesToWindowState(false));
+                    test('Auto save notebook when window state changes to being focused', async () =>
+                        testAutoSavingWithChangesToWindowState(true));
+
+                    test('Should not auto save notebook when window state changes', async () => {
+                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
+                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
+                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, {
+                            timeoutMs: 5_000
+                        });
+
+                        await modifyNotebook();
+                        await dirtyPromise;
+
+                        // Configure notebook to save when active editor changes.
+                        when(ioc.mockedWorkspaceConfig.get('autoSave', 'off')).thenReturn('onFocusChange');
+                        ioc.forceSettingsChanged(ioc.getSettings().pythonPath);
+
+                        // Now that the notebook is dirty, change window state.
+                        // This should not trigger a save of notebook (as its configured to save only when focus is changed).
+                        windowStateChangeHandlers.forEach(item => item({ focused: false }));
+                        windowStateChangeHandlers.forEach(item => item({ focused: true }));
+
+                        // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
+                        await expect(cleanPromise).to.eventually.be.rejected;
+                        // Confirm file has not been updated as well.
+                        assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
+                    }).timeout(10_000);
+                });
+
+                const oldJson: nbformat.INotebookContent = {
+                    nbformat: 4,
+                    nbformat_minor: 2,
+                    cells: [
+                        {
+                            cell_type: 'code',
+                            execution_count: 1,
+                            metadata: {
+                                collapsed: true
+                            },
+                            outputs: [
+                                {
+                                    data: {
+                                        'text/plain': ['1']
+                                    },
+                                    output_type: 'execute_result',
+                                    execution_count: 1,
+                                    metadata: {}
+                                }
+                            ],
+                            source: ['a=1\n', 'a']
+                        },
+                        {
+                            cell_type: 'code',
+                            execution_count: 2,
+                            metadata: {},
+                            outputs: [
+                                {
+                                    data: {
+                                        'text/plain': ['2']
+                                    },
+                                    output_type: 'execute_result',
+                                    execution_count: 2,
+                                    metadata: {}
+                                }
+                            ],
+                            source: ['b=2\n', 'b']
+                        },
+                        {
+                            cell_type: 'code',
+                            execution_count: 3,
+                            metadata: {},
+                            outputs: [
+                                {
+                                    data: {
+                                        'text/plain': ['3']
+                                    },
+                                    output_type: 'execute_result',
+                                    execution_count: 3,
+                                    metadata: {}
+                                }
+                            ],
+                            source: ['c=3\n', 'c']
+                        }
+                    ],
+                    metadata: {
+                        orig_nbformat: 4,
+                        kernelspec: {
+                            display_name: 'JUNK',
+                            name: 'JUNK'
+                        },
+                        language_info: {
+                            name: 'python',
+                            version: '1.2.3'
+                        }
+                    }
+                };
+
+                suite('Update Metadata', () => {
+                    setup(async function() {
+                        initIoc();
+                        // tslint:disable-next-line: no-invalid-this
+                        await setupFunction.call(this, JSON.stringify(oldJson));
+                    });
+
+                    test('Update notebook metadata on execution', async () => {
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookProvider.editors[0];
+                        assert.ok(editor, 'No editor when saving');
+
+                        // add cells, run them and save
+                        await addCell(wrapper, ioc, 'a=1\na');
+                        const runAllButton = findButton(wrapper, NativeEditor, 0);
+                        const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
+                        await threeCellsUpdated;
+
+                        const saveButton = findButton(wrapper, NativeEditor, 8);
+                        const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
+                        await saved;
+
+                        // the file has output and execution count
+                        const fileContent = await fs.readFile(notebookFile.filePath, 'utf8');
+                        const fileObject = JSON.parse(fileContent);
+
+                        // First cell should still have the 'collapsed' metadata
+                        assert.ok(fileObject.cells[0].metadata.collapsed, 'Metadata erased during execution');
+
+                        // The version should be updated to something not "1.2.3"
+                        assert.notEqual(fileObject.metadata.language_info.version, '1.2.3');
+
+                        // Some tests don't have a kernelspec, in which case we should remove it
+                        // If there is a spec, we should update the name and display name
+                        const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
+                        if (isRollingBuild && fileObject.metadata.kernelspec) {
+                            assert.notEqual(fileObject.metadata.kernelspec.display_name, 'JUNK');
+                            assert.notEqual(fileObject.metadata.kernelspec.name, 'JUNK');
+                        }
+                    });
+                });
+
+                suite('Clear Outputs', () => {
+                    setup(async function() {
+                        initIoc();
+                        // tslint:disable-next-line: no-invalid-this
+                        await setupFunction.call(this, JSON.stringify(oldJson));
+                    });
+
+                    function verifyExecutionCount(cellIndex: number, executionCountContent: string) {
+                        assert.equal(
+                            wrapper
+                                .find(ExecutionCount)
+                                .at(cellIndex)
+                                .props().count,
+                            executionCountContent
+                        );
+                    }
+
+                    test('Clear Outputs in WebView', async () => {
+                        const runAllButton = findButton(wrapper, NativeEditor, 0);
+                        const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
+                        await threeCellsUpdated;
+
+                        verifyExecutionCount(0, '1');
+                        verifyExecutionCount(1, '2');
+                        verifyExecutionCount(2, '3');
+
+                        // Press clear all outputs
+                        const clearAllOutput = waitForMessage(ioc, InteractiveWindowMessages.ClearAllOutputs);
+                        const clearAllOutputButton = findButton(wrapper, NativeEditor, 6);
+                        await waitForMessageResponse(ioc, () => clearAllOutputButton!.simulate('click'));
+                        await clearAllOutput;
+
+                        verifyExecutionCount(0, '-');
+                        verifyExecutionCount(1, '-');
+                        verifyExecutionCount(2, '-');
+                    });
+
+                    test('Clear execution_count and outputs in notebook', async () => {
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookProvider.editors[0];
+                        assert.ok(editor, 'No editor when saving');
+                        // add cells, run them and save
+                        // await addCell(wrapper, ioc, 'a=1\na');
+                        const runAllButton = findButton(wrapper, NativeEditor, 0);
+                        const threeCellsUpdated = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        await waitForMessageResponse(ioc, () => runAllButton!.simulate('click'));
+                        await threeCellsUpdated;
+
+                        const saveButton = findButton(wrapper, NativeEditor, 8);
+                        let saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
+                        await saved;
+
+                        // press clear all outputs, and save
+                        const clearAllOutputButton = findButton(wrapper, NativeEditor, 6);
+                        await waitForMessageResponse(ioc, () => clearAllOutputButton!.simulate('click'));
+
+                        saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
+                        await saved;
+
+                        const nb = JSON.parse(
+                            await fs.readFile(notebookFile.filePath, 'utf8')
+                        ) as nbformat.INotebookContent;
+                        assert.equal(nb.cells[0].execution_count, null);
+                        assert.equal(nb.cells[1].execution_count, null);
+                        assert.equal(nb.cells[2].execution_count, null);
+                        expect(nb.cells[0].outputs).to.be.lengthOf(0);
+                        expect(nb.cells[1].outputs).to.be.lengthOf(0);
+                        expect(nb.cells[2].outputs).to.be.lengthOf(0);
+                    });
+                });
             });
         });
     });

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1366,9 +1366,10 @@ df.head()`;
                 assert.equal(wrapper.find('NativeCell').length, 3);
 
                 clickCell(1);
+                const addedCell = waitForMessage(ioc, CommonActionType.INSERT_BELOW_AND_FOCUS_NEW_CELL);
                 const update = waitForUpdate(wrapper, NativeEditor, 1);
                 simulateKeyPressOnCell(1, { code: 'b' });
-                await update;
+                await Promise.all([update, addedCell]);
 
                 // There should be 4 cells.
                 assert.equal(wrapper.find('NativeCell').length, 4);

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -80,7 +80,7 @@ use(chaiAsPromised);
 
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
 
-suite('xDataScience Native Editor', () => {
+suite('DataScience Native Editor', () => {
     const originalPlatform = window.navigator.platform;
     Object.defineProperty(
         window.navigator,

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -77,8 +77,8 @@ import {
 } from './testHelpers';
 
 use(chaiAsPromised);
+
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
-// tslint:disable:no-any no-multiline-string max-func-body-length no-console max-classes-per-file trailing-comma
 
 suite('xDataScience Native Editor', () => {
     const originalPlatform = window.navigator.platform;

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1596,7 +1596,9 @@ df.head()`;
                 (window.navigator as any).platform = 'Win';
                 clickCell(0);
 
+                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
                 await addCell(wrapper, ioc, 'a=1\na', true);
+                await dirtyPromise;
 
                 const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
                 const editor = notebookProvider.editors[0];
@@ -1604,15 +1606,14 @@ df.head()`;
                 const savedPromise = createDeferred();
                 editor.saved(() => savedPromise.resolve());
 
+                const clean = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
                 simulateKeyPressOnCell(1, { code: 's', ctrlKey: true });
-                console.error('1');
                 await waitForCondition(
                     () => savedPromise.promise.then(() => true).catch(() => false),
-                    1_000,
+                    10_000,
                     'Timedout'
                 );
-                console.error('2');
-
+                await clean;
                 assert.ok(!editor!.isDirty, 'Editor should not be dirty after saving');
             });
 
@@ -1620,7 +1621,9 @@ df.head()`;
                 (window.navigator as any).platform = 'Mac';
                 clickCell(0);
 
+                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
                 await addCell(wrapper, ioc, 'a=1\na', true);
+                await dirtyPromise;
 
                 const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
                 const editor = notebookProvider.editors[0];
@@ -1633,6 +1636,7 @@ df.head()`;
                 await expect(
                     waitForCondition(() => savedPromise.promise.then(() => true).catch(() => false), 1_000, 'Timedout')
                 ).to.eventually.be.rejected;
+
                 assert.ok(editor!.isDirty, 'Editor be dirty as nothing got saved');
             });
 
@@ -1641,7 +1645,9 @@ df.head()`;
 
                 clickCell(0);
 
+                const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
                 await addCell(wrapper, ioc, 'a=1\na', true);
+                await dirtyPromise;
 
                 const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
                 const editor = notebookProvider.editors[0];
@@ -1651,11 +1657,13 @@ df.head()`;
 
                 simulateKeyPressOnCell(1, { code: 's', metaKey: true });
 
+                const clean = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
                 await waitForCondition(
                     () => savedPromise.promise.then(() => true).catch(() => false),
                     1_000,
                     'Timedout'
                 );
+                await clean;
 
                 assert.ok(!editor!.isDirty, 'Editor should not be dirty after saving');
             });
@@ -1678,6 +1686,7 @@ df.head()`;
                 await expect(
                     waitForCondition(() => savedPromise.promise.then(() => true).catch(() => false), 1_000, 'Timedout')
                 ).to.eventually.be.rejected;
+
                 assert.ok(editor!.isDirty, 'Editor be dirty as nothing got saved');
             });
         });

--- a/src/test/datascience/testNativeEditorProvider.ts
+++ b/src/test/datascience/testNativeEditorProvider.ts
@@ -10,6 +10,7 @@ import {
     IDocumentManager,
     IWorkspaceService
 } from '../../client/common/application/types';
+import { UseCustomEditorApi } from '../../client/common/constants';
 import { IFileSystem } from '../../client/common/platform/types';
 import {
     IAsyncDisposableRegistry,
@@ -44,7 +45,7 @@ export class TestNativeEditorProvider implements INotebookEditorProvider {
     }
 
     constructor(
-        @inject('USE_CUSTOM_EDITOR') useCustomEditor: boolean,
+        @inject(UseCustomEditorApi) useCustomEditor: boolean,
         @inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,


### PR DESCRIPTION
Restore old webview provider so ds/cusom_editor can be merged into master.
* Bug fix with run all cells
* Removed error message from telemetry, as it can contain PII

**Separate PRs to:**
* [x] Restore tests
    * [x] Double check all
    * [x] Save As
    * [x] Save
    * [x] Hot exit
    * [x] Undo/redo
    * [x] Keyboard shortcuts (`z`)
* [x] Opening ipynb in notebook
* [x] Open all ipynb in notebook editor after extension activates
* [x] Restore undo/redo or similar (what ever has been removed)
* [x] Restore support for saving (save and save as)
* [x] Restore hot exit (saving when existing VSC and restoring after opening VSC)
* [x] Restore other features that have been removed/disabled as a result of using the new VSC custom editor (i.e. restore old webview approach functionality)

# Note: Custom editor has been disabled in this PR.
Once merged into master, I'll bring them back as a subsequent PR.
