### PR TITLE
Fix regression in typeshed/exclude paths from #11315

### DIFF
--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -99,6 +99,9 @@ export class DotNetLanguageServerAnalysisOptions extends LanguageServerAnalysisO
 
         searchPaths = searchPaths.map((p) => path.normalize(p));
 
+        this.excludedFiles = this.getExcludedFiles();
+        this.typeshedPaths = this.getTypeshedPaths();
+
         return {
             interpreter: {
                 properties


### PR DESCRIPTION
Fixes a regression I accidentally introduced in #11315. The typeshed and exclude paths weren't being set, breaking the LS and change events.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
