### PR TITLE
Expose currently selected interpreter path using API

### DIFF
--- a/news/1 Enhancements/11294.md
+++ b/news/1 Enhancements/11294.md
@@ -1,0 +1,1 @@
+Expose currently selected interpreter path using API.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "displayName": "Python",
     "description": "Linting, Debugging (multi-threaded, remote), Intellisense, Jupyter Notebooks, code formatting, refactoring, unit tests, snippets, and more.",
     "version": "2020.5.0-dev",
+    "featureFlags": {
+        "usingNewInterpreterStorage": true
+    },
     "languageServerVersion": "0.5.30",
     "publisher": "ms-python",
     "enableProposedApi": false,

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -35,7 +35,7 @@ export interface IExtensionApi {
         getRemoteLauncherCommand(host: string, port: number, waitUntilDebuggerAttaches: boolean): Promise<string[]>;
     };
     /**
-     * Return internal settings within the extension stored in VSCode storage
+     * Return internal settings within the extension which are stored in VSCode storage
      */
     settings: {
         /**

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -39,14 +39,20 @@ export interface IExtensionApi {
      */
     settings: {
         /**
-         * Returns the Python interpreter path corresponding to the specified resource, taking into account
+         * Returns the Python execution command corresponding to the specified resource, taking into account
          * any workspace-specific settings for the workspace to which this resource belongs.
+         * E.g of execution commands returned could be,
+         * * `['<path to the interpreter set in settings>']`
+         * * `['<path to the interpreter selected by the extension when setting is not set>']`
+         * * `['conda', 'run', 'python']` which is used to run from within Conda environments.
+         * or something similar for some other Python environments.
          * @param {Resource} [resource] A resource for which the setting is asked for.
          * * When no resource is provided, the setting scoped to the first workspace folder is returned.
          * * If no folder is present, it returns the global setting.
-         * @returns {string}
+         * @returns {(string[] | undefined)} When return value is `undefined`, it means no interpreter is set.
+         * Otherwise, join the items returned using space to construct the full execution command.
          */
-        getInterpreterPath(resource?: Resource): string;
+        getExecutionCommand(resource?: Resource): string[] | undefined;
     };
 }
 
@@ -88,8 +94,10 @@ export function buildApi(
             }
         },
         settings: {
-            getInterpreterPath(resource?: Resource) {
-                return configurationService.getSettings(resource).pythonPath;
+            getExecutionCommand(resource?: Resource) {
+                const pythonPath = configurationService.getSettings(resource).pythonPath;
+                // If pythonPath equals an empty string, no interpreter is set.
+                return pythonPath === '' ? undefined : [pythonPath];
             }
         }
     };

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -39,8 +39,11 @@ export interface IExtensionApi {
      */
     settings: {
         /**
-         * Return the currently selected interpreter path.
-         * @param {Resource} [resource]
+         * Returns the Python interpreter path corresponding to the specified resource, taking into account
+         * any workspace-specific settings for the workspace to which this resource belongs.
+         * @param {Resource} [resource] A resource for which the setting is asked for.
+         * * When no resource is provided, the setting scoped to the first workspace folder is returned.
+         * * If no folder is present, it returns the global setting.
          * @returns {string}
          */
         getInterpreterPath(resource?: Resource): string;

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -630,6 +630,7 @@ export class PythonSettings implements IPythonSettings {
             }
         }
         if (inExperiment && this.pythonPath === DEFAULT_INTERPRETER_SETTING) {
+            // If no interpreter is selected, set pythonPath to an empty string.
             // This is to ensure that we ask users to select an interpreter in case auto selected interpreter is not safe to select
             this.pythonPath = '';
         }

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -5,7 +5,7 @@
 
 // tslint:disable:no-any max-func-body-length
 
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import * as path from 'path';
 import { anyString, instance, mock, when } from 'ts-mockito';
 import { Uri } from 'vscode';
@@ -51,7 +51,7 @@ suite('Extension API', () => {
             instance(serviceContainer)
         ).settings.getExecutionCommand(resource);
 
-        expect(interpreterPath).to.equal(['settingValue']);
+        assert.deepEqual(interpreterPath, ['settingValue']);
     });
 
     test('Execution command settings API returns `undefined` if interpreter is set', async () => {

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -41,7 +41,7 @@ suite('Extension API', () => {
         when(serviceContainer.get<IExperimentsManager>(IExperimentsManager)).thenReturn(instance(experimentsManager));
     });
 
-    test('Test interpreter path settings API', async () => {
+    test('Execution command settings API returns expected array if interpreter is set', async () => {
         const resource = Uri.parse('a');
         when(configurationService.getSettings(resource)).thenReturn({ pythonPath: 'settingValue' } as any);
 
@@ -49,9 +49,22 @@ suite('Extension API', () => {
             Promise.resolve(),
             instance(serviceManager),
             instance(serviceContainer)
-        ).settings.getInterpreterPath(resource);
+        ).settings.getExecutionCommand(resource);
 
-        expect(interpreterPath).to.equal('settingValue');
+        expect(interpreterPath).to.equal(['settingValue']);
+    });
+
+    test('Execution command settings API returns `undefined` if interpreter is set', async () => {
+        const resource = Uri.parse('a');
+        when(configurationService.getSettings(resource)).thenReturn({ pythonPath: '' } as any);
+
+        const interpreterPath = buildApi(
+            Promise.resolve(),
+            instance(serviceManager),
+            instance(serviceContainer)
+        ).settings.getExecutionCommand(resource);
+
+        expect(interpreterPath).to.equal(undefined, '');
     });
 
     test('Test debug launcher args (no-wait and not in experiment)', async () => {

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -8,15 +8,17 @@
 import { expect } from 'chai';
 import * as path from 'path';
 import { anyString, instance, mock, when } from 'ts-mockito';
+import { Uri } from 'vscode';
 import { buildApi } from '../client/api';
+import { ConfigurationService } from '../client/common/configuration/service';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 import { ExperimentsManager } from '../client/common/experiments';
-import { IExperimentsManager } from '../client/common/types';
+import { IConfigurationService, IExperimentsManager } from '../client/common/types';
 import { ServiceContainer } from '../client/ioc/container';
 import { ServiceManager } from '../client/ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
 
-suite('Extension API - Debugger', () => {
+suite('Extension API', () => {
     const expectedLauncherPath = `${EXTENSION_ROOT_DIR.fileToCommandArgument()}/pythonFiles/ptvsd_launcher.py`;
     const ptvsdPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'debugpy', 'no_wheels', 'debugpy');
     const ptvsdHost = 'somehost';
@@ -25,13 +27,31 @@ suite('Extension API - Debugger', () => {
     let serviceContainer: IServiceContainer;
     let serviceManager: IServiceManager;
     let experimentsManager: IExperimentsManager;
+    let configurationService: IConfigurationService;
 
     setup(() => {
         serviceContainer = mock(ServiceContainer);
         serviceManager = mock(ServiceManager);
         experimentsManager = mock(ExperimentsManager);
+        configurationService = mock(ConfigurationService);
 
+        when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(
+            instance(configurationService)
+        );
         when(serviceContainer.get<IExperimentsManager>(IExperimentsManager)).thenReturn(instance(experimentsManager));
+    });
+
+    test('Test interpreter path settings API', async () => {
+        const resource = Uri.parse('a');
+        when(configurationService.getSettings(resource)).thenReturn({ pythonPath: 'settingValue' } as any);
+
+        const interpreterPath = buildApi(
+            Promise.resolve(),
+            instance(serviceManager),
+            instance(serviceContainer)
+        ).settings.getInterpreterPath(resource);
+
+        expect(interpreterPath).to.equal('settingValue');
     });
 
     test('Test debug launcher args (no-wait and not in experiment)', async () => {


### PR DESCRIPTION
For #11294 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
