### PR TITLE
Remove isolate script when running unittest

### DIFF
--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -331,5 +331,5 @@ export function testlauncher(testArgs: string[]): string[] {
 export function visualstudio_py_testlauncher(testArgs: string[]): string[] {
     const script = path.join(SCRIPTS_DIR, 'visualstudio_py_testlauncher.py');
     // There is no output to parse, so we do not return a function.
-    return [ISOLATED, script, ...testArgs];
+    return [script, ...testArgs];
 }

--- a/src/test/testing/common/debugLauncher.unit.test.ts
+++ b/src/test/testing/common/debugLauncher.unit.test.ts
@@ -207,8 +207,14 @@ suite('Unit Tests - Debug Launcher', () => {
             expected = getDefaultDebugConfig();
         }
         expected.rules = [{ path: path.join(EXTENSION_ROOT_DIR, 'pythonFiles'), include: false }];
-        expected.program = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'pyvsc-run-isolated.py');
-        expected.args = [testLaunchScript, ...options.args];
+        if (testProvider === 'unittest') {
+            expected.program = testLaunchScript;
+            expected.args = options.args;
+        } else {
+            expected.program = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'pyvsc-run-isolated.py');
+            expected.args = [testLaunchScript, ...options.args];
+        }
+
         if (!expected.cwd) {
             expected.cwd = workspaceFolders[0].uri.fsPath;
         }


### PR DESCRIPTION
For #11264

Looks like this fix #11353 is incomplete. we need to remove isolation for this as well with `unittest`.