### PR TITLE
Show a prompt asking user to upgrade Code runner to new version to keep using it

### DIFF
--- a/news/1 Enhancements/11327.md
+++ b/news/1 Enhancements/11327.md
@@ -1,0 +1,1 @@
+Show a prompt asking user to upgrade Code runner to new version to keep using it when in Deprecate PythonPath experiment.

--- a/package.nls.json
+++ b/package.nls.json
@@ -151,7 +151,7 @@
     "InterpreterQuickPickList.enterPath.placeholder": "Enter path to a Python interpreter.",
     "InterpreterQuickPickList.browsePath.label": "Find...",
     "InterpreterQuickPickList.browsePath.detail": "Browse your file system to find a Python interpreter.",
-    "diagnostics.upgradeCodeRunner": "Please update Code Runner extension for it to be compatible with the Python extension.",
+    "diagnostics.upgradeCodeRunner": "Please update the Code Runner extension for it to be compatible with the Python extension.",
     "Common.bannerLabelYes": "Yes",
     "Common.bannerLabelNo": "No",
     "Common.doNotShowAgain": "Do not show again",

--- a/package.nls.json
+++ b/package.nls.json
@@ -151,6 +151,7 @@
     "InterpreterQuickPickList.enterPath.placeholder": "Enter path to a Python interpreter.",
     "InterpreterQuickPickList.browsePath.label": "Find...",
     "InterpreterQuickPickList.browsePath.detail": "Browse your file system to find a Python interpreter.",
+    "diagnostics.upgradeCodeRunner": "Please update Code Runner extension for it to be compatible with the Python extension.",
     "Common.bannerLabelYes": "Yes",
     "Common.bannerLabelNo": "No",
     "Common.doNotShowAgain": "Do not show again",

--- a/src/client/application/diagnostics/checks/upgradeCodeRunner.ts
+++ b/src/client/application/diagnostics/checks/upgradeCodeRunner.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, named } from 'inversify';
+import { DiagnosticSeverity } from 'vscode';
+import { IWorkspaceService } from '../../../common/application/types';
+import { CODE_RUNNER_EXTENSION_ID } from '../../../common/constants';
+import { DeprecatePythonPath } from '../../../common/experimentGroups';
+import { IDisposableRegistry, IExperimentsManager, IExtensions, Resource } from '../../../common/types';
+import { Common, Diagnostics } from '../../../common/utils/localize';
+import { IServiceContainer } from '../../../ioc/types';
+import { BaseDiagnostic, BaseDiagnosticsService } from '../base';
+import { IDiagnosticsCommandFactory } from '../commands/types';
+import { DiagnosticCodes } from '../constants';
+import { DiagnosticCommandPromptHandlerServiceId, MessageCommandPrompt } from '../promptHandler';
+import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../types';
+
+export class UpgradeCodeRunnerDiagnostic extends BaseDiagnostic {
+    constructor(message: string, resource: Resource) {
+        super(
+            DiagnosticCodes.UpgradeCodeRunnerDiagnostic,
+            message,
+            DiagnosticSeverity.Information,
+            DiagnosticScope.Global,
+            resource
+        );
+    }
+}
+
+export const UpgradeCodeRunnerDiagnosticServiceId = 'UpgradeCodeRunnerDiagnosticServiceId';
+
+export class UpgradeCodeRunnerDiagnosticService extends BaseDiagnosticsService {
+    public _diagnosticReturned: boolean = false;
+    private workspaceService: IWorkspaceService;
+    constructor(
+        @inject(IServiceContainer) serviceContainer: IServiceContainer,
+        @inject(IDiagnosticHandlerService)
+        @named(DiagnosticCommandPromptHandlerServiceId)
+        protected readonly messageService: IDiagnosticHandlerService<MessageCommandPrompt>,
+        @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
+        @inject(IExtensions) private readonly extensions: IExtensions
+    ) {
+        super([DiagnosticCodes.UpgradeCodeRunnerDiagnostic], serviceContainer, disposableRegistry, true);
+        this.workspaceService = this.serviceContainer.get<IWorkspaceService>(IWorkspaceService);
+    }
+    public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
+        if (this._diagnosticReturned) {
+            return [];
+        }
+        const experiments = this.serviceContainer.get<IExperimentsManager>(IExperimentsManager);
+        experiments.sendTelemetryIfInExperiment(DeprecatePythonPath.control);
+        if (!experiments.inExperiment(DeprecatePythonPath.experiment)) {
+            return [];
+        }
+        const extension = this.extensions.getExtension(CODE_RUNNER_EXTENSION_ID);
+        if (!extension) {
+            return [];
+        }
+        const flagValue: boolean | undefined = extension.packageJSON?.featureFlags?.usingNewPythonInterpreterPathApi;
+        if (flagValue) {
+            // Using new version of Code runner already, no need to upgrade
+            return [];
+        }
+        const pythonExecutor = this.workspaceService
+            .getConfiguration('code-runner', resource)
+            .get<string>('executorMap.python');
+        if (pythonExecutor?.includes('$pythonPath')) {
+            this._diagnosticReturned = true;
+            return [new UpgradeCodeRunnerDiagnostic(Diagnostics.upgradeCodeRunner(), resource)];
+        }
+        return [];
+    }
+
+    protected async onHandle(diagnostics: IDiagnostic[]): Promise<void> {
+        if (diagnostics.length === 0 || !(await this.canHandle(diagnostics[0]))) {
+            return;
+        }
+        const diagnostic = diagnostics[0];
+        if (await this.filterService.shouldIgnoreDiagnostic(diagnostic.code)) {
+            return;
+        }
+        const commandFactory = this.serviceContainer.get<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory);
+        const options = [
+            {
+                prompt: Common.doNotShowAgain(),
+                command: commandFactory.createCommand(diagnostic, { type: 'ignore', options: DiagnosticScope.Global })
+            }
+        ];
+
+        await this.messageService.handle(diagnostic, { commandPrompts: options });
+    }
+}

--- a/src/client/application/diagnostics/constants.ts
+++ b/src/client/application/diagnostics/constants.ts
@@ -17,5 +17,6 @@ export enum DiagnosticCodes {
     PythonPathDeprecatedDiagnostic = 'PythonPathDeprecatedDiagnostic',
     JustMyCodeDiagnostic = 'JustMyCodeDiagnostic',
     ConsoleTypeDiagnostic = 'ConsoleTypeDiagnostic',
-    ConfigPythonPathDiagnostic = 'ConfigPythonPathDiagnostic'
+    ConfigPythonPathDiagnostic = 'ConfigPythonPathDiagnostic',
+    UpgradeCodeRunnerDiagnostic = 'UpgradeCodeRunnerDiagnostic'
 }

--- a/src/client/application/diagnostics/serviceRegistry.ts
+++ b/src/client/application/diagnostics/serviceRegistry.ts
@@ -33,6 +33,7 @@ import {
     PythonPathDeprecatedDiagnosticService,
     PythonPathDeprecatedDiagnosticServiceId
 } from './checks/pythonPathDeprecated';
+import { UpgradeCodeRunnerDiagnosticService, UpgradeCodeRunnerDiagnosticServiceId } from './checks/upgradeCodeRunner';
 import { DiagnosticsCommandFactory } from './commands/factory';
 import { IDiagnosticsCommandFactory } from './commands/types';
 import { DiagnosticFilterService } from './filter';
@@ -84,6 +85,12 @@ export function registerTypes(serviceManager: IServiceManager, languageServerTyp
         IDiagnosticsService,
         PythonPathDeprecatedDiagnosticService,
         PythonPathDeprecatedDiagnosticServiceId
+    );
+
+    serviceManager.addSingleton<IDiagnosticsService>(
+        IDiagnosticsService,
+        UpgradeCodeRunnerDiagnosticService,
+        UpgradeCodeRunnerDiagnosticServiceId
     );
     serviceManager.addSingleton<IDiagnosticsCommandFactory>(IDiagnosticsCommandFactory, DiagnosticsCommandFactory);
     serviceManager.addSingleton<IApplicationDiagnostics>(IApplicationDiagnostics, ApplicationDiagnostics);

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -26,6 +26,10 @@ export namespace Diagnostics {
         'diagnostics.lsNotSupported',
         'Your operating system does not meet the minimum requirements of the Python Language Server. Reverting to the alternative autocompletion provider, Jedi.'
     );
+    export const upgradeCodeRunner = localize(
+        'diagnostics.upgradeCodeRunner',
+        'Please update Code Runner extension for it to be compatible with the Python extension.'
+    );
     export const removePythonPathSettingsJson = localize(
         'diagnostics.removePythonPathSettingsJson',
         'The setting "python.pythonPath" defined in your workspace settings is now deprecated. Do you want us to delete it? This will only remove the "python.pythonPath" entry from your settings.json.'

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -28,7 +28,7 @@ export namespace Diagnostics {
     );
     export const upgradeCodeRunner = localize(
         'diagnostics.upgradeCodeRunner',
-        'Please update Code Runner extension for it to be compatible with the Python extension.'
+        'Please update the Code Runner extension for it to be compatible with the Python extension.'
     );
     export const removePythonPathSettingsJson = localize(
         'diagnostics.removePythonPathSettingsJson',

--- a/src/test/application/diagnostics/checks/upgradeCodeRunner.unit.test.ts
+++ b/src/test/application/diagnostics/checks/upgradeCodeRunner.unit.test.ts
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// tslint:disable:max-func-body-length no-any max-classes-per-file
+
+import { assert, expect } from 'chai';
+import * as typemoq from 'typemoq';
+import { DiagnosticSeverity, Extension, Uri, WorkspaceConfiguration } from 'vscode';
+import { BaseDiagnostic, BaseDiagnosticsService } from '../../../../client/application/diagnostics/base';
+import {
+    UpgradeCodeRunnerDiagnostic,
+    UpgradeCodeRunnerDiagnosticService
+} from '../../../../client/application/diagnostics/checks/upgradeCodeRunner';
+import { CommandOption, IDiagnosticsCommandFactory } from '../../../../client/application/diagnostics/commands/types';
+import { DiagnosticCodes } from '../../../../client/application/diagnostics/constants';
+import {
+    DiagnosticCommandPromptHandlerServiceId,
+    MessageCommandPrompt
+} from '../../../../client/application/diagnostics/promptHandler';
+import {
+    DiagnosticScope,
+    IDiagnostic,
+    IDiagnosticCommand,
+    IDiagnosticFilterService,
+    IDiagnosticHandlerService
+} from '../../../../client/application/diagnostics/types';
+import { IWorkspaceService } from '../../../../client/common/application/types';
+import { CODE_RUNNER_EXTENSION_ID } from '../../../../client/common/constants';
+import { DeprecatePythonPath } from '../../../../client/common/experimentGroups';
+import { IDisposableRegistry, IExperimentsManager, IExtensions, Resource } from '../../../../client/common/types';
+import { Common, Diagnostics } from '../../../../client/common/utils/localize';
+import { IServiceContainer } from '../../../../client/ioc/types';
+
+suite('Application Diagnostics - Upgrade Code Runner', () => {
+    const resource = Uri.parse('a');
+    let diagnosticService: UpgradeCodeRunnerDiagnosticService;
+    let messageHandler: typemoq.IMock<IDiagnosticHandlerService<MessageCommandPrompt>>;
+    let commandFactory: typemoq.IMock<IDiagnosticsCommandFactory>;
+    let workspaceService: typemoq.IMock<IWorkspaceService>;
+    let filterService: typemoq.IMock<IDiagnosticFilterService>;
+    let serviceContainer: typemoq.IMock<IServiceContainer>;
+    let experimentsManager: typemoq.IMock<IExperimentsManager>;
+    let extensions: typemoq.IMock<IExtensions>;
+    function createContainer() {
+        extensions = typemoq.Mock.ofType<IExtensions>();
+        serviceContainer = typemoq.Mock.ofType<IServiceContainer>();
+        experimentsManager = typemoq.Mock.ofType<IExperimentsManager>();
+        filterService = typemoq.Mock.ofType<IDiagnosticFilterService>();
+        messageHandler = typemoq.Mock.ofType<IDiagnosticHandlerService<MessageCommandPrompt>>();
+        serviceContainer
+            .setup((s) =>
+                s.get(
+                    typemoq.It.isValue(IDiagnosticHandlerService),
+                    typemoq.It.isValue(DiagnosticCommandPromptHandlerServiceId)
+                )
+            )
+            .returns(() => messageHandler.object);
+        commandFactory = typemoq.Mock.ofType<IDiagnosticsCommandFactory>();
+        serviceContainer
+            .setup((s) => s.get(typemoq.It.isValue(IExperimentsManager)))
+            .returns(() => experimentsManager.object);
+        serviceContainer
+            .setup((s) => s.get(typemoq.It.isValue(IDiagnosticFilterService)))
+            .returns(() => filterService.object);
+        serviceContainer
+            .setup((s) => s.get(typemoq.It.isValue(IDiagnosticsCommandFactory)))
+            .returns(() => commandFactory.object);
+        workspaceService = typemoq.Mock.ofType<IWorkspaceService>();
+        serviceContainer
+            .setup((s) => s.get(typemoq.It.isValue(IWorkspaceService)))
+            .returns(() => workspaceService.object);
+        serviceContainer.setup((s) => s.get(typemoq.It.isValue(IDisposableRegistry))).returns(() => []);
+        return serviceContainer.object;
+    }
+    suite('Diagnostics', () => {
+        setup(() => {
+            diagnosticService = new (class extends UpgradeCodeRunnerDiagnosticService {
+                public _clear() {
+                    while (BaseDiagnosticsService.handledDiagnosticCodeKeys.length > 0) {
+                        BaseDiagnosticsService.handledDiagnosticCodeKeys.shift();
+                    }
+                }
+            })(createContainer(), messageHandler.object, [], extensions.object);
+            (diagnosticService as any)._clear();
+        });
+
+        test('Can handle UpgradeCodeRunnerDiagnostic diagnostics', async () => {
+            const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
+            diagnostic
+                .setup((d) => d.code)
+                .returns(() => DiagnosticCodes.UpgradeCodeRunnerDiagnostic)
+                .verifiable(typemoq.Times.atLeastOnce());
+
+            const canHandle = await diagnosticService.canHandle(diagnostic.object);
+            expect(canHandle).to.be.equal(
+                true,
+                `Should be able to handle ${DiagnosticCodes.UpgradeCodeRunnerDiagnostic}`
+            );
+            diagnostic.verifyAll();
+        });
+
+        test('Can not handle non-UpgradeCodeRunnerDiagnostic diagnostics', async () => {
+            const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
+            diagnostic
+                .setup((d) => d.code)
+                .returns(() => 'Something Else' as any)
+                .verifiable(typemoq.Times.atLeastOnce());
+
+            const canHandle = await diagnosticService.canHandle(diagnostic.object);
+            expect(canHandle).to.be.equal(false, 'Invalid value');
+            diagnostic.verifyAll();
+        });
+
+        test('Should not display a message if the diagnostic code has been ignored', async () => {
+            const diagnostic = typemoq.Mock.ofType<IDiagnostic>();
+
+            filterService
+                .setup((f) => f.shouldIgnoreDiagnostic(typemoq.It.isValue(DiagnosticCodes.UpgradeCodeRunnerDiagnostic)))
+                .returns(() => Promise.resolve(true))
+                .verifiable(typemoq.Times.once());
+            diagnostic
+                .setup((d) => d.code)
+                .returns(() => DiagnosticCodes.UpgradeCodeRunnerDiagnostic)
+                .verifiable(typemoq.Times.atLeastOnce());
+            commandFactory
+                .setup((f) => f.createCommand(typemoq.It.isAny(), typemoq.It.isAny()))
+                .verifiable(typemoq.Times.never());
+            messageHandler
+                .setup((m) => m.handle(typemoq.It.isAny(), typemoq.It.isAny()))
+                .verifiable(typemoq.Times.never());
+
+            await diagnosticService.handle([diagnostic.object]);
+
+            filterService.verifyAll();
+            diagnostic.verifyAll();
+            commandFactory.verifyAll();
+            messageHandler.verifyAll();
+        });
+
+        test('UpgradeCodeRunnerDiagnostic is handled as expected', async () => {
+            const diagnostic = new UpgradeCodeRunnerDiagnostic('message', resource);
+            const ignoreCmd = ({ cmd: 'ignoreCmd' } as any) as IDiagnosticCommand;
+            filterService
+                .setup((f) => f.shouldIgnoreDiagnostic(typemoq.It.isValue(DiagnosticCodes.UpgradeCodeRunnerDiagnostic)))
+                .returns(() => Promise.resolve(false));
+            let messagePrompt: MessageCommandPrompt | undefined;
+            messageHandler
+                .setup((i) => i.handle(typemoq.It.isValue(diagnostic), typemoq.It.isAny()))
+                .callback((_d, p: MessageCommandPrompt) => (messagePrompt = p))
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.once());
+
+            commandFactory
+                .setup((f) =>
+                    f.createCommand(
+                        typemoq.It.isAny(),
+                        typemoq.It.isObjectWith<CommandOption<'ignore', DiagnosticScope>>({ type: 'ignore' })
+                    )
+                )
+                .returns(() => ignoreCmd)
+                .verifiable(typemoq.Times.once());
+
+            await diagnosticService.handle([diagnostic]);
+
+            messageHandler.verifyAll();
+            commandFactory.verifyAll();
+            expect(messagePrompt).not.be.equal(undefined, 'Message prompt not set');
+            expect(messagePrompt!.commandPrompts.length).to.equal(1, 'Incorrect length');
+            expect(messagePrompt!.commandPrompts[0]).to.be.deep.equal({
+                prompt: Common.doNotShowAgain(),
+                command: ignoreCmd
+            });
+        });
+
+        test('Handling an empty diagnostic should not show a message nor return a command', async () => {
+            const diagnostics: IDiagnostic[] = [];
+
+            messageHandler
+                .setup((i) => i.handle(typemoq.It.isAny(), typemoq.It.isAny()))
+                .callback((_d, p: MessageCommandPrompt) => p)
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.never());
+            commandFactory
+                .setup((f) => f.createCommand(typemoq.It.isAny(), typemoq.It.isAny()))
+                .verifiable(typemoq.Times.never());
+
+            await diagnosticService.handle(diagnostics);
+
+            messageHandler.verifyAll();
+            commandFactory.verifyAll();
+        });
+
+        test('Handling an unsupported diagnostic code should not show a message nor return a command', async () => {
+            const diagnostic = new (class SomeRandomDiagnostic extends BaseDiagnostic {
+                constructor(message: string, uri: Resource) {
+                    super(
+                        'SomeRandomDiagnostic' as any,
+                        message,
+                        DiagnosticSeverity.Information,
+                        DiagnosticScope.WorkspaceFolder,
+                        uri
+                    );
+                }
+            })('message', undefined);
+            messageHandler
+                .setup((i) => i.handle(typemoq.It.isAny(), typemoq.It.isAny()))
+                .callback((_d, p: MessageCommandPrompt) => p)
+                .returns(() => Promise.resolve())
+                .verifiable(typemoq.Times.never());
+            commandFactory
+                .setup((f) => f.createCommand(typemoq.It.isAny(), typemoq.It.isAny()))
+                .verifiable(typemoq.Times.never());
+
+            await diagnosticService.handle([diagnostic]);
+
+            messageHandler.verifyAll();
+            commandFactory.verifyAll();
+        });
+
+        test('If a diagnostic has already been returned, empty diagnostics is returned', async () => {
+            diagnosticService._diagnosticReturned = false;
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            assert.deepEqual(diagnostics, []);
+        });
+
+        test('If not in DeprecatePythonPath experiment, empty diagnostics is returned', async () => {
+            experimentsManager.setup((e) => e.inExperiment(DeprecatePythonPath.experiment)).returns(() => false);
+            experimentsManager
+                .setup((e) => e.sendTelemetryIfInExperiment(DeprecatePythonPath.control))
+                .returns(() => undefined);
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            assert.deepEqual(diagnostics, []);
+        });
+
+        test('If Code Runner extension is not installed, empty diagnostics is returned', async () => {
+            experimentsManager.setup((e) => e.inExperiment(DeprecatePythonPath.experiment)).returns(() => true);
+            experimentsManager
+                .setup((e) => e.sendTelemetryIfInExperiment(DeprecatePythonPath.control))
+                .returns(() => undefined);
+            extensions.setup((e) => e.getExtension(CODE_RUNNER_EXTENSION_ID)).returns(() => undefined);
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            assert.deepEqual(diagnostics, []);
+        });
+
+        test('If Code Runner extension is installed but the appropriate feature flag is set in package.json, empty diagnostics is returned', async () => {
+            experimentsManager.setup((e) => e.inExperiment(DeprecatePythonPath.experiment)).returns(() => true);
+            experimentsManager
+                .setup((e) => e.sendTelemetryIfInExperiment(DeprecatePythonPath.control))
+                .returns(() => undefined);
+            const extension = typemoq.Mock.ofType<Extension<any>>();
+            extensions.setup((e) => e.getExtension(CODE_RUNNER_EXTENSION_ID)).returns(() => extension.object);
+            extension
+                .setup((e) => e.packageJSON)
+                .returns(() => ({
+                    featureFlags: {
+                        usingNewPythonInterpreterPathApi: true
+                    }
+                }));
+            workspaceService
+                .setup((w) => w.getConfiguration('code-runner', resource))
+                .verifiable(typemoq.Times.never());
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            assert.deepEqual(diagnostics, []);
+            workspaceService.verifyAll();
+        });
+
+        test('If old version of Code Runner extension is installed but setting `code-runner.executorMap.python` is not set, empty diagnostics is returned', async () => {
+            experimentsManager.setup((e) => e.inExperiment(DeprecatePythonPath.experiment)).returns(() => true);
+            experimentsManager
+                .setup((e) => e.sendTelemetryIfInExperiment(DeprecatePythonPath.control))
+                .returns(() => undefined);
+            const workspaceConfig = typemoq.Mock.ofType<WorkspaceConfiguration>();
+            const extension = typemoq.Mock.ofType<Extension<any>>();
+            extensions.setup((e) => e.getExtension(CODE_RUNNER_EXTENSION_ID)).returns(() => extension.object);
+            extension.setup((e) => e.packageJSON).returns(() => undefined);
+            workspaceService
+                .setup((w) => w.getConfiguration('code-runner', resource))
+                .returns(() => workspaceConfig.object)
+                .verifiable(typemoq.Times.once());
+            workspaceConfig.setup((w) => w.get<string>('executorMap.python')).returns(() => undefined);
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            assert.deepEqual(diagnostics, []);
+            workspaceService.verifyAll();
+        });
+
+        test('If old version of Code Runner extension is installed but $pythonPath is not being used, empty diagnostics is returned', async () => {
+            experimentsManager.setup((e) => e.inExperiment(DeprecatePythonPath.experiment)).returns(() => true);
+            experimentsManager
+                .setup((e) => e.sendTelemetryIfInExperiment(DeprecatePythonPath.control))
+                .returns(() => undefined);
+            const workspaceConfig = typemoq.Mock.ofType<WorkspaceConfiguration>();
+            const extension = typemoq.Mock.ofType<Extension<any>>();
+            extensions.setup((e) => e.getExtension(CODE_RUNNER_EXTENSION_ID)).returns(() => extension.object);
+            extension.setup((e) => e.packageJSON).returns(() => undefined);
+            workspaceService
+                .setup((w) => w.getConfiguration('code-runner', resource))
+                .returns(() => workspaceConfig.object)
+                .verifiable(typemoq.Times.once());
+            workspaceConfig.setup((w) => w.get<string>('executorMap.python')).returns(() => 'Random string');
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            assert.deepEqual(diagnostics, []);
+            workspaceService.verifyAll();
+        });
+
+        test('If old version of Code Runner extension is installed and $pythonPath is being used, diagnostic with appropriate message is returned', async () => {
+            experimentsManager.setup((e) => e.inExperiment(DeprecatePythonPath.experiment)).returns(() => true);
+            experimentsManager
+                .setup((e) => e.sendTelemetryIfInExperiment(DeprecatePythonPath.control))
+                .returns(() => undefined);
+            const workspaceConfig = typemoq.Mock.ofType<WorkspaceConfiguration>();
+            const extension = typemoq.Mock.ofType<Extension<any>>();
+            extensions.setup((e) => e.getExtension(CODE_RUNNER_EXTENSION_ID)).returns(() => extension.object);
+            extension.setup((e) => e.packageJSON).returns(() => undefined);
+            workspaceService
+                .setup((w) => w.getConfiguration('code-runner', resource))
+                .returns(() => workspaceConfig.object)
+                .verifiable(typemoq.Times.once());
+            workspaceConfig
+                .setup((w) => w.get<string>('executorMap.python'))
+                .returns(() => 'This string contains $pythonPath');
+
+            const diagnostics = await diagnosticService.diagnose(resource);
+
+            expect(diagnostics.length).to.equal(1);
+            expect(diagnostics[0].message).to.equal(Diagnostics.upgradeCodeRunner());
+            expect(diagnostics[0].resource).to.equal(resource);
+            expect(diagnosticService._diagnosticReturned).to.equal(true, '');
+
+            workspaceService.verifyAll();
+        });
+    });
+});

--- a/src/test/application/diagnostics/serviceRegistry.unit.test.ts
+++ b/src/test/application/diagnostics/serviceRegistry.unit.test.ts
@@ -38,6 +38,10 @@ import {
     PythonPathDeprecatedDiagnosticService,
     PythonPathDeprecatedDiagnosticServiceId
 } from '../../../client/application/diagnostics/checks/pythonPathDeprecated';
+import {
+    UpgradeCodeRunnerDiagnosticService,
+    UpgradeCodeRunnerDiagnosticServiceId
+} from '../../../client/application/diagnostics/checks/upgradeCodeRunner';
 import { DiagnosticsCommandFactory } from '../../../client/application/diagnostics/commands/factory';
 import { IDiagnosticsCommandFactory } from '../../../client/application/diagnostics/commands/types';
 import { DiagnosticFilterService } from '../../../client/application/diagnostics/filter';
@@ -86,6 +90,13 @@ suite('Application Diagnostics - Register classes in IOC Container', () => {
                 IDiagnosticsService,
                 InvalidLaunchJsonDebuggerService,
                 InvalidLaunchJsonDebuggerServiceId
+            )
+        );
+        verify(
+            serviceManager.addSingleton<IDiagnosticsService>(
+                IDiagnosticsService,
+                UpgradeCodeRunnerDiagnosticService,
+                UpgradeCodeRunnerDiagnosticServiceId
             )
         );
         verify(


### PR DESCRIPTION
### ⚠ DON'T MERGE THIS UNTIL NEW CODE RUNNER EXTENSION IS RELEASED

For #11327 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
