### PR TITLE
Use a single language server instance when type set to Node

### DIFF
--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -322,6 +322,12 @@ export class LanguageServerExtensionActivationService
         }
     }
     private async getKey(resource: Resource, interpreter?: PythonInterpreter): Promise<string> {
+        const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
+        const serverType = configurationService.getSettings(this.resource).languageServer;
+        if (serverType === LanguageServerType.Node) {
+            return 'shared-ls';
+        }
+
         const resourcePortion = this.workspaceService.getWorkspaceFolderIdentifier(
             resource,
             workspacePathNameForGlobalWorkspaces

--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -17,13 +17,13 @@ export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServ
     protected disposables: Disposable[] = [];
     protected readonly didChange = new EventEmitter<void>();
     private envPythonPath: string = '';
-    private output: IOutputChannel;
+    private readonly output: IOutputChannel;
 
     protected constructor(
         private readonly envVarsProvider: IEnvironmentVariablesProvider,
-        protected readonly lsOutputChannel: ILanguageServerOutputChannel
+        lsOutputChannel: ILanguageServerOutputChannel
     ) {
-        this.output = this.lsOutputChannel.channel;
+        this.output = lsOutputChannel.channel;
     }
 
     public async initialize(_resource: Resource, _interpreter: PythonInterpreter | undefined) {

--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { injectable } from 'inversify';
+import { Disposable, Event, EventEmitter, WorkspaceFolder } from 'vscode';
+import { DocumentFilter, LanguageClientOptions, RevealOutputChannelOn } from 'vscode-languageclient';
+
+import { IWorkspaceService } from '../../common/application/types';
+import { PYTHON_LANGUAGE } from '../../common/constants';
+import { traceDecorators } from '../../common/logger';
+import { IOutputChannel, Resource } from '../../common/types';
+import { debounceSync } from '../../common/utils/decorators';
+import { IEnvironmentVariablesProvider } from '../../common/variables/types';
+import { PythonInterpreter } from '../../interpreter/contracts';
+import { ILanguageServerAnalysisOptions, ILanguageServerOutputChannel } from '../types';
+
+@injectable()
+export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServerAnalysisOptions {
+    public get onDidChange(): Event<void> {
+        return this.didChange.event;
+    }
+
+    protected disposables: Disposable[] = [];
+    protected resource: Resource;
+    protected readonly didChange = new EventEmitter<void>();
+    private envPythonPath: string = '';
+    private output: IOutputChannel;
+
+    protected constructor(
+        private readonly envVarsProvider: IEnvironmentVariablesProvider,
+        protected readonly workspace: IWorkspaceService,
+        protected readonly lsOutputChannel: ILanguageServerOutputChannel
+    ) {
+        this.output = this.lsOutputChannel.channel;
+    }
+
+    public async initialize(resource: Resource, _interpreter: PythonInterpreter | undefined) {
+        this.resource = resource;
+
+        const disposable = this.envVarsProvider.onDidEnvironmentVariablesChange(this.onEnvVarChange, this);
+        this.disposables.push(disposable);
+    }
+
+    public dispose(): void {
+        this.disposables.forEach((d) => d.dispose());
+        this.didChange.dispose();
+    }
+
+    @traceDecorators.error('Failed to get analysis options')
+    public async getAnalysisOptions(): Promise<LanguageClientOptions> {
+        const workspaceFolder = this.workspace.getWorkspaceFolder(this.resource);
+        const documentSelector = this.getDocumentFilters(workspaceFolder);
+        // Options to control the language client.
+        return {
+            // Register the server for Python documents.
+            documentSelector,
+            workspaceFolder,
+            synchronize: {
+                configurationSection: PYTHON_LANGUAGE
+            },
+            outputChannel: this.output,
+            revealOutputChannelOn: RevealOutputChannelOn.Never,
+            initializationOptions: await this.getInitializationOptions()
+        };
+    }
+
+    // tslint:disable-next-line: no-any
+    protected abstract async getInitializationOptions(): Promise<any>;
+
+    protected getDocumentFilters(_workspaceFolder?: WorkspaceFolder): DocumentFilter[] {
+        return [
+            { scheme: 'file', language: PYTHON_LANGUAGE },
+            { scheme: 'untitled', language: PYTHON_LANGUAGE }
+        ];
+    }
+
+    protected async getEnvPythonPath() {
+        const vars = await this.envVarsProvider.getEnvironmentVariables();
+        this.envPythonPath = vars.PYTHONPATH || '';
+        return this.envPythonPath;
+    }
+
+    @debounceSync(1000)
+    protected onEnvVarChange(): void {
+        this.notifyifEnvPythonPathChanged().ignoreErrors();
+    }
+
+    protected async notifyifEnvPythonPathChanged(): Promise<void> {
+        const vars = await this.envVarsProvider.getEnvironmentVariables();
+        const envPythonPath = vars.PYTHONPATH || '';
+
+        if (this.envPythonPath !== envPythonPath) {
+            this.didChange.fire();
+        }
+    }
+}

--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -14,10 +14,6 @@ import { ILanguageServerAnalysisOptions, ILanguageServerOutputChannel } from '..
 
 @injectable()
 export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServerAnalysisOptions {
-    public get onDidChange(): Event<void> {
-        return this.didChange.event;
-    }
-
     protected disposables: Disposable[] = [];
     protected readonly didChange = new EventEmitter<void>();
     private envPythonPath: string = '';
@@ -33,6 +29,10 @@ export abstract class LanguageServerAnalysisOptionsBase implements ILanguageServ
     public async initialize(_resource: Resource, _interpreter: PythonInterpreter | undefined) {
         const disposable = this.envVarsProvider.onDidEnvironmentVariablesChange(this.onEnvVarChange, this);
         this.disposables.push(disposable);
+    }
+
+    public get onDidChange(): Event<void> {
+        return this.didChange.event;
     }
 
     public dispose(): void {

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -6,7 +6,6 @@ import { ConfigurationChangeEvent, WorkspaceFolder } from 'vscode';
 import { DocumentFilter } from 'vscode-languageclient';
 
 import { IWorkspaceService } from '../../common/application/types';
-import { isTestExecution } from '../../common/constants';
 import { traceDecorators, traceError } from '../../common/logger';
 import { IConfigurationService, IExtensionContext, IPathUtils, Resource } from '../../common/types';
 import { debounceSync } from '../../common/utils/decorators';
@@ -73,13 +72,11 @@ export class DotNetLanguageServerAnalysisOptions extends LanguageServerAnalysisO
             throw Error('did not find an active interpreter');
         }
 
-        // tslint:disable-next-line:no-string-literal
-        properties['InterpreterPath'] = interpreterInfo.path;
+        properties.InterpreterPath = interpreterInfo.path;
 
         const version = interpreterInfo.version;
         if (version) {
-            // tslint:disable-next-line:no-string-literal
-            properties['Version'] = `${version.major}.${version.minor}.${version.patch}`;
+            properties.Version = `${version.major}.${version.minor}.${version.patch}`;
         } else {
             traceError('Unable to determine Python version. Analysis may be limited.');
         }
@@ -106,21 +103,10 @@ export class DotNetLanguageServerAnalysisOptions extends LanguageServerAnalysisO
             interpreter: {
                 properties
             },
-            displayOptions: {
-                preferredFormat: 'markdown',
-                trimDocumentationLines: false,
-                maxDocumentationLineLength: 0,
-                trimDocumentationText: false,
-                maxDocumentationTextLength: 0
-            },
             searchPaths,
             typeStubSearchPaths: this.typeshedPaths,
             cacheFolderPath: this.getCacheFolderPath(),
-            excludeFiles: this.excludedFiles,
-            testEnvironment: isTestExecution(),
-            analysisUpdates: true,
-            traceLogging: true, // Max level, let LS decide through settings actual level of logging.
-            asyncStartup: true
+            excludeFiles: this.excludedFiles
         };
     }
 

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -38,7 +38,9 @@ export class DotNetLanguageServerManager implements ILanguageServerManager {
     private connected: boolean = false;
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
-        @inject(ILanguageServerAnalysisOptions) private readonly analysisOptions: ILanguageServerAnalysisOptions,
+        @inject(ILanguageServerAnalysisOptions)
+        @named(LanguageServerType.Microsoft)
+        private readonly analysisOptions: ILanguageServerAnalysisOptions,
         @inject(ILanguageServerExtension) private readonly lsExtension: ILanguageServerExtension,
         @inject(IPythonExtensionBanner)
         @named(BANNER_NAME_LS_SURVEY)

--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { inject, injectable } from 'inversify';
+
+import { IWorkspaceService } from '../../common/application/types';
+import { IEnvironmentVariablesProvider } from '../../common/variables/types';
+import { LanguageServerAnalysisOptionsBase } from '../common/analysisOptions';
+import { ILanguageServerOutputChannel } from '../types';
+
+@injectable()
+export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOptionsBase {
+    constructor(
+        @inject(IEnvironmentVariablesProvider) envVarsProvider: IEnvironmentVariablesProvider,
+        @inject(IWorkspaceService) workspace: IWorkspaceService,
+        @inject(ILanguageServerOutputChannel) lsOutputChannel: ILanguageServerOutputChannel
+    ) {
+        super(envVarsProvider, workspace, lsOutputChannel);
+    }
+
+    protected async getInitializationOptions() {
+        return {};
+    }
+}

--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
 
-import { IWorkspaceService } from '../../common/application/types';
 import { IEnvironmentVariablesProvider } from '../../common/variables/types';
 import { LanguageServerAnalysisOptionsBase } from '../common/analysisOptions';
 import { ILanguageServerOutputChannel } from '../types';
@@ -11,13 +10,8 @@ import { ILanguageServerOutputChannel } from '../types';
 export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOptionsBase {
     constructor(
         @inject(IEnvironmentVariablesProvider) envVarsProvider: IEnvironmentVariablesProvider,
-        @inject(IWorkspaceService) workspace: IWorkspaceService,
         @inject(ILanguageServerOutputChannel) lsOutputChannel: ILanguageServerOutputChannel
     ) {
-        super(envVarsProvider, workspace, lsOutputChannel);
-    }
-
-    protected async getInitializationOptions() {
-        return {};
+        super(envVarsProvider, lsOutputChannel);
     }
 }

--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -37,7 +37,9 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
     private connected: boolean = false;
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
-        @inject(ILanguageServerAnalysisOptions) private readonly analysisOptions: ILanguageServerAnalysisOptions,
+        @inject(ILanguageServerAnalysisOptions)
+        @named(LanguageServerType.Node)
+        private readonly analysisOptions: ILanguageServerAnalysisOptions,
         @inject(IPythonExtensionBanner)
         @named(BANNER_NAME_LS_SURVEY)
         private readonly surveyBanner: IPythonExtensionBanner,

--- a/src/client/activation/serviceRegistry.ts
+++ b/src/client/activation/serviceRegistry.ts
@@ -24,7 +24,7 @@ import { LanguageServerDownloadChannel } from './common/packageRepository';
 import { ExtensionSurveyPrompt } from './extensionSurvey';
 import { JediExtensionActivator } from './jedi';
 import { DotNetLanguageServerActivator } from './languageServer/activator';
-import { LanguageServerAnalysisOptions } from './languageServer/analysisOptions';
+import { DotNetLanguageServerAnalysisOptions } from './languageServer/analysisOptions';
 import { DotNetLanguageClientFactory } from './languageServer/languageClientFactory';
 import { LanguageServerCompatibilityService } from './languageServer/languageServerCompatibilityService';
 import { LanguageServerExtension } from './languageServer/languageServerExtension';
@@ -40,6 +40,7 @@ import { DotNetLanguageServerManager } from './languageServer/manager';
 import { LanguageServerOutputChannel } from './languageServer/outputChannel';
 import { PlatformData } from './languageServer/platformData';
 import { NodeLanguageServerActivator } from './node/activator';
+import { NodeLanguageServerAnalysisOptions } from './node/analysisOptions';
 import { NodeLanguageClientFactory } from './node/languageClientFactory';
 import { NodeLanguageServerFolderService } from './node/languageServerFolderService';
 import {
@@ -84,7 +85,6 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
         JediExtensionActivator,
         LanguageServerType.Jedi
     );
-    serviceManager.add<ILanguageServerAnalysisOptions>(ILanguageServerAnalysisOptions, LanguageServerAnalysisOptions);
 
     serviceManager.addSingleton<IPythonExtensionBanner>(
         IPythonExtensionBanner,
@@ -108,6 +108,11 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
     );
 
     if (languageServerType === LanguageServerType.Microsoft) {
+        serviceManager.add<ILanguageServerAnalysisOptions>(
+            ILanguageServerAnalysisOptions,
+            DotNetLanguageServerAnalysisOptions,
+            LanguageServerType.Microsoft
+        );
         serviceManager.add<ILanguageServerActivator>(
             ILanguageServerActivator,
             DotNetLanguageServerActivator,
@@ -146,6 +151,11 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
         );
         registerDotNetTypes(serviceManager);
     } else if (languageServerType === LanguageServerType.Node) {
+        serviceManager.add<ILanguageServerAnalysisOptions>(
+            ILanguageServerAnalysisOptions,
+            NodeLanguageServerAnalysisOptions,
+            LanguageServerType.Node
+        );
         serviceManager.add<ILanguageServerActivator>(
             ILanguageServerActivator,
             NodeLanguageServerActivator,

--- a/src/test/activation/languageServer/analysisOptions.unit.test.ts
+++ b/src/test/activation/languageServer/analysisOptions.unit.test.ts
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import { instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { ConfigurationChangeEvent, Uri, WorkspaceFolder } from 'vscode';
-import { DocumentSelector } from 'vscode-languageclient';
+import { DocumentFilter } from 'vscode-languageclient';
 
-import { LanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
+import { DotNetLanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
 import { DotNetLanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';
 import { ILanguageServerFolderService, ILanguageServerOutputChannel } from '../../../client/activation/types';
 import { IWorkspaceService } from '../../../client/common/application/types';
@@ -28,9 +28,9 @@ import { sleep } from '../../core';
 // tslint:disable:no-unnecessary-override no-any chai-vague-errors no-unused-expression max-func-body-length
 
 suite('Language Server - Analysis Options', () => {
-    class TestClass extends LanguageServerAnalysisOptions {
-        public getDocumentSelector(workspaceFolder?: WorkspaceFolder): DocumentSelector {
-            return super.getDocumentSelector(workspaceFolder);
+    class TestClass extends DotNetLanguageServerAnalysisOptions {
+        public getDocumentFilters(workspaceFolder?: WorkspaceFolder): DocumentFilter[] {
+            return super.getDocumentFilters(workspaceFolder);
         }
         public getExcludedFiles(): string[] {
             return super.getExcludedFiles();
@@ -213,7 +213,7 @@ suite('Language Server - Analysis Options', () => {
             { scheme: 'untitled', language: PYTHON_LANGUAGE }
         ];
 
-        const selector = analysisOptions.getDocumentSelector();
+        const selector = analysisOptions.getDocumentFilters();
 
         expect(selector).to.deep.equal(expectedSelector);
     });
@@ -226,7 +226,7 @@ suite('Language Server - Analysis Options', () => {
             { scheme: 'untitled', language: PYTHON_LANGUAGE }
         ];
 
-        const selector = analysisOptions.getDocumentSelector(workspaceFolder);
+        const selector = analysisOptions.getDocumentFilters(workspaceFolder);
 
         expect(selector).to.deep.equal(expectedSelector);
     });
@@ -240,7 +240,7 @@ suite('Language Server - Analysis Options', () => {
             { scheme: 'untitled', language: PYTHON_LANGUAGE }
         ];
 
-        const selector = analysisOptions.getDocumentSelector(workspaceFolder1);
+        const selector = analysisOptions.getDocumentFilters(workspaceFolder1);
 
         expect(selector).to.deep.equal(expectedSelector);
     });

--- a/src/test/activation/languageServer/manager.unit.test.ts
+++ b/src/test/activation/languageServer/manager.unit.test.ts
@@ -5,7 +5,7 @@ import * as chaiAsPromised from 'chai-as-promised';
 import { instance, mock, verify, when } from 'ts-mockito';
 import { Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient';
-import { LanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
+import { DotNetLanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
 import { LanguageServerExtension } from '../../../client/activation/languageServer/languageServerExtension';
 import { DotNetLanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';
 import { DotNetLanguageServerProxy } from '../../../client/activation/languageServer/languageServerProxy';
@@ -42,7 +42,7 @@ suite('Language Server - Manager', () => {
     const languageClientOptions = ({ x: 1 } as any) as LanguageClientOptions;
     setup(() => {
         serviceContainer = mock(ServiceContainer);
-        analysisOptions = mock(LanguageServerAnalysisOptions);
+        analysisOptions = mock(DotNetLanguageServerAnalysisOptions);
         languageServer = mock(DotNetLanguageServerProxy);
         lsExtension = mock(LanguageServerExtension);
         surveyBanner = mock(ProposeLanguageServerBanner);

--- a/src/test/activation/serviceRegistry.unit.test.ts
+++ b/src/test/activation/serviceRegistry.unit.test.ts
@@ -11,7 +11,7 @@ import { LanguageServerDownloadChannel } from '../../client/activation/common/pa
 import { ExtensionSurveyPrompt } from '../../client/activation/extensionSurvey';
 import { JediExtensionActivator } from '../../client/activation/jedi';
 import { DotNetLanguageServerActivator } from '../../client/activation/languageServer/activator';
-import { LanguageServerAnalysisOptions } from '../../client/activation/languageServer/analysisOptions';
+import { DotNetLanguageServerAnalysisOptions } from '../../client/activation/languageServer/analysisOptions';
 import { DotNetLanguageClientFactory } from '../../client/activation/languageServer/languageClientFactory';
 import { LanguageServerCompatibilityService } from '../../client/activation/languageServer/languageServerCompatibilityService';
 import { LanguageServerExtension } from '../../client/activation/languageServer/languageServerExtension';
@@ -198,7 +198,7 @@ suite('Unit Tests - Language Server Activation Service Registry', () => {
         verify(
             serviceManager.add<ILanguageServerAnalysisOptions>(
                 ILanguageServerAnalysisOptions,
-                LanguageServerAnalysisOptions
+                DotNetLanguageServerAnalysisOptions
             )
         ).once();
         verify(serviceManager.add<ILanguageServerProxy>(ILanguageServerProxy, DotNetLanguageServerProxy)).once();

--- a/src/test/activation/serviceRegistry.unit.test.ts
+++ b/src/test/activation/serviceRegistry.unit.test.ts
@@ -198,7 +198,8 @@ suite('Unit Tests - Language Server Activation Service Registry', () => {
         verify(
             serviceManager.add<ILanguageServerAnalysisOptions>(
                 ILanguageServerAnalysisOptions,
-                DotNetLanguageServerAnalysisOptions
+                DotNetLanguageServerAnalysisOptions,
+                LanguageServerType.Microsoft
             )
         ).once();
         verify(serviceManager.add<ILanguageServerProxy>(ILanguageServerProxy, DotNetLanguageServerProxy)).once();


### PR DESCRIPTION
This PR splits apart `analysisOptions.ts` into two implementations, switching between them depending on the language server type setting. It also makes the LS key a static string to ensure only a single instance is spawned.

This means that the LS can be started without any document selectors (eventually leading to handling of #5132), and only have a single instance to handle all workspaces at once.

Also, while moving this code, delete some ancient deprecated options which no recent LS has used.

While working on this, I discovered the reason for https://github.com/microsoft/vscode-python/issues/5132#issuecomment-603571156; I'll file a new issue about that as it's out of scope for this PR.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
