### PR TITLE
Wire unhandled widget messages to the jupyter output

### DIFF
--- a/news/2 Fixes/11239.md
+++ b/news/2 Fixes/11239.md
@@ -1,0 +1,1 @@
+Show unhandled widget messages in the jupyter output window.

--- a/package.nls.json
+++ b/package.nls.json
@@ -471,5 +471,6 @@
     "DataScience.loadClassFailedWithNoInternet": "Error loading {0}:{1}. Internet connection required for loading 3rd party widgets.",
     "DataScience.useCDNForWidgets": "Widgets require us to download supporting files from a 3rd party website. Click [here](https://aka.ms/PVSCIPyWidgets) for more information.",
     "DataScience.loadThirdPartyWidgetScriptsPostEnabled": "Please restart the Kernel when changing the setting 'python.dataScience.widgetScriptSources'.",
-    "DataScience.enableCDNForWidgetsSetting": "Widgets require us to download supporting files from a 3rd party website. Click <a href='https://command:python.datascience.enableLoadingWidgetScriptsFromThirdPartySource'>here</a> to enable this or click <a href='https://aka.ms/PVSCIPyWidgets'>here</a> for more information. (Error loading {0}:{1})."
+    "DataScience.enableCDNForWidgetsSetting": "Widgets require us to download supporting files from a 3rd party website. Click <a href='https://command:python.datascience.enableLoadingWidgetScriptsFromThirdPartySource'>here</a> to enable this or click <a href='https://aka.ms/PVSCIPyWidgets'>here</a> for more information. (Error loading {0}:{1}).",
+    "DataScience.unhandledMessage": "Unhandled kernel message from a widget: {0} : {1}"
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -865,6 +865,11 @@ export namespace DataScience {
         'DataScience.enableCDNForWidgetsSetting',
         "Widgets require us to download supporting files from a 3rd party website. Click <a href='https://command:python.datascience.enableLoadingWidgetScriptsFromThirdPartySource'>here</a> to enable this or click <a href='https://aka.ms/PVSCIPyWidgets'>here</a> for more information. (Error loading {0}:{1})."
     );
+
+    export const unhandledMessage = localize(
+        'DataScience.unhandledMessage',
+        'Unhandled kernel message from a widget: {0} : {1}'
+    );
 }
 
 export namespace DebugConfigStrings {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -299,7 +299,8 @@ export enum Telemetry {
     IPyWidgetPromptToUseCDN = 'DS_INTERNAL.IPYWIDGET_PROMPT_TO_USE_CDN',
     IPyWidgetPromptToUseCDNSelection = 'DS_INTERNAL.IPYWIDGET_PROMPT_TO_USE_CDN_SELECTION',
     IPyWidgetOverhead = 'DS_INTERNAL.IPYWIDGET_OVERHEAD',
-    IPyWidgetRenderFailure = 'DS_INTERNAL.IPYWIDGET_RENDER_FAILURE'
+    IPyWidgetRenderFailure = 'DS_INTERNAL.IPYWIDGET_RENDER_FAILURE',
+    IPyWidgetUnhandledMessage = 'DS_INTERNAL.IPYWIDGET_UNHANDLED_MESSAGE'
 }
 
 export enum NativeKeyboardCommandTelemetry {

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -116,7 +116,8 @@ export enum InteractiveWindowMessages {
     UpdateDisplayData = 'update_display_data',
     IPyWidgetLoadSuccess = 'ipywidget_load_success',
     IPyWidgetLoadFailure = 'ipywidget_load_failure',
-    IPyWidgetRenderFailure = 'ipywidget_render_failure'
+    IPyWidgetRenderFailure = 'ipywidget_render_failure',
+    IPyWidgetUnhandledKernelMessage = 'ipywidget_unhandled_kernel_message'
 }
 
 export enum IPyWidgetMessages {
@@ -582,4 +583,5 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.ConvertUriForUseInWebViewRequest]: Uri;
     public [InteractiveWindowMessages.ConvertUriForUseInWebViewResponse]: { request: Uri; response: Uri };
     public [InteractiveWindowMessages.IPyWidgetRenderFailure]: Error;
+    public [InteractiveWindowMessages.IPyWidgetUnhandledKernelMessage]: KernelMessage.IMessage;
 }

--- a/src/client/datascience/interactive-common/synchronization.ts
+++ b/src/client/datascience/interactive-common/synchronization.ts
@@ -118,6 +118,7 @@ const messageWithMessageTypes: MessageMapping<IInteractiveWindowMapping> & Messa
     [InteractiveWindowMessages.IPyWidgetLoadSuccess]: MessageType.other,
     [InteractiveWindowMessages.IPyWidgetLoadFailure]: MessageType.other,
     [InteractiveWindowMessages.IPyWidgetRenderFailure]: MessageType.other,
+    [InteractiveWindowMessages.IPyWidgetUnhandledKernelMessage]: MessageType.other,
     [InteractiveWindowMessages.LoadAllCells]: MessageType.other,
     [InteractiveWindowMessages.LoadAllCellsComplete]: MessageType.other,
     [InteractiveWindowMessages.LoadOnigasmAssemblyRequest]: MessageType.other,

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -2001,4 +2001,10 @@ export interface IEventNamePropertyMapping {
      * Telemetry event sent when the widget render function fails (note, this may not be sufficient to capture all failures).
      */
     [Telemetry.IPyWidgetRenderFailure]: never | undefined;
+    /**
+     * Telemetry event sent when the widget tries to send a kernel message but nothing was listening
+     */
+    [Telemetry.IPyWidgetUnhandledMessage]: {
+        msg_type: string;
+    };
 }

--- a/src/datascience-ui/ipywidgets/types.ts
+++ b/src/datascience-ui/ipywidgets/types.ts
@@ -6,6 +6,7 @@
 import * as jupyterlab from '@jupyter-widgets/base/lib';
 import type { Kernel, KernelMessage } from '@jupyterlab/services';
 import type { nbformat } from '@jupyterlab/services/node_modules/@jupyterlab/coreutils';
+import { ISignal } from '@phosphor/signaling';
 import { Widget } from '@phosphor/widgets';
 import { IInteractiveWindowMapping } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 
@@ -25,6 +26,10 @@ export type IJupyterLabWidgetManagerCtor = new (
 ) => IJupyterLabWidgetManager;
 
 export interface IJupyterLabWidgetManager {
+    /**
+     * Signal emitted when a view emits an IO Pub message but nothing handles it.
+     */
+    readonly onUnhandledIOPubMessage: ISignal<this, KernelMessage.IIOPubMessage>;
     dispose(): void;
     /**
      * Close all widgets and empty the widget state.

--- a/src/ipywidgets/src/manager.ts
+++ b/src/ipywidgets/src/manager.ts
@@ -95,6 +95,10 @@ export class WidgetManager extends jupyterlab.WidgetManager {
         // This throws errors if enabled, can be added later.
     }
 
+    public get onUnhandledIOPubMessage() {
+        return super.onUnhandledIOPubMessage;
+    }
+
     protected async loadClass(className: string, moduleName: string, moduleVersion: string): Promise<any> {
         // Call the base class to try and load. If that fails, look locally
         window.console.log(`WidgetManager: Loading class ${className}:${moduleName}:${moduleVersion}`);


### PR DESCRIPTION
For #11239

Jupyter lab doesn't handle this bug either, so doing what they do too. Output unhandled messages to the jupyter output tab.

