### PR TITLE
Rename ${config:python.pythonPath} used in launch.json to ${config:python.interpreterPath}

### DIFF
--- a/news/1 Enhancements/11446.md
+++ b/news/1 Enhancements/11446.md
@@ -1,0 +1,1 @@
+Rename string `${config:python.pythonPath}` which is used in `launch.json` to refer to interpreter path set in settings, to `${config:python.interpreterPath}`.

--- a/package.json
+++ b/package.json
@@ -1210,8 +1210,8 @@
                             },
                             "pythonPath": {
                                 "type": "string",
-                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings.json",
-                                "default": "${config:python.pythonPath}"
+                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings",
+                                "default": "${config:python.interpreterPath}"
                             },
                             "args": {
                                 "type": "array",
@@ -1348,8 +1348,8 @@
                         "properties": {
                             "pythonPath": {
                                 "type": "string",
-                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings.json",
-                                "default": "${config:python.pythonPath}"
+                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings",
+                                "default": "${config:python.interpreterPath}"
                             },
                             "stopOnEntry": {
                                 "type": "boolean",

--- a/src/client/application/diagnostics/base.ts
+++ b/src/client/application/diagnostics/base.ts
@@ -21,7 +21,8 @@ export abstract class BaseDiagnostic implements IDiagnostic {
         public readonly severity: DiagnosticSeverity,
         public readonly scope: DiagnosticScope,
         public readonly resource: Resource,
-        public readonly invokeHandler: 'always' | 'default' = 'default'
+        public readonly invokeHandler: 'always' | 'default' = 'default',
+        public readonly shouldShowPrompt = true
     ) {}
 }
 

--- a/src/client/application/diagnostics/checks/invalidLaunchJsonDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidLaunchJsonDebugger.ts
@@ -63,7 +63,8 @@ export class InvalidLaunchJsonDebuggerService extends BaseDiagnosticsService {
             [
                 DiagnosticCodes.InvalidDebuggerTypeDiagnostic,
                 DiagnosticCodes.JustMyCodeDiagnostic,
-                DiagnosticCodes.ConsoleTypeDiagnostic
+                DiagnosticCodes.ConsoleTypeDiagnostic,
+                DiagnosticCodes.ConfigPythonPathDiagnostic
             ],
             serviceContainer,
             disposableRegistry,

--- a/src/client/application/diagnostics/checks/invalidLaunchJsonDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidLaunchJsonDebugger.ts
@@ -20,7 +20,8 @@ import { DiagnosticScope, IDiagnostic, IDiagnosticHandlerService } from '../type
 const messages = {
     [DiagnosticCodes.InvalidDebuggerTypeDiagnostic]: Diagnostics.invalidDebuggerTypeDiagnostic(),
     [DiagnosticCodes.JustMyCodeDiagnostic]: Diagnostics.justMyCodeDiagnostic(),
-    [DiagnosticCodes.ConsoleTypeDiagnostic]: Diagnostics.consoleTypeDiagnostic()
+    [DiagnosticCodes.ConsoleTypeDiagnostic]: Diagnostics.consoleTypeDiagnostic(),
+    [DiagnosticCodes.ConfigPythonPathDiagnostic]: ''
 };
 
 export class InvalidLaunchJsonDebuggerDiagnostic extends BaseDiagnostic {
@@ -28,10 +29,20 @@ export class InvalidLaunchJsonDebuggerDiagnostic extends BaseDiagnostic {
         code:
             | DiagnosticCodes.InvalidDebuggerTypeDiagnostic
             | DiagnosticCodes.JustMyCodeDiagnostic
-            | DiagnosticCodes.ConsoleTypeDiagnostic,
-        resource: Resource
+            | DiagnosticCodes.ConsoleTypeDiagnostic
+            | DiagnosticCodes.ConfigPythonPathDiagnostic,
+        resource: Resource,
+        shouldShowPrompt: boolean = true
     ) {
-        super(code, messages[code], DiagnosticSeverity.Error, DiagnosticScope.WorkspaceFolder, resource, 'always');
+        super(
+            code,
+            messages[code],
+            DiagnosticSeverity.Error,
+            DiagnosticScope.WorkspaceFolder,
+            resource,
+            'always',
+            shouldShowPrompt
+        );
     }
 }
 
@@ -101,11 +112,19 @@ export class InvalidLaunchJsonDebuggerService extends BaseDiagnosticsService {
         if (fileContents.indexOf('"console": "none"') > 0) {
             diagnostics.push(new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.ConsoleTypeDiagnostic, resource));
         }
+        if (fileContents.indexOf('{config:python.pythonPath}') > 0) {
+            diagnostics.push(
+                new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.ConfigPythonPathDiagnostic, resource, false)
+            );
+        }
         return diagnostics;
     }
     private async handleDiagnostic(diagnostic: IDiagnostic): Promise<void> {
         if (!this.canHandle(diagnostic)) {
             return;
+        }
+        if (!diagnostic.shouldShowPrompt) {
+            return this.fixLaunchJson(diagnostic.code);
         }
         const commandPrompts = [
             {
@@ -143,6 +162,14 @@ export class InvalidLaunchJsonDebuggerService extends BaseDiagnosticsService {
             }
             case DiagnosticCodes.ConsoleTypeDiagnostic: {
                 fileContents = this.findAndReplace(fileContents, '"console": "none"', '"console": "internalConsole"');
+                break;
+            }
+            case DiagnosticCodes.ConfigPythonPathDiagnostic: {
+                fileContents = this.findAndReplace(
+                    fileContents,
+                    '{config:python.pythonPath}',
+                    '{config:python.interpreterPath}'
+                );
                 break;
             }
             default: {

--- a/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
@@ -76,7 +76,7 @@ export class InvalidPythonPathInDebuggerService extends BaseDiagnosticsService
     public async validatePythonPath(pythonPath?: string, pythonPathSource?: PythonPathSource, resource?: Uri) {
         pythonPath = pythonPath ? this.resolveVariables(pythonPath, resource) : undefined;
         // tslint:disable-next-line:no-invalid-template-strings
-        if (pythonPath === '${config:python.pythonPath}' || !pythonPath) {
+        if (pythonPath === '${config:python.interpreterPath}' || !pythonPath) {
             pythonPath = this.configService.getSettings(resource).pythonPath;
         }
         if (await this.interpreterHelper.getInterpreterInformation(pythonPath).catch(() => undefined)) {

--- a/src/client/application/diagnostics/constants.ts
+++ b/src/client/application/diagnostics/constants.ts
@@ -16,5 +16,6 @@ export enum DiagnosticCodes {
     LSNotSupportedDiagnostic = 'LSNotSupportedDiagnostic',
     PythonPathDeprecatedDiagnostic = 'PythonPathDeprecatedDiagnostic',
     JustMyCodeDiagnostic = 'JustMyCodeDiagnostic',
-    ConsoleTypeDiagnostic = 'ConsoleTypeDiagnostic'
+    ConsoleTypeDiagnostic = 'ConsoleTypeDiagnostic',
+    ConfigPythonPathDiagnostic = 'ConfigPythonPathDiagnostic'
 }

--- a/src/client/application/diagnostics/types.ts
+++ b/src/client/application/diagnostics/types.ts
@@ -25,6 +25,7 @@ export interface IDiagnostic {
     readonly scope: DiagnosticScope;
     readonly resource: Resource;
     readonly invokeHandler: 'always' | 'default';
+    readonly shouldShowPrompt?: boolean;
 }
 
 export const IDiagnosticsService = Symbol('IDiagnosticsService');

--- a/src/client/debugger/extension/configuration/resolvers/base.ts
+++ b/src/client/debugger/extension/configuration/resolvers/base.ts
@@ -91,7 +91,7 @@ export abstract class BaseConfigurationResolver<T extends DebugConfiguration>
         if (!debugConfiguration) {
             return;
         }
-        if (debugConfiguration.pythonPath === '${config:python.pythonPath}' || !debugConfiguration.pythonPath) {
+        if (debugConfiguration.pythonPath === '${config:python.interpreterPath}' || !debugConfiguration.pythonPath) {
             const pythonPath = this.configurationService.getSettings(workspaceFolder).pythonPath;
             debugConfiguration.pythonPath = pythonPath;
             this.pythonPathSource = PythonPathSource.settingsJson;

--- a/src/test/application/diagnostics/checks/invalidLaunchJsonDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidLaunchJsonDebugger.unit.test.ts
@@ -193,6 +193,31 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
         fs.verifyAll();
     });
 
+    test('Should return ConfigPythonPathDiagnostic if file launch.json contains string "{config:python.pythonPath}"', async () => {
+        const fileContents = 'Hello I am launch.json, I contain string {config:python.pythonPath}';
+        workspaceService
+            .setup((w) => w.hasWorkspaceFolders)
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
+        workspaceService
+            .setup((w) => w.workspaceFolders)
+            .returns(() => [workspaceFolder])
+            .verifiable(TypeMoq.Times.once());
+        fs.setup((w) => w.fileExists(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(true))
+            .verifiable(TypeMoq.Times.once());
+        fs.setup((w) => w.readFile(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(fileContents))
+            .verifiable(TypeMoq.Times.once());
+        const diagnostics = await diagnosticService.diagnose(undefined);
+        expect(diagnostics).to.be.deep.equal(
+            [new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.ConfigPythonPathDiagnostic, undefined, false)],
+            'not the same'
+        );
+        workspaceService.verifyAll();
+        fs.verifyAll();
+    });
+
     test('Should return both diagnostics if file launch.json contains string "debugStdLib" and  "pythonExperimental"', async () => {
         const fileContents = 'Hello I am launch.json, I contain both "debugStdLib" and "pythonExperimental"';
         workspaceService
@@ -221,7 +246,7 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
         fs.verifyAll();
     });
 
-    test('All InvalidLaunchJsonDebugger diagnostics should display 2 options to with one command', async () => {
+    test('All InvalidLaunchJsonDebugger diagnostics with `shouldShowPrompt` set to `true` should display 2 options to with one command', async () => {
         for (const code of [
             DiagnosticCodes.InvalidDebuggerTypeDiagnostic,
             DiagnosticCodes.JustMyCodeDiagnostic,
@@ -232,6 +257,10 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
             diagnostic
                 .setup((d) => d.code)
                 .returns(() => code)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+            diagnostic
+                .setup((d) => d.shouldShowPrompt)
+                .returns(() => true)
                 .verifiable(TypeMoq.Times.atLeastOnce());
             messageHandler
                 .setup((m) => m.handle(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
@@ -251,6 +280,39 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
             expect(options!.commandPrompts).to.be.lengthOf(2);
             expect(options!.commandPrompts[0].prompt).to.be.equal(Diagnostics.yesUpdateLaunch());
             expect(options!.commandPrompts[0].command).not.to.be.equal(undefined, 'Command not set');
+        }
+    });
+
+    test('All InvalidLaunchJsonDebugger diagnostics with `shouldShowPrompt` set to `false` should directly fix launch.json', async () => {
+        for (const code of [DiagnosticCodes.ConfigPythonPathDiagnostic]) {
+            let called = false;
+            (diagnosticService as any).fixLaunchJson = () => {
+                called = true;
+            };
+            const diagnostic = TypeMoq.Mock.ofType<IDiagnostic>();
+            diagnostic
+                .setup((d) => d.code)
+                .returns(() => code)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+            diagnostic
+                .setup((d) => d.shouldShowPrompt)
+                .returns(() => false)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+            messageHandler
+                .setup((m) => m.handle(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .verifiable(TypeMoq.Times.never());
+            baseWorkspaceService
+                .setup((c) => c.getWorkspaceFolder(TypeMoq.It.isAny()))
+                .returns(() => workspaceFolder)
+                .verifiable(TypeMoq.Times.atLeastOnce());
+
+            await diagnosticService.handle([diagnostic.object]);
+
+            diagnostic.verifyAll();
+            commandFactory.verifyAll();
+            messageHandler.verifyAll();
+            baseWorkspaceService.verifyAll();
+            expect(called).to.equal(true, '');
         }
     });
 
@@ -404,6 +466,31 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
             .returns(() => Promise.resolve())
             .verifiable(TypeMoq.Times.once());
         await (diagnosticService as any).fixLaunchJson(DiagnosticCodes.ConsoleTypeDiagnostic);
+        workspaceService.verifyAll();
+        fs.verifyAll();
+    });
+
+    test('File launch.json is fixed correctly when code equals ConfigPythonPathDiagnostic ', async () => {
+        const launchJson = 'This string contains {config:python.pythonPath}';
+        const correctedlaunchJson = 'This string contains {config:python.interpreterPath}';
+        workspaceService
+            .setup((w) => w.hasWorkspaceFolders)
+            .returns(() => true)
+            .verifiable(TypeMoq.Times.once());
+        workspaceService
+            .setup((w) => w.workspaceFolders)
+            .returns(() => [workspaceFolder])
+            .verifiable(TypeMoq.Times.once());
+        fs.setup((w) => w.fileExists(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(true))
+            .verifiable(TypeMoq.Times.once());
+        fs.setup((w) => w.readFile(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(launchJson))
+            .verifiable(TypeMoq.Times.atLeastOnce());
+        fs.setup((w) => w.writeFile(TypeMoq.It.isAnyString(), correctedlaunchJson))
+            .returns(() => Promise.resolve())
+            .verifiable(TypeMoq.Times.once());
+        await (diagnosticService as any).fixLaunchJson(DiagnosticCodes.ConfigPythonPathDiagnostic);
         workspaceService.verifyAll();
         fs.verifyAll();
     });

--- a/src/test/application/diagnostics/checks/invalidLaunchJsonDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidLaunchJsonDebugger.unit.test.ts
@@ -162,7 +162,7 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
         const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal(
             [new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.InvalidDebuggerTypeDiagnostic, undefined)],
-            'not the same'
+            'Diagnostics returned are not as expected'
         );
         workspaceService.verifyAll();
         fs.verifyAll();
@@ -187,7 +187,7 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
         const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal(
             [new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.JustMyCodeDiagnostic, undefined)],
-            'not the same'
+            'Diagnostics returned are not as expected'
         );
         workspaceService.verifyAll();
         fs.verifyAll();
@@ -212,7 +212,7 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
         const diagnostics = await diagnosticService.diagnose(undefined);
         expect(diagnostics).to.be.deep.equal(
             [new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.ConfigPythonPathDiagnostic, undefined, false)],
-            'not the same'
+            'Diagnostics returned are not as expected'
         );
         workspaceService.verifyAll();
         fs.verifyAll();
@@ -240,13 +240,13 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
                 new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.InvalidDebuggerTypeDiagnostic, undefined),
                 new InvalidLaunchJsonDebuggerDiagnostic(DiagnosticCodes.JustMyCodeDiagnostic, undefined)
             ],
-            'not the same'
+            'Diagnostics returned are not as expected'
         );
         workspaceService.verifyAll();
         fs.verifyAll();
     });
 
-    test('All InvalidLaunchJsonDebugger diagnostics with `shouldShowPrompt` set to `true` should display 2 options to with one command', async () => {
+    test('All InvalidLaunchJsonDebugger diagnostics with `shouldShowPrompt` set to `true` should display a prompt with 2 buttons where clicking the first button will invoke a command', async () => {
         for (const code of [
             DiagnosticCodes.InvalidDebuggerTypeDiagnostic,
             DiagnosticCodes.JustMyCodeDiagnostic,

--- a/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidPythonPathInDebugger.unit.test.ts
@@ -227,8 +227,8 @@ suite('Application Diagnostics - Checks Python Path in debugger', () => {
         expect(options!.commandPrompts).to.be.lengthOf(1);
         expect(options!.commandPrompts[0].prompt).to.be.equal('Open launch.json');
     });
-    test('Ensure we get python path from config when path = ${config:python.pythonPath}', async () => {
-        const pythonPath = '${config:python.pythonPath}';
+    test('Ensure we get python path from config when path = ${config:python.interpreterPath}', async () => {
+        const pythonPath = '${config:python.interpreterPath}';
 
         const settings = typemoq.Mock.ofType<IPythonSettings>();
         settings

--- a/src/test/debugger/extension/configuration/resolvers/base.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/base.unit.test.ts
@@ -195,9 +195,9 @@ suite('Debugging - Config Resolver', () => {
 
         expect(config).to.have.property('pythonPath', pythonPath);
     });
-    test('Python path in debug config must point to pythonpath in settings  if pythonPath in config is ${config:python.pythonPath}', () => {
+    test('Python path in debug config must point to pythonpath in settings  if pythonPath in config is ${config:python.interpreterPath}', () => {
         const config = {
-            pythonPath: '${config:python.pythonPath}'
+            pythonPath: '${config:python.interpreterPath}'
         };
         const pythonPath = path.join('1', '2', '3');
 

--- a/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
@@ -485,7 +485,7 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
                 }
             ]);
         });
-        test('Ensure `${config:python.pythonPath}` is replaced with actual pythonPath', async () => {
+        test('Ensure `${config:python.interpreterPath}` is replaced with actual pythonPath', async () => {
             const pythonPath = `PythonPath_${new Date().toString()}`;
             const activeFile = 'xyz.py';
             const workspaceFolder = createMoqWorkspaceFolder(__dirname);
@@ -495,7 +495,7 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
             setupWorkspaces([defaultWorkspace]);
 
             const debugConfig = await debugProvider.resolveDebugConfiguration!(workspaceFolder, ({
-                pythonPath: '${config:python.pythonPath}'
+                pythonPath: '${config:python.interpreterPath}'
             } as any) as DebugConfiguration);
 
             expect(debugConfig).to.have.property('pythonPath', pythonPath);


### PR DESCRIPTION
For #11446

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
