### PR TITLE
Fix pdf viewer so that we just ship the standalone version.

### DIFF
--- a/build/webpack/common.js
+++ b/build/webpack/common.js
@@ -27,7 +27,7 @@ exports.nodeModulesToExternalize = [
     'node-stream-zip',
     'xml2js',
     'vsls/vscode',
-    'pdfkit',
+    'pdfkit/js/pdfkit.standalone',
     'crypto-js',
     'fontkit',
     'linebreak',

--- a/build/webpack/webpack.extension.config.js
+++ b/build/webpack/webpack.extension.config.js
@@ -67,18 +67,16 @@ const config = {
     externals: ['vscode', 'commonjs', ...ppaPackageList, ...existingModulesInOutDir],
     plugins: [
         ...common.getDefaultPlugins('extension'),
-        // Copy pdfkit bits after extension builds. webpack can't handle pdfkit.
-        new FileManagerPlugin({
-            onEnd: [
-                {
-                    copy: [
-                        { source: './node_modules/fontkit/*.trie', destination: './out/client/node_modules' },
-                        { source: './node_modules/pdfkit/js/data/*.*', destination: './out/client/node_modules/data' },
-                        { source: './node_modules/pdfkit/js/pdfkit.js', destination: './out/client/node_modules/' }
-                    ]
-                }
-            ]
+        // Copy pdfkit after extension builds. webpack can't handle pdfkit.
+        new removeFilesWebpackPlugin({
+            after: { include: ['./out/client/node_modules/pdfkit/js/pdfkit.standalone.*'] }
         }),
+        new copyWebpackPlugin([
+            {
+                from: './node_modules/pdfkit/js/pdfkit.standalone.js',
+                to: './node_modules/pdfkit/js/pdfkit.standalone.js'
+            }
+        ]),
         // ZMQ requires prebuilds to be in our node_modules directory. So recreate the ZMQ structure.
         // However we don't webpack to manage this, so it was part of the excluded modules. Delete it from there
         // so at runtime we pick up the original structure.

--- a/news/2 Fixes/11157.md
+++ b/news/2 Fixes/11157.md
@@ -1,0 +1,1 @@
+Fix saving to PDF for viewed plots.

--- a/src/client/datascience/plotting/plotViewer.ts
+++ b/src/client/datascience/plotting/plotViewer.ts
@@ -147,7 +147,7 @@ export class PlotViewer extends WebViewHost<IPlotViewerMapping> implements IPlot
                         const SVGtoPDF = require('svg-to-pdfkit');
                         const deferred = createDeferred<void>();
                         // tslint:disable-next-line: no-require-imports
-                        const pdfkit = require('pdfkit') as typeof import('pdfkit');
+                        const pdfkit = require('pdfkit/js/pdfkit.standalone') as typeof import('pdfkit');
                         const doc = new pdfkit();
                         const ws = this.fileSystem.createWriteStream(file.fsPath);
                         traceInfo(`Writing pdf to ${file.fsPath}`);


### PR DESCRIPTION
For #11157

Recent update to pdfkit broke saving but only when the full extension is built. Fixed this to use the pdfkit.standalone which doesn't have any other dependencies so we don't have to special package up fontkit.