### PR TITLE
Disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Stack Overflow
     url: https://stackoverflow.com/questions/tagged/visual-studio-code+python


### PR DESCRIPTION
Hide the ` Don’t see your issue here? Open a blank issue.` option when users create an issue in the repo.

See https://github.blog/changelog/2019-10-28-new-issue-template-configuration-options/