### PR TITLE
Fix background (again) for ipywidgets

### DIFF
--- a/news/2 Fixes/11060.md
+++ b/news/2 Fixes/11060.md
@@ -1,0 +1,1 @@
+Make sure ipywidgets have a white background so they display in dark themes.

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -129,10 +129,13 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                 ? `cell-output cell-output-${this.props.baseTheme}`
                 : 'markdown-cell-output-container';
 
-            // Then combine them inside a div
+            // Then combine them inside a div. IPyWidget ref has to be separate so we don't end up
+            // with a div in the way. If we try setting all div's background colors, we break
+            // some widgets
             return (
-                <div className={outputClassNames} ref={this.ipyWidgetRef}>
+                <div className={outputClassNames}>
                     {this.renderResults()}
+                    <div className="cell-output-ipywidget-background" ref={this.ipyWidgetRef}></div>
                 </div>
             );
         }

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -565,15 +565,6 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<ICodeCssGenerator>(ICodeCssGenerator, CodeCssGenerator);
         this.serviceManager.addSingleton<IStatusProvider>(IStatusProvider, StatusProvider);
         this.serviceManager.addSingleton<IInterpreterPathService>(IInterpreterPathService, InterpreterPathService);
-        this.serviceManager.addSingleton<IInterpreterSecurityService>(
-            IInterpreterSecurityService,
-            InterpreterSecurityService
-        );
-        this.serviceManager.addSingleton<IInterpreterSecurityStorage>(
-            IInterpreterSecurityStorage,
-            InterpreterSecurityStorage
-        );
-        this.serviceManager.addSingleton<IInterpreterEvaluation>(IInterpreterEvaluation, InterpreterEvaluation);
         this.serviceManager.addSingleton<IBrowserService>(IBrowserService, BrowserService);
         this.serviceManager.addSingletonInstance<IAsyncDisposableRegistry>(
             IAsyncDisposableRegistry,
@@ -944,6 +935,15 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
                 InterpeterHashProviderFactory,
                 InterpeterHashProviderFactory
             );
+            this.serviceManager.addSingleton<IInterpreterSecurityService>(
+                IInterpreterSecurityService,
+                InterpreterSecurityService
+            );
+            this.serviceManager.addSingleton<IInterpreterSecurityStorage>(
+                IInterpreterSecurityStorage,
+                InterpreterSecurityStorage
+            );
+            this.serviceManager.addSingleton<IInterpreterEvaluation>(IInterpreterEvaluation, InterpreterEvaluation);
             this.serviceManager.addSingleton<WindowsStoreInterpreter>(WindowsStoreInterpreter, WindowsStoreInterpreter);
             this.serviceManager.addSingleton<InterpreterHashProvider>(InterpreterHashProvider, InterpreterHashProvider);
             this.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);


### PR DESCRIPTION
For #11060 

I had removed this by accident on my refactor for how widgets were rendered.

Also fixed a problem with the functional tests running with real jupyter (caused by the IInterpreterSecurity stuff). @karrtikr you fixed the functional tests when running without jupyter, but it's a little bit more tricky than that. Some of our services a registered differently when using real jupyter (Nightly Flake tests)

