### PR TITLE
Fix failing unit tests on windows

### DIFF
--- a/src/test/common/terminals/synchronousTerminalService.unit.test.ts
+++ b/src/test/common/terminals/synchronousTerminalService.unit.test.ts
@@ -107,14 +107,7 @@ suite('Terminal Service (synchronous)', () => {
             verify(
                 terminalService.sendCommand(
                     'python',
-                    deepEqual([
-                        isolated.fileToCommandArgument(),
-                        shellExecFile.fileToCommandArgument(),
-                        'cmd'.fileToCommandArgument(),
-                        '1',
-                        '2',
-                        tmpFile.filePath.fileToCommandArgument()
-                    ])
+                    deepEqual([isolated, shellExecFile, 'cmd', '1', '2', tmpFile.filePath.fileToCommandArgument()])
                 )
             ).once();
         }).timeout(1_000);
@@ -150,14 +143,7 @@ suite('Terminal Service (synchronous)', () => {
             verify(
                 terminalService.sendCommand(
                     'python',
-                    deepEqual([
-                        isolated.fileToCommandArgument(),
-                        shellExecFile.fileToCommandArgument(),
-                        'cmd'.fileToCommandArgument(),
-                        '1',
-                        '2',
-                        tmpFile.filePath.fileToCommandArgument()
-                    ])
+                    deepEqual([isolated, shellExecFile, 'cmd', '1', '2', tmpFile.filePath.fileToCommandArgument()])
                 )
             ).once();
         }).timeout(2_000);

--- a/src/test/interpreters/activation/terminalEnvironmentActivationService.unit.test.ts
+++ b/src/test/interpreters/activation/terminalEnvironmentActivationService.unit.test.ts
@@ -104,11 +104,7 @@ suite('Interpreters Activation - Python Environment Variables (using terminals)'
                         verify(
                             terminal.sendCommand(
                                 cmd,
-                                deepEqual([
-                                    isolated.fileToCommandArgument(),
-                                    pyFile.fileToCommandArgument(),
-                                    jsonFile.fileToCommandArgument()
-                                ]),
+                                deepEqual([isolated, pyFile, jsonFile.fileToCommandArgument()]),
                                 anything(),
                                 false
                             )


### PR DESCRIPTION
CI build has been failing since last thursday for the 6 tests fixed by this change.
https://dev.azure.com/ms/vscode-python/_build/results?buildId=74001&view=ms.vss-test-web.build-test-results-tab&runId=2243262&resultId=104539&paneView=debug

We have a need to share the insider's so I thought I'd just fix them. Assuming this passes on linux/mac as well, I think we don't need to convert the file paths to unix.