### PR TITLE
current interface and type

### DIFF
--- a/src/client/datascience/raw-kernel/enchannelJMPConnection.ts
+++ b/src/client/datascience/raw-kernel/enchannelJMPConnection.ts
@@ -1,0 +1,34 @@
+import { KernelMessage } from '@jupyterlab/services';
+//import { Channels } from '@nteract/messaging';
+//import { createMainChannel } from 'enchannel-zmq-backend';
+import { IJMPConnection, IJMPConnectionInfo } from '../types';
+
+export class EnchannelJMPConnection implements IJMPConnection {
+    //private mainChannel: Channels | undefined;
+
+    public async connect(_connectInfo: IJMPConnectionInfo, _sessionID: string): Promise<void> {
+        // tslint:disable-next-line:no-any
+        //this.mainChannel = await createMainChannel(connectInfo as any, undefined, sessionID);
+    }
+    public sendMessage(_message: KernelMessage.IMessage): void {
+        //if (this.mainChannel) {
+        //// jupyterlab types and enchannel types seem to have small changes
+        //// with how they are defined, just use an any cast for now, but they appear to be the
+        //// same actual object
+        //// tslint:disable-next-line:no-any
+        //this.mainChannel.next(message as any);
+        //}
+    }
+    public subscribe(_handlerFunc: (message: KernelMessage.IMessage) => void) {
+        //if (this.mainChannel) {
+        //// tslint:disable-next-line:no-any
+        //this.mainChannel.subscribe(handlerFunc as any);
+        //}
+    }
+
+    public dispose(): void {
+        //if (this.mainChannel) {
+        //this.mainChannel.unsubscribe();
+        //}
+    }
+}

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -857,3 +857,24 @@ export interface INotebookProvider {
      */
     getNotebook(server: INotebookServer, resource: Uri, options?: nbformat.INotebookMetadata): Promise<INotebook>;
 }
+
+// Connection info to connect to a kernel over JMP
+export interface IJMPConnectionInfo {
+    version: number;
+    iopub_port: number;
+    shell_port: number;
+    stdin_port: number;
+    control_port: number;
+    signature_scheme: string;
+    hb_port: number;
+    ip: string;
+    key: string;
+    transport: string;
+}
+
+// A service to send and recieve messages over Jupyter messaging protocol
+export interface IJMPConnection extends IDisposable {
+    connect(connectInfo: IJMPConnectionInfo, sessionID: string): Promise<void>;
+    sendMessage(message: KernelMessage.IMessage): void;
+    subscribe(handlerFunc: (message: KernelMessage.IMessage) => void): void;
+}


### PR DESCRIPTION
This is the current interface that I'm using for my JMP requests. Also included is my enchannel-zmq implementation of this interface. I've commented out the enchannel specific types so npm doesn't need to include enchannel which brings in the old zmq and messes things up.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [ ] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
