### PR TITLE
use only resource on kernel launcher

### DIFF
--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -72,8 +72,7 @@ export class KernelFinder implements IKernelFinder {
             }
 
             if (kernelSpec) {
-                // tslint:disable-next-line: no-floating-promises
-                this.writeCache(this.cache);
+                this.writeCache(this.cache).ignoreErrors();
                 return kernelSpec;
             }
 
@@ -94,8 +93,7 @@ export class KernelFinder implements IKernelFinder {
             foundKernel = await this.getDefaultKernelSpec(resource);
         }
 
-        // tslint:disable-next-line: no-floating-promises
-        this.writeCache(this.cache);
+        this.writeCache(this.cache).ignoreErrors();
         return foundKernel;
     }
 

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -5,11 +5,9 @@
 import { Kernel } from '@jupyterlab/services';
 import { inject, injectable, named } from 'inversify';
 import * as path from 'path';
-import { InterpreterUri } from '../../common/installer/types';
 import { traceError, traceInfo } from '../../common/logger';
 import { IFileSystem, IPlatformService } from '../../common/platform/types';
 import { IExtensionContext, IPathUtils, Resource } from '../../common/types';
-import { isResource } from '../../common/utils/misc';
 import {
     IInterpreterLocatorService,
     IInterpreterService,
@@ -54,11 +52,9 @@ export class KernelFinder implements IKernelFinder {
         @inject(IExtensionContext) private readonly context: IExtensionContext
     ) {}
 
-    public async findKernelSpec(interpreterUri: InterpreterUri, kernelName?: string): Promise<IJupyterKernelSpec> {
+    public async findKernelSpec(resource: Resource, kernelName?: string): Promise<IJupyterKernelSpec> {
         this.cache = await this.readCache();
         let foundKernel: IJupyterKernelSpec | undefined;
-        const resource = isResource(interpreterUri) ? interpreterUri : undefined;
-        const notebookInterpreter = isResource(interpreterUri) ? undefined : interpreterUri;
 
         if (kernelName) {
             let kernelSpec = this.cache.find((ks) => ks.name === kernelName);
@@ -67,9 +63,7 @@ export class KernelFinder implements IKernelFinder {
                 return kernelSpec;
             }
 
-            if (!notebookInterpreter) {
-                kernelSpec = await this.getKernelSpecFromActiveInterpreter(resource, kernelName);
-            }
+            kernelSpec = await this.getKernelSpecFromActiveInterpreter(resource, kernelName);
 
             if (kernelSpec) {
                 this.writeCache(this.cache).ignoreErrors();

--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -8,10 +8,10 @@ import * as portfinder from 'portfinder';
 import { promisify } from 'util';
 import * as uuid from 'uuid/v4';
 import { Event, EventEmitter } from 'vscode';
-import { InterpreterUri } from '../../common/installer/types';
 import { traceInfo, traceWarning } from '../../common/logger';
 import { IFileSystem, TemporaryFile } from '../../common/platform/types';
 import { IPythonExecutionFactory } from '../../common/process/types';
+import { Resource } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
@@ -136,14 +136,11 @@ export class KernelLauncher implements IKernelLauncher {
         @inject(IFileSystem) private file: IFileSystem
     ) {}
 
-    public async launch(
-        interpreterUri: InterpreterUri,
-        kernelName?: string | IJupyterKernelSpec
-    ): Promise<IKernelProcess> {
+    public async launch(resource: Resource, kernelName?: string | IJupyterKernelSpec): Promise<IKernelProcess> {
         let kernelSpec: IJupyterKernelSpec;
         if (!kernelName || typeof kernelName === 'string') {
             // string or undefined
-            kernelSpec = await this.kernelFinder.findKernelSpec(interpreterUri, kernelName);
+            kernelSpec = await this.kernelFinder.findKernelSpec(resource, kernelName);
         } else {
             // IJupyterKernelSpec
             kernelSpec = kernelName;

--- a/src/test/datascience/kernelLauncher.functional.test.ts
+++ b/src/test/datascience/kernelLauncher.functional.test.ts
@@ -69,32 +69,6 @@ suite('DataScience - Kernel Launcher', () => {
         }
     }).timeout(10_000);
 
-    test('Launch from PythonInterpreter', async function () {
-        if (!process.env.VSCODE_PYTHON_ROLLING) {
-            // tslint:disable-next-line: no-invalid-this
-            this.skip();
-        } else {
-            const kernel = await kernelLauncher.launch(pythonInterpreter, kernelName);
-            const exited = new Promise<boolean>((resolve) => kernel.exited(() => resolve(true)));
-
-            // It should not exit.
-            assert.isRejected(
-                waitForCondition(() => exited, 5_000, 'Timeout'),
-                'Timeout'
-            );
-
-            assert.isOk<IKernelConnection | undefined>(kernel.connection, 'Connection not found');
-
-            // Upon disposing, we should get an exit event within 100ms or less.
-            // If this happens, then we know a process existed.
-            kernel.dispose();
-            assert.isRejected(
-                waitForCondition(() => exited, 100, 'Timeout'),
-                'Timeout'
-            );
-        }
-    });
-
     function createExecutionMessage(code: string, sessionId: string): KernelMessage.IExecuteRequestMsg {
         return {
             channel: 'shell',
@@ -182,7 +156,7 @@ suite('DataScience - Kernel Launcher', () => {
             };
             kernelFinder.addKernelSpec(pythonInterpreter.path, spec);
 
-            const kernel = await kernelLauncher.launch(pythonInterpreter, kernelName);
+            const kernel = await kernelLauncher.launch(resource, kernelName);
             const exited = new Promise<boolean>((resolve) => kernel.exited(() => resolve(true)));
 
             // It should not exit.


### PR DESCRIPTION
For #11314

Also, I removed the comment to disable tslint and used ignoreErrors

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
