### PR TITLE
Ensure local host only if connection not available

### DIFF
--- a/news/2 Fixes/10597.md
+++ b/news/2 Fixes/10597.md
@@ -1,0 +1,1 @@
+Ensure default `host` is not set, if `connect` or `listen` settings are available.

--- a/src/client/debugger/extension/configuration/resolvers/attach.ts
+++ b/src/client/debugger/extension/configuration/resolvers/attach.ts
@@ -55,7 +55,8 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         if (!Array.isArray(debugConfiguration.debugOptions)) {
             debugConfiguration.debugOptions = [];
         }
-        if (!debugConfiguration.host) {
+        if (!(debugConfiguration.connect || debugConfiguration.listen) && !debugConfiguration.host) {
+            // Connect and listen cannot be mixed with host property.
             debugConfiguration.host = 'localhost';
         }
         if (debugConfiguration.justMyCode === undefined) {
@@ -116,7 +117,7 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
 
     private resolvePathMappings(
         pathMappings: PathMapping[],
-        host: string,
+        host?: string,
         localRoot?: string,
         remoteRoot?: string,
         workspaceFolder?: Uri

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -26,6 +26,11 @@ export type PathMapping = {
     localRoot: string;
     remoteRoot: string;
 };
+export type Connection = {
+    host: string;
+    port: number;
+};
+
 interface ICommonDebugArguments {
     redirectOutput?: boolean;
     django?: boolean;
@@ -54,6 +59,8 @@ export interface IKnownAttachDebugArguments extends ICommonDebugArguments {
     subProcessId?: number;
 
     processId?: number | string;
+    connect?: Connection;
+    listen?: Connection;
 }
 
 export interface IKnownLaunchRequestArguments extends ICommonDebugArguments {

--- a/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/attach.unit.test.ts
@@ -181,6 +181,32 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
                 .deep.equal(debugOptionsAvailable);
             expect(debugConfig).to.have.property('host', 'localhost');
         });
+        test('Default host should not be added if connect is available.', async () => {
+            const pythonFile = 'xyz.py';
+
+            setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
+            setupWorkspaces([]);
+
+            const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, {
+                request: 'attach',
+                connect: { host: 'localhost', port: 5678 }
+            } as AttachRequestArguments);
+
+            expect(debugConfig).to.not.have.property('host', 'localhost');
+        });
+        test('Default host should not be added if listen is available.', async () => {
+            const pythonFile = 'xyz.py';
+
+            setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
+            setupWorkspaces([]);
+
+            const debugConfig = await debugProvider.resolveDebugConfiguration!(undefined, {
+                request: 'attach',
+                listen: { host: 'localhost', port: 5678 }
+            } as AttachRequestArguments);
+
+            expect(debugConfig).to.not.have.property('host', 'localhost');
+        });
         test("Ensure 'localRoot' is left unaltered", async () => {
             const activeFile = 'xyz.py';
             const workspaceFolder = createMoqWorkspaceFolder(__dirname);


### PR DESCRIPTION
For #10597

- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [x] Appropriate comments and documentation strings in the code.

This is currently breaking multi-proc in insiders. This feature is not shipped yet, so stable is fine.