### PR TITLE
GHA: Install debugpy only for Python 3.X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,13 +248,8 @@ jobs:
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
         if: steps.pythonFiles-cache.outputs.cache-hit == false
-
-      - name: Install debugpy wheels if not cached
-        run: |
-          python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
-          python ./pythonFiles/install_debugpy.py
-        if: steps.pythonFiles-cache.outputs.cache-hit == false && startsWith(matrix.python, 3.)
 
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         # Run the tests on the oldest and most recent versions of Python.
         python: [2.7, 3.8]
-        test-suite: [ts-unit, python-unit, venv, single-workspace, multi-workspace, debugger, functional]
+        test-suite: [ts-unit, python-unit]
     env:
       # Something in Node 12.16.0 breaks the TS debug adapter, and ubuntu-latest bundles Node 12.16.1.
       # We can remove this when we switch over to the python-based DA in https://github.com/microsoft/vscode-python/issues/7136.
@@ -254,7 +254,7 @@ jobs:
         run: |
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py
-        if: steps.pythonFiles-cache.outputs.cache-hit == false
+        if: steps.pythonFiles-cache.outputs.cache-hit == false && startsWith(matrix.python, "3.")
 
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
@@ -321,7 +321,7 @@ jobs:
       # Run TypeScript unit tests only for Python 3.X.
       - name: Run TypeScript unit tests
         run: npm run test:unittests:cover
-        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, 3.)
+        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, "3.")
 
       # Upload unit test coverage reports for later use in the "reports" job.
       - name: Upload unit test coverage reports
@@ -329,7 +329,7 @@ jobs:
         with:
           name: ${{runner.os}}-${{env.COVERAGE_REPORTS}}
           path: .nyc_output
-        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, 3.)
+        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, "3.")
 
       # Run the Python and IPython tests in our codebase.
       - name: Run Python and IPython unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py
-        if: steps.pythonFiles-cache.outputs.cache-hit == false && startsWith(matrix.python, "3.")
+        if: steps.pythonFiles-cache.outputs.cache-hit == false && startsWith(matrix.python, '3.')
 
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         run: |
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py
-        if: steps.pythonFiles-cache.outputs.cache-hit == false && startsWith(matrix.python, '3.')
+        if: steps.pythonFiles-cache.outputs.cache-hit == false && startsWith(matrix.python, 3.)
 
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
@@ -321,7 +321,7 @@ jobs:
       # Run TypeScript unit tests only for Python 3.X.
       - name: Run TypeScript unit tests
         run: npm run test:unittests:cover
-        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, "3.")
+        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, 3.)
 
       # Upload unit test coverage reports for later use in the "reports" job.
       - name: Upload unit test coverage reports
@@ -329,7 +329,7 @@ jobs:
         with:
           name: ${{runner.os}}-${{env.COVERAGE_REPORTS}}
           path: .nyc_output
-        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, "3.")
+        if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, 3.)
 
       # Run the Python and IPython tests in our codebase.
       - name: Run Python and IPython unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # Run the CI workflow only on master for microsoft/vscode-python for now.
-      - gha-*
+      - master
 
 env:
   PYTHON_VERSION: 3.8
@@ -23,7 +23,7 @@ jobs:
   python-deps:
     name: Install Python Requirements
     runs-on: ubuntu-latest
-    # if: github.repository == 'microsoft/vscode-python'
+    if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
   js-ts-deps:
     name: Install npm dependencies
     runs-on: ubuntu-latest
-    # if: github.repository == 'microsoft/vscode-python'
+    if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -182,7 +182,7 @@ jobs:
     name: Tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
-    # if: github.repository == 'microsoft/vscode-python'
+    if: github.repository == 'microsoft/vscode-python'
     needs: [python-deps, js-ts-deps]
     strategy:
       matrix:
@@ -191,7 +191,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         # Run the tests on the oldest and most recent versions of Python.
         python: [2.7, 3.8]
-        test-suite: [ts-unit, python-unit]
+        test-suite: [ts-unit, python-unit, venv, single-workspace, multi-workspace, debugger, functional]
     env:
       # Something in Node 12.16.0 breaks the TS debug adapter, and ubuntu-latest bundles Node 12.16.1.
       # We can remove this when we switch over to the python-based DA in https://github.com/microsoft/vscode-python/issues/7136.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+          # We need to have debugpy available in wheels/ so that tests relying on it keep passing, but we don't need install_debugpy's logic
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
         if: steps.pythonFiles-cache.outputs.cache-hit == false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
-          # We need to have debugpy available in wheels/ so that tests relying on it keep passing, but we don't need install_debugpy's logic
+          # We need to have debugpy available in wheels/ so that tests relying on it keep passing, but we don't need install_debugpy's logic in the test phase.
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
         if: steps.pythonFiles-cache.outputs.cache-hit == false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # Run the CI workflow only on master for microsoft/vscode-python for now.
-      - master
+      - gha-*
 
 env:
   PYTHON_VERSION: 3.8
@@ -23,7 +23,7 @@ jobs:
   python-deps:
     name: Install Python Requirements
     runs-on: ubuntu-latest
-    if: github.repository == 'microsoft/vscode-python'
+    # if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -68,7 +68,7 @@ jobs:
   js-ts-deps:
     name: Install npm dependencies
     runs-on: ubuntu-latest
-    if: github.repository == 'microsoft/vscode-python'
+    # if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -182,7 +182,7 @@ jobs:
     name: Tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'microsoft/vscode-python'
+    # if: github.repository == 'microsoft/vscode-python'
     needs: [python-deps, js-ts-deps]
     strategy:
       matrix:


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/10721

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [ ] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
