### PR TITLE
Allow kernel switching to fail before setting it as the used kernel

### DIFF
--- a/news/2 Fixes/9250.md
+++ b/news/2 Fixes/9250.md
@@ -1,0 +1,1 @@
+Allow a user to skip switching to a kernel if the kernel dies during startup.

--- a/package.nls.json
+++ b/package.nls.json
@@ -447,5 +447,5 @@
     "DataScience.connectingToJupyterUri": "Connecting to Jupyter server at {0}",
     "DataScience.createdNewNotebook": "{0}: Creating new notebook ",
     "DataScience.createdNewKernel": "{0}: Kernel started: {1}",
-    "DataScience.kernelIsDead": "Kernel died while starting. Check the Jupyter output tab for more information."
+    "DataScience.kernelIsDead": "Kernel {0} died while starting. Check the Jupyter output tab for more information."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -446,5 +446,6 @@
     "DataScience.trimmedOutput": "Output was trimmed for performance reasons.\nTo see the full output set the setting \"python.dataScience.textOutputLimit\" to 0.",
     "DataScience.connectingToJupyterUri": "Connecting to Jupyter server at {0}",
     "DataScience.createdNewNotebook": "{0}: Creating new notebook ",
-    "DataScience.createdNewKernel": "{0}: Kernel started: {1}"
+    "DataScience.createdNewKernel": "{0}: Kernel started: {1}",
+    "DataScience.kernelIsDead": "Kernel died while starting. Check the Jupyter output tab for more information."
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -799,6 +799,10 @@ export namespace DataScience {
     export const createdNewNotebook = localize('DataScience.createdNewNotebook', '{0}: Creating new notebook ');
 
     export const createdNewKernel = localize('DataScience.createdNewKernel', '{0}: Kernel started: {1}');
+    export const kernelIsDead = localize(
+        'DataScience.kernelIsDead',
+        'Kernel died while starting. Check the Jupyter output tab.'
+    );
 }
 
 export namespace DebugConfigStrings {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -801,7 +801,7 @@ export namespace DataScience {
     export const createdNewKernel = localize('DataScience.createdNewKernel', '{0}: Kernel started: {1}');
     export const kernelIsDead = localize(
         'DataScience.kernelIsDead',
-        'Kernel died while starting. Check the Jupyter output tab.'
+        'Kernel {0} died while starting. Check the Jupyter output tab for more information.'
     );
 }
 

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -335,7 +335,9 @@ export class JupyterSession implements IJupyterSession {
                     resolve();
                 } else if (e === 'dead') {
                     traceError('Kernel died while waiting for idle');
-                    reject(new JupyterWaitForIdleError(localize.DataScience.kernelIsDead()));
+                    reject(
+                        new JupyterWaitForIdleError(localize.DataScience.kernelIsDead().format(session.kernel.name))
+                    );
                 }
             };
 

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -18,7 +18,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 import { Cancellation } from '../../common/cancellation';
 import { isTestExecution } from '../../common/constants';
-import { traceInfo, traceWarning } from '../../common/logger';
+import { traceError, traceInfo, traceWarning } from '../../common/logger';
 import { IOutputChannel } from '../../common/types';
 import { sleep, waitForPromise } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
@@ -156,7 +156,11 @@ export class JupyterSession implements IJupyterSession {
             this.session.statusChanged.connect(this.statusHandler);
 
             // After switching, start another in case we restart again.
-            this.restartSessionPromise = this.createRestartSession(oldSession.serverSettings, this.contentsManager);
+            this.restartSessionPromise = this.createRestartSession(
+                oldSession.serverSettings,
+                this.kernelSpec,
+                this.contentsManager
+            );
             traceInfo('Started new restart session');
             if (oldStatusHandler) {
                 oldSession.statusChanged.disconnect(oldStatusHandler);
@@ -226,7 +230,12 @@ export class JupyterSession implements IJupyterSession {
         }
 
         // Start a new session
-        this.session = await this.createSession(this.serverSettings, this.contentsManager, cancelToken);
+        this.session = await this.createSession(
+            this.serverSettings,
+            this.kernelSpec,
+            this.contentsManager,
+            cancelToken
+        );
 
         // Listen for session status changes
         this.session.statusChanged.connect(this.statusHandler);
@@ -240,6 +249,18 @@ export class JupyterSession implements IJupyterSession {
     }
 
     public async changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void> {
+        let newSession: Session.ISession | undefined;
+        try {
+            // Don't immediately assume this kernel is valid. Try creating a session with it first.
+            newSession = await this.createSession(this.serverSettings, kernel, this.contentsManager);
+
+            // Make sure it is idle before we return
+            await this.waitForIdleOnSession(newSession, timeoutMS);
+        } catch (exc) {
+            // Throw a new exception indicating we cannot change.
+            throw new JupyterSessionStartError(exc);
+        }
+
         if (kernel.id && this.session && 'session' in kernel) {
             // Shutdown the current session
             this.shutdownSession(this.session, this.statusHandler).ignoreErrors();
@@ -260,17 +281,14 @@ export class JupyterSession implements IJupyterSession {
         // Update our kernel spec
         this.kernelSpec = kernel;
 
-        // Start a new session
-        this.session = await this.createSession(this.serverSettings, this.contentsManager);
-
-        // Make sure it is idle before we return
-        await this.waitForIdleOnSession(this.session, timeoutMS);
+        // Save the new session
+        this.session = newSession;
 
         // Listen for session status changes
         this.session.statusChanged.connect(this.statusHandler);
 
         // Start the restart session promise too.
-        this.restartSessionPromise = this.createRestartSession(this.serverSettings, this.contentsManager);
+        this.restartSessionPromise = this.createRestartSession(this.serverSettings, kernel, this.contentsManager);
     }
 
     private getServerStatus(): ServerStatus {
@@ -299,7 +317,11 @@ export class JupyterSession implements IJupyterSession {
 
     private startRestartSession() {
         if (!this.restartSessionPromise && this.session && this.contentsManager) {
-            this.restartSessionPromise = this.createRestartSession(this.session.serverSettings, this.contentsManager);
+            this.restartSessionPromise = this.createRestartSession(
+                this.session.serverSettings,
+                this.kernelSpec,
+                this.contentsManager
+            );
         }
     }
 
@@ -307,14 +329,21 @@ export class JupyterSession implements IJupyterSession {
     private async waitForIdleOnSession(session: ISession | undefined, timeout: number): Promise<void> {
         if (session && session.kernel) {
             traceInfo(`Waiting for idle on (kernel): ${session.kernel.id} -> ${session.kernel.status}`);
+            // tslint:disable-next-line: no-any
+            const statusHandler = (resolve: () => void, reject: (exc: any) => void, e: Kernel.Status | undefined) => {
+                if (e === 'idle') {
+                    resolve();
+                } else if (e === 'dead') {
+                    traceError('Kernel died while waiting for idle');
+                    reject(new JupyterWaitForIdleError(localize.DataScience.kernelIsDead()));
+                }
+            };
 
-            const kernelStatusChangedPromise = new Promise(resolve =>
-                session.statusChanged.connect((_, e) => (e === 'idle' ? resolve() : undefined))
+            const kernelStatusChangedPromise = new Promise((resolve, reject) =>
+                session.statusChanged.connect((_, e) => statusHandler(resolve, reject, e))
             );
-            const statusChangedPromise = new Promise(resolve =>
-                session.kernelChanged.connect((_, e) =>
-                    e.newValue && e.newValue.status === 'idle' ? resolve() : undefined
-                )
+            const statusChangedPromise = new Promise((resolve, reject) =>
+                session.kernelChanged.connect((_, e) => statusHandler(resolve, reject, e.newValue?.status))
             );
             const checkStatusPromise = new Promise(async resolve => {
                 // This function seems to cause CI builds to timeout randomly on
@@ -345,6 +374,7 @@ export class JupyterSession implements IJupyterSession {
 
     private async createRestartSession(
         serverSettings: ServerConnection.ISettings,
+        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
         contentsManager: ContentsManager,
         cancelToken?: CancellationToken
     ): Promise<ISession> {
@@ -354,7 +384,7 @@ export class JupyterSession implements IJupyterSession {
         let exception: any;
         while (tryCount < 3) {
             try {
-                result = await this.createSession(serverSettings, contentsManager, cancelToken);
+                result = await this.createSession(serverSettings, kernelSpec, contentsManager, cancelToken);
                 await this.waitForIdleOnSession(result, 30000);
                 this.kernelSelector.addKernelToIgnoreList(result.kernel);
                 return result;
@@ -373,6 +403,7 @@ export class JupyterSession implements IJupyterSession {
 
     private async createSession(
         serverSettings: ServerConnection.ISettings,
+        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
         contentsManager: ContentsManager,
         cancelToken?: CancellationToken
     ): Promise<Session.ISession> {
@@ -382,7 +413,7 @@ export class JupyterSession implements IJupyterSession {
         // Create our session options using this temporary notebook and our connection info
         const options: Session.IOptions = {
             path: this.notebookFiles[this.notebookFiles.length - 1].path,
-            kernelName: this.kernelSpec ? this.kernelSpec.name : '',
+            kernelName: kernelSpec ? kernelSpec.name : '',
             name: uuid(), // This is crucial to distinguish this session from any other.
             serverSettings: serverSettings
         };

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -216,6 +216,9 @@ suite('Data Science - JupyterSession', () => {
                 remoteSessionInstance = instance(remoteSession);
                 remoteSessionInstance.isRemoteSession = false;
                 when(remoteSession.kernel).thenReturn(instance(remoteKernel));
+                when(sessionManager.startNew(anything())).thenCall(() => {
+                    return Promise.resolve(instance(remoteSession));
+                });
             });
             suite('Switching kernels', () => {
                 setup(async () => {
@@ -232,7 +235,6 @@ suite('Data Science - JupyterSession', () => {
                 });
                 test('Will shutdown to old session', async () => {
                     verify(session.shutdown()).once();
-                    verify(session.dispose()).once();
                 });
                 test('Will connect to existing session', async () => {
                     verify(sessionManager.connectTo(newActiveRemoteKernel.session)).once();
@@ -241,8 +243,8 @@ suite('Data Science - JupyterSession', () => {
                     // Confirm the new session is flagged as remote
                     assert.isTrue(newActiveRemoteKernel.session.isRemoteSession);
                 });
-                test('Will note create a new session', async () => {
-                    verify(sessionManager.startNew(anything())).once();
+                test('Will not create a new session', async () => {
+                    verify(sessionManager.startNew(anything())).twice();
                 });
                 test('Restart should restart the new remote kernel', async () => {
                     when(remoteKernel.restart()).thenResolve();


### PR DESCRIPTION
For #9250

Make sure that if an invalid kernel is picked, the user can back out of the decision. Do this by watching for 'dead'.

Would be nice if we had some kernel switching functional tests, but I believe that requires this issue to be fixed first:
https://github.com/microsoft/vscode-python/issues/10134