### PR TITLE
Fix undo in notebooks

### DIFF
--- a/news/2 Fixes/11160.md
+++ b/news/2 Fixes/11160.md
@@ -1,0 +1,1 @@
+Fix CTRL+Z and Z for undo on notebooks.

--- a/src/client/datascience/data-viewing/dataViewer.ts
+++ b/src/client/datascience/data-viewing/dataViewer.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import { ViewColumn } from 'vscode';
 
 import { IApplicationShell, IWebPanelProvider, IWorkspaceService } from '../../common/application/types';
-import { EXTENSION_ROOT_DIR } from '../../common/constants';
+import { EXTENSION_ROOT_DIR, UseCustomEditorApi } from '../../common/constants';
 import { WebHostNotebook } from '../../common/experimentGroups';
 import { traceError } from '../../common/logger';
 import { IConfigurationService, IDisposable, IExperimentsManager, Resource } from '../../common/types';
@@ -39,7 +39,8 @@ export class DataViewer extends WebViewHost<IDataViewerMapping> implements IData
         @inject(IWorkspaceService) workspaceService: IWorkspaceService,
         @inject(IJupyterVariables) private variableManager: IJupyterVariables,
         @inject(IApplicationShell) private applicationShell: IApplicationShell,
-        @inject(IExperimentsManager) experimentsManager: IExperimentsManager
+        @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
+        @inject(UseCustomEditorApi) useCustomEditorApi: boolean
     ) {
         super(
             configuration,
@@ -52,7 +53,8 @@ export class DataViewer extends WebViewHost<IDataViewerMapping> implements IData
             [path.join(dataExplorereDir, 'commons.initial.bundle.js'), path.join(dataExplorereDir, 'dataExplorer.js')],
             localize.DataScience.dataExplorerTitle(),
             ViewColumn.One,
-            experimentsManager.inExperiment(WebHostNotebook.experiment)
+            experimentsManager.inExperiment(WebHostNotebook.experiment),
+            useCustomEditorApi
         );
 
         // Load the web panel using our current directory as we don't expect to load any other files

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -150,7 +150,8 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         @unmanaged() viewColumn: ViewColumn,
         @unmanaged() experimentsManager: IExperimentsManager,
         @unmanaged() private switcher: KernelSwitcher,
-        @unmanaged() private readonly notebookProvider: INotebookProvider
+        @unmanaged() private readonly notebookProvider: INotebookProvider,
+        @unmanaged() useCustomEditorApi: boolean
     ) {
         super(
             configuration,
@@ -163,7 +164,8 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             scripts,
             title,
             viewColumn,
-            experimentsManager.inExperiment(WebHostNotebook.experiment)
+            experimentsManager.inExperiment(WebHostNotebook.experiment),
+            useCustomEditorApi
         );
 
         // Create our unique id. We use this to skip messages we send to other interactive windows

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -90,7 +90,7 @@ import { nbformat } from '@jupyterlab/coreutils';
 import cloneDeep = require('lodash/cloneDeep');
 import { concatMultilineStringInput } from '../../../datascience-ui/common';
 import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
-import { isTestExecution } from '../../common/constants';
+import { isTestExecution, UseCustomEditorApi } from '../../common/constants';
 import { KernelSwitcher } from '../jupyter/kernels/kernelSwitcher';
 
 const nativeEditorDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', 'notebook');
@@ -177,7 +177,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
         @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
         @inject(KernelSwitcher) switcher: KernelSwitcher,
-        @inject(INotebookProvider) notebookProvider: INotebookProvider
+        @inject(INotebookProvider) notebookProvider: INotebookProvider,
+        @inject(UseCustomEditorApi) useCustomEditorApi: boolean
     ) {
         super(
             listeners,
@@ -212,7 +213,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             ViewColumn.Active,
             experimentsManager,
             switcher,
-            notebookProvider
+            notebookProvider,
+            useCustomEditorApi
         );
         asyncRegistry.push(this);
 

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -15,6 +15,7 @@ import {
     IWebPanelProvider,
     IWorkspaceService
 } from '../../common/application/types';
+import { UseCustomEditorApi } from '../../common/constants';
 import { traceError } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 import {
@@ -95,7 +96,8 @@ export class NativeEditorOldWebView extends NativeEditor {
         @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
         @inject(IAsyncDisposableRegistry) asyncRegistry: IAsyncDisposableRegistry,
         @inject(KernelSwitcher) switcher: KernelSwitcher,
-        @inject(INotebookProvider) notebookProvider: INotebookProvider
+        @inject(INotebookProvider) notebookProvider: INotebookProvider,
+        @inject(UseCustomEditorApi) useCustomEditorApi: boolean
     ) {
         super(
             listeners,
@@ -124,7 +126,8 @@ export class NativeEditorOldWebView extends NativeEditor {
             experimentsManager,
             asyncRegistry,
             switcher,
-            notebookProvider
+            notebookProvider,
+            useCustomEditorApi
         );
         asyncRegistry.push(this);
         // No ui syncing in old notebooks.

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -13,6 +13,7 @@ import {
     IWebPanelProvider,
     IWorkspaceService
 } from '../../common/application/types';
+import { UseCustomEditorApi } from '../../common/constants';
 import { ContextKey } from '../../common/contextKey';
 import '../../common/extensions';
 import { traceError } from '../../common/logger';
@@ -108,7 +109,8 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         @inject(IMemento) @named(GLOBAL_MEMENTO) globalStorage: Memento,
         @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
         @inject(KernelSwitcher) switcher: KernelSwitcher,
-        @inject(INotebookProvider) notebookProvider: INotebookProvider
+        @inject(INotebookProvider) notebookProvider: INotebookProvider,
+        @inject(UseCustomEditorApi) useCustomEditorApi: boolean
     ) {
         super(
             listeners,
@@ -143,7 +145,8 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
             ViewColumn.Two,
             experimentsManager,
             switcher,
-            notebookProvider
+            notebookProvider,
+            useCustomEditorApi
         );
 
         // Send a telemetry event to indicate window is opening

--- a/src/client/datascience/plotting/plotViewer.ts
+++ b/src/client/datascience/plotting/plotViewer.ts
@@ -10,7 +10,7 @@ import { Event, EventEmitter, ViewColumn } from 'vscode';
 import { traceInfo } from '../../../client/common/logger';
 import { createDeferred } from '../../../client/common/utils/async';
 import { IApplicationShell, IWebPanelProvider, IWorkspaceService } from '../../common/application/types';
-import { EXTENSION_ROOT_DIR } from '../../common/constants';
+import { EXTENSION_ROOT_DIR, UseCustomEditorApi } from '../../common/constants';
 import { WebHostNotebook } from '../../common/experimentGroups';
 import { traceError } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
@@ -35,7 +35,8 @@ export class PlotViewer extends WebViewHost<IPlotViewerMapping> implements IPlot
         @inject(IWorkspaceService) workspaceService: IWorkspaceService,
         @inject(IApplicationShell) private applicationShell: IApplicationShell,
         @inject(IFileSystem) private fileSystem: IFileSystem,
-        @inject(IExperimentsManager) experimentsManager: IExperimentsManager
+        @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
+        @inject(UseCustomEditorApi) useCustomEditorApi: boolean
     ) {
         super(
             configuration,
@@ -48,7 +49,8 @@ export class PlotViewer extends WebViewHost<IPlotViewerMapping> implements IPlot
             [path.join(plotDir, 'commons.initial.bundle.js'), path.join(plotDir, 'plotViewer.js')],
             localize.DataScience.plotViewerTitle(),
             ViewColumn.One,
-            experimentsManager.inExperiment(WebHostNotebook.experiment)
+            experimentsManager.inExperiment(WebHostNotebook.experiment),
+            useCustomEditorApi
         );
         // Load the web panel using our current directory as we don't expect to load any other files
         super.loadWebPanel(process.cwd()).catch(traceError);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -652,6 +652,7 @@ export interface IDataScienceExtraSettings extends IDataScienceSettings {
             fontFamily: string;
         };
         theme: string;
+        useCustomEditorApi: boolean;
     };
     intellisenseOptions: {
         quickSuggestions: {

--- a/src/client/datascience/webViewHost.ts
+++ b/src/client/datascience/webViewHost.ts
@@ -50,7 +50,8 @@ export abstract class WebViewHost<IMapping> implements IDisposable {
         @unmanaged() private scripts: string[],
         @unmanaged() private title: string,
         @unmanaged() private viewColumn: ViewColumn,
-        @unmanaged() private readonly useWebViewServer: boolean
+        @unmanaged() private readonly useWebViewServer: boolean,
+        @unmanaged() protected readonly useCustomEditorApi: boolean
     ) {
         // Create our message listener for our web panel.
         this.messageListener = messageListenerCtor(
@@ -193,7 +194,8 @@ export abstract class WebViewHost<IMapping> implements IDisposable {
                     fontSize: this.getValue(editor, 'fontSize', 14),
                     fontFamily: this.getValue(editor, 'fontFamily', "Consolas, 'Courier New', monospace")
                 },
-                theme: theme
+                theme: theme,
+                useCustomEditorApi: this.useCustomEditorApi
             },
             intellisenseOptions: {
                 quickSuggestions: {

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -19,7 +19,7 @@ import { CellOutput } from '../interactive-common/cellOutput';
 import { ExecutionCount } from '../interactive-common/executionCount';
 import { InformationMessages } from '../interactive-common/informationMessages';
 import { CursorPos, ICellViewModel, IFont } from '../interactive-common/mainState';
-import { getOSType, UseCustomEditor } from '../react-common/constants';
+import { getOSType } from '../react-common/constants';
 import { IKeyboardEvent } from '../react-common/event';
 import { Image, ImageName } from '../react-common/image';
 import { ImageButton } from '../react-common/imageButton';
@@ -51,6 +51,7 @@ interface INativeCellBaseProps {
     themeMatplotlibPlots: boolean | undefined;
     focusPending: number;
     busy: boolean;
+    useCustomEditorApi: boolean;
 }
 
 type INativeCellProps = INativeCellBaseProps & typeof actionCreators;
@@ -356,7 +357,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 break;
             case 'z':
             case 'Z':
-                if (!this.isFocused() && !UseCustomEditor.enabled) {
+                if (!this.isFocused() && !this.props.useCustomEditorApi) {
                     if (e.shiftKey && !e.ctrlKey && !e.altKey) {
                         e.stopPropagation();
                         this.props.redo();
@@ -657,7 +658,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                         keyDown={this.keyDownInput}
                         showLineNumbers={this.props.cellVM.showLineNumbers}
                         font={this.props.font}
-                        disableUndoStack={UseCustomEditor.enabled}
+                        disableUndoStack={this.props.useCustomEditorApi}
                         codeVersion={this.props.cellVM.codeVersion ? this.props.cellVM.codeVersion : 1}
                         focusPending={this.props.focusPending}
                     />

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -11,7 +11,7 @@ import { handleLinkClick } from '../interactive-common/handlers';
 import { getSelectedAndFocusedInfo, ICellViewModel, IMainState } from '../interactive-common/mainState';
 import { IMainWithVariables, IStore } from '../interactive-common/redux/store';
 import { IVariablePanelProps, VariablePanel } from '../interactive-common/variablePanel';
-import { getOSType, UseCustomEditor } from '../react-common/constants';
+import { getOSType } from '../react-common/constants';
 import { ErrorBoundary } from '../react-common/errorBoundary';
 import { getLocString } from '../react-common/locReactSide';
 import { Progress } from '../react-common/progress';
@@ -193,7 +193,10 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             }
             case 'z':
             case 'Z':
-                if (!getSelectedAndFocusedInfo(this.props).focusedCellId && !UseCustomEditor.enabled) {
+                if (
+                    !getSelectedAndFocusedInfo(this.props).focusedCellId &&
+                    !this.props.settings?.extraSettings.useCustomEditorApi
+                ) {
                     if (event.shiftKey && !event.ctrlKey && !event.altKey) {
                         event.stopPropagation();
                         this.props.redo();
@@ -283,6 +286,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                         // Focus pending does not apply to native editor.
                         focusPending={0}
                         busy={this.props.busy}
+                        useCustomEditorApi={this.props.settings?.extraSettings.useCustomEditorApi}
                     />
                 </ErrorBoundary>
                 {lastLine}

--- a/src/datascience-ui/react-common/constants.ts
+++ b/src/datascience-ui/react-common/constants.ts
@@ -23,5 +23,3 @@ export function getOSType() {
         return OSType.Unknown;
     }
 }
-
-export const UseCustomEditor = { enabled: true };

--- a/src/datascience-ui/react-common/settingsReactSide.ts
+++ b/src/datascience-ui/react-common/settingsReactSide.ts
@@ -46,7 +46,8 @@ export function getDefaultSettings() {
                 fontSize: 14,
                 fontFamily: "Consolas, 'Courier New', monospace"
             },
-            theme: 'Default Dark+'
+            theme: 'Default Dark+',
+            useCustomEditorApi: false
         },
         intellisenseOptions: {
             quickSuggestions: {

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -38,7 +38,6 @@ import { ExecutionCount } from '../../datascience-ui/interactive-common/executio
 import { CommonActionType } from '../../datascience-ui/interactive-common/redux/reducers/types';
 import { NativeCell } from '../../datascience-ui/native-editor/nativeCell';
 import { NativeEditor } from '../../datascience-ui/native-editor/nativeEditor';
-import { UseCustomEditor } from '../../datascience-ui/react-common/constants';
 import { IKeyboardEvent } from '../../datascience-ui/react-common/event';
 import { ImageButton } from '../../datascience-ui/react-common/imageButton';
 import { IMonacoEditorState, MonacoEditor } from '../../datascience-ui/react-common/monacoEditor';
@@ -130,7 +129,6 @@ suite('DataScience Native Editor', () => {
                 };
 
                 setup(async () => {
-                    UseCustomEditor.enabled = useCustomEditorApi;
                     ioc = new DataScienceIocContainer();
                     ioc.registerDataScienceTypes(useCustomEditorApi);
                     await ioc.activate();
@@ -906,7 +904,6 @@ df.head()`;
                     cleanupCallback: Function;
                 };
                 function initIoc() {
-                    UseCustomEditor.enabled = useCustomEditorApi;
                     ioc = new DataScienceIocContainer();
                     ioc.registerDataScienceTypes(useCustomEditorApi);
                     return ioc.activate();

--- a/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
@@ -14,7 +14,6 @@ import * as path from 'path';
 import * as sinon from 'sinon';
 import { Disposable } from 'vscode';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
-import { UseCustomEditor } from '../../../datascience-ui/react-common/constants';
 import { retryIfFail as retryIfFailOriginal } from '../../common';
 import { mockedVSCodeNamespaces } from '../../vscode-mock';
 import { DataScienceIocContainer } from '../dataScienceIocContainer';
@@ -37,7 +36,6 @@ use(chaiAsPromised);
 
         suiteSetup(function () {
             // These are UI tests, hence nothing to do with platforms.
-            UseCustomEditor.enabled = useCustomEditorApi;
             this.timeout(30_000); // UI Tests, need time to start jupyter.
             if (!process.env.VSCODE_PYTHON_ROLLING) {
                 // Skip all tests unless using real jupyter
@@ -45,7 +43,6 @@ use(chaiAsPromised);
             }
         });
         setup(async () => {
-            UseCustomEditor.enabled = useCustomEditorApi;
             ioc = new DataScienceIocContainer(true);
             ioc.registerDataScienceTypes(useCustomEditorApi);
             await ioc.activate();


### PR DESCRIPTION
For #11160

UseCustomEditor was set to 'true' in the UI.

Changed the logic to use the actual computation we perform and pass it through settings.

When we actually switch to the custom editor we can just remove this.