### PR TITLE
Add status bar item with icon during installs

### DIFF
--- a/news/1 Enhancements/10495.md
+++ b/news/1 Enhancements/10495.md
@@ -1,1 +1,2 @@
 Add status bar item with icon when installing Insiders/Stable build.
+(thanks to [ErwanDL](https://github.com/ErwanDL/))

--- a/news/1 Enhancements/10495.md
+++ b/news/1 Enhancements/10495.md
@@ -1,0 +1,1 @@
+Add status bar item with icon when installing Insiders/Stable build.


### PR DESCRIPTION
For #10495.

We created a `withProgressCustomIcon` helper in #10687 and used it to display custom icons in the status bar while downloading Insiders/MLPS. As suggested by @kimadeline, this also adds a status bar item with a custom icon when installing packages (Insiders build and Stable build). From what I've seen, MLPS is never installed (just downloaded), so I don't think there is something to display there.

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   ~[ ] Appropriate comments and documentation strings in the code.~
-   ~[ ] Has sufficient logging.~
-  ~[ ] Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
