### PR TITLE
Fix scrolling when don't have focus

### DIFF
--- a/news/2 Fixes/11238.md
+++ b/news/2 Fixes/11238.md
@@ -1,0 +1,1 @@
+Fix scrolling in a notebook whenever resizing or opening.

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -551,7 +551,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
 
     private scrollToCurrentPosition(_editor: monacoEditor.editor.IStandaloneCodeEditor) {
         // Unfortunately during functional tests we hack the line count and the like.
-        if (isTestExecution()) {
+        if (isTestExecution() || !this.props.hasFocus) {
             return;
         }
         // Scroll to the visible line that has our current line. Note: Visible lines are not sorted by monaco


### PR DESCRIPTION
For #11238

Monaco editor was forcing a scroll to its own lines even when it doesn't have focus.