### PR TITLE
RawSession added, BaseJupyterSession class with raw and server versions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -186,6 +186,7 @@
                 "--recursive",
                 "--colors",
                 //"--grep", "<suite name>",
+                "--grep", "RawSession",
                 "--timeout=300000"
             ],
             "outFiles": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -186,7 +186,6 @@
                 "--recursive",
                 "--colors",
                 //"--grep", "<suite name>",
-                "--grep", "RawSession",
                 "--timeout=300000"
             ],
             "outFiles": [

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -38,6 +38,11 @@ export class JupyterSessionStartError extends Error {
     }
 }
 
+/*
+BaseJupyterSession represention functionality shared by a session regardless of if you are connected to a 
+server via JupyterLabs interfaces or via a raw ZMQ connection to a kernel. Raw classes implement the 
+jupyterlab interfaces so shared functionality that goes through the ISession or IKernel should go in here
+*/
 export abstract class BaseJupyterSession implements IJupyterSession {
     protected session: ISession | undefined;
     protected connected: boolean = false;
@@ -49,7 +54,6 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     }
 
     // Abstracts for each Session type to implement
-    //public abstract async connect(cancelToken?: CancellationToken): Promise<void>;
     public abstract async shutdown(): Promise<void>;
     public abstract async restart(timeout: number): Promise<void>;
     public abstract async changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void>;
@@ -135,10 +139,10 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         kernelPromise: Promise<void>,
         timeout: number,
         errorMessage: string
-    ): Promise<void | null> {
+    ): Promise<void> {
         // Wait for this kernel promise to happen
         try {
-            return await waitForPromise(kernelPromise, timeout);
+            await waitForPromise(kernelPromise, timeout);
         } catch (e) {
             if (!e) {
                 // We timed out. Throw a specific exception

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { Kernel, KernelMessage, Session } from '@jupyterlab/services';
+import { JSONObject } from '@phosphor/coreutils';
+import { Slot } from '@phosphor/signaling';
+import { Event, EventEmitter } from 'vscode';
+import { ServerStatus } from '../../datascience-ui/interactive-common/mainState';
+import { waitForPromise } from '../common/utils/async';
+import * as localize from '../common/utils/localize';
+import { sendTelemetryEvent } from '../telemetry';
+import { Telemetry } from './constants';
+import { JupyterKernelPromiseFailedError } from './jupyter/kernels/jupyterKernelPromiseFailedError';
+import { LiveKernelModel } from './jupyter/kernels/types';
+import { IJupyterKernelSpec, IJupyterSession } from './types';
+
+export type ISession = Session.ISession & {
+    /**
+     * Whether this is a remote session that we attached to.
+     *
+     * @type {boolean}
+     */
+    isRemoteSession?: boolean;
+};
+
+/**
+ * Exception raised when starting a Jupyter Session fails.
+ *
+ * @export
+ * @class JupyterSessionStartError
+ * @extends {Error}
+ */
+export class JupyterSessionStartError extends Error {
+    constructor(originalException: Error) {
+        super(originalException.message);
+        this.stack = originalException.stack;
+        sendTelemetryEvent(Telemetry.StartSessionFailedJupyter);
+    }
+}
+
+export abstract class BaseJupyterSession implements IJupyterSession {
+    protected session: ISession | undefined;
+    protected connected: boolean = false;
+    protected onStatusChangedEvent: EventEmitter<ServerStatus> = new EventEmitter<ServerStatus>();
+    protected statusHandler: Slot<ISession, Kernel.Status>;
+
+    constructor() {
+        this.statusHandler = this.onStatusChanged.bind(this);
+    }
+
+    // Abstracts for each Session type to implement
+    //public abstract async connect(cancelToken?: CancellationToken): Promise<void>;
+    public abstract async shutdown(): Promise<void>;
+    public abstract async restart(timeout: number): Promise<void>;
+    public abstract async changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void>;
+    public abstract async waitForIdle(timeout: number): Promise<void>;
+
+    // When we are disposed, call our shutdown function
+    public dispose(): Promise<void> {
+        return this.shutdown();
+    }
+
+    public async interrupt(timeout: number): Promise<void> {
+        if (this.session && this.session.kernel) {
+            // Listen for session status changes
+            this.session.statusChanged.connect(this.statusHandler);
+
+            await this.waitForKernelPromise(
+                this.session.kernel.interrupt(),
+                timeout,
+                localize.DataScience.interruptingKernelFailed()
+            );
+        }
+    }
+
+    // Return if we are connected to an active kernel
+    public get isConnected(): boolean {
+        return this.connected;
+    }
+
+    // Return the current kernel status of our server
+    public get status(): ServerStatus {
+        return this.getServerStatus();
+    }
+
+    // Event for server status changes
+    public get onSessionStatusChanged(): Event<ServerStatus> {
+        if (!this.onStatusChangedEvent) {
+            this.onStatusChangedEvent = new EventEmitter<ServerStatus>();
+        }
+        return this.onStatusChangedEvent.event;
+    }
+
+    public requestExecute(
+        content: KernelMessage.IExecuteRequestMsg['content'],
+        disposeOnDone?: boolean,
+        metadata?: JSONObject
+    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined {
+        return this.session && this.session.kernel
+            ? this.session.kernel.requestExecute(content, disposeOnDone, metadata)
+            : undefined;
+    }
+
+    public requestInspect(
+        content: KernelMessage.IInspectRequestMsg['content']
+    ): Promise<KernelMessage.IInspectReplyMsg | undefined> {
+        return this.session && this.session.kernel
+            ? this.session.kernel.requestInspect(content)
+            : Promise.resolve(undefined);
+    }
+
+    public requestComplete(
+        content: KernelMessage.ICompleteRequestMsg['content']
+    ): Promise<KernelMessage.ICompleteReplyMsg | undefined> {
+        return this.session && this.session.kernel
+            ? this.session.kernel.requestComplete(content)
+            : Promise.resolve(undefined);
+    }
+
+    public sendInputReply(content: string) {
+        if (this.session && this.session.kernel) {
+            // tslint:disable-next-line: no-any
+            this.session.kernel.sendInputReply({ value: content, status: 'ok' });
+        }
+    }
+
+    // Respond to status changes on the session
+    protected onStatusChanged(_s: Session.ISession) {
+        if (this.onStatusChangedEvent) {
+            this.onStatusChangedEvent.fire(this.getServerStatus());
+        }
+    }
+
+    private async waitForKernelPromise(
+        kernelPromise: Promise<void>,
+        timeout: number,
+        errorMessage: string
+    ): Promise<void | null> {
+        // Wait for this kernel promise to happen
+        try {
+            return await waitForPromise(kernelPromise, timeout);
+        } catch (e) {
+            if (!e) {
+                // We timed out. Throw a specific exception
+                throw new JupyterKernelPromiseFailedError(errorMessage);
+            }
+            throw e;
+        }
+    }
+
+    private getServerStatus(): ServerStatus {
+        if (this.session) {
+            switch (this.session.kernel.status) {
+                case 'busy':
+                    return ServerStatus.Busy;
+                case 'dead':
+                    return ServerStatus.Dead;
+                case 'idle':
+                case 'connected':
+                    return ServerStatus.Idle;
+                case 'restarting':
+                case 'autorestarting':
+                case 'reconnecting':
+                    return ServerStatus.Restarting;
+                case 'starting':
+                    return ServerStatus.Starting;
+                default:
+                    return ServerStatus.NotStarted;
+            }
+        }
+
+        return ServerStatus.NotStarted;
+    }
+}

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -14,6 +14,7 @@ import { StopWatch } from '../../common/utils/stopWatch';
 import { IInterpreterService, PythonInterpreter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
+import { JupyterSessionStartError } from '../baseJupyterSession';
 import { Commands, Telemetry } from '../constants';
 import {
     IConnection,
@@ -25,7 +26,6 @@ import {
     INotebookServerOptions
 } from '../types';
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
-import { JupyterSessionStartError } from './jupyterSession';
 import { createRemoteConnectionInfo } from './jupyterUtils';
 import { JupyterWaitForIdleError } from './jupyterWaitForIdleError';
 import { JupyterZMQBinariesNotFoundError } from './jupyterZMQBinariesNotFoundError';

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -13,9 +13,7 @@ import {
 import { JSONObject } from '@phosphor/coreutils';
 import { Slot } from '@phosphor/signaling';
 import * as uuid from 'uuid/v4';
-import { Event, EventEmitter } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
-import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 import { Cancellation } from '../../common/cancellation';
 import { isTestExecution } from '../../common/constants';
 import { traceError, traceInfo, traceWarning } from '../../common/logger';
@@ -23,48 +21,21 @@ import { IOutputChannel } from '../../common/types';
 import { sleep, waitForPromise } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
-import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
+import { captureTelemetry } from '../../telemetry';
+import { BaseJupyterSession, ISession, JupyterSessionStartError } from '../baseJupyterSession';
 import { Telemetry } from '../constants';
 import { reportAction } from '../progress/decorator';
 import { ReportableAction } from '../progress/types';
-import { IConnection, IJupyterKernelSpec, IJupyterSession } from '../types';
+import { IConnection, IJupyterKernelSpec } from '../types';
 import { JupyterInvalidKernelError } from './jupyterInvalidKernelError';
 import { JupyterWaitForIdleError } from './jupyterWaitForIdleError';
-import { JupyterKernelPromiseFailedError } from './kernels/jupyterKernelPromiseFailedError';
 import { KernelSelector } from './kernels/kernelSelector';
 import { LiveKernelModel } from './kernels/types';
 
-type ISession = Session.ISession & {
-    /**
-     * Whether this is a remote session that we attached to.
-     *
-     * @type {boolean}
-     */
-    isRemoteSession?: boolean;
-};
-
-/**
- * Exception raised when starting a Jupyter Session fails.
- *
- * @export
- * @class JupyterSessionStartError
- * @extends {Error}
- */
-export class JupyterSessionStartError extends Error {
-    constructor(originalException: Error) {
-        super(originalException.message);
-        this.stack = originalException.stack;
-        sendTelemetryEvent(Telemetry.StartSessionFailedJupyter);
-    }
-}
-
-export class JupyterSession implements IJupyterSession {
-    private session: ISession | undefined;
+export class JupyterSession extends BaseJupyterSession {
     private restartSessionPromise: Promise<ISession | undefined> | undefined;
     private notebookFiles: Contents.IModel[] = [];
-    private onStatusChangedEvent: EventEmitter<ServerStatus> = new EventEmitter<ServerStatus>();
-    private statusHandler: Slot<ISession, Kernel.Status>;
-    private connected: boolean = false;
+
     constructor(
         private connInfo: IConnection,
         private serverSettings: ServerConnection.ISettings,
@@ -74,11 +45,7 @@ export class JupyterSession implements IJupyterSession {
         private readonly kernelSelector: KernelSelector,
         private readonly outputChannel: IOutputChannel
     ) {
-        this.statusHandler = this.onStatusChanged.bind(this);
-    }
-
-    public dispose(): Promise<void> {
-        return this.shutdown();
+        super();
     }
 
     public async shutdown(): Promise<void> {
@@ -113,17 +80,6 @@ export class JupyterSession implements IJupyterSession {
             this.onStatusChangedEvent.dispose();
         }
         traceInfo('Shutdown session -- complete');
-    }
-
-    public get onSessionStatusChanged(): Event<ServerStatus> {
-        if (!this.onStatusChangedEvent) {
-            this.onStatusChangedEvent = new EventEmitter<ServerStatus>();
-        }
-        return this.onStatusChangedEvent.event;
-    }
-
-    public get status(): ServerStatus {
-        return this.getServerStatus();
     }
 
     @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
@@ -178,57 +134,18 @@ export class JupyterSession implements IJupyterSession {
         }
     }
 
-    public async interrupt(timeout: number): Promise<void> {
-        if (this.session && this.session.kernel) {
-            // Listen for session status changes
-            this.session.statusChanged.connect(this.statusHandler);
-
-            await this.waitForKernelPromise(
-                this.session.kernel.interrupt(),
-                timeout,
-                localize.DataScience.interruptingKernelFailed()
-            );
-        }
-    }
-
     public requestExecute(
         content: KernelMessage.IExecuteRequestMsg['content'],
         disposeOnDone?: boolean,
         metadata?: JSONObject
     ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined {
-        const result =
-            this.session && this.session.kernel
-                ? this.session.kernel.requestExecute(content, disposeOnDone, metadata)
-                : undefined;
+        const result = super.requestExecute(content, disposeOnDone, metadata);
         // It has been observed that starting the restart session slows down first time to execute a cell.
         // Solution is to start the restart session after the first execution of user code.
         if (!content.silent && result && !isTestExecution()) {
             result.done.finally(() => this.startRestartSession()).ignoreErrors();
         }
         return result;
-    }
-
-    public requestInspect(
-        content: KernelMessage.IInspectRequestMsg['content']
-    ): Promise<KernelMessage.IInspectReplyMsg | undefined> {
-        return this.session && this.session.kernel
-            ? this.session.kernel.requestInspect(content)
-            : Promise.resolve(undefined);
-    }
-
-    public requestComplete(
-        content: KernelMessage.ICompleteRequestMsg['content']
-    ): Promise<KernelMessage.ICompleteReplyMsg | undefined> {
-        return this.session && this.session.kernel
-            ? this.session.kernel.requestComplete(content)
-            : Promise.resolve(undefined);
-    }
-
-    public sendInputReply(content: string) {
-        if (this.session && this.session.kernel) {
-            // tslint:disable-next-line: no-any
-            this.session.kernel.sendInputReply({ value: content, status: 'ok' });
-        }
     }
 
     public async connect(cancelToken?: CancellationToken): Promise<void> {
@@ -249,10 +166,6 @@ export class JupyterSession implements IJupyterSession {
 
         // Made it this far, we're connected now
         this.connected = true;
-    }
-
-    public get isConnected(): boolean {
-        return this.connected;
     }
 
     public async changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, timeoutMS: number): Promise<void> {
@@ -297,30 +210,6 @@ export class JupyterSession implements IJupyterSession {
 
         // Start the restart session promise too.
         this.restartSessionPromise = this.createRestartSession(this.serverSettings, kernel, this.contentsManager);
-    }
-
-    private getServerStatus(): ServerStatus {
-        if (this.session) {
-            switch (this.session.kernel.status) {
-                case 'busy':
-                    return ServerStatus.Busy;
-                case 'dead':
-                    return ServerStatus.Dead;
-                case 'idle':
-                case 'connected':
-                    return ServerStatus.Idle;
-                case 'restarting':
-                case 'autorestarting':
-                case 'reconnecting':
-                    return ServerStatus.Restarting;
-                case 'starting':
-                    return ServerStatus.Starting;
-                default:
-                    return ServerStatus.NotStarted;
-            }
-        }
-
-        return ServerStatus.NotStarted;
     }
 
     private startRestartSession() {
@@ -454,29 +343,6 @@ export class JupyterSession implements IJupyterSession {
     private logRemoteOutput(output: string) {
         if (this.connInfo && !this.connInfo.localLaunch) {
             this.outputChannel.appendLine(output);
-        }
-    }
-
-    private async waitForKernelPromise(
-        kernelPromise: Promise<void>,
-        timeout: number,
-        errorMessage: string
-    ): Promise<void | null> {
-        // Wait for this kernel promise to happen
-        try {
-            return await waitForPromise(kernelPromise, timeout);
-        } catch (e) {
-            if (!e) {
-                // We timed out. Throw a specific exception
-                throw new JupyterKernelPromiseFailedError(errorMessage);
-            }
-            throw e;
-        }
-    }
-
-    private onStatusChanged(_s: Session.ISession) {
-        if (this.onStatusChangedEvent) {
-            this.onStatusChangedEvent.fire(this.getServerStatus());
         }
     }
 

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -9,10 +9,10 @@ import { IApplicationShell } from '../../../common/application/types';
 import { IConfigurationService, Resource } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { StopWatch } from '../../../common/utils/stopWatch';
+import { JupyterSessionStartError } from '../../baseJupyterSession';
 import { Commands, Settings } from '../../constants';
 import { IConnection, IJupyterKernelSpec, IJupyterSessionManagerFactory, INotebook } from '../../types';
 import { JupyterInvalidKernelError } from '../jupyterInvalidKernelError';
-import { JupyterSessionStartError } from '../jupyterSession';
 import { KernelSelector, KernelSpecInterpreter } from './kernelSelector';
 import { LiveKernelModel } from './types';
 

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -40,7 +40,7 @@ export class RawJupyterSession extends BaseJupyterSession {
 
     @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
     public async waitForIdle(_timeout: number): Promise<void> {
-        // RAWKERNEL: Do We have the same issue here with waiting for idle?
+        // RawKernels are good to go right away
     }
 
     public async restart(_timeout: number): Promise<void> {

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { CancellationToken } from 'vscode-jsonrpc';
+import { traceInfo } from '../../common/logger';
+import { BaseJupyterSession } from '../baseJupyterSession';
+import { LiveKernelModel } from '../jupyter/kernels/types';
+import { reportAction } from '../progress/decorator';
+import { ReportableAction } from '../progress/types';
+import { RawSession } from '../raw-kernel/rawSession';
+import { IJMPConnection, IJMPConnectionInfo, IJupyterKernelSpec } from '../types';
+
+/* 
+RawJupyterSession is the implementation of IJupyterSession that instead off
+connecting to JupyterLab services it instead connects to a kernel directly
+through ZMQ.
+It's responsible for translating our IJupyterSession interface into the
+jupyterlabs interface as well as starting up and connecting to a raw session
+*/
+export class RawJupyterSession extends BaseJupyterSession {
+    private rawSession: RawSession;
+
+    constructor(connection: IJMPConnection) {
+        super();
+        this.rawSession = new RawSession(connection);
+        this.session = this.rawSession;
+    }
+
+    public async shutdown(): Promise<void> {
+        if (this.session) {
+            this.session.dispose();
+            this.session = undefined;
+        }
+
+        if (this.onStatusChangedEvent) {
+            this.onStatusChangedEvent.dispose();
+        }
+        traceInfo('Shutdown session -- complete');
+    }
+
+    @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
+    public async waitForIdle(_timeout: number): Promise<void> {
+        // RAWKERNEL: Do We have the same issue here with waiting for idle?
+    }
+
+    public async restart(_timeout: number): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
+    // RAWKERNEL: Cancel token routed down?
+    public async connect(connectionInfo: IJMPConnectionInfo, _cancelToken?: CancellationToken): Promise<void> {
+        await this.rawSession.connect(connectionInfo);
+
+        // At this point we are connected and ready to work
+        this.connected = true;
+    }
+
+    public async changeKernel(_kernel: IJupyterKernelSpec | LiveKernelModel, _timeoutMS: number): Promise<void> {
+        throw new Error('Not implemented');
+    }
+}

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -36,7 +36,7 @@ export class RawKernel implements Kernel.IKernel {
 
     // IKernelConnection properties
     get id(): string {
-        throw new Error('Not yet implemented');
+        return this._id;
     }
     get name(): string {
         throw new Error('Not yet implemented');
@@ -70,6 +70,7 @@ export class RawKernel implements Kernel.IKernel {
     private jmpConnection: IJMPConnection;
     private messageChain: Promise<void> = Promise.resolve();
 
+    private _id: string;
     private _clientId: string;
     private _status: Kernel.Status;
     private _statusChanged: Signal<this, Kernel.Status>;
@@ -81,11 +82,13 @@ export class RawKernel implements Kernel.IKernel {
     >();
 
     // JMP connection should be injected, but no need to yet until it actually exists
-    constructor(connection: IJMPConnection) {
-        this._clientId = uuid();
+    constructor(jmpConnection: IJMPConnection, clientID: string) {
+        // clientID is controlled by the session as we keep the same id
+        this._clientId = clientID;
+        this._id = uuid();
         this._status = 'unknown';
         this._statusChanged = new Signal<this, Kernel.Status>(this);
-        this.jmpConnection = connection;
+        this.jmpConnection = jmpConnection;
     }
 
     public async connect(connectInfo: IJMPConnectionInfo) {
@@ -226,6 +229,10 @@ export class RawKernel implements Kernel.IKernel {
             // Send off our input reply no futures or promises
             this.jmpConnection.sendMessage(inputReplyMessage);
         }
+
+        // RAWKERNEL: What should we do here? Throw?
+        // Probably should not get here if session is not available
+        throw new Error('No session available?');
     }
 
     // On dispose close down our connection and get rid of saved futures

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -229,10 +229,6 @@ export class RawKernel implements Kernel.IKernel {
             // Send off our input reply no futures or promises
             this.jmpConnection.sendMessage(inputReplyMessage);
         }
-
-        // RAWKERNEL: What should we do here? Throw?
-        // Probably should not get here if session is not available
-        throw new Error('No session available?');
     }
 
     // On dispose close down our connection and get rid of saved futures

--- a/src/client/datascience/raw-kernel/rawSession.ts
+++ b/src/client/datascience/raw-kernel/rawSession.ts
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Kernel, KernelMessage, ServerConnection, Session } from '@jupyterlab/services';
+import { ISignal, Signal } from '@phosphor/signaling';
+import * as uuid from 'uuid/v4';
+import { IJMPConnection, IJMPConnectionInfo } from '../types';
+import { RawKernel } from './rawKernel';
+
+/*
+RawSession class implements a jupyterlab ISession object
+This provides enough of the ISession interface so that our direct
+ZMQ Kernel connection can pretend to be a jupyterlab Session
+*/
+export class RawSession implements Session.ISession {
+    public isDisposed: boolean = false;
+
+    // Note, ID is the ID of this session
+    // ClientID is the ID that we pass in messages to the kernel
+    // and is also the clientID of the active kernel
+    private _id: string;
+    private _clientID: string;
+    private _kernel: RawKernel;
+    private _statusChanged = new Signal<this, Kernel.Status>(this);
+
+    // RAWKERNEL: Still just pass connection for now, we'll have to
+    // inject this further up the chain
+    constructor(connection: IJMPConnection) {
+        // Unique ID for this session instance
+        this._id = uuid();
+
+        // ID for our client JMP connection
+        this._clientID = uuid();
+
+        // Connect our kernel
+        this._kernel = new RawKernel(connection, this._clientID);
+    }
+
+    public async connect(connectionInfo: IJMPConnectionInfo) {
+        await this._kernel.connect(connectionInfo);
+
+        // Connect for status changes
+        this._kernel.statusChanged.connect(this.onKernelStatus, this);
+    }
+
+    public dispose() {
+        if (!this.isDisposed) {
+            this._kernel.dispose();
+        }
+
+        this.isDisposed = true;
+    }
+
+    // Return the ID, this is session's ID, not clientID for messages
+    get id(): string {
+        return this._id;
+    }
+
+    // Return the current kernel for this session
+    get kernel(): Kernel.IKernelConnection {
+        return this._kernel;
+    }
+
+    // Provide status changes for the attached kernel
+    get statusChanged(): ISignal<this, Kernel.Status> {
+        return this._statusChanged;
+    }
+
+    // Shutdown our session and kernel
+    public shutdown(): Promise<void> {
+        this.dispose();
+        // Normally the server session has to shutdown here with an await on a rest call
+        // but we just have a local connection, so dispose and resolve
+        return Promise.resolve();
+    }
+
+    // Not Implemented ISession
+    get terminated(): ISignal<this, void> {
+        throw new Error('Not yet implemented');
+    }
+    get kernelChanged(): ISignal<this, Session.IKernelChangedArgs> {
+        throw new Error('Not yet implemented');
+    }
+    get propertyChanged(): ISignal<this, 'path' | 'name' | 'type'> {
+        throw new Error('Not yet implemented');
+    }
+    get iopubMessage(): ISignal<this, KernelMessage.IIOPubMessage> {
+        throw new Error('Not yet implemented');
+    }
+    get unhandledMessage(): ISignal<this, KernelMessage.IMessage> {
+        throw new Error('Not yet implemented');
+    }
+    get anyMessage(): ISignal<this, Kernel.IAnyMessageArgs> {
+        throw new Error('Not yet implemented');
+    }
+    get path(): string {
+        throw new Error('Not yet implemented');
+    }
+    get name(): string {
+        throw new Error('Not yet implemented');
+    }
+    get type(): string {
+        throw new Error('Not yet implemented');
+    }
+    get serverSettings(): ServerConnection.ISettings {
+        throw new Error('Not yet implemented');
+    }
+    get model(): Session.IModel {
+        throw new Error('Not yet implemented');
+    }
+    get status(): Kernel.Status {
+        throw new Error('Not yet implemented');
+    }
+    public setPath(_path: string): Promise<void> {
+        throw new Error('Not yet implemented');
+    }
+    public setName(_name: string): Promise<void> {
+        throw new Error('Not yet implemented');
+    }
+    public setType(_type: string): Promise<void> {
+        throw new Error('Not yet implemented');
+    }
+    public changeKernel(_options: Partial<Kernel.IModel>): Promise<Kernel.IKernelConnection> {
+        throw new Error('Not yet implemented');
+    }
+
+    // Private
+    // Send out a message when our kernel changes state
+    private onKernelStatus(_sender: Kernel.IKernelConnection, state: Kernel.Status) {
+        this._statusChanged.emit(state);
+    }
+}

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -13,10 +13,10 @@ import { ConfigurationService } from '../../../../client/common/configuration/se
 import { IConfigurationService, IPythonSettings } from '../../../../client/common/types';
 import { Common, DataScience } from '../../../../client/common/utils/localize';
 import { Architecture } from '../../../../client/common/utils/platform';
+import { JupyterSessionStartError } from '../../../../client/datascience/baseJupyterSession';
 import { Commands } from '../../../../client/datascience/constants';
 import { JupyterNotebookBase } from '../../../../client/datascience/jupyter/jupyterNotebook';
 import { JupyterServerWrapper } from '../../../../client/datascience/jupyter/jupyterServerWrapper';
-import { JupyterSessionStartError } from '../../../../client/datascience/jupyter/jupyterSession';
 import { JupyterSessionManagerFactory } from '../../../../client/datascience/jupyter/jupyterSessionManagerFactory';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../../../../client/datascience/jupyter/kernels/kernelSwitcher';

--- a/src/test/datascience/raw-kernel/rawJupyterSession.unit.test.ts
+++ b/src/test/datascience/raw-kernel/rawJupyterSession.unit.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import { mock } from 'ts-mockito';
+import { RawJupyterSession } from '../../../client/datascience/raw-kernel/rawJupyterSession';
+import { IJMPConnection, IJMPConnectionInfo } from '../../../client/datascience/types';
+
+// Note: The jupyterSession.unit.test.ts tests cover much of the base class functionality
+// and lower level is handled by RawFuture, RawKernel, and RawSession
+// tslint:disable: max-func-body-length
+suite('Data Science - RawJupyterSession', () => {
+    let rawJupyterSession: RawJupyterSession;
+    let jmpConnection: IJMPConnection;
+    let connectInfo: IJMPConnectionInfo;
+
+    setup(() => {
+        jmpConnection = mock<IJMPConnection>();
+        connectInfo = {
+            version: 0,
+            transport: 'tcp',
+            ip: '127.0.0.1',
+            shell_port: 55196,
+            iopub_port: 55197,
+            stdin_port: 55198,
+            hb_port: 55200,
+            control_port: 55199,
+            signature_scheme: 'hmac-sha256',
+            key: 'adaf9032-487d222a85026db284c3d5e7'
+        };
+        rawJupyterSession = new RawJupyterSession(jmpConnection);
+    });
+
+    test('RawJupyterSession - connect', async () => {
+        await rawJupyterSession.connect(connectInfo);
+
+        assert.isTrue(rawJupyterSession.isConnected);
+    });
+
+    test('RawJupyterSession - shutdown on dispose', async () => {
+        const shutdown = sinon.stub(rawJupyterSession, 'shutdown');
+        shutdown.resolves();
+        await rawJupyterSession.dispose();
+        assert.isTrue(shutdown.calledOnce);
+    });
+});

--- a/src/test/datascience/raw-kernel/rawKernel.unit.test.ts
+++ b/src/test/datascience/raw-kernel/rawKernel.unit.test.ts
@@ -4,6 +4,7 @@ import { Kernel, KernelMessage } from '@jupyterlab/services';
 import { Slot } from '@phosphor/signaling';
 import { assert, expect } from 'chai';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import * as uuid from 'uuid/v4';
 import { RawKernel } from '../../../client/datascience/raw-kernel/rawKernel';
 import { IJMPConnection, IJMPConnectionInfo } from '../../../client/datascience/types';
 import { MockJMPConnection } from './mockJMP';
@@ -19,7 +20,7 @@ suite('Data Science - RawKernel', () => {
             jmpConnection = mock<IJMPConnection>();
             when(jmpConnection.connect(anything())).thenResolve();
             when(jmpConnection.subscribe(anything())).thenReturn();
-            rawKernel = new RawKernel(instance(jmpConnection));
+            rawKernel = new RawKernel(instance(jmpConnection), uuid());
 
             connectInfo = {
                 version: 0,
@@ -39,6 +40,8 @@ suite('Data Science - RawKernel', () => {
             await rawKernel.connect(connectInfo);
             verify(jmpConnection.connect(deepEqual(connectInfo))).once();
             verify(jmpConnection.subscribe(anything())).once();
+            // Verify that we have a client id an a kernel id
+            expect(rawKernel.id).to.not.equal(rawKernel.clientId);
         });
 
         test('RawKernel dispose should dispose the jmp', async () => {
@@ -103,7 +106,7 @@ suite('Data Science - RawKernel', () => {
 
         setup(() => {
             mockJmpConnection = new MockJMPConnection();
-            rawKernel = new RawKernel(mockJmpConnection);
+            rawKernel = new RawKernel(mockJmpConnection, uuid());
         });
 
         test('RawKernel executeRequest messages', async () => {

--- a/src/test/datascience/raw-kernel/rawSession.unit.test.ts
+++ b/src/test/datascience/raw-kernel/rawSession.unit.test.ts
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 import { Kernel, KernelMessage } from '@jupyterlab/services';
 import { Slot } from '@phosphor/signaling';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
-import * as uuid from 'uuid/v4';
 import { RawSession } from '../../../client/datascience/raw-kernel/rawSession';
 import { IJMPConnection, IJMPConnectionInfo } from '../../../client/datascience/types';
 import { MockJMPConnection } from './mockJMP';

--- a/src/test/datascience/raw-kernel/rawSession.unit.test.ts
+++ b/src/test/datascience/raw-kernel/rawSession.unit.test.ts
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { Slot } from '@phosphor/signaling';
+import { assert, expect } from 'chai';
+import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
+import * as uuid from 'uuid/v4';
+import { RawSession } from '../../../client/datascience/raw-kernel/rawSession';
+import { IJMPConnection, IJMPConnectionInfo } from '../../../client/datascience/types';
+import { MockJMPConnection } from './mockJMP';
+import { buildStatusMessage } from './rawKernel.unit.test';
+
+// tslint:disable: max-func-body-length
+suite('Data Science - RawSession', () => {
+    let rawSession: RawSession;
+    let connectInfo: IJMPConnectionInfo;
+
+    suite('RawSession - basic JMP', () => {
+        let jmpConnection: IJMPConnection;
+        setup(() => {
+            jmpConnection = mock<IJMPConnection>();
+            when(jmpConnection.connect(anything())).thenResolve();
+            when(jmpConnection.subscribe(anything())).thenReturn();
+            rawSession = new RawSession(instance(jmpConnection));
+
+            connectInfo = {
+                version: 0,
+                transport: 'tcp',
+                ip: '127.0.0.1',
+                shell_port: 55196,
+                iopub_port: 55197,
+                stdin_port: 55198,
+                hb_port: 55200,
+                control_port: 55199,
+                signature_scheme: 'hmac-sha256',
+                key: 'adaf9032-487d222a85026db284c3d5e7'
+            };
+        });
+
+        test('RawSession construct', async () => {
+            // Kernel status should be unknown
+            expect(rawSession.kernel.status).to.equal('unknown');
+
+            // The ID of the session is not the same as the kernel client id
+            expect(rawSession.kernel.clientId).to.not.equal(rawSession.id);
+        });
+
+        test('RawSession connect', async () => {
+            await rawSession.connect(connectInfo);
+
+            // Did we hook up our connection
+            verify(jmpConnection.connect(deepEqual(connectInfo))).once();
+            verify(jmpConnection.subscribe(anything())).once();
+            // The ID of the session is not the same as the kernel client id
+            expect(rawSession.kernel.clientId).to.not.equal(rawSession.id);
+            expect(rawSession.kernel.id).to.not.equal(rawSession.id);
+        });
+
+        test('RawSession dispose', async () => {
+            // Kernel status should be unknown
+            expect(rawSession.kernel.status).to.equal('unknown');
+
+            // The ID of the session is not the same as the kernel client id
+            expect(rawSession.kernel.clientId).to.not.equal(rawSession.id);
+            expect(rawSession.kernel.id).to.not.equal(rawSession.id);
+        });
+    });
+
+    suite('RawSession - mock JMP', () => {
+        let mockJmpConnection: MockJMPConnection;
+        setup(() => {
+            mockJmpConnection = new MockJMPConnection();
+            rawSession = new RawSession(mockJmpConnection);
+
+            connectInfo = {
+                version: 0,
+                transport: 'tcp',
+                ip: '127.0.0.1',
+                shell_port: 55196,
+                iopub_port: 55197,
+                stdin_port: 55198,
+                hb_port: 55200,
+                control_port: 55199,
+                signature_scheme: 'hmac-sha256',
+                key: 'adaf9032-487d222a85026db284c3d5e7'
+            };
+        });
+
+        test('RawSession status updates', async () => {
+            await rawSession.connect(connectInfo);
+
+            const statusChanges = ['busy', 'idle'];
+            let statusHit = 0;
+            const statusHandler: Slot<RawSession, Kernel.Status> = (_sender: RawSession, args: Kernel.Status) => {
+                const targetStatus = statusChanges[statusHit];
+                expect(rawSession.kernel.status).to.equal(targetStatus);
+                expect(args).to.equal(targetStatus);
+                statusHit = statusHit + 1;
+            };
+            rawSession.statusChanged.connect(statusHandler);
+
+            // Create a future for an execute code request
+            const code = 'print("hello world")';
+            const executeContent: KernelMessage.IExecuteRequestMsg['content'] = {
+                code
+            };
+            const future = rawSession.kernel.requestExecute(executeContent, true, undefined);
+
+            // 1. First message is iopub busy status
+            const iopubBusyMessage = buildStatusMessage('busy', rawSession.kernel.clientId, future.msg.header);
+            mockJmpConnection.messageBack(iopubBusyMessage);
+
+            // 2. an idle message
+            const iopubIdleMessage = buildStatusMessage('idle', rawSession.kernel.clientId, future.msg.header);
+            mockJmpConnection.messageBack(iopubIdleMessage);
+
+            // 3. Last thing back is a reply message
+            const replyOptions: KernelMessage.IOptions<KernelMessage.IExecuteReplyMsg> = {
+                channel: 'shell',
+                session: rawSession.kernel.clientId,
+                msgType: 'execute_reply',
+                content: { status: 'ok', execution_count: 1, payload: [], user_expressions: {} }
+            };
+            const replyMessage = KernelMessage.createMessage<KernelMessage.IExecuteReplyMsg>(replyOptions);
+            replyMessage.parent_header = future.msg.header;
+            mockJmpConnection.messageBack(replyMessage);
+
+            await future.done;
+
+            // Did we hit the status changes that we expect
+            expect(statusHit).to.equal(statusChanges.length);
+        });
+    });
+});


### PR DESCRIPTION
Add the RawSession level in.

Create a BaseJupyterSession to implement shared functionality for JupyterSession and RawJupyterSession. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
- [x] Title summarizes what is changing.
- [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
- [x] Appropriate comments and documentation strings in the code.
- [ ] Has sufficient logging.
- [ ] Has telemetry for enhancements.
- [x] Unit tests & system/integration tests are added/updated.
- [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
- [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
- [ ] The wiki is updated with any design decisions/details.
