### PR TITLE
Validate python when nb opened not on extension activates

### DIFF
--- a/news/2 Fixes/10893.md
+++ b/news/2 Fixes/10893.md
@@ -1,0 +1,1 @@
+Performa validation of interpreter only when a Notebook is opened instead of when extension activates.

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -28,8 +28,6 @@ export class Activation implements IExtensionSingleActivationService {
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookEditorProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
-        // Warm up our selected interpreter for the extension
-        this.jupyterInterpreterService.setInitialInterpreter().ignoreErrors();
         this.contextService.activate().ignoreErrors();
     }
 
@@ -37,10 +35,14 @@ export class Activation implements IExtensionSingleActivationService {
         this.notebookOpened = true;
         this.PreWarmDaemonPool().ignoreErrors();
         sendTelemetryEvent(Telemetry.OpenNotebookAll);
+        // Warm up our selected interpreter for the extension
+        this.jupyterInterpreterService.setInitialInterpreter().ignoreErrors();
     }
 
     private onDidChangeInterpreter() {
         if (this.notebookOpened) {
+            // Warm up our selected interpreter for the extension
+            this.jupyterInterpreterService.setInitialInterpreter().ignoreErrors();
             this.PreWarmDaemonPool().ignoreErrors();
         }
     }


### PR DESCRIPTION
For #10893

Currently we run the process of validating python extension for Jupyter when extension activates.

Moved this code to when a notebook is opened (this code already runs when we start Jupyter).
