### PR TITLE
Fixes to telemetry Keyboard and mouse nb telemetry

### DIFF
--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -5,7 +5,6 @@
 import { PYTHON_LANGUAGE } from '../common/constants';
 import { IS_WINDOWS } from '../common/platform/constants';
 import { IVariableQuery } from '../common/types';
-import { NativeCommandType } from './interactive-common/interactiveWindowTypes';
 
 export const DefaultTheme = 'Default Light+';
 // Identifier for the output panel that will display the output from the Jupyter Server.
@@ -305,70 +304,40 @@ export enum Telemetry {
 }
 
 export enum NativeKeyboardCommandTelemetry {
-    AddToEnd = 'DATASCIENCE.NATIVE.KEYBOARD.ADD_TO_END',
     ArrowDown = 'DATASCIENCE.NATIVE.KEYBOARD.ARROW_DOWN',
     ArrowUp = 'DATASCIENCE.NATIVE.KEYBOARD.ARROW_UP',
     ChangeToCode = 'DATASCIENCE.NATIVE.KEYBOARD.CHANGE_TO_CODE',
     ChangeToMarkdown = 'DATASCIENCE.NATIVE.KEYBOARD.CHANGE_TO_MARKDOWN',
-    CollapseInput = 'DATASCIENCE.NATIVE.KEYBOARD.COLLAPSE_INPUT',
-    CollapseOutput = 'DATASCIENCE.NATIVE.KEYBOARD.COLLAPSE_OUTPUT',
     DeleteCell = 'DATASCIENCE.NATIVE.KEYBOARD.DELETE_CELL',
     InsertAbove = 'DATASCIENCE.NATIVE.KEYBOARD.INSERT_ABOVE',
     InsertBelow = 'DATASCIENCE.NATIVE.KEYBOARD.INSERT_BELOW',
-    MoveCellDown = 'DATASCIENCE.NATIVE.KEYBOARD.MOVE_CELL_DOWN',
-    MoveCellUp = 'DATASCIENCE.NATIVE.KEYBOARD.MOVE_CELL_UP',
+    Redo = 'DATASCIENCE.NATIVE.KEYBOARD.REDO',
     Run = 'DATASCIENCE.NATIVE.KEYBOARD.RUN',
     Save = 'DATASCIENCE.NATIVE.KEYBOARD.SAVE',
-    RunAbove = 'DATASCIENCE.NATIVE.KEYBOARD.RUN_ABOVE',
-    RunAll = 'DATASCIENCE.NATIVE.KEYBOARD.RUN_ALL',
     RunAndAdd = 'DATASCIENCE.NATIVE.KEYBOARD.RUN_AND_ADD',
     RunAndMove = 'DATASCIENCE.NATIVE.KEYBOARD.RUN_AND_MOVE',
-    RunBelow = 'DATASCIENCE.NATIVE.KEYBOARD.RUN_BELOW',
     ToggleLineNumbers = 'DATASCIENCE.NATIVE.KEYBOARD.TOGGLE_LINE_NUMBERS',
     ToggleOutput = 'DATASCIENCE.NATIVE.KEYBOARD.TOGGLE_OUTPUT',
-    ToggleVariableExplorer = 'DATASCIENCE.NATIVE.KEYBOARD.TOGGLE_VARIABLE_EXPLORER',
     Undo = 'DATASCIENCE.NATIVE.KEYBOARD.UNDO',
     Unfocus = 'DATASCIENCE.NATIVE.KEYBOARD.UNFOCUS'
 }
 
-export let NativeKeyboardCommandTelemetryLookup: { [id: number]: NativeKeyboardCommandTelemetry } = {};
-const keys = [...Object.keys(NativeCommandType)];
-const values1 = [...Object.values(NativeKeyboardCommandTelemetry)];
-for (let i = 0; i < keys.length; i += 1) {
-    NativeKeyboardCommandTelemetryLookup[i] = values1[i];
-}
-
 export enum NativeMouseCommandTelemetry {
     AddToEnd = 'DATASCIENCE.NATIVE.MOUSE.ADD_TO_END',
-    ArrowDown = 'DATASCIENCE.NATIVE.MOUSE.ARROW_DOWN',
-    ArrowUp = 'DATASCIENCE.NATIVE.MOUSE.ARROW_UP',
     ChangeToCode = 'DATASCIENCE.NATIVE.MOUSE.CHANGE_TO_CODE',
     ChangeToMarkdown = 'DATASCIENCE.NATIVE.MOUSE.CHANGE_TO_MARKDOWN',
-    CollapseInput = 'DATASCIENCE.NATIVE.MOUSE.COLLAPSE_INPUT',
-    CollapseOutput = 'DATASCIENCE.NATIVE.MOUSE.COLLAPSE_OUTPUT',
     DeleteCell = 'DATASCIENCE.NATIVE.MOUSE.DELETE_CELL',
-    InsertAbove = 'DATASCIENCE.NATIVE.MOUSE.INSERT_ABOVE',
     InsertBelow = 'DATASCIENCE.NATIVE.MOUSE.INSERT_BELOW',
     MoveCellDown = 'DATASCIENCE.NATIVE.MOUSE.MOVE_CELL_DOWN',
     MoveCellUp = 'DATASCIENCE.NATIVE.MOUSE.MOVE_CELL_UP',
     Run = 'DATASCIENCE.NATIVE.MOUSE.RUN',
     RunAbove = 'DATASCIENCE.NATIVE.MOUSE.RUN_ABOVE',
     RunAll = 'DATASCIENCE.NATIVE.MOUSE.RUN_ALL',
-    RunAndAdd = 'DATASCIENCE.NATIVE.MOUSE.RUN_AND_ADD',
-    RunAndMove = 'DATASCIENCE.NATIVE.MOUSE.RUN_AND_MOVE',
     RunBelow = 'DATASCIENCE.NATIVE.MOUSE.RUN_BELOW',
+    SelectKernel = 'DATASCIENCE.NATIVE.MOUSE.SELECT_KERNEL',
+    SelectServer = 'DATASCIENCE.NATIVE.MOUSE.SELECT_SERVER',
     Save = 'DATASCIENCE.NATIVE.MOUSE.SAVE',
-    ToggleLineNumbers = 'DATASCIENCE.NATIVE.MOUSE.TOGGLE_LINE_NUMBERS',
-    ToggleOutput = 'DATASCIENCE.NATIVE.MOUSE.TOGGLE_OUTPUT',
-    ToggleVariableExplorer = 'DATASCIENCE.NATIVE.MOUSE.TOGGLE_VARIABLE_EXPLORER',
-    Undo = 'DATASCIENCE.NATIVE.MOUSE.UNDO',
-    Unfocus = 'DATASCIENCE.NATIVE.MOUSE.UNFOCUS'
-}
-
-export let NativeMouseCommandTelemetryLookup: { [id: number]: NativeMouseCommandTelemetry } = {};
-const values2 = [...Object.values(NativeMouseCommandTelemetry)];
-for (let i = 0; i < keys.length; i += 1) {
-    NativeMouseCommandTelemetryLookup[i] = values2[i];
+    ToggleVariableExplorer = 'DATASCIENCE.NATIVE.MOUSE.TOGGLE_VARIABLE_EXPLORER'
 }
 
 export namespace HelpLinks {

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -13,6 +13,7 @@ import {
     LoadIPyWidgetClassLoadAction
 } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import { PythonInterpreter } from '../../interpreter/contracts';
+import { NativeKeyboardCommandTelemetry, NativeMouseCommandTelemetry } from '../constants';
 import { WidgetScriptSource } from '../ipywidgets/types';
 import { LiveKernelModel } from '../jupyter/kernels/types';
 import { CssMessages, IGetCssRequest, IGetCssResponse, IGetMonacoThemeRequest, SharedMessages } from '../messages';
@@ -141,35 +142,6 @@ export enum IPyWidgetMessages {
     IPyWidgets_MessageHookCall = 'IPyWidgets_MessageHookCall',
     IPyWidgets_MessageHookResult = 'IPyWidgets_MessageHookResult',
     IPyWidgets_mirror_execute = 'IPyWidgets_mirror_execute'
-}
-export enum NativeCommandType {
-    AddToEnd = 0,
-    ArrowDown,
-    ArrowUp,
-    ChangeToCode,
-    ChangeToMarkdown,
-    CollapseInput,
-    CollapseOutput,
-    DeleteCell,
-    Save,
-    InsertAbove,
-    InsertBelow,
-    MoveCellDown,
-    MoveCellUp,
-    Redo,
-    Run,
-    RunAbove,
-    RunAll,
-    RunAndAdd,
-    RunAndMove,
-    RunBelow,
-    SelectKernel,
-    SelectServer,
-    ToggleLineNumbers,
-    ToggleOutput,
-    ToggleVariableExplorer,
-    Undo,
-    Unfocus
 }
 
 // These are the messages that will mirror'd to guest/hosts in
@@ -338,8 +310,7 @@ export interface ISaveAll {
 }
 
 export interface INativeCommand {
-    command: NativeCommandType;
-    source: 'keyboard' | 'mouse';
+    command: NativeKeyboardCommandTelemetry | NativeMouseCommandTelemetry;
 }
 
 export interface IRenderComplete {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -44,13 +44,7 @@ import { StopWatch } from '../../common/utils/stopWatch';
 import { EXTENSION_ROOT_DIR } from '../../constants';
 import { PythonInterpreter } from '../../interpreter/contracts';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import {
-    EditorContexts,
-    Identifiers,
-    NativeKeyboardCommandTelemetryLookup,
-    NativeMouseCommandTelemetryLookup,
-    Telemetry
-} from '../constants';
+import { EditorContexts, Identifiers, Telemetry } from '../constants';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
 import {
     INativeCommand,
@@ -672,11 +666,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     }
 
     private logNativeCommand(args: INativeCommand) {
-        const telemetryEvent =
-            args.source === 'mouse'
-                ? NativeMouseCommandTelemetryLookup[args.command]
-                : NativeKeyboardCommandTelemetryLookup[args.command];
-        sendTelemetryEvent(telemetryEvent);
+        sendTelemetryEvent(args.command);
     }
 
     private async loadCellsComplete() {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1678,54 +1678,37 @@ export interface IEventNamePropertyMapping {
          */
         result?: 'notSelected' | 'selected' | 'installationCancelled';
     };
-    [NativeKeyboardCommandTelemetry.AddToEnd]: never | undefined;
     [NativeKeyboardCommandTelemetry.ArrowDown]: never | undefined;
     [NativeKeyboardCommandTelemetry.ArrowUp]: never | undefined;
     [NativeKeyboardCommandTelemetry.ChangeToCode]: never | undefined;
     [NativeKeyboardCommandTelemetry.ChangeToMarkdown]: never | undefined;
-    [NativeKeyboardCommandTelemetry.CollapseInput]: never | undefined;
-    [NativeKeyboardCommandTelemetry.CollapseOutput]: never | undefined;
     [NativeKeyboardCommandTelemetry.DeleteCell]: never | undefined;
     [NativeKeyboardCommandTelemetry.InsertAbove]: never | undefined;
     [NativeKeyboardCommandTelemetry.InsertBelow]: never | undefined;
-    [NativeKeyboardCommandTelemetry.MoveCellDown]: never | undefined;
-    [NativeKeyboardCommandTelemetry.MoveCellUp]: never | undefined;
+    [NativeKeyboardCommandTelemetry.Redo]: never | undefined;
     [NativeKeyboardCommandTelemetry.Run]: never | undefined;
-    [NativeKeyboardCommandTelemetry.RunAbove]: never | undefined;
-    [NativeKeyboardCommandTelemetry.RunAll]: never | undefined;
     [NativeKeyboardCommandTelemetry.RunAndAdd]: never | undefined;
     [NativeKeyboardCommandTelemetry.RunAndMove]: never | undefined;
-    [NativeKeyboardCommandTelemetry.RunBelow]: never | undefined;
     [NativeKeyboardCommandTelemetry.Save]: never | undefined;
     [NativeKeyboardCommandTelemetry.ToggleLineNumbers]: never | undefined;
     [NativeKeyboardCommandTelemetry.ToggleOutput]: never | undefined;
-    [NativeKeyboardCommandTelemetry.ToggleVariableExplorer]: never | undefined;
     [NativeKeyboardCommandTelemetry.Undo]: never | undefined;
     [NativeKeyboardCommandTelemetry.Unfocus]: never | undefined;
     [NativeMouseCommandTelemetry.AddToEnd]: never | undefined;
-    [NativeMouseCommandTelemetry.ArrowDown]: never | undefined;
-    [NativeMouseCommandTelemetry.ArrowUp]: never | undefined;
     [NativeMouseCommandTelemetry.ChangeToCode]: never | undefined;
     [NativeMouseCommandTelemetry.ChangeToMarkdown]: never | undefined;
-    [NativeMouseCommandTelemetry.CollapseInput]: never | undefined;
-    [NativeMouseCommandTelemetry.CollapseOutput]: never | undefined;
     [NativeMouseCommandTelemetry.DeleteCell]: never | undefined;
-    [NativeMouseCommandTelemetry.InsertAbove]: never | undefined;
     [NativeMouseCommandTelemetry.InsertBelow]: never | undefined;
     [NativeMouseCommandTelemetry.MoveCellDown]: never | undefined;
     [NativeMouseCommandTelemetry.MoveCellUp]: never | undefined;
     [NativeMouseCommandTelemetry.Run]: never | undefined;
     [NativeMouseCommandTelemetry.RunAbove]: never | undefined;
     [NativeMouseCommandTelemetry.RunAll]: never | undefined;
-    [NativeMouseCommandTelemetry.RunAndAdd]: never | undefined;
-    [NativeMouseCommandTelemetry.RunAndMove]: never | undefined;
     [NativeMouseCommandTelemetry.RunBelow]: never | undefined;
     [NativeMouseCommandTelemetry.Save]: never | undefined;
-    [NativeMouseCommandTelemetry.ToggleLineNumbers]: never | undefined;
-    [NativeMouseCommandTelemetry.ToggleOutput]: never | undefined;
+    [NativeMouseCommandTelemetry.SelectKernel]: never | undefined;
+    [NativeMouseCommandTelemetry.SelectServer]: never | undefined;
     [NativeMouseCommandTelemetry.ToggleVariableExplorer]: never | undefined;
-    [NativeMouseCommandTelemetry.Undo]: never | undefined;
-    [NativeMouseCommandTelemetry.Unfocus]: never | undefined;
     /*
     Telemetry event sent with details of Jedi Memory usage.
     mem_use - Memory usage of Process in kb.

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -55,8 +55,7 @@ export namespace Transfer {
 
     export function sendCommand(arg: CommonReducerArg<CommonActionType, ISendCommandAction>): IMainState {
         postActionToExtension(arg, InteractiveWindowMessages.NativeCommand, {
-            command: arg.payload.data.command,
-            source: arg.payload.data.commandType
+            command: arg.payload.data.command
         });
         return arg.prevState;
     }

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 'use strict';
 
+import { NativeKeyboardCommandTelemetry, NativeMouseCommandTelemetry } from '../../../../client/datascience/constants';
 import {
     IEditorContentChange,
     InteractiveWindowMessages,
-    IShowDataViewer,
-    NativeCommandType
+    IShowDataViewer
 } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { BaseReduxActionPayload } from '../../../../client/datascience/interactive-common/types';
 import { IJupyterVariablesRequest } from '../../../../client/datascience/types';
@@ -201,8 +201,7 @@ export interface IRefreshVariablesAction {
 export interface IShowDataViewerAction extends IShowDataViewer {}
 
 export interface ISendCommandAction {
-    commandType: 'mouse' | 'keyboard';
-    command: NativeCommandType;
+    command: NativeKeyboardCommandTelemetry | NativeMouseCommandTelemetry;
 }
 
 export interface IChangeCellTypeAction {

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -10,8 +10,11 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 
 import { OSType } from '../../client/common/utils/platform';
-import { Identifiers } from '../../client/datascience/constants';
-import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import {
+    Identifiers,
+    NativeKeyboardCommandTelemetry,
+    NativeMouseCommandTelemetry
+} from '../../client/datascience/constants';
 import { CellState } from '../../client/datascience/types';
 import { concatMultilineStringInput } from '../common';
 import { CellInput } from '../interactive-common/cellInput';
@@ -296,7 +299,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     e.preventDefault();
                     this.props.changeCellType(cellId);
-                    this.props.sendCommand(NativeCommandType.ChangeToCode, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.ChangeToCode);
                 }
                 break;
             case 'm':
@@ -304,7 +307,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     e.preventDefault();
                     this.props.changeCellType(cellId);
-                    this.props.sendCommand(NativeCommandType.ChangeToMarkdown, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.ChangeToMarkdown);
                 }
                 break;
             case 'l':
@@ -312,7 +315,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     e.preventDefault();
                     this.props.toggleLineNumbers(cellId);
-                    this.props.sendCommand(NativeCommandType.ToggleLineNumbers, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.ToggleLineNumbers);
                 }
                 break;
             case 'o':
@@ -320,7 +323,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     e.preventDefault();
                     this.props.toggleOutput(cellId);
-                    this.props.sendCommand(NativeCommandType.ToggleOutput, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.ToggleOutput);
                 }
                 break;
             case 'NumpadEnter':
@@ -340,7 +343,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     this.lastKeyPressed = undefined; // Reset it so we don't keep deleting
                     this.props.deleteCell(cellId);
-                    this.props.sendCommand(NativeCommandType.DeleteCell, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.DeleteCell);
                 }
                 break;
             case 'a':
@@ -348,7 +351,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     e.preventDefault();
                     setTimeout(() => this.props.insertAbove(cellId), 1);
-                    this.props.sendCommand(NativeCommandType.InsertAbove, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.InsertAbove);
                 }
                 break;
             case 'b':
@@ -356,7 +359,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     e.stopPropagation();
                     e.preventDefault();
                     setTimeout(() => this.props.insertBelow(cellId), 1);
-                    this.props.sendCommand(NativeCommandType.InsertBelow, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.InsertBelow);
                 }
                 break;
             case 'z':
@@ -365,11 +368,11 @@ export class NativeCell extends React.Component<INativeCellProps> {
                     if (e.shiftKey && !e.ctrlKey && !e.altKey) {
                         e.stopPropagation();
                         this.props.redo();
-                        this.props.sendCommand(NativeCommandType.Redo, 'keyboard');
+                        this.props.sendCommand(NativeKeyboardCommandTelemetry.Redo);
                     } else if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
                         e.stopPropagation();
                         this.props.undo();
-                        this.props.sendCommand(NativeCommandType.Undo, 'keyboard');
+                        this.props.sendCommand(NativeKeyboardCommandTelemetry.Undo);
                     }
                 }
                 break;
@@ -389,7 +392,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         if (this.wrapperRef && this.wrapperRef.current && this.isFocused()) {
             e.stopPropagation();
             this.wrapperRef.current.focus();
-            this.props.sendCommand(NativeCommandType.Unfocus, 'keyboard');
+            this.props.sendCommand(NativeKeyboardCommandTelemetry.Unfocus);
         }
     };
 
@@ -397,14 +400,14 @@ export class NativeCell extends React.Component<INativeCellProps> {
         e.stopPropagation();
         e.preventDefault();
         this.props.arrowUp(this.cellId, this.getCurrentCode());
-        this.props.sendCommand(NativeCommandType.ArrowUp, 'keyboard');
+        this.props.sendCommand(NativeKeyboardCommandTelemetry.ArrowUp);
     };
 
     private arrowDownFromCell = (e: IKeyboardEvent) => {
         e.stopPropagation();
         e.preventDefault();
         this.props.arrowDown(this.cellId, this.getCurrentCode());
-        this.props.sendCommand(NativeCommandType.ArrowDown, 'keyboard');
+        this.props.sendCommand(NativeKeyboardCommandTelemetry.ArrowDown);
     };
 
     private enterCell = (e: IKeyboardEvent) => {
@@ -424,7 +427,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         // Submit and move to the next.
         this.runAndMove();
 
-        this.props.sendCommand(NativeCommandType.RunAndMove, 'keyboard');
+        this.props.sendCommand(NativeKeyboardCommandTelemetry.RunAndMove);
     };
 
     private altEnterCell = (e: IKeyboardEvent) => {
@@ -435,7 +438,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
         // Submit this cell
         this.runAndAdd();
 
-        this.props.sendCommand(NativeCommandType.RunAndAdd, 'keyboard');
+        this.props.sendCommand(NativeKeyboardCommandTelemetry.RunAndAdd);
     };
 
     private runAndMove() {
@@ -460,7 +463,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
         // Submit this cell
         this.submitCell('none');
-        this.props.sendCommand(NativeCommandType.Run, 'keyboard');
+        this.props.sendCommand(NativeKeyboardCommandTelemetry.Run);
     };
 
     private submitCell = (moveOp: 'add' | 'select' | 'none') => {
@@ -469,23 +472,27 @@ export class NativeCell extends React.Component<INativeCellProps> {
 
     private addNewCell = () => {
         setTimeout(() => this.props.insertBelow(this.cellId), 1);
-        this.props.sendCommand(NativeCommandType.AddToEnd, 'mouse');
+        this.props.sendCommand(NativeMouseCommandTelemetry.AddToEnd);
+    };
+    private addNewCellBelow = () => {
+        setTimeout(() => this.props.insertBelow(this.cellId), 1);
+        this.props.sendCommand(NativeMouseCommandTelemetry.InsertBelow);
     };
 
     private renderNavbar = () => {
         const moveUp = () => {
             this.props.moveCellUp(this.cellId);
-            this.props.sendCommand(NativeCommandType.MoveCellUp, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.MoveCellUp);
         };
         const moveDown = () => {
             this.props.moveCellDown(this.cellId);
-            this.props.sendCommand(NativeCommandType.MoveCellDown, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.MoveCellDown);
         };
         const addButtonRender = !this.props.lastCell ? (
             <div className="navbar-add-button">
                 <ImageButton
                     baseTheme={this.props.baseTheme}
-                    onClick={this.addNewCell}
+                    onClick={this.addNewCellBelow}
                     tooltip={getLocString('DataScience.insertBelow', 'Insert cell below')}
                 >
                     <Image baseTheme={this.props.baseTheme} class="image-button-image" image={ImageName.InsertBelow} />
@@ -549,14 +556,14 @@ export class NativeCell extends React.Component<INativeCellProps> {
         const cellId = this.props.cellVM.cell.id;
         const runCell = () => {
             this.runAndMove();
-            this.props.sendCommand(NativeCommandType.Run, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.Run);
         };
         const gatherCell = () => {
             this.props.gatherCell(cellId);
         };
         const deleteCell = () => {
             this.props.deleteCell(cellId);
-            this.props.sendCommand(NativeCommandType.DeleteCell, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.DeleteCell);
         };
         const gatherDisabled =
             this.props.cellVM.cell.data.execution_count === null ||
@@ -571,7 +578,9 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 : getLocString('DataScience.switchToCode', 'Change to code');
         const otherCellType = this.props.cellVM.cell.data.cell_type === 'code' ? 'markdown' : 'code';
         const otherCellTypeCommand =
-            otherCellType === 'markdown' ? NativeCommandType.ChangeToMarkdown : NativeCommandType.ChangeToCode;
+            otherCellType === 'markdown'
+                ? NativeMouseCommandTelemetry.ChangeToMarkdown
+                : NativeMouseCommandTelemetry.ChangeToCode;
         const otherCellImage = otherCellType === 'markdown' ? ImageName.SwitchToMarkdown : ImageName.SwitchToCode;
         const switchCellType = (event: React.MouseEvent<HTMLButtonElement>) => {
             // Prevent this mouse click from stealing focus so that we
@@ -579,7 +588,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
             event.stopPropagation();
             event.preventDefault();
             this.props.changeCellType(cellId);
-            this.props.sendCommand(otherCellTypeCommand, 'mouse');
+            this.props.sendCommand(otherCellTypeCommand);
         };
         const toolbarClassName = this.props.cellVM.cell.data.cell_type === 'code' ? '' : 'markdown-toolbar';
 

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { OSType } from '../../client/common/utils/platform';
-import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { NativeKeyboardCommandTelemetry, NativeMouseCommandTelemetry } from '../../client/datascience/constants';
 import { buildSettingsCss } from '../interactive-common/buildSettingsCss';
 import { ContentPanel, IContentPanelProps } from '../interactive-common/contentPanel';
 import { handleLinkClick } from '../interactive-common/handlers';
@@ -187,7 +187,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                 if ((event.ctrlKey && getOSType() !== OSType.OSX) || (event.metaKey && getOSType() === OSType.OSX)) {
                     // This is save, save our cells
                     this.props.save();
-                    this.props.sendCommand(NativeCommandType.Save, 'keyboard');
+                    this.props.sendCommand(NativeKeyboardCommandTelemetry.Save);
                 }
                 break;
             }
@@ -200,11 +200,11 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                     if (event.shiftKey && !event.ctrlKey && !event.altKey) {
                         event.stopPropagation();
                         this.props.redo();
-                        this.props.sendCommand(NativeCommandType.Redo, 'keyboard');
+                        this.props.sendCommand(NativeKeyboardCommandTelemetry.Redo);
                     } else if (!event.shiftKey && !event.altKey && !event.ctrlKey) {
                         event.stopPropagation();
                         this.props.undo();
-                        this.props.sendCommand(NativeCommandType.Undo, 'keyboard');
+                        this.props.sendCommand(NativeKeyboardCommandTelemetry.Undo);
                     }
                 }
                 break;
@@ -252,7 +252,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
         }
         const addNewCell = () => {
             setTimeout(() => this.props.insertBelow(cellVM.cell.id), 1);
-            this.props.sendCommand(NativeCommandType.AddToEnd, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.AddToEnd);
         };
         const firstLine = index === 0;
         const lastLine =

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 'use strict';
 import * as uuid from 'uuid/v4';
+import { NativeKeyboardCommandTelemetry, NativeMouseCommandTelemetry } from '../../../client/datascience/constants';
 import {
     IInteractiveWindowMapping,
-    InteractiveWindowMessages,
-    NativeCommandType
+    InteractiveWindowMessages
 } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterVariable, IJupyterVariablesRequest } from '../../../client/datascience/types';
 import { CursorPos } from '../../interactive-common/mainState';
@@ -74,8 +74,9 @@ export const actionCreators = {
     save: (): CommonAction => createIncomingAction(CommonActionType.SAVE),
     showDataViewer: (variable: IJupyterVariable, columnSize: number): CommonAction<IShowDataViewerAction> =>
         createIncomingActionWithPayload(CommonActionType.SHOW_DATA_VIEWER, { variable, columnSize }),
-    sendCommand: (command: NativeCommandType, commandType: 'mouse' | 'keyboard'): CommonAction<ISendCommandAction> =>
-        createIncomingActionWithPayload(CommonActionType.SEND_COMMAND, { command, commandType }),
+    sendCommand: (
+        command: NativeKeyboardCommandTelemetry | NativeMouseCommandTelemetry
+    ): CommonAction<ISendCommandAction> => createIncomingActionWithPayload(CommonActionType.SEND_COMMAND, { command }),
     moveCellUp: (cellId: string): CommonAction<ICellAction> =>
         createIncomingActionWithPayload(CommonActionType.MOVE_CELL_UP, { cellId }),
     moveCellDown: (cellId: string): CommonAction<ICellAction> =>

--- a/src/datascience-ui/native-editor/toolbar.tsx
+++ b/src/datascience-ui/native-editor/toolbar.tsx
@@ -3,7 +3,7 @@
 'use strict';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { NativeCommandType } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { NativeMouseCommandTelemetry } from '../../client/datascience/constants';
 import { KernelSelection } from '../interactive-common/kernelSelection';
 import {
     getSelectedAndFocusedInfo,
@@ -66,20 +66,20 @@ export class Toolbar extends React.PureComponent<INativeEditorToolbarProps> {
 
         const addCell = () => {
             setTimeout(() => this.props.addCell(), 1);
-            this.props.sendCommand(NativeCommandType.AddToEnd, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.AddToEnd);
         };
         const runAll = () => {
             // Run all cells currently available.
             this.props.executeAllCells();
-            this.props.sendCommand(NativeCommandType.RunAll, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.RunAll);
         };
         const save = () => {
             this.props.save();
-            this.props.sendCommand(NativeCommandType.Save, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.Save);
         };
         const toggleVariableExplorer = () => {
             this.props.toggleVariableExplorer();
-            this.props.sendCommand(NativeCommandType.ToggleVariableExplorer, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.ToggleVariableExplorer);
         };
         const variableExplorerTooltip = this.props.variablesVisible
             ? getLocString('DataScience.collapseVariableExplorerTooltip', 'Hide variables active in jupyter kernel')
@@ -87,7 +87,7 @@ export class Toolbar extends React.PureComponent<INativeEditorToolbarProps> {
         const runAbove = () => {
             if (selectedInfo.selectedCellId) {
                 this.props.executeAbove(selectedInfo.selectedCellId);
-                this.props.sendCommand(NativeCommandType.RunAbove, 'mouse');
+                this.props.sendCommand(NativeMouseCommandTelemetry.RunAbove);
             }
         };
         const runBelow = () => {
@@ -95,16 +95,16 @@ export class Toolbar extends React.PureComponent<INativeEditorToolbarProps> {
                 // tslint:disable-next-line: no-suspicious-comment
                 // TODO: Is the source going to be up to date during run below?
                 this.props.executeCellAndBelow(selectedInfo.selectedCellId);
-                this.props.sendCommand(NativeCommandType.RunBelow, 'mouse');
+                this.props.sendCommand(NativeMouseCommandTelemetry.RunBelow);
             }
         };
         const selectKernel = () => {
             this.props.selectKernel();
-            this.props.sendCommand(NativeCommandType.SelectKernel, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.SelectKernel);
         };
         const selectServer = () => {
             this.props.selectServer();
-            this.props.sendCommand(NativeCommandType.SelectServer, 'mouse');
+            this.props.sendCommand(NativeMouseCommandTelemetry.SelectServer);
         };
         const canRunAbove = (selectedInfo.selectedCellIndex ?? -1) > 0;
         const canRunBelow =


### PR DESCRIPTION
For #10809 

* Changed to use enums (strongly typed) without any mapping of values.
* We can now see (find references etc) where telemetry is used/sent (instead of string search).
* Removed redundant telemetry (e.g. keyboard to move cells up/down, this can only be done via mouse)
* Added missing telemetry (due to mapping we had missed some telemetry, now that its strongly typed we shouldn't have this problem)