### PR TITLE
Send LS version in static enabled/ready/startup events via lazy properties

### DIFF
--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -35,6 +35,8 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
     private middleware: LanguageClientMiddleware | undefined;
     private disposables: IDisposable[] = [];
     private connected: boolean = false;
+    private lsVersion: string | undefined;
+
     constructor(
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
         @inject(ILanguageServerAnalysisOptions)
@@ -48,6 +50,12 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
         @inject(IConfigurationService) private readonly configService: IConfigurationService
     ) {}
 
+    private static versionTelemetryProps(instance: NodeLanguageServerManager) {
+        return {
+            lsVersion: instance.lsVersion
+        };
+    }
+
     public dispose() {
         if (this.languageProxy) {
             this.languageProxy.dispose();
@@ -58,7 +66,6 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
     public get languageProxy() {
         return this.languageServerProxy;
     }
-
     @traceDecorators.error('Failed to start Language Server')
     public async start(resource: Resource, interpreter: PythonInterpreter | undefined): Promise<void> {
         if (this.languageProxy) {
@@ -67,6 +74,9 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
         this.resource = resource;
         this.interpreter = interpreter;
         this.analysisOptions.onDidChange(this.restartLanguageServerDebounced, this, this.disposables);
+
+        const versionPair = await this.folderService.getCurrentLanguageServerDirectory();
+        this.lsVersion = versionPair?.version.format();
 
         await this.analysisOptions.initialize(resource, interpreter);
         await this.startLanguageServer();
@@ -96,12 +106,16 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
         await this.startLanguageServer();
     }
 
-    @captureTelemetry(EventName.LANGUAGE_SERVER_STARTUP, undefined, true)
+    @captureTelemetry(
+        EventName.LANGUAGE_SERVER_STARTUP,
+        undefined,
+        true,
+        undefined,
+        NodeLanguageServerManager.versionTelemetryProps
+    )
     @traceDecorators.verbose('Starting Language Server')
     protected async startLanguageServer(): Promise<void> {
         this.languageServerProxy = this.serviceContainer.get<ILanguageServerProxy>(ILanguageServerProxy);
-
-        const versionPair = await this.folderService.getCurrentLanguageServerDirectory();
 
         const options = await this.analysisOptions!.getAnalysisOptions();
         options.middleware = this.middleware = new LanguageClientMiddleware(
@@ -109,7 +123,7 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
             this.experimentsManager,
             this.configService,
             LanguageServerType.Node,
-            versionPair?.version.format()
+            this.lsVersion
         );
 
         // Make sure the middleware is connected if we restart and we we're already connected.

--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -66,6 +66,7 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
     public get languageProxy() {
         return this.languageServerProxy;
     }
+
     @traceDecorators.error('Failed to start Language Server')
     public async start(resource: Resource, interpreter: PythonInterpreter | undefined): Promise<void> {
         if (this.languageProxy) {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -141,22 +141,22 @@ type TypedMethodDescriptor<T> = (
 ) => TypedPropertyDescriptor<T> | void;
 
 // tslint:disable-next-line:no-any function-name
-export function captureTelemetry<T, P extends IEventNamePropertyMapping, E extends keyof P>(
+export function captureTelemetry<This, P extends IEventNamePropertyMapping, E extends keyof P>(
     eventName: E,
     properties?: P[E],
     captureDuration: boolean = true,
     failureEventName?: E,
-    lazyProperties?: (obj: T) => P[E]
-): TypedMethodDescriptor<(this: T, ...args: any[]) => any> {
+    lazyProperties?: (obj: This) => P[E]
+): TypedMethodDescriptor<(this: This, ...args: any[]) => any> {
     // tslint:disable-next-line:no-function-expression no-any
     return function (
         _target: Object,
         _propertyKey: string | symbol,
-        descriptor: TypedPropertyDescriptor<(this: T, ...args: any[]) => any>
+        descriptor: TypedPropertyDescriptor<(this: This, ...args: any[]) => any>
     ) {
         const originalMethod = descriptor.value!;
         // tslint:disable-next-line:no-function-expression no-any
-        descriptor.value = function (this: T, ...args: any[]) {
+        descriptor.value = function (this: This, ...args: any[]) {
             // Legacy case; fast path that sends event before method executes.
             // Does not set "failed" if the result is a Promise and throws an exception.
             if (!captureDuration && !lazyProperties) {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -140,6 +140,15 @@ type TypedMethodDescriptor<T> = (
     descriptor: TypedPropertyDescriptor<T>
 ) => TypedPropertyDescriptor<T> | void;
 
+/**
+ * Decorates a method, sending a telemetry event with the given properties.
+ * @param eventName The event name to send.
+ * @param properties Properties to send with the event; must be valid for the event.
+ * @param captureDuration True if the method's execution duration should be captured.
+ * @param failureEventName If the decorated method returns a Promise and fails, send this event instead of eventName.
+ * @param lazyProperties A static function on the decorated class which returns extra properties to add to the event.
+ * This can be used to provide properties which are only known at runtime (after the decorator has executed).
+ */
 // tslint:disable-next-line:no-any function-name
 export function captureTelemetry<This, P extends IEventNamePropertyMapping, E extends keyof P>(
     eventName: E,

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -150,7 +150,7 @@ export function captureTelemetry<T, P extends IEventNamePropertyMapping, E exten
         const originalMethod = descriptor.value!;
         // tslint:disable-next-line:no-function-expression no-any
         descriptor.value = function (this: T, ...args: any[]) {
-            // Legacy case; fast path sent before method executes.
+            // Legacy case; fast path that sends event before method executes.
             if (!captureDuration && !lazyProperties) {
                 sendTelemetryEvent(eventName, undefined, properties);
                 // tslint:disable-next-line:no-invalid-this


### PR DESCRIPTION
These events are the only ones which did not include an LS version, which makes it difficult to get statistics on load timings.

Unfortunately, these events are "static" by nature of them using the decorator form of the telemetry helpers. To handle this, introduce a "lazy properties" callback which allows decorated functions to add properties at call time. For all existing uses of `captureTelemetry`, the behavior is unchanged (including a behavior which I believe to be a mistake; I will point that out in a PR comment after posting).

I'm looking for feedback on this solution. It's a little bit unique due to the way that decorators currently work. Unfortunately the decorator feature itself is experimental and TS can't do the one check I need to make this perfectly type-safe -- checking that the `this` type for the decorated method is compatible with the callback's parameter type. But, it's no more unsafe than before.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
