### PR TITLE
Raw Notebook Provider

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -124,6 +124,8 @@
     "DataScience.jupyterSelfCertEnable": "Yes, connect anyways",
     "DataScience.jupyterSelfCertClose": "No, close the connection",
     "DataScience.jupyterServerCrashed": "Jupyter server crashed. Unable to connect. \r\nError code from jupyter: {0}",
+    "DataScience.rawConnectionDisplayName": "Direct kernel connection",
+    "DataScience.rawConnectionBrokenError": "Direct kernel connection broken",
     "DataScience.pythonInteractiveHelpLink": "Get more help",
     "DataScience.markdownHelpInstallingMissingDependencies": "See [https://aka.ms/pyaiinstall](https://aka.ms/pyaiinstall) for help on installing Jupyter and related dependencies.",
     "DataScience.importingFormat": "Importing {0}",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -471,6 +471,14 @@ export namespace DataScience {
         'DataScience.jupyterNotebookRemoteConnectSelfCertsFailed',
         'Failed to connect to remote Jupyter notebook.\r\nSpecified server is using self signed certs. Enable Allow Unauthorized Remote Connection setting to connect anyways\r\n{0}\r\n{1}'
     );
+    export const rawConnectionDisplayName = localize(
+        'DataScience.rawConnectionDisplayName',
+        'Direct kernel connection'
+    );
+    export const rawConnectionBrokenError = localize(
+        'DataScience.rawConnectionBrokenError',
+        'Direct kernel connection broken'
+    );
     export const jupyterServerCrashed = localize(
         'DataScience.jupyterServerCrashed',
         'Jupyter server crashed. Unable to connect. \r\nError code from jupyter: {0}'

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -383,6 +383,7 @@ export namespace Identifiers {
     export const EmptyFileName = '2DB9B899-6519-4E1B-88B0-FA728A274115';
     export const GeneratedThemeName = 'ipython-theme'; // This needs to be all lower class and a valid class name.
     export const HistoryPurpose = 'history';
+    export const RawPurpose = 'raw';
     export const PingPurpose = 'ping';
     export const MatplotLibDefaultParams = '_VSCode_defaultMatplotlib_Params';
     export const EditCellId = '3D3AB152-ADC1-4501-B813-4B83B49B0C10';

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -429,6 +429,7 @@ export namespace LiveShare {
     export const InteractiveWindowProviderService = 'interactiveWindowProviderService';
     export const GuestCheckerService = 'guestCheckerService';
     export const LiveShareBroadcastRequest = 'broadcastRequest';
+    export const RawNotebookProviderService = 'rawNotebookProviderSharedService';
     export const ResponseLifetime = 15000;
     export const ResponseRange = 1000; // Range of time alloted to check if a response matches or not
     export const InterruptDefaultTimeout = 10000;

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -17,7 +17,8 @@ import {
     INotebookEditorProvider,
     INotebookProvider,
     INotebookProviderConnection,
-    INotebookServerProvider
+    INotebookServerProvider,
+    IRawNotebookProvider
 } from '../types';
 
 @injectable()
@@ -32,7 +33,8 @@ export class NotebookProvider implements INotebookProvider {
         @inject(INotebookEditorProvider) private readonly editorProvider: INotebookEditorProvider,
         @inject(IInteractiveWindowProvider) private readonly interactiveWindowProvider: IInteractiveWindowProvider,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
-        @inject(INotebookServerProvider) private readonly serverProvider: INotebookServerProvider
+        @inject(INotebookServerProvider) private readonly serverProvider: INotebookServerProvider,
+        @inject(IRawNotebookProvider) private readonly rawNotebookProvider: IRawNotebookProvider
     ) {
         disposables.push(editorProvider.onDidCloseNotebookEditor(this.onDidCloseNotebookEditor, this));
         disposables.push(

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -54,6 +54,10 @@ export class NotebookProvider implements INotebookProvider {
 
     // Attempt to connect to our server provider, and if we do, return the connection info
     public async connect(options: ConnectNotebookProviderOptions): Promise<INotebookProviderConnection | undefined> {
+        // IANHU: just for testing
+        const zmqSupported = await this.rawNotebookProvider.supported();
+        const zmqConnection = await this.rawNotebookProvider.connect();
+
         const server = await this.serverProvider.getOrCreateServer(options);
 
         return server?.getConnectionInfo();

--- a/src/client/datascience/interactive-common/notebookServerProvider.ts
+++ b/src/client/datascience/interactive-common/notebookServerProvider.ts
@@ -20,14 +20,14 @@ import { ProgressReporter } from '../progress/progressReporter';
 import {
     GetServerOptions,
     IJupyterExecution,
+    IJupyterServerProvider,
     INotebook,
     INotebookServer,
-    INotebookServerOptions,
-    INotebookServerProvider
+    INotebookServerOptions
 } from '../types';
 
 @injectable()
-export class NotebookServerProvider implements INotebookServerProvider {
+export class NotebookServerProvider implements IJupyterServerProvider {
     private serverPromise: Promise<INotebookServer | undefined> | undefined;
     private allowingUI = false;
     private _notebookCreated = new EventEmitter<{ identity: Uri; notebook: INotebook }>();

--- a/src/client/datascience/ipywidgets/ipyWidgetMessageDispatcherFactory.ts
+++ b/src/client/datascience/ipywidgets/ipyWidgetMessageDispatcherFactory.ts
@@ -87,7 +87,13 @@ export class IPyWidgetMessageDispatcherFactory implements IDisposable {
         notebookProvider.onNotebookCreated(e => this.trackDisposingOfNotebook(e.notebook), this, this.disposables);
 
         notebookProvider.activeNotebooks.forEach(nbPromise =>
-            nbPromise.then(notebook => this.trackDisposingOfNotebook(notebook)).ignoreErrors()
+            nbPromise
+                .then(notebook => {
+                    if (notebook) {
+                        this.trackDisposingOfNotebook(notebook);
+                    }
+                })
+                .ignoreErrors()
         );
     }
 

--- a/src/client/datascience/ipywidgets/ipyWidgetMessageDispatcherFactory.ts
+++ b/src/client/datascience/ipywidgets/ipyWidgetMessageDispatcherFactory.ts
@@ -87,13 +87,7 @@ export class IPyWidgetMessageDispatcherFactory implements IDisposable {
         notebookProvider.onNotebookCreated(e => this.trackDisposingOfNotebook(e.notebook), this, this.disposables);
 
         notebookProvider.activeNotebooks.forEach(nbPromise =>
-            nbPromise
-                .then(notebook => {
-                    if (notebook) {
-                        this.trackDisposingOfNotebook(notebook);
-                    }
-                })
-                .ignoreErrors()
+            nbPromise.then(notebook => this.trackDisposingOfNotebook(notebook)).ignoreErrors()
         );
     }
 

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import * as localize from '../../common/utils/localize';
+import {
+    ConnectNotebookProviderOptions,
+    GetNotebookOptions,
+    IConnection,
+    IJupyterNotebookProvider,
+    INotebook,
+    INotebookServerProvider
+} from '../types';
+
+// When the NotebookProvider looks to create a notebook it uses this class to create a Jupyter notebook
+// This class uses the INotebookServerProvider and the server to create the notebook
+@injectable()
+export class JupyterNotebookProvider implements IJupyterNotebookProvider {
+    constructor(@inject(INotebookServerProvider) private readonly serverProvider: INotebookServerProvider) {}
+
+    public async disconnect(options: ConnectNotebookProviderOptions): Promise<void> {
+        const server = await this.serverProvider.getOrCreateServer(options);
+
+        return server?.dispose();
+    }
+
+    public async connect(options: ConnectNotebookProviderOptions): Promise<IConnection | undefined> {
+        const server = await this.serverProvider.getOrCreateServer(options);
+        return server?.getConnectionInfo();
+    }
+    public async createNotebook(options: GetNotebookOptions): Promise<INotebook> {
+        // Make sure we have a server
+        const server = await this.serverProvider.getOrCreateServer({
+            getOnly: options.getOnly,
+            disableUI: options.disableUI
+        });
+
+        if (server) {
+            return server.createNotebook(options.identity, options.identity, options.metadata);
+        }
+
+        // We want createNotebook to always return a notebook promise, so if we don't have a server
+        // here throw our generic server disposed message that we use in server creation
+        throw new Error(localize.DataScience.sessionDisposed());
+    }
+    public async getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
+        const server = await this.serverProvider.getOrCreateServer({
+            getOnly: options.getOnly,
+            disableUI: options.disableUI
+        });
+        if (server) {
+            return server.getNotebook(options.identity);
+        }
+    }
+}

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -9,15 +9,14 @@ import {
     GetNotebookOptions,
     IConnection,
     IJupyterNotebookProvider,
-    INotebook,
-    INotebookServerProvider
+    IJupyterServerProvider,
+    INotebook
 } from '../types';
 
 // When the NotebookProvider looks to create a notebook it uses this class to create a Jupyter notebook
-// This class uses the INotebookServerProvider and the server to create the notebook
 @injectable()
 export class JupyterNotebookProvider implements IJupyterNotebookProvider {
-    constructor(@inject(INotebookServerProvider) private readonly serverProvider: INotebookServerProvider) {}
+    constructor(@inject(IJupyterServerProvider) private readonly serverProvider: IJupyterServerProvider) {}
 
     public async disconnect(options: ConnectNotebookProviderOptions): Promise<void> {
         const server = await this.serverProvider.getOrCreateServer(options);

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import * as localize from '../../common/utils/localize';
 import {
     ConnectNotebookProviderOptions,
     GetNotebookOptions,
@@ -30,7 +29,8 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         const server = await this.serverProvider.getOrCreateServer(options);
         return server?.getConnectionInfo();
     }
-    public async createNotebook(options: GetNotebookOptions): Promise<INotebook> {
+
+    public async createNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
         // Make sure we have a server
         const server = await this.serverProvider.getOrCreateServer({
             getOnly: options.getOnly,
@@ -41,9 +41,7 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
             return server.createNotebook(options.identity, options.identity, options.metadata);
         }
 
-        // We want createNotebook to always return a notebook promise, so if we don't have a server
-        // here throw our generic server disposed message that we use in server creation
-        throw new Error(localize.DataScience.sessionDisposed());
+        return undefined;
     }
     public async getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
         const server = await this.serverProvider.getOrCreateServer({

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
+import * as localize from '../../common/utils/localize';
 import {
     ConnectNotebookProviderOptions,
     GetNotebookOptions,
@@ -29,7 +30,7 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         return server?.getConnectionInfo();
     }
 
-    public async createNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
+    public async createNotebook(options: GetNotebookOptions): Promise<INotebook> {
         // Make sure we have a server
         const server = await this.serverProvider.getOrCreateServer({
             getOnly: options.getOnly,
@@ -39,8 +40,9 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         if (server) {
             return server.createNotebook(options.identity, options.identity, options.metadata);
         }
-
-        return undefined;
+        // We want createNotebook to always return a notebook promise, so if we don't have a server
+        // here throw our generic server disposed message that we use in server creatio n
+        throw new Error(localize.DataScience.sessionDisposed());
     }
     public async getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
         const server = await this.serverProvider.getOrCreateServer({

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -49,7 +49,7 @@ export class GuestRawNotebookProvider
         _resource: Resource,
         _notebookMetadata: nbformat.INotebookMetadata,
         _cancelToken: CancellationToken
-    ): Promise<INotebook | undefined> {
+    ): Promise<INotebook> {
         throw new Error('Not implemented');
     }
 

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -5,8 +5,16 @@ import { nbformat } from '@jupyterlab/coreutils';
 import { Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import * as vsls from 'vsls/vscode';
-import { ILiveShareApi } from '../../../common/application/types';
-import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../../common/types';
+import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../../common/application/types';
+import { IFileSystem } from '../../../common/platform/types';
+import {
+    IAsyncDisposableRegistry,
+    IConfigurationService,
+    IDisposableRegistry,
+    IExperimentsManager,
+    Resource
+} from '../../../common/types';
+import { IServiceContainer } from '../../../ioc/types';
 import { LiveShare } from '../../constants';
 import {
     LiveShareParticipantDefault,
@@ -20,10 +28,16 @@ export class GuestRawNotebookProvider
     implements IRawNotebookProvider, ILiveShareParticipant {
     //private notebooks = new Map<string, Promise<INotebook>>();
 
+    // IANHU: Clean up constructor ordering to not have unused types here?
     constructor(
         liveShare: ILiveShareApi,
+        _disposableRegistry: IDisposableRegistry,
         _asyncRegistry: IAsyncDisposableRegistry,
         _configService: IConfigurationService,
+        _workspaceService: IWorkspaceService,
+        _appShell: IApplicationShell,
+        _fs: IFileSystem,
+        _serviceContainer: IServiceContainer,
         _experimentsManager: IExperimentsManager
     ) {
         super(liveShare);

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -26,9 +26,6 @@ import { INotebook, IRawConnection, IRawNotebookProvider } from '../../types';
 export class GuestRawNotebookProvider
     extends LiveShareParticipantGuest(LiveShareParticipantDefault, LiveShare.RawNotebookProviderService)
     implements IRawNotebookProvider, ILiveShareParticipant {
-    //private notebooks = new Map<string, Promise<INotebook>>();
-
-    // IANHU: Clean up constructor ordering to not have unused types here?
     constructor(
         liveShare: ILiveShareApi,
         _disposableRegistry: IDisposableRegistry,
@@ -60,81 +57,23 @@ export class GuestRawNotebookProvider
         throw new Error('Not implemented');
     }
 
-    //public async createNotebook(resource: Resource, identity: Uri): Promise<INotebook> {
-    //// Remember we can have multiple native editors opened against the same ipynb file.
-    //if (this.notebooks.get(identity.toString())) {
-    //return this.notebooks.get(identity.toString())!;
-    //}
-
-    //const deferred = createDeferred<INotebook>();
-    //this.notebooks.set(identity.toString(), deferred.promise);
-    //// Tell the host side to generate a notebook for this uri
-    //const service = await this.waitForService();
-    //if (service) {
-    //const resourceString = resource ? resource.toString() : undefined;
-    //const identityString = identity.toString();
-    //await service.request(LiveShareCommands.createNotebook, [resourceString, identityString]);
-    //}
-
-    //// Return a new notebook to listen to
-    //const result = new GuestJupyterNotebook(
-    //this.liveShare,
-    //this.disposableRegistry,
-    //this.configService,
-    //resource,
-    //identity,
-    //this.launchInfo,
-    //this.dataScience.activationStartTime
-    //);
-    //deferred.resolve(result);
-    //const oldDispose = result.dispose.bind(result);
-    //result.dispose = () => {
-    //this.notebooks.delete(identity.toString());
-    //return oldDispose();
-    //};
-
-    //return result;
-    //}
-
-    public async onSessionChange(api: vsls.LiveShare | null): Promise<void> {
-        await super.onSessionChange(api);
-
-        //this.notebooks.forEach(async notebook => {
-        //const guestNotebook = (await notebook) as GuestJupyterNotebook;
-        //if (guestNotebook) {
-        //await guestNotebook.onSessionChange(api);
-        //}
-        //});
+    public async onSessionChange(_api: vsls.LiveShare | null): Promise<void> {
+        throw new Error('Not implemented');
     }
 
     public async getNotebook(_resource: Uri): Promise<INotebook | undefined> {
         throw new Error('Not implemented');
-        //return this.notebooks.get(resource.toString());
     }
 
     public async shutdown(): Promise<void> {
-        // Send this across to the other side. Otherwise the host server will remain running (like during an export)
-        //const service = await this.waitForService();
-        //if (service) {
-        //await service.request(LiveShareCommands.disposeServer, []);
-        //}
+        throw new Error('Not implemented');
     }
 
     public dispose(): Promise<void> {
-        return this.shutdown();
+        throw new Error('Not implemented');
     }
 
-    public async onAttach(api: vsls.LiveShare | null): Promise<void> {
-        await super.onAttach(api);
-
-        //if (api) {
-        //const service = await this.waitForService();
-
-        //// Wait for sync up
-        //const synced = service ? await service.request(LiveShareCommands.syncRequest, []) : undefined;
-        //if (!synced && api.session && api.session.role !== vsls.Role.None) {
-        //throw new Error(localize.DataScience.liveShareSyncFailure());
-        //}
-        //}
+    public async onAttach(_api: vsls.LiveShare | null): Promise<void> {
+        throw new Error('Not implemented');
     }
 }

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -13,7 +13,7 @@ import {
     LiveShareParticipantGuest
 } from '../../jupyter/liveshare/liveShareParticipantMixin';
 import { ILiveShareParticipant } from '../../jupyter/liveshare/types';
-import { INotebook, IRawNotebookProvider } from '../../types';
+import { INotebook, IRawConnection, IRawNotebookProvider } from '../../types';
 
 export class GuestRawNotebookProvider
     extends LiveShareParticipantGuest(LiveShareParticipantDefault, LiveShare.RawNotebookProviderService)
@@ -39,6 +39,10 @@ export class GuestRawNotebookProvider
         _notebookMetadata: nbformat.INotebookMetadata,
         _cancelToken: CancellationToken
     ): Promise<INotebook | undefined> {
+        throw new Error('Not implemented');
+    }
+
+    public connect(): Promise<IRawConnection> {
         throw new Error('Not implemented');
     }
 

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { nbformat } from '@jupyterlab/coreutils';
+import { Uri } from 'vscode';
+import { CancellationToken } from 'vscode-jsonrpc';
+import * as vsls from 'vsls/vscode';
+import { ILiveShareApi } from '../../../common/application/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../../common/types';
+import { LiveShare } from '../../constants';
+import {
+    LiveShareParticipantDefault,
+    LiveShareParticipantGuest
+} from '../../jupyter/liveshare/liveShareParticipantMixin';
+import { ILiveShareParticipant } from '../../jupyter/liveshare/types';
+import { INotebook, IRawNotebookProvider } from '../../types';
+
+export class GuestRawNotebookProvider
+    extends LiveShareParticipantGuest(LiveShareParticipantDefault, LiveShare.RawNotebookProviderService)
+    implements IRawNotebookProvider, ILiveShareParticipant {
+    //private notebooks = new Map<string, Promise<INotebook>>();
+
+    constructor(
+        liveShare: ILiveShareApi,
+        _asyncRegistry: IAsyncDisposableRegistry,
+        _configService: IConfigurationService,
+        _experimentsManager: IExperimentsManager
+    ) {
+        super(liveShare);
+    }
+
+    public async supported(): Promise<boolean> {
+        throw new Error('Not implemented');
+    }
+
+    public async createNotebook(
+        _identity: Uri,
+        _resource: Resource,
+        _notebookMetadata: nbformat.INotebookMetadata,
+        _cancelToken: CancellationToken
+    ): Promise<INotebook | undefined> {
+        throw new Error('Not implemented');
+    }
+
+    //public async createNotebook(resource: Resource, identity: Uri): Promise<INotebook> {
+    //// Remember we can have multiple native editors opened against the same ipynb file.
+    //if (this.notebooks.get(identity.toString())) {
+    //return this.notebooks.get(identity.toString())!;
+    //}
+
+    //const deferred = createDeferred<INotebook>();
+    //this.notebooks.set(identity.toString(), deferred.promise);
+    //// Tell the host side to generate a notebook for this uri
+    //const service = await this.waitForService();
+    //if (service) {
+    //const resourceString = resource ? resource.toString() : undefined;
+    //const identityString = identity.toString();
+    //await service.request(LiveShareCommands.createNotebook, [resourceString, identityString]);
+    //}
+
+    //// Return a new notebook to listen to
+    //const result = new GuestJupyterNotebook(
+    //this.liveShare,
+    //this.disposableRegistry,
+    //this.configService,
+    //resource,
+    //identity,
+    //this.launchInfo,
+    //this.dataScience.activationStartTime
+    //);
+    //deferred.resolve(result);
+    //const oldDispose = result.dispose.bind(result);
+    //result.dispose = () => {
+    //this.notebooks.delete(identity.toString());
+    //return oldDispose();
+    //};
+
+    //return result;
+    //}
+
+    public async onSessionChange(api: vsls.LiveShare | null): Promise<void> {
+        await super.onSessionChange(api);
+
+        //this.notebooks.forEach(async notebook => {
+        //const guestNotebook = (await notebook) as GuestJupyterNotebook;
+        //if (guestNotebook) {
+        //await guestNotebook.onSessionChange(api);
+        //}
+        //});
+    }
+
+    public async getNotebook(_resource: Uri): Promise<INotebook | undefined> {
+        throw new Error('Not implemented');
+        //return this.notebooks.get(resource.toString());
+    }
+
+    public async shutdown(): Promise<void> {
+        // Send this across to the other side. Otherwise the host server will remain running (like during an export)
+        //const service = await this.waitForService();
+        //if (service) {
+        //await service.request(LiveShareCommands.disposeServer, []);
+        //}
+    }
+
+    public dispose(): Promise<void> {
+        return this.shutdown();
+    }
+
+    public async onAttach(api: vsls.LiveShare | null): Promise<void> {
+        await super.onAttach(api);
+
+        //if (api) {
+        //const service = await this.waitForService();
+
+        //// Wait for sync up
+        //const synced = service ? await service.request(LiveShareCommands.syncRequest, []) : undefined;
+        //if (!synced && api.session && api.session.role !== vsls.Role.None) {
+        //throw new Error(localize.DataScience.liveShareSyncFailure());
+        //}
+        //}
+    }
+}

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -7,13 +7,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import * as vsls from 'vsls/vscode';
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../../common/application/types';
 import { IFileSystem } from '../../../common/platform/types';
-import {
-    IAsyncDisposableRegistry,
-    IConfigurationService,
-    IDisposableRegistry,
-    IExperimentsManager,
-    Resource
-} from '../../../common/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, Resource } from '../../../common/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { LiveShare } from '../../constants';
 import {
@@ -34,8 +28,7 @@ export class GuestRawNotebookProvider
         _workspaceService: IWorkspaceService,
         _appShell: IApplicationShell,
         _fs: IFileSystem,
-        _serviceContainer: IServiceContainer,
-        _experimentsManager: IExperimentsManager
+        _serviceContainer: IServiceContainer
     ) {
         super(liveShare);
     }

--- a/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/guestRawNotebookProvider.ts
@@ -41,7 +41,8 @@ export class GuestRawNotebookProvider
     }
 
     public async supported(): Promise<boolean> {
-        throw new Error('Not implemented');
+        // For now just false, but when implemented will message the host
+        return false;
     }
 
     public async createNotebook(
@@ -58,7 +59,7 @@ export class GuestRawNotebookProvider
     }
 
     public async onSessionChange(_api: vsls.LiveShare | null): Promise<void> {
-        throw new Error('Not implemented');
+        // Not implemented yet
     }
 
     public async getNotebook(_resource: Uri): Promise<INotebook | undefined> {
@@ -74,6 +75,6 @@ export class GuestRawNotebookProvider
     }
 
     public async onAttach(_api: vsls.LiveShare | null): Promise<void> {
-        throw new Error('Not implemented');
+        // Not implemented yet
     }
 }

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -58,19 +58,19 @@ export class HostRawNotebookProvider
     }
 
     public async onAttach(_api: vsls.LiveShare | null): Promise<void> {
-        throw new Error('Not implemented');
+        // Not implemented yet
     }
 
     public async onSessionChange(_api: vsls.LiveShare | null): Promise<void> {
-        throw new Error('Not implemented');
+        // Not implemented yet
     }
 
     public async onDetach(_api: vsls.LiveShare | null): Promise<void> {
-        throw new Error('Not implemented');
+        // Not implemented yet
     }
 
     public async waitForServiceName(): Promise<string> {
-        throw new Error('Not implemented');
+        return 'Not implemented';
     }
 
     protected async createNotebookInstance(

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -36,8 +36,6 @@ export class HostRawNotebookProvider
     extends LiveShareParticipantHost(RawNotebookProviderBase, LiveShare.RawNotebookProviderService)
     implements IRoleBasedObject, IRawNotebookProvider {
     private disposed = false;
-    //private portToForward = 0;
-    //private sharedPort: vscode.Disposable | undefined;
     constructor(
         private liveShare: ILiveShareApi,
         private disposableRegistry: IDisposableRegistry,
@@ -61,86 +59,20 @@ export class HostRawNotebookProvider
         }
     }
 
-    // IANHU: Port forwarding?
-    //public async connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void> {
-    //if (launchInfo.connectionInfo && launchInfo.connectionInfo.localLaunch) {
-    //const portMatch = RegExpValues.ExtractPortRegex.exec(launchInfo.connectionInfo.baseUrl);
-    //if (portMatch && portMatch.length > 1) {
-    //const port = parseInt(portMatch[1], 10);
-    //await this.attemptToForwardPort(this.finishedApi, port);
-    //}
-    //}
-    //return super.connect(launchInfo, cancelToken);
-    //}
-
-    public async onAttach(api: vsls.LiveShare | null): Promise<void> {
-        await super.onAttach(api);
-
-        //if (api && !this.disposed) {
-        //const service = await this.waitForService();
-
-        //// Attach event handlers to different requests
-        //if (service) {
-        //// Requests return arrays
-        //service.onRequest(LiveShareCommands.syncRequest, (_args: any[], _cancellation: CancellationToken) =>
-        //this.onSync()
-        //);
-        //service.onRequest(LiveShareCommands.disposeServer, (_args: any[], _cancellation: CancellationToken) =>
-        //this.dispose()
-        //);
-        //service.onRequest(
-        //LiveShareCommands.createNotebook,
-        //async (args: any[], cancellation: CancellationToken) => {
-        //const resource = this.parseUri(args[0]);
-        //const identity = this.parseUri(args[1]);
-        //// Don't return the notebook. We don't want it to be serialized. We just want its live share server to be started.
-        //const notebook = (await this.createNotebook(
-        //resource,
-        //identity!,
-        //undefined,
-        //cancellation
-        //)) as HostJupyterNotebook;
-        //await notebook.onAttach(api);
-        //}
-        //);
-
-        //// See if we need to forward the port
-        //await this.attemptToForwardPort(api, this.portToForward);
-        //}
-        //}
+    public async onAttach(_api: vsls.LiveShare | null): Promise<void> {
+        throw new Error('Not implemented');
     }
 
-    public async onSessionChange(api: vsls.LiveShare | null): Promise<void> {
-        await super.onSessionChange(api);
-
-        //this.getNotebooks().forEach(async notebook => {
-        //const hostNotebook = (await notebook) as HostJupyterNotebook;
-        //if (hostNotebook) {
-        //await hostNotebook.onSessionChange(api);
-        //}
-        //});
+    public async onSessionChange(_api: vsls.LiveShare | null): Promise<void> {
+        throw new Error('Not implemented');
     }
 
-    public async onDetach(api: vsls.LiveShare | null): Promise<void> {
-        await super.onDetach(api);
-
-        // Make sure to unshare our port
-        //if (api && this.sharedPort) {
-        //this.sharedPort.dispose();
-        //this.sharedPort = undefined;
-        //}
+    public async onDetach(_api: vsls.LiveShare | null): Promise<void> {
+        throw new Error('Not implemented');
     }
 
     public async waitForServiceName(): Promise<string> {
         throw new Error('Not implemented');
-        // First wait for connect to occur
-        //const launchInfo = await this.waitForConnect();
-        //// Use our base name plus our purpose. This means one unique server per purpose
-        //if (!launchInfo) {
-        //return LiveShare.JupyterServerSharedService;
-        //}
-        //// tslint:disable-next-line:no-suspicious-comment
-        //return `${LiveShare.JupyterServerSharedService}${launchInfo.purpose}`;
     }
 
     protected async createNotebookInstance(
@@ -233,20 +165,4 @@ export class HostRawNotebookProvider
             purpose: undefined
         };
     }
-
-    //private async attemptToForwardPort(api: vsls.LiveShare | null | undefined, port: number): Promise<void> {
-    //if (port !== 0 && api && api.session && api.session.role === vsls.Role.Host) {
-    //this.portToForward = 0;
-    //this.sharedPort = await api.shareServer({
-    //port,
-    //displayName: localize.DataScience.liveShareHostFormat().format(os.hostname())
-    //});
-    //} else {
-    //this.portToForward = port;
-    //}
-    //}
-
-    //private onSync(): Promise<any> {
-    //return Promise.resolve(true);
-    //}
 }

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../common/types';
 import { createDeferred } from '../../../common/utils/async';
 import { IServiceContainer } from '../../../ioc/types';
-import { LiveShare } from '../../constants';
+import { Identifiers, LiveShare, Settings } from '../../constants';
 import { HostJupyterNotebook } from '../../jupyter/liveshare/hostJupyterNotebook';
 import { LiveShareParticipantHost } from '../../jupyter/liveshare/liveShareParticipantMixin';
 import { IRoleBasedObject } from '../../jupyter/liveshare/roleBasedFactory';
@@ -158,11 +158,11 @@ export class HostRawNotebookProvider
     ): INotebookExecutionInfo {
         return {
             connectionInfo: this.getConnection(),
-            uri: undefined,
+            uri: Settings.JupyterServerLocalLaunch,
             interpreter: undefined,
             kernelSpec: undefined,
             workingDir: undefined,
-            purpose: undefined
+            purpose: Identifiers.RawPurpose
         };
     }
 }

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -11,13 +11,7 @@ import { nbformat } from '@jupyterlab/coreutils';
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../../common/application/types';
 import { traceInfo } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
-import {
-    IAsyncDisposableRegistry,
-    IConfigurationService,
-    IDisposableRegistry,
-    IExperimentsManager,
-    Resource
-} from '../../../common/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, Resource } from '../../../common/types';
 import { createDeferred } from '../../../common/utils/async';
 import { IServiceContainer } from '../../../ioc/types';
 import { Identifiers, LiveShare, Settings } from '../../constants';
@@ -44,10 +38,9 @@ export class HostRawNotebookProvider
         private workspaceService: IWorkspaceService,
         private appShell: IApplicationShell,
         private fs: IFileSystem,
-        private serviceContainer: IServiceContainer,
-        experimentsManager: IExperimentsManager
+        private serviceContainer: IServiceContainer
     ) {
-        super(liveShare, asyncRegistry, configService, experimentsManager);
+        super(liveShare, asyncRegistry);
     }
 
     public async dispose(): Promise<void> {

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import '../../../common/extensions';
+
+import * as vsls from 'vsls/vscode';
+
+import { ILiveShareApi } from '../../../common/application/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager } from '../../../common/types';
+import { LiveShare } from '../../constants';
+import { LiveShareParticipantHost } from '../../jupyter/liveshare/liveShareParticipantMixin';
+import { IRoleBasedObject } from '../../jupyter/liveshare/roleBasedFactory';
+import { IRawNotebookProvider } from '../../types';
+import { RawNotebookProviderBase } from '../rawNotebookProvider';
+
+// tslint:disable-next-line: no-require-imports
+// tslint:disable:no-any
+
+export class HostRawNotebookProvider
+    extends LiveShareParticipantHost(RawNotebookProviderBase, LiveShare.RawNotebookProviderService)
+    implements IRoleBasedObject, IRawNotebookProvider {
+    private disposed = false;
+    //private portToForward = 0;
+    //private sharedPort: vscode.Disposable | undefined;
+    constructor(
+        liveShare: ILiveShareApi,
+        asyncRegistry: IAsyncDisposableRegistry,
+        configService: IConfigurationService,
+        experimentsManager: IExperimentsManager
+    ) {
+        super(liveShare, asyncRegistry, configService, experimentsManager);
+    }
+
+    public async dispose(): Promise<void> {
+        if (!this.disposed) {
+            this.disposed = true;
+            await super.dispose();
+            const api = await this.api;
+            return this.onDetach(api);
+        }
+    }
+
+    // IANHU: Port forwarding?
+    //public async connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void> {
+    //if (launchInfo.connectionInfo && launchInfo.connectionInfo.localLaunch) {
+    //const portMatch = RegExpValues.ExtractPortRegex.exec(launchInfo.connectionInfo.baseUrl);
+    //if (portMatch && portMatch.length > 1) {
+    //const port = parseInt(portMatch[1], 10);
+    //await this.attemptToForwardPort(this.finishedApi, port);
+    //}
+    //}
+    //return super.connect(launchInfo, cancelToken);
+    //}
+
+    public async onAttach(api: vsls.LiveShare | null): Promise<void> {
+        await super.onAttach(api);
+
+        //if (api && !this.disposed) {
+        //const service = await this.waitForService();
+
+        //// Attach event handlers to different requests
+        //if (service) {
+        //// Requests return arrays
+        //service.onRequest(LiveShareCommands.syncRequest, (_args: any[], _cancellation: CancellationToken) =>
+        //this.onSync()
+        //);
+        //service.onRequest(LiveShareCommands.disposeServer, (_args: any[], _cancellation: CancellationToken) =>
+        //this.dispose()
+        //);
+        //service.onRequest(
+        //LiveShareCommands.createNotebook,
+        //async (args: any[], cancellation: CancellationToken) => {
+        //const resource = this.parseUri(args[0]);
+        //const identity = this.parseUri(args[1]);
+        //// Don't return the notebook. We don't want it to be serialized. We just want its live share server to be started.
+        //const notebook = (await this.createNotebook(
+        //resource,
+        //identity!,
+        //undefined,
+        //cancellation
+        //)) as HostJupyterNotebook;
+        //await notebook.onAttach(api);
+        //}
+        //);
+
+        //// See if we need to forward the port
+        //await this.attemptToForwardPort(api, this.portToForward);
+        //}
+        //}
+    }
+
+    public async onSessionChange(api: vsls.LiveShare | null): Promise<void> {
+        await super.onSessionChange(api);
+
+        //this.getNotebooks().forEach(async notebook => {
+        //const hostNotebook = (await notebook) as HostJupyterNotebook;
+        //if (hostNotebook) {
+        //await hostNotebook.onSessionChange(api);
+        //}
+        //});
+    }
+
+    public async onDetach(api: vsls.LiveShare | null): Promise<void> {
+        await super.onDetach(api);
+
+        // Make sure to unshare our port
+        //if (api && this.sharedPort) {
+        //this.sharedPort.dispose();
+        //this.sharedPort = undefined;
+        //}
+    }
+
+    public async waitForServiceName(): Promise<string> {
+        throw new Error('Not implemented');
+        // First wait for connect to occur
+        //const launchInfo = await this.waitForConnect();
+        //// Use our base name plus our purpose. This means one unique server per purpose
+        //if (!launchInfo) {
+        //return LiveShare.JupyterServerSharedService;
+        //}
+        //// tslint:disable-next-line:no-suspicious-comment
+        //return `${LiveShare.JupyterServerSharedService}${launchInfo.purpose}`;
+    }
+
+    //private async attemptToForwardPort(api: vsls.LiveShare | null | undefined, port: number): Promise<void> {
+    //if (port !== 0 && api && api.session && api.session.role === vsls.Role.Host) {
+    //this.portToForward = 0;
+    //this.sharedPort = await api.shareServer({
+    //port,
+    //displayName: localize.DataScience.liveShareHostFormat().format(os.hostname())
+    //});
+    //} else {
+    //this.portToForward = port;
+    //}
+    //}
+
+    //private onSync(): Promise<any> {
+    //return Promise.resolve(true);
+    //}
+}

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -54,8 +54,6 @@ export class HostRawNotebookProvider
         if (!this.disposed) {
             this.disposed = true;
             await super.dispose();
-            const api = await this.api;
-            return this.onDetach(api);
         }
     }
 

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -81,7 +81,8 @@ export class HostRawNotebookProvider
         notebookMetadata?: nbformat.INotebookMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
-        // IANHU: Hack to create session
+        throw new Error('Not implemented');
+        // RAWKERNEL: Hack to create session, uncomment throw and update ci to connect to a running kernel
         const ci = {
             version: 0,
             transport: 'tcp',
@@ -139,7 +140,6 @@ export class HostRawNotebookProvider
 
                 notebookPromise.resolve(notebook);
             } else {
-                // IANHU: Error message type
                 notebookPromise.reject(this.getDisposedError());
             }
         } catch (ex) {
@@ -151,10 +151,10 @@ export class HostRawNotebookProvider
         return notebookPromise.promise;
     }
 
-    // IANHU: Not the real execution info, just stub it out for now
+    // RAWKERNEL: Not the real execution info, just stub it out for now
     private getExecutionInfo(
-        resource: Resource,
-        notebookMetadata?: nbformat.INotebookMetadata
+        _resource: Resource,
+        _notebookMetadata?: nbformat.INotebookMetadata
     ): INotebookExecutionInfo {
         return {
             connectionInfo: this.getConnection(),

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -460,7 +460,6 @@ export class RawKernel implements Kernel.IKernel {
 
     // Handle a new message arriving from JMP connection
     private async handleMessage(message: KernelMessage.IMessage): Promise<void> {
-        // IANHU: CONVERT TO USING ONE REQUIRE?
         // tslint:disable-next-line:no-require-imports
         const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
 

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -2,29 +2,43 @@
 // Licensed under the MIT License.
 'use strict';
 import { nbformat } from '@jupyterlab/coreutils';
-import { Uri } from 'vscode';
+import { Event, EventEmitter, Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { ILiveShareApi } from '../../common/application/types';
+import { LocalZMQKernel } from '../../common/experimentGroups';
 import '../../common/extensions';
+import { traceError, traceInfo } from '../../common/logger';
 import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../common/types';
-import { INotebook, IRawNotebookProvider } from '../types';
+import { noop } from '../../common/utils/misc';
+import { sendTelemetryEvent } from '../../telemetry';
+import { Settings, Telemetry } from '../constants';
+import { INotebook, IRawConnection, IRawNotebookProvider } from '../types';
 
 export class RawNotebookProviderBase implements IRawNotebookProvider {
     // Keep track of the notebooks that we have provided
     private notebooks = new Map<string, Promise<INotebook>>();
+    private _zmqSupported: boolean | undefined;
+    private rawConnection = new RawConnection();
 
     constructor(
         _liveShare: ILiveShareApi,
         private asyncRegistry: IAsyncDisposableRegistry,
-        _configService: IConfigurationService,
-        _experimentsManager: IExperimentsManager
+        private configuration: IConfigurationService,
+        private experimentsManager: IExperimentsManager
     ) {
         this.asyncRegistry.push(this);
     }
 
+    // Check to see if this machine supports raw notebooks
+    // It needs to be in the experiement, have ZMQ, and be a local launch scenario
     public async supported(): Promise<boolean> {
-        return Promise.resolve(true);
-        //throw new Error('Not implemented');
+        const zmqOk = await this.zmqSupported();
+
+        return zmqOk && this.localLaunch() && this.inExperiment() ? true : false;
+    }
+
+    public connect(): Promise<IRawConnection> {
+        return Promise.resolve(this.rawConnection);
     }
 
     public async createNotebook(
@@ -44,6 +58,39 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         throw new Error('Not implemented');
     }
 
+    private localLaunch(): boolean {
+        const settings = this.configuration.getSettings(undefined);
+        const serverURI: string | undefined = settings.datascience.jupyterServerURI;
+
+        if (!serverURI || serverURI.toLowerCase() === Settings.JupyterServerLocalLaunch) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private inExperiment(): boolean {
+        return this.experimentsManager.inExperiment(LocalZMQKernel.experiment);
+    }
+
+    private async zmqSupported(): Promise<boolean> {
+        if (this._zmqSupported) {
+            return this._zmqSupported;
+        }
+
+        try {
+            await import('zeromq');
+            traceInfo(`ZMQ install verified.`);
+            this._zmqSupported = true;
+        } catch (e) {
+            traceError(`Exception while attempting zmq :`, e);
+            sendTelemetryEvent(Telemetry.ZMQNotSupported);
+            this._zmqSupported = false;
+        }
+
+        return this._zmqSupported;
+    }
+
     //protected createNotebookInstance(
     //_resource: Resource,
     //_identity: Uri,
@@ -57,4 +104,20 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
     //): Promise<INotebook> {
     //throw new Error('You forgot to override createNotebookInstance');
     //}
+}
+
+class RawConnection implements IRawConnection {
+    public readonly type = 'raw';
+    public readonly localLaunch = true;
+    public readonly valid = true;
+    // IANHU: Localize?
+    public readonly displayName = 'Raw Connection';
+    private eventEmitter: EventEmitter<number> = new EventEmitter<number>();
+
+    public dispose() {
+        noop();
+    }
+    public get disconnected(): Event<number> {
+        return this.eventEmitter.event;
+    }
 }

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -6,10 +6,12 @@ import * as uuid from 'uuid/v4';
 import { Event, EventEmitter, Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { ILiveShareApi } from '../../common/application/types';
-import { LocalZMQKernel } from '../../common/experimentGroups';
+// RAWKERNEL: Enable when experiment is in
+//import { LocalZMQKernel } from '../../common/experimentGroups';
 import '../../common/extensions';
 import { traceError, traceInfo } from '../../common/logger';
 import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../common/types';
+import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { sendTelemetryEvent } from '../../telemetry';
 import { Settings, Telemetry } from '../constants';
@@ -19,8 +21,7 @@ class RawConnection implements IRawConnection {
     public readonly type = 'raw';
     public readonly localLaunch = true;
     public readonly valid = true;
-    // IANHU: Localize?
-    public readonly displayName = 'Raw Connection';
+    public readonly displayName = localize.DataScience.rawConnectionDisplayName();
     private eventEmitter: EventEmitter<number> = new EventEmitter<number>();
 
     public dispose() {
@@ -45,7 +46,7 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         _liveShare: ILiveShareApi,
         private asyncRegistry: IAsyncDisposableRegistry,
         private configuration: IConfigurationService,
-        private experimentsManager: IExperimentsManager
+        _experimentsManager: IExperimentsManager
     ) {
         this.asyncRegistry.push(this);
     }
@@ -79,11 +80,9 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         throw new Error('Not implemented');
     }
 
-    // IANHU: Jupyter notebook needs this, but kinda a no-op for raw case
-    // For jupyter case it looks for a server crash error and returns that
+    // This may be a bit of a noop in the raw case
     public getDisposedError(): Error {
-        // IANHU: Error message
-        return new Error('Raw Notebook Provider Disposed');
+        return new Error(localize.DataScience.rawConnectionBrokenError());
     }
 
     protected getConnection(): IRawConnection {
@@ -132,8 +131,8 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
     }
 
     private inExperiment(): boolean {
-        return true;
-        // Current experiements are loading from a local cache which doesn't include
+        return false;
+        // RAWKERNEL: Current experiements are loading from a local cache which doesn't include
         // my new experiment value, so I can't even opt into it
         //return this.experimentsManager.inExperiment(LocalZMQKernel.experiment);
     }

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -15,6 +15,22 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { Settings, Telemetry } from '../constants';
 import { INotebook, IRawConnection, IRawNotebookProvider } from '../types';
 
+class RawConnection implements IRawConnection {
+    public readonly type = 'raw';
+    public readonly localLaunch = true;
+    public readonly valid = true;
+    // IANHU: Localize?
+    public readonly displayName = 'Raw Connection';
+    private eventEmitter: EventEmitter<number> = new EventEmitter<number>();
+
+    public dispose() {
+        noop();
+    }
+    public get disconnected(): Event<number> {
+        return this.eventEmitter.event;
+    }
+}
+
 export class RawNotebookProviderBase implements IRawNotebookProvider {
     public get id(): string {
         return this._id;
@@ -51,7 +67,7 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         resource: Resource,
         notebookMetadata: nbformat.INotebookMetadata,
         cancelToken: CancellationToken
-    ): Promise<INotebook | undefined> {
+    ): Promise<INotebook> {
         return this.createNotebookInstance(resource, identity, notebookMetadata, cancelToken);
     }
 
@@ -138,21 +154,5 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         }
 
         return this._zmqSupported;
-    }
-}
-
-class RawConnection implements IRawConnection {
-    public readonly type = 'raw';
-    public readonly localLaunch = true;
-    public readonly valid = true;
-    // IANHU: Localize?
-    public readonly displayName = 'Raw Connection';
-    private eventEmitter: EventEmitter<number> = new EventEmitter<number>();
-
-    public dispose() {
-        noop();
-    }
-    public get disconnected(): Event<number> {
-        return this.eventEmitter.event;
     }
 }

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { nbformat } from '@jupyterlab/coreutils';
+import { Uri } from 'vscode';
+import { CancellationToken } from 'vscode-jsonrpc';
+import { ILiveShareApi } from '../../common/application/types';
+import '../../common/extensions';
+import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../common/types';
+import { INotebook, IRawNotebookProvider } from '../types';
+
+export class RawNotebookProviderBase implements IRawNotebookProvider {
+    // Keep track of the notebooks that we have provided
+    private notebooks = new Map<string, Promise<INotebook>>();
+
+    constructor(
+        _liveShare: ILiveShareApi,
+        private asyncRegistry: IAsyncDisposableRegistry,
+        _configService: IConfigurationService,
+        _experimentsManager: IExperimentsManager
+    ) {
+        this.asyncRegistry.push(this);
+    }
+
+    public async supported(): Promise<boolean> {
+        return Promise.resolve(true);
+        //throw new Error('Not implemented');
+    }
+
+    public async createNotebook(
+        _identity: Uri,
+        _resource: Resource,
+        _notebookMetadata: nbformat.INotebookMetadata,
+        _cancelToken: CancellationToken
+    ): Promise<INotebook | undefined> {
+        throw new Error('Not implemented');
+    }
+
+    public async getNotebook(_identity: Uri): Promise<INotebook | undefined> {
+        throw new Error('Not implemented');
+    }
+
+    public dispose(): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
+    //protected createNotebookInstance(
+    //_resource: Resource,
+    //_identity: Uri,
+    //_sessionManager: IJupyterSessionManager,
+    //_savedSession: IJupyterSession | undefined,
+    //_disposableRegistry: IDisposableRegistry,
+    //_configService: IConfigurationService,
+    //_serviceContainer: IServiceContainer,
+    //_notebookMetadata?: nbformat.INotebookMetadata,
+    //_cancelToken?: CancellationToken
+    //): Promise<INotebook> {
+    //throw new Error('You forgot to override createNotebookInstance');
+    //}
+}

--- a/src/client/datascience/raw-kernel/rawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProvider.ts
@@ -76,8 +76,10 @@ export class RawNotebookProviderBase implements IRawNotebookProvider {
         return this.notebooks.get(identity.toString());
     }
 
-    public dispose(): Promise<void> {
-        throw new Error('Not implemented');
+    public async dispose(): Promise<void> {
+        traceInfo(`Shutting down notebooks for ${this.id}`);
+        const notebooks = await Promise.all([...this.notebooks.values()]);
+        await Promise.all(notebooks.map(n => n?.dispose()));
     }
 
     // This may be a bit of a noop in the raw case

--- a/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { nbformat } from '@jupyterlab/coreutils';
+import { inject, injectable } from 'inversify';
+import { Uri } from 'vscode';
+import { CancellationToken } from 'vscode-jsonrpc';
+import * as vsls from 'vsls/vscode';
+import { ILiveShareApi } from '../../common/application/types';
+import '../../common/extensions';
+import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../common/types';
+import { IRoleBasedObject, RoleBasedFactory } from '../jupyter/liveshare/roleBasedFactory';
+import { ILiveShareHasRole } from '../jupyter/liveshare/types';
+import { INotebook, IRawNotebookProvider } from '../types';
+import { GuestRawNotebookProvider } from './liveshare/guestRawNotebookProvider';
+import { HostRawNotebookProvider } from './liveshare/hostRawNotebookProvider';
+
+interface IRawNotebookProviderInterface extends IRoleBasedObject, IRawNotebookProvider {}
+
+// tslint:disable:callable-types
+type RawNotebookProviderClassType = {
+    new (
+        liveShare: ILiveShareApi,
+        asyncRegistry: IAsyncDisposableRegistry,
+        configService: IConfigurationService,
+        experimentsManager: IExperimentsManager
+    ): IRawNotebookProviderInterface;
+};
+// tslint:enable:callable-types
+
+// This class wraps either a HostRawNotebookProvider or a GuestRawNotebookProvider based on the liveshare state. It abstracts
+// out the live share specific parts.
+@injectable()
+export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveShareHasRole {
+    private serverFactory: RoleBasedFactory<IRawNotebookProviderInterface, RawNotebookProviderClassType>;
+
+    constructor(
+        @inject(ILiveShareApi) liveShare: ILiveShareApi,
+        @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
+        @inject(IConfigurationService) configService: IConfigurationService,
+        @inject(IExperimentsManager) experimentsManager: IExperimentsManager
+    ) {
+        // The server factory will create the appropriate HostRawNotebookProvider or GuestRawNotebookProvider based on
+        // the liveshare state.
+        this.serverFactory = new RoleBasedFactory<IRawNotebookProviderInterface, RawNotebookProviderClassType>(
+            liveShare,
+            HostRawNotebookProvider,
+            GuestRawNotebookProvider,
+            liveShare,
+            asyncRegistry,
+            configService,
+            experimentsManager
+        );
+    }
+
+    public get role(): vsls.Role {
+        return this.serverFactory.role;
+    }
+
+    public async supported(): Promise<boolean> {
+        const notebookProvider = await this.serverFactory.get();
+        return notebookProvider.supported();
+    }
+
+    public async createNotebook(
+        identity: Uri,
+        resource: Resource,
+        notebookMetadata: nbformat.INotebookMetadata,
+        cancelToken: CancellationToken
+    ): Promise<INotebook | undefined> {
+        const notebookProvider = await this.serverFactory.get();
+        return notebookProvider.createNotebook(identity, resource, notebookMetadata, cancelToken);
+    }
+
+    public async getNotebook(identity: Uri): Promise<INotebook | undefined> {
+        const notebookProvider = await this.serverFactory.get();
+        return notebookProvider.getNotebook(identity);
+    }
+
+    public async dispose(): Promise<void> {
+        const server = await this.serverFactory.get();
+        return server.dispose();
+    }
+}

--- a/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
@@ -9,13 +9,7 @@ import * as vsls from 'vsls/vscode';
 import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../common/application/types';
 import '../../common/extensions';
 import { IFileSystem } from '../../common/platform/types';
-import {
-    IAsyncDisposableRegistry,
-    IConfigurationService,
-    IDisposableRegistry,
-    IExperimentsManager,
-    Resource
-} from '../../common/types';
+import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry, Resource } from '../../common/types';
 import { IServiceContainer } from '../../ioc/types';
 import { IRoleBasedObject, RoleBasedFactory } from '../jupyter/liveshare/roleBasedFactory';
 import { ILiveShareHasRole } from '../jupyter/liveshare/types';
@@ -35,8 +29,7 @@ type RawNotebookProviderClassType = {
         workspaceService: IWorkspaceService,
         appShell: IApplicationShell,
         fs: IFileSystem,
-        serviceContainer: IServiceContainer,
-        experimentsManager: IExperimentsManager
+        serviceContainer: IServiceContainer
     ): IRawNotebookProviderInterface;
 };
 // tslint:enable:callable-types
@@ -55,8 +48,7 @@ export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveSh
         @inject(IWorkspaceService) workspaceService: IWorkspaceService,
         @inject(IApplicationShell) appShell: IApplicationShell,
         @inject(IFileSystem) fs: IFileSystem,
-        @inject(IServiceContainer) serviceContainer: IServiceContainer,
-        @inject(IExperimentsManager) experimentsManager: IExperimentsManager
+        @inject(IServiceContainer) serviceContainer: IServiceContainer
     ) {
         // The server factory will create the appropriate HostRawNotebookProvider or GuestRawNotebookProvider based on
         // the liveshare state.
@@ -71,18 +63,12 @@ export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveSh
             workspaceService,
             appShell,
             fs,
-            serviceContainer,
-            experimentsManager
+            serviceContainer
         );
     }
 
     public get role(): vsls.Role {
         return this.serverFactory.role;
-    }
-
-    public async supported(): Promise<boolean> {
-        const notebookProvider = await this.serverFactory.get();
-        return notebookProvider.supported();
     }
 
     public async connect(): Promise<IRawConnection> {

--- a/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
@@ -11,7 +11,7 @@ import '../../common/extensions';
 import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../common/types';
 import { IRoleBasedObject, RoleBasedFactory } from '../jupyter/liveshare/roleBasedFactory';
 import { ILiveShareHasRole } from '../jupyter/liveshare/types';
-import { INotebook, IRawNotebookProvider } from '../types';
+import { INotebook, IRawConnection, IRawNotebookProvider } from '../types';
 import { GuestRawNotebookProvider } from './liveshare/guestRawNotebookProvider';
 import { HostRawNotebookProvider } from './liveshare/hostRawNotebookProvider';
 
@@ -60,6 +60,11 @@ export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveSh
     public async supported(): Promise<boolean> {
         const notebookProvider = await this.serverFactory.get();
         return notebookProvider.supported();
+    }
+
+    public async connect(): Promise<IRawConnection> {
+        const notebookProvider = await this.serverFactory.get();
+        return notebookProvider.connect();
     }
 
     public async createNotebook(

--- a/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
@@ -95,7 +95,7 @@ export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveSh
         resource: Resource,
         notebookMetadata: nbformat.INotebookMetadata,
         cancelToken: CancellationToken
-    ): Promise<INotebook | undefined> {
+    ): Promise<INotebook> {
         const notebookProvider = await this.serverFactory.get();
         return notebookProvider.createNotebook(identity, resource, notebookMetadata, cancelToken);
     }

--- a/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookProviderWrapper.ts
@@ -6,9 +6,17 @@ import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import * as vsls from 'vsls/vscode';
-import { ILiveShareApi } from '../../common/application/types';
+import { IApplicationShell, ILiveShareApi, IWorkspaceService } from '../../common/application/types';
 import '../../common/extensions';
-import { IAsyncDisposableRegistry, IConfigurationService, IExperimentsManager, Resource } from '../../common/types';
+import { IFileSystem } from '../../common/platform/types';
+import {
+    IAsyncDisposableRegistry,
+    IConfigurationService,
+    IDisposableRegistry,
+    IExperimentsManager,
+    Resource
+} from '../../common/types';
+import { IServiceContainer } from '../../ioc/types';
 import { IRoleBasedObject, RoleBasedFactory } from '../jupyter/liveshare/roleBasedFactory';
 import { ILiveShareHasRole } from '../jupyter/liveshare/types';
 import { INotebook, IRawConnection, IRawNotebookProvider } from '../types';
@@ -21,8 +29,13 @@ interface IRawNotebookProviderInterface extends IRoleBasedObject, IRawNotebookPr
 type RawNotebookProviderClassType = {
     new (
         liveShare: ILiveShareApi,
+        disposableRegistry: IDisposableRegistry,
         asyncRegistry: IAsyncDisposableRegistry,
         configService: IConfigurationService,
+        workspaceService: IWorkspaceService,
+        appShell: IApplicationShell,
+        fs: IFileSystem,
+        serviceContainer: IServiceContainer,
         experimentsManager: IExperimentsManager
     ): IRawNotebookProviderInterface;
 };
@@ -36,8 +49,13 @@ export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveSh
 
     constructor(
         @inject(ILiveShareApi) liveShare: ILiveShareApi,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
         @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
         @inject(IConfigurationService) configService: IConfigurationService,
+        @inject(IWorkspaceService) workspaceService: IWorkspaceService,
+        @inject(IApplicationShell) appShell: IApplicationShell,
+        @inject(IFileSystem) fs: IFileSystem,
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
         @inject(IExperimentsManager) experimentsManager: IExperimentsManager
     ) {
         // The server factory will create the appropriate HostRawNotebookProvider or GuestRawNotebookProvider based on
@@ -47,8 +65,13 @@ export class RawNotebookProviderWrapper implements IRawNotebookProvider, ILiveSh
             HostRawNotebookProvider,
             GuestRawNotebookProvider,
             liveShare,
+            disposableRegistry,
             asyncRegistry,
             configService,
+            workspaceService,
+            appShell,
+            fs,
+            serviceContainer,
             experimentsManager
         );
     }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -109,6 +109,7 @@ import {
     IJupyterInterpreterDependencyManager,
     IJupyterNotebookProvider,
     IJupyterPasswordConnect,
+    IJupyterServerProvider,
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
     IJupyterVariables,
@@ -119,7 +120,6 @@ import {
     INotebookImporter,
     INotebookProvider,
     INotebookServer,
-    INotebookServerProvider,
     INotebookStorage,
     IPlotViewer,
     IPlotViewerProvider,
@@ -204,7 +204,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<ProgressReporter>(ProgressReporter, ProgressReporter);
     serviceManager.addSingleton<NativeEditorSynchronizer>(NativeEditorSynchronizer, NativeEditorSynchronizer);
     serviceManager.addSingleton<INotebookProvider>(INotebookProvider, NotebookProvider);
-    serviceManager.addSingleton<INotebookServerProvider>(INotebookServerProvider, NotebookServerProvider);
+    serviceManager.addSingleton<IJupyterServerProvider>(IJupyterServerProvider, NotebookServerProvider);
     serviceManager.addSingleton<IPyWidgetMessageDispatcherFactory>(IPyWidgetMessageDispatcherFactory, IPyWidgetMessageDispatcherFactory);
     serviceManager.add<IJMPConnection>(IJMPConnection, EnchannelJMPConnection);
 

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -63,6 +63,7 @@ import { JupyterDebugger } from './jupyter/jupyterDebugger';
 import { JupyterExecutionFactory } from './jupyter/jupyterExecutionFactory';
 import { JupyterExporter } from './jupyter/jupyterExporter';
 import { JupyterImporter } from './jupyter/jupyterImporter';
+import { JupyterNotebookProvider } from './jupyter/jupyterNotebookProvider';
 import { JupyterPasswordConnect } from './jupyter/jupyterPasswordConnect';
 import { JupyterServerWrapper } from './jupyter/jupyterServerWrapper';
 import { JupyterSessionManagerFactory } from './jupyter/jupyterSessionManagerFactory';
@@ -106,6 +107,7 @@ import {
     IJupyterDebugger,
     IJupyterExecution,
     IJupyterInterpreterDependencyManager,
+    IJupyterNotebookProvider,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
@@ -153,6 +155,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.add<INotebookServer>(INotebookServer, JupyterServerWrapper);
     serviceManager.add<INotebookStorage>(INotebookStorage, NativeEditorStorage);
     serviceManager.addSingleton<IRawNotebookProvider>(IRawNotebookProvider, RawNotebookProviderWrapper);
+    serviceManager.addSingleton<IJupyterNotebookProvider>(IJupyterNotebookProvider, JupyterNotebookProvider);
     serviceManager.add<IPlotViewer>(IPlotViewer, PlotViewer);
     serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
     serviceManager.addSingleton<CellOutputMimeTypeTracker>(CellOutputMimeTypeTracker, CellOutputMimeTypeTracker, undefined, [IExtensionSingleActivationService, INotebookExecutionLogger]);

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -79,6 +79,7 @@ import { PlotViewerProvider } from './plotting/plotViewerProvider';
 import { PreWarmActivatedJupyterEnvironmentVariables } from './preWarmVariables';
 import { ProgressReporter } from './progress/progressReporter';
 import { EnchannelJMPConnection } from './raw-kernel/enchannelJMPConnection';
+import { RawNotebookProviderWrapper } from './raw-kernel/rawNotebookProviderWrapper';
 import { StatusProvider } from './statusProvider';
 import { ThemeFinder } from './themeFinder';
 import {
@@ -120,6 +121,7 @@ import {
     INotebookStorage,
     IPlotViewer,
     IPlotViewerProvider,
+    IRawNotebookProvider,
     IStatusProvider,
     IThemeFinder
 } from './types';
@@ -150,6 +152,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.add<INotebookImporter>(INotebookImporter, JupyterImporter);
     serviceManager.add<INotebookServer>(INotebookServer, JupyterServerWrapper);
     serviceManager.add<INotebookStorage>(INotebookStorage, NativeEditorStorage);
+    serviceManager.addSingleton<IRawNotebookProvider>(IRawNotebookProvider, RawNotebookProviderWrapper);
     serviceManager.add<IPlotViewer>(IPlotViewer, PlotViewer);
     serviceManager.addSingleton<ActiveEditorContextService>(ActiveEditorContextService, ActiveEditorContextService);
     serviceManager.addSingleton<CellOutputMimeTypeTracker>(CellOutputMimeTypeTracker, CellOutputMimeTypeTracker, undefined, [IExtensionSingleActivationService, INotebookExecutionLogger]);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -149,6 +149,15 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
     getNotebook(identity: Uri): Promise<INotebook | undefined>;
 }
 
+// Provides notebooks that talk to jupyter servers
+export const IJupyterNotebookProvider = Symbol('IJupyterNotebookProvider');
+export interface IJupyterNotebookProvider {
+    connect(options: ConnectNotebookProviderOptions): Promise<IConnection | undefined>;
+    createNotebook(options: GetNotebookOptions): Promise<INotebook>;
+    getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
+    disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
+}
+
 export interface INotebook extends IAsyncDisposable {
     readonly resource: Resource;
     readonly identity: Uri;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -153,7 +153,7 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
 export const IJupyterNotebookProvider = Symbol('IJupyterNotebookProvider');
 export interface IJupyterNotebookProvider {
     connect(options: ConnectNotebookProviderOptions): Promise<IConnection | undefined>;
-    createNotebook(options: GetNotebookOptions): Promise<INotebook>;
+    createNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
     getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
     disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
 }
@@ -978,7 +978,7 @@ export interface INotebookProvider {
     /**
      * List of all notebooks (active and ones that are being constructed).
      */
-    activeNotebooks: Promise<INotebook>[];
+    activeNotebooks: Promise<INotebook | undefined>[];
 
     /**
      * Gets or creates a notebook, and manages the lifetime of notebooks.

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -136,6 +136,20 @@ export interface INotebookServer extends IAsyncDisposable {
     shutdown(): Promise<void>;
 }
 
+// Provides notebooks that talk directly to kernels as opposed to a jupyter server
+// IANHU: Not sure if need the disposable here or not
+export const IRawNotebookProvider = Symbol('IRawNotebookProvider');
+export interface IRawNotebookProvider extends IAsyncDisposable {
+    supported(): Promise<boolean>;
+    createNotebook(
+        identity: Uri,
+        resource: Resource,
+        notebookMetadata?: nbformat.INotebookMetadata,
+        cancelToken?: CancellationToken
+    ): Promise<INotebook | undefined>;
+    getNotebook(identity: Uri): Promise<INotebook | undefined>;
+}
+
 export interface INotebook extends IAsyncDisposable {
     readonly resource: Resource;
     readonly identity: Uri;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -139,7 +139,6 @@ export interface INotebookServer extends IAsyncDisposable {
 // Provides notebooks that talk directly to kernels as opposed to a jupyter server
 export const IRawNotebookProvider = Symbol('IRawNotebookProvider');
 export interface IRawNotebookProvider extends IAsyncDisposable {
-    supported(): Promise<boolean>;
     connect(): Promise<IRawConnection>;
     createNotebook(
         identity: Uri,

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -141,6 +141,8 @@ export interface INotebookServer extends IAsyncDisposable {
 export const IRawNotebookProvider = Symbol('IRawNotebookProvider');
 export interface IRawNotebookProvider extends IAsyncDisposable {
     supported(): Promise<boolean>;
+    // IANU: Needs async for wrapper level?
+    connect(): Promise<IRawConnection>;
     createNotebook(
         identity: Uri,
         resource: Resource,

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -996,8 +996,8 @@ export interface INotebookProvider {
     disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
 }
 
-export const INotebookServerProvider = Symbol('INotebookServerProvider');
-export interface INotebookServerProvider {
+export const IJupyterServerProvider = Symbol('IJupyterServerProvider');
+export interface IJupyterServerProvider {
     /**
      * Gets the server used for starting notebooks
      */

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -148,7 +148,7 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
         resource: Resource,
         notebookMetadata?: nbformat.INotebookMetadata,
         cancelToken?: CancellationToken
-    ): Promise<INotebook | undefined>;
+    ): Promise<INotebook>;
     getNotebook(identity: Uri): Promise<INotebook | undefined>;
 }
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -137,11 +137,9 @@ export interface INotebookServer extends IAsyncDisposable {
 }
 
 // Provides notebooks that talk directly to kernels as opposed to a jupyter server
-// IANHU: Not sure if need the disposable here or not
 export const IRawNotebookProvider = Symbol('IRawNotebookProvider');
 export interface IRawNotebookProvider extends IAsyncDisposable {
     supported(): Promise<boolean>;
-    // IANU: Needs async for wrapper level?
     connect(): Promise<IRawConnection>;
     createNotebook(
         identity: Uri,

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -153,7 +153,7 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
 export const IJupyterNotebookProvider = Symbol('IJupyterNotebookProvider');
 export interface IJupyterNotebookProvider {
     connect(options: ConnectNotebookProviderOptions): Promise<IConnection | undefined>;
-    createNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
+    createNotebook(options: GetNotebookOptions): Promise<INotebook>;
     getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
     disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
 }
@@ -978,7 +978,7 @@ export interface INotebookProvider {
     /**
      * List of all notebooks (active and ones that are being constructed).
      */
-    activeNotebooks: Promise<INotebook | undefined>[];
+    activeNotebooks: Promise<INotebook>[];
 
     /**
      * Gets or creates a notebook, and manages the lifetime of notebooks.

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -249,6 +249,7 @@ import {
     IJupyterInterpreterDependencyManager,
     IJupyterNotebookProvider,
     IJupyterPasswordConnect,
+    IJupyterServerProvider,
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
     IJupyterVariables,
@@ -259,7 +260,6 @@ import {
     INotebookImporter,
     INotebookProvider,
     INotebookServer,
-    INotebookServerProvider,
     INotebookStorage,
     IPlotViewer,
     IPlotViewerProvider,
@@ -680,7 +680,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
         this.serviceManager.addSingleton<INotebookProvider>(INotebookProvider, NotebookProvider);
         this.serviceManager.addSingleton<IJupyterNotebookProvider>(IJupyterNotebookProvider, JupyterNotebookProvider);
-        this.serviceManager.addSingleton<INotebookServerProvider>(INotebookServerProvider, NotebookServerProvider);
+        this.serviceManager.addSingleton<IJupyterServerProvider>(IJupyterServerProvider, NotebookServerProvider);
 
         this.serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, IntellisenseProvider);
         this.serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, AutoSaveService);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -219,6 +219,7 @@ import { PlotViewer } from '../../client/datascience/plotting/plotViewer';
 import { PlotViewerProvider } from '../../client/datascience/plotting/plotViewerProvider';
 import { ProgressReporter } from '../../client/datascience/progress/progressReporter';
 import { EnchannelJMPConnection } from '../../client/datascience/raw-kernel/enchannelJMPConnection';
+import { RawNotebookProviderWrapper } from '../../client/datascience/raw-kernel/rawNotebookProviderWrapper';
 import { StatusProvider } from '../../client/datascience/statusProvider';
 import { ThemeFinder } from '../../client/datascience/themeFinder';
 import {
@@ -260,6 +261,7 @@ import {
     INotebookStorage,
     IPlotViewer,
     IPlotViewerProvider,
+    IRawNotebookProvider,
     IStatusProvider,
     IThemeFinder
 } from '../../client/datascience/types';
@@ -542,6 +544,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<IExtensions>(IExtensions, MockExtensions);
         this.serviceManager.add<INotebookServer>(INotebookServer, JupyterServerWrapper);
         this.serviceManager.add<IJupyterCommandFactory>(IJupyterCommandFactory, JupyterCommandFactory);
+        this.serviceManager.addSingleton<IRawNotebookProvider>(IRawNotebookProvider, RawNotebookProviderWrapper);
         this.serviceManager.addSingleton<IThemeFinder>(IThemeFinder, ThemeFinder);
         this.serviceManager.addSingleton<ICodeCssGenerator>(ICodeCssGenerator, CodeCssGenerator);
         this.serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -204,6 +204,7 @@ import { JupyterDebugger } from '../../client/datascience/jupyter/jupyterDebugge
 import { JupyterExecutionFactory } from '../../client/datascience/jupyter/jupyterExecutionFactory';
 import { JupyterExporter } from '../../client/datascience/jupyter/jupyterExporter';
 import { JupyterImporter } from '../../client/datascience/jupyter/jupyterImporter';
+import { JupyterNotebookProvider } from '../../client/datascience/jupyter/jupyterNotebookProvider';
 import { JupyterPasswordConnect } from '../../client/datascience/jupyter/jupyterPasswordConnect';
 import { JupyterServerWrapper } from '../../client/datascience/jupyter/jupyterServerWrapper';
 import { JupyterSessionManagerFactory } from '../../client/datascience/jupyter/jupyterSessionManagerFactory';
@@ -246,6 +247,7 @@ import {
     IJupyterDebugger,
     IJupyterExecution,
     IJupyterInterpreterDependencyManager,
+    IJupyterNotebookProvider,
     IJupyterPasswordConnect,
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
@@ -677,6 +679,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         }
 
         this.serviceManager.addSingleton<INotebookProvider>(INotebookProvider, NotebookProvider);
+        this.serviceManager.addSingleton<IJupyterNotebookProvider>(IJupyterNotebookProvider, JupyterNotebookProvider);
         this.serviceManager.addSingleton<INotebookServerProvider>(INotebookServerProvider, NotebookServerProvider);
 
         this.serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, IntellisenseProvider);

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -5,14 +5,19 @@ import { anything, instance, mock, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import * as vscode from 'vscode';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { IConfigurationService, IDisposableRegistry, IExperimentsManager } from '../../../client/common/types';
+import {
+    IConfigurationService,
+    IDataScienceSettings,
+    IDisposableRegistry,
+    IExperimentsManager,
+    IPythonSettings
+} from '../../../client/common/types';
 import { NotebookProvider } from '../../../client/datascience/interactive-common/notebookProvider';
 import {
     IInteractiveWindowProvider,
+    IJupyterNotebookProvider,
     INotebook,
     INotebookEditorProvider,
-    INotebookServer,
-    INotebookServerProvider,
     IRawNotebookProvider
 } from '../../../client/datascience/types';
 
@@ -37,99 +42,72 @@ suite('Data Science - NotebookProvider', () => {
     let notebookEditorProvider: INotebookEditorProvider;
     let interactiveWindowProvider: IInteractiveWindowProvider;
     let disposableRegistry: IDisposableRegistry;
-    let notebookServerProvider: INotebookServerProvider;
+    let jupyterNotebookProvider: IJupyterNotebookProvider;
     let rawNotebookProvider: IRawNotebookProvider;
     let experimentsManager: IExperimentsManager;
     let configuration: IConfigurationService;
+    let pythonSettings: IPythonSettings;
+    let dataScienceSettings: IDataScienceSettings;
 
     setup(() => {
         fileSystem = mock<IFileSystem>();
         notebookEditorProvider = mock<INotebookEditorProvider>();
         interactiveWindowProvider = mock<IInteractiveWindowProvider>();
         disposableRegistry = mock<IDisposableRegistry>();
-        notebookServerProvider = mock<INotebookServerProvider>();
+        jupyterNotebookProvider = mock<IJupyterNotebookProvider>();
         rawNotebookProvider = mock<IRawNotebookProvider>();
         experimentsManager = mock<IExperimentsManager>();
         configuration = mock<IConfigurationService>();
+
+        // Set up our settings
+        pythonSettings = mock<IPythonSettings>();
+        dataScienceSettings = mock<IDataScienceSettings>();
+        when(pythonSettings.datascience).thenReturn(instance(dataScienceSettings));
+        when(dataScienceSettings.jupyterServerURI).thenReturn('local');
+        when(dataScienceSettings.useDefaultConfigForJupyter).thenReturn(true);
+        when(configuration.getSettings(anything())).thenReturn(instance(pythonSettings));
+
+        // Set up experiment manager
+        when(experimentsManager.inExperiment(anything())).thenReturn(false);
+
         notebookProvider = new NotebookProvider(
             instance(fileSystem),
             instance(notebookEditorProvider),
             instance(interactiveWindowProvider),
             instance(disposableRegistry),
-            instance(notebookServerProvider),
             instance(rawNotebookProvider),
+            instance(jupyterNotebookProvider),
             instance(configuration),
             instance(experimentsManager)
         );
     });
 
-    test('NotebookProvider getOrCreateNotebook no server', async () => {
-        when(notebookServerProvider.getOrCreateServer(anything())).thenResolve(undefined);
+    test('NotebookProvider getOrCreateNotebook jupyter provider has notebook already', async () => {
+        const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
+        when(jupyterNotebookProvider.getNotebook(anything())).thenResolve(notebookMock.object);
 
         const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
-        expect(notebook).to.equal(undefined, 'No server should return no notebook');
+        expect(notebook).to.not.equal(undefined, 'Provider should return a notebook');
     });
 
-    test('NotebookProvider getOrCreateNotebook server has notebook already', async () => {
-        const notebookServer = createTypeMoq<INotebookServer>('jupyter server');
+    test('NotebookProvider getOrCreateNotebook jupyter provider does not have notebook already', async () => {
         const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
-        notebookServer
-            .setup(s => s.getNotebook(typemoq.It.isAny()))
-            .returns(() => Promise.resolve(notebookMock.object));
-        when(notebookServerProvider.getOrCreateServer(anything())).thenResolve(notebookServer.object);
+        when(jupyterNotebookProvider.getNotebook(anything())).thenResolve(undefined);
+        when(jupyterNotebookProvider.createNotebook(anything())).thenResolve(notebookMock.object);
 
         const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
-        expect(notebook).to.not.equal(undefined, 'Server should return a notebook');
-    });
-
-    test('NotebookProvider getOrCreateNotebook server does not have notebook already', async () => {
-        const notebookServer = createTypeMoq<INotebookServer>('jupyter server');
-        const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
-        // Get notebook undefined, but create notebook set
-        notebookServer.setup(s => s.getNotebook(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
-        notebookServer
-            .setup(s => s.createNotebook(typemoq.It.isAny(), typemoq.It.isAny(), typemoq.It.isAny()))
-            .returns(() => Promise.resolve(notebookMock.object));
-        when(notebookServerProvider.getOrCreateServer(anything())).thenResolve(notebookServer.object);
-
-        const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
-        expect(notebook).to.not.equal(undefined, 'Server should return a notebook');
-    });
-
-    test('NotebookProvider getOrCreateNotebook getOnly server does not have notebook already', async () => {
-        const notebookServer = createTypeMoq<INotebookServer>('jupyter server');
-        const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
-        // Get notebook undefined, but create notebook set
-        notebookServer.setup(s => s.getNotebook(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
-        notebookServer
-            .setup(s => s.createNotebook(typemoq.It.isAny(), typemoq.It.isAny(), typemoq.It.isAny()))
-            .returns(() => Promise.resolve(notebookMock.object));
-        when(notebookServerProvider.getOrCreateServer(anything())).thenResolve(notebookServer.object);
-
-        const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
-        expect(notebook).to.not.equal(undefined, 'Server should return a notebook');
+        expect(notebook).to.not.equal(undefined, 'Provider should return a notebook');
     });
 
     test('NotebookProvider getOrCreateNotebook second request should return the notebook already cached', async () => {
-        const notebookServer = createTypeMoq<INotebookServer>('jupyter server');
         const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
-        // Get notebook undefined, but create notebook set
-        notebookServer.setup(s => s.getNotebook(typemoq.It.isAny())).returns(() => Promise.resolve(undefined));
-        notebookServer
-            .setup(s => s.createNotebook(typemoq.It.isAny(), typemoq.It.isAny(), typemoq.It.isAny()))
-            .returns(() => Promise.resolve(notebookMock.object));
-        when(notebookServerProvider.getOrCreateServer(anything())).thenResolve(notebookServer.object);
+        when(jupyterNotebookProvider.getNotebook(anything())).thenResolve(undefined);
+        when(jupyterNotebookProvider.createNotebook(anything())).thenResolve(notebookMock.object);
 
         const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
         expect(notebook).to.not.equal(undefined, 'Server should return a notebook');
 
         const notebook2 = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
         expect(notebook2).to.equal(notebook);
-
-        // Only one create call
-        notebookServer.verify(
-            s => s.createNotebook(typemoq.It.isAny(), typemoq.It.isAny(), typemoq.It.isAny()),
-            typemoq.Times.once()
-        );
     });
 });

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -94,6 +94,7 @@ suite('Data Science - NotebookProvider', () => {
         const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
         when(jupyterNotebookProvider.getNotebook(anything())).thenResolve(undefined);
         when(jupyterNotebookProvider.createNotebook(anything())).thenResolve(notebookMock.object);
+        when(jupyterNotebookProvider.connect(anything())).thenResolve({} as any);
 
         const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
         expect(notebook).to.not.equal(undefined, 'Provider should return a notebook');
@@ -103,6 +104,7 @@ suite('Data Science - NotebookProvider', () => {
         const notebookMock = createTypeMoq<INotebook>('jupyter notebook');
         when(jupyterNotebookProvider.getNotebook(anything())).thenResolve(undefined);
         when(jupyterNotebookProvider.createNotebook(anything())).thenResolve(notebookMock.object);
+        when(jupyterNotebookProvider.connect(anything())).thenResolve({} as any);
 
         const notebook = await notebookProvider.getOrCreateNotebook({ identity: Uri('C:\\\\foo.py') });
         expect(notebook).to.not.equal(undefined, 'Server should return a notebook');

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -12,7 +12,8 @@ import {
     INotebook,
     INotebookEditorProvider,
     INotebookServer,
-    INotebookServerProvider
+    INotebookServerProvider,
+    IRawNotebookProvider
 } from '../../../client/datascience/types';
 
 function Uri(filename: string): vscode.Uri {
@@ -37,6 +38,7 @@ suite('Data Science - NotebookProvider', () => {
     let interactiveWindowProvider: IInteractiveWindowProvider;
     let disposableRegistry: IDisposableRegistry;
     let notebookServerProvider: INotebookServerProvider;
+    let rawNotebookProvider: IRawNotebookProvider;
 
     setup(() => {
         fileSystem = mock<IFileSystem>();
@@ -44,12 +46,14 @@ suite('Data Science - NotebookProvider', () => {
         interactiveWindowProvider = mock<IInteractiveWindowProvider>();
         disposableRegistry = mock<IDisposableRegistry>();
         notebookServerProvider = mock<INotebookServerProvider>();
+        rawNotebookProvider = mock<IRawNotebookProvider>();
         notebookProvider = new NotebookProvider(
             instance(fileSystem),
             instance(notebookEditorProvider),
             instance(interactiveWindowProvider),
             instance(disposableRegistry),
-            instance(notebookServerProvider)
+            instance(notebookServerProvider),
+            instance(rawNotebookProvider)
         );
     });
 

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -5,7 +5,7 @@ import { anything, instance, mock, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import * as vscode from 'vscode';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { IDisposableRegistry } from '../../../client/common/types';
+import { IConfigurationService, IDisposableRegistry, IExperimentsManager } from '../../../client/common/types';
 import { NotebookProvider } from '../../../client/datascience/interactive-common/notebookProvider';
 import {
     IInteractiveWindowProvider,
@@ -39,6 +39,8 @@ suite('Data Science - NotebookProvider', () => {
     let disposableRegistry: IDisposableRegistry;
     let notebookServerProvider: INotebookServerProvider;
     let rawNotebookProvider: IRawNotebookProvider;
+    let experimentsManager: IExperimentsManager;
+    let configuration: IConfigurationService;
 
     setup(() => {
         fileSystem = mock<IFileSystem>();
@@ -47,13 +49,17 @@ suite('Data Science - NotebookProvider', () => {
         disposableRegistry = mock<IDisposableRegistry>();
         notebookServerProvider = mock<INotebookServerProvider>();
         rawNotebookProvider = mock<IRawNotebookProvider>();
+        experimentsManager = mock<IExperimentsManager>();
+        configuration = mock<IConfigurationService>();
         notebookProvider = new NotebookProvider(
             instance(fileSystem),
             instance(notebookEditorProvider),
             instance(interactiveWindowProvider),
             instance(disposableRegistry),
             instance(notebookServerProvider),
-            instance(rawNotebookProvider)
+            instance(rawNotebookProvider),
+            instance(configuration),
+            instance(experimentsManager)
         );
     });
 


### PR DESCRIPTION
For #10770 

Prior to merging with David's Kernel Launcher work I'd like to get my rawNotebookProvider split into ds/rawKernel. Help keep the code reviews to more manageable sizes. Though there is some hand waving in a few places since LiveShare is stubbed out and it's not merged with the launcher.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
