### PR TITLE
Update auto save for focus changes to include more cases

### DIFF
--- a/news/2 Fixes/10853.md
+++ b/news/2 Fixes/10853.md
@@ -1,0 +1,1 @@
+Auto save for focusChange is not respected when switching to non text documents. Menu focus will still not cause a save (no calllback from VS code for this), but should work for switching to other apps and non text documents.

--- a/src/client/datascience/data-viewing/dataViewerMessageListener.ts
+++ b/src/client/datascience/data-viewing/dataViewerMessageListener.ts
@@ -39,8 +39,6 @@ export class DataViewerMessageListener implements IWebPanelMessageListener {
 
     public onChangeViewState(panel: IWebPanel) {
         // Forward this onto our callback
-        if (this.viewChanged) {
-            this.viewChanged(panel);
-        }
+        this.viewChanged(panel);
     }
 }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -41,6 +41,7 @@ import { IFileSystem } from '../../common/platform/types';
 import { IConfigurationService, IDisposableRegistry, IExperimentsManager } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
+import { noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { PythonInterpreter } from '../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
@@ -440,6 +441,9 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         if (args.current.active && !args.previous.active) {
             this.activating().ignoreErrors();
         }
+
+        // Tell our listeners, they may need to know too
+        this.listeners.forEach((l) => (l.onViewStateChanged ? l.onViewStateChanged(args) : noop()));
     }
 
     protected async activating() {

--- a/src/client/datascience/interactive-common/interactiveWindowMessageListener.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowMessageListener.ts
@@ -66,9 +66,7 @@ export class InteractiveWindowMessageListener implements IWebPanelMessageListene
 
     public onChangeViewState(panel: IWebPanel) {
         // Forward this onto our callback
-        if (this.viewChanged) {
-            this.viewChanged(panel);
-        }
+        this.viewChanged(panel);
     }
 
     private getInteractiveWindowMessages(): string[] {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -466,6 +466,11 @@ export interface IInteractiveWindowListener extends IDisposable {
      */
     // tslint:disable-next-line: no-any
     onMessage(message: string, payload?: any): void;
+    /**
+     * Fired when the view state of the interactive window changes
+     * @param args
+     */
+    onViewStateChanged?(args: WebViewViewChangeEventArgs): void;
 }
 
 // Wraps the vscode API in order to send messages back and forth from a webview

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -1272,6 +1272,20 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         delete msg.payload;
     }
 
+    public changeViewState(active: boolean, visible: boolean) {
+        if (this.webPanelListener) {
+            this.webPanelListener.onChangeViewState({
+                isActive: () => active,
+                isVisible: () => visible,
+                setTitle: noop,
+                show: noop as any,
+                postMessage: noop as any,
+                close: noop,
+                updateCwd: noop as any
+            });
+        }
+    }
+
     public getWorkspaceConfig(section: string | undefined, resource?: Resource): MockWorkspaceConfiguration {
         if (!section || section !== 'python') {
             return this.emptyConfig;

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -2336,31 +2336,6 @@ df.head()`;
                         // Confirm file has been updated as well.
                         assert.notEqual(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
                     });
-
-                    test('Should not auto save notebook when window state changes', async () => {
-                        const notebookFileContents = await fs.readFile(notebookFile.filePath, 'utf8');
-                        const dirtyPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookDirty);
-                        const cleanPromise = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean, {
-                            timeoutMs: 5_000
-                        });
-
-                        await modifyNotebook();
-                        await dirtyPromise;
-
-                        // Configure notebook to save when active editor changes.
-                        await updateFileConfig('autoSave', 'onFocusChange');
-                        ioc.forceSettingsChanged(undefined, ioc.getSettings().pythonPath);
-
-                        // Now that the notebook is dirty, change window state.
-                        // This should not trigger a save of notebook (as its configured to save only when focus is changed).
-                        windowStateChangeHandlers.forEach((item) => item({ focused: false }));
-                        windowStateChangeHandlers.forEach((item) => item({ focused: true }));
-
-                        // Confirm the message is not clean, trying to wait for it to get saved will timeout (i.e. rejected).
-                        await expect(cleanPromise).to.eventually.be.rejected;
-                        // Confirm file has not been updated as well.
-                        assert.equal(await fs.readFile(notebookFile.filePath, 'utf8'), notebookFileContents);
-                    }).timeout(10_000);
                 });
 
                 const oldJson: nbformat.INotebookContent = {


### PR DESCRIPTION
For #10853

Window state changes and view state changes for a webview should all cause a 'focus' change. Include these in our list of stuff that causes a focus change save.