### PR TITLE
Remove post office methods from root state

### DIFF
--- a/src/datascience-ui/history-react/index.tsx
+++ b/src/datascience-ui/history-react/index.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
-import { IVsCodeApi } from '../react-common/postOffice';
+import { IVsCodeApi, PostOffice } from '../react-common/postOffice';
 import { detectBaseTheme } from '../react-common/themeDetector';
 import { getConnectedInteractiveEditor } from './interactivePanel';
 import { createStore } from './redux/store';
@@ -27,7 +27,7 @@ const testMode = (window as any).inTestMode;
 const skipDefault = testMode ? false : typeof acquireVsCodeApi !== 'undefined';
 
 // Create the redux store
-const store = createStore(skipDefault, baseTheme, testMode);
+const store = createStore(skipDefault, baseTheme, testMode, new PostOffice());
 
 // Wire up a connected react control for our InteractiveEditor
 const ConnectedInteractiveEditor = getConnectedInteractiveEditor();

--- a/src/datascience-ui/history-react/redux/store.ts
+++ b/src/datascience-ui/history-react/redux/store.ts
@@ -3,9 +3,10 @@
 'use strict';
 
 import * as ReduxCommon from '../../interactive-common/redux/store';
+import { PostOffice } from '../../react-common/postOffice';
 import { reducerMap } from './reducers';
 
 // This special version uses the reducer map from the IInteractiveWindowMapping
-export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean) {
-    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, false, reducerMap);
+export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean, postOffice: PostOffice) {
+    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, false, reducerMap, postOffice);
 }

--- a/src/datascience-ui/ipywidgets/container.tsx
+++ b/src/datascience-ui/ipywidgets/container.tsx
@@ -4,35 +4,38 @@
 'use strict';
 
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { Observable } from 'rxjs/Observable';
-import { IInteractiveWindowMapping } from '../../client/datascience/interactive-common/interactiveWindowTypes';
-import { IStore } from '../interactive-common/redux/store';
+import { Subject } from 'rxjs/Subject';
+import { AllowedIPyWidgetMessages } from '../interactive-common/redux/postOffice';
+import { PostOffice } from '../react-common/postOffice';
 import { WidgetManager } from './manager';
 
 type Props = {
-    // tslint:disable-next-line: no-any
-    messages: Observable<{ type: string; payload?: any }>;
-    sendMessage<M extends IInteractiveWindowMapping, T extends keyof M>(type: T, payload?: M[T]): void;
+    postOffice: PostOffice;
+    widgetContainerId: string;
 };
 
-function mapStateToProps(state: IStore): Props {
-    return { messages: state.widgetMessagses, sendMessage: state.sendMessage };
-}
-// Default dispatcher (not required, but required for strictness).
-function mapDispatchToProps(dispatch: Function) {
-    return { dispatch };
-}
-
-class Container extends React.Component<Props> {
+export class WidgetManagerComponent extends React.Component<Props> {
     private readonly widgetManager: WidgetManager;
 
     constructor(props: Props) {
         super(props);
+        // tslint:disable-next-line: no-any
+        const widgetMessages = new Subject<{ type: string; payload?: any }>();
+        this.props.postOffice.addHandler({
+            // tslint:disable-next-line: no-any
+            handleMessage(message: string, payload?: any): boolean {
+                // Double check this is one of our messages. React will actually post messages here too during development
+                if (AllowedIPyWidgetMessages.find(k => k === message)) {
+                    widgetMessages.next({ type: message, payload });
+                }
+                return true;
+            }
+        });
+
         this.widgetManager = new WidgetManager(
-            document.getElementById('rootWidget')!,
-            props.messages,
-            props.sendMessage
+            document.getElementById(this.props.widgetContainerId)!,
+            widgetMessages.asObservable(),
+            this.props.postOffice.sendMessage.bind(this.props.postOffice)
         );
     }
     public render() {
@@ -42,5 +45,3 @@ class Container extends React.Component<Props> {
         this.widgetManager.dispose();
     }
 }
-
-export const WidgetManagerComponent = connect(mapStateToProps, mapDispatchToProps)(Container);

--- a/src/datascience-ui/native-editor/index.tsx
+++ b/src/datascience-ui/native-editor/index.tsx
@@ -14,7 +14,7 @@ import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import { WidgetManagerComponent } from '../ipywidgets/container';
-import { IVsCodeApi } from '../react-common/postOffice';
+import { IVsCodeApi, PostOffice } from '../react-common/postOffice';
 import { detectBaseTheme } from '../react-common/themeDetector';
 import { getConnectedNativeEditor } from './nativeEditor';
 import { createStore } from './redux/store';
@@ -28,17 +28,17 @@ const testMode = (window as any).inTestMode;
 const skipDefault = testMode ? false : typeof acquireVsCodeApi !== 'undefined';
 
 // Create the redux store
-const store = createStore(skipDefault, baseTheme, testMode);
+const postOffice = new PostOffice();
+const store = createStore(skipDefault, baseTheme, testMode, postOffice);
 
 // Wire up a connected react control for our NativeEditor
 const ConnectedNativeEditor = getConnectedNativeEditor();
 
 // Stick them all together
-// tslint:disable:no-typeof-undefined
 ReactDOM.render(
     <Provider store={store}>
         <ConnectedNativeEditor />
-        <WidgetManagerComponent />
+        <WidgetManagerComponent postOffice={postOffice} widgetContainerId={'rootWidget'} />
     </Provider>,
     document.getElementById('root') as HTMLElement
 );

--- a/src/datascience-ui/native-editor/redux/store.ts
+++ b/src/datascience-ui/native-editor/redux/store.ts
@@ -3,9 +3,10 @@
 'use strict';
 
 import * as ReduxCommon from '../../interactive-common/redux/store';
+import { PostOffice } from '../../react-common/postOffice';
 import { reducerMap } from './reducers';
 
 // This special version uses the reducer map from the INativeEditorMapping
-export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean) {
-    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, true, reducerMap);
+export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean, postOffice: PostOffice) {
+    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, true, reducerMap, postOffice);
 }

--- a/src/test/datascience/testHelpers.tsx
+++ b/src/test/datascience/testHelpers.tsx
@@ -22,6 +22,7 @@ import * as NativeStore from '../../datascience-ui/native-editor/redux/store';
 import { IKeyboardEvent } from '../../datascience-ui/react-common/event';
 import { ImageButton } from '../../datascience-ui/react-common/imageButton';
 import { MonacoEditor } from '../../datascience-ui/react-common/monacoEditor';
+import { PostOffice } from '../../datascience-ui/react-common/postOffice';
 import { noop } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 import { createInputEvent, createKeyboardEvent } from './reactHelpers';
@@ -760,7 +761,7 @@ export function mountConnectedMainPanel(type: 'native' | 'interactive') {
 
     // Create the redux store in test mode.
     const createStore = type === 'native' ? NativeStore.createStore : InteractiveStore.createStore;
-    const store = createStore(true, 'vs-light', true);
+    const store = createStore(true, 'vs-light', true, new PostOffice());
 
     // Mount this with a react redux provider
     return mount(
@@ -773,7 +774,7 @@ export function mountConnectedMainPanel(type: 'native' | 'interactive') {
 export function mountComponent<P>(type: 'native' | 'interactive', Component: React.ReactElement<P>) {
     // Create the redux store in test mode.
     const createStore = type === 'native' ? NativeStore.createStore : InteractiveStore.createStore;
-    const store = createStore(true, 'vs-light', true);
+    const store = createStore(true, 'vs-light', true, new PostOffice());
 
     // Mount this with a react redux provider
     return mount(<Provider store={store}>{Component}</Provider>);


### PR DESCRIPTION
Part of #9516
Move `PostOffice` from redux store and pass it into store and widget manager. This way it is treated as a communication channel, and can change independently.

IPywidgets manager no longer relies on root state or similar, it just needs a post office (class with methods to send and receive messages from extension).

@rich, once this is done I'll move onto fixing the functional tests.