### PR TITLE
updating LS telemetry

### DIFF
--- a/src/client/activation/common/downloader.ts
+++ b/src/client/activation/common/downloader.ts
@@ -53,12 +53,12 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
                 uri = uri.replace(/^https:/, 'http:');
             }
         }
-
-        return [uri, info.version.raw];
+        const lsNameTrimmed = info.package.split('.')[0];
+        return [uri, info.version.raw, lsNameTrimmed];
     }
 
     public async downloadLanguageServer(destinationFolder: string, resource: Resource): Promise<void> {
-        const [downloadUri, lsVersion] = await this.getDownloadInfo(resource);
+        const [downloadUri, lsVersion, lsName] = await this.getDownloadInfo(resource);
         const timer: StopWatch = new StopWatch();
         let success: boolean = true;
         let localTempFilePath = '';
@@ -85,7 +85,8 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_DOWNLOADED, timer.elapsedTime, {
                 success,
                 lsVersion,
-                usedSSL
+                usedSSL,
+                lsName
             });
         }
 
@@ -105,7 +106,11 @@ export class LanguageServerDownloader implements ILanguageServerDownloader {
             );
             throw new Error(err);
         } finally {
-            sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_EXTRACTED, timer.elapsedTime, { success, lsVersion });
+            sendTelemetryEvent(EventName.PYTHON_LANGUAGE_SERVER_EXTRACTED, timer.elapsedTime, {
+                success,
+                lsVersion,
+                lsName
+            });
             await this.fs.deleteFile(localTempFilePath);
         }
     }

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1082,6 +1082,11 @@ export interface IEventNamePropertyMapping {
          * Whether download uri starts with `https:` or not
          */
         usedSSL?: boolean;
+
+        /**
+         * Name of LS downloaded
+         */
+        lsName?: string;
     };
     /**
      * Telemetry event sent when LS is started for workspace (workspace folder in case of multi-root)
@@ -1112,6 +1117,10 @@ export interface IEventNamePropertyMapping {
          * Whether download uri starts with `https:` or not
          */
         usedSSL?: boolean;
+        /**
+         * Package name of LS extracted
+         */
+        lsName?: string;
     };
     /**
      * Telemetry event sent if azure blob packages are being listed

--- a/src/test/activation/languageServer/downloader.unit.test.ts
+++ b/src/test/activation/languageServer/downloader.unit.test.ts
@@ -73,12 +73,13 @@ suite('Language Server Activation - Downloader', () => {
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const [uri, version] = await languageServerDownloader.getDownloadInfo(resource);
+        const [uri, version, name] = await languageServerDownloader.getDownloadInfo(resource);
 
         folderService.verifyAll();
         workspaceService.verifyAll();
         expect(uri).to.equal(pkg.uri);
         expect(version).to.equal(pkg.version.raw);
+        expect(name).to.equal('ls');
     });
 
     test('Get download info - HTTPS without resource', async () => {
@@ -97,12 +98,13 @@ suite('Language Server Activation - Downloader', () => {
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const [uri, version] = await languageServerDownloader.getDownloadInfo(undefined);
+        const [uri, version, name] = await languageServerDownloader.getDownloadInfo(undefined);
 
         folderService.verifyAll();
         workspaceService.verifyAll();
         expect(uri).to.equal(pkg.uri);
         expect(version).to.equal(pkg.version.raw);
+        expect(name).to.equal('ls');
     });
 
     test('Get download info - HTTPS disabled', async () => {
@@ -121,13 +123,14 @@ suite('Language Server Activation - Downloader', () => {
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const [uri, version] = await languageServerDownloader.getDownloadInfo(resource);
+        const [uri, version, name] = await languageServerDownloader.getDownloadInfo(resource);
 
         folderService.verifyAll();
         workspaceService.verifyAll();
         // tslint:disable-next-line:no-http-string
         expect(uri).to.deep.equal('http://a.b.com/x/y/z/ls.nupkg');
         expect(version).to.equal(pkg.version.raw);
+        expect(name).to.equal('ls');
     });
 
     test('Get download info - HTTP', async () => {
@@ -138,12 +141,13 @@ suite('Language Server Activation - Downloader', () => {
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const [uri, version] = await languageServerDownloader.getDownloadInfo(resource);
+        const [uri, version, name] = await languageServerDownloader.getDownloadInfo(resource);
 
         folderService.verifyAll();
         workspaceService.verifyAll();
         expect(uri).to.equal(pkg.uri);
         expect(version).to.equal(pkg.version.raw);
+        expect(name).to.equal('ls');
     });
 
     test('Get download info - bogus URL', async () => {
@@ -153,12 +157,13 @@ suite('Language Server Activation - Downloader', () => {
             .returns(() => Promise.resolve(pkg))
             .verifiable(TypeMoq.Times.once());
 
-        const [uri, version] = await languageServerDownloader.getDownloadInfo(resource);
+        const [uri, version, name] = await languageServerDownloader.getDownloadInfo(resource);
 
         folderService.verifyAll();
         workspaceService.verifyAll();
         expect(uri).to.equal(pkg.uri);
         expect(version).to.equal(pkg.version.raw);
+        expect(name).to.equal('ls');
     });
 
     suite('Test LanguageServerDownloader.downloadFile', () => {


### PR DESCRIPTION
appending language server package name to ls telemetry so that we can filter out different servers

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [x] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [x] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
