### PR TITLE
SendInputReply, expectReply for futures and tests for both

### DIFF
--- a/src/test/datascience/raw-kernel/mockJMP.ts
+++ b/src/test/datascience/raw-kernel/mockJMP.ts
@@ -5,6 +5,7 @@ import { IJMPConnection, IJMPConnectionInfo } from '../../../client/datascience/
 
 export class MockJMPConnection implements IJMPConnection {
     public firstHeaderSeen: KernelMessage.IHeader | undefined;
+    public messagesSeen: KernelMessage.IMessage[] = [];
     private callback: ((message: KernelMessage.IMessage) => void) | undefined;
 
     public async connect(_connectInfo: IJMPConnectionInfo): Promise<void> {
@@ -14,6 +15,9 @@ export class MockJMPConnection implements IJMPConnection {
         if (!this.firstHeaderSeen) {
             this.firstHeaderSeen = message.header;
         }
+
+        this.messagesSeen.push(message);
+
         return;
     }
     public subscribe(handlerFunc: (message: KernelMessage.IMessage) => void): void {

--- a/src/test/datascience/raw-kernel/rawFuture.unit.test.ts
+++ b/src/test/datascience/raw-kernel/rawFuture.unit.test.ts
@@ -3,7 +3,9 @@
 import { KernelMessage } from '@jupyterlab/services';
 import { expect } from 'chai';
 import * as uuid from 'uuid/v4';
+import { noop } from '../../../client/common/utils/misc';
 import { RawFuture } from '../../../client/datascience/raw-kernel/rawFuture';
+import { buildExecuteReplyMessage, buildStatusMessage } from './rawKernel.unit.test';
 
 // tslint:disable: max-func-body-length
 suite('Data Science - RawFuture', () => {
@@ -22,10 +24,75 @@ suite('Data Science - RawFuture', () => {
             content: { code: 'print("hello world")' }
         };
         executeMessage = KernelMessage.createMessage<KernelMessage.IExecuteRequestMsg>(executeOptions);
-        rawFuture = new RawFuture(executeMessage, true);
+        rawFuture = new RawFuture(executeMessage, true, true);
     });
 
-    test('Check our reply message channel', async () => {
+    test('RawFuture dispose', async () => {
+        // Set up some handlers
+        rawFuture.onReply = _msg => {
+            noop();
+        };
+        rawFuture.onIOPub = _msg => {
+            noop();
+        };
+        rawFuture.onStdin = _msg => {
+            noop();
+        };
+
+        rawFuture.done.catch(reason => {
+            const error = reason as Error;
+            expect(error.message).to.equal('Disposed Future');
+        });
+
+        // dispose of the future
+        rawFuture.dispose();
+
+        expect(rawFuture.onReply).to.equal(noop);
+        expect(rawFuture.onIOPub).to.equal(noop);
+        expect(rawFuture.onStdin).to.equal(noop);
+        expect(rawFuture.isDisposed).to.equal(true, 'Done promise not rejected ;on dispose');
+    });
+
+    test('RawFuture Check future expect reply off', async () => {
+        // Since expect reply is turned off, the done should be resolved without a reply message
+        rawFuture = new RawFuture(executeMessage, false, true);
+
+        const idleMessage = buildStatusMessage('idle', sessionID, executeMessage.header);
+
+        await rawFuture.handleMessage(idleMessage);
+
+        await rawFuture.done;
+    });
+
+    test('RawFuture Check future expect reply on, dispose on done on', async () => {
+        // Since expect reply is turned on, the done should be resolved with a reply and an idle status
+        const idleMessage = buildStatusMessage('idle', sessionID, executeMessage.header);
+        const replyMessage = buildExecuteReplyMessage(sessionID, executeMessage.header);
+
+        await rawFuture.handleMessage(idleMessage);
+        await rawFuture.handleMessage(replyMessage);
+
+        await rawFuture.done;
+        expect(rawFuture.isDisposed).to.equal(true, 'Future not disposed on done');
+    });
+
+    test('RawFuture Check future dispose on done off', async () => {
+        // Turn off dispose on done
+        rawFuture = new RawFuture(executeMessage, true, false);
+
+        const idleMessage = buildStatusMessage('idle', sessionID, executeMessage.header);
+        const replyMessage = buildExecuteReplyMessage(sessionID, executeMessage.header);
+
+        await rawFuture.handleMessage(idleMessage);
+        await rawFuture.handleMessage(replyMessage);
+
+        await rawFuture.done;
+        expect(rawFuture.isDisposed).to.equal(false, 'Future disposed when dispose on done turned off');
+        rawFuture.dispose();
+        expect(rawFuture.isDisposed).to.equal(true, 'Future not disposed when dispose called');
+    });
+
+    test('RawFuture Check our reply message channel', async () => {
         const replyOptions: KernelMessage.IOptions<KernelMessage.IExecuteReplyMsg> = {
             channel: 'shell',
             session: sessionID,
@@ -50,7 +117,7 @@ suite('Data Science - RawFuture', () => {
         await rawFuture.handleMessage(replyMessage);
     });
 
-    test('Check our IOPub message channel', async () => {
+    test('RawFuture Check our IOPub message channel', async () => {
         const ioPubMessageOptions: KernelMessage.IOptions<KernelMessage.IStreamMsg> = {
             session: sessionID,
             msgType: 'stream',


### PR DESCRIPTION
SendInputReply, expectReply for futures and tests for both

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [ ] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
