### PR TITLE
Disable custom editor API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}",
-                "--enable-proposed-api",
-                "ms-python.python"
+                "--extensionDevelopmentPath=${workspaceFolder}"
             ],
             "stopOnEntry": false,
             "smartStep": true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "2020.4.0-dev",
     "languageServerVersion": "0.5.30",
     "publisher": "ms-python",
-    "enableProposedApi": true,
+    "enableProposedApi": false,
     "author": {
         "name": "Microsoft Corporation"
     },
@@ -2869,18 +2869,7 @@
                     "when": "testsDiscovered"
                 }
             ]
-        },
-        "customEditors": [
-            {
-                "viewType": "NativeEditorProvider.ipynb",
-                "displayName": "Jupyter Notebook",
-                "selector": [
-                    {
-                        "filenamePattern": "*.ipynb"
-                    }
-                ]
-            }            
-        ]
+        }
     },
     "scripts": {
         "package": "gulp clean && gulp prePublishBundle && vsce package -o ms-python-insiders.vsix",

--- a/src/test/debuggerTest.ts
+++ b/src/test/debuggerTest.ts
@@ -18,7 +18,7 @@ function start() {
         extensionDevelopmentPath: EXTENSION_ROOT_DIR_FOR_TESTS,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
         launchArgs: [workspacePath],
-        version: 'insiders',
+        version: 'stable',
         extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' }
     }).catch(ex => {
         console.error('End Debugger tests (with errors)', ex);

--- a/src/test/multiRootTest.ts
+++ b/src/test/multiRootTest.ts
@@ -13,8 +13,8 @@ function start() {
     runTests({
         extensionDevelopmentPath: EXTENSION_ROOT_DIR_FOR_TESTS,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
-        launchArgs: [workspacePath, '--enable-proposed-api', 'ms-python.python'],
-        version: 'insiders',
+        launchArgs: [workspacePath],
+        version: 'stable',
         extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' }
     }).catch(ex => {
         console.error('End Multiroot tests (with errors)', ex);

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -19,8 +19,8 @@ function start() {
     runTests({
         extensionDevelopmentPath: extensionDevelopmentPath,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
-        launchArgs: [workspacePath, '--enable-proposed-api', 'ms-python.python'],
-        version: 'insiders',
+        launchArgs: [workspacePath],
+        version: 'stable',
         extensionTestsEnv: { ...process.env, UITEST_DISABLE_INSIDERS: '1' }
     }).catch(ex => {
         console.error('End Standard tests (with errors)', ex);


### PR DESCRIPTION
Disable API, then merge ds/custom_editor into master.
Then revert this PR in ds/custom_editor.

This is to keep master updated with fixes from ds/custom_editor.
Then we can minimize merge conflicts and the like when working on ds/custom_editor and ds/ipywidgets & master.

Once master has been updated with ds/custom_editor, i will revert this PR in ds/custom_editor