### PR TITLE
requestInspect + requestComplete + tests for both

### DIFF
--- a/src/client/datascience/raw-kernel/rawFuture.ts
+++ b/src/client/datascience/raw-kernel/rawFuture.ts
@@ -111,12 +111,15 @@ export class RawFuture<
     }
 
     private async handleIOPub(message: KernelMessage.IIOPubMessage): Promise<void> {
+        // tslint:disable-next-line:no-require-imports
+        const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
+
         // RAWKERNEL: Check hooks process first?
         // tslint:disable-next-line:no-any
         await this.ioPub(message);
 
         // If we get an idle status message and a reply then we are done
-        if (KernelMessage.isStatusMsg(message) && message.content.execution_state === 'idle') {
+        if (jupyterLab.KernelMessage.isStatusMsg(message) && message.content.execution_state === 'idle') {
             this.idleSeen = true;
 
             if (this.replyMessage) {

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -101,6 +101,9 @@ export class RawKernel implements Kernel.IKernel {
         _metadata?: JSONObject
     ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> {
         if (this.jmpConnection) {
+            // tslint:disable-next-line:no-require-imports
+            const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
+
             // Build our execution message
             // Silent is supposed to be options, but in my testing the message was not passing
             // correctly without it, so specifying it here with default false
@@ -111,7 +114,9 @@ export class RawKernel implements Kernel.IKernel {
                 username: 'vscode',
                 content: { ...content, silent: content.silent || false }
             };
-            const executeMessage = KernelMessage.createMessage<KernelMessage.IExecuteRequestMsg>(executeOptions);
+            const executeMessage = jupyterLab.KernelMessage.createMessage<KernelMessage.IExecuteRequestMsg>(
+                executeOptions
+            );
 
             const newFuture = this.sendShellMessage(executeMessage, disposeOnDone || true);
 
@@ -127,6 +132,9 @@ export class RawKernel implements Kernel.IKernel {
         content: KernelMessage.ICompleteRequestMsg['content']
     ): Promise<KernelMessage.ICompleteReplyMsg> {
         if (this.jmpConnection) {
+            // tslint:disable-next-line:no-require-imports
+            const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
+
             const completeOptions: KernelMessage.IOptions<KernelMessage.ICompleteRequestMsg> = {
                 session: this._clientId,
                 channel: 'shell',
@@ -134,7 +142,9 @@ export class RawKernel implements Kernel.IKernel {
                 username: 'vscode',
                 content
             };
-            const completeMessage = KernelMessage.createMessage<KernelMessage.ICompleteRequestMsg>(completeOptions);
+            const completeMessage = jupyterLab.KernelMessage.createMessage<KernelMessage.ICompleteRequestMsg>(
+                completeOptions
+            );
 
             return this.handleShellMessage(completeMessage) as Promise<KernelMessage.ICompleteReplyMsg>;
         }
@@ -148,6 +158,9 @@ export class RawKernel implements Kernel.IKernel {
         content: KernelMessage.IInspectRequestMsg['content']
     ): Promise<KernelMessage.IInspectReplyMsg> {
         if (this.jmpConnection) {
+            // tslint:disable-next-line:no-require-imports
+            const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
+
             const inspectOptions: KernelMessage.IOptions<KernelMessage.IInspectRequestMsg> = {
                 session: this._clientId,
                 channel: 'shell',
@@ -155,7 +168,9 @@ export class RawKernel implements Kernel.IKernel {
                 username: 'vscode',
                 content
             };
-            const inspectMessage = KernelMessage.createMessage<KernelMessage.IInspectRequestMsg>(inspectOptions);
+            const inspectMessage = jupyterLab.KernelMessage.createMessage<KernelMessage.IInspectRequestMsg>(
+                inspectOptions
+            );
 
             return this.handleShellMessage(inspectMessage) as Promise<KernelMessage.IInspectReplyMsg>;
         }

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -146,7 +146,7 @@ export class RawKernel implements Kernel.IKernel {
                 completeOptions
             );
 
-            return this.handleShellMessage(completeMessage) as Promise<KernelMessage.ICompleteReplyMsg>;
+            return this.sendShellMessage(completeMessage).done as Promise<KernelMessage.ICompleteReplyMsg>;
         }
 
         // RAWKERNEL: What should we do here? Throw?
@@ -172,7 +172,7 @@ export class RawKernel implements Kernel.IKernel {
                 inspectOptions
             );
 
-            return this.handleShellMessage(inspectMessage) as Promise<KernelMessage.IInspectReplyMsg>;
+            return this.sendShellMessage(inspectMessage).done as Promise<KernelMessage.IInspectReplyMsg>;
         }
 
         // RAWKERNEL: What should we do here? Throw?
@@ -341,14 +341,6 @@ export class RawKernel implements Kernel.IKernel {
             const newStatus = (message as KernelMessage.IStatusMsg).content.execution_state;
             this.updateStatus(newStatus);
         }
-    }
-
-    // Some shell messages just need to wait for a reply, so return back the done promise for when it is
-    // completed
-    private handleShellMessage<T extends KernelMessage.ShellMessageType>(message: KernelMessage.IShellMessage<T>) {
-        // Create a future that expects a reply
-        const future = this.sendShellMessage(message, true);
-        return future.done;
     }
 
     // The status for our kernel has changed

--- a/src/test/datascience/raw-kernel/mockJMP.ts
+++ b/src/test/datascience/raw-kernel/mockJMP.ts
@@ -4,12 +4,16 @@ import { KernelMessage } from '@jupyterlab/services';
 import { IJMPConnection, IJMPConnectionInfo } from '../../../client/datascience/types';
 
 export class MockJMPConnection implements IJMPConnection {
+    public firstHeaderSeen: KernelMessage.IHeader | undefined;
     private callback: ((message: KernelMessage.IMessage) => void) | undefined;
 
     public async connect(_connectInfo: IJMPConnectionInfo): Promise<void> {
         return;
     }
-    public sendMessage(_message: KernelMessage.IMessage): void {
+    public sendMessage(message: KernelMessage.IMessage): void {
+        if (!this.firstHeaderSeen) {
+            this.firstHeaderSeen = message.header;
+        }
         return;
     }
     public subscribe(handlerFunc: (message: KernelMessage.IMessage) => void): void {


### PR DESCRIPTION
Two more of the main kernel functions that we use. A refactor to let them share future creation and unit tests for both. 
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
