### PR TITLE
Make sure user modules can be imported

### DIFF
--- a/news/2 Fixes/11264.md
+++ b/news/2 Fixes/11264.md
@@ -1,0 +1,1 @@
+Allow user modules import when discovering tests.

--- a/src/client/testing/unittest/services/discoveryService.ts
+++ b/src/client/testing/unittest/services/discoveryService.ts
@@ -29,6 +29,8 @@ export class TestDiscoveryService implements ITestDiscoveryService {
         const pythonScript = this.getDiscoveryScript(options);
         const unitTestOptions = this.translateOptions(options);
         const runOptions: Options = {
+            // unittest needs to load modules in the workspace
+            // isolating it breaks unittest discovery
             args: internalPython.execCode(pythonScript, false),
             cwd: options.cwd,
             workspaceFolder: options.workspaceFolder,

--- a/src/client/testing/unittest/services/discoveryService.ts
+++ b/src/client/testing/unittest/services/discoveryService.ts
@@ -29,7 +29,7 @@ export class TestDiscoveryService implements ITestDiscoveryService {
         const pythonScript = this.getDiscoveryScript(options);
         const unitTestOptions = this.translateOptions(options);
         const runOptions: Options = {
-            args: internalPython.execCode(pythonScript),
+            args: internalPython.execCode(pythonScript, false),
             cwd: options.cwd,
             workspaceFolder: options.workspaceFolder,
             token: options.token,

--- a/src/test/testing/unittest/unittest.discovery.unit.test.ts
+++ b/src/test/testing/unittest/unittest.discovery.unit.test.ts
@@ -71,8 +71,8 @@ suite('Unit Tests - Unittest - Discovery', () => {
             .setup((r) => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
-                expect(opts.args[2]).to.contain(dir);
-                expect(opts.args[2]).to.not.contain('loader.discover("."');
+                expect(opts.args[1]).to.contain(dir);
+                expect(opts.args[1]).to.not.contain('loader.discover("."');
             })
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());
@@ -117,8 +117,8 @@ suite('Unit Tests - Unittest - Discovery', () => {
             .setup((r) => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
-                expect(opts.args[2]).to.contain(dir);
-                expect(opts.args[2]).to.not.contain('loader.discover("."');
+                expect(opts.args[1]).to.contain(dir);
+                expect(opts.args[1]).to.not.contain('loader.discover("."');
             })
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());
@@ -163,8 +163,8 @@ suite('Unit Tests - Unittest - Discovery', () => {
             .setup((r) => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
-                expect(opts.args[2]).to.not.contain(dir);
-                expect(opts.args[2]).to.contain('loader.discover("."');
+                expect(opts.args[1]).to.not.contain(dir);
+                expect(opts.args[1]).to.contain('loader.discover("."');
             })
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());
@@ -205,8 +205,8 @@ suite('Unit Tests - Unittest - Discovery', () => {
             .setup((r) => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
-                expect(opts.args[2]).to.contain(pattern);
-                expect(opts.args[2]).to.not.contain('test*.py');
+                expect(opts.args[1]).to.contain(pattern);
+                expect(opts.args[1]).to.not.contain('test*.py');
             })
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());
@@ -251,8 +251,8 @@ suite('Unit Tests - Unittest - Discovery', () => {
             .setup((r) => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
-                expect(opts.args[2]).to.contain(pattern);
-                expect(opts.args[2]).to.not.contain('test*.py');
+                expect(opts.args[1]).to.contain(pattern);
+                expect(opts.args[1]).to.not.contain('test*.py');
             })
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());
@@ -297,8 +297,8 @@ suite('Unit Tests - Unittest - Discovery', () => {
             .setup((r) => r.run(typeMoq.It.isValue(UNITTEST_PROVIDER), typeMoq.It.isAny()))
             .callback((_, opts: Options) => {
                 expect(opts.args).to.include('-c');
-                expect(opts.args[2]).to.not.contain(pattern);
-                expect(opts.args[2]).to.contain('test*.py');
+                expect(opts.args[1]).to.not.contain(pattern);
+                expect(opts.args[1]).to.contain('test*.py');
             })
             .returns(() => Promise.resolve(runOutput))
             .verifiable(typeMoq.Times.once());

--- a/src/test/testing/unittest/unittest.run.test.ts
+++ b/src/test/testing/unittest/unittest.run.test.ts
@@ -145,11 +145,10 @@ suite('Unit Tests - unittest - run with mocked process output', () => {
             .create()) as MockProcessService;
         procService.onExecObservable((_file, args, _options, callback) => {
             if (
-                //args[0] is pyvsc-run-isolated.py.
                 args.length > 1 &&
-                args[1] === '-c' &&
-                args[2].includes('import unittest') &&
-                args[2].includes('loader = unittest.TestLoader()')
+                args[0] === '-c' &&
+                args[1].includes('import unittest') &&
+                args[1].includes('loader = unittest.TestLoader()')
             ) {
                 callback({
                     // Ensure any spaces added during code formatting or the like are removed


### PR DESCRIPTION
For #11264 

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).

This is a hotfix for #11264. We may need to look at this issue deeper to better handle test discovery for unittest.