### PR TITLE
Add telemetry to capture perf of methods between two points in time

### DIFF
--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -103,7 +103,9 @@ function buildConfiguration(isNotebook) {
         devtool: 'source-map',
         optimization: {
             minimize: isProdBuild,
-            minimizer: isProdBuild ? [new TerserPlugin({ sourceMap: true })] : [],
+            minimizer: isProdBuild
+                ? [new TerserPlugin({ sourceMap: true, terserOptions: { keep_classnames: true } })]
+                : [],
             moduleIds: 'hashed', // (doesn't re-generate bundles unnecessarily) https://webpack.js.org/configuration/optimization/#optimizationmoduleids.
             splitChunks: {
                 chunks: 'all',

--- a/news/3 Code Health/10252.md
+++ b/news/3 Code Health/10252.md
@@ -1,0 +1,1 @@
+Add ability to capture performance telemetry across two points in time.

--- a/src/client/common/variables/environmentVariablesProvider.ts
+++ b/src/client/common/variables/environmentVariablesProvider.ts
@@ -3,6 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import { ConfigurationChangeEvent, Disposable, Event, EventEmitter, FileSystemWatcher, Uri } from 'vscode';
+import { capturePerformance } from '../../telemetry';
 import { IWorkspaceService } from '../application/types';
 import { IPlatformService } from '../platform/types';
 import { IConfigurationService, ICurrentProcess, IDisposableRegistry } from '../types';
@@ -42,6 +43,7 @@ export class EnvironmentVariablesProvider implements IEnvironmentVariablesProvid
             }
         });
     }
+    @capturePerformance()
     @cacheResourceSpecificInterpreterData('getEnvironmentVariables', cacheDuration)
     public async getEnvironmentVariables(resource?: Uri): Promise<EnvironmentVariables> {
         let mergedVars = await this.getCustomEnvironmentVariables(resource);

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandFinder.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandFinder.ts
@@ -29,7 +29,7 @@ import {
     IKnownSearchPathsForInterpreters,
     PythonInterpreter
 } from '../../../interpreter/contracts';
-import { sendTelemetryEvent } from '../../../telemetry';
+import { capturePerformance, sendTelemetryEvent } from '../../../telemetry';
 import { JupyterCommands, PythonDaemonModule, RegExpValues, Telemetry } from '../../constants';
 import { IJupyterCommand, IJupyterCommandFactory } from '../../types';
 
@@ -578,6 +578,7 @@ export class JupyterCommandFinder extends JupyterCommandFinderImpl {
     private get cacheStore(): CacheInfo {
         return this.workspace.hasWorkspaceFolders ? this.workspaceJupyterInterpreter : this.globalJupyterInterpreter;
     }
+    @capturePerformance()
     public findBestCommand(command: JupyterCommands, token?: CancellationToken): Promise<IFindCommandResult> {
         if (
             command === JupyterCommands.NotebookCommand &&

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -20,6 +20,7 @@ import { JupyterServerInfo } from '../jupyterConnection';
 import { JupyterInstallError } from '../jupyterInstallError';
 import { JupyterKernelSpec, parseKernelSpecs } from '../kernels/jupyterKernelSpec';
 import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder';
+import { capturePerformance } from '../../../telemetry';
 
 /**
  * Responsible for execution of jupyter sub commands using the command finder and related classes.
@@ -68,6 +69,7 @@ export class JupyterCommandFinderInterpreterExecutionService implements IJupyter
 
         return undefined;
     }
+    @capturePerformance()
     public async startNotebook(
         notebookArgs: string[],
         options: SpawnOptions
@@ -78,6 +80,7 @@ export class JupyterCommandFinderInterpreterExecutionService implements IJupyter
         return notebookCommand!.command!.execObservable(notebookArgs, options);
     }
 
+    @capturePerformance()
     public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
         const [interpreter, activeInterpreter] = await Promise.all([
             this.getSelectedInterpreter(token),

--- a/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommandInterpreterExecutionService.ts
@@ -14,13 +14,13 @@ import { DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
+import { capturePerformance } from '../../../telemetry';
 import { JupyterCommands, PythonDaemonModule } from '../../constants';
 import { IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterServerInfo } from '../jupyterConnection';
 import { JupyterInstallError } from '../jupyterInstallError';
 import { JupyterKernelSpec, parseKernelSpecs } from '../kernels/jupyterKernelSpec';
 import { IFindCommandResult, JupyterCommandFinder } from './jupyterCommandFinder';
-import { capturePerformance } from '../../../telemetry';
 
 /**
  * Responsible for execution of jupyter sub commands using the command finder and related classes.

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -13,7 +13,7 @@ import { IInstaller, InstallerResponse, Product } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { PythonInterpreter } from '../../../interpreter/contracts';
-import { sendTelemetryEvent } from '../../../telemetry';
+import { capturePerformance, sendTelemetryEvent } from '../../../telemetry';
 import { HelpLinks, JupyterCommands, Telemetry } from '../../constants';
 import { IJupyterCommandFactory } from '../../types';
 import { JupyterInstallError } from '../jupyterInstallError';
@@ -126,6 +126,7 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<JupyterInterpreterDependencyResponse>}
      * @memberof JupyterInterpreterDependencyService
      */
+    @capturePerformance()
     public async installMissingDependencies(
         interpreter: PythonInterpreter,
         _error?: JupyterInstallError,
@@ -213,6 +214,7 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<boolean>}
      * @memberof JupyterInterpreterConfigurationService
      */
+    @capturePerformance()
     public async areDependenciesInstalled(interpreter: PythonInterpreter, token?: CancellationToken): Promise<boolean> {
         return this.getDependenciesNotInstalled(interpreter, token).then(items => items.length === 0);
     }
@@ -226,6 +228,7 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<boolean>}
      * @memberof JupyterInterpreterConfigurationService
      */
+    @capturePerformance()
     public async isExportSupported(interpreter: PythonInterpreter, _token?: CancellationToken): Promise<boolean> {
         if (this.nbconvertInstalledInInterpreter.has(interpreter.path)) {
             return true;
@@ -245,6 +248,7 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<Product[]>}
      * @memberof JupyterInterpreterConfigurationService
      */
+    @capturePerformance()
     public async getDependenciesNotInstalled(
         interpreter: PythonInterpreter,
         token?: CancellationToken
@@ -292,6 +296,7 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<boolean>}
      * @memberof JupyterInterpreterConfigurationService
      */
+    @capturePerformance()
     private async isKernelSpecAvailable(interpreter: PythonInterpreter, _token?: CancellationToken): Promise<boolean> {
         const command = this.commandFactory.createInterpreterCommand(
             JupyterCommands.KernelSpecCommand,
@@ -322,6 +327,7 @@ export class JupyterInterpreterDependencyService {
      * @returns {Promise<JupyterInterpreterDependencyResponse>}
      * @memberof JupyterInterpreterConfigurationService
      */
+    @capturePerformance()
     private async checkKernelSpecAvailability(
         interpreter: PythonInterpreter,
         token?: CancellationToken

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterService.ts
@@ -10,7 +10,7 @@ import { createPromiseFromCancellation } from '../../../common/cancellation';
 import '../../../common/extensions';
 import { noop } from '../../../common/utils/misc';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
-import { sendTelemetryEvent } from '../../../telemetry';
+import { capturePerformance, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
 import {
     JupyterInterpreterDependencyResponse,
@@ -45,6 +45,7 @@ export class JupyterInterpreterService {
      * @returns {(Promise<PythonInterpreter | undefined>)}
      * @memberof JupyterInterpreterService
      */
+    @capturePerformance()
     public async getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined> {
         // Before we return _selected interpreter make sure that we have run our initial set interpreter once
         // because _selectedInterpreter can be changed by other function and at other times, this promise
@@ -138,6 +139,7 @@ export class JupyterInterpreterService {
 
     // For a given python path check if it can run jupyter for us
     // if so, return the interpreter
+    @capturePerformance()
     private async validateInterpreterPath(
         pythonPath: string,
         token?: CancellationToken
@@ -167,6 +169,7 @@ export class JupyterInterpreterService {
         return undefined;
     }
 
+    @capturePerformance()
     private async getInitialInterpreterImpl(token?: CancellationToken): Promise<PythonInterpreter | undefined> {
         let interpreter: PythonInterpreter | undefined;
 

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -15,7 +15,7 @@ import { DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
-import { sendTelemetryEvent } from '../../../telemetry';
+import { capturePerformance, sendTelemetryEvent } from '../../../telemetry';
 import { JUPYTER_OUTPUT_CHANNEL, PythonDaemonModule, Telemetry } from '../../constants';
 import { IJupyterInterpreterDependencyManager, IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterServerInfo } from '../jupyterConnection';
@@ -100,6 +100,7 @@ export class JupyterInterpreterSubCommandExecutionService
     public async getSelectedInterpreter(token?: CancellationToken): Promise<PythonInterpreter | undefined> {
         return this.jupyterInterpreter.getSelectedInterpreter(token);
     }
+    @capturePerformance()
     public async startNotebook(
         notebookArgs: string[],
         options: SpawnOptions
@@ -118,6 +119,7 @@ export class JupyterInterpreterSubCommandExecutionService
         return executionService.execModuleObservable('jupyter', ['notebook'].concat(notebookArgs), options);
     }
 
+    @capturePerformance()
     public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
         const daemon = await this.pythonExecutionFactory.createDaemon({
@@ -176,6 +178,7 @@ export class JupyterInterpreterSubCommandExecutionService
             .ignoreErrors();
     }
 
+    @capturePerformance()
     public async getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
         const daemon = await this.pythonExecutionFactory.createDaemon({
@@ -226,6 +229,7 @@ export class JupyterInterpreterSubCommandExecutionService
         }
     }
 
+    @capturePerformance()
     public async installMissingDependencies(err?: JupyterInstallError): Promise<void> {
         let interpreter = await this.jupyterInterpreter.getSelectedInterpreter();
         if (!interpreter) {

--- a/src/client/datascience/jupyter/jupyterConnection.ts
+++ b/src/client/datascience/jupyter/jupyterConnection.ts
@@ -13,10 +13,10 @@ import { IConfigurationService, IDisposable } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { IServiceContainer } from '../../ioc/types';
+import { capturePerformance } from '../../telemetry';
 import { RegExpValues } from '../constants';
 import { IConnection } from '../types';
 import { JupyterConnectError } from './jupyterConnectError';
-import { capturePerformance } from '../../telemetry';
 
 // tslint:disable-next-line:no-require-imports no-var-requires no-any
 const namedRegexp = require('named-js-regexp');

--- a/src/client/datascience/jupyter/jupyterConnection.ts
+++ b/src/client/datascience/jupyter/jupyterConnection.ts
@@ -16,6 +16,7 @@ import { IServiceContainer } from '../../ioc/types';
 import { RegExpValues } from '../constants';
 import { IConnection } from '../types';
 import { JupyterConnectError } from './jupyterConnectError';
+import { capturePerformance } from '../../telemetry';
 
 // tslint:disable-next-line:no-require-imports no-var-requires no-any
 const namedRegexp = require('named-js-regexp');
@@ -94,6 +95,7 @@ export class JupyterConnectionWaiter implements IDisposable {
         clearTimeout(this.launchTimeout as any);
     }
 
+    @capturePerformance()
     public waitForConnection(): Promise<IConnection> {
         return this.startPromise.promise;
     }

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -358,7 +358,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
     }
 
     // tslint:disable-next-line: max-func-body-length
-    @captureTelemetry(Telemetry.StartJupyter)
+    @captureTelemetry(Telemetry.StartJupyter, undefined, true, undefined, true)
     private async startNotebookServer(
         useDefaultConfig: boolean,
         customCommandLine: string[],

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -20,7 +20,7 @@ import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { PythonInterpreter } from '../../interpreter/contracts';
-import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
+import { capturePerformance, captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { generateCells } from '../cellFactory';
 import { CellMatcher } from '../cellMatcher';
 import { CodeSnippits, Identifiers, Telemetry } from '../constants';
@@ -235,11 +235,13 @@ export class JupyterNotebookBase implements INotebook {
         return this._identity;
     }
 
+    @capturePerformance()
     public waitForIdle(timeoutMs: number): Promise<void> {
         return this.session ? this.session.waitForIdle(timeoutMs) : Promise.resolve();
     }
 
     // Set up our initial plotting and imports
+    @capturePerformance()
     public async initialize(cancelToken?: CancellationToken): Promise<void> {
         if (this.ranInitialSetup) {
             return;
@@ -283,6 +285,7 @@ export class JupyterNotebookBase implements INotebook {
         noop();
     }
 
+    @capturePerformance()
     public execute(
         code: string,
         file: string,
@@ -354,6 +357,7 @@ export class JupyterNotebookBase implements INotebook {
         return deferred.promise;
     }
 
+    @capturePerformance()
     public setLaunchingFile(file: string): Promise<void> {
         // Update our working directory if we don't have one set already
         return this.updateWorkingDirectory(file);
@@ -389,6 +393,7 @@ export class JupyterNotebookBase implements INotebook {
         });
     }
 
+    @capturePerformance()
     public async getSysInfo(): Promise<ICell> {
         // tslint:disable-next-line:no-multiline-string
         const versionCells = await this.executeSilently(`import sys\r\nsys.version`);
@@ -524,6 +529,7 @@ export class JupyterNotebookBase implements INotebook {
         throw this.getDisposedError();
     }
 
+    @capturePerformance()
     public async setMatplotLibStyle(useDark: boolean): Promise<void> {
         // Make sure matplotlib is initialized
         if (!this.initializedMatplotlib) {
@@ -597,6 +603,7 @@ export class JupyterNotebookBase implements INotebook {
         return this.launchInfo.kernelSpec;
     }
 
+    @capturePerformance()
     public async setKernelSpec(spec: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void> {
         // We need to start a new session with the new kernel spec
         if (this.session) {
@@ -620,6 +627,7 @@ export class JupyterNotebookBase implements INotebook {
         this.kernelChanged.fire(spec);
     }
 
+    @capturePerformance()
     private async initializeMatplotlib(cancelToken?: CancellationToken): Promise<void> {
         const settings = this.configService.getSettings(this.resource).datascience;
         if (settings && settings.themeMatplotlibPlots) {

--- a/src/client/datascience/jupyter/jupyterServer.ts
+++ b/src/client/datascience/jupyter/jupyterServer.ts
@@ -12,6 +12,7 @@ import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, R
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
+import { capturePerformance } from '../../telemetry';
 import {
     IConnection,
     IJupyterSession,
@@ -22,7 +23,6 @@ import {
     INotebookServer,
     INotebookServerLaunchInfo
 } from '../types';
-import { capturePerformance } from '../../telemetry';
 
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services

--- a/src/client/datascience/jupyter/jupyterServer.ts
+++ b/src/client/datascience/jupyter/jupyterServer.ts
@@ -22,6 +22,7 @@ import {
     INotebookServer,
     INotebookServerLaunchInfo
 } from '../types';
+import { capturePerformance } from '../../telemetry';
 
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services
@@ -47,6 +48,7 @@ export class JupyterServerBase implements INotebookServer {
         this.asyncRegistry.push(this);
     }
 
+    @capturePerformance()
     public async connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void> {
         traceInfo(
             `Connecting server ${this.id} kernelSpec ${launchInfo.kernelSpec ? launchInfo.kernelSpec.name : 'unknown'}`

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -22,7 +22,7 @@ import { traceInfo, traceWarning } from '../../common/logger';
 import { sleep, waitForPromise } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
-import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
+import { capturePerformance, captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { reportAction } from '../progress/decorator';
 import { ReportableAction } from '../progress/types';
@@ -123,6 +123,7 @@ export class JupyterSession implements IJupyterSession {
         return this.getServerStatus();
     }
 
+    @capturePerformance()
     @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
     public async waitForIdle(timeout: number): Promise<void> {
         // Wait for idle on this session
@@ -218,6 +219,7 @@ export class JupyterSession implements IJupyterSession {
         }
     }
 
+    @capturePerformance()
     public async connect(cancelToken?: CancellationToken): Promise<void> {
         if (!this.connInfo) {
             throw new Error(localize.DataScience.sessionDisposed());
@@ -237,6 +239,7 @@ export class JupyterSession implements IJupyterSession {
         return this.connected;
     }
 
+    @capturePerformance()
     public async changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void> {
         if (kernel.id && this.session && 'session' in kernel) {
             // Shutdown the current session
@@ -341,6 +344,7 @@ export class JupyterSession implements IJupyterSession {
         }
     }
 
+    @capturePerformance()
     private async createRestartSession(
         serverSettings: ServerConnection.ISettings,
         contentsManager: ContentsManager,
@@ -369,6 +373,7 @@ export class JupyterSession implements IJupyterSession {
         throw exception;
     }
 
+    @capturePerformance()
     private async createSession(
         serverSettings: ServerConnection.ISettings,
         contentsManager: ContentsManager,
@@ -391,6 +396,7 @@ export class JupyterSession implements IJupyterSession {
         );
     }
 
+    @capturePerformance()
     private async waitForKernelPromise(
         kernelPromise: Promise<void>,
         timeout: number,

--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { traceInfo } from '../../common/logger';
 import { IConfigurationService } from '../../common/types';
 import * as localize from '../../common/utils/localize';
+import { capturePerformance } from '../../telemetry';
 import {
     IConnection,
     IJupyterKernel,
@@ -60,6 +61,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         this.contentsManager = new ContentsManager({ serverSettings: this.serverSettings });
     }
 
+    @capturePerformance()
     public async getRunningSessions(): Promise<Session.IModel[]> {
         if (!this.sessionManager) {
             return [];
@@ -79,6 +81,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         return sessions;
     }
 
+    @capturePerformance()
     public async getRunningKernels(): Promise<IJupyterKernel[]> {
         const models = await Kernel.listRunning(this.serverSettings);
         // Remove duplicates.
@@ -100,7 +103,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
                 return true;
             });
     }
-
+    @capturePerformance()
     public async startNew(
         kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
         cancelToken?: CancellationToken
@@ -127,6 +130,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         return session;
     }
 
+    @capturePerformance()
     public async getKernelSpecs(): Promise<IJupyterKernelSpec[]> {
         if (!this.connInfo || !this.sessionManager || !this.contentsManager) {
             throw new Error(localize.DataScience.sessionDisposed());

--- a/src/client/datascience/jupyter/kernels/kernelSelections.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelections.ts
@@ -10,6 +10,7 @@ import { IFileSystem } from '../../../common/platform/types';
 import { IPathUtils, Resource } from '../../../common/types';
 import * as localize from '../../../common/utils/localize';
 import { IInterpreterSelector } from '../../../interpreter/configuration/types';
+import { capturePerformance } from '../../../telemetry';
 import { IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
 import { KernelService } from './kernelService';
 import { IKernelSelectionListProvider, IKernelSpecQuickPickItem, LiveKernelModel } from './types';
@@ -64,6 +65,7 @@ function getQuickPickItemForActiveKernel(kernel: LiveKernelModel, pathUtils: IPa
  */
 export class ActiveJupyterSessionKernelSelectionListProvider implements IKernelSelectionListProvider {
     constructor(private readonly sessionManager: IJupyterSessionManager, private readonly pathUtils: IPathUtils) {}
+    @capturePerformance()
     public async getKernelSelections(
         _resource: Resource,
         _cancelToken?: CancellationToken | undefined
@@ -106,6 +108,7 @@ export class InstalledJupyterKernelSelectionListProvider implements IKernelSelec
         private readonly pathUtils: IPathUtils,
         private readonly sessionManager?: IJupyterSessionManager
     ) {}
+    @capturePerformance()
     public async getKernelSelections(
         _resource: Resource,
         cancelToken?: CancellationToken | undefined
@@ -127,6 +130,7 @@ export class InstalledJupyterKernelSelectionListProvider implements IKernelSelec
  */
 export class InterpreterKernelSelectionListProvider implements IKernelSelectionListProvider {
     constructor(private readonly interpreterSelector: IInterpreterSelector) {}
+    @capturePerformance()
     public async getKernelSelections(
         resource: Resource,
         _cancelToken?: CancellationToken | undefined
@@ -167,6 +171,7 @@ export class KernelSelectionProvider {
      * @returns {Promise<IKernelSpecQuickPickItem[]>}
      * @memberof KernelSelectionProvider
      */
+    @capturePerformance()
     public async getKernelSelectionsForRemoteSession(
         resource: Resource,
         sessionManager: IJupyterSessionManager,
@@ -204,6 +209,7 @@ export class KernelSelectionProvider {
      * @returns {Promise<IKernelSelectionListProvider>}
      * @memberof KernelSelectionProvider
      */
+    @capturePerformance()
     public async getKernelSelectionsForLocalSession(
         resource: Resource,
         sessionManager?: IJupyterSessionManager,

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -14,7 +14,7 @@ import * as localize from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { StopWatch } from '../../../common/utils/stopWatch';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
-import { IEventNamePropertyMapping, sendTelemetryEvent } from '../../../telemetry';
+import { capturePerformance, IEventNamePropertyMapping, sendTelemetryEvent } from '../../../telemetry';
 import { KnownNotebookLanguages, Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
@@ -89,6 +89,7 @@ export class KernelSelector {
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
      */
+    @capturePerformance()
     public async selectRemoteKernel(
         resource: Resource,
         stopWatch: StopWatch,
@@ -120,6 +121,7 @@ export class KernelSelector {
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
      */
+    @capturePerformance()
     public async selectLocalKernel(
         resource: Resource,
         stopWatch: StopWatch,
@@ -153,6 +155,7 @@ export class KernelSelector {
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
      */
+    @capturePerformance()
     @reportAction(ReportableAction.KernelsGetKernelForLocalConnection)
     public async getKernelForLocalConnection(
         resource: Resource,
@@ -235,6 +238,7 @@ export class KernelSelector {
      * @memberof KernelSelector
      */
     // tslint:disable-next-line: cyclomatic-complexity
+    @capturePerformance()
     @reportAction(ReportableAction.KernelsGetKernelForRemoteConnection)
     public async getKernelForRemoteConnection(
         resource: Resource,
@@ -293,6 +297,7 @@ export class KernelSelector {
             interpreter: interpreter
         };
     }
+    @capturePerformance()
     private async selectKernel(
         resource: Resource,
         stopWatch: StopWatch,
@@ -360,6 +365,7 @@ export class KernelSelector {
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
      */
+    @capturePerformance()
     private async useInterpreterAsKernel(
         resource: Resource,
         interpreter: PythonInterpreter,

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -227,7 +227,7 @@ export class KernelService {
         }
     }
     @capturePerformance()
-   public async searchAndRegisterKernel(
+    public async searchAndRegisterKernel(
         interpreter: PythonInterpreter,
         disableUI?: boolean,
         cancelToken?: CancellationToken

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -20,7 +20,7 @@ import { sleep } from '../../../common/utils/async';
 import { noop } from '../../../common/utils/misc';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
-import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
+import { capturePerformance, captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
@@ -93,6 +93,7 @@ export class KernelService {
         sessionManager?: IJupyterSessionManager | undefined,
         cancelToken?: CancellationToken
     ): Promise<IJupyterKernelSpec | undefined>;
+    @capturePerformance()
     public async findMatchingKernelSpec(
         option: nbformat.IKernelspecMetadata | PythonInterpreter,
         sessionManager: IJupyterSessionManager | undefined,
@@ -128,6 +129,7 @@ export class KernelService {
      * @returns {(Promise<PythonInterpreter | undefined>)}
      * @memberof KernelService
      */
+    @capturePerformance()
     public async findMatchingInterpreter(
         kernelSpec: IJupyterKernelSpec | LiveKernelModel,
         cancelToken?: CancellationToken
@@ -224,7 +226,8 @@ export class KernelService {
             }
         }
     }
-    public async searchAndRegisterKernel(
+    @capturePerformance()
+   public async searchAndRegisterKernel(
         interpreter: PythonInterpreter,
         disableUI?: boolean,
         cancelToken?: CancellationToken
@@ -253,6 +256,7 @@ export class KernelService {
      */
     // tslint:disable-next-line: max-func-body-length
     // tslint:disable-next-line: cyclomatic-complexity
+    @capturePerformance()
     @captureTelemetry(Telemetry.RegisterInterpreterAsKernel, undefined, true)
     @traceDecorators.error('Failed to register an interpreter as a kernel')
     @reportAction(ReportableAction.KernelsRegisterKernel)
@@ -409,6 +413,7 @@ export class KernelService {
      * @returns {Promise<IJupyterKernelSpec[]>}
      * @memberof KernelService
      */
+    @capturePerformance()
     @reportAction(ReportableAction.KernelsGetKernelSpecs)
     public async getKernelSpecs(
         sessionManager?: IJupyterSessionManager,
@@ -454,6 +459,7 @@ export class KernelService {
      * @returns {JupyterKernelSpec}
      * @memberof KernelService
      */
+    @capturePerformance()
     @traceDecorators.error('Failed to parse kernel creation stdout')
     private async getKernelSpecFromStdOut(output: string): Promise<JupyterKernelSpec | undefined> {
         if (!output) {

--- a/src/client/datascience/jupyter/notebookStarter.ts
+++ b/src/client/datascience/jupyter/notebookStarter.ts
@@ -16,7 +16,7 @@ import { IDisposable, IOutputChannel } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { IServiceContainer } from '../../ioc/types';
-import { sendTelemetryEvent } from '../../telemetry';
+import { capturePerformance, sendTelemetryEvent } from '../../telemetry';
 import { JUPYTER_OUTPUT_CHANNEL, Telemetry } from '../constants';
 import { reportAction } from '../progress/decorator';
 import { ReportableAction } from '../progress/types';
@@ -56,6 +56,7 @@ export class NotebookStarter implements Disposable {
     }
     // tslint:disable-next-line: max-func-body-length
     @reportAction(ReportableAction.NotebookStart)
+    @capturePerformance()
     public async start(
         useDefaultConfig: boolean,
         customCommandLine: string[],
@@ -156,6 +157,7 @@ export class NotebookStarter implements Disposable {
         }
     }
 
+    @capturePerformance()
     private async generateDefaultArguments(
         useDefaultConfig: boolean,
         tempDirPromise: Promise<TemporaryDirectory>
@@ -265,6 +267,7 @@ export class NotebookStarter implements Disposable {
             return args;
         }
     }
+    @capturePerformance()
     private async generateTempDir(): Promise<TemporaryDirectory> {
         const resultDir = path.join(os.tmpdir(), uuid());
         await this.fileSystem.createDirectory(resultDir);

--- a/src/client/interpreter/activation/terminalEnvironmentActivationService.ts
+++ b/src/client/interpreter/activation/terminalEnvironmentActivationService.ts
@@ -12,7 +12,7 @@ import { IFileSystem } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { Resource } from '../../common/types';
 import { IEnvironmentVariablesProvider } from '../../common/variables/types';
-import { captureTelemetry } from '../../telemetry';
+import { capturePerformance, captureTelemetry } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { PythonInterpreter } from '../contracts';
 import { IEnvironmentActivationService } from './types';
@@ -37,6 +37,7 @@ export class TerminalEnvironmentActivationService implements IEnvironmentActivat
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(IEnvironmentVariablesProvider) private readonly envVarsProvider: IEnvironmentVariablesProvider
     ) {}
+    @capturePerformance()
     @traceDecorators.verbose('getActivatedEnvironmentVariables', LogOptions.Arguments)
     @captureTelemetry(
         EventName.PYTHON_INTERPRETER_ACTIVATION_ENVIRONMENT_VARIABLES,

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -17,7 +17,7 @@ import {
 } from '../common/types';
 import { sleep } from '../common/utils/async';
 import { IServiceContainer } from '../ioc/types';
-import { captureTelemetry } from '../telemetry';
+import { capturePerformance, captureTelemetry } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import {
     IInterpreterDisplay,
@@ -124,6 +124,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
         return this.getInterpreterDetails(fullyQualifiedPath, resource);
     }
+    @capturePerformance()
     public async getInterpreterDetails(pythonPath: string, resource?: Uri): Promise<PythonInterpreter | undefined> {
         // If we don't have the fully qualified path, then get it.
         if (path.basename(pythonPath) === pythonPath) {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -188,6 +188,9 @@ function createPerfTracker(
                 perfGroupTracker.delete(eventName!.toString());
             }
         };
+    } else if (perfGroupTracker.size === 0) {
+        // No perf has been setup to be captured.
+        return { completed: noop, failed: noop };
     }
 
     // Build a name = <class>.<method>


### PR DESCRIPTION
For #10252

* I'd like to get this in at least for Insiders build.
* Currently capturing perf for:
    * Starting jupyter
    * Starting jupter to run a cell
    * Running first cell

I.e. we will capture time taken by specific methods along with the times when they get executed.

Basically we'll end up with something similar to a gantt chart - hopefully we can find critical paths (hot spots/bottlenecks) and the like.