### PR TITLE
Update cell code in model as user types into editor

### DIFF
--- a/news/2 Fixes/8589.md
+++ b/news/2 Fixes/8589.md
@@ -1,0 +1,1 @@
+Ensure model is updated with user changes after user types into the editor.

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -356,6 +356,11 @@ export interface INotebookModelAddChange extends INotebookModelChange {
     currentText: string;
 }
 
+export interface INotebookModelChangeTypeChange extends INotebookModelChange {
+    kind: 'changeCellType';
+    cell: ICell;
+}
+
 export interface IEditorPosition {
     /**
      * line number (starts at 1)
@@ -438,7 +443,8 @@ export type NotebookModelChange =
     | INotebookModelAddChange
     | INotebookModelEditChange
     | INotebookModelVersionChange
-    | INotebookModelFileChange;
+    | INotebookModelFileChange
+    | INotebookModelChangeTypeChange;
 
 // Map all messages to specific payloads
 export class IInteractiveWindowMapping {

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -184,7 +184,7 @@ export interface ISubmitNewCell {
 }
 
 export interface IReExecuteCells {
-    entries: { cell: ICell; code: string }[];
+    cellIds: string[];
 }
 
 export interface IProvideCompletionItemsRequest {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -132,8 +132,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     public get isDirty(): boolean {
         return this.model ? this.model.isDirty : false;
     }
+    // Public for testing purposes.
+    public model: Readonly<INotebookModel> | undefined;
     protected savedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
-    protected model: INotebookModel | undefined;
     protected closedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
     protected modifiedEvent: EventEmitter<INotebookEditor> = new EventEmitter<INotebookEditor>();
 

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -332,7 +332,7 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
     }
 
     private changeCellType(cell: ICell): boolean {
-        // Update these cells in our list
+        // Update the cell in our list.
         const index = this.cells.findIndex(v => v.id === cell.id);
         this._state.cells[index] = this.asCell(cell);
         return true;

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -193,6 +193,9 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
             case 'insert':
                 changed = this.insertCell(change.cell, change.index);
                 break;
+            case 'changeCellType':
+                changed = this.changeCellType(change.cell);
+                break;
             case 'modify':
                 changed = this.modifyCells(change.newCells);
                 break;
@@ -235,6 +238,10 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
                 break;
             case 'edit':
                 this.editCell(change.reverse, change.id);
+                changed = true;
+                break;
+            case 'changeCellType':
+                this.changeCellType(change.cell);
                 changed = true;
                 break;
             case 'insert':
@@ -318,6 +325,13 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
             const index = this.cells.findIndex(v => v.id === c.id);
             this._state.cells[index] = this.asCell(c);
         });
+        return true;
+    }
+
+    private changeCellType(cell: ICell): boolean {
+        // Update these cells in our list
+        const index = this.cells.findIndex(v => v.id === cell.id);
+        this._state.cells[index] = this.asCell(cell);
         return true;
     }
 

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -290,7 +290,10 @@ export class NativeEditorStorage implements INotebookModel, INotebookStorage {
             const after = contents.substr(change.rangeOffset + change.rangeLength);
             const newContents = `${before}${normalized}${after}`;
             if (contents !== newContents) {
-                const newCell = { ...this.cells[index], data: { ...this.cells[index].data, source: newContents } };
+                const newCell = {
+                    ...this.cells[index],
+                    data: { ...this.cells[index].data, source: splitMultilineString(newContents) }
+                };
                 this._state.cells[index] = this.asCell(newCell);
                 return true;
             }

--- a/src/datascience-ui/interactive-common/cellInput.tsx
+++ b/src/datascience-ui/interactive-common/cellInput.tsx
@@ -29,6 +29,9 @@ interface ICellInputProps {
     showLineNumbers?: boolean;
     font: IFont;
     disableUndoStack: boolean;
+    /**
+     * Only used in interactive window.
+     */
     focusPending: number;
     onCodeChange(e: IMonacoModelContentChangeEvent): void;
     onCodeCreated(code: string, file: string, cellId: string, modelId: string): void;
@@ -116,7 +119,6 @@ export class CellInput extends React.Component<ICellInputProps> {
                         font={this.props.font}
                         disableUndoStack={this.props.disableUndoStack}
                         version={this.props.codeVersion}
-                        previousCode={this.props.cellVM.uncommittedText}
                         focusPending={this.props.focusPending}
                     />
                 </div>
@@ -152,7 +154,6 @@ export class CellInput extends React.Component<ICellInputProps> {
                         font={this.props.font}
                         disableUndoStack={this.props.disableUndoStack}
                         version={this.props.codeVersion}
-                        previousMarkdown={this.props.cellVM.uncommittedText}
                     />
                 </div>
             );

--- a/src/datascience-ui/interactive-common/code.tsx
+++ b/src/datascience-ui/interactive-common/code.tsx
@@ -13,7 +13,6 @@ import { CursorPos, IFont } from './mainState';
 
 export interface ICodeProps {
     code: string;
-    previousCode: string | undefined;
     version: number;
     codeTheme: string;
     testMode: boolean;
@@ -90,7 +89,6 @@ export class Code extends React.Component<ICodeProps, ICodeState> {
                     font={this.props.font}
                     disableUndoStack={this.props.disableUndoStack}
                     version={this.props.version}
-                    previousContent={this.props.previousCode}
                 />
                 <div className={waterMarkClass} role="textbox" onClick={this.clickWatermark}>
                     {this.getWatermarkString()}

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -14,7 +14,6 @@ import { CursorPos, IFont } from './mainState';
 // tslint:disable-next-line: import-name
 export interface IEditorProps {
     content: string;
-    previousContent: string | undefined;
     version: number;
     codeTheme: string;
     readOnly: boolean;
@@ -114,7 +113,6 @@ export class Editor extends React.Component<IEditorProps> {
                 measureWidthClassName={this.props.editorMeasureClassName}
                 testMode={this.props.testMode}
                 value={this.props.content}
-                previousValue={this.props.previousContent}
                 outermostParentClass={this.props.outermostParentClass}
                 theme={this.props.monacoTheme ? this.props.monacoTheme : 'vs'}
                 language={this.props.language}

--- a/src/datascience-ui/interactive-common/mainState.ts
+++ b/src/datascience-ui/interactive-common/mainState.ts
@@ -39,7 +39,6 @@ export interface ICellViewModel {
     cursorPos: CursorPos | IEditorPosition;
     hasBeenRun: boolean;
     runDuringDebug?: boolean;
-    uncommittedText?: string;
     codeVersion?: number;
 }
 

--- a/src/datascience-ui/interactive-common/markdown.tsx
+++ b/src/datascience-ui/interactive-common/markdown.tsx
@@ -11,7 +11,6 @@ import { CursorPos, IFont } from './mainState';
 
 export interface IMarkdownProps {
     markdown: string;
-    previousMarkdown: string | undefined;
     version: number;
     codeTheme: string;
     testMode: boolean;
@@ -70,7 +69,6 @@ export class Markdown extends React.Component<IMarkdownProps> {
                     font={this.props.font}
                     disableUndoStack={this.props.disableUndoStack}
                     version={this.props.version}
-                    previousContent={this.props.previousMarkdown}
                 />
             </div>
         );

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -236,6 +236,14 @@ export namespace Transfer {
                 const current = arg.prevState.cellVMs[index];
                 const newCell = {
                     ...current,
+                    inputBlockText: arg.payload.data.code,
+                    cell: {
+                        ...current.cell,
+                        data: {
+                            ...current.cell.data,
+                            source: arg.payload.data.code
+                        }
+                    },
                     codeVersion: arg.payload.data.version
                 };
 

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -158,6 +158,16 @@ export namespace Transfer {
         });
     }
 
+    export function changeCellType<T>(arg: CommonReducerArg<CommonActionType, T>, cell: ICell) {
+        postModelUpdate(arg, {
+            source: 'user',
+            kind: 'changeCellType',
+            newDirty: true,
+            oldDirty: arg.prevState.dirty,
+            cell
+        });
+    }
+
     export function postModelRemove<T>(arg: CommonReducerArg<CommonActionType, T>, index: number, cell: ICell) {
         postModelUpdate(arg, {
             source: 'user',

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -226,7 +226,6 @@ export namespace Transfer {
                 const current = arg.prevState.cellVMs[index];
                 const newCell = {
                     ...current,
-                    uncommittedText: arg.payload.data.code,
                     codeVersion: arg.payload.data.version
                 };
 

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -199,7 +199,6 @@ export interface ISendCommandAction {
 
 export interface IChangeCellTypeAction {
     cellId: string;
-    currentCode: string;
 }
 
 export interface IOpenSettingsAction {

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -94,7 +94,7 @@ export type CommonActionTypeMapping = {
     [CommonActionType.EXECUTE_CELL]: IExecuteAction;
     [CommonActionType.EXECUTE_ALL_CELLS]: never | undefined;
     [CommonActionType.EXECUTE_ABOVE]: ICellAction;
-    [CommonActionType.EXECUTE_CELL_AND_BELOW]: ICodeAction;
+    [CommonActionType.EXECUTE_CELL_AND_BELOW]: ICellAction;
     [CommonActionType.RESTART_KERNEL]: never | undefined;
     [CommonActionType.INTERRUPT_KERNEL]: never | undefined;
     [CommonActionType.EXPORT]: never | undefined;

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -174,7 +174,7 @@ export interface IEditCellAction extends ICodeAction {
 
 // I.e. when using the operation `add`, we need the corresponding `IAddCellAction`.
 // They are mutually exclusive, if not `add`, then there's no `newCellId`.
-export type IExecuteAction = ICodeAction & {
+export type IExecuteAction = ICellAction & {
     moveOp: 'select' | 'none' | 'add';
 };
 

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -245,8 +245,11 @@ function createMiddleWare(testMode: boolean): Redux.Middleware<{}, IStore>[] {
             return action;
         }
     });
+    // On CI we might want to disable logging, as its a big wall of text.
+    // TO disable that add the variable `VSC_PYTHON_DS_NO_REDUX_LOGGING=1`
     const loggerMiddleware =
-        process.env.VSC_PYTHON_FORCE_LOGGING !== undefined || (process.env.NODE_ENV !== 'production' && !testMode)
+        !process.env.VSC_PYTHON_DS_NO_REDUX_LOGGING &&
+        (process.env.VSC_PYTHON_FORCE_LOGGING !== undefined || (process.env.NODE_ENV !== 'production' && !testMode))
             ? logger
             : undefined;
     // tslint:disable-next-line: no-console

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -397,7 +397,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         e.preventDefault();
 
         // Submit and move to the next.
-        this.runAndMove(e.editorInfo ? e.editorInfo.contents : undefined);
+        this.runAndMove();
 
         this.props.sendCommand(NativeCommandType.RunAndMove, 'keyboard');
     };
@@ -408,19 +408,19 @@ export class NativeCell extends React.Component<INativeCellProps> {
         e.preventDefault();
 
         // Submit this cell
-        this.runAndAdd(e.editorInfo ? e.editorInfo.contents : undefined);
+        this.runAndAdd();
 
         this.props.sendCommand(NativeCommandType.RunAndAdd, 'keyboard');
     };
 
-    private runAndMove(possibleContents?: string) {
+    private runAndMove() {
         // Submit this cell
-        this.submitCell(possibleContents, this.props.lastCell ? 'add' : 'select');
+        this.submitCell(this.props.lastCell ? 'add' : 'select');
     }
 
-    private runAndAdd(possibleContents?: string) {
+    private runAndAdd() {
         // Submit this cell
-        this.submitCell(possibleContents, 'add');
+        this.submitCell('add');
     }
 
     private ctrlEnterCell = (e: IKeyboardEvent) => {
@@ -429,25 +429,12 @@ export class NativeCell extends React.Component<INativeCellProps> {
         e.preventDefault();
 
         // Submit this cell
-        this.submitCell(e.editorInfo ? e.editorInfo.contents : undefined, 'none');
+        this.submitCell('none');
         this.props.sendCommand(NativeCommandType.Run, 'keyboard');
     };
 
-    private submitCell = (possibleContents: string | undefined, moveOp: 'add' | 'select' | 'none') => {
-        let content: string | undefined;
-
-        // If inside editor, submit this code
-        if (possibleContents !== undefined) {
-            content = possibleContents;
-        } else {
-            // Outside editor, just use the cell
-            content = concatMultilineStringInput(this.props.cellVM.cell.data.source);
-        }
-
-        // Send to jupyter
-        if (content) {
-            this.props.executeCell(this.cellId, content, moveOp);
-        }
+    private submitCell = (moveOp: 'add' | 'select' | 'none') => {
+        this.props.executeCell(this.cellId, moveOp);
     };
 
     private addNewCell = () => {
@@ -531,7 +518,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
     private renderMiddleToolbar = () => {
         const cellId = this.props.cellVM.cell.id;
         const runCell = () => {
-            this.runAndMove(this.getCurrentCode());
+            this.runAndMove();
             this.props.sendCommand(NativeCommandType.Run, 'mouse');
         };
         const gatherCell = () => {

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -270,7 +270,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 if (!this.isFocused() && this.isSelected() && this.isMarkdownCell()) {
                     e.stopPropagation();
                     e.preventDefault();
-                    this.props.changeCellType(cellId, this.getCurrentCode());
+                    this.props.changeCellType(cellId);
                     this.props.sendCommand(NativeCommandType.ChangeToCode, 'keyboard');
                 }
                 break;
@@ -278,7 +278,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 if (!this.isFocused() && this.isSelected() && this.isCodeCell()) {
                     e.stopPropagation();
                     e.preventDefault();
-                    this.props.changeCellType(cellId, this.getCurrentCode());
+                    this.props.changeCellType(cellId);
                     this.props.sendCommand(NativeCommandType.ChangeToMarkdown, 'keyboard');
                 }
                 break;
@@ -547,7 +547,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
             // can give focus to the cell input.
             event.stopPropagation();
             event.preventDefault();
-            this.props.changeCellType(cellId, this.getCurrentCode());
+            this.props.changeCellType(cellId);
             this.props.sendCommand(otherCellTypeCommand, 'mouse');
         };
         const toolbarClassName = this.props.cellVM.cell.data.cell_type === 'code' ? '' : 'markdown-toolbar';

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { OSType } from '../../client/common/utils/platform';
 import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
-import { concatMultilineStringInput } from '../common';
 import { buildSettingsCss } from '../interactive-common/buildSettingsCss';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
 import { handleLinkClick } from '../interactive-common/handlers';
@@ -155,10 +154,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             if (selectedInfo.selectedCellId && typeof selectedInfo.selectedCellIndex === 'number') {
                 // tslint:disable-next-line: no-suspicious-comment
                 // TODO: Is the source going to be up to date during run below?
-                this.props.executeCellAndBelow(
-                    selectedInfo.selectedCellId,
-                    concatMultilineStringInput(this.props.cellVMs[selectedInfo.selectedCellIndex].cell.data.source)
-                );
+                this.props.executeCellAndBelow(selectedInfo.selectedCellId);
                 this.props.sendCommand(NativeCommandType.RunBelow, 'mouse');
             }
         };

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -80,8 +80,7 @@ export const actionCreators = {
         createIncomingActionWithPayload(CommonActionType.MOVE_CELL_UP, { cellId }),
     moveCellDown: (cellId: string): CommonAction<ICellAction> =>
         createIncomingActionWithPayload(CommonActionType.MOVE_CELL_DOWN, { cellId }),
-    changeCellType: (cellId: string, currentCode: string) =>
-        createIncomingActionWithPayload(CommonActionType.CHANGE_CELL_TYPE, { cellId, currentCode }),
+    changeCellType: (cellId: string) => createIncomingActionWithPayload(CommonActionType.CHANGE_CELL_TYPE, { cellId }),
     toggleLineNumbers: (cellId: string): CommonAction<ICellAction> =>
         createIncomingActionWithPayload(CommonActionType.TOGGLE_LINE_NUMBERS, { cellId }),
     toggleOutput: (cellId: string): CommonAction<ICellAction> =>

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -53,8 +53,8 @@ export const actionCreators = {
             cellId,
             newCellId: uuid()
         }),
-    executeCell: (cellId: string, code: string, moveOp: 'add' | 'select' | 'none') =>
-        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_ADVANCE, { cellId, code, moveOp }),
+    executeCell: (cellId: string, moveOp: 'add' | 'select' | 'none') =>
+        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_ADVANCE, { cellId, moveOp }),
     focusCell: (cellId: string, cursorPos: CursorPos = CursorPos.Current): CommonAction<ICellAndCursorAction> =>
         createIncomingActionWithPayload(CommonActionType.FOCUS_CELL, { cellId, cursorPos }),
     unfocusCell: (cellId: string, code: string) =>

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -64,8 +64,8 @@ export const actionCreators = {
     executeAllCells: (): CommonAction => createIncomingAction(CommonActionType.EXECUTE_ALL_CELLS),
     executeAbove: (cellId: string): CommonAction<ICellAction> =>
         createIncomingActionWithPayload(CommonActionType.EXECUTE_ABOVE, { cellId }),
-    executeCellAndBelow: (cellId: string, code: string): CommonAction<ICodeAction> =>
-        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_BELOW, { cellId, code }),
+    executeCellAndBelow: (cellId: string): CommonAction<ICellAction> =>
+        createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_BELOW, { cellId }),
     toggleVariableExplorer: (): CommonAction => createIncomingAction(CommonActionType.TOGGLE_VARIABLE_EXPLORER),
     restartKernel: (): CommonAction => createIncomingAction(CommonActionType.RESTART_KERNEL),
     interruptKernel: (): CommonAction => createIncomingAction(CommonActionType.INTERRUPT_KERNEL),

--- a/src/datascience-ui/native-editor/redux/reducers/creation.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/creation.ts
@@ -9,6 +9,7 @@ import {
     NotebookModelChange
 } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { ICell, IDataScienceExtraSettings } from '../../../../client/datascience/types';
+import { splitMultilineString } from '../../../common';
 import {
     createCellVM,
     createEmptyCell,
@@ -38,8 +39,7 @@ export namespace Creation {
         const newText = extractInputText(cellVM, settings);
 
         cellVM.inputBlockOpen = true;
-        // TODO: Shouldn't we be splitting into multi line here?
-        cell.data.source = newText;
+        cell.data.source = splitMultilineString(newText);
         cellVM.hasBeenRun = hasBeenRun;
 
         return cellVM;
@@ -216,8 +216,7 @@ export namespace Creation {
                 newVM.inputBlockText = `${before}${c.text}${after}`;
             });
             newVM.codeVersion = newVM.codeVersion ? newVM.codeVersion + 1 : 1;
-            // TODO: Should we be splitting into mult-line text?
-            newVM.cell.data.source = newVM.inputBlockText;
+            newVM.cell.data.source = splitMultilineString(newVM.inputBlockText);
             newVM.cursorPos = arg.payload.data.changes[0].position;
             const newVMs = [...arg.prevState.cellVMs];
             newVMs[index] = Helpers.asCellViewModel(newVM);

--- a/src/datascience-ui/native-editor/redux/reducers/creation.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/creation.ts
@@ -38,7 +38,8 @@ export namespace Creation {
         const newText = extractInputText(cellVM, settings);
 
         cellVM.inputBlockOpen = true;
-        cellVM.inputBlockText = newText;
+        // TODO: Shouldn't we be splitting into multi line here?
+        cell.data.source = newText;
         cellVM.hasBeenRun = hasBeenRun;
 
         return cellVM;
@@ -208,14 +209,15 @@ export namespace Creation {
         if (index >= 0) {
             const newVM = { ...arg.prevState.cellVMs[index] };
             arg.payload.data.changes.forEach(c => {
-                const source = newVM.uncommittedText ? newVM.uncommittedText : newVM.inputBlockText;
+                const source = newVM.inputBlockText;
                 const before = source.slice(0, c.rangeOffset);
                 // tslint:disable-next-line: restrict-plus-operands
                 const after = source.slice(c.rangeOffset + c.rangeLength);
-                newVM.uncommittedText = `${before}${c.text}${after}`;
+                newVM.inputBlockText = `${before}${c.text}${after}`;
             });
             newVM.codeVersion = newVM.codeVersion ? newVM.codeVersion + 1 : 1;
-            newVM.inputBlockText = newVM.cell.data.source = newVM.uncommittedText!;
+            // TODO: Should we be splitting into mult-line text?
+            newVM.cell.data.source = newVM.inputBlockText;
             newVM.cursorPos = arg.payload.data.changes[0].position;
             const newVMs = [...arg.prevState.cellVMs];
             newVMs[index] = Helpers.asCellViewModel(newVM);

--- a/src/datascience-ui/native-editor/redux/reducers/effects.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/effects.ts
@@ -6,7 +6,7 @@ import { IDataScienceExtraSettings } from '../../../../client/datascience/types'
 import { getSelectedAndFocusedInfo, IMainState } from '../../../interactive-common/mainState';
 import { postActionToExtension } from '../../../interactive-common/redux/helpers';
 import { Helpers } from '../../../interactive-common/redux/reducers/helpers';
-import { ICellAction, ICellAndCursorAction, ICodeAction } from '../../../interactive-common/redux/reducers/types';
+import { ICellAction, ICellAndCursorAction } from '../../../interactive-common/redux/reducers/types';
 import { computeEditorOptions } from '../../../react-common/settingsReactSide';
 import { NativeEditorReducerArg } from '../mapping';
 
@@ -27,14 +27,12 @@ export namespace Effects {
                 }
 
                 if (typeof removeFocusIndex === 'number') {
-                    const oldFocusCell = prevState.cellVMs[removeFocusIndex];
-                    const oldCode = oldFocusCell.uncommittedText || oldFocusCell.inputBlockText;
                     prevState = unfocusCell({
                         ...arg,
                         prevState,
                         payload: {
                             ...arg.payload,
-                            data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode }
+                            data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id }
                         }
                     });
                     prevState = deselectCell({
@@ -67,7 +65,7 @@ export namespace Effects {
         return arg.prevState;
     }
 
-    export function unfocusCell(arg: NativeEditorReducerArg<ICellAction | ICodeAction>): IMainState {
+    export function unfocusCell(arg: NativeEditorReducerArg<ICellAction>): IMainState {
         // Unfocus the cell
         const index = arg.prevState.cellVMs.findIndex(c => c.cell.id === arg.payload.data.cellId);
         const selectionInfo = getSelectedAndFocusedInfo(arg.prevState);
@@ -76,15 +74,7 @@ export namespace Effects {
             const current = arg.prevState.cellVMs[index];
             const newCell = {
                 ...current,
-                inputBlockText: 'code' in arg.payload.data ? arg.payload.data.code : current.inputBlockText,
-                focused: false,
-                cell: {
-                    ...current.cell,
-                    data: {
-                        ...current.cell.data,
-                        source: 'code' in arg.payload.data ? arg.payload.data.code : current.cell.data.source
-                    }
-                }
+                focused: false
             };
 
             // tslint:disable-next-line: no-any
@@ -99,15 +89,7 @@ export namespace Effects {
             const newVMs = [...arg.prevState.cellVMs];
             const current = arg.prevState.cellVMs[index];
             const newCell = {
-                ...current,
-                inputBlockText: 'code' in arg.payload.data ? arg.payload.data.code : current.inputBlockText,
-                cell: {
-                    ...current.cell,
-                    data: {
-                        ...current.cell.data,
-                        source: 'code' in arg.payload.data ? arg.payload.data.code : current.cell.data.source
-                    }
-                }
+                ...current
             };
 
             // tslint:disable-next-line: no-any
@@ -168,14 +150,12 @@ export namespace Effects {
             }
 
             if (removeFocusIndex >= 0) {
-                const oldFocusCell = prevState.cellVMs[removeFocusIndex];
-                const oldCode = oldFocusCell.uncommittedText || oldFocusCell.inputBlockText;
                 prevState = unfocusCell({
                     ...arg,
                     prevState,
                     payload: {
                         ...arg.payload,
-                        data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id, code: oldCode }
+                        data: { cellId: prevState.cellVMs[removeFocusIndex].cell.id }
                     }
                 });
                 prevState = deselectCell({

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -220,7 +220,6 @@ export namespace Execution {
             const current = arg.prevState.cellVMs[index];
             const newType = current.cell.data.cell_type === 'code' ? 'markdown' : 'code';
             const newNotebookCell = createCellFrom(current.cell.data, newType);
-            newNotebookCell.source = arg.payload.data.currentCode;
             const newCell: ICellViewModel = {
                 ...current,
                 cell: {
@@ -228,18 +227,8 @@ export namespace Execution {
                     data: newNotebookCell
                 }
             };
-            // tslint:disable-next-line: no-any
-            cellVMs[index] = newCell as any; // This is because IMessageCell doesn't fit in here. But message cells can't change type
-            if (newType === 'code') {
-                Transfer.postModelInsert(
-                    arg,
-                    index,
-                    cellVMs[index].cell,
-                    Helpers.firstCodeCellAbove(arg.prevState, current.cell.id)
-                );
-            } else {
-                Transfer.postModelRemove(arg, index, current.cell);
-            }
+            cellVMs[index] = newCell;
+            Transfer.changeCellType(arg, cellVMs[index].cell);
 
             return {
                 ...arg.prevState,

--- a/src/datascience-ui/native-editor/redux/reducers/execution.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/execution.ts
@@ -41,9 +41,8 @@ export namespace Execution {
                 return;
             }
             const orig = prevState.cellVMs[index];
-            const code = concatMultilineStringInput(orig.cell.data.source);
             // noop if the submitted code is just a cell marker
-            if (code && orig.cell.data.cell_type === 'code') {
+            if (orig.cell.data.cell_type === 'code' && concatMultilineStringInput(orig.cell.data.source)) {
                 // When cloning cells, preserve the metadata (hence deep clone).
                 const clonedCell = cloneDeep(orig.cell.data);
                 // Update our input cell to be in progress again and clear outputs

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -43,6 +43,7 @@ import { IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
+import { concatMultilineStringInput } from '../../../datascience-ui/common';
 
 // tslint:disable: no-any chai-vague-errors no-unused-expression
 class MockWorkspaceConfiguration implements WorkspaceConfiguration {
@@ -468,7 +469,7 @@ suite('Data Science - Native Editor Storage', () => {
         let cells = storage.cells;
         expect(cells).to.be.lengthOf(3);
         expect(cells[1].id).to.be.match(/NotebookImport#1/);
-        expect(cells[1].data.source).to.be.equals('b=2\nab');
+        expect(concatMultilineStringInput(cells[1].data.source)).to.be.equals('b=2\nab');
         expect(storage.isDirty).to.be.equal(true, 'Editor should be dirty');
         removeCell(0, cells[0]);
         cells = storage.cells;

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -41,9 +41,9 @@ import { JupyterExecutionFactory } from '../../../client/datascience/jupyter/jup
 import { ICell, IJupyterExecution, INotebookServerOptions } from '../../../client/datascience/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
+import { concatMultilineStringInput } from '../../../datascience-ui/common';
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
-import { concatMultilineStringInput } from '../../../datascience-ui/common';
 
 // tslint:disable: no-any chai-vague-errors no-unused-expression
 class MockWorkspaceConfiguration implements WorkspaceConfiguration {

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1190,6 +1190,7 @@ df.head()`;
                             if (e.kind === 'edit') {
                                 // Find the first deferred that's no completed.
                                 const deferred = modelEditsInExtension.find(d => !d.completed);
+                                // Resolve promise with the character/string it received as edit.
                                 deferred?.resolve(e.forward.map(m => m.text).join(''));
                             }
                         });
@@ -1198,11 +1199,10 @@ df.head()`;
                             // Single character to be typed into the editor.
                             const characterToTypeIntoEditor = stringToType.substring(index, index + 1);
 
-                            // Type into new cell
+                            // Type a character into the editor.
                             const editorEnzyme = getNativeFocusedEditor(wrapper);
                             typeCode(editorEnzyme, characterToTypeIntoEditor);
 
-                            // Verify cell content
                             const reactEditor = editorEnzyme!.instance() as MonacoEditor;
                             const editorValue = reactEditor.state.editor!.getModel()!.getValue();
                             const expectedString = stringToType.substring(0, index + 1);
@@ -1211,14 +1211,14 @@ df.head()`;
                             // Confirms value in the editor is as expected.
                             assert.equal(editorValue, expectedString, 'Text does not match');
 
-                            // 2. Validate the value in the monaco editor state (redux state).
-                            // Ensures we are keeping redux upto date.
+                            // 2. Validate the value in the redux state (props - update in redux, will push through to props).
+                            // Confirms value in the props is as expected.
                             assert.equal(reactEditor.props.value, expectedString, 'Text does not match');
 
                             // 3. Validate the edit received by the extension from the react side.
-                            // This edit will be received by the model.
                             // When user types `H`, then we'll expect to see `H` edit received in the model, then `i`, `!` & so on.
                             const expectedModelEditInExtension = modelEditsInExtension[index];
+                            // Verify against the character the user typed.
                             await assert.eventually.equal(
                                 expectedModelEditInExtension.promise,
                                 characterToTypeIntoEditor
@@ -1273,7 +1273,6 @@ df.head()`;
                         await modelEditsInExtension.promise;
                         assert.equal(concatMultilineStringInput(model?.cells[3].data.source!), stringToType);
 
-                        // Toggle to markdown.
                         // Now hit escape.
                         let update = waitForUpdate(wrapper, NativeEditor, 1);
                         simulateKeyPressOnCell(cellIndex, { code: 'Escape' });

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -30,6 +30,7 @@ import {
     INotebookExporter
 } from '../../client/datascience/types';
 import { PythonInterpreter } from '../../client/interpreter/contracts';
+import { concatMultilineStringInput } from '../../datascience-ui/common';
 import { Editor } from '../../datascience-ui/interactive-common/editor';
 import { ExecutionCount } from '../../datascience-ui/interactive-common/executionCount';
 import { CommonActionType } from '../../datascience-ui/interactive-common/redux/reducers/types';
@@ -1170,8 +1171,9 @@ df.head()`;
                     });
 
                     test('Update as user types into editor (update redux store and model)', async () => {
+                        const cellIndex = 3;
                         await addCell(wrapper, ioc, '', false);
-                        assert.ok(isCellFocused(wrapper, 'NativeCell', 3));
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', cellIndex));
                         assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
 
                         const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
@@ -1222,6 +1224,80 @@ df.head()`;
                                 characterToTypeIntoEditor
                             );
                         }
+                    });
+                    test('Updates are not lost when switching to markdown (update redux store and model)', async () => {
+                        const cellIndex = 3;
+                        await addCell(wrapper, ioc, '', false);
+                        assert.ok(isCellFocused(wrapper, 'NativeCell', cellIndex));
+                        assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
+
+                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const model = (notebookProvider.editors[0] as NativeEditorWebView).model;
+
+                        // This is the string the user will type in a character at a time into the editor.
+                        const stringToType = 'Hi Bob!';
+
+                        // We are expecting to receive multiple edits to the model in the backend/extension from react, one for each character.
+                        // Lets create deferreds that we can await on, and each will be resolved with the edit it received.
+                        // For first edit, we'll expect `H`, then `i`, then `!`
+                        const modelEditsInExtension = createDeferred();
+                        // Create deferred to detect changes to cellType.
+                        const modelCellChangedInExtension = createDeferred();
+                        model?.changed(e => {
+                            // Resolve promise when we receive last edit (the last character `!`).
+                            if (e.kind === 'edit' && e.forward.map(m => m.text).join('') === '!') {
+                                modelEditsInExtension.resolve();
+                            }
+                            if (e.kind === 'changeCellType') {
+                                modelCellChangedInExtension.resolve();
+                            }
+                        });
+
+                        // Type into new cell in one go (e.g. a paste operation)
+                        const editorEnzyme = getNativeFocusedEditor(wrapper);
+                        typeCode(editorEnzyme, stringToType);
+
+                        // Verify cell content
+                        const reactEditor = editorEnzyme!.instance() as MonacoEditor;
+                        const editorValue = reactEditor.state.editor!.getModel()!.getValue();
+
+                        // 1. Validate the value in the monaco editor.
+                        // Confirms value in the editor is as expected.
+                        assert.equal(editorValue, stringToType, 'Text does not match');
+
+                        // 2. Validate the value in the monaco editor state (redux state).
+                        // Ensures we are keeping redux upto date.
+                        assert.equal(reactEditor.props.value, stringToType, 'Text does not match');
+
+                        // 3. Validate the edit received by the extension from the react side.
+                        await modelEditsInExtension.promise;
+                        assert.equal(concatMultilineStringInput(model?.cells[3].data.source!), stringToType);
+
+                        // Toggle to markdown.
+                        // Now hit escape.
+                        let update = waitForUpdate(wrapper, NativeEditor, 1);
+                        simulateKeyPressOnCell(cellIndex, { code: 'Escape' });
+                        await update;
+
+                        // Confirm it is no longer focused, and it is selected.
+                        assert.equal(isCellSelected(wrapper, 'NativeCell', cellIndex), true);
+                        assert.equal(isCellFocused(wrapper, 'NativeCell', cellIndex), false);
+
+                        // Switch to markdown
+                        update = waitForMessage(ioc, CommonActionType.CHANGE_CELL_TYPE);
+                        simulateKeyPressOnCell(cellIndex, { code: 'm' });
+                        await update;
+
+                        // Monaco editor should be rendered and the cell should be markdown
+                        assert.ok(!isCellFocused(wrapper, 'NativeCell', cellIndex), 'cell is not focused');
+                        assert.ok(isCellMarkdown(wrapper, 'NativeCell', cellIndex), 'cell is not markdown');
+
+                        // Confirm cell has been changed in model.
+                        await modelCellChangedInExtension.promise;
+                        // Verify the cell type.
+                        assert.equal(model?.cells[3].data.cell_type, 'markdown');
+                        // Verify that changing cell type didn't result in a loss of data.
+                        assert.equal(concatMultilineStringInput(model?.cells[3].data.source!), stringToType);
                     });
                 });
 

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -703,7 +703,7 @@ df.head()`;
                     const runButton = imageButtons.findWhere(w => w.props().tooltip === 'Run cell');
                     assert.equal(runButton.length, 1, 'No run button found');
                     const update = waitForMessage(ioc, InteractiveWindowMessages.ExecutionRendered, {
-                        numberOfTimes: 2
+                        numberOfTimes: 3
                     });
                     runButton.simulate('click');
                     await update;


### PR DESCRIPTION
For #8589
For #9870

* Code is kept upto date as user types into the editor/cell
* Hence when running a cell, we only pass the cell id
* When moving a cell up/down we only need the cell id
* When changing focus we no longer attempt to update the cell source
* When changing cell types from markdown to code, we use code in current state instead of passing it.

**Basically the expectation is that the cells in extension and state will always be up to date with latest code**
We'll always strive to keep the cells updated with the latest source upon typing text as per issue requirement.

Found some places where we're blowing away cell `source`, hence stuff thats supposed to be multi line isn't.

**Again, WIP**
* [x] Add functional tests
* [x] Review issues where code was lost (when changing cell types), ensure this still works
* [x] Add tests for https://github.com/microsoft/vscode-python/issues/9719
* [x] Add tests to ensure redux state is updated as we type into the editor
    * The `cell.data.code` should be updated with latest code
    * The `inputBlockText` should be updated with latest code
* [x] Add tests to ensure the model in extension is updated as a result of changes in editor.
* [x] Add tests to ensure changing from markdown to code results in 
    * [x] Updates to corresponding cells in redux state
    * [x] Updates to corresponding cells in extension model
    * [ ] Mardown to code
    * [x] Code to markdwon
