### PR TITLE
Huge perf improvement on windows to functional tests. 

### DIFF
--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -362,6 +362,7 @@ import { MockJupyterManagerFactory } from './mockJupyterManagerFactory';
 import { MockLanguageServerAnalysisOptions } from './mockLanguageServerAnalysisOptions';
 import { MockLanguageServerProxy } from './mockLanguageServerProxy';
 import { MockLiveShareApi } from './mockLiveShare';
+import { MockPythonSettings } from './mockPythonSettings';
 import { MockWorkspaceConfiguration } from './mockWorkspaceConfig';
 import { MockWorkspaceFolder } from './mockWorkspaceFolder';
 import { TestInteractiveWindowProvider } from './testInteractiveWindowProvider';
@@ -390,6 +391,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         return this.kernelServiceMock;
     }
     private static jupyterInterpreters: PythonInterpreter[] = [];
+    private static foundPythonPath: string | undefined;
     public webPanelListener: IWebPanelMessageListener | undefined;
     public readonly useCommandFinderForJupyterServer = false;
     public wrapper: ReactWrapper<any, Readonly<{}>, React.Component> | undefined;
@@ -1167,11 +1169,11 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         if (!setting && !this.disposed) {
             // Make sure we have the default config for this resource first.
             this.getWorkspaceConfig('python', resource);
-            setting = new (class extends PythonSettings {
-                public fireChangeEvent() {
-                    this.changed.fire();
-                }
-            })(resource, new MockAutoSelectionService(), this.serviceManager.get<IWorkspaceService>(IWorkspaceService));
+            setting = new MockPythonSettings(
+                resource,
+                new MockAutoSelectionService(),
+                this.serviceManager.get<IWorkspaceService>(IWorkspaceService)
+            );
             this.settingsMap.set(key, setting);
         } else if (this.disposed) {
             setting = this.generatePythonSettings();
@@ -1346,7 +1348,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     private generatePythonSettings() {
         // Create a dummy settings just to setup the workspace config
-        const pythonSettings = new PythonSettings(undefined, new MockAutoSelectionService());
+        const pythonSettings = new MockPythonSettings(undefined, new MockAutoSelectionService());
         pythonSettings.pythonPath = this.defaultPythonPath!;
         pythonSettings.datascience = {
             allowImportFromNotebook: true,
@@ -1476,13 +1478,17 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     private findPythonPath(): string {
         try {
-            // Give preference to the CI test python (could also be set in launch.json for debugging).
-            const output = child_process.execFileSync(
-                process.env.CI_PYTHON_PATH || 'python',
-                ['-c', 'import sys;print(sys.executable)'],
-                { encoding: 'utf8' }
-            );
-            return output.replace(/\r?\n/g, '');
+            // Use a static variable so we don't have to recompute this on subsequenttests
+            if (!DataScienceIocContainer.foundPythonPath) {
+                // Give preference to the CI test python (could also be set in launch.json for debugging).
+                const output = child_process.execFileSync(
+                    process.env.CI_PYTHON_PATH || 'python',
+                    ['-c', 'import sys;print(sys.executable)'],
+                    { encoding: 'utf8' }
+                );
+                DataScienceIocContainer.foundPythonPath = output.replace(/\r?\n/g, '');
+            }
+            return DataScienceIocContainer.foundPythonPath;
         } catch (ex) {
             return 'python';
         }

--- a/src/test/datascience/mockPythonSettings.ts
+++ b/src/test/datascience/mockPythonSettings.ts
@@ -1,0 +1,37 @@
+import { IWorkspaceService } from '../../client/common/application/types';
+import { PythonSettings } from '../../client/common/configSettings';
+import { IExperimentsManager, IInterpreterPathService, Resource } from '../../client/common/types';
+import {
+    IInterpreterAutoSeletionProxyService,
+    IInterpreterSecurityService
+} from '../../client/interpreter/autoSelection/types';
+
+export class MockPythonSettings extends PythonSettings {
+    constructor(
+        workspaceFolder: Resource,
+        interpreterAutoSelectionService: IInterpreterAutoSeletionProxyService,
+        workspace?: IWorkspaceService,
+        experimentsManager?: IExperimentsManager,
+        interpreterPathService?: IInterpreterPathService,
+        interpreterSecurityService?: IInterpreterSecurityService
+    ) {
+        super(
+            workspaceFolder,
+            interpreterAutoSelectionService,
+            workspace,
+            experimentsManager,
+            interpreterPathService,
+            interpreterSecurityService
+        );
+    }
+
+    public fireChangeEvent() {
+        this.changed.fire();
+    }
+
+    protected getPythonExecutable(v: string) {
+        // Don't validate python paths during tests. On windows this can take 4 or 5 seconds
+        // and slow down every test
+        return v;
+    }
+}


### PR DESCRIPTION
Every time a test starts up it generates a PythonSettings. Internally this class tries to validate the pythonPath it has by running python code.

On Windows this can cause a 4 or 5 second delay for every test. And the test doesn't report it as part of the time for the test.

This changes the time on my machine to run the windows tests from 20 minutes to 5.

Hopefully on the build machine this same improvement will occur (and maybe Don can start running functional tests locally :) )

Oh and PS, @greazer asked to be on our PRs from now on, especially since he's actually coding.