### PR TITLE
Do a one-off transfer of existing values for `python.pythonPath` setting to new Interpreter storage if in DeprecatePythonPath experiment

### DIFF
--- a/news/1 Enhancements/11052.md
+++ b/news/1 Enhancements/11052.md
@@ -1,0 +1,1 @@
+Do a one-off transfer of existing values for `python.pythonPath` setting to new Interpreter storage if in DeprecatePythonPath experiment.

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -66,6 +66,12 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
             return;
         }
         this.activatedWorkspaces.add(key);
+
+        if (this.experiments.inExperiment(DeprecatePythonPath.experiment)) {
+            await this.interpreterPathService.copyOldInterpreterStorageValuesToNew(resource);
+        }
+        this.experiments.sendTelemetryIfInExperiment(DeprecatePythonPath.control);
+
         // Get latest interpreter list in the background.
         this.interpreterService.getInterpreters(resource).ignoreErrors();
 

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -632,4 +632,5 @@ export interface IInterpreterPathService {
     get(resource: Resource): string;
     inspect(resource: Resource): InspectInterpreterSettingType;
     update(resource: Resource, configTarget: ConfigurationTarget, value: string | undefined): Promise<void>;
+    copyOldInterpreterStorageValuesToNew(resource: Uri | undefined): Promise<void>;
 }

--- a/src/client/interpreter/autoSelection/constants.ts
+++ b/src/client/interpreter/autoSelection/constants.ts
@@ -6,5 +6,5 @@
 export const unsafeInterpreterPromptKey = 'unsafeInterpreterPromptKey';
 export const unsafeInterpretersKey = 'unsafeInterpretersKey';
 export const safeInterpretersKey = 'safeInterpretersKey';
-export const flaggedWorkspacesKeysStorageKey = 'flaggedWorkspacesKeysStorageKey';
+export const flaggedWorkspacesKeysStorageKey = 'flaggedWorkspacesKeysInterpreterSecurityStorageKey';
 export const learnMoreOnInterpreterSecurityURI = 'https://aka.ms/AA7jfor';

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -33,495 +33,507 @@ import { InterpreterService } from '../../client/interpreter/interpreterService'
 import * as EnvFileTelemetry from '../../client/telemetry/envFileTelemetry';
 import { sleep } from '../core';
 
-// tslint:disable:max-func-body-length no-any
-suite('Language Server Activation - ActivationManager', () => {
-    class ExtensionActivationManagerTest extends ExtensionActivationManager {
-        // tslint:disable-next-line:no-unnecessary-override
-        public addHandlers() {
-            return super.addHandlers();
+suite('Activation Manager', () => {
+    // tslint:disable:max-func-body-length no-any
+    suite('Language Server Activation - ActivationManager', () => {
+        class ExtensionActivationManagerTest extends ExtensionActivationManager {
+            // tslint:disable-next-line:no-unnecessary-override
+            public addHandlers() {
+                return super.addHandlers();
+            }
+            // tslint:disable-next-line:no-unnecessary-override
+            public async initialize() {
+                return super.initialize();
+            }
+            // tslint:disable-next-line:no-unnecessary-override
+            public addRemoveDocOpenedHandlers() {
+                super.addRemoveDocOpenedHandlers();
+            }
         }
-        // tslint:disable-next-line:no-unnecessary-override
-        public async initialize() {
-            return super.initialize();
-        }
-        // tslint:disable-next-line:no-unnecessary-override
-        public addRemoveDocOpenedHandlers() {
-            super.addRemoveDocOpenedHandlers();
-        }
-    }
-    let managerTest: ExtensionActivationManagerTest;
-    let workspaceService: IWorkspaceService;
-    let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
-    let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
-    let interpreterService: IInterpreterService;
-    let activeResourceService: IActiveResourceService;
-    let documentManager: typemoq.IMock<IDocumentManager>;
-    let interpreterSecurityService: IInterpreterSecurityService;
-    let interpreterPathService: typemoq.IMock<IInterpreterPathService>;
-    let experiments: IExperimentsManager;
-    let activationService1: IExtensionActivationService;
-    let activationService2: IExtensionActivationService;
-    let fileSystem: IFileSystem;
-    setup(() => {
-        interpreterSecurityService = mock(InterpreterSecurityService);
-        experiments = mock(ExperimentsManager);
-        interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
-        workspaceService = mock(WorkspaceService);
-        activeResourceService = mock(ActiveResourceService);
-        appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
-        autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
-        interpreterService = mock(InterpreterService);
-        documentManager = typemoq.Mock.ofType<IDocumentManager>();
-        activationService1 = mock(LanguageServerExtensionActivationService);
-        activationService2 = mock(LanguageServerExtensionActivationService);
-        fileSystem = mock(FileSystem);
-        interpreterPathService
-            .setup((i) => i.onDidChange(typemoq.It.isAny()))
-            .returns(() => typemoq.Mock.ofType<IDisposable>().object);
-        managerTest = new ExtensionActivationManagerTest(
-            [instance(activationService1), instance(activationService2)],
-            [],
-            documentManager.object,
-            instance(interpreterService),
-            autoSelection.object,
-            appDiagnostics.object,
-            instance(workspaceService),
-            instance(fileSystem),
-            instance(activeResourceService),
-            instance(experiments),
-            interpreterPathService.object,
-            instance(interpreterSecurityService)
-        );
+        let managerTest: ExtensionActivationManagerTest;
+        let workspaceService: IWorkspaceService;
+        let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
+        let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
+        let interpreterService: IInterpreterService;
+        let activeResourceService: IActiveResourceService;
+        let documentManager: typemoq.IMock<IDocumentManager>;
+        let interpreterSecurityService: IInterpreterSecurityService;
+        let interpreterPathService: typemoq.IMock<IInterpreterPathService>;
+        let experiments: IExperimentsManager;
+        let activationService1: IExtensionActivationService;
+        let activationService2: IExtensionActivationService;
+        let fileSystem: IFileSystem;
+        setup(() => {
+            interpreterSecurityService = mock(InterpreterSecurityService);
+            experiments = mock(ExperimentsManager);
+            interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
+            workspaceService = mock(WorkspaceService);
+            activeResourceService = mock(ActiveResourceService);
+            appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
+            autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
+            interpreterService = mock(InterpreterService);
+            documentManager = typemoq.Mock.ofType<IDocumentManager>();
+            activationService1 = mock(LanguageServerExtensionActivationService);
+            activationService2 = mock(LanguageServerExtensionActivationService);
+            fileSystem = mock(FileSystem);
+            interpreterPathService
+                .setup((i) => i.onDidChange(typemoq.It.isAny()))
+                .returns(() => typemoq.Mock.ofType<IDisposable>().object);
+            managerTest = new ExtensionActivationManagerTest(
+                [instance(activationService1), instance(activationService2)],
+                [],
+                documentManager.object,
+                instance(interpreterService),
+                autoSelection.object,
+                appDiagnostics.object,
+                instance(workspaceService),
+                instance(fileSystem),
+                instance(activeResourceService),
+                instance(experiments),
+                interpreterPathService.object,
+                instance(interpreterSecurityService)
+            );
 
-        sinon.stub(EnvFileTelemetry, 'sendActivationTelemetry').resolves();
-        managerTest.evaluateAutoSelectedInterpreterSafety = () => Promise.resolve();
-    });
-
-    teardown(() => {
-        sinon.restore();
-    });
-
-    test('Initialize will add event handlers and will dispose them when running dispose', async () => {
-        const disposable = typemoq.Mock.ofType<IDisposable>();
-        const disposable2 = typemoq.Mock.ofType<IDisposable>();
-        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(() => disposable.object);
-        when(workspaceService.workspaceFolders).thenReturn([1 as any, 2 as any]);
-        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
-        const eventDef = () => disposable2.object;
-        documentManager
-            .setup((d) => d.onDidOpenTextDocument)
-            .returns(() => eventDef)
-            .verifiable(typemoq.Times.once());
-
-        await managerTest.initialize();
-
-        verify(workspaceService.workspaceFolders).once();
-        verify(workspaceService.hasWorkspaceFolders).once();
-        verify(workspaceService.onDidChangeWorkspaceFolders).once();
-
-        documentManager.verifyAll();
-
-        disposable.setup((d) => d.dispose()).verifiable(typemoq.Times.once());
-        disposable2.setup((d) => d.dispose()).verifiable(typemoq.Times.once());
-
-        managerTest.dispose();
-
-        disposable.verifyAll();
-        disposable2.verifyAll();
-    });
-    test('Remove text document opened handler if there is only one workspace', async () => {
-        const disposable = typemoq.Mock.ofType<IDisposable>();
-        const disposable2 = typemoq.Mock.ofType<IDisposable>();
-        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(() => disposable.object);
-        when(workspaceService.workspaceFolders).thenReturn([1 as any, 2 as any]);
-        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
-        const eventDef = () => disposable2.object;
-        documentManager
-            .setup((d) => d.onDidOpenTextDocument)
-            .returns(() => eventDef)
-            .verifiable(typemoq.Times.once());
-        disposable.setup((d) => d.dispose());
-        disposable2.setup((d) => d.dispose());
-
-        await managerTest.initialize();
-
-        verify(workspaceService.workspaceFolders).once();
-        verify(workspaceService.hasWorkspaceFolders).once();
-        verify(workspaceService.onDidChangeWorkspaceFolders).once();
-        documentManager.verifyAll();
-        disposable.verify((d) => d.dispose(), typemoq.Times.never());
-        disposable2.verify((d) => d.dispose(), typemoq.Times.never());
-
-        when(workspaceService.workspaceFolders).thenReturn([]);
-        when(workspaceService.hasWorkspaceFolders).thenReturn(false);
-
-        await managerTest.initialize();
-
-        verify(workspaceService.hasWorkspaceFolders).twice();
-        disposable.verify((d) => d.dispose(), typemoq.Times.never());
-        disposable2.verify((d) => d.dispose(), typemoq.Times.once());
-
-        managerTest.dispose();
-
-        disposable.verify((d) => d.dispose(), typemoq.Times.atLeast(1));
-        disposable2.verify((d) => d.dispose(), typemoq.Times.once());
-    });
-    test('Activate workspace specific to the resource in case of Multiple workspaces when a file is opened', async () => {
-        const disposable1 = typemoq.Mock.ofType<IDisposable>();
-        const disposable2 = typemoq.Mock.ofType<IDisposable>();
-        let fileOpenedHandler!: (e: TextDocument) => Promise<void>;
-        let workspaceFoldersChangedHandler!: Function;
-        const documentUri = Uri.file('a');
-        const document = typemoq.Mock.ofType<TextDocument>();
-        document.setup((d) => d.uri).returns(() => documentUri);
-        document.setup((d) => d.languageId).returns(() => PYTHON_LANGUAGE);
-
-        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn((cb) => {
-            workspaceFoldersChangedHandler = cb;
-            return disposable1.object;
+            sinon.stub(EnvFileTelemetry, 'sendActivationTelemetry').resolves();
+            managerTest.evaluateAutoSelectedInterpreterSafety = () => Promise.resolve();
         });
-        documentManager
-            .setup((w) => w.onDidOpenTextDocument(typemoq.It.isAny(), typemoq.It.isAny()))
-            .callback((cb) => (fileOpenedHandler = cb))
-            .returns(() => disposable2.object)
-            .verifiable(typemoq.Times.once());
 
-        const resource = Uri.parse('two');
-        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
-        const folder2 = { name: 'two', uri: resource, index: 2 };
-        when(workspaceService.getWorkspaceFolderIdentifier(anything(), anything())).thenReturn('one');
-        when(workspaceService.workspaceFolders).thenReturn([folder1, folder2]);
-        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
-        when(workspaceService.getWorkspaceFolder(document.object.uri)).thenReturn(folder2);
-
-        when(workspaceService.getWorkspaceFolder(resource)).thenReturn(folder2);
-        when(activationService1.activate(resource)).thenResolve();
-        when(activationService2.activate(resource)).thenResolve();
-        when(interpreterService.getInterpreters(anything())).thenResolve();
-        autoSelection
-            .setup((a) => a.autoSelectInterpreter(resource))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        appDiagnostics
-            .setup((a) => a.performPreStartupHealthCheck(resource))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        // Add workspaceFoldersChangedHandler
-        managerTest.addHandlers();
-        expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
-
-        // Add fileOpenedHandler
-        workspaceFoldersChangedHandler.call(managerTest);
-        expect(fileOpenedHandler).not.to.be.equal(undefined, 'Handler not set');
-
-        // Check if activate workspace is called on opening a file
-        await fileOpenedHandler.call(managerTest, document.object);
-        await sleep(1);
-
-        documentManager.verifyAll();
-        verify(workspaceService.onDidChangeWorkspaceFolders).once();
-        verify(workspaceService.workspaceFolders).atLeast(1);
-        verify(workspaceService.hasWorkspaceFolders).once();
-        verify(workspaceService.getWorkspaceFolder(anything())).atLeast(1);
-        verify(activationService1.activate(resource)).once();
-        verify(activationService2.activate(resource)).once();
-    });
-    test('Function activateWorkspace() will be filtered to current resource', async () => {
-        const resource = Uri.parse('two');
-        when(activationService1.activate(resource)).thenResolve();
-        when(activationService2.activate(resource)).thenResolve();
-        when(interpreterService.getInterpreters(anything())).thenResolve();
-        autoSelection
-            .setup((a) => a.autoSelectInterpreter(resource))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        appDiagnostics
-            .setup((a) => a.performPreStartupHealthCheck(resource))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-
-        await managerTest.activateWorkspace(resource);
-
-        verify(activationService1.activate(resource)).once();
-        verify(activationService2.activate(resource)).once();
-    });
-
-    test("The same workspace isn't activated more than once", async () => {
-        const resource = Uri.parse('two');
-        when(activationService1.activate(resource)).thenResolve();
-        when(activationService2.activate(resource)).thenResolve();
-        when(interpreterService.getInterpreters(anything())).thenResolve();
-        autoSelection
-            .setup((a) => a.autoSelectInterpreter(resource))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        appDiagnostics
-            .setup((a) => a.performPreStartupHealthCheck(resource))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-
-        await managerTest.activateWorkspace(resource);
-        await managerTest.activateWorkspace(resource);
-
-        verify(activationService1.activate(resource)).once();
-        verify(activationService2.activate(resource)).once();
-        autoSelection.verifyAll();
-        appDiagnostics.verifyAll();
-    });
-
-    test('If doc opened is not python, return', async () => {
-        const doc = {
-            uri: Uri.parse('doc'),
-            languageId: 'NOT PYTHON'
-        };
-
-        managerTest.onDocOpened(doc as any);
-        verify(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).never();
-    });
-
-    test('If we have opened a doc that does not belong to workspace, then do nothing', async () => {
-        const doc = {
-            uri: Uri.parse('doc'),
-            languageId: PYTHON_LANGUAGE
-        };
-        when(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).thenReturn('');
-        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
-
-        managerTest.onDocOpened(doc as any);
-
-        verify(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).once();
-        verify(workspaceService.getWorkspaceFolder(doc.uri)).never();
-    });
-
-    test('If workspace corresponding to the doc has already been activated, then do nothing', async () => {
-        const doc = {
-            uri: Uri.parse('doc'),
-            languageId: PYTHON_LANGUAGE
-        };
-        when(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).thenReturn('key');
-        managerTest.activatedWorkspaces.add('key');
-
-        managerTest.onDocOpened(doc as any);
-
-        verify(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).once();
-        verify(workspaceService.getWorkspaceFolder(doc.uri)).never();
-    });
-
-    test('List of activated workspaces is updated & Handler docOpenedHandler is disposed in case no. of workspace folders decreases to one', async () => {
-        const disposable1 = typemoq.Mock.ofType<IDisposable>();
-        const disposable2 = typemoq.Mock.ofType<IDisposable>();
-        let docOpenedHandler!: (e: TextDocument) => Promise<void>;
-        let workspaceFoldersChangedHandler!: Function;
-        const documentUri = Uri.file('a');
-        const document = typemoq.Mock.ofType<TextDocument>();
-        document.setup((d) => d.uri).returns(() => documentUri);
-
-        when(workspaceService.onDidChangeWorkspaceFolders).thenReturn((cb) => {
-            workspaceFoldersChangedHandler = cb;
-            return disposable1.object;
+        teardown(() => {
+            sinon.restore();
         });
-        documentManager
-            .setup((w) => w.onDidOpenTextDocument(typemoq.It.isAny(), typemoq.It.isAny()))
-            .callback((cb) => (docOpenedHandler = cb))
-            .returns(() => disposable2.object)
-            .verifiable(typemoq.Times.once());
 
-        const resource = Uri.parse('two');
-        const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
-        const folder2 = { name: 'two', uri: resource, index: 2 };
-        when(workspaceService.workspaceFolders).thenReturn([folder1, folder2]);
+        test('Initialize will add event handlers and will dispose them when running dispose', async () => {
+            const disposable = typemoq.Mock.ofType<IDisposable>();
+            const disposable2 = typemoq.Mock.ofType<IDisposable>();
+            when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(() => disposable.object);
+            when(workspaceService.workspaceFolders).thenReturn([1 as any, 2 as any]);
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+            const eventDef = () => disposable2.object;
+            documentManager
+                .setup((d) => d.onDidOpenTextDocument)
+                .returns(() => eventDef)
+                .verifiable(typemoq.Times.once());
 
-        when(workspaceService.getWorkspaceFolderIdentifier(folder1.uri, anything())).thenReturn('one');
-        when(workspaceService.getWorkspaceFolderIdentifier(folder2.uri, anything())).thenReturn('two');
-        // Assume the two workspaces are already activated, so their keys will be present in `activatedWorkspaces` set
-        managerTest.activatedWorkspaces.add('one');
-        managerTest.activatedWorkspaces.add('two');
+            await managerTest.initialize();
 
-        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
-        // Add workspaceFoldersChangedHandler
-        managerTest.addHandlers();
-        expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
+            verify(workspaceService.workspaceFolders).once();
+            verify(workspaceService.hasWorkspaceFolders).once();
+            verify(workspaceService.onDidChangeWorkspaceFolders).once();
 
-        // Add docOpenedHandler
-        workspaceFoldersChangedHandler.call(managerTest);
-        expect(docOpenedHandler).not.to.be.equal(undefined, 'Handler not set');
+            documentManager.verifyAll();
 
-        documentManager.verifyAll();
-        verify(workspaceService.onDidChangeWorkspaceFolders).once();
-        verify(workspaceService.workspaceFolders).atLeast(1);
-        verify(workspaceService.hasWorkspaceFolders).once();
+            disposable.setup((d) => d.dispose()).verifiable(typemoq.Times.once());
+            disposable2.setup((d) => d.dispose()).verifiable(typemoq.Times.once());
 
-        //Removed no. of folders to one
-        when(workspaceService.workspaceFolders).thenReturn([folder1]);
-        when(workspaceService.hasWorkspaceFolders).thenReturn(true);
-        disposable2.setup((d) => d.dispose()).verifiable(typemoq.Times.once());
+            managerTest.dispose();
 
-        workspaceFoldersChangedHandler.call(managerTest);
+            disposable.verifyAll();
+            disposable2.verifyAll();
+        });
+        test('Remove text document opened handler if there is only one workspace', async () => {
+            const disposable = typemoq.Mock.ofType<IDisposable>();
+            const disposable2 = typemoq.Mock.ofType<IDisposable>();
+            when(workspaceService.onDidChangeWorkspaceFolders).thenReturn(() => disposable.object);
+            when(workspaceService.workspaceFolders).thenReturn([1 as any, 2 as any]);
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+            const eventDef = () => disposable2.object;
+            documentManager
+                .setup((d) => d.onDidOpenTextDocument)
+                .returns(() => eventDef)
+                .verifiable(typemoq.Times.once());
+            disposable.setup((d) => d.dispose());
+            disposable2.setup((d) => d.dispose());
 
-        verify(workspaceService.workspaceFolders).atLeast(1);
-        verify(workspaceService.hasWorkspaceFolders).twice();
-        disposable2.verifyAll();
+            await managerTest.initialize();
 
-        assert.deepEqual(Array.from(managerTest.activatedWorkspaces.keys()), ['one']);
+            verify(workspaceService.workspaceFolders).once();
+            verify(workspaceService.hasWorkspaceFolders).once();
+            verify(workspaceService.onDidChangeWorkspaceFolders).once();
+            documentManager.verifyAll();
+            disposable.verify((d) => d.dispose(), typemoq.Times.never());
+            disposable2.verify((d) => d.dispose(), typemoq.Times.never());
+
+            when(workspaceService.workspaceFolders).thenReturn([]);
+            when(workspaceService.hasWorkspaceFolders).thenReturn(false);
+
+            await managerTest.initialize();
+
+            verify(workspaceService.hasWorkspaceFolders).twice();
+            disposable.verify((d) => d.dispose(), typemoq.Times.never());
+            disposable2.verify((d) => d.dispose(), typemoq.Times.once());
+
+            managerTest.dispose();
+
+            disposable.verify((d) => d.dispose(), typemoq.Times.atLeast(1));
+            disposable2.verify((d) => d.dispose(), typemoq.Times.once());
+        });
+        test('Activate workspace specific to the resource in case of Multiple workspaces when a file is opened', async () => {
+            const disposable1 = typemoq.Mock.ofType<IDisposable>();
+            const disposable2 = typemoq.Mock.ofType<IDisposable>();
+            let fileOpenedHandler!: (e: TextDocument) => Promise<void>;
+            let workspaceFoldersChangedHandler!: Function;
+            const documentUri = Uri.file('a');
+            const document = typemoq.Mock.ofType<TextDocument>();
+            document.setup((d) => d.uri).returns(() => documentUri);
+            document.setup((d) => d.languageId).returns(() => PYTHON_LANGUAGE);
+
+            when(workspaceService.onDidChangeWorkspaceFolders).thenReturn((cb) => {
+                workspaceFoldersChangedHandler = cb;
+                return disposable1.object;
+            });
+            documentManager
+                .setup((w) => w.onDidOpenTextDocument(typemoq.It.isAny(), typemoq.It.isAny()))
+                .callback((cb) => (fileOpenedHandler = cb))
+                .returns(() => disposable2.object)
+                .verifiable(typemoq.Times.once());
+
+            const resource = Uri.parse('two');
+            const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
+            const folder2 = { name: 'two', uri: resource, index: 2 };
+            when(workspaceService.getWorkspaceFolderIdentifier(anything(), anything())).thenReturn('one');
+            when(workspaceService.workspaceFolders).thenReturn([folder1, folder2]);
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+            when(workspaceService.getWorkspaceFolder(document.object.uri)).thenReturn(folder2);
+
+            when(workspaceService.getWorkspaceFolder(resource)).thenReturn(folder2);
+            when(activationService1.activate(resource)).thenResolve();
+            when(activationService2.activate(resource)).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
+            autoSelection
+                .setup((a) => a.autoSelectInterpreter(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            appDiagnostics
+                .setup((a) => a.performPreStartupHealthCheck(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            // Add workspaceFoldersChangedHandler
+            managerTest.addHandlers();
+            expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+            // Add fileOpenedHandler
+            workspaceFoldersChangedHandler.call(managerTest);
+            expect(fileOpenedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+            // Check if activate workspace is called on opening a file
+            await fileOpenedHandler.call(managerTest, document.object);
+            await sleep(1);
+
+            documentManager.verifyAll();
+            verify(workspaceService.onDidChangeWorkspaceFolders).once();
+            verify(workspaceService.workspaceFolders).atLeast(1);
+            verify(workspaceService.hasWorkspaceFolders).once();
+            verify(workspaceService.getWorkspaceFolder(anything())).atLeast(1);
+            verify(activationService1.activate(resource)).once();
+            verify(activationService2.activate(resource)).once();
+        });
+
+        test('Function activateWorkspace() will be filtered to current resource', async () => {
+            const resource = Uri.parse('two');
+            when(activationService1.activate(resource)).thenResolve();
+            when(activationService2.activate(resource)).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
+            autoSelection
+                .setup((a) => a.autoSelectInterpreter(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            appDiagnostics
+                .setup((a) => a.performPreStartupHealthCheck(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+
+            await managerTest.activateWorkspace(resource);
+
+            verify(activationService1.activate(resource)).once();
+            verify(activationService2.activate(resource)).once();
+        });
+
+        test('If in Deprecate PythonPath experiment, method activateWorkspace() will copy old interpreter storage values to new', async () => {
+            const resource = Uri.parse('two');
+            when(activationService1.activate(resource)).thenResolve();
+            when(activationService2.activate(resource)).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
+            when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
+            interpreterPathService
+                .setup((i) => i.copyOldInterpreterStorageValuesToNew(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            autoSelection
+                .setup((a) => a.autoSelectInterpreter(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            appDiagnostics
+                .setup((a) => a.performPreStartupHealthCheck(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+
+            await managerTest.activateWorkspace(resource);
+
+            interpreterPathService.verifyAll();
+            verify(activationService1.activate(resource)).once();
+            verify(activationService2.activate(resource)).once();
+        });
+
+        test("The same workspace isn't activated more than once", async () => {
+            const resource = Uri.parse('two');
+            when(activationService1.activate(resource)).thenResolve();
+            when(activationService2.activate(resource)).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
+            autoSelection
+                .setup((a) => a.autoSelectInterpreter(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            appDiagnostics
+                .setup((a) => a.performPreStartupHealthCheck(resource))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+
+            await managerTest.activateWorkspace(resource);
+            await managerTest.activateWorkspace(resource);
+
+            verify(activationService1.activate(resource)).once();
+            verify(activationService2.activate(resource)).once();
+            autoSelection.verifyAll();
+            appDiagnostics.verifyAll();
+        });
+
+        test('If doc opened is not python, return', async () => {
+            const doc = {
+                uri: Uri.parse('doc'),
+                languageId: 'NOT PYTHON'
+            };
+
+            managerTest.onDocOpened(doc as any);
+            verify(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).never();
+        });
+
+        test('If we have opened a doc that does not belong to workspace, then do nothing', async () => {
+            const doc = {
+                uri: Uri.parse('doc'),
+                languageId: PYTHON_LANGUAGE
+            };
+            when(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).thenReturn('');
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+
+            managerTest.onDocOpened(doc as any);
+
+            verify(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).once();
+            verify(workspaceService.getWorkspaceFolder(doc.uri)).never();
+        });
+
+        test('If workspace corresponding to the doc has already been activated, then do nothing', async () => {
+            const doc = {
+                uri: Uri.parse('doc'),
+                languageId: PYTHON_LANGUAGE
+            };
+            when(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).thenReturn('key');
+            managerTest.activatedWorkspaces.add('key');
+
+            managerTest.onDocOpened(doc as any);
+
+            verify(workspaceService.getWorkspaceFolderIdentifier(doc.uri, anything())).once();
+            verify(workspaceService.getWorkspaceFolder(doc.uri)).never();
+        });
+
+        test('List of activated workspaces is updated & Handler docOpenedHandler is disposed in case no. of workspace folders decreases to one', async () => {
+            const disposable1 = typemoq.Mock.ofType<IDisposable>();
+            const disposable2 = typemoq.Mock.ofType<IDisposable>();
+            let docOpenedHandler!: (e: TextDocument) => Promise<void>;
+            let workspaceFoldersChangedHandler!: Function;
+            const documentUri = Uri.file('a');
+            const document = typemoq.Mock.ofType<TextDocument>();
+            document.setup((d) => d.uri).returns(() => documentUri);
+
+            when(workspaceService.onDidChangeWorkspaceFolders).thenReturn((cb) => {
+                workspaceFoldersChangedHandler = cb;
+                return disposable1.object;
+            });
+            documentManager
+                .setup((w) => w.onDidOpenTextDocument(typemoq.It.isAny(), typemoq.It.isAny()))
+                .callback((cb) => (docOpenedHandler = cb))
+                .returns(() => disposable2.object)
+                .verifiable(typemoq.Times.once());
+
+            const resource = Uri.parse('two');
+            const folder1 = { name: 'one', uri: Uri.parse('one'), index: 1 };
+            const folder2 = { name: 'two', uri: resource, index: 2 };
+            when(workspaceService.workspaceFolders).thenReturn([folder1, folder2]);
+
+            when(workspaceService.getWorkspaceFolderIdentifier(folder1.uri, anything())).thenReturn('one');
+            when(workspaceService.getWorkspaceFolderIdentifier(folder2.uri, anything())).thenReturn('two');
+            // Assume the two workspaces are already activated, so their keys will be present in `activatedWorkspaces` set
+            managerTest.activatedWorkspaces.add('one');
+            managerTest.activatedWorkspaces.add('two');
+
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+            // Add workspaceFoldersChangedHandler
+            managerTest.addHandlers();
+            expect(workspaceFoldersChangedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+            // Add docOpenedHandler
+            workspaceFoldersChangedHandler.call(managerTest);
+            expect(docOpenedHandler).not.to.be.equal(undefined, 'Handler not set');
+
+            documentManager.verifyAll();
+            verify(workspaceService.onDidChangeWorkspaceFolders).once();
+            verify(workspaceService.workspaceFolders).atLeast(1);
+            verify(workspaceService.hasWorkspaceFolders).once();
+
+            //Removed no. of folders to one
+            when(workspaceService.workspaceFolders).thenReturn([folder1]);
+            when(workspaceService.hasWorkspaceFolders).thenReturn(true);
+            disposable2.setup((d) => d.dispose()).verifiable(typemoq.Times.once());
+
+            workspaceFoldersChangedHandler.call(managerTest);
+
+            verify(workspaceService.workspaceFolders).atLeast(1);
+            verify(workspaceService.hasWorkspaceFolders).twice();
+            disposable2.verifyAll();
+
+            assert.deepEqual(Array.from(managerTest.activatedWorkspaces.keys()), ['one']);
+        });
     });
-});
 
-suite('Language Server Activation - activate()', () => {
-    let workspaceService: IWorkspaceService;
-    let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
-    let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
-    let interpreterService: IInterpreterService;
-    let activeResourceService: IActiveResourceService;
-    let documentManager: typemoq.IMock<IDocumentManager>;
-    let interpreterSecurityService: IInterpreterSecurityService;
-    let activationService1: IExtensionActivationService;
-    let activationService2: IExtensionActivationService;
-    let fileSystem: IFileSystem;
-    let singleActivationService: typemoq.IMock<IExtensionSingleActivationService>;
-    let initialize: sinon.SinonStub<any>;
-    let activateWorkspace: sinon.SinonStub<any>;
-    let managerTest: ExtensionActivationManager;
-    const resource = Uri.parse('a');
-    let interpreterPathService: typemoq.IMock<IInterpreterPathService>;
-    let experiments: IExperimentsManager;
+    suite('Language Server Activation - activate()', () => {
+        let workspaceService: IWorkspaceService;
+        let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
+        let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
+        let interpreterService: IInterpreterService;
+        let activeResourceService: IActiveResourceService;
+        let documentManager: typemoq.IMock<IDocumentManager>;
+        let interpreterSecurityService: IInterpreterSecurityService;
+        let activationService1: IExtensionActivationService;
+        let activationService2: IExtensionActivationService;
+        let fileSystem: IFileSystem;
+        let singleActivationService: typemoq.IMock<IExtensionSingleActivationService>;
+        let initialize: sinon.SinonStub<any>;
+        let activateWorkspace: sinon.SinonStub<any>;
+        let managerTest: ExtensionActivationManager;
+        const resource = Uri.parse('a');
+        let interpreterPathService: typemoq.IMock<IInterpreterPathService>;
+        let experiments: IExperimentsManager;
 
-    setup(() => {
-        interpreterSecurityService = mock(InterpreterSecurityService);
-        experiments = mock(ExperimentsManager);
-        workspaceService = mock(WorkspaceService);
-        activeResourceService = mock(ActiveResourceService);
-        appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
-        autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
-        interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
-        interpreterService = mock(InterpreterService);
-        documentManager = typemoq.Mock.ofType<IDocumentManager>();
-        activationService1 = mock(LanguageServerExtensionActivationService);
-        activationService2 = mock(LanguageServerExtensionActivationService);
-        fileSystem = mock(FileSystem);
-        singleActivationService = typemoq.Mock.ofType<IExtensionSingleActivationService>();
-        initialize = sinon.stub(ExtensionActivationManager.prototype, 'initialize');
-        initialize.resolves();
-        activateWorkspace = sinon.stub(ExtensionActivationManager.prototype, 'activateWorkspace');
-        activateWorkspace.resolves();
-        interpreterPathService
-            .setup((i) => i.onDidChange(typemoq.It.isAny()))
-            .returns(() => typemoq.Mock.ofType<IDisposable>().object);
-        managerTest = new ExtensionActivationManager(
-            [instance(activationService1), instance(activationService2)],
-            [singleActivationService.object],
-            documentManager.object,
-            instance(interpreterService),
-            autoSelection.object,
-            appDiagnostics.object,
-            instance(workspaceService),
-            instance(fileSystem),
-            instance(activeResourceService),
-            instance(experiments),
-            interpreterPathService.object,
-            instance(interpreterSecurityService)
-        );
-        managerTest.evaluateAutoSelectedInterpreterSafety = () => Promise.resolve();
+        setup(() => {
+            interpreterSecurityService = mock(InterpreterSecurityService);
+            experiments = mock(ExperimentsManager);
+            workspaceService = mock(WorkspaceService);
+            activeResourceService = mock(ActiveResourceService);
+            appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
+            autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
+            interpreterPathService = typemoq.Mock.ofType<IInterpreterPathService>();
+            interpreterService = mock(InterpreterService);
+            documentManager = typemoq.Mock.ofType<IDocumentManager>();
+            activationService1 = mock(LanguageServerExtensionActivationService);
+            activationService2 = mock(LanguageServerExtensionActivationService);
+            fileSystem = mock(FileSystem);
+            singleActivationService = typemoq.Mock.ofType<IExtensionSingleActivationService>();
+            initialize = sinon.stub(ExtensionActivationManager.prototype, 'initialize');
+            initialize.resolves();
+            activateWorkspace = sinon.stub(ExtensionActivationManager.prototype, 'activateWorkspace');
+            activateWorkspace.resolves();
+            interpreterPathService
+                .setup((i) => i.onDidChange(typemoq.It.isAny()))
+                .returns(() => typemoq.Mock.ofType<IDisposable>().object);
+            managerTest = new ExtensionActivationManager(
+                [instance(activationService1), instance(activationService2)],
+                [singleActivationService.object],
+                documentManager.object,
+                instance(interpreterService),
+                autoSelection.object,
+                appDiagnostics.object,
+                instance(workspaceService),
+                instance(fileSystem),
+                instance(activeResourceService),
+                instance(experiments),
+                interpreterPathService.object,
+                instance(interpreterSecurityService)
+            );
+            managerTest.evaluateAutoSelectedInterpreterSafety = () => Promise.resolve();
+        });
+
+        teardown(() => {
+            sinon.restore();
+        });
+
+        test('Execution goes as expected if there are no errors', async () => {
+            singleActivationService
+                .setup((s) => s.activate())
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            autoSelection
+                .setup((a) => a.autoSelectInterpreter(undefined))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            when(activeResourceService.getActiveResource()).thenReturn(resource);
+            await managerTest.activate();
+            assert.ok(initialize.calledOnce);
+            assert.ok(activateWorkspace.calledOnce);
+            singleActivationService.verifyAll();
+            autoSelection.verifyAll();
+        });
+
+        test('Throws error if execution fails', async () => {
+            singleActivationService
+                .setup((s) => s.activate())
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+            autoSelection
+                .setup((a) => a.autoSelectInterpreter(undefined))
+                .returns(() => Promise.reject(new Error('Kaboom')))
+                .verifiable(typemoq.Times.once());
+            when(activeResourceService.getActiveResource()).thenReturn(resource);
+            const promise = managerTest.activate();
+            await expect(promise).to.eventually.be.rejectedWith('Kaboom');
+        });
     });
 
-    teardown(() => {
-        sinon.restore();
-    });
+    suite('Selected Python Activation - evaluateIfAutoSelectedInterpreterIsSafe()', () => {
+        let workspaceService: IWorkspaceService;
+        let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
+        let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
+        let interpreterService: IInterpreterService;
+        let activeResourceService: IActiveResourceService;
+        let documentManager: typemoq.IMock<IDocumentManager>;
+        let activationService1: IExtensionActivationService;
+        let activationService2: IExtensionActivationService;
+        let fileSystem: IFileSystem;
+        let managerTest: ExtensionActivationManager;
+        const resource = Uri.parse('a');
+        let interpreterSecurityService: IInterpreterSecurityService;
+        let interpreterPathService: IInterpreterPathService;
+        let experiments: IExperimentsManager;
+        setup(() => {
+            interpreterSecurityService = mock(InterpreterSecurityService);
+            experiments = mock(ExperimentsManager);
+            fileSystem = mock(FileSystem);
+            interpreterPathService = mock(InterpreterPathService);
+            workspaceService = mock(WorkspaceService);
+            activeResourceService = mock(ActiveResourceService);
+            appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
+            autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
+            interpreterService = mock(InterpreterService);
+            documentManager = typemoq.Mock.ofType<IDocumentManager>();
+            activationService1 = mock(LanguageServerExtensionActivationService);
+            activationService2 = mock(LanguageServerExtensionActivationService);
+            when(experiments.sendTelemetryIfInExperiment(DeprecatePythonPath.control)).thenReturn(undefined);
+            managerTest = new ExtensionActivationManager(
+                [instance(activationService1), instance(activationService2)],
+                [],
+                documentManager.object,
+                instance(interpreterService),
+                autoSelection.object,
+                appDiagnostics.object,
+                instance(workspaceService),
+                instance(fileSystem),
+                instance(activeResourceService),
+                instance(experiments),
+                instance(interpreterPathService),
+                instance(interpreterSecurityService)
+            );
+        });
 
-    test('Execution goes as expected if there are no errors', async () => {
-        singleActivationService
-            .setup((s) => s.activate())
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        autoSelection
-            .setup((a) => a.autoSelectInterpreter(undefined))
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        when(activeResourceService.getActiveResource()).thenReturn(resource);
-        await managerTest.activate();
-        assert.ok(initialize.calledOnce);
-        assert.ok(activateWorkspace.calledOnce);
-        singleActivationService.verifyAll();
-        autoSelection.verifyAll();
-    });
-
-    test('Throws error if execution fails', async () => {
-        singleActivationService
-            .setup((s) => s.activate())
-            .returns(() => Promise.resolve())
-            .verifiable(typemoq.Times.once());
-        autoSelection
-            .setup((a) => a.autoSelectInterpreter(undefined))
-            .returns(() => Promise.reject(new Error('Kaboom')))
-            .verifiable(typemoq.Times.once());
-        when(activeResourceService.getActiveResource()).thenReturn(resource);
-        const promise = managerTest.activate();
-        await expect(promise).to.eventually.be.rejectedWith('Kaboom');
-    });
-});
-
-suite('Selected Python Activation - evaluateIfAutoSelectedInterpreterIsSafe()', () => {
-    let workspaceService: IWorkspaceService;
-    let appDiagnostics: typemoq.IMock<IApplicationDiagnostics>;
-    let autoSelection: typemoq.IMock<IInterpreterAutoSelectionService>;
-    let interpreterService: IInterpreterService;
-    let activeResourceService: IActiveResourceService;
-    let documentManager: typemoq.IMock<IDocumentManager>;
-    let activationService1: IExtensionActivationService;
-    let activationService2: IExtensionActivationService;
-    let fileSystem: IFileSystem;
-    let managerTest: ExtensionActivationManager;
-    const resource = Uri.parse('a');
-    let interpreterSecurityService: IInterpreterSecurityService;
-    let interpreterPathService: IInterpreterPathService;
-    let experiments: IExperimentsManager;
-    setup(() => {
-        interpreterSecurityService = mock(InterpreterSecurityService);
-        experiments = mock(ExperimentsManager);
-        fileSystem = mock(FileSystem);
-        interpreterPathService = mock(InterpreterPathService);
-        workspaceService = mock(WorkspaceService);
-        activeResourceService = mock(ActiveResourceService);
-        appDiagnostics = typemoq.Mock.ofType<IApplicationDiagnostics>();
-        autoSelection = typemoq.Mock.ofType<IInterpreterAutoSelectionService>();
-        interpreterService = mock(InterpreterService);
-        documentManager = typemoq.Mock.ofType<IDocumentManager>();
-        activationService1 = mock(LanguageServerExtensionActivationService);
-        activationService2 = mock(LanguageServerExtensionActivationService);
-        when(experiments.sendTelemetryIfInExperiment(DeprecatePythonPath.control)).thenReturn(undefined);
-        managerTest = new ExtensionActivationManager(
-            [instance(activationService1), instance(activationService2)],
-            [],
-            documentManager.object,
-            instance(interpreterService),
-            autoSelection.object,
-            appDiagnostics.object,
-            instance(workspaceService),
-            instance(fileSystem),
-            instance(activeResourceService),
-            instance(experiments),
-            instance(interpreterPathService),
-            instance(interpreterSecurityService)
-        );
-    });
-
-    test(`If in Deprecate PythonPath experiment, and setting is not set, fetch autoselected interpreter but don't evaluate it if it equals 'undefined'`, async () => {
-        const interpreter = undefined;
-        when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
-        when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
-        autoSelection
-            .setup((a) => a.getAutoSelectedInterpreter(resource))
-            .returns(() => interpreter as any)
-            .verifiable(typemoq.Times.once());
-        when(interpreterPathService.get(resource)).thenReturn('python');
-        when(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).thenResolve();
-        await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
-        autoSelection.verifyAll();
-        verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
-    });
-
-    ['', 'python'].forEach((setting) => {
-        test(`If in Deprecate PythonPath experiment, and setting equals '${setting}', fetch autoselected interpreter and evaluate it`, async () => {
-            const interpreter = { path: 'pythonPath' };
+        test(`If in Deprecate PythonPath experiment, and setting is not set, fetch autoselected interpreter but don't evaluate it if it equals 'undefined'`, async () => {
+            const interpreter = undefined;
             when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
             when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
             autoSelection
@@ -534,56 +546,83 @@ suite('Selected Python Activation - evaluateIfAutoSelectedInterpreterIsSafe()', 
             ).thenResolve();
             await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
             autoSelection.verifyAll();
-            verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).once();
+            verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
         });
-    });
 
-    test(`If in Deprecate PythonPath experiment, and setting is not set, fetch autoselected interpreter but don't evaluate it if it equals 'undefined'`, async () => {
-        const interpreter = undefined;
-        when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
-        when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
-        autoSelection
-            .setup((a) => a.getAutoSelectedInterpreter(resource))
-            .returns(() => interpreter as any)
-            .verifiable(typemoq.Times.once());
-        when(interpreterPathService.get(resource)).thenReturn('python');
-        when(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).thenResolve();
-        await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
-        autoSelection.verifyAll();
-        verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
-    });
+        ['', 'python'].forEach((setting) => {
+            test(`If in Deprecate PythonPath experiment, and setting equals '${setting}', fetch autoselected interpreter and evaluate it`, async () => {
+                const interpreter = { path: 'pythonPath' };
+                when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
+                when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
+                autoSelection
+                    .setup((a) => a.getAutoSelectedInterpreter(resource))
+                    .returns(() => interpreter as any)
+                    .verifiable(typemoq.Times.once());
+                when(interpreterPathService.get(resource)).thenReturn('python');
+                when(
+                    interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
+                ).thenResolve();
+                await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
+                autoSelection.verifyAll();
+                verify(
+                    interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
+                ).once();
+            });
+        });
 
-    test(`If in Deprecate PythonPath experiment, and setting is set, simply return`, async () => {
-        const interpreter = undefined;
-        when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
-        when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
-        autoSelection
-            .setup((a) => a.getAutoSelectedInterpreter(resource))
-            .returns(() => interpreter as any)
-            .verifiable(typemoq.Times.never());
-        when(interpreterPathService.get(resource)).thenReturn('settingSetToSomePath');
-        when(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).thenResolve();
-        await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
-        autoSelection.verifyAll();
-        verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
-    });
+        test(`If in Deprecate PythonPath experiment, and setting is not set, fetch autoselected interpreter but don't evaluate it if it equals 'undefined'`, async () => {
+            const interpreter = undefined;
+            when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
+            when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
+            autoSelection
+                .setup((a) => a.getAutoSelectedInterpreter(resource))
+                .returns(() => interpreter as any)
+                .verifiable(typemoq.Times.once());
+            when(interpreterPathService.get(resource)).thenReturn('python');
+            when(
+                interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
+            ).thenResolve();
+            await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
+            autoSelection.verifyAll();
+            verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
+        });
 
-    test(`If in Deprecate PythonPath experiment, if setting is set during evaluation, don't wait for the evaluation to finish to resolve method promise`, async () => {
-        const interpreter = { path: 'pythonPath' };
-        const evaluateIfInterpreterIsSafeDeferred = createDeferred<void>();
-        when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
-        when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
-        autoSelection.setup((a) => a.getAutoSelectedInterpreter(resource)).returns(() => interpreter as any);
-        when(interpreterPathService.get(resource)).thenReturn('python');
-        when(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).thenReturn(
-            evaluateIfInterpreterIsSafeDeferred.promise
-        );
-        const deferredPromise = createDeferredFromPromise(managerTest.evaluateAutoSelectedInterpreterSafety(resource));
-        expect(deferredPromise.completed).to.equal(false, 'Promise should not be resolved yet');
-        reset(interpreterPathService);
-        when(interpreterPathService.get(resource)).thenReturn('settingSetToSomePath');
-        await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
-        await sleep(1);
-        expect(deferredPromise.completed).to.equal(true, 'Promise should be resolved');
+        test(`If in Deprecate PythonPath experiment, and setting is set, simply return`, async () => {
+            const interpreter = undefined;
+            when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
+            when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
+            autoSelection
+                .setup((a) => a.getAutoSelectedInterpreter(resource))
+                .returns(() => interpreter as any)
+                .verifiable(typemoq.Times.never());
+            when(interpreterPathService.get(resource)).thenReturn('settingSetToSomePath');
+            when(
+                interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
+            ).thenResolve();
+            await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
+            autoSelection.verifyAll();
+            verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
+        });
+
+        test(`If in Deprecate PythonPath experiment, if setting is set during evaluation, don't wait for the evaluation to finish to resolve method promise`, async () => {
+            const interpreter = { path: 'pythonPath' };
+            const evaluateIfInterpreterIsSafeDeferred = createDeferred<void>();
+            when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
+            when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
+            autoSelection.setup((a) => a.getAutoSelectedInterpreter(resource)).returns(() => interpreter as any);
+            when(interpreterPathService.get(resource)).thenReturn('python');
+            when(
+                interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
+            ).thenReturn(evaluateIfInterpreterIsSafeDeferred.promise);
+            const deferredPromise = createDeferredFromPromise(
+                managerTest.evaluateAutoSelectedInterpreterSafety(resource)
+            );
+            expect(deferredPromise.completed).to.equal(false, 'Promise should not be resolved yet');
+            reset(interpreterPathService);
+            when(interpreterPathService.get(resource)).thenReturn('settingSetToSomePath');
+            await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
+            await sleep(1);
+            expect(deferredPromise.completed).to.equal(true, 'Promise should be resolved');
+        });
     });
 });

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -558,7 +558,7 @@ suite('Activation Manager', () => {
                     .setup((a) => a.getAutoSelectedInterpreter(resource))
                     .returns(() => interpreter as any)
                     .verifiable(typemoq.Times.once());
-                when(interpreterPathService.get(resource)).thenReturn('python');
+                when(interpreterPathService.get(resource)).thenReturn(setting);
                 when(
                     interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
                 ).thenResolve();
@@ -588,20 +588,12 @@ suite('Activation Manager', () => {
         });
 
         test(`If in Deprecate PythonPath experiment, and setting is set, simply return`, async () => {
-            const interpreter = undefined;
             when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
             when(workspaceService.getWorkspaceFolderIdentifier(resource)).thenReturn('1');
-            autoSelection
-                .setup((a) => a.getAutoSelectedInterpreter(resource))
-                .returns(() => interpreter as any)
-                .verifiable(typemoq.Times.never());
+            autoSelection.setup((a) => a.getAutoSelectedInterpreter(resource)).verifiable(typemoq.Times.never());
             when(interpreterPathService.get(resource)).thenReturn('settingSetToSomePath');
-            when(
-                interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)
-            ).thenResolve();
             await managerTest.evaluateAutoSelectedInterpreterSafety(resource);
             autoSelection.verifyAll();
-            verify(interpreterSecurityService.evaluateAndRecordInterpreterSafety(interpreter as any, resource)).never();
         });
 
         test(`If in Deprecate PythonPath experiment, if setting is set during evaluation, don't wait for the evaluation to finish to resolve method promise`, async () => {

--- a/src/test/common/interpreterPathService.unit.test.ts
+++ b/src/test/common/interpreterPathService.unit.test.ts
@@ -23,7 +23,7 @@ import {
 import { InterpreterConfigurationScope, IPersistentState, IPersistentStateFactory } from '../../client/common/types';
 import { createDeferred, sleep } from '../../client/common/utils/async';
 
-suite('Interpreter Path Service', async () => {
+suite('xInterpreter Path Service', async () => {
     let interpreterPathService: InterpreterPathService;
     let persistentStateFactory: TypeMoq.IMock<IPersistentStateFactory>;
     let workspaceService: TypeMoq.IMock<IWorkspaceService>;
@@ -227,7 +227,7 @@ suite('Interpreter Path Service', async () => {
 
     test('Workspace settings are correctly updated in case of multiroot folders', async () => {
         const workspaceFileUri = Uri.parse('path/to/workspaceFile');
-        const expectedSettingKey = `WORKSPACE_INTERPRETER_PATH_${workspaceFileUri.fsPath}`;
+        const expectedSettingKey = 'WORKSPACE_INTERPRETER_PATH_PATH\\TO\\WORKSPACEFILE';
         const persistentState = TypeMoq.Mock.ofType<IPersistentState<string | undefined>>();
         workspaceService.setup((w) => w.getWorkspaceFolderIdentifier(resource)).returns(() => resource.fsPath);
         workspaceService.setup((w) => w.workspaceFile).returns(() => workspaceFileUri);
@@ -404,7 +404,7 @@ suite('Interpreter Path Service', async () => {
 
     test('Inspecting settings returns as expected in case of multiroot folders', async () => {
         const workspaceFileUri = Uri.parse('path/to/workspaceFile');
-        const expectedWorkspaceSettingKey = `WORKSPACE_INTERPRETER_PATH_${workspaceFileUri.fsPath}`;
+        const expectedWorkspaceSettingKey = 'WORKSPACE_INTERPRETER_PATH_PATH\\TO\\WORKSPACEFILE';
         const expectedWorkspaceFolderSettingKey = `WORKSPACE_FOLDER_INTERPRETER_PATH_${resource.fsPath}`;
         const workspaceConfig = TypeMoq.Mock.ofType<WorkspaceConfiguration>();
         // A workspace file is present in case of multiroot workspace folders


### PR DESCRIPTION
### Recommended to hide whitespaces before reviewing

For #11052 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
