### PR TITLE
Modified `Select interpreter` command & add a reset interpreter command

### DIFF
--- a/news/1 Enhancements/10372.md
+++ b/news/1 Enhancements/10372.md
@@ -1,0 +1,1 @@
+Modified `Select interpreter` command to support setting interpreter at workspace level.

--- a/news/1 Enhancements/10374.md
+++ b/news/1 Enhancements/10374.md
@@ -1,0 +1,1 @@
+Added a command to reset value of Python interpreter.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "onCommand:python.switchOffInsidersChannel",
         "onCommand:python.switchToDailyChannel",
         "onCommand:python.switchToWeeklyChannel",
+        "onCommand:python.resetPythonInterpreter",
         "onCommand:python.datascience.createnewnotebook",
         "onCommand:python.datascience.showhistorypane",
         "onCommand:python.datascience.importnotebook",
@@ -220,6 +221,11 @@
             {
                 "command": "python.switchToWeeklyChannel",
                 "title": "%python.command.python.switchToWeeklyChannel.title%",
+                "category": "Python"
+            },
+            {
+                "command": "python.resetPythonInterpreter",
+                "title": "%python.command.python.resetPythonInterpreter.title%",
                 "category": "Python"
             },
             {
@@ -745,6 +751,11 @@
                     "title": "%python.command.python.switchToWeeklyChannel.title%",
                     "category": "Python",
                     "when": "config.python.insidersChannel != 'weekly'"
+                },
+                {
+                    "command": "python.resetPythonInterpreter",
+                    "title": "%python.command.python.resetPythonInterpreter.title%",
+                    "category": "Python"
                 },
                 {
                     "command": "python.viewOutput",

--- a/package.nls.json
+++ b/package.nls.json
@@ -131,6 +131,7 @@
     "DataScience.connectingToJupyter": "Connecting to Jupyter server",
     "Experiments.inGroup": "User belongs to experiment group '{0}'",
     "Interpreters.RefreshingInterpreters": "Refreshing Python Interpreters",
+    "Interpreters.entireWorkspace": "Entire workspace",
     "Interpreters.LoadingInterpreters": "Loading Python Interpreters",
     "Interpreters.condaInheritEnvMessage": "We noticed you're using a conda environment. If you are experiencing issues with this environment in the integrated terminal, we recommend that you let the Python extension change \"terminal.integrated.inheritEnv\" to false in your user settings.",
     "Logging.CurrentWorkingDirectory": "cwd:",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,6 +10,7 @@
     "python.command.python.switchOffInsidersChannel.title": "Switch to Default Channel",
     "python.command.python.switchToDailyChannel.title": "Switch to Insiders Daily Channel",
     "python.command.python.switchToWeeklyChannel.title": "Switch to Insiders Weekly Channel",
+    "python.command.python.resetPythonInterpreter.title": "Reset Python Interpreter",
     "python.command.python.refactorExtractVariable.title": "Extract Variable",
     "python.command.python.refactorExtractMethod.title": "Extract Method",
     "python.command.python.viewOutput.title": "Show Output",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -22,6 +22,7 @@ export type CommandsWithoutArgs = keyof ICommandNameWithoutArgumentTypeMapping;
 interface ICommandNameWithoutArgumentTypeMapping {
     [Commands.SwitchToInsidersDaily]: [];
     [Commands.SwitchToInsidersWeekly]: [];
+    [Commands.ResetPythonInterpreter]: [];
     [Commands.SwitchOffInsidersChannel]: [];
     [Commands.Set_Interpreter]: [];
     [Commands.Set_ShebangInterpreter]: [];

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -63,6 +63,7 @@ export namespace Commands {
     export const SwitchToInsidersDaily = 'python.switchToDailyChannel';
     export const SwitchToInsidersWeekly = 'python.switchToWeeklyChannel';
     export const PickLocalProcess = 'python.pickLocalProcess';
+    export const ResetPythonInterpreter = 'python.resetPythonInterpreter';
 }
 export namespace Octicons {
     export const Test_Pass = '$(check)';

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -139,6 +139,7 @@ export namespace Interpreters {
         'Interpreters.environmentPromptMessage',
         'We noticed a new virtual environment has been created. Do you want to select it for the workspace folder?'
     );
+    export const entireWorkspace = localize('Interpreters.entireWorkspace', 'Entire workspace');
     export const selectInterpreterTip = localize(
         'Interpreters.selectInterpreterTip',
         'Tip: you can change the Python interpreter used by the Python extension by clicking on the Python version in the status bar'

--- a/src/client/interpreter/configuration/interpreterSelector.ts
+++ b/src/client/interpreter/configuration/interpreterSelector.ts
@@ -175,11 +175,11 @@ export class InterpreterSelector implements IInterpreterSelector {
         type WorkspaceSelectionQuickPickItem = QuickPickItem & { uri: Uri };
         const quickPickItems: WorkspaceSelectionQuickPickItem[] = [
             ...this.workspaceService.workspaceFolders.map(w => {
-                return {
+                ({
                     label: w.name,
                     description: path.dirname(w.uri.fsPath),
                     uri: w.uri
-                };
+                })
             }),
             {
                 label: Interpreters.entireWorkspace(),

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -24,7 +24,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         this.executionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
     }
     public async updatePythonPath(
-        pythonPath: string,
+        pythonPath: string | undefined,
         configTarget: ConfigurationTarget,
         trigger: 'ui' | 'shebang' | 'load',
         wkspace?: Uri
@@ -33,7 +33,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         const pythonPathUpdater = this.getPythonUpdaterService(configTarget, wkspace);
         let failed = false;
         try {
-            await pythonPathUpdater.updatePythonPath(path.normalize(pythonPath));
+            await pythonPathUpdater.updatePythonPath(pythonPath ? path.normalize(pythonPath) : undefined);
         } catch (reason) {
             failed = true;
             // tslint:disable-next-line:no-unsafe-any prefer-type-cast
@@ -50,13 +50,13 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         duration: number,
         failed: boolean,
         trigger: 'ui' | 'shebang' | 'load',
-        pythonPath: string
+        pythonPath: string | undefined
     ) {
         const telemtryProperties: PythonInterpreterTelemetry = {
             failed,
             trigger
         };
-        if (!failed) {
+        if (!failed && pythonPath) {
             const processService = await this.executionFactory.create({ pythonPath });
             const infoPromise = processService
                 .getInterpreterInformation()

--- a/src/client/interpreter/configuration/services/globalUpdaterService.ts
+++ b/src/client/interpreter/configuration/services/globalUpdaterService.ts
@@ -3,7 +3,7 @@ import { IPythonPathUpdaterService } from '../types';
 
 export class GlobalPythonPathUpdaterService implements IPythonPathUpdaterService {
     constructor(private readonly workspaceService: IWorkspaceService) {}
-    public async updatePythonPath(pythonPath: string): Promise<void> {
+    public async updatePythonPath(pythonPath: string | undefined): Promise<void> {
         const pythonConfig = this.workspaceService.getConfiguration('python');
         const pythonPathValue = pythonConfig.inspect<string>('pythonPath');
 

--- a/src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
+++ b/src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
@@ -5,14 +5,14 @@ import { IPythonPathUpdaterService } from '../types';
 
 export class WorkspaceFolderPythonPathUpdaterService implements IPythonPathUpdaterService {
     constructor(private workspaceFolder: Uri, private readonly workspaceService: IWorkspaceService) {}
-    public async updatePythonPath(pythonPath: string): Promise<void> {
+    public async updatePythonPath(pythonPath: string | undefined): Promise<void> {
         const pythonConfig = this.workspaceService.getConfiguration('python', this.workspaceFolder);
         const pythonPathValue = pythonConfig.inspect<string>('pythonPath');
 
         if (pythonPathValue && pythonPathValue.workspaceFolderValue === pythonPath) {
             return;
         }
-        if (pythonPath.startsWith(this.workspaceFolder.fsPath)) {
+        if (pythonPath && pythonPath.startsWith(this.workspaceFolder.fsPath)) {
             pythonPath = path.relative(this.workspaceFolder.fsPath, pythonPath);
         }
         await pythonConfig.update('pythonPath', pythonPath, ConfigurationTarget.WorkspaceFolder);

--- a/src/client/interpreter/configuration/types.ts
+++ b/src/client/interpreter/configuration/types.ts
@@ -3,7 +3,7 @@ import { Resource } from '../../common/types';
 import { PythonInterpreter } from '../contracts';
 
 export interface IPythonPathUpdaterService {
-    updatePythonPath(pythonPath: string): Promise<void>;
+    updatePythonPath(pythonPath: string | undefined): Promise<void>;
 }
 
 export const IPythonPathUpdaterServiceFactory = Symbol('IPythonPathUpdaterServiceFactory');
@@ -16,7 +16,7 @@ export interface IPythonPathUpdaterServiceFactory {
 export const IPythonPathUpdaterServiceManager = Symbol('IPythonPathUpdaterServiceManager');
 export interface IPythonPathUpdaterServiceManager {
     updatePythonPath(
-        pythonPath: string,
+        pythonPath: string | undefined,
         configTarget: ConfigurationTarget,
         trigger: 'ui' | 'shebang' | 'load',
         wkspace?: Uri

--- a/src/test/configuration/interpreterSelector.unit.test.ts
+++ b/src/test/configuration/interpreterSelector.unit.test.ts
@@ -68,6 +68,8 @@ suite('Interpreters - selector', () => {
     let shebangProvider: TypeMoq.IMock<IShebangCodeLensProvider>;
     let configurationService: TypeMoq.IMock<IConfigurationService>;
     let pythonSettings: TypeMoq.IMock<IPythonSettings>;
+    const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
+    const folder2 = { name: 'two', uri: Uri.parse('two'), index: 2 };
 
     class TestInterpreterSelector extends InterpreterSelector {
         // tslint:disable-next-line:no-unnecessary-override
@@ -85,7 +87,14 @@ suite('Interpreters - selector', () => {
         public async setShebangInterpreter() {
             return super.setShebangInterpreter();
         }
+        // tslint:disable-next-line:no-unnecessary-override
+        public async resetInterpreter() {
+            return super.resetInterpreter();
+        }
     }
+
+    let selector: TestInterpreterSelector;
+
     setup(() => {
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
         comparer = TypeMoq.Mock.ofType<IInterpreterComparer>();
@@ -105,11 +114,23 @@ suite('Interpreters - selector', () => {
         configurationService.setup(x => x.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
 
         comparer.setup(c => c.compare(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => 0);
+        selector = new TestInterpreterSelector(
+            interpreterService.object,
+            workspace.object,
+            appShell.object,
+            documentManager.object,
+            new PathUtils(false),
+            comparer.object,
+            pythonPathUpdater.object,
+            shebangProvider.object,
+            configurationService.object,
+            commandManager.object
+        );
     });
 
     [true, false].forEach(isWindows => {
         test(`Suggestions (${isWindows ? 'Windows' : 'Non-Windows'})`, async () => {
-            const selector = new InterpreterSelector(
+            const interpreterSelector = new InterpreterSelector(
                 interpreterService.object,
                 workspace.object,
                 appShell.object,
@@ -136,7 +157,7 @@ suite('Interpreters - selector', () => {
                 .setup(x => x.getInterpreters(TypeMoq.It.isAny()))
                 .returns(() => new Promise(resolve => resolve(initial)));
 
-            const actual = await selector.getSuggestions(undefined);
+            const actual = await interpreterSelector.getSuggestions(undefined);
 
             const expected: InterpreterQuickPickItem[] = [
                 new InterpreterQuickPickItem('1', 'c:/path1/path1'),
@@ -163,319 +184,431 @@ suite('Interpreters - selector', () => {
         });
     });
 
-    test('Update Global settings when there are no workspaces', async () => {
-        const selector = new TestInterpreterSelector(
-            interpreterService.object,
-            workspace.object,
-            appShell.object,
-            documentManager.object,
-            new PathUtils(false),
-            comparer.object,
-            pythonPathUpdater.object,
-            shebangProvider.object,
-            configurationService.object,
-            commandManager.object
-        );
-        pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
-        const selectedItem: IInterpreterQuickPickItem = {
-            description: '',
-            detail: '',
-            label: '',
-            path: 'This is the selected Python path',
-            // tslint:disable-next-line: no-any
-            interpreter: {} as any
-        };
+    // tslint:disable-next-line: max-func-body-length
+    suite('Test method setInterpreter()', async () => {
+        test('Update Global settings when there are no workspaces', async () => {
+            pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+            const selectedItem: IInterpreterQuickPickItem = {
+                description: '',
+                detail: '',
+                label: '',
+                path: 'This is the selected Python path',
+                // tslint:disable-next-line: no-any
+                interpreter: {} as any
+            };
 
-        workspace.setup(w => w.workspaceFolders).returns(() => undefined);
+            workspace.setup(w => w.workspaceFolders).returns(() => undefined);
 
-        selector.getSuggestions = () => Promise.resolve([]);
-        appShell
-            .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(selectedItem))
-            .verifiable(TypeMoq.Times.once());
-        pythonPathUpdater
-            .setup(p =>
-                p.updatePythonPath(
-                    TypeMoq.It.isValue(selectedItem.path),
-                    TypeMoq.It.isValue(ConfigurationTarget.Global),
-                    TypeMoq.It.isValue('ui'),
-                    TypeMoq.It.isValue(undefined)
+            selector.getSuggestions = () => Promise.resolve([]);
+            appShell
+                .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(selectedItem))
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(selectedItem.path),
+                        TypeMoq.It.isValue(ConfigurationTarget.Global),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(undefined)
+                    )
                 )
-            )
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.once());
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
 
-        await selector.setInterpreter();
+            await selector.setInterpreter();
 
-        appShell.verifyAll();
-        workspace.verifyAll();
-        pythonPathUpdater.verifyAll();
-    });
-    test('Update workspace folder settings when there is one workspace folder', async () => {
-        const selector = new TestInterpreterSelector(
-            interpreterService.object,
-            workspace.object,
-            appShell.object,
-            documentManager.object,
-            new PathUtils(false),
-            comparer.object,
-            pythonPathUpdater.object,
-            shebangProvider.object,
-            configurationService.object,
-            commandManager.object
-        );
-        pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
-        const selectedItem: IInterpreterQuickPickItem = {
-            description: '',
-            detail: '',
-            label: '',
-            path: 'This is the selected Python path',
-            // tslint:disable-next-line: no-any
-            interpreter: {} as any
-        };
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Update workspace folder settings when there is one workspace folder', async () => {
+            pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+            const selectedItem: IInterpreterQuickPickItem = {
+                description: '',
+                detail: '',
+                label: '',
+                path: 'This is the selected Python path',
+                // tslint:disable-next-line: no-any
+                interpreter: {} as any
+            };
 
-        const folder = { name: 'one', uri: Uri.parse('one'), index: 0 };
-        workspace.setup(w => w.workspaceFolders).returns(() => [folder]);
+            const folder = { name: 'one', uri: Uri.parse('one'), index: 0 };
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder]);
 
-        selector.getSuggestions = () => Promise.resolve([]);
-        appShell
-            .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(selectedItem))
-            .verifiable(TypeMoq.Times.once());
-        pythonPathUpdater
-            .setup(p =>
-                p.updatePythonPath(
-                    TypeMoq.It.isValue(selectedItem.path),
-                    TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
-                    TypeMoq.It.isValue('ui'),
-                    TypeMoq.It.isValue(folder.uri)
+            selector.getSuggestions = () => Promise.resolve([]);
+            appShell
+                .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(selectedItem))
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(selectedItem.path),
+                        TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(folder.uri)
+                    )
                 )
-            )
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.once());
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
 
-        await selector.setInterpreter();
+            await selector.setInterpreter();
 
-        appShell.verifyAll();
-        workspace.verifyAll();
-        pythonPathUpdater.verifyAll();
-    });
-    test('Update selected workspace folder settings when there is more than one workspace folder', async () => {
-        const selector = new TestInterpreterSelector(
-            interpreterService.object,
-            workspace.object,
-            appShell.object,
-            documentManager.object,
-            new PathUtils(false),
-            comparer.object,
-            pythonPathUpdater.object,
-            shebangProvider.object,
-            configurationService.object,
-            commandManager.object
-        );
-        pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
-        const selectedItem: IInterpreterQuickPickItem = {
-            description: '',
-            detail: '',
-            label: '',
-            path: 'This is the selected Python path',
-            // tslint:disable-next-line: no-any
-            interpreter: {} as any
-        };
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Update selected workspace folder settings when there is more than one workspace folder', async () => {
+            pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+            const selectedItem: IInterpreterQuickPickItem = {
+                description: '',
+                detail: '',
+                label: '',
+                path: 'This is the selected Python path',
+                // tslint:disable-next-line: no-any
+                interpreter: {} as any
+            };
 
-        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
-        const folder2 = { name: 'two', uri: Uri.parse('two'), index: 2 };
-        workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
-        const expectedItems = [
-            {
-                label: 'one',
-                description: path.dirname(folder1.uri.fsPath),
-                uri: folder1.uri
-            },
-            {
-                label: 'two',
-                description: path.dirname(folder2.uri.fsPath),
-                uri: folder2.uri
-            },
-            {
-                label: Interpreters.entireWorkspace(),
-                uri: folder1.uri
-            }
-        ];
-        selector.getSuggestions = () => Promise.resolve([]);
-        appShell
-            .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isValue([]), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(selectedItem))
-            .verifiable(TypeMoq.Times.once());
-        appShell
-            .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
-            .returns(() =>
-                Promise.resolve({
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+            const expectedItems = [
+                {
+                    label: 'one',
+                    description: path.dirname(folder1.uri.fsPath),
+                    uri: folder1.uri
+                },
+                {
                     label: 'two',
                     description: path.dirname(folder2.uri.fsPath),
                     uri: folder2.uri
-                })
-            )
-            .verifiable(TypeMoq.Times.once());
-        pythonPathUpdater
-            .setup(p =>
-                p.updatePythonPath(
-                    TypeMoq.It.isValue(selectedItem.path),
-                    TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
-                    TypeMoq.It.isValue('ui'),
-                    TypeMoq.It.isValue(folder2.uri)
-                )
-            )
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.once());
-
-        await selector.setInterpreter();
-
-        appShell.verifyAll();
-        workspace.verifyAll();
-        pythonPathUpdater.verifyAll();
-    });
-    test('Update entire workspace settings when there is more than one workspace folder and `Entire workspace` is selected', async () => {
-        const selector = new TestInterpreterSelector(
-            interpreterService.object,
-            workspace.object,
-            appShell.object,
-            documentManager.object,
-            new PathUtils(false),
-            comparer.object,
-            pythonPathUpdater.object,
-            shebangProvider.object,
-            configurationService.object,
-            commandManager.object
-        );
-        pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
-        const selectedItem: IInterpreterQuickPickItem = {
-            description: '',
-            detail: '',
-            label: '',
-            path: 'This is the selected Python path',
-            // tslint:disable-next-line: no-any
-            interpreter: {} as any
-        };
-
-        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
-        const folder2 = { name: 'two', uri: Uri.parse('two'), index: 2 };
-        workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
-        const expectedItems = [
-            {
-                label: 'one',
-                description: path.dirname(folder1.uri.fsPath),
-                uri: folder1.uri
-            },
-            {
-                label: 'two',
-                description: path.dirname(folder2.uri.fsPath),
-                uri: folder2.uri
-            },
-            {
-                label: Interpreters.entireWorkspace(),
-                uri: folder1.uri
-            }
-        ];
-        selector.getSuggestions = () => Promise.resolve([selectedItem]);
-        appShell
-            .setup(s =>
-                s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isValue([selectedItem]), TypeMoq.It.isAny())
-            )
-            .returns(() => Promise.resolve(selectedItem))
-            .verifiable(TypeMoq.Times.once());
-        appShell
-            .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
-            .returns(() =>
-                Promise.resolve({
+                },
+                {
                     label: Interpreters.entireWorkspace(),
                     uri: folder1.uri
-                })
-            )
-            .verifiable(TypeMoq.Times.once());
-        pythonPathUpdater
-            .setup(p =>
-                p.updatePythonPath(
-                    TypeMoq.It.isValue(selectedItem.path),
-                    TypeMoq.It.isValue(ConfigurationTarget.Workspace),
-                    TypeMoq.It.isValue('ui'),
-                    TypeMoq.It.isValue(folder1.uri)
+                }
+            ];
+            selector.getSuggestions = () => Promise.resolve([]);
+            appShell
+                .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isValue([]), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(selectedItem))
+                .verifiable(TypeMoq.Times.once());
+            appShell
+                .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
+                .returns(() =>
+                    Promise.resolve({
+                        label: 'two',
+                        description: path.dirname(folder2.uri.fsPath),
+                        uri: folder2.uri
+                    })
                 )
-            )
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.once());
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(selectedItem.path),
+                        TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(folder2.uri)
+                    )
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
 
-        await selector.setInterpreter();
+            await selector.setInterpreter();
 
-        appShell.verifyAll();
-        workspace.verifyAll();
-        pythonPathUpdater.verifyAll();
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Update entire workspace settings when there is more than one workspace folder and `Entire workspace` is selected', async () => {
+            pythonSettings.setup(p => p.pythonPath).returns(() => 'python');
+            const selectedItem: IInterpreterQuickPickItem = {
+                description: '',
+                detail: '',
+                label: '',
+                path: 'This is the selected Python path',
+                // tslint:disable-next-line: no-any
+                interpreter: {} as any
+            };
+
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+            const expectedItems = [
+                {
+                    label: 'one',
+                    description: path.dirname(folder1.uri.fsPath),
+                    uri: folder1.uri
+                },
+                {
+                    label: 'two',
+                    description: path.dirname(folder2.uri.fsPath),
+                    uri: folder2.uri
+                },
+                {
+                    label: Interpreters.entireWorkspace(),
+                    uri: folder1.uri
+                }
+            ];
+            selector.getSuggestions = () => Promise.resolve([selectedItem]);
+            appShell
+                .setup(s =>
+                    s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isValue([selectedItem]), TypeMoq.It.isAny())
+                )
+                .returns(() => Promise.resolve(selectedItem))
+                .verifiable(TypeMoq.Times.once());
+            appShell
+                .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
+                .returns(() =>
+                    Promise.resolve({
+                        label: Interpreters.entireWorkspace(),
+                        uri: folder1.uri
+                    })
+                )
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(selectedItem.path),
+                        TypeMoq.It.isValue(ConfigurationTarget.Workspace),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(folder1.uri)
+                    )
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
+
+            await selector.setInterpreter();
+
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Do not update anything when user does not select a workspace folder and there is more than one workspace folder', async () => {
+            const selectedItem: IInterpreterQuickPickItem = {
+                description: '',
+                detail: '',
+                label: '',
+                path: 'This is the selected Python path',
+                // tslint:disable-next-line: no-any
+                interpreter: {} as any
+            };
+
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+
+            selector.getSuggestions = () => Promise.resolve([]);
+            appShell
+                .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isValue([]), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(selectedItem))
+                .verifiable(TypeMoq.Times.never());
+
+            const expectedItems = [
+                {
+                    label: 'one',
+                    description: path.dirname(folder1.uri.fsPath),
+                    uri: folder1.uri
+                },
+                {
+                    label: 'two',
+                    description: path.dirname(folder2.uri.fsPath),
+                    uri: folder2.uri
+                },
+                {
+                    label: Interpreters.entireWorkspace(),
+                    uri: folder1.uri
+                }
+            ];
+
+            appShell
+                .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.never());
+
+            await selector.setInterpreter();
+
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
     });
-    test('Do not update anything when user does not select a workspace folder and there is more than one workspace folder', async () => {
-        const selector = new TestInterpreterSelector(
-            interpreterService.object,
-            workspace.object,
-            appShell.object,
-            documentManager.object,
-            new PathUtils(false),
-            comparer.object,
-            pythonPathUpdater.object,
-            shebangProvider.object,
-            configurationService.object,
-            commandManager.object
-        );
 
-        const selectedItem: IInterpreterQuickPickItem = {
-            description: '',
-            detail: '',
-            label: '',
-            path: 'This is the selected Python path',
-            // tslint:disable-next-line: no-any
-            interpreter: {} as any
-        };
+    // tslint:disable-next-line: max-func-body-length
+    suite('Test method resetInterpreter()', async () => {
+        test('Update Global settings when there are no workspaces', async () => {
+            workspace.setup(w => w.workspaceFolders).returns(() => undefined);
 
-        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
-        const folder2 = { name: 'two', uri: Uri.parse('two'), index: 2 };
-        workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(undefined),
+                        TypeMoq.It.isValue(ConfigurationTarget.Global),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(undefined)
+                    )
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
 
-        selector.getSuggestions = () => Promise.resolve([]);
-        appShell
-            .setup(s => s.showQuickPick<IInterpreterQuickPickItem>(TypeMoq.It.isValue([]), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(selectedItem))
-            .verifiable(TypeMoq.Times.never());
+            await selector.resetInterpreter();
 
-        const expectedItems = [
-            {
-                label: 'one',
-                description: path.dirname(folder1.uri.fsPath),
-                uri: folder1.uri
-            },
-            {
-                label: 'two',
-                description: path.dirname(folder2.uri.fsPath),
-                uri: folder2.uri
-            },
-            {
-                label: Interpreters.entireWorkspace(),
-                uri: folder1.uri
-            }
-        ];
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Update workspace folder settings when there is one workspace folder', async () => {
+            const folder = { name: 'one', uri: Uri.parse('one'), index: 0 };
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder]);
 
-        appShell
-            .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
-            .returns(() => Promise.resolve(undefined))
-            .verifiable(TypeMoq.Times.once());
-        pythonPathUpdater
-            .setup(p =>
-                p.updatePythonPath(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())
-            )
-            .returns(() => Promise.resolve())
-            .verifiable(TypeMoq.Times.never());
+            selector.getSuggestions = () => Promise.resolve([]);
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(undefined),
+                        TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(folder.uri)
+                    )
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
 
-        await selector.setInterpreter();
+            await selector.resetInterpreter();
 
-        appShell.verifyAll();
-        workspace.verifyAll();
-        pythonPathUpdater.verifyAll();
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Update selected workspace folder settings when there is more than one workspace folder', async () => {
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+            const expectedItems = [
+                {
+                    label: 'one',
+                    description: path.dirname(folder1.uri.fsPath),
+                    uri: folder1.uri
+                },
+                {
+                    label: 'two',
+                    description: path.dirname(folder2.uri.fsPath),
+                    uri: folder2.uri
+                },
+                {
+                    label: Interpreters.entireWorkspace(),
+                    uri: folder1.uri
+                }
+            ];
+            appShell
+                .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
+                .returns(() =>
+                    Promise.resolve({
+                        label: 'two',
+                        description: path.dirname(folder2.uri.fsPath),
+                        uri: folder2.uri
+                    })
+                )
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(undefined),
+                        TypeMoq.It.isValue(ConfigurationTarget.WorkspaceFolder),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(folder2.uri)
+                    )
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
+
+            await selector.resetInterpreter();
+
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Update entire workspace settings when there is more than one workspace folder and `Entire workspace` is selected', async () => {
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+            const expectedItems = [
+                {
+                    label: 'one',
+                    description: path.dirname(folder1.uri.fsPath),
+                    uri: folder1.uri
+                },
+                {
+                    label: 'two',
+                    description: path.dirname(folder2.uri.fsPath),
+                    uri: folder2.uri
+                },
+                {
+                    label: Interpreters.entireWorkspace(),
+                    uri: folder1.uri
+                }
+            ];
+            appShell
+                .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
+                .returns(() =>
+                    Promise.resolve({
+                        label: Interpreters.entireWorkspace(),
+                        uri: folder1.uri
+                    })
+                )
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(
+                        TypeMoq.It.isValue(undefined),
+                        TypeMoq.It.isValue(ConfigurationTarget.Workspace),
+                        TypeMoq.It.isValue('ui'),
+                        TypeMoq.It.isValue(folder1.uri)
+                    )
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.once());
+
+            await selector.resetInterpreter();
+
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
+        test('Do not update anything when user does not select a workspace folder and there is more than one workspace folder', async () => {
+            workspace.setup(w => w.workspaceFolders).returns(() => [folder1, folder2]);
+
+            const expectedItems = [
+                {
+                    label: 'one',
+                    description: path.dirname(folder1.uri.fsPath),
+                    uri: folder1.uri
+                },
+                {
+                    label: 'two',
+                    description: path.dirname(folder2.uri.fsPath),
+                    uri: folder2.uri
+                },
+                {
+                    label: Interpreters.entireWorkspace(),
+                    uri: folder1.uri
+                }
+            ];
+
+            appShell
+                .setup(s => s.showQuickPick(TypeMoq.It.isValue(expectedItems), TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(undefined))
+                .verifiable(TypeMoq.Times.once());
+            pythonPathUpdater
+                .setup(p =>
+                    p.updatePythonPath(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())
+                )
+                .returns(() => Promise.resolve())
+                .verifiable(TypeMoq.Times.never());
+
+            await selector.resetInterpreter();
+
+            appShell.verifyAll();
+            workspace.verifyAll();
+            pythonPathUpdater.verifyAll();
+        });
     });
 });


### PR DESCRIPTION
### I recommend to hide whitespace changes before reviewing

- Modified `Select interpreter` command to support setting interpreter at workspace level
- Added a reset interpreter command in a similar way

For #10372 #10374

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [x] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
