### PR TITLE
Address conda environment parsing issues

### DIFF
--- a/news/2 Fixes/10942.md
+++ b/news/2 Fixes/10942.md
@@ -1,0 +1,1 @@
+Fix issue with parsing long conda environment names.

--- a/src/client/interpreter/locators/services/condaHelper.ts
+++ b/src/client/interpreter/locators/services/condaHelper.ts
@@ -95,6 +95,12 @@ function parseCondaEnvFileLine(line: string): { name: string; path: string; isAc
     // form as the environment name. lastIndexOf() can also be used but that assumes
     // that `path` does NOT end with 5*spaces.
     let spaceIndex = line.indexOf('     ');
+    if (spaceIndex === -1) {
+        // This means the environment name is longer than 17 characters and it is
+        // active. Try '  *  ' for separator between name and path.
+        spaceIndex = line.indexOf('  *  ');
+    }
+
     if (spaceIndex > 0) {
         // Parsing `name`
         // > `conda create -n <name>`
@@ -113,14 +119,6 @@ function parseCondaEnvFileLine(line: string): { name: string; path: string; isAc
         // are NOT allowed. But leading spaces are allowed. Currently there no
         // special separator character between name and path, other than spaces.
         // We will need a well known separator if this ever becomes a issue.
-        name = line.substring(0, spaceIndex).trimRight();
-        remainder = line.substring(spaceIndex);
-    }
-
-    // This means the environment name is longer than 17 characters and it is
-    // active. Try '  *  ' for separator between name and path.
-    if (spaceIndex === -1) {
-        spaceIndex = line.indexOf('  *  ');
         name = line.substring(0, spaceIndex).trimRight();
         remainder = line.substring(spaceIndex);
     }

--- a/src/client/interpreter/locators/services/condaHelper.ts
+++ b/src/client/interpreter/locators/services/condaHelper.ts
@@ -11,81 +11,126 @@ export type EnvironmentName = string;
 /**
  * Helpers for conda.
  */
-export class CondaHelper {
-    /**
-     * Return the string to display for the conda interpreter.
-     */
-    public getDisplayName(condaInfo: CondaInfo = {}): string {
-        // Samples.
-        // "3.6.1 |Anaconda 4.4.0 (64-bit)| (default, May 11 2017, 13:25:24) [MSC v.1900 64 bit (AMD64)]".
-        // "3.6.2 |Anaconda, Inc.| (default, Sep 21 2017, 18:29:43) \n[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]".
-        const sysVersion = condaInfo['sys.version'];
-        if (!sysVersion) {
-            return AnacondaDisplayName;
-        }
 
-        // Take the second part of the sys.version.
-        const sysVersionParts = sysVersion.split('|', 2);
-        if (sysVersionParts.length === 2) {
-            const displayName = sysVersionParts[1].trim();
-            if (this.isIdentifiableAsAnaconda(displayName)) {
-                return displayName;
-            } else {
-                return `${displayName} : ${AnacondaDisplayName}`;
-            }
+/**
+ * Return the string to display for the conda interpreter.
+ */
+export function getDisplayName(condaInfo: CondaInfo = {}): string {
+    // Samples.
+    // "3.6.1 |Anaconda 4.4.0 (64-bit)| (default, May 11 2017, 13:25:24) [MSC v.1900 64 bit (AMD64)]".
+    // "3.6.2 |Anaconda, Inc.| (default, Sep 21 2017, 18:29:43) \n[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)]".
+    const sysVersion = condaInfo['sys.version'];
+    if (!sysVersion) {
+        return AnacondaDisplayName;
+    }
+
+    // Take the second part of the sys.version.
+    const sysVersionParts = sysVersion.split('|', 2);
+    if (sysVersionParts.length === 2) {
+        const displayName = sysVersionParts[1].trim();
+        if (isIdentifiableAsAnaconda(displayName)) {
+            return displayName;
         } else {
-            return AnacondaDisplayName;
+            return `${displayName} : ${AnacondaDisplayName}`;
         }
+    } else {
+        return AnacondaDisplayName;
     }
+}
 
-    /**
-     * Parses output returned by the command `conda env list`.
-     * Sample output is as follows:
-     * # conda environments:
-     * #
-     * base                  *  /Users/donjayamanne/anaconda3
-     * one                      /Users/donjayamanne/anaconda3/envs/one
-     * one two                  /Users/donjayamanne/anaconda3/envs/one two
-     * py27                     /Users/donjayamanne/anaconda3/envs/py27
-     * py36                     /Users/donjayamanne/anaconda3/envs/py36
-     * three                    /Users/donjayamanne/anaconda3/envs/three
-     *                          /Users/donjayamanne/anaconda3/envs/four
-     *                          /Users/donjayamanne/anaconda3/envs/five 5
-     * @param {string} condaEnvironmentList
-     * @param {CondaInfo} condaInfo
-     * @returns {{ name: string, path: string }[] | undefined}
-     * @memberof CondaHelper
-     */
-    public parseCondaEnvironmentNames(condaEnvironmentList: string): { name: string; path: string }[] | undefined {
-        const environments = condaEnvironmentList.splitLines({ trim: false });
-        const baseEnvironmentLine = environments.filter((line) => line.indexOf('*') > 0);
-        if (baseEnvironmentLine.length === 0) {
-            return;
+/**
+ * Parses output returned by the command `conda env list`.
+ * Sample output is as follows:
+ * # conda environments:
+ * #
+ * base                  *  /Users/donjayamanne/anaconda3
+ * one                      /Users/donjayamanne/anaconda3/envs/one
+ * py27                     /Users/donjayamanne/anaconda3/envs/py27
+ * py36                     /Users/donjayamanne/anaconda3/envs/py36
+ * three                    /Users/donjayamanne/anaconda3/envs/three
+ *                          /Users/donjayamanne/anaconda3/envs/four
+ *                          /Users/donjayamanne/anaconda3/envs/five 5
+ * aaaa_bbbb_cccc_dddd_eeee_ffff_gggg     /Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg
+ * with*star                /Users/donjayamanne/anaconda3/envs/with*star
+ *                          "/Users/donjayamanne/anaconda3/envs/seven "
+ */
+export function parseCondaEnvFileContents(
+    condaEnvFileContents: string
+): { name: string; path: string; isBase: boolean }[] | undefined {
+    // Don't trim the lines. `path` portion of the line can end with a space.
+    const lines = condaEnvFileContents.splitLines({ trim: false });
+    const envs: { name: string; path: string; isBase: boolean }[] = [];
+
+    lines.forEach((line) => {
+        const item = parseCondaEnvFileLine(line);
+        if (item) {
+            envs.push(item);
         }
-        const pathStartIndex = baseEnvironmentLine[0].indexOf(baseEnvironmentLine[0].split('*')[1].trim());
-        const envs: { name: string; path: string }[] = [];
-        environments.forEach((line) => {
-            if (line.length <= pathStartIndex) {
-                return;
-            }
-            let name = line.substring(0, pathStartIndex).trim();
-            if (name.endsWith('*')) {
-                name = name.substring(0, name.length - 1).trim();
-            }
-            const envPath = line.substring(pathStartIndex).trim();
-            if (envPath.length > 0) {
-                envs.push({ name, path: envPath });
-            }
-        });
+    });
 
-        return envs;
+    return envs.length > 0 ? envs : undefined;
+}
+
+function parseCondaEnvFileLine(line: string): { name: string; path: string; isBase: boolean } | undefined {
+    // Empty lines or lines starting with `#` are comments and can be ignored.
+    if (line.length === 0 || line.startsWith('#')) {
+        return undefined;
     }
 
-    /**
-     * Does the given string match a known Anaconda identifier.
-     */
-    private isIdentifiableAsAnaconda(value: string) {
-        const valueToSearch = value.toLowerCase();
-        return AnacondaIdentifiers.some((item) => valueToSearch.indexOf(item.toLowerCase()) !== -1);
+    // If conda environment was created using `-p` then it may NOT have a name.
+    // Use empty string as default name for envs created using path only.
+    let name = '';
+    let remainder = line;
+
+    // The `name` and `path` parts are separated by at least 5 spaces. We cannot
+    // use a single space here since it can be part of the name (see below for
+    // name spec). Another assumption here is that `name` does not start with
+    // 5*spaces or somewhere in the center. However, `     name` or `a     b` is
+    // a valid name when using --clone. Highly unlikely that users will have this
+    // form as the environment name. lastIndexOf() can also be used but that assumes
+    // that `path` does NOT end with 5*spaces.
+    const spaceIndex = line.indexOf('     ');
+    if (spaceIndex > 0) {
+        // Parsing `name`
+        // > `conda create -n <name>`
+        // conda environment `name` should NOT have following characters
+        // ('/', ' ', ':', '#'). So we can use the index of 5*space
+        // characters to extract the name.
+        //
+        // > `conda create --clone one -p "~/envs/one two"`
+        // this can generate a cloned env with name `one two`. This is
+        // only allowed for cloned environments. In both cases, the best
+        // separator is 5*spaces. It is highly unlikely that users will have
+        // 5*spaces in their environment name.
+        //
+        // Notes: When using clone if the path has a trailing space, it will
+        // not be preserved for the name. Trailing spaces in environment names
+        // are NOT allowed. But leading spaces are allowed. Currently there no
+        // special separator character between name and path, other than spaces.
+        // We will need a well known separator if this ever becomes a issue.
+        name = line.substring(0, spaceIndex).trimRight();
+        remainder = line.substring(spaceIndex);
     }
+
+    // Detecting Base:
+    // Only `base` environment will have `*` between `name` and `path`. `name`
+    // or `path` can have `*` in them as well. So we have to look for `*` in
+    // between `name` and `path`. We already extracted the name, the next non-
+    // whitespace character should either be `*` or environment path.
+    remainder = remainder.trimLeft();
+    const isBase = remainder.startsWith('*');
+
+    // Parsing `path`
+    // If `*` is the first then we can skip that character. Trim left again,
+    // don't do trim() or trimRight(), since paths can end with a space.
+    remainder = (isBase ? remainder.substring(1) : remainder).trimLeft();
+
+    return { name, path: remainder, isBase };
+}
+/**
+ * Does the given string match a known Anaconda identifier.
+ */
+function isIdentifiableAsAnaconda(value: string) {
+    const valueToSearch = value.toLowerCase();
+    return AnacondaIdentifiers.some((item) => valueToSearch.indexOf(item.toLowerCase()) !== -1);
 }

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -18,7 +18,7 @@ import {
     PythonInterpreter,
     WINDOWS_REGISTRY_SERVICE
 } from '../../contracts';
-import { CondaHelper } from './condaHelper';
+import { parseCondaEnvFileContents } from './condaHelper';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 const untildify: (value: string) => string = require('untildify');
@@ -58,7 +58,6 @@ export const CondaGetEnvironmentPrefix = 'Outputting Environment Now...';
 export class CondaService implements ICondaService {
     private condaFile?: Promise<string | undefined>;
     private isAvailable: boolean | undefined;
-    private readonly condaHelper = new CondaHelper();
 
     constructor(
         @inject(IProcessServiceFactory) private processServiceFactory: IProcessServiceFactory,
@@ -260,7 +259,7 @@ export class CondaService implements ICondaService {
                     .exec(condaFile, ['env', 'list'], { env: newEnv })
                     .then((output) => output.stdout);
             }
-            const environments = this.condaHelper.parseCondaEnvironmentNames(envInfo);
+            const environments = parseCondaEnvFileContents(envInfo);
             await globalPersistence.updateValue({ data: environments });
             return environments;
         } catch (ex) {

--- a/src/test/interpreters/condaHelper.unit.test.ts
+++ b/src/test/interpreters/condaHelper.unit.test.ts
@@ -56,25 +56,43 @@ three                    /Users/donjayamanne/anaconda3/envs/three
                          /Users/donjayamanne/anaconda3/envs/four
                          /Users/donjayamanne/anaconda3/envs/five six
 aaaa_bbbb_cccc_dddd_eeee_ffff_gggg     /Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg
+aaaa_bbbb_cccc_dddd_eeee_ffff_gggg  *  /Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg
 with*star                /Users/donjayamanne/anaconda3/envs/with*star
+with*one*two*three*four*five*six*seven*     /Users/donjayamanne/anaconda3/envs/with*one*two*three*four*five*six*seven*
+with*one*two*three*four*five*six*seven*  *  /Users/donjayamanne/anaconda3/envs/with*one*two*three*four*five*six*seven*
                          /Users/donjayamanne/anaconda3/envs/seven `; // note the space after seven
 
         const expectedList = [
-            { name: 'base', path: '/Users/donjayamanne/anaconda3', isBase: true },
-            { name: '', path: '/Users/donjayamanne/anaconda3', isBase: true },
-            { name: 'one', path: '/Users/donjayamanne/anaconda3/envs/one', isBase: false },
-            { name: ' one', path: '/Users/donjayamanne/anaconda3/envs/ one', isBase: false },
-            { name: 'one two', path: '/Users/donjayamanne/anaconda3/envs/one two', isBase: false },
-            { name: 'three', path: '/Users/donjayamanne/anaconda3/envs/three', isBase: false },
-            { name: '', path: '/Users/donjayamanne/anaconda3/envs/four', isBase: false },
-            { name: '', path: '/Users/donjayamanne/anaconda3/envs/five six', isBase: false },
+            { name: 'base', path: '/Users/donjayamanne/anaconda3', isActive: true },
+            { name: '', path: '/Users/donjayamanne/anaconda3', isActive: true },
+            { name: 'one', path: '/Users/donjayamanne/anaconda3/envs/one', isActive: false },
+            { name: ' one', path: '/Users/donjayamanne/anaconda3/envs/ one', isActive: false },
+            { name: 'one two', path: '/Users/donjayamanne/anaconda3/envs/one two', isActive: false },
+            { name: 'three', path: '/Users/donjayamanne/anaconda3/envs/three', isActive: false },
+            { name: '', path: '/Users/donjayamanne/anaconda3/envs/four', isActive: false },
+            { name: '', path: '/Users/donjayamanne/anaconda3/envs/five six', isActive: false },
             {
                 name: 'aaaa_bbbb_cccc_dddd_eeee_ffff_gggg',
                 path: '/Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg',
-                isBase: false
+                isActive: false
             },
-            { name: 'with*star', path: '/Users/donjayamanne/anaconda3/envs/with*star', isBase: false },
-            { name: '', path: '/Users/donjayamanne/anaconda3/envs/seven ', isBase: false }
+            {
+                name: 'aaaa_bbbb_cccc_dddd_eeee_ffff_gggg',
+                path: '/Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg',
+                isActive: true
+            },
+            { name: 'with*star', path: '/Users/donjayamanne/anaconda3/envs/with*star', isActive: false },
+            {
+                name: 'with*one*two*three*four*five*six*seven*',
+                path: '/Users/donjayamanne/anaconda3/envs/with*one*two*three*four*five*six*seven*',
+                isActive: false
+            },
+            {
+                name: 'with*one*two*three*four*five*six*seven*',
+                path: '/Users/donjayamanne/anaconda3/envs/with*one*two*three*four*five*six*seven*',
+                isActive: true
+            },
+            { name: '', path: '/Users/donjayamanne/anaconda3/envs/seven ', isActive: false }
         ];
 
         const list = parseCondaEnvFileContents(environments);

--- a/src/test/interpreters/condaHelper.unit.test.ts
+++ b/src/test/interpreters/condaHelper.unit.test.ts
@@ -2,20 +2,19 @@ import * as assert from 'assert';
 import { expect } from 'chai';
 import { CondaInfo } from '../../client/interpreter/contracts';
 import { AnacondaDisplayName } from '../../client/interpreter/locators/services/conda';
-import { CondaHelper } from '../../client/interpreter/locators/services/condaHelper';
+import { getDisplayName, parseCondaEnvFileContents } from '../../client/interpreter/locators/services/condaHelper';
 
 // tslint:disable-next-line:max-func-body-length
 suite('Interpreters display name from Conda Environments', () => {
-    const condaHelper = new CondaHelper();
     test('Must return default display name for invalid Conda Info', () => {
-        assert.equal(condaHelper.getDisplayName(), AnacondaDisplayName, 'Incorrect display name');
-        assert.equal(condaHelper.getDisplayName({}), AnacondaDisplayName, 'Incorrect display name');
+        assert.equal(getDisplayName(), AnacondaDisplayName, 'Incorrect display name');
+        assert.equal(getDisplayName({}), AnacondaDisplayName, 'Incorrect display name');
     });
     test('Must return at least Python Version', () => {
         const info: CondaInfo = {
             python_version: '3.6.1.final.10'
         };
-        const displayName = condaHelper.getDisplayName(info);
+        const displayName = getDisplayName(info);
         assert.equal(displayName, AnacondaDisplayName, 'Incorrect display name');
     });
     test('Must return info without first part if not a python version', () => {
@@ -23,7 +22,7 @@ suite('Interpreters display name from Conda Environments', () => {
             'sys.version':
                 '3.6.1 |Anaconda 4.4.0 (64-bit)| (default, May 11 2017, 13:25:24) [MSC v.1900 64 bit (AMD64)]'
         };
-        const displayName = condaHelper.getDisplayName(info);
+        const displayName = getDisplayName(info);
         assert.equal(displayName, 'Anaconda 4.4.0 (64-bit)', 'Incorrect display name');
     });
     test("Must return info without prefixing with word 'Python'", () => {
@@ -32,7 +31,7 @@ suite('Interpreters display name from Conda Environments', () => {
             'sys.version':
                 '3.6.1 |Anaconda 4.4.0 (64-bit)| (default, May 11 2017, 13:25:24) [MSC v.1900 64 bit (AMD64)]'
         };
-        const displayName = condaHelper.getDisplayName(info);
+        const displayName = getDisplayName(info);
         assert.equal(displayName, 'Anaconda 4.4.0 (64-bit)', 'Incorrect display name');
     });
     test('Must include Ananconda name if Company name not found', () => {
@@ -40,7 +39,7 @@ suite('Interpreters display name from Conda Environments', () => {
             python_version: '3.6.1.final.10',
             'sys.version': '3.6.1 |4.4.0 (64-bit)| (default, May 11 2017, 13:25:24) [MSC v.1900 64 bit (AMD64)]'
         };
-        const displayName = condaHelper.getDisplayName(info);
+        const displayName = getDisplayName(info);
         assert.equal(displayName, `4.4.0 (64-bit) : ${AnacondaDisplayName}`, 'Incorrect display name');
     });
     test('Parse conda environments', () => {
@@ -49,22 +48,36 @@ suite('Interpreters display name from Conda Environments', () => {
 # conda environments:
 #
 base                  *  /Users/donjayamanne/anaconda3
-one1                     /Users/donjayamanne/anaconda3/envs/one
-two2 2                   /Users/donjayamanne/anaconda3/envs/two 2
-three3                   /Users/donjayamanne/anaconda3/envs/three
+                      *  /Users/donjayamanne/anaconda3
+one                      /Users/donjayamanne/anaconda3/envs/one
+ one                      /Users/donjayamanne/anaconda3/envs/ one
+one two                  /Users/donjayamanne/anaconda3/envs/one two
+three                    /Users/donjayamanne/anaconda3/envs/three
                          /Users/donjayamanne/anaconda3/envs/four
-                         /Users/donjayamanne/anaconda3/envs/five 5`;
+                         /Users/donjayamanne/anaconda3/envs/five six
+aaaa_bbbb_cccc_dddd_eeee_ffff_gggg     /Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg
+with*star                /Users/donjayamanne/anaconda3/envs/with*star
+                         /Users/donjayamanne/anaconda3/envs/seven `; // note the space after seven
 
         const expectedList = [
-            { name: 'base', path: '/Users/donjayamanne/anaconda3' },
-            { name: 'one1', path: '/Users/donjayamanne/anaconda3/envs/one' },
-            { name: 'two2 2', path: '/Users/donjayamanne/anaconda3/envs/two 2' },
-            { name: 'three3', path: '/Users/donjayamanne/anaconda3/envs/three' },
-            { name: '', path: '/Users/donjayamanne/anaconda3/envs/four' },
-            { name: '', path: '/Users/donjayamanne/anaconda3/envs/five 5' }
+            { name: 'base', path: '/Users/donjayamanne/anaconda3', isBase: true },
+            { name: '', path: '/Users/donjayamanne/anaconda3', isBase: true },
+            { name: 'one', path: '/Users/donjayamanne/anaconda3/envs/one', isBase: false },
+            { name: ' one', path: '/Users/donjayamanne/anaconda3/envs/ one', isBase: false },
+            { name: 'one two', path: '/Users/donjayamanne/anaconda3/envs/one two', isBase: false },
+            { name: 'three', path: '/Users/donjayamanne/anaconda3/envs/three', isBase: false },
+            { name: '', path: '/Users/donjayamanne/anaconda3/envs/four', isBase: false },
+            { name: '', path: '/Users/donjayamanne/anaconda3/envs/five six', isBase: false },
+            {
+                name: 'aaaa_bbbb_cccc_dddd_eeee_ffff_gggg',
+                path: '/Users/donjayamanne/anaconda3/envs/aaaa_bbbb_cccc_dddd_eeee_ffff_gggg',
+                isBase: false
+            },
+            { name: 'with*star', path: '/Users/donjayamanne/anaconda3/envs/with*star', isBase: false },
+            { name: '', path: '/Users/donjayamanne/anaconda3/envs/seven ', isBase: false }
         ];
 
-        const list = condaHelper.parseCondaEnvironmentNames(environments);
+        const list = parseCondaEnvFileContents(environments);
         expect(list).deep.equal(expectedList);
     });
 });


### PR DESCRIPTION
For #10942 

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.

I looked into this as a part of investigating #10942, since the env list does not have clear separators between name and paths. Since spaces are allowed to in both paths and names, there are some cases where it is not clear ow to extract the name. This is best effort. I wanted to capture the algorithm before I forget.

Another thing in this change is that I removed the stateless helper class.