### PR TITLE
Turn off reload experiment

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -57,13 +57,13 @@
         "name": "Reload - control",
         "salt": "DebugAdapterFactory",
         "min": 0,
-        "max": 30
+        "max": 0
     },
     {
         "name": "Reload - experiment",
         "salt": "DebugAdapterFactory",
-        "min": 70,
-        "max": 100
+        "min": 0,
+        "max": 0
     },
     {
         "name": "LS - enabled",


### PR DESCRIPTION
Turning reload experiment off. It is interfering with some cases where users really want `--no-reload`. Turning this off for now, we will likely remove this experiment.