### PR TITLE
Fix venv test failures on mac

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -130,12 +130,10 @@ steps:
     condition: and(succeeded(), eq(variables['NeedsPythonFunctionalReqs'], 'true'), eq(variables['Agent.Os'], 'Windows_NT'))
 
   # On MAC let CONDA update install paths
-  #
-  # This task will only run if variable `NeedsPythonFunctionalReqs` is true.
   - bash: |
       sudo chown -R $USER $CONDA
     displayName: 'Give CONDA permission to its own files'
-    condition: and(succeeded(), eq(variables['NeedsPythonFunctionalReqs'], 'true'), eq(variables['Agent.Os'], 'Darwin'))
+    condition: and(succeeded(), 'true'), eq(variables['Agent.Os'], 'Darwin'))
 
   # Create the two anaconda environments
   #

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -133,7 +133,7 @@ steps:
   - bash: |
       sudo chown -R $USER $CONDA
     displayName: 'Give CONDA permission to its own files'
-    condition: and(succeeded(), 'true'), eq(variables['Agent.Os'], 'Darwin'))
+    condition: and(succeeded(), eq(variables['Agent.Os'], 'Darwin'))
 
   # Create the two anaconda environments
   #


### PR DESCRIPTION
The venv-test is failing on mac for all CI runs
https://dev.azure.com/ms/vscode-python/_build/results?buildId=69191&view=logs&j=67dd891a-c21e-5444-1dc6-ca8b091da2c5&t=9223d52d-8b3b-56f5-7c2a-602872b7a02a

Looks to me like it's a permission problem with conda
