### PR TITLE
Expose active interpreter path via command

### DIFF
--- a/news/1 Enhancements/11440.md
+++ b/news/1 Enhancements/11440.md
@@ -1,0 +1,1 @@
+Expose active interpreter path which appears on the status bar via command.

--- a/package.json
+++ b/package.json
@@ -1192,7 +1192,8 @@
                 "program": "./out/client/debugger/debugAdapter/main.js",
                 "runtime": "node",
                 "variables": {
-                    "pickProcess": "python.pickLocalProcess"
+                    "pickProcess": "python.pickLocalProcess",
+                    "pythonPath": "python.getActiveInterpreter"
                 },
                 "configurationSnippets": [],
                 "configurationAttributes": {
@@ -1209,9 +1210,20 @@
                                 "default": "${file}"
                             },
                             "pythonPath": {
-                                "type": "string",
-                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings.json",
-                                "default": "${config:python.pythonPath}"
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "description": "Path (fully qualified) to python executable. Defaults to the value in settings.json",
+                                        "default": "${config:python.pythonPath}"
+                                    },
+                                    {
+                                        "enum": [
+                                            "${command:activeInterpreter}"
+                                        ],
+                                        "description": "Use to get the (fully qualified) path to Active interpreter which appears on the status bar",
+                                        "default": "${command:activeInterpreter}"
+                                    }
+                                ]
                             },
                             "args": {
                                 "type": "array",
@@ -1347,9 +1359,20 @@
                     "test": {
                         "properties": {
                             "pythonPath": {
-                                "type": "string",
-                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings.json",
-                                "default": "${config:python.pythonPath}"
+                                "anyOf": [
+                                    {
+                                        "type": "string",
+                                        "description": "Path (fully qualified) to python executable. Defaults to the value in settings.json",
+                                        "default": "${config:python.pythonPath}"
+                                    },
+                                    {
+                                        "enum": [
+                                            "${command:activeInterpreter}"
+                                        ],
+                                        "description": "Use to get the Active interpreter path which appears on the status bar",
+                                        "default": "${command:activeInterpreter}"
+                                    }
+                                ]
                             },
                             "stopOnEntry": {
                                 "type": "boolean",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -20,6 +20,7 @@ export type CommandsWithoutArgs = keyof ICommandNameWithoutArgumentTypeMapping;
  * @interface ICommandNameWithoutArgumentTypeMapping
  */
 interface ICommandNameWithoutArgumentTypeMapping {
+    [Commands.GetSelectedInterpreterPath]: [];
     [Commands.SwitchToInsidersDaily]: [];
     [Commands.SwitchToInsidersWeekly]: [];
     [Commands.ClearWorkspaceInterpreter]: [];

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -63,6 +63,7 @@ export namespace Commands {
     export const SwitchToInsidersDaily = 'python.switchToDailyChannel';
     export const SwitchToInsidersWeekly = 'python.switchToWeeklyChannel';
     export const PickLocalProcess = 'python.pickLocalProcess';
+    export const GetSelectedInterpreterPath = 'python.getSelectedInterpreterPath';
     export const ClearWorkspaceInterpreter = 'python.clearWorkspaceInterpreter';
     export const ResetInterpreterSecurityStorage = 'python.resetInterpreterSecurityStorage';
 }

--- a/src/client/common/constants.ts
+++ b/src/client/common/constants.ts
@@ -63,7 +63,7 @@ export namespace Commands {
     export const SwitchToInsidersDaily = 'python.switchToDailyChannel';
     export const SwitchToInsidersWeekly = 'python.switchToWeeklyChannel';
     export const PickLocalProcess = 'python.pickLocalProcess';
-    export const GetSelectedInterpreterPath = 'python.getSelectedInterpreterPath';
+    export const GetSelectedInterpreterPath = 'python.getActiveInterpreter';
     export const ClearWorkspaceInterpreter = 'python.clearWorkspaceInterpreter';
     export const ResetInterpreterSecurityStorage = 'python.resetInterpreterSecurityStorage';
 }

--- a/src/client/debugger/extension/configuration/launch.json/interpreterPathCommand.ts
+++ b/src/client/debugger/extension/configuration/launch.json/interpreterPathCommand.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { IExtensionSingleActivationService } from '../../../../activation/types';
+import { ICommandManager } from '../../../../common/application/types';
+import { Commands } from '../../../../common/constants';
+import { IDisposable, IDisposableRegistry } from '../../../../common/types';
+import { IInterpreterDisplay } from '../../../../interpreter/contracts';
+
+@injectable()
+export class InterpreterPathCommand implements IExtensionSingleActivationService {
+    constructor(
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IInterpreterDisplay) private readonly interpreterDisplay: IInterpreterDisplay,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposable[]
+    ) {}
+
+    public async activate() {
+        this.disposables.push(
+            this.commandManager.registerCommand(
+                Commands.GetSelectedInterpreterPath,
+                () => this.interpreterDisplay.interpreterPath
+            )
+        );
+    }
+}

--- a/src/client/debugger/extension/serviceRegistry.ts
+++ b/src/client/debugger/extension/serviceRegistry.ts
@@ -15,6 +15,7 @@ import { IAttachProcessProviderFactory } from './attachQuickPick/types';
 import { DebuggerBanner } from './banner';
 import { PythonDebugConfigurationService } from './configuration/debugConfigurationService';
 import { LaunchJsonCompletionProvider } from './configuration/launch.json/completionProvider';
+import { InterpreterPathCommand } from './configuration/launch.json/interpreterPathCommand';
 import { LaunchJsonUpdaterService } from './configuration/launch.json/updaterService';
 import { DjangoLaunchDebugConfigurationProvider } from './configuration/providers/djangoLaunch';
 import { FileLaunchDebugConfigurationProvider } from './configuration/providers/fileLaunch';
@@ -50,6 +51,10 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         LaunchJsonCompletionProvider
+    );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        InterpreterPathCommand
     );
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -101,6 +101,7 @@ export interface IInterpreterService {
 
 export const IInterpreterDisplay = Symbol('IInterpreterDisplay');
 export interface IInterpreterDisplay {
+    readonly interpreterPath: string | undefined;
     refresh(resource?: Uri): Promise<void>;
 }
 

--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -12,6 +12,10 @@ import { IInterpreterDisplay, IInterpreterHelper, IInterpreterService, PythonInt
 // tslint:disable-next-line:completed-docs
 @injectable()
 export class InterpreterDisplay implements IInterpreterDisplay {
+    public get interpreterPath(): string | undefined {
+        return this._interpreterPath;
+    }
+    public _interpreterPath: string | undefined;
     private readonly statusBar: StatusBarItem;
     private readonly helper: IInterpreterHelper;
     private readonly workspaceService: IWorkspaceService;
@@ -20,8 +24,6 @@ export class InterpreterDisplay implements IInterpreterDisplay {
     private currentlySelectedInterpreterPath?: string;
     private currentlySelectedWorkspaceFolder: Resource;
     private readonly autoSelection: IInterpreterAutoSelectionService;
-    private interpreterPath: string | undefined;
-
     constructor(@inject(IServiceContainer) private readonly serviceContainer: IServiceContainer) {
         this.helper = serviceContainer.get<IInterpreterHelper>(IInterpreterHelper);
         this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
@@ -42,6 +44,7 @@ export class InterpreterDisplay implements IInterpreterDisplay {
             disposableRegistry
         );
     }
+
     public async refresh(resource?: Uri) {
         // Use the workspace Uri if available
         if (resource && this.workspaceService.getWorkspaceFolder(resource)) {
@@ -65,14 +68,14 @@ export class InterpreterDisplay implements IInterpreterDisplay {
         if (interpreter) {
             this.statusBar.color = '';
             this.statusBar.tooltip = this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath);
-            if (this.interpreterPath !== interpreter.path) {
+            if (this._interpreterPath !== interpreter.path) {
                 const output = this.serviceContainer.get<OutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
                 output.appendLine(
                     Interpreters.pythonInterpreterPath().format(
                         this.pathUtils.getDisplayName(interpreter.path, workspaceFolder?.fsPath)
                     )
                 );
-                this.interpreterPath = interpreter.path;
+                this._interpreterPath = interpreter.path;
             }
             this.statusBar.text = interpreter.displayName!;
             this.currentlySelectedInterpreterPath = interpreter.path;

--- a/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
+++ b/src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.unit.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import * as TypeMoq from 'typemoq';
+import { CommandManager } from '../../../../../client/common/application/commandManager';
+import { ICommandManager } from '../../../../../client/common/application/types';
+import { Commands } from '../../../../../client/common/constants';
+import { IDisposable } from '../../../../../client/common/types';
+import { InterpreterPathCommand } from '../../../../../client/debugger/extension/configuration/launch.json/interpreterPathCommand';
+import { IInterpreterDisplay } from '../../../../../client/interpreter/contracts';
+import { InterpreterDisplay } from '../../../../../client/interpreter/display';
+
+suite('Interpreter Path Command', () => {
+    let cmdManager: ICommandManager;
+    let interpreterDisplay: IInterpreterDisplay;
+    let interpreterPathCommand: InterpreterPathCommand;
+    setup(() => {
+        cmdManager = mock(CommandManager);
+        interpreterDisplay = mock(InterpreterDisplay);
+        interpreterPathCommand = new InterpreterPathCommand(instance(cmdManager), instance(interpreterDisplay), []);
+    });
+
+    test('Ensure command is registered with the correct callback handlers', async () => {
+        let getInterpreterPathHandler!: Function;
+        when(cmdManager.registerCommand(Commands.GetSelectedInterpreterPath, anything())).thenCall((_, cb) => {
+            getInterpreterPathHandler = cb;
+            return TypeMoq.Mock.ofType<IDisposable>().object;
+        });
+
+        await interpreterPathCommand.activate();
+
+        when(interpreterDisplay.interpreterPath).thenResolve();
+        getInterpreterPathHandler();
+        verify(interpreterDisplay.interpreterPath).once();
+
+        verify(cmdManager.registerCommand(Commands.GetSelectedInterpreterPath, anything())).once();
+    });
+});

--- a/src/test/debugger/extension/serviceRegistry.unit.test.ts
+++ b/src/test/debugger/extension/serviceRegistry.unit.test.ts
@@ -16,6 +16,7 @@ import { IAttachProcessProviderFactory } from '../../../client/debugger/extensio
 import { DebuggerBanner } from '../../../client/debugger/extension/banner';
 import { PythonDebugConfigurationService } from '../../../client/debugger/extension/configuration/debugConfigurationService';
 import { LaunchJsonCompletionProvider } from '../../../client/debugger/extension/configuration/launch.json/completionProvider';
+import { InterpreterPathCommand } from '../../../client/debugger/extension/configuration/launch.json/interpreterPathCommand';
 import { LaunchJsonUpdaterService } from '../../../client/debugger/extension/configuration/launch.json/updaterService';
 import { DjangoLaunchDebugConfigurationProvider } from '../../../client/debugger/extension/configuration/providers/djangoLaunch';
 import { FileLaunchDebugConfigurationProvider } from '../../../client/debugger/extension/configuration/providers/fileLaunch';
@@ -59,6 +60,12 @@ suite('Debugging - Service Registry', () => {
     test('Registrations', () => {
         registerTypes(instance(serviceManager));
 
+        verify(
+            serviceManager.addSingleton<IExtensionSingleActivationService>(
+                IExtensionSingleActivationService,
+                InterpreterPathCommand
+            )
+        ).once();
         verify(
             serviceManager.addSingleton<IDebugConfigurationService>(
                 IDebugConfigurationService,

--- a/src/test/interpreters/display.unit.test.ts
+++ b/src/test/interpreters/display.unit.test.ts
@@ -19,7 +19,6 @@ import { Architecture } from '../../client/common/utils/platform';
 import { InterpreterAutoSelectionService } from '../../client/interpreter/autoSelection';
 import { IInterpreterAutoSelectionService } from '../../client/interpreter/autoSelection/types';
 import {
-    IInterpreterDisplay,
     IInterpreterHelper,
     IInterpreterService,
     InterpreterType,
@@ -54,7 +53,7 @@ suite('Interpreters Display', () => {
     let statusBar: TypeMoq.IMock<StatusBarItem>;
     let pythonSettings: TypeMoq.IMock<IPythonSettings>;
     let configurationService: TypeMoq.IMock<IConfigurationService>;
-    let interpreterDisplay: IInterpreterDisplay;
+    let interpreterDisplay: InterpreterDisplay;
     let interpreterHelper: TypeMoq.IMock<IInterpreterHelper>;
     let pathUtils: TypeMoq.IMock<IPathUtils>;
     let output: TypeMoq.IMock<IOutputChannel>;
@@ -261,5 +260,10 @@ suite('Interpreters Display', () => {
         interpreterService.verifyAll();
         statusBar.verify((s) => (s.text = TypeMoq.It.isValue(activeInterpreter.displayName)!), TypeMoq.Times.once());
         statusBar.verify((s) => (s.tooltip = TypeMoq.It.isValue(pythonPath)!), TypeMoq.Times.atLeastOnce());
+    });
+    test('Get interpreter path returns the correct path', async () => {
+        interpreterDisplay._interpreterPath = 'path/to/interpreter';
+        const result = interpreterDisplay.interpreterPath;
+        expect(result).to.equal('path/to/interpreter');
     });
 });


### PR DESCRIPTION
For #11440

Closing this PR as `${config:python.pythonPath}` already provides this functionality in a more robust way, which makes this redundant. More details in the issue.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
