### PR TITLE
Refactor daemon pool factory to allow creation of daemons outside pools

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*"
             ],
-            "preLaunchTask": "Compile",
+            // "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "outFiles": [
                 "${workspaceFolder}/out/**/*"
             ],
-            // "preLaunchTask": "Compile",
+            "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
             ],

--- a/pythonFiles/vscode_datascience_helpers/daemon/__main__.py
+++ b/pythonFiles/vscode_datascience_helpers/daemon/__main__.py
@@ -11,7 +11,7 @@ import sys
 
 log = logging.getLogger(__name__)
 
-LOG_FORMAT = "%(asctime)s UTC - %(levelname)s - %(name)s - %(message)s"
+LOG_FORMAT = "%(asctime)s UTC - %(levelname)s - (PID: %(process)d) - %(name)s - %(message)s"
 queue_handler = None
 
 
@@ -62,7 +62,7 @@ class TemporaryQueueHandler(logging.Handler):
         self.queue = []
 
     def emit(self, record):
-        data = {"level": record.levelname, "msg": self.format(record)}
+        data = {"level": record.levelname, "msg": self.format(record), "pid": os.getpid()}
         # If we don't have the server, then queue it and send it later.
         if self.server is None:
             self.queue.append(data)

--- a/pythonFiles/vscode_datascience_helpers/daemon/__main__.py
+++ b/pythonFiles/vscode_datascience_helpers/daemon/__main__.py
@@ -11,7 +11,9 @@ import sys
 
 log = logging.getLogger(__name__)
 
-LOG_FORMAT = "%(asctime)s UTC - %(levelname)s - (PID: %(process)d) - %(name)s - %(message)s"
+LOG_FORMAT = (
+    "%(asctime)s UTC - %(levelname)s - (PID: %(process)d) - %(name)s - %(message)s"
+)
 queue_handler = None
 
 
@@ -62,7 +64,11 @@ class TemporaryQueueHandler(logging.Handler):
         self.queue = []
 
     def emit(self, record):
-        data = {"level": record.levelname, "msg": self.format(record), "pid": os.getpid()}
+        data = {
+            "level": record.levelname,
+            "msg": self.format(record),
+            "pid": os.getpid(),
+        }
         # If we don't have the server, then queue it and send it later.
         if self.server is None:
             self.queue.append(data)

--- a/src/client/common/process/baseDaemon.ts
+++ b/src/client/common/process/baseDaemon.ts
@@ -1,0 +1,360 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { ChildProcess } from 'child_process';
+import * as os from 'os';
+import { Subject } from 'rxjs/Subject';
+import * as util from 'util';
+import { MessageConnection, NotificationType, RequestType, RequestType0 } from 'vscode-jsonrpc';
+import { traceError, traceInfo, traceVerbose, traceWarning } from '../logger';
+import { IDisposable } from '../types';
+import { createDeferred, Deferred } from '../utils/async';
+import { noop } from '../utils/misc';
+import {
+    ExecutionResult,
+    IPythonExecutionService,
+    ObservableExecutionResult,
+    Output,
+    SpawnOptions,
+    StdErrError
+} from './types';
+
+type ErrorResponse = { error?: string };
+
+export class ConnectionClosedError extends Error {
+    constructor(public readonly message: string) {
+        super();
+    }
+}
+
+export class DaemonError extends Error {
+    constructor(public readonly message: string) {
+        super();
+    }
+}
+export abstract class BasePythonDaemon {
+    public get isAlive(): boolean {
+        return this.connectionClosedMessage === '';
+    }
+    private connectionClosedMessage: string = '';
+    private outputObservale = new Subject<Output<string>>();
+    // tslint:disable-next-line: no-any
+    private readonly connectionClosedDeferred: Deferred<any>;
+    private disposables: IDisposable[] = [];
+    private disposed = false;
+    constructor(
+        protected readonly pythonExecutionService: IPythonExecutionService,
+        protected readonly pythonPath: string,
+        public readonly proc: ChildProcess,
+        public readonly connection: MessageConnection
+    ) {
+        // tslint:disable-next-line: no-any
+        this.connectionClosedDeferred = createDeferred<any>();
+        // This promise gets used conditionally, if it doesn't get used, and the promise is rejected,
+        // then node logs errors. We don't want that, hence add a dummy error handler.
+        this.connectionClosedDeferred.promise.catch(noop);
+        this.monitorConnection();
+    }
+    public dispose() {
+        try {
+            this.disposed = true;
+            // The daemon should die as a result of this.
+            this.connection.sendNotification(new NotificationType('exit'));
+            this.proc.kill();
+        } catch {
+            noop();
+        }
+        this.disposables.forEach((item) => item.dispose());
+    }
+    public execObservable(args: string[], options: SpawnOptions): ObservableExecutionResult<string> {
+        if (this.isAlive && this.canExecFileUsingDaemon(args, options)) {
+            try {
+                return this.execAsObservable({ fileName: args[0] }, args.slice(1), options);
+            } catch (ex) {
+                if (ex instanceof DaemonError || ex instanceof ConnectionClosedError) {
+                    traceWarning('Falling back to Python Execution Service due to failure in daemon', ex);
+                    return this.pythonExecutionService.execObservable(args, options);
+                } else {
+                    throw ex;
+                }
+            }
+        } else {
+            return this.pythonExecutionService.execObservable(args, options);
+        }
+    }
+    public execModuleObservable(
+        moduleName: string,
+        args: string[],
+        options: SpawnOptions
+    ): ObservableExecutionResult<string> {
+        if (this.isAlive && this.canExecModuleUsingDaemon(moduleName, args, options)) {
+            try {
+                return this.execAsObservable({ moduleName }, args, options);
+            } catch (ex) {
+                if (ex instanceof DaemonError || ex instanceof ConnectionClosedError) {
+                    traceWarning('Falling back to Python Execution Service due to failure in daemon', ex);
+                    return this.pythonExecutionService.execModuleObservable(moduleName, args, options);
+                } else {
+                    throw ex;
+                }
+            }
+        } else {
+            return this.pythonExecutionService.execModuleObservable(moduleName, args, options);
+        }
+    }
+    public async exec(args: string[], options: SpawnOptions): Promise<ExecutionResult<string>> {
+        if (this.isAlive && this.canExecFileUsingDaemon(args, options)) {
+            try {
+                return await this.execFileWithDaemon(args[0], args.slice(1), options);
+            } catch (ex) {
+                if (ex instanceof DaemonError || ex instanceof ConnectionClosedError) {
+                    traceWarning('Falling back to Python Execution Service due to failure in daemon', ex);
+                    return this.pythonExecutionService.exec(args, options);
+                } else {
+                    throw ex;
+                }
+            }
+        } else {
+            return this.pythonExecutionService.exec(args, options);
+        }
+    }
+    public async execModule(
+        moduleName: string,
+        args: string[],
+        options: SpawnOptions
+    ): Promise<ExecutionResult<string>> {
+        if (this.isAlive && this.canExecModuleUsingDaemon(moduleName, args, options)) {
+            try {
+                return await this.execModuleWithDaemon(moduleName, args, options);
+            } catch (ex) {
+                if (ex instanceof DaemonError || ex instanceof ConnectionClosedError) {
+                    traceWarning('Falling back to Python Execution Service due to failure in daemon', ex);
+                    return this.pythonExecutionService.execModule(moduleName, args, options);
+                } else {
+                    throw ex;
+                }
+            }
+        } else {
+            return this.pythonExecutionService.execModule(moduleName, args, options);
+        }
+    }
+    protected canExecFileUsingDaemon(args: string[], options: SpawnOptions): boolean {
+        return args[0].toLowerCase().endsWith('.py') && this.areOptionsSupported(options);
+    }
+    protected canExecModuleUsingDaemon(_moduleName: string, _args: string[], options: SpawnOptions): boolean {
+        return this.areOptionsSupported(options);
+    }
+    protected areOptionsSupported(options: SpawnOptions): boolean {
+        const daemonSupportedSpawnOptions: (keyof SpawnOptions)[] = [
+            'cwd',
+            'env',
+            'throwOnStdErr',
+            'token',
+            'encoding',
+            'mergeStdOutErr',
+            'extraVariables'
+        ];
+        // tslint:disable-next-line: no-any
+        return Object.keys(options).every((item) => daemonSupportedSpawnOptions.indexOf(item as any) >= 0);
+    }
+    protected sendRequestWithoutArgs<R, E, RO>(type: RequestType0<R, E, RO>): Thenable<R> {
+        return Promise.race([this.connection.sendRequest(type), this.connectionClosedDeferred.promise]);
+    }
+    protected sendRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, params?: P): Thenable<R> {
+        // Throw an error if the connection has been closed.
+        return Promise.race([this.connection.sendRequest(type, params), this.connectionClosedDeferred.promise]);
+    }
+    protected throwIfRPCConnectionIsDead() {
+        if (!this.isAlive) {
+            throw new ConnectionClosedError(this.connectionClosedMessage);
+        }
+    }
+    protected execAsObservable(
+        moduleOrFile: { moduleName: string } | { fileName: string },
+        args: string[],
+        options: SpawnOptions
+    ): ObservableExecutionResult<string> {
+        const subject = new Subject<Output<string>>();
+        const start = async () => {
+            type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
+            let response: ExecResponse;
+            if ('fileName' in moduleOrFile) {
+                const request = new RequestType<
+                    // tslint:disable-next-line: no-any
+                    { file_name: string; args: string[]; cwd?: string; env?: any },
+                    ExecResponse,
+                    void,
+                    void
+                >('exec_file_observable');
+                response = await this.sendRequest(request, {
+                    file_name: moduleOrFile.fileName,
+                    args,
+                    cwd: options.cwd,
+                    env: options.env
+                });
+            } else {
+                const request = new RequestType<
+                    // tslint:disable-next-line: no-any
+                    { module_name: string; args: string[]; cwd?: string; env?: any },
+                    ExecResponse,
+                    void,
+                    void
+                >('exec_module_observable');
+                response = await this.sendRequest(request, {
+                    module_name: moduleOrFile.moduleName,
+                    args,
+                    cwd: options.cwd,
+                    env: options.env
+                });
+            }
+            // Might not get a response object back, as its observable.
+            if (response && response.error) {
+                throw new DaemonError(response.error);
+            }
+        };
+        let stdErr = '';
+        this.proc.stderr.on('data', (output: string | Buffer) => (stdErr += output.toString()));
+        // Wire up stdout/stderr.
+        const subscription = this.outputObservale.subscribe((out) => {
+            if (out.source === 'stderr' && options.throwOnStdErr) {
+                subject.error(new StdErrError(out.out));
+            } else if (out.source === 'stderr' && options.mergeStdOutErr) {
+                subject.next({ source: 'stdout', out: out.out });
+            } else {
+                subject.next(out);
+            }
+        });
+        start()
+            .catch((ex) => {
+                const errorMsg = `Failed to run ${
+                    'fileName' in moduleOrFile ? moduleOrFile.fileName : moduleOrFile.moduleName
+                } as observable with args ${args.join(' ')}`;
+                traceError(errorMsg, ex);
+                subject.next({ source: 'stderr', out: `${errorMsg}\n${stdErr}` });
+                subject.error(ex);
+            })
+            .finally(() => {
+                // Wait until all messages are received.
+                setTimeout(() => {
+                    subscription.unsubscribe();
+                    subject.complete();
+                }, 100);
+            })
+            .ignoreErrors();
+
+        return {
+            proc: this.proc,
+            dispose: () => this.dispose(),
+            out: subject
+        };
+    }
+    /**
+     * Process the response.
+     *
+     * @private
+     * @param {{ error?: string | undefined; stdout: string; stderr?: string }} response
+     * @param {SpawnOptions} options
+     * @memberof PythonDaemonExecutionService
+     */
+    private processResponse(
+        response: { error?: string | undefined; stdout: string; stderr?: string },
+        options: SpawnOptions
+    ) {
+        if (response.error) {
+            throw new DaemonError(`Failed to execute using the daemon, ${response.error}`);
+        }
+        // Throw an error if configured to do so if there's any output in stderr.
+        if (response.stderr && options.throwOnStdErr) {
+            throw new StdErrError(response.stderr);
+        }
+        // Merge stdout and stderr into on if configured to do so.
+        if (response.stderr && options.mergeStdOutErr) {
+            response.stdout = `${response.stdout || ''}${os.EOL}${response.stderr}`;
+        }
+    }
+    private async execFileWithDaemon(
+        fileName: string,
+        args: string[],
+        options: SpawnOptions
+    ): Promise<ExecutionResult<string>> {
+        type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
+        const request = new RequestType<
+            // tslint:disable-next-line: no-any
+            { file_name: string; args: string[]; cwd?: string; env?: any },
+            ExecResponse,
+            void,
+            void
+        >('exec_file');
+        const response = await this.sendRequest(request, {
+            file_name: fileName,
+            args,
+            cwd: options.cwd,
+            env: options.env
+        });
+        this.processResponse(response, options);
+        return response;
+    }
+    private async execModuleWithDaemon(
+        moduleName: string,
+        args: string[],
+        options: SpawnOptions
+    ): Promise<ExecutionResult<string>> {
+        type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
+        const request = new RequestType<
+            // tslint:disable-next-line: no-any
+            { module_name: string; args: string[]; cwd?: string; env?: any },
+            ExecResponse,
+            void,
+            void
+        >('exec_module');
+        const response = await this.sendRequest(request, {
+            module_name: moduleName,
+            args,
+            cwd: options.cwd,
+            env: options.env
+        });
+        this.processResponse(response, options);
+        return response;
+    }
+    private monitorConnection() {
+        // tslint:disable-next-line: no-any
+        const logConnectionStatus = (msg: string, ex?: any) => {
+            if (!this.disposed) {
+                this.connectionClosedMessage += msg + (ex ? `, With Error: ${util.format(ex)}` : '');
+                this.connectionClosedDeferred.reject(new ConnectionClosedError(this.connectionClosedMessage));
+                traceWarning(msg);
+                if (ex) {
+                    traceError('Connection errored', ex);
+                }
+            }
+        };
+        this.disposables.push(this.connection.onClose(() => logConnectionStatus('Daemon Connection Closed')));
+        this.disposables.push(this.connection.onDispose(() => logConnectionStatus('Daemon Connection disposed')));
+        this.disposables.push(this.connection.onError((ex) => logConnectionStatus('Daemon Connection errored', ex)));
+        // this.proc.on('error', error => logConnectionStatus('Daemon Processed died with error', error));
+        this.proc.on('exit', (code) => logConnectionStatus('Daemon Processed died with exit code', code));
+        // Wire up stdout/stderr.
+        const OuputNotification = new NotificationType<Output<string>, void>('output');
+        this.connection.onNotification(OuputNotification, (output) => this.outputObservale.next(output));
+        const logNotification = new NotificationType<
+            { level: 'WARN' | 'WARNING' | 'INFO' | 'DEBUG' | 'NOTSET'; msg: string; pid?: string },
+            void
+        >('log');
+        this.connection.onNotification(logNotification, (output) => {
+            const pid = output.pid ? ` (pid: ${output.pid})` : '';
+            const msg = `Python Daemon${pid}: ${output.msg}`;
+            if (output.level === 'DEBUG' || output.level === 'NOTSET') {
+                traceVerbose(msg);
+            } else if (output.level === 'INFO') {
+                traceInfo(msg);
+            } else if (output.level === 'WARN' || output.level === 'WARNING') {
+                traceWarning(msg);
+            } else {
+                traceError(msg);
+            }
+        });
+        this.connection.onUnhandledNotification(traceError);
+    }
+}

--- a/src/client/common/process/pythonDaemon.ts
+++ b/src/client/common/process/pythonDaemon.ts
@@ -227,10 +227,10 @@ export class PythonDaemonExecutionService implements IPythonDaemonExecutionServi
         // tslint:disable-next-line: no-any
         return Object.keys(options).every((item) => daemonSupportedSpawnOptions.indexOf(item as any) >= 0);
     }
-    private sendRequestWithoutArgs<R, E, RO>(type: RequestType0<R, E, RO>): Thenable<R> {
+    protected sendRequestWithoutArgs<R, E, RO>(type: RequestType0<R, E, RO>): Thenable<R> {
         return Promise.race([this.connection.sendRequest(type), this.connectionClosedDeferred.promise]);
     }
-    private sendRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, params?: P): Thenable<R> {
+    protected sendRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, params?: P): Thenable<R> {
         // Throw an error if the connection has been closed.
         return Promise.race([this.connection.sendRequest(type, params), this.connectionClosedDeferred.promise]);
     }
@@ -402,11 +402,12 @@ export class PythonDaemonExecutionService implements IPythonDaemonExecutionServi
         const OuputNotification = new NotificationType<Output<string>, void>('output');
         this.connection.onNotification(OuputNotification, (output) => this.outputObservale.next(output));
         const logNotification = new NotificationType<
-            { level: 'WARN' | 'WARNING' | 'INFO' | 'DEBUG' | 'NOTSET'; msg: string },
+            { level: 'WARN' | 'WARNING' | 'INFO' | 'DEBUG' | 'NOTSET'; msg: string; pid?: string },
             void
         >('log');
         this.connection.onNotification(logNotification, (output) => {
-            const msg = `Python Daemon: ${output.msg}`;
+            const pid = output.pid ? ` (pid: ${output.pid})` : '';
+            const msg = `Python Daemon${pid}: ${output.msg}`;
             if (output.level === 'DEBUG' || output.level === 'NOTSET') {
                 traceVerbose(msg);
             } else if (output.level === 'INFO') {

--- a/src/client/common/process/pythonDaemon.ts
+++ b/src/client/common/process/pythonDaemon.ts
@@ -4,27 +4,19 @@
 'use strict';
 
 import { ChildProcess } from 'child_process';
-import * as os from 'os';
-import { Subject } from 'rxjs/Subject';
-import * as util from 'util';
-import { MessageConnection, NotificationType, RequestType, RequestType0 } from 'vscode-jsonrpc';
-import { traceError, traceInfo, traceVerbose, traceWarning } from '../logger';
-import { IDisposable } from '../types';
-import { createDeferred, Deferred } from '../utils/async';
-import { noop } from '../utils/misc';
+import { MessageConnection, RequestType, RequestType0 } from 'vscode-jsonrpc';
+import { traceWarning } from '../logger';
 import { Architecture } from '../utils/platform';
 import { parsePythonVersion } from '../utils/version';
+import { BasePythonDaemon } from './baseDaemon';
 import {
-    ExecutionResult,
     InterpreterInfomation,
     IPythonDaemonExecutionService,
     IPythonExecutionService,
     ObservableExecutionResult,
-    Output,
     PythonExecutionInfo,
     PythonVersionInfo,
-    SpawnOptions,
-    StdErrError
+    SpawnOptions
 } from './types';
 
 type ErrorResponse = { error?: string };
@@ -40,39 +32,14 @@ export class DaemonError extends Error {
         super();
     }
 }
-export class PythonDaemonExecutionService implements IPythonDaemonExecutionService {
-    private connectionClosedMessage: string = '';
-    private outputObservale = new Subject<Output<string>>();
-    // tslint:disable-next-line: no-any
-    private readonly connectionClosedDeferred: Deferred<any>;
-    private disposables: IDisposable[] = [];
-    public get isAlive(): boolean {
-        return this.connectionClosedMessage === '';
-    }
-    private disposed = false;
+export class PythonDaemonExecutionService extends BasePythonDaemon implements IPythonDaemonExecutionService {
     constructor(
-        protected readonly pythonExecutionService: IPythonExecutionService,
-        protected readonly pythonPath: string,
-        public readonly proc: ChildProcess,
-        public readonly connection: MessageConnection
+        pythonExecutionService: IPythonExecutionService,
+        pythonPath: string,
+        proc: ChildProcess,
+        connection: MessageConnection
     ) {
-        // tslint:disable-next-line: no-any
-        this.connectionClosedDeferred = createDeferred<any>();
-        // This promise gets used conditionally, if it doesn't get used, and the promise is rejected,
-        // then node logs errors. We don't want that, hence add a dummy error handler.
-        this.connectionClosedDeferred.promise.catch(noop);
-        this.monitorConnection();
-    }
-    public dispose() {
-        try {
-            this.disposed = true;
-            // The daemon should die as a result of this.
-            this.connection.sendNotification(new NotificationType('exit'));
-            this.proc.kill();
-        } catch {
-            noop();
-        }
-        this.disposables.forEach((item) => item.dispose());
+        super(pythonExecutionService, pythonPath, proc, connection);
     }
     public async getInterpreterInformation(): Promise<InterpreterInfomation | undefined> {
         try {
@@ -170,259 +137,6 @@ export class PythonDaemonExecutionService implements IPythonDaemonExecutionServi
             }
         } else {
             return this.pythonExecutionService.execModuleObservable(moduleName, args, options);
-        }
-    }
-    public async exec(args: string[], options: SpawnOptions): Promise<ExecutionResult<string>> {
-        if (this.isAlive && this.canExecFileUsingDaemon(args, options)) {
-            try {
-                return await this.execFileWithDaemon(args[0], args.slice(1), options);
-            } catch (ex) {
-                if (ex instanceof DaemonError || ex instanceof ConnectionClosedError) {
-                    traceWarning('Falling back to Python Execution Service due to failure in daemon', ex);
-                    return this.pythonExecutionService.exec(args, options);
-                } else {
-                    throw ex;
-                }
-            }
-        } else {
-            return this.pythonExecutionService.exec(args, options);
-        }
-    }
-    public async execModule(
-        moduleName: string,
-        args: string[],
-        options: SpawnOptions
-    ): Promise<ExecutionResult<string>> {
-        if (this.isAlive && this.canExecModuleUsingDaemon(moduleName, args, options)) {
-            try {
-                return await this.execModuleWithDaemon(moduleName, args, options);
-            } catch (ex) {
-                if (ex instanceof DaemonError || ex instanceof ConnectionClosedError) {
-                    traceWarning('Falling back to Python Execution Service due to failure in daemon', ex);
-                    return this.pythonExecutionService.execModule(moduleName, args, options);
-                } else {
-                    throw ex;
-                }
-            }
-        } else {
-            return this.pythonExecutionService.execModule(moduleName, args, options);
-        }
-    }
-    protected canExecFileUsingDaemon(args: string[], options: SpawnOptions): boolean {
-        return args[0].toLowerCase().endsWith('.py') && this.areOptionsSupported(options);
-    }
-    protected canExecModuleUsingDaemon(_moduleName: string, _args: string[], options: SpawnOptions): boolean {
-        return this.areOptionsSupported(options);
-    }
-    protected areOptionsSupported(options: SpawnOptions): boolean {
-        const daemonSupportedSpawnOptions: (keyof SpawnOptions)[] = [
-            'cwd',
-            'env',
-            'throwOnStdErr',
-            'token',
-            'encoding',
-            'mergeStdOutErr',
-            'extraVariables'
-        ];
-        // tslint:disable-next-line: no-any
-        return Object.keys(options).every((item) => daemonSupportedSpawnOptions.indexOf(item as any) >= 0);
-    }
-    protected sendRequestWithoutArgs<R, E, RO>(type: RequestType0<R, E, RO>): Thenable<R> {
-        return Promise.race([this.connection.sendRequest(type), this.connectionClosedDeferred.promise]);
-    }
-    protected sendRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, params?: P): Thenable<R> {
-        // Throw an error if the connection has been closed.
-        return Promise.race([this.connection.sendRequest(type, params), this.connectionClosedDeferred.promise]);
-    }
-    /**
-     * Process the response.
-     *
-     * @private
-     * @param {{ error?: string | undefined; stdout: string; stderr?: string }} response
-     * @param {SpawnOptions} options
-     * @memberof PythonDaemonExecutionService
-     */
-    private processResponse(
-        response: { error?: string | undefined; stdout: string; stderr?: string },
-        options: SpawnOptions
-    ) {
-        if (response.error) {
-            throw new DaemonError(`Failed to execute using the daemon, ${response.error}`);
-        }
-        // Throw an error if configured to do so if there's any output in stderr.
-        if (response.stderr && options.throwOnStdErr) {
-            throw new StdErrError(response.stderr);
-        }
-        // Merge stdout and stderr into on if configured to do so.
-        if (response.stderr && options.mergeStdOutErr) {
-            response.stdout = `${response.stdout || ''}${os.EOL}${response.stderr}`;
-        }
-    }
-    private async execFileWithDaemon(
-        fileName: string,
-        args: string[],
-        options: SpawnOptions
-    ): Promise<ExecutionResult<string>> {
-        type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
-        const request = new RequestType<
-            // tslint:disable-next-line: no-any
-            { file_name: string; args: string[]; cwd?: string; env?: any },
-            ExecResponse,
-            void,
-            void
-        >('exec_file');
-        const response = await this.sendRequest(request, {
-            file_name: fileName,
-            args,
-            cwd: options.cwd,
-            env: options.env
-        });
-        this.processResponse(response, options);
-        return response;
-    }
-    private async execModuleWithDaemon(
-        moduleName: string,
-        args: string[],
-        options: SpawnOptions
-    ): Promise<ExecutionResult<string>> {
-        type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
-        const request = new RequestType<
-            // tslint:disable-next-line: no-any
-            { module_name: string; args: string[]; cwd?: string; env?: any },
-            ExecResponse,
-            void,
-            void
-        >('exec_module');
-        const response = await this.sendRequest(request, {
-            module_name: moduleName,
-            args,
-            cwd: options.cwd,
-            env: options.env
-        });
-        this.processResponse(response, options);
-        return response;
-    }
-    private execAsObservable(
-        moduleOrFile: { moduleName: string } | { fileName: string },
-        args: string[],
-        options: SpawnOptions
-    ): ObservableExecutionResult<string> {
-        const subject = new Subject<Output<string>>();
-        const start = async () => {
-            type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
-            let response: ExecResponse;
-            if ('fileName' in moduleOrFile) {
-                const request = new RequestType<
-                    // tslint:disable-next-line: no-any
-                    { file_name: string; args: string[]; cwd?: string; env?: any },
-                    ExecResponse,
-                    void,
-                    void
-                >('exec_file_observable');
-                response = await this.sendRequest(request, {
-                    file_name: moduleOrFile.fileName,
-                    args,
-                    cwd: options.cwd,
-                    env: options.env
-                });
-            } else {
-                const request = new RequestType<
-                    // tslint:disable-next-line: no-any
-                    { module_name: string; args: string[]; cwd?: string; env?: any },
-                    ExecResponse,
-                    void,
-                    void
-                >('exec_module_observable');
-                response = await this.sendRequest(request, {
-                    module_name: moduleOrFile.moduleName,
-                    args,
-                    cwd: options.cwd,
-                    env: options.env
-                });
-            }
-            // Might not get a response object back, as its observable.
-            if (response && response.error) {
-                throw new DaemonError(response.error);
-            }
-        };
-        let stdErr = '';
-        this.proc.stderr.on('data', (output: string | Buffer) => (stdErr += output.toString()));
-        // Wire up stdout/stderr.
-        const subscription = this.outputObservale.subscribe((out) => {
-            if (out.source === 'stderr' && options.throwOnStdErr) {
-                subject.error(new StdErrError(out.out));
-            } else if (out.source === 'stderr' && options.mergeStdOutErr) {
-                subject.next({ source: 'stdout', out: out.out });
-            } else {
-                subject.next(out);
-            }
-        });
-        start()
-            .catch((ex) => {
-                const errorMsg = `Failed to run ${
-                    'fileName' in moduleOrFile ? moduleOrFile.fileName : moduleOrFile.moduleName
-                } as observable with args ${args.join(' ')}`;
-                traceError(errorMsg, ex);
-                subject.next({ source: 'stderr', out: `${errorMsg}\n${stdErr}` });
-                subject.error(ex);
-            })
-            .finally(() => {
-                // Wait until all messages are received.
-                setTimeout(() => {
-                    subscription.unsubscribe();
-                    subject.complete();
-                }, 100);
-            })
-            .ignoreErrors();
-
-        return {
-            proc: this.proc,
-            dispose: () => this.dispose(),
-            out: subject
-        };
-    }
-    private monitorConnection() {
-        // tslint:disable-next-line: no-any
-        const logConnectionStatus = (msg: string, ex?: any) => {
-            if (!this.disposed) {
-                this.connectionClosedMessage += msg + (ex ? `, With Error: ${util.format(ex)}` : '');
-                this.connectionClosedDeferred.reject(new ConnectionClosedError(this.connectionClosedMessage));
-                traceWarning(msg);
-                if (ex) {
-                    traceError('Connection errored', ex);
-                }
-            }
-        };
-        this.disposables.push(this.connection.onClose(() => logConnectionStatus('Daemon Connection Closed')));
-        this.disposables.push(this.connection.onDispose(() => logConnectionStatus('Daemon Connection disposed')));
-        this.disposables.push(this.connection.onError((ex) => logConnectionStatus('Daemon Connection errored', ex)));
-        // this.proc.on('error', error => logConnectionStatus('Daemon Processed died with error', error));
-        this.proc.on('exit', (code) => logConnectionStatus('Daemon Processed died with exit code', code));
-        // Wire up stdout/stderr.
-        const OuputNotification = new NotificationType<Output<string>, void>('output');
-        this.connection.onNotification(OuputNotification, (output) => this.outputObservale.next(output));
-        const logNotification = new NotificationType<
-            { level: 'WARN' | 'WARNING' | 'INFO' | 'DEBUG' | 'NOTSET'; msg: string; pid?: string },
-            void
-        >('log');
-        this.connection.onNotification(logNotification, (output) => {
-            const pid = output.pid ? ` (pid: ${output.pid})` : '';
-            const msg = `Python Daemon${pid}: ${output.msg}`;
-            if (output.level === 'DEBUG' || output.level === 'NOTSET') {
-                traceVerbose(msg);
-            } else if (output.level === 'INFO') {
-                traceInfo(msg);
-            } else if (output.level === 'WARN' || output.level === 'WARNING') {
-                traceWarning(msg);
-            } else {
-                traceError(msg);
-            }
-        });
-        this.connection.onUnhandledNotification(traceError);
-    }
-    private throwIfRPCConnectionIsDead() {
-        if (!this.isAlive) {
-            throw new ConnectionClosedError(this.connectionClosedMessage);
         }
     }
 }

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -51,11 +51,7 @@ export class PythonDaemonFactory {
     }
     @traceDecorators.error('Failed to create daemon')
     public async createDaemonService<T extends IPythonDaemonExecutionService>(): Promise<T> {
-        const loggingArgs: string[] = [
-            '-v',
-            '--v',
-            '--log-file=/Users/donjayamanne/Desktop/Development/vsc/pythonVSCode/daaemon.log'
-        ]; // Log information messages or greater (see daemon.__main__.py for options).
+        const loggingArgs: string[] = ['-v']; // Log information messages or greater (see daemon.__main__.py for options).
         const args = (this.options.daemonModule ? [`--daemon-module=${this.options.daemonModule}`] : []).concat(
             loggingArgs
         );

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -19,13 +19,13 @@ import { PythonDaemonExecutionService } from './pythonDaemon';
 import { DaemonExecutionFactoryCreationOptions, IPythonDaemonExecutionService, IPythonExecutionService } from './types';
 
 export class PythonDaemonFactory {
-    private readonly envVariables: NodeJS.ProcessEnv;
-    private readonly pythonPath: string;
+    protected readonly envVariables: NodeJS.ProcessEnv;
+    protected readonly pythonPath: string;
     constructor(
         protected readonly disposables: IDisposableRegistry,
-        private readonly options: DaemonExecutionFactoryCreationOptions,
-        private readonly pythonExecutionService: IPythonExecutionService,
-        private readonly activatedEnvVariables?: NodeJS.ProcessEnv
+        protected readonly options: DaemonExecutionFactoryCreationOptions,
+        protected readonly pythonExecutionService: IPythonExecutionService,
+        protected readonly activatedEnvVariables?: NodeJS.ProcessEnv
     ) {
         if (!options.pythonPath) {
             throw new Error('options.pythonPath is empty when it shoud not be');
@@ -50,7 +50,7 @@ export class PythonDaemonFactory {
         this.envVariables[PYTHON_WARNINGS] = 'ignore';
     }
     @traceDecorators.error('Failed to create daemon')
-    public async createDaemonServices<T extends IPythonDaemonExecutionService>(): Promise<T> {
+    public async createDaemonService<T extends IPythonDaemonExecutionService>(): Promise<T> {
         const loggingArgs: string[] = [
             '-v',
             '--v',
@@ -111,7 +111,7 @@ export class PythonDaemonFactory {
      * @memberof PythonDaemonExecutionServicePool
      */
     @traceDecorators.error('Pinging Daemon Failed')
-    private async testDaemon(connection: MessageConnection) {
+    protected async testDaemon(connection: MessageConnection) {
         // If we don't get a reply to the ping in 5 seconds assume it will never work. Bomb out.
         // At this point there should be some information logged in stderr of the daemon process.
         const fail = createDeferred<{ pong: string }>();

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ChildProcess } from 'child_process';
+import * as path from 'path';
+import {
+    createMessageConnection,
+    MessageConnection,
+    RequestType,
+    StreamMessageReader,
+    StreamMessageWriter
+} from 'vscode-jsonrpc';
+
+import { EXTENSION_ROOT_DIR } from '../../constants';
+import { PYTHON_WARNINGS } from '../constants';
+import { traceDecorators, traceError } from '../logger';
+import { IDisposableRegistry } from '../types';
+import { createDeferred } from '../utils/async';
+import { PythonDaemonExecutionService } from './pythonDaemon';
+import { DaemonExecutionFactoryCreationOptions, IPythonDaemonExecutionService, IPythonExecutionService } from './types';
+
+export class PythonDaemonFactory {
+    private readonly envVariables: NodeJS.ProcessEnv;
+    private readonly pythonPath: string;
+    constructor(
+        protected readonly disposables: IDisposableRegistry,
+        private readonly options: DaemonExecutionFactoryCreationOptions,
+        private readonly pythonExecutionService: IPythonExecutionService,
+        private readonly activatedEnvVariables?: NodeJS.ProcessEnv
+    ) {
+        if (!options.pythonPath) {
+            throw new Error('options.pythonPath is empty when it shoud not be');
+        }
+        this.pythonPath = options.pythonPath;
+        // Setup environment variables for the daemon.
+        // The daemon must have access to the Python Module that'll run the daemon
+        // & also access to a Python package used for the JSON rpc comms.
+        const envPythonPath = `${path.join(EXTENSION_ROOT_DIR, 'pythonFiles')}${path.delimiter}${path.join(
+            EXTENSION_ROOT_DIR,
+            'pythonFiles',
+            'lib',
+            'python'
+        )}`;
+        this.envVariables = this.activatedEnvVariables ? { ...this.activatedEnvVariables } : { ...process.env };
+        this.envVariables.PYTHONPATH = this.envVariables.PYTHONPATH
+            ? `${this.envVariables.PYTHONPATH}${path.delimiter}${envPythonPath}`
+            : envPythonPath;
+        this.envVariables.PYTHONUNBUFFERED = '1';
+
+        // Always ignore warnings as the user should never see the output of the daemon running
+        this.envVariables[PYTHON_WARNINGS] = 'ignore';
+    }
+    @traceDecorators.error('Failed to create daemon')
+    public async createDaemonServices<T extends IPythonDaemonExecutionService>(): Promise<T> {
+        const loggingArgs: string[] = [
+            '-v',
+            '--v',
+            '--log-file=/Users/donjayamanne/Desktop/Development/vsc/pythonVSCode/daaemon.log'
+        ]; // Log information messages or greater (see daemon.__main__.py for options).
+        const args = (this.options.daemonModule ? [`--daemon-module=${this.options.daemonModule}`] : []).concat(
+            loggingArgs
+        );
+        const env = this.envVariables;
+        const daemonProc = this.pythonExecutionService!.execModuleObservable(
+            'vscode_datascience_helpers.daemon',
+            args,
+            { env }
+        );
+        if (!daemonProc.proc) {
+            throw new Error('Failed to create Daemon Proc');
+        }
+        const connection = this.createConnection(daemonProc.proc);
+
+        connection.listen();
+        let stdError = '';
+        let procEndEx: Error | undefined;
+        daemonProc.proc.stderr.on('data', (data: string | Buffer) => {
+            data = typeof data === 'string' ? data : data.toString('utf8');
+            stdError += data;
+        });
+        daemonProc.proc.on('error', (ex) => (procEndEx = ex));
+
+        try {
+            await this.testDaemon(connection);
+
+            const cls = this.options.daemonClass ?? PythonDaemonExecutionService;
+            const instance = new cls(this.pythonExecutionService, this.pythonPath, daemonProc.proc, connection);
+            if (instance instanceof PythonDaemonExecutionService) {
+                this.disposables.push(instance);
+                return (instance as unknown) as T;
+            }
+            throw new Error(`Daemon class ${cls.name} must inherit PythonDaemonExecutionService.`);
+        } catch (ex) {
+            traceError('Failed to start the Daemon, StdErr: ', stdError);
+            traceError('Failed to start the Daemon, ProcEndEx', procEndEx || ex);
+            traceError('Failed  to start the Daemon, Ex', ex);
+            throw ex;
+        }
+    }
+    /**
+     * Protected so we can override for testing purposes.
+     */
+    protected createConnection(proc: ChildProcess) {
+        return createMessageConnection(new StreamMessageReader(proc.stdout), new StreamMessageWriter(proc.stdin));
+    }
+    /**
+     * Tests whether a daemon is usable or not by checking whether it responds to a simple ping.
+     * If a daemon doesn't reply to a ping in 5s, then its deemed to be dead/not usable.
+     *
+     * @private
+     * @param {MessageConnection} connection
+     * @memberof PythonDaemonExecutionServicePool
+     */
+    @traceDecorators.error('Pinging Daemon Failed')
+    private async testDaemon(connection: MessageConnection) {
+        // If we don't get a reply to the ping in 5 seconds assume it will never work. Bomb out.
+        // At this point there should be some information logged in stderr of the daemon process.
+        const fail = createDeferred<{ pong: string }>();
+        const timer = setTimeout(() => fail.reject(new Error('Timeout waiting for daemon to start')), 5_000);
+        const request = new RequestType<{ data: string }, { pong: string }, void, void>('ping');
+        // Check whether the daemon has started correctly, by sending a ping.
+        const result = await Promise.race([fail.promise, connection.sendRequest(request, { data: 'hello' })]);
+        clearTimeout(timer);
+        if (result.pong !== 'hello') {
+            throw new Error(`Daemon did not reply to the ping, received: ${result.pong}`);
+        }
+    }
+}

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -13,8 +13,9 @@ import {
 import { EXTENSION_ROOT_DIR } from '../../constants';
 import { PYTHON_WARNINGS } from '../constants';
 import { traceDecorators, traceError } from '../logger';
-import { IDisposableRegistry } from '../types';
+import { IDisposable, IDisposableRegistry } from '../types';
 import { createDeferred } from '../utils/async';
+import { BasePythonDaemon } from './baseDaemon';
 import { PythonDaemonExecutionService } from './pythonDaemon';
 import { DaemonExecutionFactoryCreationOptions, IPythonDaemonExecutionService, IPythonExecutionService } from './types';
 
@@ -50,7 +51,7 @@ export class PythonDaemonFactory {
         this.envVariables[PYTHON_WARNINGS] = 'ignore';
     }
     @traceDecorators.error('Failed to create daemon')
-    public async createDaemonService<T extends IPythonDaemonExecutionService>(): Promise<T> {
+    public async createDaemonService<T extends IPythonDaemonExecutionService | IDisposable>(): Promise<T> {
         const loggingArgs: string[] = ['-v']; // Log information messages or greater (see daemon.__main__.py for options).
         const args = (this.options.daemonModule ? [`--daemon-module=${this.options.daemonModule}`] : []).concat(
             loggingArgs
@@ -80,11 +81,11 @@ export class PythonDaemonFactory {
 
             const cls = this.options.daemonClass ?? PythonDaemonExecutionService;
             const instance = new cls(this.pythonExecutionService, this.pythonPath, daemonProc.proc, connection);
-            if (instance instanceof PythonDaemonExecutionService) {
+            if (instance instanceof BasePythonDaemon) {
                 this.disposables.push(instance);
                 return (instance as unknown) as T;
             }
-            throw new Error(`Daemon class ${cls.name} must inherit PythonDaemonExecutionService.`);
+            throw new Error(`Daemon class ${cls.name} must inherit BasePythonDaemon.`);
         } catch (ex) {
             traceError('Failed to start the Daemon, StdErr: ', stdError);
             traceError('Failed to start the Daemon, ProcEndEx', procEndEx || ex);

--- a/src/client/common/process/pythonDaemonPool.ts
+++ b/src/client/common/process/pythonDaemonPool.ts
@@ -38,8 +38,8 @@ export class PythonDaemonExecutionServicePool extends PythonDaemonFactory implem
         this.disposables.push(this);
     }
     public async initialize() {
-        // If `daemonCount` is not in optoins, then we are not initializing a pool of daemons.
-        if (!('daemonCount' in this.options)) {
+        // If `dedicated` is in optoins, then we are not initializing a pool of daemons.
+        if ('dedicated' in this.options) {
             return;
         }
         const promises = Promise.all(

--- a/src/client/common/process/pythonDaemonPool.ts
+++ b/src/client/common/process/pythonDaemonPool.ts
@@ -38,6 +38,7 @@ export class PythonDaemonExecutionServicePool extends PythonDaemonFactory implem
         this.disposables.push(this);
     }
     public async initialize() {
+        // If `daemonCount` is not in optoins, then we are not initializing a pool of daemons.
         if (!('daemonCount' in this.options)) {
             return;
         }

--- a/src/client/common/process/pythonDaemonPool.ts
+++ b/src/client/common/process/pythonDaemonPool.ts
@@ -1,24 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ChildProcess } from 'child_process';
-import * as path from 'path';
-import {
-    createMessageConnection,
-    MessageConnection,
-    RequestType,
-    StreamMessageReader,
-    StreamMessageWriter
-} from 'vscode-jsonrpc';
 
-import { EXTENSION_ROOT_DIR } from '../../constants';
-import { PYTHON_WARNINGS } from '../constants';
-import { traceDecorators, traceError } from '../logger';
 import { IDisposableRegistry } from '../types';
-import { createDeferred, sleep } from '../utils/async';
+import { sleep } from '../utils/async';
 import { noop } from '../utils/misc';
 import { StopWatch } from '../utils/stopWatch';
 import { ProcessService } from './proc';
 import { PythonDaemonExecutionService } from './pythonDaemon';
+import { PythonDaemonFactory } from './pythonDaemonFactory';
 import {
     ExecutionResult,
     InterpreterInfomation,
@@ -33,44 +22,25 @@ import {
 
 type DaemonType = 'StandardDaemon' | 'ObservableDaemon';
 
-export class PythonDaemonExecutionServicePool implements IPythonDaemonExecutionService {
+export class PythonDaemonExecutionServicePool extends PythonDaemonFactory implements IPythonDaemonExecutionService {
     private readonly daemons: IPythonDaemonExecutionService[] = [];
     private readonly observableDaemons: IPythonDaemonExecutionService[] = [];
-    private readonly envVariables: NodeJS.ProcessEnv;
-    private readonly pythonPath: string;
     private _disposed = false;
     constructor(
         private readonly logger: IProcessLogger,
-        private readonly disposables: IDisposableRegistry,
-        private readonly options: PooledDaemonExecutionFactoryCreationOptions,
-        private readonly pythonExecutionService: IPythonExecutionService,
-        private readonly activatedEnvVariables?: NodeJS.ProcessEnv,
+        disposables: IDisposableRegistry,
+        options: PooledDaemonExecutionFactoryCreationOptions,
+        pythonExecutionService: IPythonExecutionService,
+        activatedEnvVariables?: NodeJS.ProcessEnv,
         private readonly timeoutWaitingForDaemon: number = 1_000
     ) {
-        if (!options.pythonPath) {
-            throw new Error('options.pythonPath is empty when it shoud not be');
-        }
-        this.pythonPath = options.pythonPath;
-        // Setup environment variables for the daemon.
-        // The daemon must have access to the Python Module that'll run the daemon
-        // & also access to a Python package used for the JSON rpc comms.
-        const envPythonPath = `${path.join(EXTENSION_ROOT_DIR, 'pythonFiles')}${path.delimiter}${path.join(
-            EXTENSION_ROOT_DIR,
-            'pythonFiles',
-            'lib',
-            'python'
-        )}`;
-        this.envVariables = this.activatedEnvVariables ? { ...this.activatedEnvVariables } : { ...process.env };
-        this.envVariables.PYTHONPATH = this.envVariables.PYTHONPATH
-            ? `${this.envVariables.PYTHONPATH}${path.delimiter}${envPythonPath}`
-            : envPythonPath;
-        this.envVariables.PYTHONUNBUFFERED = '1';
-
-        // Always ignore warnings as the user should never see the output of the daemon running
-        this.envVariables[PYTHON_WARNINGS] = 'ignore';
+        super(disposables, options, pythonExecutionService, activatedEnvVariables);
         this.disposables.push(this);
     }
     public async initialize() {
+        if (!('daemonCount' in this.options)) {
+            return;
+        }
         const promises = Promise.all(
             [
                 // tslint:disable-next-line: prefer-array-literal
@@ -127,60 +97,6 @@ export class PythonDaemonExecutionServicePool implements IPythonDaemonExecutionS
     ): ObservableExecutionResult<string> {
         const msg = { args: ['-m', moduleName].concat(args), options };
         return this.wrapObservableCall((daemon) => daemon.execModuleObservable(moduleName, args, options), msg);
-    }
-    /**
-     * Protected so we can override for testing purposes.
-     *
-     * @protected
-     * @param {ChildProcess} proc
-     * @returns
-     * @memberof PythonDaemonExecutionServicePool
-     */
-    protected createConnection(proc: ChildProcess) {
-        return createMessageConnection(new StreamMessageReader(proc.stdout), new StreamMessageWriter(proc.stdin));
-    }
-    @traceDecorators.error('Failed to create daemon')
-    protected async createDaemonServices(): Promise<IPythonDaemonExecutionService> {
-        const loggingArgs: string[] = ['-v']; // Log information messages or greater (see daemon.__main__.py for options).
-        const args = (this.options.daemonModule ? [`--daemon-module=${this.options.daemonModule}`] : []).concat(
-            loggingArgs
-        );
-        const env = this.envVariables;
-        const daemonProc = this.pythonExecutionService!.execModuleObservable(
-            'vscode_datascience_helpers.daemon',
-            args,
-            { env }
-        );
-        if (!daemonProc.proc) {
-            throw new Error('Failed to create Daemon Proc');
-        }
-        const connection = this.createConnection(daemonProc.proc);
-
-        connection.listen();
-        let stdError = '';
-        let procEndEx: Error | undefined;
-        daemonProc.proc.stderr.on('data', (data: string | Buffer) => {
-            data = typeof data === 'string' ? data : data.toString('utf8');
-            stdError += data;
-        });
-        daemonProc.proc.on('error', (ex) => (procEndEx = ex));
-
-        try {
-            await this.testDaemon(connection);
-
-            const cls = this.options.daemonClass ?? PythonDaemonExecutionService;
-            const instance = new cls(this.pythonExecutionService, this.pythonPath, daemonProc.proc, connection);
-            if (instance instanceof PythonDaemonExecutionService) {
-                this.disposables.push(instance);
-                return instance;
-            }
-            throw new Error(`Daemon class ${cls.name} must inherit PythonDaemonExecutionService.`);
-        } catch (ex) {
-            traceError('Failed to start the Daemon, StdErr: ', stdError);
-            traceError('Failed to start the Daemon, ProcEndEx', procEndEx || ex);
-            traceError('Failed  to start the Daemon, Ex', ex);
-            throw ex;
-        }
     }
     /**
      * Wrapper for all promise operations to be performed on a daemon.
@@ -259,7 +175,7 @@ export class PythonDaemonExecutionServicePool implements IPythonDaemonExecutionS
      * @memberof PythonDaemonExecutionServicePool
      */
     private async addDaemonService(type: DaemonType) {
-        const daemon = await this.createDaemonServices();
+        const daemon = await this.createDaemonService();
         const pool = type === 'StandardDaemon' ? this.daemons : this.observableDaemons;
         pool.push(daemon);
     }
@@ -341,27 +257,5 @@ export class PythonDaemonExecutionServicePool implements IPythonDaemonExecutionS
         };
 
         testAndPushIntoPool().ignoreErrors();
-    }
-    /**
-     * Tests whether a daemon is usable or not by checking whether it responds to a simple ping.
-     * If a daemon doesn't reply to a ping in 5s, then its deemed to be dead/not usable.
-     *
-     * @private
-     * @param {MessageConnection} connection
-     * @memberof PythonDaemonExecutionServicePool
-     */
-    @traceDecorators.error('Pinging Daemon Failed')
-    private async testDaemon(connection: MessageConnection) {
-        // If we don't get a reply to the ping in 5 seconds assume it will never work. Bomb out.
-        // At this point there should be some information logged in stderr of the daemon process.
-        const fail = createDeferred<{ pong: string }>();
-        const timer = setTimeout(() => fail.reject(new Error('Timeout waiting for daemon to start')), 5_000);
-        const request = new RequestType<{ data: string }, { pong: string }, void, void>('ping');
-        // Check whether the daemon has started correctly, by sending a ping.
-        const result = await Promise.race([fail.promise, connection.sendRequest(request, { data: 'hello' })]);
-        clearTimeout(timer);
-        if (result.pong !== 'hello') {
-            throw new Error(`Daemon did not reply to the ping, received: ${result.pong}`);
-        }
     }
 }

--- a/src/client/common/process/pythonDaemonPool.ts
+++ b/src/client/common/process/pythonDaemonPool.ts
@@ -176,7 +176,7 @@ export class PythonDaemonExecutionServicePool extends PythonDaemonFactory implem
      * @memberof PythonDaemonExecutionServicePool
      */
     private async addDaemonService(type: DaemonType) {
-        const daemon = await this.createDaemonService();
+        const daemon = await this.createDaemonService<IPythonDaemonExecutionService>();
         const pool = type === 'StandardDaemon' ? this.daemons : this.observableDaemons;
         pool.push(daemon);
     }

--- a/src/client/common/process/pythonDaemonPool.ts
+++ b/src/client/common/process/pythonDaemonPool.ts
@@ -20,13 +20,13 @@ import { StopWatch } from '../utils/stopWatch';
 import { ProcessService } from './proc';
 import { PythonDaemonExecutionService } from './pythonDaemon';
 import {
-    DaemonExecutionFactoryCreationOptions,
     ExecutionResult,
     InterpreterInfomation,
     IProcessLogger,
     IPythonDaemonExecutionService,
     IPythonExecutionService,
     ObservableExecutionResult,
+    PooledDaemonExecutionFactoryCreationOptions,
     PythonExecutionInfo,
     SpawnOptions
 } from './types';
@@ -42,7 +42,7 @@ export class PythonDaemonExecutionServicePool implements IPythonDaemonExecutionS
     constructor(
         private readonly logger: IProcessLogger,
         private readonly disposables: IDisposableRegistry,
-        private readonly options: DaemonExecutionFactoryCreationOptions,
+        private readonly options: PooledDaemonExecutionFactoryCreationOptions,
         private readonly pythonExecutionService: IPythonExecutionService,
         private readonly activatedEnvVariables?: NodeJS.ProcessEnv,
         private readonly timeoutWaitingForDaemon: number = 1_000

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -13,7 +13,7 @@ import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { traceError } from '../logger';
 import { IFileSystem } from '../platform/types';
-import { IConfigurationService, IDisposableRegistry } from '../types';
+import { IConfigurationService, IDisposable, IDisposableRegistry } from '../types';
 import { ProcessService } from './proc';
 import { PythonDaemonFactory } from './pythonDaemonFactory';
 import { PythonDaemonExecutionServicePool } from './pythonDaemonPool';
@@ -64,7 +64,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         );
     }
 
-    public async createDaemon<T extends IPythonDaemonExecutionService>(
+    public async createDaemon<T extends IPythonDaemonExecutionService | IDisposable>(
         options: DaemonExecutionFactoryCreationOptions
     ): Promise<T> {
         const pythonPath = options.pythonPath

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -103,7 +103,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
                     activatedProc!,
                     activatedEnvVars
                 );
-                return factory.createDaemonServices<T>();
+                return factory.createDaemonService<T>();
             }
             const daemon = new PythonDaemonExecutionServicePool(
                 logger,

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -15,6 +15,7 @@ import { traceError } from '../logger';
 import { IFileSystem } from '../platform/types';
 import { IConfigurationService, IDisposableRegistry } from '../types';
 import { ProcessService } from './proc';
+import { PythonDaemonFactory } from './pythonDaemonFactory';
 import { PythonDaemonExecutionServicePool } from './pythonDaemonPool';
 import { createCondaEnv, createPythonEnv, createWindowsStoreEnv } from './pythonEnvironment';
 import { createPythonProcessService } from './pythonProcess';
@@ -63,7 +64,9 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         );
     }
 
-    public async createDaemon(options: DaemonExecutionFactoryCreationOptions): Promise<IPythonExecutionService> {
+    public async createDaemon<T extends IPythonDaemonExecutionService>(
+        options: DaemonExecutionFactoryCreationOptions
+    ): Promise<T> {
         const pythonPath = options.pythonPath
             ? options.pythonPath
             : this.configService.getSettings(options.resource).pythonPath;
@@ -81,17 +84,27 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         });
         // No daemon support in Python 2.7.
         if (interpreter?.version && interpreter.version.major < 3) {
-            return activatedProcPromise!;
+            return (activatedProcPromise! as unknown) as T;
         }
 
+        const createDedicatedDaemon = 'dedicated' in options && options.dedicated;
         // Ensure we do not start multiple daemons for the same interpreter.
         // Cache the promise.
-        const start = async () => {
+        const start = async (): Promise<T> => {
             const [activatedProc, activatedEnvVars] = await Promise.all([
                 activatedProcPromise,
                 this.activationHelper.getActivatedEnvironmentVariables(options.resource, interpreter, true)
             ]);
 
+            if (createDedicatedDaemon) {
+                const factory = new PythonDaemonFactory(
+                    disposables,
+                    { ...options, pythonPath },
+                    activatedProc!,
+                    activatedEnvVars
+                );
+                return factory.createDaemonServices<T>();
+            }
             const daemon = new PythonDaemonExecutionServicePool(
                 logger,
                 disposables,
@@ -101,21 +114,27 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             );
             await daemon.initialize();
             disposables.push(daemon);
-            return daemon;
+            return (daemon as unknown) as T;
         };
 
-        // Ensure we do not create multiple daemon pools for the same python interpreter.
-        let promise = this.daemonsPerPythonService.get(daemonPoolKey);
-        if (!promise) {
+        let promise: Promise<T>;
+
+        if (createDedicatedDaemon) {
             promise = start();
-            this.daemonsPerPythonService.set(daemonPoolKey, promise);
+        } else {
+            // Ensure we do not create multiple daemon pools for the same python interpreter.
+            promise = (this.daemonsPerPythonService.get(daemonPoolKey) as unknown) as Promise<T>;
+            if (!promise) {
+                promise = start();
+                this.daemonsPerPythonService.set(daemonPoolKey, promise);
+            }
         }
         return promise.catch((ex) => {
             // Ok, we failed to create the daemon (or failed to start).
             // What ever the cause, we need to log this & give a standard IPythonExecutionService
             traceError('Failed to create the daemon service, defaulting to activated environment', ex);
             this.daemonsPerPythonService.delete(daemonPoolKey);
-            return activatedProcPromise;
+            return (activatedProcPromise as unknown) as T;
         });
     }
     public async createActivatedEnvironment(

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -126,7 +126,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             promise = (this.daemonsPerPythonService.get(daemonPoolKey) as unknown) as Promise<T>;
             if (!promise) {
                 promise = start();
-                this.daemonsPerPythonService.set(daemonPoolKey, promise);
+                this.daemonsPerPythonService.set(daemonPoolKey, promise as Promise<IPythonDaemonExecutionService>);
             }
         }
         return promise.catch((ex) => {

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -65,7 +65,8 @@ export type ExecutionFactoryCreationOptions = {
     resource?: Uri;
     pythonPath?: string;
 };
-export type DaemonExecutionFactoryCreationOptions = ExecutionFactoryCreationOptions & {
+// This daemon will belong to a daemon pool (i.e it goes back into a pool for re-use).
+export type PooledDaemonExecutionFactoryCreationOptions = ExecutionFactoryCreationOptions & {
     /**
      * Python file that implements the daemon.
      *
@@ -96,6 +97,26 @@ export type DaemonExecutionFactoryCreationOptions = ExecutionFactoryCreationOpti
      */
     observableDaemonCount?: number;
 };
+// This daemon will not belong to a daemon pool (i.e its a dedicated daemon and cannot be re-used).
+export type DedicatedDaemonExecutionFactoryCreationOptions = ExecutionFactoryCreationOptions & {
+    /**
+     * Python file that implements the daemon.
+     */
+    daemonModule?: string;
+    /**
+     * Typescript Daemon class (client) that maps to the Python daemon.
+     * Defaults to `PythonDaemonExecutionService`.
+     * Any other class provided must extend `PythonDaemonExecutionService`.
+     */
+    daemonClass?: Newable<IPythonDaemonExecutionService>;
+    /**
+     * This flag indicates it is a dedicated daemon.
+     */
+    dedicated: true;
+};
+export type DaemonExecutionFactoryCreationOptions =
+    | PooledDaemonExecutionFactoryCreationOptions
+    | DedicatedDaemonExecutionFactoryCreationOptions;
 export type ExecutionFactoryCreateWithEnvironmentOptions = {
     resource?: Uri;
     interpreter?: PythonInterpreter;
@@ -117,10 +138,10 @@ export interface IPythonExecutionFactory {
      * Note: The returned execution service is always using an activated environment.
      *
      * @param {ExecutionFactoryCreationOptions} options
-     * @returns {(Promise<IPythonExecutionService & IDisposable>)}
+     * @returns {(Promise<IPythonDaemonExecutionService>)}
      * @memberof IPythonExecutionFactory
      */
-    createDaemon(options: DaemonExecutionFactoryCreationOptions): Promise<IPythonExecutionService>;
+    createDaemon<T extends IPythonDaemonExecutionService>(options: DaemonExecutionFactoryCreationOptions): Promise<T>;
     createActivatedEnvironment(options: ExecutionFactoryCreateWithEnvironmentOptions): Promise<IPythonExecutionService>;
     createCondaExecutionService(
         pythonPath: string,

--- a/src/client/common/process/types.ts
+++ b/src/client/common/process/types.ts
@@ -141,7 +141,9 @@ export interface IPythonExecutionFactory {
      * @returns {(Promise<IPythonDaemonExecutionService>)}
      * @memberof IPythonExecutionFactory
      */
-    createDaemon<T extends IPythonDaemonExecutionService>(options: DaemonExecutionFactoryCreationOptions): Promise<T>;
+    createDaemon<T extends IPythonDaemonExecutionService | IDisposable>(
+        options: DaemonExecutionFactoryCreationOptions
+    ): Promise<T>;
     createActivatedEnvironment(options: ExecutionFactoryCreateWithEnvironmentOptions): Promise<IPythonExecutionService>;
     createCondaExecutionService(
         pythonPath: string,

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -6,7 +6,7 @@
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../activation/types';
 import '../common/extensions';
-import { IPythonExecutionFactory, IPythonDaemonExecutionService } from '../common/process/types';
+import { IPythonDaemonExecutionService, IPythonExecutionFactory } from '../common/process/types';
 import { IDisposableRegistry } from '../common/types';
 import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
 import { sendTelemetryEvent } from '../telemetry';

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -6,7 +6,7 @@
 import { inject, injectable } from 'inversify';
 import { IExtensionSingleActivationService } from '../activation/types';
 import '../common/extensions';
-import { IPythonExecutionFactory } from '../common/process/types';
+import { IPythonExecutionFactory, IPythonDaemonExecutionService } from '../common/process/types';
 import { IDisposableRegistry } from '../common/types';
 import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
 import { sendTelemetryEvent } from '../telemetry';
@@ -54,6 +54,9 @@ export class Activation implements IExtensionSingleActivationService {
         if (!interpreter) {
             return;
         }
-        await this.factory.createDaemon({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path });
+        await this.factory.createDaemon<IPythonDaemonExecutionService>({
+            daemonModule: JupyterDaemonModule,
+            pythonPath: interpreter.path
+        });
     }
 }

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -10,7 +10,7 @@ import { IPythonExecutionFactory } from '../common/process/types';
 import { IDisposableRegistry } from '../common/types';
 import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
 import { sendTelemetryEvent } from '../telemetry';
-import { PythonDaemonModule, Telemetry } from './constants';
+import { JupyterDaemonModule, Telemetry } from './constants';
 import { ActiveEditorContextService } from './context/activeEditorContext';
 import { JupyterInterpreterService } from './jupyter/interpreter/jupyterInterpreterService';
 import { INotebookEditor, INotebookEditorProvider } from './types';
@@ -54,6 +54,6 @@ export class Activation implements IExtensionSingleActivationService {
         if (!interpreter) {
             return;
         }
-        await this.factory.createDaemon({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path });
+        await this.factory.createDaemon({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path });
     }
 }

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -75,7 +75,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         if (session && oldSession !== session) {
             const socket = JupyterWebSockets.get(session.kernel.id);
             if (!socket) {
-                traceError(`Unable to find WebSocket connetion assocated with kerne ${session.kernel.id}`);
+                traceError(`Unable to find WebSocket connetion assocated with kernel ${session.kernel.id}`);
                 this._kernelSocket.next(undefined);
                 return;
             }

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -11,7 +11,7 @@ export const DefaultTheme = 'Default Light+';
 export const JUPYTER_OUTPUT_CHANNEL = 'JUPYTER_OUTPUT_CHANNEL';
 
 // Python Module to be used when instantiating the Python Daemon.
-export const PythonDaemonModule = 'vscode_datascience_helpers.jupyter_daemon';
+export const JupyterDaemonModule = 'vscode_datascience_helpers.jupyter_daemon';
 
 // List of 'language' names that we know about. All should be lower case as that's how we compare.
 export const KnownNotebookLanguages: string[] = [

--- a/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
@@ -11,7 +11,8 @@ import {
     IProcessServiceFactory,
     IPythonExecutionFactory,
     IPythonExecutionService,
-    ObservableExecutionResult
+    ObservableExecutionResult,
+    IPythonDaemonExecutionService
 } from '../../../common/process/types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';
@@ -87,7 +88,7 @@ class InterpreterJupyterCommand implements IJupyterCommand {
             // Create a daemon only if the interpreter is the same as the current interpreter.
             // We don't want too many daemons (we don't want one for each of the users interpreter on their machine).
             if (isActiveInterpreter) {
-                const svc = await pythonExecutionFactory.createDaemon({
+                const svc = await pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
                     daemonModule: JupyterDaemonModule,
                     pythonPath: interpreter!.path
                 });

--- a/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
@@ -9,10 +9,10 @@ import {
     ExecutionResult,
     IProcessService,
     IProcessServiceFactory,
+    IPythonDaemonExecutionService,
     IPythonExecutionFactory,
     IPythonExecutionService,
-    ObservableExecutionResult,
-    IPythonDaemonExecutionService
+    ObservableExecutionResult
 } from '../../../common/process/types';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';

--- a/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterCommand.ts
@@ -16,7 +16,7 @@ import {
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
-import { JupyterCommands, PythonDaemonModule } from '../../constants';
+import { JupyterCommands, JupyterDaemonModule } from '../../constants';
 import { IJupyterCommand, IJupyterCommandFactory } from '../../types';
 
 // JupyterCommand objects represent some process that can be launched that should be guaranteed to work because it
@@ -88,7 +88,7 @@ class InterpreterJupyterCommand implements IJupyterCommand {
             // We don't want too many daemons (we don't want one for each of the users interpreter on their machine).
             if (isActiveInterpreter) {
                 const svc = await pythonExecutionFactory.createDaemon({
-                    daemonModule: PythonDaemonModule,
+                    daemonModule: JupyterDaemonModule,
                     pythonPath: interpreter!.path
                 });
 

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -9,7 +9,12 @@ import { CancellationToken } from 'vscode';
 import { Cancellation } from '../../../common/cancellation';
 import { traceError, traceInfo, traceWarning } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
-import { IPythonExecutionFactory, ObservableExecutionResult, SpawnOptions } from '../../../common/process/types';
+import {
+    IPythonDaemonExecutionService,
+    IPythonExecutionFactory,
+    ObservableExecutionResult,
+    SpawnOptions
+} from '../../../common/process/types';
 import { IOutputChannel, IPathUtils, Product } from '../../../common/types';
 import { DataScience } from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
@@ -110,7 +115,7 @@ export class JupyterInterpreterSubCommandExecutionService
                 notebookArgs.join(' ')
             )
         );
-        const executionService = await this.pythonExecutionFactory.createDaemon({
+        const executionService = await this.pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
             daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
@@ -119,7 +124,7 @@ export class JupyterInterpreterSubCommandExecutionService
 
     public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
-        const daemon = await this.pythonExecutionFactory.createDaemon({
+        const daemon = await this.pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
             daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
@@ -145,7 +150,7 @@ export class JupyterInterpreterSubCommandExecutionService
             throw new Error(DataScience.jupyterNbConvertNotSupported());
         }
 
-        const daemon = await this.pythonExecutionFactory.createDaemon({
+        const daemon = await this.pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
             daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
@@ -177,7 +182,7 @@ export class JupyterInterpreterSubCommandExecutionService
 
     public async getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
-        const daemon = await this.pythonExecutionFactory.createDaemon({
+        const daemon = await this.pythonExecutionFactory.createDaemon<IPythonDaemonExecutionService>({
             daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -16,7 +16,7 @@ import { noop } from '../../../common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../constants';
 import { IInterpreterService, PythonInterpreter } from '../../../interpreter/contracts';
 import { sendTelemetryEvent } from '../../../telemetry';
-import { JUPYTER_OUTPUT_CHANNEL, PythonDaemonModule, Telemetry } from '../../constants';
+import { JUPYTER_OUTPUT_CHANNEL, JupyterDaemonModule, Telemetry } from '../../constants';
 import { IJupyterInterpreterDependencyManager, IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterServerInfo } from '../jupyterConnection';
 import { JupyterInstallError } from '../jupyterInstallError';
@@ -111,7 +111,7 @@ export class JupyterInterpreterSubCommandExecutionService
             )
         );
         const executionService = await this.pythonExecutionFactory.createDaemon({
-            daemonModule: PythonDaemonModule,
+            daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
         return executionService.execModuleObservable('jupyter', ['notebook'].concat(notebookArgs), options);
@@ -120,7 +120,7 @@ export class JupyterInterpreterSubCommandExecutionService
     public async getRunningJupyterServers(token?: CancellationToken): Promise<JupyterServerInfo[] | undefined> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
         const daemon = await this.pythonExecutionFactory.createDaemon({
-            daemonModule: PythonDaemonModule,
+            daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
 
@@ -146,7 +146,7 @@ export class JupyterInterpreterSubCommandExecutionService
         }
 
         const daemon = await this.pythonExecutionFactory.createDaemon({
-            daemonModule: PythonDaemonModule,
+            daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
         // Wait for the nbconvert to finish
@@ -178,7 +178,7 @@ export class JupyterInterpreterSubCommandExecutionService
     public async getKernelSpecs(token?: CancellationToken): Promise<JupyterKernelSpec[]> {
         const interpreter = await this.getSelectedInterpreterAndThrowIfNotAvailable(token);
         const daemon = await this.pythonExecutionFactory.createDaemon({
-            daemonModule: PythonDaemonModule,
+            daemonModule: JupyterDaemonModule,
             pythonPath: interpreter.path
         });
         if (Cancellation.isCanceled(token)) {

--- a/src/test/common/process/pythonDaemonPool.functional.test.ts
+++ b/src/test/common/process/pythonDaemonPool.functional.test.ts
@@ -54,8 +54,8 @@ suite('Daemon - Python Daemon Pool', () => {
     let logger: IProcessLogger;
     class DaemonPool extends PythonDaemonExecutionServicePool {
         // tslint:disable-next-line: no-unnecessary-override
-        public createDaemonServices(): Promise<IPythonDaemonExecutionService> {
-            return super.createDaemonServices();
+        public createDaemonService<T extends IPythonDaemonExecutionService>(): Promise<T> {
+            return super.createDaemonService();
         }
     }
     suiteSetup(() => {
@@ -72,7 +72,7 @@ suite('Daemon - Python Daemon Pool', () => {
             return this.skip();
         }
         logger = mock(ProcessLogger);
-        createDaemonServicesSpy = sinon.spy(DaemonPool.prototype, 'createDaemonServices');
+        createDaemonServicesSpy = sinon.spy(DaemonPool.prototype, 'createDaemonService');
         pythonExecutionService = mock<IPythonExecutionService>();
         when(
             pythonExecutionService.execModuleObservable('vscode_datascience_helpers.daemon', anything(), anything())

--- a/src/test/common/process/pythonDaemonPool.functional.test.ts
+++ b/src/test/common/process/pythonDaemonPool.functional.test.ts
@@ -50,11 +50,11 @@ suite('Daemon - Python Daemon Pool', () => {
     let pythonDaemonPool: PythonDaemonExecutionServicePool;
     let pythonExecutionService: IPythonExecutionService;
     let disposables: IDisposable[] = [];
-    let createDaemonServicesSpy: sinon.SinonSpy<[], Promise<IPythonDaemonExecutionService>>;
+    let createDaemonServicesSpy: sinon.SinonSpy<[], Promise<IPythonDaemonExecutionService | IDisposable>>;
     let logger: IProcessLogger;
     class DaemonPool extends PythonDaemonExecutionServicePool {
         // tslint:disable-next-line: no-unnecessary-override
-        public createDaemonService<T extends IPythonDaemonExecutionService>(): Promise<T> {
+        public createDaemonService<T extends IPythonDaemonExecutionService | IDisposable>(): Promise<T> {
             return super.createDaemonService();
         }
     }

--- a/src/test/common/process/pythonDaemonPool.functional.test.ts
+++ b/src/test/common/process/pythonDaemonPool.functional.test.ts
@@ -31,7 +31,7 @@ import { noop } from '../../../client/common/utils/misc';
 import { Architecture } from '../../../client/common/utils/platform';
 import { parsePythonVersion } from '../../../client/common/utils/version';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
-import { PythonDaemonModule } from '../../../client/datascience/constants';
+import { JupyterDaemonModule } from '../../../client/datascience/constants';
 import { isPythonVersion, PYTHON_PATH, waitForCondition } from '../../common';
 import { createTemporaryFile } from '../../utils/fs';
 use(chaiPromised);
@@ -90,7 +90,7 @@ suite('Daemon - Python Daemon Pool', () => {
         });
         const options = {
             pythonPath: fullyQualifiedPythonPath,
-            daemonModule: PythonDaemonModule,
+            daemonModule: JupyterDaemonModule,
             daemonCount: 2,
             observableDaemonCount: 1
         };

--- a/src/test/datascience/activation.unit.test.ts
+++ b/src/test/datascience/activation.unit.test.ts
@@ -69,7 +69,9 @@ suite('Data Science - Activation', () => {
 
         verify(executionFactory.createDaemon(anything())).once();
         verify(
-            executionFactory.createDaemon(deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path }))
+            executionFactory.createDaemon(
+                deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path })
+            )
         ).once();
     }
 
@@ -85,7 +87,9 @@ suite('Data Science - Activation', () => {
         await fakeTimer.wait();
 
         verify(
-            executionFactory.createDaemon(deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path }))
+            executionFactory.createDaemon(
+                deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path })
+            )
         ).twice();
     });
     test('Changing interpreter without opening a notebook does not result in a daemon being created', async () => {

--- a/src/test/datascience/activation.unit.test.ts
+++ b/src/test/datascience/activation.unit.test.ts
@@ -10,7 +10,7 @@ import { PythonExecutionFactory } from '../../client/common/process/pythonExecut
 import { IPythonExecutionFactory } from '../../client/common/process/types';
 import { sleep } from '../../client/common/utils/async';
 import { Activation } from '../../client/datascience/activation';
-import { PythonDaemonModule } from '../../client/datascience/constants';
+import { JupyterDaemonModule } from '../../client/datascience/constants';
 import { ActiveEditorContextService } from '../../client/datascience/context/activeEditorContext';
 import { NativeEditor } from '../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorProvider } from '../../client/datascience/interactive-ipynb/nativeEditorProvider';
@@ -69,7 +69,7 @@ suite('Data Science - Activation', () => {
 
         verify(executionFactory.createDaemon(anything())).once();
         verify(
-            executionFactory.createDaemon(deepEqual({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path }))
+            executionFactory.createDaemon(deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path }))
         ).once();
     }
 
@@ -85,7 +85,7 @@ suite('Data Science - Activation', () => {
         await fakeTimer.wait();
 
         verify(
-            executionFactory.createDaemon(deepEqual({ daemonModule: PythonDaemonModule, pythonPath: interpreter.path }))
+            executionFactory.createDaemon(deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: interpreter.path }))
         ).twice();
     });
     test('Changing interpreter without opening a notebook does not result in a daemon being created', async () => {

--- a/src/test/datascience/execution.unit.test.ts
+++ b/src/test/datascience/execution.unit.test.ts
@@ -27,6 +27,7 @@ import {
     ExecutionResult,
     IProcessService,
     IProcessServiceFactory,
+    IPythonDaemonExecutionService,
     IPythonExecutionFactory,
     IPythonExecutionService,
     ObservableExecutionResult,
@@ -814,19 +815,19 @@ suite('Jupyter Execution', async () => {
 
         when(
             executionFactory.createDaemon(argThat((o) => o.pythonPath && o.pythonPath === workingPython.path))
-        ).thenResolve(workingService.object);
+        ).thenResolve((workingService.object as unknown) as IPythonDaemonExecutionService);
 
         when(
             executionFactory.createDaemon(argThat((o) => o.pythonPath && o.pythonPath === missingKernelPython.path))
-        ).thenResolve(missingKernelService.object);
+        ).thenResolve((missingKernelService.object as unknown) as IPythonDaemonExecutionService);
 
         when(
             executionFactory.createDaemon(argThat((o) => o.pythonPath && o.pythonPath === missingNotebookPython.path))
-        ).thenResolve(missingNotebookService.object);
+        ).thenResolve((missingNotebookService.object as unknown) as IPythonDaemonExecutionService);
 
         when(
             executionFactory.createDaemon(argThat((o) => o.pythonPath && o.pythonPath === missingNotebookPython2.path))
-        ).thenResolve(missingNotebookService2.object);
+        ).thenResolve((missingNotebookService2.object as unknown) as IPythonDaemonExecutionService);
 
         let activeService = workingService;
         if (activeInterpreter === missingKernelPython) {

--- a/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
+++ b/src/test/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.unit.test.ts
@@ -14,12 +14,16 @@ import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { PathUtils } from '../../../../client/common/platform/pathUtils';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { PythonExecutionFactory } from '../../../../client/common/process/pythonExecutionFactory';
-import { IPythonExecutionService, ObservableExecutionResult, Output } from '../../../../client/common/process/types';
+import {
+    IPythonDaemonExecutionService,
+    ObservableExecutionResult,
+    Output
+} from '../../../../client/common/process/types';
 import { Product } from '../../../../client/common/types';
 import { DataScience } from '../../../../client/common/utils/localize';
 import { noop } from '../../../../client/common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../../client/constants';
-import { PythonDaemonModule } from '../../../../client/datascience/constants';
+import { JupyterDaemonModule } from '../../../../client/datascience/constants';
 import { JupyterInterpreterDependencyService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService';
 import { JupyterInterpreterService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterService';
 import { JupyterInterpreterSubCommandExecutionService } from '../../../../client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService';
@@ -37,7 +41,7 @@ suite('Data Science - Jupyter InterpreterSubCommandExecutionService', () => {
     let interperterService: IInterpreterService;
     let jupyterDependencyService: JupyterInterpreterDependencyService;
     let fs: IFileSystem;
-    let execService: IPythonExecutionService;
+    let execService: IPythonDaemonExecutionService;
     let jupyterInterpreterExecutionService: JupyterInterpreterSubCommandExecutionService;
     const selectedJupyterInterpreter = createPythonInterpreter({ displayName: 'JupyterInterpreter' });
     const activePythonInterpreter = createPythonInterpreter({ displayName: 'activePythonInterpreter' });
@@ -48,10 +52,10 @@ suite('Data Science - Jupyter InterpreterSubCommandExecutionService', () => {
         jupyterDependencyService = mock(JupyterInterpreterDependencyService);
         fs = mock(FileSystem);
         const execFactory = mock(PythonExecutionFactory);
-        execService = mock<IPythonExecutionService>();
+        execService = mock<IPythonDaemonExecutionService>();
         when(
             execFactory.createDaemon(
-                deepEqual({ daemonModule: PythonDaemonModule, pythonPath: selectedJupyterInterpreter.path })
+                deepEqual({ daemonModule: JupyterDaemonModule, pythonPath: selectedJupyterInterpreter.path })
             )
         ).thenResolve(instance(execService));
         when(execFactory.createActivatedEnvironment(anything())).thenResolve(instance(execService));

--- a/src/test/datascience/kernelLauncher.functional.test.ts
+++ b/src/test/datascience/kernelLauncher.functional.test.ts
@@ -54,7 +54,7 @@ suite('Kernel Launcher', () => {
             assert.isOk<IKernelConnection | undefined>(kernel.connection, 'Connection not found');
 
             // It should not exit.
-            assert.isRejected(
+            await assert.isRejected(
                 waitForCondition(() => exited, 5_000, 'Timeout'),
                 'Timeout'
             );
@@ -78,7 +78,7 @@ suite('Kernel Launcher', () => {
             const exited = new Promise<boolean>((resolve) => kernel.exited(() => resolve(true)));
 
             // It should not exit.
-            assert.isRejected(
+            await assert.isRejected(
                 waitForCondition(() => exited, 5_000, 'Timeout'),
                 'Timeout'
             );
@@ -93,7 +93,7 @@ suite('Kernel Launcher', () => {
                 'Timeout'
             );
         }
-    });
+    }).timeout(10_000);
 
     test('Bind with ZMQ', async function () {
         if (!process.env.VSCODE_PYTHON_ROLLING) {

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -20,9 +20,9 @@ import { ProductInstaller } from '../../client/common/installer/productInstaller
 import {
     ExecutionResult,
     IProcessServiceFactory,
+    IPythonDaemonExecutionService,
     IPythonExecutionFactory,
-    Output,
-    IPythonDaemonExecutionService
+    Output
 } from '../../client/common/process/types';
 import { IConfigurationService, IInstaller, Product } from '../../client/common/types';
 import { EXTENSION_ROOT_DIR } from '../../client/constants';

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -21,7 +21,8 @@ import {
     ExecutionResult,
     IProcessServiceFactory,
     IPythonExecutionFactory,
-    Output
+    Output,
+    IPythonDaemonExecutionService
 } from '../../client/common/process/types';
 import { IConfigurationService, IInstaller, Product } from '../../client/common/types';
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
@@ -253,7 +254,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
                     })
                 )
             )
-            .returns(() => Promise.resolve(pythonService));
+            .returns(() => Promise.resolve((pythonService as unknown) as IPythonDaemonExecutionService));
         this.pythonExecutionFactory
             .setup((f) =>
                 f.createActivatedEnvironment(


### PR DESCRIPTION
For #10768
* Move daemon creation into its own factory class.
* Existing daemon pool factory will inherit the factory.

**Daemon Pool Factory Class**
* This is a pool of daemons
* Factory class that creates daemons
* If a free daemon is available it will use it (i.e. a pool)

** Daemon Factory Class **
* Similar to `Daemon Pool Factory` class.
* Except, there's no pool of daemons.
* It gets created and it NOT re-used.
