### PR TITLE
Error line numbers coming out with invalid values

### DIFF
--- a/news/2 Fixes/10708.md
+++ b/news/2 Fixes/10708.md
@@ -1,0 +1,1 @@
+Make error links in exception tracebacks support multiple cells in the stack and extra spaces.

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -27,7 +27,6 @@ import {
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp');
-
 const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)/g;
 
 interface IRangedCellHash extends ICellHash {
@@ -219,7 +218,7 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
                 endOffset,
                 deleted: false,
                 code: hashedCode,
-                trimmedRightCode: stripped.map((s) => s.replace(/[ \t\r]+$/g, '')).join(''),
+                trimmedRightCode: stripped.map((s) => s.replace(/[ \t\r]+\n$/g, '\n')).join(''),
                 realCode,
                 runtimeLine,
                 id: cell.id

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
+import type { KernelMessage } from '@jupyterlab/services';
 import * as hashjs from 'hash.js';
 import { inject, injectable, multiInject, optional } from 'inversify';
+import stripAnsi from 'strip-ansi';
 import { Event, EventEmitter, Position, Range, TextDocumentChangeEvent, TextDocumentContentChangeEvent } from 'vscode';
 
 import { splitMultilineString } from '../../../datascience-ui/common';
@@ -23,12 +25,19 @@ import {
     INotebookExecutionLogger
 } from '../types';
 
+// tslint:disable-next-line:no-require-imports no-var-requires
+const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp');
+
+const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)/g;
+
 interface IRangedCellHash extends ICellHash {
     code: string;
     startOffset: number;
     endOffset: number;
     deleted: boolean;
     realCode: string;
+    trimmedRightCode: string;
+    firstNonBlankLineIndex: number; // zero based. First non blank line of the real code.
 }
 
 // This class provides hashes for debugging jupyter cells. Call getHashes just before starting debugging to compute all of the
@@ -45,6 +54,7 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
     private executionCount: number = 0;
     private hashes: Map<string, IRangedCellHash[]> = new Map<string, IRangedCellHash[]>();
     private updateEventEmitter: EventEmitter<void> = new EventEmitter<void>();
+    private traceBackRegexes = new Map<string, RegExp>();
 
     constructor(
         @inject(IDocumentManager) private documentManager: IDocumentManager,
@@ -59,6 +69,7 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
 
     public dispose() {
         this.hashes.clear();
+        this.traceBackRegexes.clear();
     }
 
     public get updated(): Event<void> {
@@ -83,6 +94,7 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
 
     public onKernelRestarted() {
         this.hashes.clear();
+        this.traceBackRegexes.clear();
         this.executionCount = 0;
         this.updateEventEmitter.fire();
     }
@@ -110,6 +122,21 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
 
     public async postExecute(_cell: ICell, _silent: boolean): Promise<void> {
         noop();
+    }
+
+    public preHandleIOPub(msg: KernelMessage.IIOPubMessage): KernelMessage.IIOPubMessage {
+        // When an error message comes, rewrite the traceback so we can jump back to the correct
+        // cell. For now this only works with the interactive window
+        if (msg.header.msg_type === 'error') {
+            return {
+                ...msg,
+                content: {
+                    ...msg.content,
+                    traceback: this.modifyTraceback(msg as KernelMessage.IErrorMsg)
+                }
+            };
+        }
+        return msg;
     }
 
     public extractExecutableLines(cell: ICell): string[] {
@@ -143,6 +170,12 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
             }
             const line = doc.lineAt(trueStartLine);
             const endLine = doc.lineAt(Math.min(trueStartLine + stripped.length - 1, doc.lineCount - 1));
+
+            // Find the first non blank line
+            let firstNonBlankIndex = 0;
+            while (firstNonBlankIndex < stripped.length && stripped[firstNonBlankIndex].trim().length === 0) {
+                firstNonBlankIndex += 1;
+            }
 
             // Use the original values however to track edits. This is what we need
             // to move around
@@ -180,11 +213,13 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
                 hash: hashjs.sha1().update(hashedCode).digest('hex').substr(0, 12),
                 line: line.lineNumber + 1,
                 endLine: endLine.lineNumber + 1,
+                firstNonBlankLineIndex: firstNonBlankIndex + trueStartLine,
                 executionCount: expectedCount,
                 startOffset,
                 endOffset,
                 deleted: false,
                 code: hashedCode,
+                trimmedRightCode: stripped.map((s) => s.replace(/[ \t\r]+$/g, '')).join(''),
                 realCode,
                 runtimeLine,
                 id: cell.id
@@ -216,6 +251,15 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
                 list.push(hash);
             }
             this.hashes.set(cell.file, list);
+
+            // Save a regex to find this file later when looking for
+            // exceptions in output
+            if (!this.traceBackRegexes.has(cell.file)) {
+                const fileDisplayName = this.fileSystem.getDisplayName(cell.file);
+                const escaped = _escapeRegExp(fileDisplayName);
+                const fileMatchRegex = new RegExp(`\\[.*?;32m${escaped}`);
+                this.traceBackRegexes.set(cell.file, fileMatchRegex);
+            }
 
             // Tell listeners we have new hashes.
             if (this.listeners) {
@@ -305,5 +349,61 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
         }
         // No breakpoint necessary, start on the first line
         return 1;
+    }
+
+    // This function will modify a traceback from an error message.
+    // Tracebacks take a form like so:
+    // "[1;31m---------------------------------------------------------------------------[0m"
+    // "[1;31mZeroDivisionError[0m                         Traceback (most recent call last)"
+    // "[1;32md:\Training\SnakePython\foo.py[0m in [0;36m<module>[1;34m[0m\n[0;32m      1[0m [0mprint[0m[1;33m([0m[1;34m'some more'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [1;32m----> 2[1;33m [0mcause_error[0m[1;33m([0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0m"
+    // "[1;32md:\Training\SnakePython\foo.py[0m in [0;36mcause_error[1;34m()[0m\n[0;32m      3[0m     [0mprint[0m[1;33m([0m[1;34m'error'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0;32m      4[0m     [0mprint[0m[1;33m([0m[1;34m'now'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [1;32m----> 5[1;33m     [0mprint[0m[1;33m([0m [1;36m1[0m [1;33m/[0m [1;36m0[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0m"
+    // "[1;31mZeroDivisionError[0m: division by zero"
+    // Each item in the array being a stack frame.
+    private modifyTraceback(msg: KernelMessage.IErrorMsg): string[] {
+        // Do one frame at a time.
+        return msg.content.traceback ? msg.content.traceback.map(this.modifyTracebackFrame.bind(this)) : [];
+    }
+
+    private findCellOffset(hashes: IRangedCellHash[] | undefined, codeLines: string): number | undefined {
+        if (hashes) {
+            // Go through all cell code looking for these code lines exactly
+            // (although with right side trimmed as that's what a stack trace does)
+            for (const hash of hashes) {
+                const index = hash.trimmedRightCode.indexOf(codeLines);
+                if (index >= 0) {
+                    // Jupyter isn't counting blank lines at the top so use our
+                    // first non blank line
+                    return hash.firstNonBlankLineIndex;
+                }
+            }
+        }
+        // No hash found
+        return undefined;
+    }
+
+    private modifyTracebackFrame(traceFrame: string): string {
+        // See if this item matches any of our cell files
+        const regexes = [...this.traceBackRegexes.entries()];
+        const match = regexes.find((e) => e[1].test(traceFrame));
+        if (match) {
+            // We have a match, pull out the source lines
+            let sourceLines = '';
+            const regex = /(;32m[ ->]*?)(\d+)(.*)/g;
+            for (let l = regex.exec(traceFrame); l && l.length > 3; l = regex.exec(traceFrame)) {
+                const newLine = stripAnsi(l[3]).substr(1); // Seem to have a space on the front
+                sourceLines = `${sourceLines}${newLine}\n`;
+            }
+
+            // Now attempt to find a cell that matches these source lines
+            const offset = this.findCellOffset(this.hashes.get(match[0]), sourceLines);
+            if (offset !== undefined) {
+                return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num) => {
+                    const n = parseInt(num, 10);
+                    const newLine = offset + n - 1;
+                    return `${prefix}<a href='file://${match[0]}?line=${newLine}'>${newLine + 1}</a>`;
+                });
+            }
+        }
+        return traceFrame;
     }
 }

--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -26,7 +26,7 @@ import {
 } from '../types';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
-const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp');
+const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp'); // NOSONAR
 const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)/g;
 
 interface IRangedCellHash extends ICellHash {
@@ -131,7 +131,7 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
                 ...msg,
                 content: {
                     ...msg.content,
-                    traceback: this.modifyTraceback(msg as KernelMessage.IErrorMsg)
+                    traceback: this.modifyTraceback(msg as KernelMessage.IErrorMsg) // NOSONAR
                 }
             };
         }

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -37,7 +37,7 @@ import {
     InterruptResult,
     KernelSocketInformation
 } from '../types';
-import { expandWorkingDir, modifyTraceback } from './jupyterUtils';
+import { expandWorkingDir } from './jupyterUtils';
 import { LiveKernelModel } from './kernels/types';
 
 // tslint:disable-next-line: no-require-imports
@@ -940,6 +940,9 @@ export class JupyterNotebookBase implements INotebook {
         // tslint:disable-next-line: no-any
         let result: Promise<any> = Promise.resolve();
 
+        // Let our loggers get a first crack at the message. They may change it
+        this.getLoggers().forEach((f) => (msg = f.preHandleIOPub ? f.preHandleIOPub(msg) : msg));
+
         // tslint:disable-next-line:no-require-imports
         const jupyterLab = require('@jupyterlab/services') as typeof import('@jupyterlab/services');
 
@@ -1366,7 +1369,7 @@ export class JupyterNotebookBase implements INotebook {
             output_type: 'error',
             ename: msg.content.ename,
             evalue: msg.content.evalue,
-            traceback: modifyTraceback(cell.file, this.fs.getDisplayName(cell.file), cell.line, msg.content.traceback)
+            traceback: msg.content.traceback
         };
         this.addToCellData(cell, output, clearState);
         cell.state = CellState.error;

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -6,16 +6,15 @@ import '../../common/extensions';
 import * as path from 'path';
 import { Uri } from 'vscode';
 
+import stripAnsi from 'strip-ansi';
 import { IWorkspaceService } from '../../common/application/types';
 import { IDataScienceSettings } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { SystemVariables } from '../../common/variables/systemVariables';
-import { Identifiers } from '../constants';
 import { getJupyterConnectionDisplayName } from '../jupyter/jupyterConnection';
 import { IConnection } from '../types';
 
-// tslint:disable-next-line:no-require-imports no-var-requires
-const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp');
+const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)/g;
 
 export function expandWorkingDir(
     workingDir: string | undefined,
@@ -63,43 +62,69 @@ export function createRemoteConnectionInfo(uri: string, settings: IDataScienceSe
     };
 }
 
-const LineMatchRegex = /(;32m[ ->]*?)(\d+)/g;
-const IPythonMatchRegex = /(<ipython-input.*?>)/g;
-
-function modifyLineNumbers(entry: string, file: string, startLine: number): string {
-    return entry.replace(LineMatchRegex, (_s, prefix, num) => {
-        const n = parseInt(num, 10);
-        const newLine = startLine + n;
-        return `${prefix}<a href='file://${file}?line=${newLine}'>${newLine + 1}</a>`;
-    });
-}
-
-function modifyTracebackEntry(
-    fileMatchRegex: RegExp,
-    file: string,
-    fileDisplayName: string,
-    startLine: number,
-    entry: string
-): string {
-    if (fileMatchRegex.test(entry)) {
-        return modifyLineNumbers(entry, file, startLine);
-    } else if (IPythonMatchRegex.test(entry)) {
-        const ipythonReplaced = entry.replace(IPythonMatchRegex, fileDisplayName);
-        return modifyLineNumbers(ipythonReplaced, file, startLine);
-    }
-    return entry;
-}
-
+// This function will modify a traceback from an error message.
+// Tracebacks take a form like so:
+// "[1;31m---------------------------------------------------------------------------[0m"
+// "[1;31mZeroDivisionError[0m                         Traceback (most recent call last)"
+// "[1;32md:\Training\SnakePython\foo.py[0m in [0;36m<module>[1;34m[0m\n[0;32m      1[0m [0mprint[0m[1;33m([0m[1;34m'some more'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [1;32m----> 2[1;33m [0mcause_error[0m[1;33m([0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0m"
+// "[1;32md:\Training\SnakePython\foo.py[0m in [0;36mcause_error[1;34m()[0m\n[0;32m      3[0m     [0mprint[0m[1;33m([0m[1;34m'error'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0;32m      4[0m     [0mprint[0m[1;33m([0m[1;34m'now'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [1;32m----> 5[1;33m     [0mprint[0m[1;33m([0m [1;36m1[0m [1;33m/[0m [1;36m0[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0m"
+// "[1;31mZeroDivisionError[0m: division by zero"
+// Each item in the array being a stack frame.
 export function modifyTraceback(
-    file: string,
-    fileDisplayName: string,
-    startLine: number,
-    traceback: string[]
+    traceback: string[],
+    traceBackRegexes: Map<string, RegExp>,
+    hashes: Map<string, { trimmedRightCode: string; firstNonBlankLineIndex: number }[]>
 ): string[] {
-    if (file && file !== Identifiers.EmptyFileName) {
-        const escaped = _escapeRegExp(fileDisplayName);
-        const fileMatchRegex = new RegExp(`\\[.*?;32m${escaped}`);
-        return traceback.map(modifyTracebackEntry.bind(undefined, fileMatchRegex, file, fileDisplayName, startLine));
+    // Do one frame at a time.
+    return traceback ? traceback.map(modifyTracebackFrame.bind(undefined, traceBackRegexes, hashes)) : [];
+}
+
+function findCellOffset(
+    hashes: { trimmedRightCode: string; firstNonBlankLineIndex: number }[] | undefined,
+    codeLines: string
+): number | undefined {
+    if (hashes) {
+        // Go through all cell code looking for these code lines exactly
+        // (although with right side trimmed as that's what a stack trace does)
+        for (const hash of hashes) {
+            const index = hash.trimmedRightCode.indexOf(codeLines);
+            if (index >= 0) {
+                // Jupyter isn't counting blank lines at the top so use our
+                // first non blank line
+                return hash.firstNonBlankLineIndex;
+            }
+        }
     }
-    return traceback;
+    // No hash found
+    return undefined;
+}
+
+function modifyTracebackFrame(
+    traceBackRegexes: Map<string, RegExp>,
+    hashes: Map<string, { trimmedRightCode: string; firstNonBlankLineIndex: number }[]>,
+    traceFrame: string
+): string {
+    // See if this item matches any of our cell files
+    const regexes = [...traceBackRegexes.entries()];
+    const match = regexes.find((e) => e[1].test(traceFrame));
+    if (match) {
+        // We have a match, pull out the source lines
+        let sourceLines = '';
+        const regex = /(;32m[ ->]*?)(\d+)(.*)/g;
+        for (let l = regex.exec(traceFrame); l && l.length > 3; l = regex.exec(traceFrame)) {
+            const newLine = stripAnsi(l[3]).substr(1); // Seem to have a space on the front
+            sourceLines = `${sourceLines}${newLine}\n`;
+        }
+
+        // Now attempt to find a cell that matches these source lines
+        const offset = findCellOffset(hashes.get(match[0]), sourceLines);
+        if (offset !== undefined) {
+            return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num) => {
+                const n = parseInt(num, 10);
+                const newLine = offset + n - 1;
+                return `${prefix}<a href='file://${match[0]}?line=${newLine}'>${newLine + 1}</a>`;
+            });
+        }
+    }
+    return traceFrame;
 }

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -6,15 +6,12 @@ import '../../common/extensions';
 import * as path from 'path';
 import { Uri } from 'vscode';
 
-import stripAnsi from 'strip-ansi';
 import { IWorkspaceService } from '../../common/application/types';
 import { IDataScienceSettings } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { SystemVariables } from '../../common/variables/systemVariables';
 import { getJupyterConnectionDisplayName } from '../jupyter/jupyterConnection';
 import { IConnection } from '../types';
-
-const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)/g;
 
 export function expandWorkingDir(
     workingDir: string | undefined,
@@ -60,71 +57,4 @@ export function createRemoteConnectionInfo(uri: string, settings: IDataScienceSe
         },
         dispose: noop
     };
-}
-
-// This function will modify a traceback from an error message.
-// Tracebacks take a form like so:
-// "[1;31m---------------------------------------------------------------------------[0m"
-// "[1;31mZeroDivisionError[0m                         Traceback (most recent call last)"
-// "[1;32md:\Training\SnakePython\foo.py[0m in [0;36m<module>[1;34m[0m\n[0;32m      1[0m [0mprint[0m[1;33m([0m[1;34m'some more'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [1;32m----> 2[1;33m [0mcause_error[0m[1;33m([0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0m"
-// "[1;32md:\Training\SnakePython\foo.py[0m in [0;36mcause_error[1;34m()[0m\n[0;32m      3[0m     [0mprint[0m[1;33m([0m[1;34m'error'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0;32m      4[0m     [0mprint[0m[1;33m([0m[1;34m'now'[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [1;32m----> 5[1;33m     [0mprint[0m[1;33m([0m [1;36m1[0m [1;33m/[0m [1;36m0[0m[1;33m)[0m[1;33m[0m[1;33m[0m[0m\n    [0m"
-// "[1;31mZeroDivisionError[0m: division by zero"
-// Each item in the array being a stack frame.
-export function modifyTraceback(
-    traceback: string[],
-    traceBackRegexes: Map<string, RegExp>,
-    hashes: Map<string, { trimmedRightCode: string; firstNonBlankLineIndex: number }[]>
-): string[] {
-    // Do one frame at a time.
-    return traceback ? traceback.map(modifyTracebackFrame.bind(undefined, traceBackRegexes, hashes)) : [];
-}
-
-function findCellOffset(
-    hashes: { trimmedRightCode: string; firstNonBlankLineIndex: number }[] | undefined,
-    codeLines: string
-): number | undefined {
-    if (hashes) {
-        // Go through all cell code looking for these code lines exactly
-        // (although with right side trimmed as that's what a stack trace does)
-        for (const hash of hashes) {
-            const index = hash.trimmedRightCode.indexOf(codeLines);
-            if (index >= 0) {
-                // Jupyter isn't counting blank lines at the top so use our
-                // first non blank line
-                return hash.firstNonBlankLineIndex;
-            }
-        }
-    }
-    // No hash found
-    return undefined;
-}
-
-function modifyTracebackFrame(
-    traceBackRegexes: Map<string, RegExp>,
-    hashes: Map<string, { trimmedRightCode: string; firstNonBlankLineIndex: number }[]>,
-    traceFrame: string
-): string {
-    // See if this item matches any of our cell files
-    const regexes = [...traceBackRegexes.entries()];
-    const match = regexes.find((e) => e[1].test(traceFrame));
-    if (match) {
-        // We have a match, pull out the source lines
-        let sourceLines = '';
-        const regex = /(;32m[ ->]*?)(\d+)(.*)/g;
-        for (let l = regex.exec(traceFrame); l && l.length > 3; l = regex.exec(traceFrame)) {
-            const newLine = stripAnsi(l[3]).substr(1); // Seem to have a space on the front
-            sourceLines = `${sourceLines}${newLine}\n`;
-        }
-
-        // Now attempt to find a cell that matches these source lines
-        const offset = findCellOffset(hashes.get(match[0]), sourceLines);
-        if (offset !== undefined) {
-            return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num) => {
-                const n = parseInt(num, 10);
-                const newLine = offset + n - 1;
-                return `${prefix}<a href='file://${match[0]}?line=${newLine}'>${newLine + 1}</a>`;
-            });
-        }
-    }
-    return traceFrame;
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -249,6 +249,7 @@ export interface INotebookExecutionLogger {
     preExecute(cell: ICell, silent: boolean): Promise<void>;
     postExecute(cell: ICell, silent: boolean): Promise<void>;
     onKernelRestarted(): void;
+    preHandleIOPub?(msg: KernelMessage.IIOPubMessage): KernelMessage.IIOPubMessage;
 }
 
 export const IGatherProvider = Symbol('IGatherProvider');

--- a/src/test/datascience/jupyterUtils.unit.test.ts
+++ b/src/test/datascience/jupyterUtils.unit.test.ts
@@ -1,15 +1,43 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
+import type { KernelMessage } from '@jupyterlab/services';
 import { assert } from 'chai';
 import { anything, instance, mock, when } from 'ts-mockito';
 import { Uri } from 'vscode';
+import { DebugService } from '../../client/common/application/debugService';
 import { WorkspaceService } from '../../client/common/application/workspace';
+import { ConfigurationService } from '../../client/common/configuration/service';
 import { IS_WINDOWS } from '../../client/common/platform/constants';
-import { expandWorkingDir, modifyTraceback } from '../../client/datascience/jupyter/jupyterUtils';
+import { FileSystem } from '../../client/common/platform/fileSystem';
+import { CellHashProvider } from '../../client/datascience/editor-integration/cellhashprovider';
+import { expandWorkingDir } from '../../client/datascience/jupyter/jupyterUtils';
+import { createEmptyCell } from '../../datascience-ui/interactive-common/mainState';
+import { MockAutoSelectionService } from '../mocks/autoSelector';
+import { MockDocument } from './mockDocument';
+import { MockDocumentManager } from './mockDocumentManager';
+import { MockPythonSettings } from './mockPythonSettings';
 
 suite('Data Science JupyterUtils', () => {
     const workspaceService = mock(WorkspaceService);
+    const configService = mock(ConfigurationService);
+    const debugService = mock(DebugService);
+    const fileSystem = mock(FileSystem);
+    const docManager = new MockDocumentManager();
+    const dummySettings = new MockPythonSettings(undefined, new MockAutoSelectionService());
+    when(configService.getSettings(anything())).thenReturn(dummySettings);
+    when(fileSystem.getDisplayName(anything())).thenCall((a) => `${a}tastic`);
+    when(fileSystem.arePathsSame(anything(), anything())).thenCall((a, b) =>
+        a.replace(/\\/g, '/').includes(b.replace(/\\/g, '/'))
+    );
+    const hashProvider = new CellHashProvider(
+        docManager,
+        instance(configService),
+        instance(debugService),
+        instance(fileSystem),
+        []
+    );
+
     // tslint:disable: no-invalid-template-strings
     test('expanding file variables', async function () {
         // tslint:disable-next-line: no-invalid-this
@@ -37,33 +65,90 @@ suite('Data Science JupyterUtils', () => {
         );
     });
 
-    function createFileRegex(displayName: string): RegExp {}
+    function modifyTraceback(trace: string[]): string[] {
+        // Pass onto the hash provider
+        const dummyMessage: KernelMessage.IErrorMsg = {
+            channel: 'iopub',
+            content: {
+                ename: 'foo',
+                evalue: 'foo',
+                traceback: trace
+            },
+            header: {
+                msg_type: 'error',
+                msg_id: '1',
+                date: '1',
+                session: '1',
+                username: '1',
+                version: '1'
+            },
+            parent_header: {},
+            metadata: {}
+        };
 
-    test('modifying traceback', () => {
+        // tslint:disable-next-line: no-any
+        return (hashProvider.preHandleIOPub(dummyMessage).content as any).traceback;
+    }
+
+    function addCell(code: string, file: string, line: number) {
+        const doc = docManager.textDocuments.find((d) => d.fileName === file) as MockDocument;
+        if (doc) {
+            doc.addContent(code);
+        } else {
+            // Create a number of emptyish lines above the line
+            const emptyLines = Array.from('x'.repeat(line)).join('\n');
+            const docCode = `${emptyLines}\n${code}`;
+            docManager.addDocument(docCode, file);
+        }
+        const cell = createEmptyCell(undefined, null);
+        cell.file = file;
+        cell.line = line;
+        cell.data.source = code;
+        return hashProvider.preExecute(cell, false);
+    }
+
+    test('modifying traceback', async () => {
+        await addCell('sys.', 'foo.py', 60);
         const trace1 = [
-            '"\u001b[1;36m  File \u001b[1;32m"<ipython-input-2-940d61ce6e42>"\u001b[1;36m, line \u001b[1;32m599999\u001b[0m\n\u001b[1;33m    sys.\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"'
+            '"\u001b[1;36m  File \u001b[1;32mfoo.pytastic\u001b[1;36m, line \u001b[1;32m599999\u001b[0m\n\u001b[1;33m    sys.\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"'
         ];
         const after1 = [
-            `"\u001b[1;36m  File \u001b[1;32m"footastic.py"\u001b[1;36m, line \u001b[1;32m<a href='file://foo.py?line=600001'>600002</a>\u001b[0m\n\u001b[1;33m    sys.\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"`
+            `"\u001b[1;36m  File \u001b[1;32mfoo.pytastic\u001b[1;36m, line \u001b[1;32m<a href='file://foo.py?line=600058'>600059</a>\u001b[0m\n\u001b[1;33m    sys.\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"`
         ];
-        const file1 = 'foo.py';
-        const fileHash1 = new Map<string, RegExp>([[file1, createFileRegex('footastic.py')]]);
         // Use a join after to make the assert show the results
-        assert.equal(after1.join('\n'), modifyTraceback(trace1, fileHash1).join('\n'), 'Syntax error failure');
+        assert.equal(after1.join('\n'), modifyTraceback(trace1).join('\n'), 'Syntax error failure');
+
+        await addCell(
+            `for i in trange(100):
+    time.sleep(0.01)
+    raise Exception('spam')`,
+            'd:\\Training\\SnakePython\\manualTestFile.py',
+            1
+        );
         const trace2 = [
             '\u001b[1;31m---------------------------------------------------------------------------\u001b[0m',
             '\u001b[1;31mException\u001b[0m                                 Traceback (most recent call last)',
-            "\u001b[1;32md:\\Training\\SnakePython\\manualTestFile.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mtrange\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m100\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0mtime\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msleep\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m0.01\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 5\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'spam'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[1;32md:\\Training\\SnakePython\\manualTestFile.pytastic\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      3\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mtrange\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m100\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0mtime\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msleep\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m0.01\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 5\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'spam'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
             '\u001b[1;31mException\u001b[0m: spam'
         ];
         const after2 = [
             '\u001b[1;31m---------------------------------------------------------------------------\u001b[0m',
             '\u001b[1;31mException\u001b[0m                                 Traceback (most recent call last)',
-            `\u001b[1;32md:\\Training\\SnakePython\\manualTestFile.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\manualTestFile.py?line=23'>24</a>\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mtrange\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m100\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\manualTestFile.py?line=24'>25</a>\u001b[0m     \u001b[0mtime\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msleep\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m0.01\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> <a href='file://d:\\Training\\SnakePython\\manualTestFile.py?line=25'>26</a>\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'spam'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m`,
+            `\u001b[1;32md:\\Training\\SnakePython\\manualTestFile.pytastic\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\manualTestFile.py?line=3'>4</a>\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mtrange\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m100\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\manualTestFile.py?line=4'>5</a>\u001b[0m     \u001b[0mtime\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0msleep\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;36m0.01\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> <a href='file://d:\\Training\\SnakePython\\manualTestFile.py?line=5'>6</a>\u001b[1;33m     \u001b[1;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'spam'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m`,
             '\u001b[1;31mException\u001b[0m: spam'
         ];
-        const file2 = 'd:\\Training\\SnakePython\\manualTestFile.py';
-        assert.equal(after2.join('\n'), modifyTraceback(file2, file2, 20, trace2).join('\n'), 'Exception failure');
+        assert.equal(after2.join('\n'), modifyTraceback(trace2).join('\n'), 'Exception failure');
+
+        when(fileSystem.getDisplayName(anything())).thenReturn('~/Test/manualTestFile.py');
+        await addCell(
+            `
+            
+import numpy as np 
+import pandas as pd
+import matplotlib.pyplot as plt`,
+            '/home/rich/Test/manualTestFile.py',
+            19
+        );
         const trace3 = [
             '\u001b[0;31m---------------------------------------------------------------------------\u001b[0m',
             '\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)',
@@ -76,12 +161,42 @@ suite('Data Science JupyterUtils', () => {
             "\u001b[0;32m~/Test/manualTestFile.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> <a href='file:///home/rich/Test/manualTestFile.py?line=24'>25</a>\u001b[0;31m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      <a href='file:///home/rich/Test/manualTestFile.py?line=25'>26</a>\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpandas\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      <a href='file:///home/rich/Test/manualTestFile.py?line=26'>27</a>\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mmatplotlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpyplot\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
             "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'numpy'"
         ];
-        const file3 = '/home/rich/Test/manualTestFile.py';
-        const display3 = '~/Test/manualTestFile.py';
-        assert.equal(
-            after3.join('\n'),
-            modifyTraceback(file3, display3, 20, trace3).join('\n'),
-            'Exception unix failure'
+        assert.equal(after3.join('\n'), modifyTraceback(trace3).join('\n'), 'Exception unix failure');
+        when(fileSystem.getDisplayName(anything())).thenReturn('d:\\Training\\SnakePython\\foo.py');
+
+        await addCell(
+            `# %%
+
+def cause_error():
+    print('start')
+    print('error') 
+    print('now')
+
+    print( 1 / 0)
+`,
+            'd:\\Training\\SnakePython\\foo.py',
+            133
         );
+        await addCell(
+            `# %%
+print('some more')
+            
+cause_error()`,
+            'd:\\Training\\SnakePython\\foo.py',
+            142
+        );
+        const trace4 = [
+            '\u001b[1;31m---------------------------------------------------------------------------\u001b[0m',
+            '\u001b[1;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)',
+            "\u001b[1;32md:\\Training\\SnakePython\\foo.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'some more'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 3\u001b[1;33m \u001b[0mcause_error\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[1;32md:\\Training\\SnakePython\\foo.py\u001b[0m in \u001b[0;36mcause_error\u001b[1;34m()\u001b[0m\n\u001b[0;32m      4\u001b[0m     \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'now'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      5\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 6\u001b[1;33m     \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m \u001b[1;36m1\u001b[0m \u001b[1;33m/\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m"
+        ];
+        const after4 = [
+            '\u001b[1;31m---------------------------------------------------------------------------\u001b[0m',
+            '\u001b[1;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)',
+            "\u001b[1;32md:\\Training\\SnakePython\\foo.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\foo.py?line=143'>144</a>\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'some more'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\foo.py?line=144'>145</a>\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> <a href='file://d:\\Training\\SnakePython\\foo.py?line=145'>146</a>\u001b[1;33m \u001b[0mcause_error\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+            "\u001b[1;32md:\\Training\\SnakePython\\foo.py\u001b[0m in \u001b[0;36mcause_error\u001b[1;34m()\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\foo.py?line=138'>139</a>\u001b[0m     \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'now'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      <a href='file://d:\\Training\\SnakePython\\foo.py?line=139'>140</a>\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> <a href='file://d:\\Training\\SnakePython\\foo.py?line=140'>141</a>\u001b[1;33m     \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m \u001b[1;36m1\u001b[0m \u001b[1;33m/\u001b[0m \u001b[1;36m0\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m"
+        ];
+        assert.equal(after4.join('\n'), modifyTraceback(trace4).join('\n'), 'Multiple levels');
     });
 });

--- a/src/test/datascience/jupyterUtils.unit.test.ts
+++ b/src/test/datascience/jupyterUtils.unit.test.ts
@@ -37,6 +37,8 @@ suite('Data Science JupyterUtils', () => {
         );
     });
 
+    function createFileRegex(displayName: string): RegExp {}
+
     test('modifying traceback', () => {
         const trace1 = [
             '"\u001b[1;36m  File \u001b[1;32m"<ipython-input-2-940d61ce6e42>"\u001b[1;36m, line \u001b[1;32m599999\u001b[0m\n\u001b[1;33m    sys.\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"'
@@ -45,12 +47,9 @@ suite('Data Science JupyterUtils', () => {
             `"\u001b[1;36m  File \u001b[1;32m"footastic.py"\u001b[1;36m, line \u001b[1;32m<a href='file://foo.py?line=600001'>600002</a>\u001b[0m\n\u001b[1;33m    sys.\u001b[0m\n\u001b[1;37m        ^\u001b[0m\n\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m invalid syntax\n"`
         ];
         const file1 = 'foo.py';
+        const fileHash1 = new Map<string, RegExp>([[file1, createFileRegex('footastic.py')]]);
         // Use a join after to make the assert show the results
-        assert.equal(
-            after1.join('\n'),
-            modifyTraceback(file1, 'footastic.py', 2, trace1).join('\n'),
-            'Syntax error failure'
-        );
+        assert.equal(after1.join('\n'), modifyTraceback(trace1, fileHash1).join('\n'), 'Syntax error failure');
         const trace2 = [
             '\u001b[1;31m---------------------------------------------------------------------------\u001b[0m',
             '\u001b[1;31mException\u001b[0m                                 Traceback (most recent call last)',

--- a/src/test/datascience/mockDocument.ts
+++ b/src/test/datascience/mockDocument.ts
@@ -66,6 +66,11 @@ export class MockDocument implements TextDocument {
         this._onSave = onSave;
     }
 
+    public addContent(contents: string) {
+        this._contents = `${this._contents}\n${contents}`;
+        this._lines = this.createLines();
+    }
+
     public forceUntitled(): void {
         this._isUntitled = true;
         this._isDirty = true;


### PR DESCRIPTION
For #10708

Number of problems here. 

Old code assumed that if the file in the error message matched the cell, it was the cell. This doesn't work if the exception is thrown in a different cell that's been referenced (as it will have the same file). The example for this is in the bug.

Old code also didn't take into account extra spacing at the top of a cell. 

New code uses the cell hash provider to look for the closest match to the source code in the stack trace (if the file matches a file that we ran cells from). 

Note that this may find invalid cells if they have duplicate code in them. Don't see a way around this without getting rid of the ```__file__``` support. An exception doesn't log any other information other than the code in the traceback.