### PR TITLE
Make switching a kernel dirty a notebook

### DIFF
--- a/news/2 Fixes/10795.md
+++ b/news/2 Fixes/10795.md
@@ -1,0 +1,1 @@
+Fix for notebooks not becoming dirty when changing a kernel

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1391,6 +1391,16 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         } else {
             await this.addSysInfo(SysInfoReason.New);
         }
+
+        // Force an update of the kernel metadata
+        const kernelSpec: IJupyterKernelSpec = {
+            path: kernel.path ?? '',
+            name: kernel.name,
+            language: kernel.language ?? 'python',
+            display_name: kernel.display_name ?? kernel.name,
+            argv: kernel.argv ?? []
+        };
+        return this.updateNotebookOptions(kernelSpec, this._notebook?.getMatchingInterpreter());
     }
 
     private openSettings(setting: string | undefined) {


### PR DESCRIPTION
For #10795

10795 was originally about the notebook kernel switch not working. I couldn't repro this, but what I could repro was the kernel switch not being saved. Thought that might be the cause of the original bug.