### PR TITLE
Do not expose kernel process

### DIFF
--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -39,9 +39,6 @@ class KernelProcess implements IKernelProcess {
     public get kernelSpec(): Readonly<IJupyterKernelSpec> {
         return this._kernelSpec;
     }
-    public get process(): ChildProcess | undefined {
-        return this._process;
-    }
     public get connection(): Readonly<IKernelConnection> {
         return this._connection;
     }

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 'use strict';
 
-import { ChildProcess } from 'child_process';
 import { IDisposable } from 'monaco-editor';
 import { Event } from 'vscode';
 import { InterpreterUri } from '../../common/installer/types';
@@ -27,7 +26,6 @@ export interface IKernelConnection {
 }
 
 export interface IKernelProcess extends IDisposable {
-    process: ChildProcess | undefined;
     readonly connection: Readonly<IKernelConnection>;
     ready: Promise<void>;
     readonly kernelSpec: Readonly<IJupyterKernelSpec>;


### PR DESCRIPTION
For #10768

The kernel process wasn't used, except in tests.
This is required, as when we spin up the kernel process in the daemon, the process returned by the TS code will return the process daemon and not the kernel process.

This separation ensure we do not rely on it for anything, after all everything we need is in IKernelConnection (ports, etc).