### PR TITLE
Remove the unnecessary EnvFileTelemetry namespace

### DIFF
--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -13,7 +13,7 @@ import { IFileSystem } from '../common/platform/types';
 import { IDisposable, Resource } from '../common/types';
 import { IInterpreterAutoSelectionService } from '../interpreter/autoSelection/types';
 import { IInterpreterService } from '../interpreter/contracts';
-import { EnvFileTelemetry } from '../telemetry/envFileTelemetry';
+import { sendActivationTelemetry } from '../telemetry/envFileTelemetry';
 import { IExtensionActivationManager, IExtensionActivationService, IExtensionSingleActivationService } from './types';
 
 @injectable()
@@ -63,7 +63,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         // Get latest interpreter list in the background.
         this.interpreterService.getInterpreters(resource).ignoreErrors();
 
-        await EnvFileTelemetry.sendActivationTelemetry(this.fileSystem, this.workspaceService, resource);
+        await sendActivationTelemetry(this.fileSystem, this.workspaceService, resource);
 
         await this.autoSelection.autoSelectInterpreter(resource);
         await Promise.all(this.activationServices.map((item) => item.activate(resource)));

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -17,7 +17,7 @@ import '../common/extensions';
 import { IInterpreterAutoSeletionProxyService } from '../interpreter/autoSelection/types';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
-import { EnvFileTelemetry } from '../telemetry/envFileTelemetry';
+import { sendSettingTelemetry } from '../telemetry/envFileTelemetry';
 import { IWorkspaceService } from './application/types';
 import { WorkspaceService } from './application/workspace';
 import { isTestExecution } from './constants';
@@ -205,7 +205,7 @@ export class PythonSettings implements IPythonSettings {
 
         const envFileSetting = pythonSettings.get<string>('envFile');
         this.envFile = systemVariables.resolveAny(envFileSetting)!;
-        EnvFileTelemetry.sendSettingTelemetry(this.workspace, envFileSetting);
+        sendSettingTelemetry(this.workspace, envFileSetting);
 
         // tslint:disable-next-line:no-any
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion no-any

--- a/src/client/common/variables/environmentVariablesProvider.ts
+++ b/src/client/common/variables/environmentVariablesProvider.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import { ConfigurationChangeEvent, Disposable, Event, EventEmitter, FileSystemWatcher, Uri } from 'vscode';
-import { EnvFileTelemetry } from '../../telemetry/envFileTelemetry';
+import { sendFileCreationTelemetry } from '../../telemetry/envFileTelemetry';
 import { IWorkspaceService } from '../application/types';
 import { IPlatformService } from '../platform/types';
 import { IConfigurationService, ICurrentProcess, IDisposableRegistry } from '../types';
@@ -97,7 +97,7 @@ export class EnvironmentVariablesProvider implements IEnvironmentVariablesProvid
 
     private onEnvironmentFileCreated(workspaceFolderUri?: Uri) {
         this.onEnvironmentFileChanged(workspaceFolderUri);
-        EnvFileTelemetry.sendFileCreationTelemetry();
+        sendFileCreationTelemetry();
     }
 
     private onEnvironmentFileChanged(workspaceFolderUri?: Uri) {

--- a/src/client/telemetry/envFileTelemetry.ts
+++ b/src/client/telemetry/envFileTelemetry.ts
@@ -11,77 +11,69 @@ import { SystemVariables } from '../common/variables/systemVariables';
 import { sendTelemetryEvent } from '.';
 import { EventName } from './constants';
 
-export namespace EnvFileTelemetry {
-    let _defaultEnvFileSetting: string | undefined;
-    let envFileTelemetrySent = false;
+let _defaultEnvFileSetting: string | undefined;
+let envFileTelemetrySent = false;
 
-    export function sendSettingTelemetry(workspaceService: IWorkspaceService, envFileSetting?: string) {
-        if (shouldSendTelemetry() && envFileSetting !== defaultEnvFileSetting(workspaceService)) {
-            sendTelemetry(true);
-        }
+export function sendSettingTelemetry(workspaceService: IWorkspaceService, envFileSetting?: string) {
+    if (shouldSendTelemetry() && envFileSetting !== defaultEnvFileSetting(workspaceService)) {
+        sendTelemetry(true);
     }
+}
 
-    export function sendFileCreationTelemetry() {
-        if (shouldSendTelemetry()) {
+export function sendFileCreationTelemetry() {
+    if (shouldSendTelemetry()) {
+        sendTelemetry();
+    }
+}
+
+export async function sendActivationTelemetry(
+    fileSystem: IFileSystem,
+    workspaceService: IWorkspaceService,
+    resource: Resource
+) {
+    if (shouldSendTelemetry()) {
+        const systemVariables = new SystemVariables(resource, undefined, workspaceService);
+        const envFilePath = systemVariables.resolveAny(defaultEnvFileSetting(workspaceService))!;
+        const envFileExists = await fileSystem.fileExists(envFilePath);
+
+        if (envFileExists) {
             sendTelemetry();
         }
     }
+}
 
-    export async function sendActivationTelemetry(
-        fileSystem: IFileSystem,
-        workspaceService: IWorkspaceService,
-        resource: Resource
-    ) {
-        if (shouldSendTelemetry()) {
-            const systemVariables = new SystemVariables(resource, undefined, workspaceService);
-            const envFilePath = systemVariables.resolveAny(defaultEnvFileSetting(workspaceService))!;
-            const envFileExists = await fileSystem.fileExists(envFilePath);
+function sendTelemetry(hasCustomEnvPath: boolean = false) {
+    sendTelemetryEvent(EventName.ENVFILE_WORKSPACE, undefined, { hasCustomEnvPath });
 
-            if (envFileExists) {
-                sendTelemetry();
-            }
+    envFileTelemetrySent = true;
+}
+
+function shouldSendTelemetry(): boolean {
+    return !envFileTelemetrySent;
+}
+
+function defaultEnvFileSetting(workspaceService: IWorkspaceService) {
+    if (!_defaultEnvFileSetting) {
+        const section = workspaceService.getConfiguration('python');
+        _defaultEnvFileSetting = section.inspect<string>('envFile')?.defaultValue || '';
+    }
+
+    return _defaultEnvFileSetting;
+}
+
+// Set state for tests.
+export namespace EnvFileTelemetryTests {
+    export function setState({ telemetrySent, defaultSetting }: { telemetrySent?: boolean; defaultSetting?: string }) {
+        if (telemetrySent !== undefined) {
+            envFileTelemetrySent = telemetrySent;
+        }
+        if (defaultEnvFileSetting !== undefined) {
+            _defaultEnvFileSetting = defaultSetting;
         }
     }
 
-    function sendTelemetry(hasCustomEnvPath: boolean = false) {
-        sendTelemetryEvent(EventName.ENVFILE_WORKSPACE, undefined, { hasCustomEnvPath });
-
-        envFileTelemetrySent = true;
-    }
-
-    function shouldSendTelemetry(): boolean {
-        return !envFileTelemetrySent;
-    }
-
-    function defaultEnvFileSetting(workspaceService: IWorkspaceService) {
-        if (!_defaultEnvFileSetting) {
-            const section = workspaceService.getConfiguration('python');
-            _defaultEnvFileSetting = section.inspect<string>('envFile')?.defaultValue || '';
-        }
-
-        return _defaultEnvFileSetting;
-    }
-
-    // Set state for tests.
-    export namespace EnvFileTelemetryTests {
-        export function setState({
-            telemetrySent,
-            defaultSetting
-        }: {
-            telemetrySent?: boolean;
-            defaultSetting?: string;
-        }) {
-            if (telemetrySent !== undefined) {
-                envFileTelemetrySent = telemetrySent;
-            }
-            if (defaultEnvFileSetting !== undefined) {
-                _defaultEnvFileSetting = defaultSetting;
-            }
-        }
-
-        export function resetState() {
-            _defaultEnvFileSetting = undefined;
-            envFileTelemetrySent = false;
-        }
+    export function resetState() {
+        _defaultEnvFileSetting = undefined;
+        envFileTelemetrySent = false;
     }
 }

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -22,7 +22,7 @@ import { IDisposable } from '../../client/common/types';
 import { IInterpreterAutoSelectionService } from '../../client/interpreter/autoSelection/types';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { InterpreterService } from '../../client/interpreter/interpreterService';
-import { EnvFileTelemetry } from '../../client/telemetry/envFileTelemetry';
+import * as EnvFileTelemetry from '../../client/telemetry/envFileTelemetry';
 import { sleep } from '../core';
 
 // tslint:disable:max-func-body-length no-any

--- a/src/test/common/configSettings/configSettings.pythonPath.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.pythonPath.unit.test.ts
@@ -13,7 +13,7 @@ import * as typemoq from 'typemoq';
 import { Uri, WorkspaceConfiguration } from 'vscode';
 import { PythonSettings } from '../../../client/common/configSettings';
 import { noop } from '../../../client/common/utils/misc';
-import { EnvFileTelemetry } from '../../../client/telemetry/envFileTelemetry';
+import * as EnvFileTelemetry from '../../../client/telemetry/envFileTelemetry';
 import { MockAutoSelectionService } from '../../mocks/autoSelector';
 const untildify = require('untildify');
 

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -27,7 +27,7 @@ import {
     IWorkspaceSymbolSettings
 } from '../../../client/common/types';
 import { noop } from '../../../client/common/utils/misc';
-import { EnvFileTelemetry } from '../../../client/telemetry/envFileTelemetry';
+import * as EnvFileTelemetry from '../../../client/telemetry/envFileTelemetry';
 import { MockAutoSelectionService } from '../../mocks/autoSelector';
 
 // tslint:disable-next-line:max-func-body-length

--- a/src/test/common/variables/environmentVariablesProvider.unit.test.ts
+++ b/src/test/common/variables/environmentVariablesProvider.unit.test.ts
@@ -21,7 +21,7 @@ import { clearCache } from '../../../client/common/utils/cacheUtils';
 import { EnvironmentVariablesService } from '../../../client/common/variables/environment';
 import { EnvironmentVariablesProvider } from '../../../client/common/variables/environmentVariablesProvider';
 import { IEnvironmentVariablesService } from '../../../client/common/variables/types';
-import { EnvFileTelemetry } from '../../../client/telemetry/envFileTelemetry';
+import * as EnvFileTelemetry from '../../../client/telemetry/envFileTelemetry';
 import { noop } from '../../core';
 
 // tslint:disable:no-any max-func-body-length

--- a/src/test/telemetry/envFileTelemetry.unit.test.ts
+++ b/src/test/telemetry/envFileTelemetry.unit.test.ts
@@ -12,7 +12,12 @@ import { FileSystem } from '../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../client/common/platform/types';
 import * as Telemetry from '../../client/telemetry';
 import { EventName } from '../../client/telemetry/constants';
-import { EnvFileTelemetry } from '../../client/telemetry/envFileTelemetry';
+import {
+    EnvFileTelemetryTests,
+    sendActivationTelemetry,
+    sendFileCreationTelemetry,
+    sendSettingTelemetry
+} from '../../client/telemetry/envFileTelemetry';
 
 suite('Env file telemetry', () => {
     const defaultEnvFileValue = 'someDefaultValue';
@@ -53,45 +58,45 @@ suite('Env file telemetry', () => {
     teardown(() => {
         telemetryEvent = undefined;
         sinon.restore();
-        EnvFileTelemetry.EnvFileTelemetryTests.resetState();
+        EnvFileTelemetryTests.resetState();
     });
 
     test('Setting telemetry should be sent with hasCustomEnvPath at true if the python.envFile setting is different from the default value', () => {
-        EnvFileTelemetry.sendSettingTelemetry(instance(workspaceService), 'bar');
+        sendSettingTelemetry(instance(workspaceService), 'bar');
 
         sinon.assert.calledOnce(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, { eventName: EventName.ENVFILE_WORKSPACE, hasCustomEnvPath: true });
     });
 
     test('Setting telemetry should not be sent if a telemetry event has already been sent', () => {
-        EnvFileTelemetry.EnvFileTelemetryTests.setState({ telemetrySent: true });
+        EnvFileTelemetryTests.setState({ telemetrySent: true });
 
-        EnvFileTelemetry.sendSettingTelemetry(instance(workspaceService), 'bar');
+        sendSettingTelemetry(instance(workspaceService), 'bar');
 
         sinon.assert.notCalled(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, undefined);
     });
 
     test('Setting telemetry should not be sent if the python.envFile setting is the same as the default value', () => {
-        EnvFileTelemetry.EnvFileTelemetryTests.setState({ defaultSetting: defaultEnvFileValue });
+        EnvFileTelemetryTests.setState({ defaultSetting: defaultEnvFileValue });
 
-        EnvFileTelemetry.sendSettingTelemetry(instance(workspaceService), defaultEnvFileValue);
+        sendSettingTelemetry(instance(workspaceService), defaultEnvFileValue);
 
         sinon.assert.notCalled(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, undefined);
     });
 
     test('File creation telemetry should be sent if no telemetry event has been sent before', () => {
-        EnvFileTelemetry.sendFileCreationTelemetry();
+        sendFileCreationTelemetry();
 
         sinon.assert.calledOnce(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, { eventName: EventName.ENVFILE_WORKSPACE, hasCustomEnvPath: false });
     });
 
     test('File creation telemetry should not be sent if a telemetry event has already been sent', () => {
-        EnvFileTelemetry.EnvFileTelemetryTests.setState({ telemetrySent: true });
+        EnvFileTelemetryTests.setState({ telemetrySent: true });
 
-        EnvFileTelemetry.sendFileCreationTelemetry();
+        sendFileCreationTelemetry();
 
         sinon.assert.notCalled(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, undefined);
@@ -100,16 +105,16 @@ suite('Env file telemetry', () => {
     test('Activation telemetry should be sent if no telemetry event has been sent before, and a .env file exists', async () => {
         when(fileSystem.fileExists(anyString())).thenResolve(true);
 
-        await EnvFileTelemetry.sendActivationTelemetry(instance(fileSystem), instance(workspaceService), resource);
+        await sendActivationTelemetry(instance(fileSystem), instance(workspaceService), resource);
 
         sinon.assert.calledOnce(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, { eventName: EventName.ENVFILE_WORKSPACE, hasCustomEnvPath: false });
     });
 
     test('Activation telemetry should not be sent if a telemetry event has already been sent', async () => {
-        EnvFileTelemetry.EnvFileTelemetryTests.setState({ telemetrySent: true });
+        EnvFileTelemetryTests.setState({ telemetrySent: true });
 
-        await EnvFileTelemetry.sendActivationTelemetry(instance(fileSystem), instance(workspaceService), resource);
+        await sendActivationTelemetry(instance(fileSystem), instance(workspaceService), resource);
 
         sinon.assert.notCalled(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, undefined);
@@ -118,7 +123,7 @@ suite('Env file telemetry', () => {
     test('Activation telemetry should not be sent if no .env file exists', async () => {
         when(fileSystem.fileExists(anyString())).thenResolve(false);
 
-        await EnvFileTelemetry.sendActivationTelemetry(instance(fileSystem), instance(workspaceService), resource);
+        await sendActivationTelemetry(instance(fileSystem), instance(workspaceService), resource);
 
         sinon.assert.notCalled(sendTelemetryStub);
         assert.deepEqual(telemetryEvent, undefined);


### PR DESCRIPTION
For #10780 

We don't need to wrap the content of `envFileTelemetry.ts` in a namespace since it's already in a module.

From the [TypeScript Deep Dive](https://basarat.gitbook.io/typescript/project/namespaces):

> For most projects we recommend using external modules and using namespace for quick demos and porting old JavaScript code.

-----

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
