### PR TITLE
Remove redundant step in autoselection

### DIFF
--- a/src/client/interpreter/autoSelection/index.ts
+++ b/src/client/interpreter/autoSelection/index.ts
@@ -135,15 +135,6 @@ export class InterpreterAutoSelectionService implements IInterpreterAutoSelectio
         return this.globallyPreferredInterpreter.value;
     }
     public async setWorkspaceInterpreter(resource: Uri, interpreter: PythonInterpreter | undefined) {
-        // We can only update the stored interpreter once we have done the necessary
-        // work of auto selecting the interpreters.
-        if (
-            !this.autoSelectedWorkspacePromises.has(this.getWorkspacePathKey(resource)) ||
-            !this.autoSelectedWorkspacePromises.get(this.getWorkspacePathKey(resource))!.completed
-        ) {
-            return;
-        }
-
         await this.storeAutoSelectedInterpreter(resource, interpreter);
     }
     public async setGlobalInterpreter(interpreter: PythonInterpreter) {

--- a/src/test/interpreters/autoSelection/index.unit.test.ts
+++ b/src/test/interpreters/autoSelection/index.unit.test.ts
@@ -319,26 +319,6 @@ suite('Interpreters - Auto Selection', () => {
         expect(selectedInterpreter).to.deep.equal(interpreterInfo);
         expect(eventFired).to.deep.equal(false, 'event fired');
     });
-    test('Storing workspace interpreter info in state store should fail', async () => {
-        const pythonPath = 'Hello World';
-        const interpreterInfo = { path: pythonPath } as any;
-        const resource = Uri.parse('one');
-        when(
-            stateFactory.createGlobalPersistentState<PythonInterpreter | undefined>(
-                preferredGlobalInterpreter,
-                undefined
-            )
-        ).thenReturn(instance(state));
-        when(workspaceService.getWorkspaceFolder(resource)).thenReturn({ name: '', index: 0, uri: resource });
-        when(workspaceService.getWorkspaceFolderIdentifier(anything(), anything())).thenReturn('');
-
-        await autoSelectionService.initializeStore(undefined);
-        await autoSelectionService.setWorkspaceInterpreter(resource, interpreterInfo);
-        const selectedInterpreter = autoSelectionService.getAutoSelectedInterpreter(resource);
-
-        verify(state.updateValue(interpreterInfo)).never();
-        expect(selectedInterpreter ? selectedInterpreter : undefined).to.deep.equal(undefined, 'not undefined');
-    });
     test('Store workspace interpreter info in state store', async () => {
         const pythonPath = 'Hello World';
         const interpreterInfo = { path: pythonPath } as any;


### PR DESCRIPTION
The original intent of this step is unclear. cc @DonJayamanne 

But it causes a bug with auto-selection process, described below.

- We call the autoselection process.
- We don't set the workspace interpreter (call it `w`) and simply return because auto selecting the interpreters has not finished.
- Because no workspace interpreter is set, autoselection process chooses a global interpreter as preferred one. (call it `g`)
- Autoselection process is called again from some other place in the extension.
- This time workspace intepreter is set because auto selecting the interpreters had already taken place.
- Because workspace interpreter is set, autoselection process changes the preferred interpreter from global interpreter to workspace one.

So user will first see the interpreter `g` selected, which will then change to `w` when the extension is loading, which is not ideal.

NOTE: This bug is only exposed just now due to some other changes made in other parts of autoselection process, so you may not have seen it before.