### PR TITLE
Ensure arguments are included in log messages when using decorators.

### DIFF
--- a/news/2 Fixes/11153.md
+++ b/news/2 Fixes/11153.md
@@ -1,0 +1,1 @@
+Ensure arguments are included in log messages when using decorators.

--- a/src/client/common/logger.ts
+++ b/src/client/common/logger.ts
@@ -295,7 +295,7 @@ function trace(message: string, options: LogOptions = LogOptions.None, logLevel?
                         returnValue ? 'truthy' : 'falsy'
                     } return value`
                 );
-                if ((options && LogOptions.Arguments) === LogOptions.Arguments) {
+                if ((options & LogOptions.Arguments) === LogOptions.Arguments) {
                     messagesToLog.push(argsToLogString(args));
                 }
                 if ((options & LogOptions.ReturnValue) === LogOptions.ReturnValue) {


### PR DESCRIPTION
For #11153.