### PR TITLE
Update debugpy to latest (1.0.0b5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
+## 2020.3.2 (2 April 2020)
+
+### Fixes
+
+1. Update `debugpy` to latest (v1.0.0b5). Fixes issue with connections with multi-process.
+
 ## 2020.3.1 (31 March 2020)
 
 ### Fixes
 
-1. Update `debugpy` to latest. Fixes issue with locale.
+1. Update `debugpy` to latest (v1.0.0b4). Fixes issue with locale.
 
 ## 2020.3.0 (19 March 2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "python",
-    "version": "2020.3.1",
+    "version": "2020.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "python",
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, Jupyter Notebooks, code formatting, refactoring, unit tests, snippets, and more.",
-    "version": "2020.3.1",
+    "version": "2020.3.2",
     "languageServerVersion": "0.5.30",
     "publisher": "ms-python",
     "author": {


### PR DESCRIPTION
No code change is necessary. Creating a new build will pull the latest version of `debugpy`.