### PR TITLE
Show notebook paths on remote kernels

### DIFF
--- a/news/2 Fixes/10521.md
+++ b/news/2 Fixes/10521.md
@@ -1,0 +1,1 @@
+Show notebook path when listing remote kernels.

--- a/src/client/datascience/jupyter/kernels/kernelSelections.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelections.ts
@@ -45,8 +45,8 @@ function getQuickPickItemForActiveKernel(kernel: LiveKernelModel, pathUtils: IPa
     const path = kernel.metadata?.interpreter?.path || kernel.path;
     return {
         label: kernel.display_name || kernel.name || '',
-        // If we have a matching interpreter, then display that path in the dropdown else path of the kernelspec.
-        detail: path ? pathUtils.getDisplayName(path) : '',
+        // If we have a session, use that path
+        detail: kernel.session.path || !path ? kernel.session.path : pathUtils.getDisplayName(path),
         description: localize.DataScience.jupyterSelectURIRunningDetailFormat().format(
             kernel.lastActivityTime.toLocaleString(),
             kernel.numberOfConnections.toString()


### PR DESCRIPTION
For #10521 

Went from this:
![image](https://user-images.githubusercontent.com/19672699/79254358-789cd080-7e39-11ea-9e62-c4c681428fe3.png)


To this:
![image](https://user-images.githubusercontent.com/19672699/79254204-3d020680-7e39-11ea-91c4-de8e7ca74682.png)

