### PR TITLE
Fix functional tests for ipywidgets and download just chrome browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4110,6 +4110,16 @@
             "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
             "dev": true
         },
+        "@types/yauzl": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+            "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@webassemblyjs/ast": {
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -18180,30 +18190,30 @@
                 "find-up": "^3.0.0"
             }
         },
-        "playwright": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-0.11.1.tgz",
-            "integrity": "sha512-Sx/WCb88u6Q73klQKGjGY2PJSbUl7JAHIie3mFGTpXPPo79cmMzVJl2e07v/qO3VGFd13bF4z8vMt2UVPc/ygQ==",
+        "playwright-chromium": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-0.13.0.tgz",
+            "integrity": "sha512-Ex9y563Vn8cnoBgMOcYLGdAVVC1xrBk/aWZ66AmOD77lk6v0x0cthLcbPX9h+tfkcWCFQQz1OWQR6V3+c3KUFA==",
             "dev": true,
             "requires": {
-                "playwright-core": "=0.11.1"
+                "playwright-core": "=0.13.0"
             }
         },
         "playwright-core": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.11.1.tgz",
-            "integrity": "sha512-9xsSkXlglvHIAofyNInA1p3beOAOBMWHZgiuH99gX1R8VL6fTXgfWD7pIvt+rJhVMJWMDAyMXRo4TYtYtdspIg==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-0.13.0.tgz",
+            "integrity": "sha512-bH9cOQhmbdXJnHX22PRZ79IdXv5wmLc9tHob2PmkT5qFilopT3INAIJcKkaLN1E/GqIDp0xGdB88Vr5f86g8pQ==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.0",
-                "extract-zip": "^1.6.6",
+                "extract-zip": "^2.0.0",
                 "https-proxy-agent": "^3.0.0",
                 "jpeg-js": "^0.3.6",
+                "mime": "^2.4.4",
                 "pngjs": "^3.4.0",
                 "progress": "^2.0.3",
-                "proxy-from-env": "^1.0.0",
+                "proxy-from-env": "^1.1.0",
                 "rimraf": "^3.0.2",
-                "uuid": "^3.4.0",
                 "ws": "^6.1.0"
             },
             "dependencies": {
@@ -18214,6 +18224,27 @@
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
+                    }
+                },
+                "extract-zip": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.0.tgz",
+                    "integrity": "sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yauzl": "^2.9.1",
+                        "debug": "^4.1.1",
+                        "get-stream": "^5.1.0",
+                        "yauzl": "^2.10.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
                     }
                 },
                 "https-proxy-agent": {
@@ -18237,17 +18268,27 @@
                         }
                     }
                 },
+                "mime": {
+                    "version": "2.4.4",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "dev": true
+                },
                 "progress": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
                     "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
                     "dev": true
                 },
-                "uuid": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-                    "dev": true
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -3184,7 +3184,7 @@
         "node-has-native-dependencies": "^1.0.2",
         "node-html-parser": "^1.1.13",
         "nyc": "^15.0.0",
-        "playwright": "^0.11.1",
+        "playwright-chromium": "^0.13.0",
         "postcss": "^7.0.27",
         "postcss-cssnext": "^3.1.0",
         "postcss-import": "^12.0.1",

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -105,6 +105,7 @@ import { ProductService } from '../../client/common/installer/productService';
 import { IInstallationChannelManager, IProductPathService, IProductService } from '../../client/common/installer/types';
 import { InterpreterPathService } from '../../client/common/interpreterPathService';
 import { BrowserService } from '../../client/common/net/browser';
+import { HttpClient } from '../../client/common/net/httpClient';
 import { IS_WINDOWS } from '../../client/common/platform/constants';
 import { PathUtils } from '../../client/common/platform/pathUtils';
 import { RegistryImplementation } from '../../client/common/platform/registry';
@@ -145,6 +146,7 @@ import {
     IExperimentsManager,
     IExtensionContext,
     IExtensions,
+    IHttpClient,
     IInstaller,
     IInterpreterPathService,
     IMemento,
@@ -192,6 +194,7 @@ import { InteractiveWindow } from '../../client/datascience/interactive-window/i
 import { InteractiveWindowCommandListener } from '../../client/datascience/interactive-window/interactiveWindowCommandListener';
 import { IPyWidgetHandler } from '../../client/datascience/ipywidgets/ipywidgetHandler';
 import { IPyWidgetMessageDispatcherFactory } from '../../client/datascience/ipywidgets/ipyWidgetMessageDispatcherFactory';
+import { IPyWidgetScriptSource } from '../../client/datascience/ipywidgets/ipyWidgetScriptSource';
 import { JupyterCommandFactory } from '../../client/datascience/jupyter/interpreter/jupyterCommand';
 import { JupyterCommandFinder } from '../../client/datascience/jupyter/interpreter/jupyterCommandFinder';
 import { JupyterCommandInterpreterDependencyService } from '../../client/datascience/jupyter/interpreter/jupyterCommandInterpreterDependencyService';
@@ -535,6 +538,8 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         when(this.webPanelProvider.create(anything())).thenCall(this.onCreateWebPanel.bind(this));
         if (this.uiTest) {
             this.serviceManager.addSingleton<IWebPanelProvider>(IWebPanelProvider, WebBrowserPanelProvider);
+            this.serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, IPyWidgetScriptSource);
+            this.serviceManager.addSingleton<IHttpClient>(IHttpClient, HttpClient);
         } else {
             this.serviceManager.addSingletonInstance<IWebPanelProvider>(
                 IWebPanelProvider,
@@ -622,6 +627,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         );
         const mockExtensionContext = TypeMoq.Mock.ofType<IExtensionContext>();
         mockExtensionContext.setup((m) => m.globalStoragePath).returns(() => os.tmpdir());
+        mockExtensionContext.setup((m) => m.extensionPath).returns(() => os.tmpdir());
         this.serviceManager.addSingletonInstance<IExtensionContext>(IExtensionContext, mockExtensionContext.object);
 
         const mockServerSelector = mock(JupyterServerSelector);
@@ -1403,7 +1409,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             variableQueries: [],
             jupyterCommandLineArguments: [],
             disableJupyterAutoStart: true,
-            widgetScriptSources: []
+            widgetScriptSources: ['jsdelivr.com', 'unpkg.com']
         };
         pythonSettings.jediEnabled = false;
         pythonSettings.downloadLanguageServer = false;

--- a/src/test/datascience/uiTests/helpers.ts
+++ b/src/test/datascience/uiTests/helpers.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as playwright from 'playwright';
+import * as playwright from 'playwright-chromium';
 import { IAsyncDisposable, IDisposable } from '../../../client/common/types';
 import { createDeferred } from '../../../client/common/utils/async';
 import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
@@ -35,7 +35,7 @@ const maxWaitTimeForMessage = 75_000;
  * UI could take a while to update, could be slower on CI server.
  * (500ms is generally enough, but increasing to 3s to avoid flaky CI tests).
  */
-export const waitTimeForUIToUpdate = 5_000;
+export const waitTimeForUIToUpdate = 10_000;
 
 export class BaseWebUI implements IAsyncDisposable {
     public page?: playwright.Page;

--- a/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
@@ -441,12 +441,12 @@ use(chaiAsPromised);
 
                 // Confirm canvas is rendered.
                 await retryIfFail(async () => {
-                    const cellOutputHtml = await notebookUI.getCellOutputHTML(3);
+                    let cellOutputHtml = await notebookUI.getCellOutputHTML(3);
                     assert.include(cellOutputHtml, '<canvas ');
                     // Last cell is flakey. Can take too long to render. We need some way
                     // to know when a widget is done rendering.
-                    // cellOutputHtml = await notebookUI.getCellOutputHTML(8);
-                    // assert.include(cellOutputHtml, '<canvas ');
+                    cellOutputHtml = await notebookUI.getCellOutputHTML(8);
+                    assert.include(cellOutputHtml, '<canvas ');
                 });
             });
             test('Render beakerx', async () => {
@@ -478,13 +478,13 @@ use(chaiAsPromised);
                 });
 
                 // This last part if flakey. BeakerX can fail itself loading settings
-                // await notebookUI.executeCell(3);
-                // await retryIfFail(async () => {
-                //     // Confirm form with fields have been rendered.
-                //     const cellOutput = await notebookUI.getCellOutput(3);
-                //     const textAreas = await cellOutput.$$('div.widget-textarea');
-                //     assert.isAtLeast(textAreas.length, 1);
-                // });
+                await notebookUI.executeCell(3);
+                await retryIfFail(async () => {
+                    // Confirm form with fields have been rendered.
+                    const cellOutput = await notebookUI.getCellOutput(3);
+                    const textAreas = await cellOutput.$$('div.widget-textarea');
+                    assert.isAtLeast(textAreas.length, 1);
+                });
             });
             test('Render bqplot', async () => {
                 const { notebookUI } = await openBqplotIpynb();

--- a/src/test/datascience/uiTests/notebookUi.ts
+++ b/src/test/datascience/uiTests/notebookUi.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { assert } from 'chai';
-import { ElementHandle } from 'playwright';
+import { ElementHandle } from 'playwright-chromium';
 import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { CommonActionType } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import { BaseWebUI } from './helpers';


### PR DESCRIPTION
For #11092

* `playwright` downloads other browsers, we need just one `chrome` (as this is closest to what VSCode is built upon)
