### PR TITLE
Add collapsible sections to the bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.md
@@ -38,14 +38,33 @@ Note: If you think a GIF of what is happening would be helpful, consider tools l
 
 ## Logs
 
-Output for `Python` in the `Output` panel (`View`→`Output`, change the drop-down the upper-right of the `Output` panel to `Python`)
+<details>
+
+<summary>Output for <code>Python</code> in the <code>Output</code> panel (<code>View</code>→<code>Output</code>, change the drop-down the upper-right of the <code>Output</code> panel to <code>Python</code>)
+</summary>
+
+<p>
 
 ```
 XXX
 ```
 
-Output from `Console` under the `Developer Tools` panel (toggle Developer Tools on under `Help`; turn on source maps to make any tracebacks be useful by running `Enable source map support for extension debugging`)
+</p>
+</details>
+
+<br />
+
+<details>
+
+<summary>
+Output from <code>Console</code> under the <code>Developer Tools</code> panel (toggle Developer Tools on under <code>Help</code>; turn on source maps to make any tracebacks be useful by running <code>Enable source map support for extension debugging</code>)
+</summary>
+
+<p>
 
 ```
-XXX
+XXXX
 ```
+
+</p>
+</details>


### PR DESCRIPTION
Sadly Markdown isn't supported in the `<summary>` tag unless there's a newline between `<summary>` and its content, at least on Firefox (see [this comment on a `<details>` gist](https://gist.github.com/ericclemmons/b146fe5da72ca1f706b2ef72a20ac39d#gistcomment-2334481)), so I had to replace it with `<code>` tags.

What do you think of adding a newline between the `Output from ....` line and the help in parenthesis?

-----

Before:

<img width="592" alt="image" src="https://user-images.githubusercontent.com/51720070/80429120-34311c00-88a0-11ea-82ec-41fe704db65e.png">

After:

<img width="593" alt="image" src="https://user-images.githubusercontent.com/51720070/80429142-3d21ed80-88a0-11ea-84c8-37419fd80a6e.png">
