### PR TITLE
Retry ipywidget tests

### DIFF
--- a/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
@@ -37,6 +37,7 @@ use(chaiAsPromised);
         suiteSetup(function () {
             // These are UI tests, hence nothing to do with platforms.
             this.timeout(30_000); // UI Tests, need time to start jupyter.
+            this.retries(3); // UI tests can be flaky.
             if (!process.env.VSCODE_PYTHON_ROLLING) {
                 // Skip all tests unless using real jupyter
                 this.skip();


### PR DESCRIPTION
A number of the IPyWidget tests are failing on the flaky pipeline.
Ensured tests are re-tried.