### PR TITLE
Fix scrolling in the monaco editor 

### DIFF
--- a/news/2 Fixes/10952.md
+++ b/news/2 Fixes/10952.md
@@ -1,0 +1,1 @@
+Scrolling in cells doesn't happen on new line.


### PR DESCRIPTION
For #10952 

Problems with scrolling on new line (caused by scroll handler being called before the line was actually there)

Problems with scrolling when typing as opposed to just up/down arrow. (caused by scroll handler not waiting for the text to appear so scrolling to a visible line that gets destroyed)

Also fixed a bug in my style speedup code. Sometimes there are no visible lines. In that case, don't remember the default of 18PX.

