### PR TITLE
Rename notebookProvider to notebookEditorProvider

### DIFF
--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -19,14 +19,14 @@ import { INotebookEditor, INotebookEditorProvider } from './types';
 export class Activation implements IExtensionSingleActivationService {
     private notebookOpened = false;
     constructor(
-        @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
         @inject(JupyterInterpreterService) private readonly jupyterInterpreterService: JupyterInterpreterService,
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService
     ) {}
     public async activate(): Promise<void> {
-        this.disposables.push(this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
+        this.disposables.push(this.notebookEditorProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
         // Warm up our selected interpreter for the extension
         this.jupyterInterpreterService.setInitialInterpreter().ignoreErrors();

--- a/src/client/datascience/commands/commandRegistry.ts
+++ b/src/client/datascience/commands/commandRegistry.ts
@@ -35,7 +35,7 @@ export class CommandRegistry implements IDisposable {
         @inject(KernelSwitcherCommand) private readonly kernelSwitcherCommand: KernelSwitcherCommand,
         @inject(JupyterCommandLineSelectorCommand)
         private readonly commandLineCommand: JupyterCommandLineSelectorCommand,
-        @inject(INotebookEditorProvider) private notebookProvider: INotebookEditorProvider,
+        @inject(INotebookEditorProvider) private notebookEditorProvider: INotebookEditorProvider,
         @inject(IDebugService) private debugService: IDebugService,
         @inject(IOutputChannel) @named(JUPYTER_OUTPUT_CHANNEL) private jupyterOutput: IOutputChannel
     ) {
@@ -312,7 +312,7 @@ export class CommandRegistry implements IDisposable {
     }
 
     private async createNewNotebook(): Promise<void> {
-        await this.notebookProvider.createNew();
+        await this.notebookEditorProvider.createNew();
     }
     private viewJupyterOutput() {
         this.jupyterOutput.show(true);

--- a/src/client/datascience/commands/kernelSwitcher.ts
+++ b/src/client/datascience/commands/kernelSwitcher.ts
@@ -18,7 +18,7 @@ export class KernelSwitcherCommand implements IDisposable {
     constructor(
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(KernelSwitcher) private kernelSwitcher: KernelSwitcher,
-        @inject(INotebookEditorProvider) private notebookProvider: INotebookEditorProvider,
+        @inject(INotebookEditorProvider) private notebookEditorProvider: INotebookEditorProvider,
         @inject(IInteractiveWindowProvider) private interactiveWindowProvider: IInteractiveWindowProvider
     ) {}
     public register() {
@@ -34,7 +34,7 @@ export class KernelSwitcherCommand implements IDisposable {
         // We need to identify the current notebook (active native editor or interactive window).
         if (!notebook) {
             notebook =
-                this.notebookProvider.activeEditor?.notebook ?? this.interactiveWindowProvider.getActive()?.notebook;
+                this.notebookEditorProvider.activeEditor?.notebook ?? this.interactiveWindowProvider.getActive()?.notebook;
         }
         if (!notebook) {
             traceError('No active notebook');

--- a/src/client/datascience/commands/kernelSwitcher.ts
+++ b/src/client/datascience/commands/kernelSwitcher.ts
@@ -34,7 +34,8 @@ export class KernelSwitcherCommand implements IDisposable {
         // We need to identify the current notebook (active native editor or interactive window).
         if (!notebook) {
             notebook =
-                this.notebookEditorProvider.activeEditor?.notebook ?? this.interactiveWindowProvider.getActive()?.notebook;
+                this.notebookEditorProvider.activeEditor?.notebook ??
+                this.interactiveWindowProvider.getActive()?.notebook;
         }
         if (!notebook) {
             traceError('No active notebook');

--- a/src/client/datascience/context/activeEditorContext.ts
+++ b/src/client/datascience/context/activeEditorContext.ts
@@ -25,7 +25,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
     private isPythonFileActive: boolean = false;
     constructor(
         @inject(IInteractiveWindowProvider) private readonly interactiveProvider: IInteractiveWindowProvider,
-        @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
         @inject(IDocumentManager) private readonly docManager: IDocumentManager,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry
@@ -57,7 +57,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
             this,
             this.disposables
         );
-        this.notebookProvider.onDidChangeActiveNotebookEditor(
+        this.notebookEditorProvider.onDidChangeActiveNotebookEditor(
             this.onDidChangeActiveNotebookEditor,
             this,
             this.disposables

--- a/src/client/datascience/interactive-ipynb/autoSaveService.ts
+++ b/src/client/datascience/interactive-ipynb/autoSaveService.ts
@@ -37,7 +37,7 @@ export class AutoSaveService implements IInteractiveWindowListener {
     constructor(
         @inject(IApplicationShell) appShell: IApplicationShell,
         @inject(IDocumentManager) documentManager: IDocumentManager,
-        @inject(INotebookEditorProvider) private readonly notebookProvider: INotebookEditorProvider,
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
     ) {
@@ -89,7 +89,7 @@ export class AutoSaveService implements IInteractiveWindowListener {
         if (!uri) {
             return;
         }
-        return this.notebookProvider.editors.find(item => this.fileSystem.arePathsSame(item.file.fsPath, uri.fsPath));
+        return this.notebookEditorProvider.editors.find(item => this.fileSystem.arePathsSame(item.file.fsPath, uri.fsPath));
     }
     private getAutoSaveSettings(): FileSettings {
         const filesConfig = this.workspace.getConfiguration('files', this.notebookUri);

--- a/src/client/datascience/interactive-ipynb/autoSaveService.ts
+++ b/src/client/datascience/interactive-ipynb/autoSaveService.ts
@@ -89,7 +89,9 @@ export class AutoSaveService implements IInteractiveWindowListener {
         if (!uri) {
             return;
         }
-        return this.notebookEditorProvider.editors.find(item => this.fileSystem.arePathsSame(item.file.fsPath, uri.fsPath));
+        return this.notebookEditorProvider.editors.find(item =>
+            this.fileSystem.arePathsSame(item.file.fsPath, uri.fsPath)
+        );
     }
     private getAutoSaveSettings(): FileSettings {
         const filesConfig = this.workspace.getConfiguration('files', this.notebookUri);

--- a/src/client/datascience/jupyter/jupyterCellOutputMimeTypeTracker.ts
+++ b/src/client/datascience/jupyter/jupyterCellOutputMimeTypeTracker.ts
@@ -17,8 +17,8 @@ export class CellOutputMimeTypeTracker implements IExtensionSingleActivationServ
     private pendingChecks = new Map<string, NodeJS.Timer | number>();
     private sentMimeTypes: Set<string> = new Set<string>();
 
-    constructor(@inject(INotebookEditorProvider) private notebookProvider: INotebookEditorProvider) {
-        this.notebookProvider.onDidOpenNotebookEditor(t => this.onOpenedOrClosedNotebook(t));
+    constructor(@inject(INotebookEditorProvider) private notebookEditorProvider: INotebookEditorProvider) {
+        this.notebookEditorProvider.onDidOpenNotebookEditor(t => this.onOpenedOrClosedNotebook(t));
     }
     public async preExecute(_cell: ICell, _silent: boolean): Promise<void> {
         // Do nothing on pre execute
@@ -30,7 +30,7 @@ export class CellOutputMimeTypeTracker implements IExtensionSingleActivationServ
     }
     public async activate(): Promise<void> {
         // Act like all of our open documents just opened; our timeout will make sure this is delayed.
-        this.notebookProvider.editors.forEach(e => this.onOpenedOrClosedNotebook(e));
+        this.notebookEditorProvider.editors.forEach(e => this.onOpenedOrClosedNotebook(e));
     }
 
     private onOpenedOrClosedNotebook(e: INotebookEditor) {

--- a/src/client/datascience/jupyter/serverPreload.ts
+++ b/src/client/datascience/jupyter/serverPreload.ts
@@ -15,11 +15,11 @@ export class ServerPreload implements IExtensionSingleActivationService {
     constructor(
         @inject(IJupyterExecution) private execution: IJupyterExecution,
         @inject(IMemento) @named(WORKSPACE_MEMENTO) private mementoStorage: Memento,
-        @inject(INotebookEditorProvider) private notebookProvider: INotebookEditorProvider,
+        @inject(INotebookEditorProvider) private notebookEditorProvider: INotebookEditorProvider,
         @inject(IInteractiveWindowProvider) private interactiveProvider: IInteractiveWindowProvider,
         @inject(IConfigurationService) private configService: IConfigurationService
     ) {
-        this.notebookProvider.onDidOpenNotebookEditor(this.onDidOpenNotebook.bind(this));
+        this.notebookEditorProvider.onDidOpenNotebookEditor(this.onDidOpenNotebook.bind(this));
         this.interactiveProvider.onDidChangeActiveInteractiveWindow(this.onDidOpenOrCloseInteractive.bind(this));
     }
     public activate(): Promise<void> {

--- a/src/client/telemetry/importTracker.ts
+++ b/src/client/telemetry/importTracker.ts
@@ -52,12 +52,12 @@ export class ImportTracker implements IExtensionSingleActivationService, INotebo
 
     constructor(
         @inject(IDocumentManager) private documentManager: IDocumentManager,
-        @inject(INotebookEditorProvider) private notebookProvider: INotebookEditorProvider
+        @inject(INotebookEditorProvider) private notebookEditorProvider: INotebookEditorProvider
     ) {
         this.documentManager.onDidOpenTextDocument(t => this.onOpenedOrSavedDocument(t));
         this.documentManager.onDidSaveTextDocument(t => this.onOpenedOrSavedDocument(t));
-        this.notebookProvider.onDidOpenNotebookEditor(t => this.onOpenedOrClosedNotebook(t));
-        this.notebookProvider.onDidCloseNotebookEditor(t => this.onOpenedOrClosedNotebook(t));
+        this.notebookEditorProvider.onDidOpenNotebookEditor(t => this.onOpenedOrClosedNotebook(t));
+        this.notebookEditorProvider.onDidCloseNotebookEditor(t => this.onOpenedOrClosedNotebook(t));
     }
     public async preExecute(_cell: ICell, _silent: boolean): Promise<void> {
         // Do nothing on pre execute
@@ -72,7 +72,7 @@ export class ImportTracker implements IExtensionSingleActivationService, INotebo
     public async activate(): Promise<void> {
         // Act like all of our open documents just opened; our timeout will make sure this is delayed.
         this.documentManager.textDocuments.forEach(d => this.onOpenedOrSavedDocument(d));
-        this.notebookProvider.editors.forEach(e => this.onOpenedOrClosedNotebook(e));
+        this.notebookEditorProvider.editors.forEach(e => this.onOpenedOrClosedNotebook(e));
     }
 
     private getDocumentLines(document: TextDocument): (string | undefined)[] {

--- a/src/test/datascience/activation.unit.test.ts
+++ b/src/test/datascience/activation.unit.test.ts
@@ -22,7 +22,7 @@ import { createPythonInterpreter } from '../utils/interpreters';
 
 suite('Data Science - Activation', () => {
     let activator: IExtensionSingleActivationService;
-    let notebookProvider: INotebookEditorProvider;
+    let notebookEditorProvider: INotebookEditorProvider;
     let jupyterInterpreterService: JupyterInterpreterService;
     let executionFactory: IPythonExecutionFactory;
     let openedEventEmitter: EventEmitter<INotebookEditor>;
@@ -36,16 +36,16 @@ suite('Data Science - Activation', () => {
         openedEventEmitter = new EventEmitter<INotebookEditor>();
         interpreterEventEmitter = new EventEmitter<PythonInterpreter>();
 
-        notebookProvider = mock(NativeEditorProvider);
+        notebookEditorProvider = mock(NativeEditorProvider);
         jupyterInterpreterService = mock(JupyterInterpreterService);
         executionFactory = mock(PythonExecutionFactory);
         contextService = mock(ActiveEditorContextService);
-        when(notebookProvider.onDidOpenNotebookEditor).thenReturn(openedEventEmitter.event);
+        when(notebookEditorProvider.onDidOpenNotebookEditor).thenReturn(openedEventEmitter.event);
         when(jupyterInterpreterService.onDidChangeInterpreter).thenReturn(interpreterEventEmitter.event);
         when(executionFactory.createDaemon(anything())).thenResolve();
         when(contextService.activate()).thenResolve();
         activator = new Activation(
-            instance(notebookProvider),
+            instance(notebookEditorProvider),
             instance(jupyterInterpreterService),
             instance(executionFactory),
             [],

--- a/src/test/datascience/commands/commandRegistry.unit.test.ts
+++ b/src/test/datascience/commands/commandRegistry.unit.test.ts
@@ -27,7 +27,7 @@ suite('Data Science - Commands', () => {
         commandLineCommand = mock(JupyterCommandLineSelectorCommand);
 
         const codeLensProvider = mock(DataScienceCodeLensProvider);
-        const notebookProvider = mock(NativeEditorProvider);
+        const notebookEditorProvider = mock(NativeEditorProvider);
         const debugService = mock(DebugService);
         const documentManager = mock(DocumentManager);
         commandManager = mock(CommandManager);
@@ -40,7 +40,7 @@ suite('Data Science - Commands', () => {
             instance(serverSelectorCommand),
             instance(kernelSwitcherCommand),
             instance(commandLineCommand),
-            instance(notebookProvider),
+            instance(notebookEditorProvider),
             instance(debugService),
             new MockOutputChannel('Jupyter')
         );

--- a/src/test/datascience/commands/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/commands/kernelSwitcher.unit.test.ts
@@ -16,19 +16,19 @@ suite('Data Science - KernelSwitcher Command', () => {
     let kernelSwitcherCommand: KernelSwitcherCommand;
     let commandManager: ICommandManager;
     let interactiveWindowProvider: IInteractiveWindowProvider;
-    let notebookProvider: INotebookEditorProvider;
+    let notebookEditorProvider: INotebookEditorProvider;
     let kernelSwitcher: KernelSwitcher;
 
     setup(() => {
         interactiveWindowProvider = mock(InteractiveWindowProvider);
-        notebookProvider = mock(NativeEditorProvider);
+        notebookEditorProvider = mock(NativeEditorProvider);
         commandManager = mock(CommandManager);
         kernelSwitcher = mock(KernelSwitcher);
 
         kernelSwitcherCommand = new KernelSwitcherCommand(
             instance(commandManager),
             instance(kernelSwitcher),
-            instance(notebookProvider),
+            instance(notebookEditorProvider),
             instance(interactiveWindowProvider)
         );
     });
@@ -62,7 +62,7 @@ suite('Data Science - KernelSwitcher Command', () => {
         test('Should switch kernel using the active Native Editor', async () => {
             const nativeEditor = mock(JupyterNotebookBase);
             // tslint:disable-next-line: no-any
-            when(notebookProvider.activeEditor).thenReturn({ notebook: instance(nativeEditor) } as any);
+            when(notebookEditorProvider.activeEditor).thenReturn({ notebook: instance(nativeEditor) } as any);
 
             await commandHandler.bind(kernelSwitcherCommand)();
 
@@ -81,7 +81,7 @@ suite('Data Science - KernelSwitcher Command', () => {
             const interactiveWindow = mock(JupyterNotebookBase);
             const nativeEditor = mock(JupyterNotebookBase);
             // tslint:disable-next-line: no-any
-            when(notebookProvider.activeEditor).thenReturn({ notebook: instance(nativeEditor) } as any);
+            when(notebookEditorProvider.activeEditor).thenReturn({ notebook: instance(nativeEditor) } as any);
             // tslint:disable-next-line: no-any
             when(interactiveWindowProvider.getActive()).thenReturn({ notebook: instance(interactiveWindow) } as any);
 

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1283,8 +1283,8 @@ df.head()`;
                         assert.ok(isCellFocused(wrapper, 'NativeCell', cellIndex));
                         assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
 
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const model = (notebookProvider.editors[0] as NativeEditorWebView).model;
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const model = (notebookEditorProvider.editors[0] as NativeEditorWebView).model;
 
                         // This is the string the user will type in a character at a time into the editor.
                         const stringToType = 'Hi! Bob!';
@@ -1338,8 +1338,8 @@ df.head()`;
                         assert.ok(isCellFocused(wrapper, 'NativeCell', cellIndex));
                         assert.equal(wrapper.find('NativeCell').length, 4, 'Cell not added');
 
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const model = (notebookProvider.editors[0] as NativeEditorWebView).model;
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const model = (notebookEditorProvider.editors[0] as NativeEditorWebView).model;
 
                         // This is the string the user will type in a character at a time into the editor.
                         const stringToType = 'Hi Bob!';
@@ -1708,8 +1708,8 @@ df.head()`;
                         await addCell(wrapper, ioc, '7', false);
 
                         // Access the code in the cells.
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const model = (notebookProvider.editors[0] as NativeEditorWebView).model;
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const model = (notebookEditorProvider.editors[0] as NativeEditorWebView).model;
 
                         // Set focus to the first cell.
                         let update = waitForUpdate(wrapper, NativeEditor, 1);
@@ -2014,8 +2014,8 @@ df.head()`;
                         await addCell(wrapper, ioc, 'a=1\na', true);
                         await dirtyPromise;
 
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const editor = notebookProvider.editors[0];
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookEditorProvider.editors[0];
                         assert.ok(editor, 'No editor when saving');
                         const savedPromise = createDeferred();
                         editor.saved(() => savedPromise.resolve());
@@ -2043,8 +2043,8 @@ df.head()`;
                         await addCell(wrapper, ioc, 'a=1\na', true);
                         await dirtyPromise;
 
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const editor = notebookProvider.editors[0];
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookEditorProvider.editors[0];
                         assert.ok(editor, 'No editor when saving');
                         const savedPromise = createDeferred();
                         editor.saved(() => savedPromise.resolve());
@@ -2075,8 +2075,8 @@ df.head()`;
                         await addCell(wrapper, ioc, 'a=1\na', true);
                         await dirtyPromise;
 
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const editor = notebookProvider.editors[0];
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookEditorProvider.editors[0];
                         assert.ok(editor, 'No editor when saving');
                         const savedPromise = createDeferred();
                         editor.saved(() => savedPromise.resolve());
@@ -2104,8 +2104,8 @@ df.head()`;
 
                         await addCell(wrapper, ioc, 'a=1\na', true);
 
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const editor = notebookProvider.editors[0];
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookEditorProvider.editors[0];
                         assert.ok(editor, 'No editor when saving');
                         const savedPromise = createDeferred();
                         editor.saved(() => savedPromise.resolve());
@@ -2440,8 +2440,8 @@ df.head()`;
                     });
 
                     test('Update notebook metadata on execution', async () => {
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const editor = notebookProvider.editors[0];
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookEditorProvider.editors[0];
                         assert.ok(editor, 'No editor when saving');
 
                         // add cells, run them and save
@@ -2519,8 +2519,8 @@ df.head()`;
                     });
 
                     test('Clear execution_count and outputs in notebook', async () => {
-                        const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
-                        const editor = notebookProvider.editors[0];
+                        const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+                        const editor = notebookEditorProvider.editors[0];
                         assert.ok(editor, 'No editor when saving');
                         // add cells, run them and save
                         // await addCell(wrapper, ioc, 'a=1\na');

--- a/src/test/datascience/nativeEditorTestHelpers.tsx
+++ b/src/test/datascience/nativeEditorTestHelpers.tsx
@@ -25,13 +25,13 @@ import {
 // tslint:disable: no-any
 
 async function getOrCreateNativeEditor(ioc: DataScienceIocContainer, uri?: Uri): Promise<INotebookEditor> {
-    const notebookProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
+    const notebookEditorProvider = ioc.get<INotebookEditorProvider>(INotebookEditorProvider);
     let editor: INotebookEditor | undefined;
     const messageWaiter = waitForMessage(ioc, InteractiveWindowMessages.LoadAllCellsComplete);
     if (uri) {
-        editor = await notebookProvider.open(uri);
+        editor = await notebookEditorProvider.open(uri);
     } else {
-        editor = await notebookProvider.createNew();
+        editor = await notebookEditorProvider.createNew();
     }
     if (editor) {
         await messageWaiter;


### PR DESCRIPTION
In preparation for #10563
Plan is to introduce a `NotebookProvider` that manages the life time of notebooks outside the Native Editor. Hence the need to change properties/variables from `notebookProvider` to `notebookEditorProvider`. 

Besides the actual interface/class is `NotebookEditorProvider`, hence changing from `notebookProvider` to `notebookEditorProvider` is better and more explicit.

Separate PR that introduces renames (else when I do the work, there's a lot of noise in PRs due to renames)