### PR TITLE
Use separate class to manage kernel dependencies

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -488,5 +488,5 @@
     "DataScience.unhandledMessage": "Unhandled kernel message from a widget: {0} : {1}",
     "DataScience.qgridWidgetScriptVersionCompatibilityWarning": "Unable to load a compatible version of the widget 'qgrid'. Consider downgrading to version 1.1.1.",
     "DataScience.kernelStarted": "Started kernel {0}",
-    "DataScience.ipykernelNotInstalled": "Ipykernel is not installed."
+    "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter": "Data Science library {1} is not installed in interpreter {0}. Install?"
 }

--- a/src/client/common/process/baseDaemon.ts
+++ b/src/client/common/process/baseDaemon.ts
@@ -21,8 +21,8 @@ import {
     StdErrError
 } from './types';
 
-type ErrorResponse = { error?: string };
-
+export type ErrorResponse = { error?: string };
+export type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
 export class ConnectionClosedError extends Error {
     constructor(public readonly message: string) {
         super();
@@ -181,7 +181,6 @@ export abstract class BasePythonDaemon {
     ): ObservableExecutionResult<string> {
         const subject = new Subject<Output<string>>();
         const start = async () => {
-            type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
             let response: ExecResponse;
             if ('fileName' in moduleOrFile) {
                 const request = new RequestType<
@@ -282,7 +281,6 @@ export abstract class BasePythonDaemon {
         args: string[],
         options: SpawnOptions
     ): Promise<ExecutionResult<string>> {
-        type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
         const request = new RequestType<
             // tslint:disable-next-line: no-any
             { file_name: string; args: string[]; cwd?: string; env?: any },
@@ -304,7 +302,6 @@ export abstract class BasePythonDaemon {
         args: string[],
         options: SpawnOptions
     ): Promise<ExecutionResult<string>> {
-        type ExecResponse = ErrorResponse & { stdout: string; stderr?: string };
         const request = new RequestType<
             // tslint:disable-next-line: no-any
             { module_name: string; args: string[]; cwd?: string; env?: any },

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -53,7 +53,10 @@ export class PythonDaemonFactory {
     @traceDecorators.error('Failed to create daemon')
     public async createDaemonService<T extends IPythonDaemonExecutionService | IDisposable>(): Promise<T> {
         // Add '--log-file=/Users/donjayamanne/Desktop/Development/vsc/pythonVSCode/daaemon.log' to log to a file.
-        const loggingArgs: string[] = ['-v']; // Log information messages or greater (see daemon.__main__.py for options).
+        const loggingArgs: string[] = [
+            '-v',
+            '--log-file=/Users/donjayamanne/Desktop/Development/vsc/pythonVSCode/daaemon.log'
+        ]; // Log information messages or greater (see daemon.__main__.py for options).
 
         const args = (this.options.daemonModule ? [`--daemon-module=${this.options.daemonModule}`] : []).concat(
             loggingArgs

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -53,10 +53,7 @@ export class PythonDaemonFactory {
     @traceDecorators.error('Failed to create daemon')
     public async createDaemonService<T extends IPythonDaemonExecutionService | IDisposable>(): Promise<T> {
         // Add '--log-file=/Users/donjayamanne/Desktop/Development/vsc/pythonVSCode/daaemon.log' to log to a file.
-        const loggingArgs: string[] = [
-            '-v',
-            '--log-file=/Users/donjayamanne/Desktop/Development/vsc/pythonVSCode/daaemon.log'
-        ]; // Log information messages or greater (see daemon.__main__.py for options).
+        const loggingArgs: string[] = ['-v']; // Log information messages or greater (see daemon.__main__.py for options).
 
         const args = (this.options.daemonModule ? [`--daemon-module=${this.options.daemonModule}`] : []).concat(
             loggingArgs

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -350,6 +350,10 @@ export namespace DataScience {
         'DataScience.libraryRequiredToLaunchJupyterNotInstalledInterpreter',
         'Data Science library {1} is not installed in interpreter {0}.'
     );
+    export const libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter = localize(
+        'DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter',
+        'Data Science library {1} is not installed in interpreter {0}. Install?'
+    );
     export const librariesRequiredToLaunchJupyterNotInstalledInterpreter = localize(
         'DataScience.librariesRequiredToLaunchJupyterNotInstalledInterpreter',
         'Data Science libraries {1} are not installed in interpreter {0}.'
@@ -920,7 +924,6 @@ export namespace DataScience {
     );
 
     export const kernelStarted = localize('DataScience.kernelStarted', 'Started kernel {0}.');
-    export const ipykernelNotInstalled = localize('DataScience.ipykernelNotInstalled', 'Ipykernel is not installed.');
 }
 
 export namespace DebugConfigStrings {

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -22,7 +22,7 @@ export enum KernelInterpreterDependencyResponse {
  * If required modules aren't installed, will prompt user to install them.
  */
 @injectable()
-export class KernelDepdencyService {
+export class KernelDependencyService {
     constructor(
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IInstaller) private readonly installer: IInstaller

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -11,18 +11,14 @@ import { ProductNames } from '../../../common/installer/productNames';
 import { IInstaller, InstallerResponse, Product } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { PythonInterpreter } from '../../../interpreter/contracts';
-
-export enum KernelInterpreterDependencyResponse {
-    ok,
-    cancel
-}
+import { IKernelDependencyService, KernelInterpreterDependencyResponse } from '../../types';
 
 /**
  * Responsible for managing dependencies of a Python interpreter required to run as a Jupyter Kernel.
  * If required modules aren't installed, will prompt user to install them.
  */
 @injectable()
-export class KernelDependencyService {
+export class KernelDependencyService implements IKernelDependencyService {
     constructor(
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IInstaller) private readonly installer: IInstaller

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable } from 'inversify';
+import { CancellationToken } from 'vscode';
+import { IApplicationShell } from '../../../common/application/types';
+import { createPromiseFromCancellation, wrapCancellationTokens } from '../../../common/cancellation';
+import { ProductNames } from '../../../common/installer/productNames';
+import { IInstaller, InstallerResponse, Product } from '../../../common/types';
+import { Common, DataScience } from '../../../common/utils/localize';
+import { PythonInterpreter } from '../../../interpreter/contracts';
+import { JupyterInstallError } from '../jupyterInstallError';
+
+export enum KernelInterpreterDependencyResponse {
+    ok,
+    cancel
+}
+
+/**
+ * Responsible for managing dependencies of a Python interpreter required to run as a Jupyter Kernel.
+ * If required modules aren't installed, will prompt user to install them.
+ */
+@injectable()
+export class KernelDepdencyService {
+    constructor(
+        @inject(IApplicationShell) private readonly appShell: IApplicationShell,
+        @inject(IInstaller) private readonly installer: IInstaller
+    ) {}
+    /**
+     * Configures the python interpreter to ensure it can run a Jupyter Kernel by installing any missing dependencies.
+     * If user opts not to install they can opt to select another interpreter.
+     */
+    public async installMissingDependencies(
+        interpreter: PythonInterpreter,
+        _error?: JupyterInstallError,
+        token?: CancellationToken
+    ): Promise<KernelInterpreterDependencyResponse> {
+        if (await this.areDependenciesInstalled(interpreter, token)) {
+            return KernelInterpreterDependencyResponse.ok;
+        }
+
+        const promptCancellationPromise = createPromiseFromCancellation({
+            cancelAction: 'resolve',
+            defaultValue: undefined,
+            token
+        });
+        const message = DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter().format(
+            interpreter.displayName || interpreter.envName || interpreter.path,
+            ProductNames.get(Product.ipykernel)!
+        );
+        const installerToken = wrapCancellationTokens(token);
+        const selection = await Promise.race([
+            this.appShell.showErrorMessage(message, Common.ok(), Common.cancel()),
+            promptCancellationPromise
+        ]);
+        if (installerToken.isCancellationRequested) {
+            return KernelInterpreterDependencyResponse.cancel;
+        }
+
+        if (selection === Common.ok()) {
+            const cancellatonPromise = createPromiseFromCancellation({
+                cancelAction: 'resolve',
+                defaultValue: InstallerResponse.Ignore,
+                token
+            });
+            // Always pass a cancellation token to `install`, to ensure it waits until the module is installed.
+            const response = await Promise.race([
+                this.installer.install(Product.ipykernel, interpreter, installerToken),
+                cancellatonPromise
+            ]);
+            if (response === InstallerResponse.Installed) {
+                return KernelInterpreterDependencyResponse.ok;
+            }
+        }
+        return KernelInterpreterDependencyResponse.cancel;
+    }
+    public areDependenciesInstalled(interpreter: PythonInterpreter, _token?: CancellationToken): Promise<boolean> {
+        return this.installer.isInstalled(Product.ipykernel, interpreter).then((installed) => installed === true);
+    }
+}

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -11,7 +11,6 @@ import { ProductNames } from '../../../common/installer/productNames';
 import { IInstaller, InstallerResponse, Product } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { PythonInterpreter } from '../../../interpreter/contracts';
-import { JupyterInstallError } from '../jupyterInstallError';
 
 export enum KernelInterpreterDependencyResponse {
     ok,
@@ -34,7 +33,6 @@ export class KernelDepdencyService {
      */
     public async installMissingDependencies(
         interpreter: PythonInterpreter,
-        _error?: JupyterInstallError,
         token?: CancellationToken
     ): Promise<KernelInterpreterDependencyResponse> {
         if (await this.areDependenciesInstalled(interpreter, token)) {

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -9,7 +9,7 @@ import { CancellationToken } from 'vscode-jsonrpc';
 
 import { IApplicationShell } from '../../../common/application/types';
 import { traceError, traceInfo, traceVerbose } from '../../../common/logger';
-import { IInstaller, Product, Resource } from '../../../common/types';
+import { Resource } from '../../../common/types';
 import * as localize from '../../../common/utils/localize';
 import { noop } from '../../../common/utils/misc';
 import { StopWatch } from '../../../common/utils/stopWatch';
@@ -19,6 +19,7 @@ import { KnownNotebookLanguages, Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
 import { IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
+import { KernelDepdencyService } from './kernelDependencyService';
 import { KernelSelectionProvider } from './kernelSelections';
 import { KernelService } from './kernelService';
 import { IKernelSpecQuickPickItem, LiveKernelModel } from './types';
@@ -57,7 +58,7 @@ export class KernelSelector {
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(KernelService) private readonly kernelService: KernelService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IInstaller) private readonly installer: IInstaller
+        @inject(KernelDepdencyService) private readonly kernelDepdencyService: KernelDepdencyService
     ) {}
 
     /**
@@ -378,7 +379,7 @@ export class KernelSelector {
     ): Promise<KernelSpecInterpreter> {
         let kernelSpec: IJupyterKernelSpec | undefined;
 
-        if (await this.installer.isInstalled(Product.ipykernel, interpreter)) {
+        if (await this.kernelDepdencyService.areDependenciesInstalled(interpreter, cancelToken)) {
             // Find the kernel associated with this interpter.
             kernelSpec = await this.kernelService.findMatchingKernelSpec(interpreter, session, cancelToken);
 

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -18,8 +18,7 @@ import { IEventNamePropertyMapping, sendTelemetryEvent } from '../../../telemetr
 import { KnownNotebookLanguages, Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
-import { IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
-import { KernelDependencyService } from './kernelDependencyService';
+import { IJupyterKernelSpec, IJupyterSessionManager, IKernelDependencyService } from '../../types';
 import { KernelSelectionProvider } from './kernelSelections';
 import { KernelService } from './kernelService';
 import { IKernelSpecQuickPickItem, LiveKernelModel } from './types';
@@ -58,7 +57,7 @@ export class KernelSelector {
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(KernelService) private readonly kernelService: KernelService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(KernelDependencyService) private readonly kernelDepdencyService: KernelDependencyService
+        @inject(IKernelDependencyService) private readonly kernelDepdencyService: IKernelDependencyService
     ) {}
 
     /**

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -19,7 +19,7 @@ import { KnownNotebookLanguages, Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
 import { IJupyterKernelSpec, IJupyterSessionManager } from '../../types';
-import { KernelDepdencyService } from './kernelDependencyService';
+import { KernelDependencyService } from './kernelDependencyService';
 import { KernelSelectionProvider } from './kernelSelections';
 import { KernelService } from './kernelService';
 import { IKernelSpecQuickPickItem, LiveKernelModel } from './types';
@@ -58,7 +58,7 @@ export class KernelSelector {
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(KernelService) private readonly kernelService: KernelService,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(KernelDepdencyService) private readonly kernelDepdencyService: KernelDepdencyService
+        @inject(KernelDependencyService) private readonly kernelDepdencyService: KernelDependencyService
     ) {}
 
     /**

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -24,9 +24,14 @@ import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
-import { IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../types';
+import {
+    IJupyterKernelSpec,
+    IJupyterSessionManager,
+    IJupyterSubCommandExecutionService,
+    IKernelDependencyService,
+    KernelInterpreterDependencyResponse
+} from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
-import { KernelDependencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
 import { LiveKernelModel } from './types';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
@@ -62,7 +67,7 @@ export class KernelService {
         private readonly jupyterInterpreterExecService: IJupyterSubCommandExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(KernelDependencyService) private readonly kernelDependencyService: KernelDependencyService,
+        @inject(IKernelDependencyService) private readonly kernelDependencyService: IKernelDependencyService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IEnvironmentActivationService) private readonly activationHelper: IEnvironmentActivationService
     ) {}

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -26,7 +26,7 @@ import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
 import { IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
-import { KernelDepdencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
+import { KernelDependencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
 import { LiveKernelModel } from './types';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
@@ -62,7 +62,7 @@ export class KernelService {
         private readonly jupyterInterpreterExecService: IJupyterSubCommandExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(KernelDepdencyService) private readonly kernelDependencyService: KernelDepdencyService,
+        @inject(KernelDependencyService) private readonly kernelDependencyService: KernelDependencyService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IEnvironmentActivationService) private readonly activationHelper: IEnvironmentActivationService
     ) {}

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -15,7 +15,7 @@ import '../../../common/extensions';
 import { traceDecorators, traceError, traceInfo, traceVerbose, traceWarning } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
 import { IPythonExecutionFactory } from '../../../common/process/types';
-import { IInstaller, InstallerResponse, Product, ReadWrite } from '../../../common/types';
+import { ReadWrite } from '../../../common/types';
 import { sleep } from '../../../common/utils/async';
 import { noop } from '../../../common/utils/misc';
 import { IEnvironmentActivationService } from '../../../interpreter/activation/types';
@@ -26,6 +26,7 @@ import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
 import { IJupyterKernelSpec, IJupyterSessionManager, IJupyterSubCommandExecutionService } from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
+import { KernelDepdencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
 import { LiveKernelModel } from './types';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
@@ -61,7 +62,7 @@ export class KernelService {
         private readonly jupyterInterpreterExecService: IJupyterSubCommandExecutionService,
         @inject(IPythonExecutionFactory) private readonly execFactory: IPythonExecutionFactory,
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IInstaller) private readonly installer: IInstaller,
+        @inject(KernelDepdencyService) private readonly kernelDependencyService: KernelDepdencyService,
         @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(IEnvironmentActivationService) private readonly activationHelper: IEnvironmentActivationService
     ) {}
@@ -280,15 +281,14 @@ export class KernelService {
         execServicePromise.ignoreErrors();
         const name = this.generateKernelNameForIntepreter(interpreter);
         // If ipykernel is not installed, prompt to install it.
-        if (!(await this.installer.isInstalled(Product.ipykernel, interpreter)) && !disableUI) {
+        if (!(await this.kernelDependencyService.areDependenciesInstalled(interpreter, cancelToken)) && !disableUI) {
             // If we wish to wait for installation to complete, we must provide a cancel token.
             const token = new CancellationTokenSource();
-            const response = await this.installer.promptToInstall(
-                Product.ipykernel,
+            const response = await this.kernelDependencyService.installMissingDependencies(
                 interpreter,
                 wrapCancellationTokens(cancelToken, token.token)
             );
-            if (response !== InstallerResponse.Installed) {
+            if (response !== KernelInterpreterDependencyResponse.ok) {
                 traceWarning(
                     `Prompted to install ipykernel, however ipykernel not installed in the interpreter ${interpreter.path}. Response ${response}`
                 );

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -4,17 +4,16 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { CancellationTokenSource, ProgressLocation, ProgressOptions } from 'vscode';
+import { ProgressLocation, ProgressOptions } from 'vscode';
 import { IApplicationShell } from '../../../common/application/types';
-import { traceVerbose } from '../../../common/logger';
-import { IConfigurationService, IInstaller, InstallerResponse, Product, Resource } from '../../../common/types';
+import { IConfigurationService, Resource } from '../../../common/types';
 import { Common, DataScience } from '../../../common/utils/localize';
 import { StopWatch } from '../../../common/utils/stopWatch';
 import { JupyterSessionStartError } from '../../baseJupyterSession';
-// import * as localize from '../../common/utils/localize';
 import { Commands, Settings } from '../../constants';
 import { IJupyterConnection, IJupyterKernelSpec, IJupyterSessionManagerFactory, INotebook } from '../../types';
 import { JupyterInvalidKernelError } from '../jupyterInvalidKernelError';
+import { KernelDepdencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
 import { KernelSelector, KernelSpecInterpreter } from './kernelSelector';
 import { LiveKernelModel } from './types';
 
@@ -25,7 +24,7 @@ export class KernelSwitcher {
         @inject(IJupyterSessionManagerFactory) private jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(KernelSelector) private kernelSelector: KernelSelector,
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(IInstaller) private readonly installer: IInstaller
+        @inject(KernelDepdencyService) private readonly kernelDependencyService: KernelDepdencyService
     ) {}
 
     public async switchKernel(notebook: INotebook): Promise<KernelSpecInterpreter | undefined> {
@@ -126,17 +125,9 @@ export class KernelSwitcher {
         }
     }
     private async switchToKernel(notebook: INotebook, kernel: KernelSpecInterpreter): Promise<void> {
-        if (
-            notebook.connection?.type === 'raw' &&
-            !(await this.installer.isInstalled(Product.ipykernel, kernel.interpreter))
-        ) {
-            const token = new CancellationTokenSource();
-            const response = await this.installer.promptToInstall(Product.ipykernel, kernel.interpreter, token.token);
-            if (response === InstallerResponse.Installed) {
-                traceVerbose(`ipykernel installed in ${kernel.interpreter!.path}.`);
-            } else {
-                this.appShell.showErrorMessage(DataScience.ipykernelNotInstalled());
-                traceVerbose(`ipykernel is not installed in ${kernel.interpreter!.path}.`);
+        if (notebook.connection?.type === 'raw' && kernel.interpreter) {
+            const response = await this.kernelDependencyService.installMissingDependencies(kernel.interpreter);
+            if (response === KernelInterpreterDependencyResponse.cancel) {
                 return;
             }
         }

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -13,7 +13,7 @@ import { JupyterSessionStartError } from '../../baseJupyterSession';
 import { Commands, Settings } from '../../constants';
 import { IJupyterConnection, IJupyterKernelSpec, IJupyterSessionManagerFactory, INotebook } from '../../types';
 import { JupyterInvalidKernelError } from '../jupyterInvalidKernelError';
-import { KernelDepdencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
+import { KernelDependencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
 import { KernelSelector, KernelSpecInterpreter } from './kernelSelector';
 import { LiveKernelModel } from './types';
 
@@ -24,7 +24,7 @@ export class KernelSwitcher {
         @inject(IJupyterSessionManagerFactory) private jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(KernelSelector) private kernelSelector: KernelSelector,
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(KernelDepdencyService) private readonly kernelDependencyService: KernelDepdencyService
+        @inject(KernelDependencyService) private readonly kernelDependencyService: KernelDependencyService
     ) {}
 
     public async switchKernel(notebook: INotebook): Promise<KernelSpecInterpreter | undefined> {

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -11,9 +11,15 @@ import { Common, DataScience } from '../../../common/utils/localize';
 import { StopWatch } from '../../../common/utils/stopWatch';
 import { JupyterSessionStartError } from '../../baseJupyterSession';
 import { Commands, Settings } from '../../constants';
-import { IJupyterConnection, IJupyterKernelSpec, IJupyterSessionManagerFactory, INotebook } from '../../types';
+import {
+    IJupyterConnection,
+    IJupyterKernelSpec,
+    IJupyterSessionManagerFactory,
+    IKernelDependencyService,
+    INotebook,
+    KernelInterpreterDependencyResponse
+} from '../../types';
 import { JupyterInvalidKernelError } from '../jupyterInvalidKernelError';
-import { KernelDependencyService, KernelInterpreterDependencyResponse } from './kernelDependencyService';
 import { KernelSelector, KernelSpecInterpreter } from './kernelSelector';
 import { LiveKernelModel } from './types';
 
@@ -24,7 +30,7 @@ export class KernelSwitcher {
         @inject(IJupyterSessionManagerFactory) private jupyterSessionManagerFactory: IJupyterSessionManagerFactory,
         @inject(KernelSelector) private kernelSelector: KernelSelector,
         @inject(IApplicationShell) private appShell: IApplicationShell,
-        @inject(KernelDependencyService) private readonly kernelDependencyService: KernelDependencyService
+        @inject(IKernelDependencyService) private readonly kernelDependencyService: IKernelDependencyService
     ) {}
 
     public async switchKernel(notebook: INotebook): Promise<KernelSpecInterpreter | undefined> {

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -113,6 +113,7 @@ import {
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
     IJupyterVariables,
+    IKernelDependencyService,
     INotebookEditor,
     INotebookEditorProvider,
     INotebookExecutionLogger,
@@ -210,7 +211,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IPyWidgetMessageDispatcherFactory>(IPyWidgetMessageDispatcherFactory, IPyWidgetMessageDispatcherFactory);
     serviceManager.addSingleton<IJupyterInterpreterDependencyManager>(IJupyterInterpreterDependencyManager, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterInterpreterSubCommandExecutionService);
-    serviceManager.addSingleton<KernelDependencyService>(KernelDependencyService, KernelDependencyService);
+    serviceManager.addSingleton<IKernelDependencyService>(IKernelDependencyService, KernelDependencyService);
 
     registerGatherTypes(serviceManager);
 }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -65,7 +65,7 @@ import { JupyterPasswordConnect } from './jupyter/jupyterPasswordConnect';
 import { JupyterServerWrapper } from './jupyter/jupyterServerWrapper';
 import { JupyterSessionManagerFactory } from './jupyter/jupyterSessionManagerFactory';
 import { JupyterVariables } from './jupyter/jupyterVariables';
-import { KernelDepdencyService } from './jupyter/kernels/kernelDependencyService';
+import { KernelDependencyService } from './jupyter/kernels/kernelDependencyService';
 import { KernelSelectionProvider } from './jupyter/kernels/kernelSelections';
 import { KernelSelector } from './jupyter/kernels/kernelSelector';
 import { KernelService } from './jupyter/kernels/kernelService';
@@ -210,7 +210,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IPyWidgetMessageDispatcherFactory>(IPyWidgetMessageDispatcherFactory, IPyWidgetMessageDispatcherFactory);
     serviceManager.addSingleton<IJupyterInterpreterDependencyManager>(IJupyterInterpreterDependencyManager, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterInterpreterSubCommandExecutionService);
-    serviceManager.addSingleton<KernelDepdencyService>(KernelDepdencyService, KernelDepdencyService);
+    serviceManager.addSingleton<KernelDependencyService>(KernelDependencyService, KernelDependencyService);
 
     registerGatherTypes(serviceManager);
 }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -127,7 +127,6 @@ import {
     IStatusProvider,
     IThemeFinder
 } from './types';
-import { KernelDaemonPool } from './kernel-launcher/kernelDaemonPool';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -212,7 +211,6 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IJupyterInterpreterDependencyManager>(IJupyterInterpreterDependencyManager, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<KernelDepdencyService>(KernelDepdencyService, KernelDepdencyService);
-    serviceManager.addSingleton<KernelDaemonPool>(KernelDaemonPool, KernelDaemonPool);
 
     registerGatherTypes(serviceManager);
 }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -65,6 +65,7 @@ import { JupyterPasswordConnect } from './jupyter/jupyterPasswordConnect';
 import { JupyterServerWrapper } from './jupyter/jupyterServerWrapper';
 import { JupyterSessionManagerFactory } from './jupyter/jupyterSessionManagerFactory';
 import { JupyterVariables } from './jupyter/jupyterVariables';
+import { KernelDepdencyService } from './jupyter/kernels/kernelDependencyService';
 import { KernelSelectionProvider } from './jupyter/kernels/kernelSelections';
 import { KernelSelector } from './jupyter/kernels/kernelSelector';
 import { KernelService } from './jupyter/kernels/kernelService';
@@ -126,6 +127,7 @@ import {
     IStatusProvider,
     IThemeFinder
 } from './types';
+import { KernelDaemonPool } from './kernel-launcher/kernelDaemonPool';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -209,6 +211,8 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IPyWidgetMessageDispatcherFactory>(IPyWidgetMessageDispatcherFactory, IPyWidgetMessageDispatcherFactory);
     serviceManager.addSingleton<IJupyterInterpreterDependencyManager>(IJupyterInterpreterDependencyManager, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterInterpreterSubCommandExecutionService);
+    serviceManager.addSingleton<KernelDepdencyService>(KernelDepdencyService, KernelDepdencyService);
+    serviceManager.addSingleton<KernelDaemonPool>(KernelDaemonPool, KernelDaemonPool);
 
     registerGatherTypes(serviceManager);
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1137,3 +1137,17 @@ export interface IJMPConnection extends IDisposable {
     // tslint:disable-next-line: no-any
     subscribe(handlerFunc: (message: KernelMessage.IMessage) => void, errorHandler?: (exc: any) => void): void;
 }
+
+export enum KernelInterpreterDependencyResponse {
+    ok,
+    cancel
+}
+
+export const IKernelDependencyService = Symbol('IKernelDependencyService');
+export interface IKernelDependencyService {
+    installMissingDependencies(
+        interpreter: PythonInterpreter,
+        token?: CancellationToken
+    ): Promise<KernelInterpreterDependencyResponse>;
+    areDependenciesInstalled(interpreter: PythonInterpreter, _token?: CancellationToken): Promise<boolean>;
+}

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -273,7 +273,8 @@ import {
     IPlotViewerProvider,
     IRawNotebookProvider,
     IStatusProvider,
-    IThemeFinder
+    IThemeFinder,
+    IKernelDependencyService
 } from '../../client/datascience/types';
 import { ProtocolParser } from '../../client/debugger/debugAdapter/Common/protocolParser';
 import { IProtocolParser } from '../../client/debugger/debugAdapter/types';
@@ -752,7 +753,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<KernelSelector>(KernelSelector, KernelSelector);
         this.serviceManager.addSingleton<KernelSelectionProvider>(KernelSelectionProvider, KernelSelectionProvider);
         this.serviceManager.addSingleton<KernelSwitcher>(KernelSwitcher, KernelSwitcher);
-        this.serviceManager.addSingleton<KernelDependencyService>(KernelDependencyService, KernelDependencyService);
+        this.serviceManager.addSingleton<IKernelDependencyService>(IKernelDependencyService, KernelDependencyService);
         this.serviceManager.addSingleton<IProductService>(IProductService, ProductService);
         this.serviceManager.addSingleton<IProductPathService>(
             IProductPathService,

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -261,6 +261,7 @@ import {
     IJupyterSessionManagerFactory,
     IJupyterSubCommandExecutionService,
     IJupyterVariables,
+    IKernelDependencyService,
     INotebookEditor,
     INotebookEditorProvider,
     INotebookExecutionLogger,
@@ -273,8 +274,7 @@ import {
     IPlotViewerProvider,
     IRawNotebookProvider,
     IStatusProvider,
-    IThemeFinder,
-    IKernelDependencyService
+    IThemeFinder
 } from '../../client/datascience/types';
 import { ProtocolParser } from '../../client/debugger/debugAdapter/Common/protocolParser';
 import { IProtocolParser } from '../../client/debugger/debugAdapter/types';

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -214,6 +214,7 @@ import { JupyterPasswordConnect } from '../../client/datascience/jupyter/jupyter
 import { JupyterServerWrapper } from '../../client/datascience/jupyter/jupyterServerWrapper';
 import { JupyterSessionManagerFactory } from '../../client/datascience/jupyter/jupyterSessionManagerFactory';
 import { JupyterVariables } from '../../client/datascience/jupyter/jupyterVariables';
+import { KernelDependencyService } from '../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelSelectionProvider } from '../../client/datascience/jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelService } from '../../client/datascience/jupyter/kernels/kernelService';
@@ -387,7 +388,6 @@ import { TestInteractiveWindowProvider } from './testInteractiveWindowProvider';
 import { TestNativeEditorProvider } from './testNativeEditorProvider';
 import { TestPersistentStateFactory } from './testPersistentStateFactory';
 import { WebBrowserPanelProvider } from './uiTests/webBrowserPanelProvider';
-import { KernelDependencyService } from '../../client/datascience/jupyter/kernels/kernelDependencyService';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -387,6 +387,7 @@ import { TestInteractiveWindowProvider } from './testInteractiveWindowProvider';
 import { TestNativeEditorProvider } from './testNativeEditorProvider';
 import { TestPersistentStateFactory } from './testPersistentStateFactory';
 import { WebBrowserPanelProvider } from './uiTests/webBrowserPanelProvider';
+import { KernelDependencyService } from '../../client/datascience/jupyter/kernels/kernelDependencyService';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {
@@ -751,6 +752,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<KernelSelector>(KernelSelector, KernelSelector);
         this.serviceManager.addSingleton<KernelSelectionProvider>(KernelSelectionProvider, KernelSelectionProvider);
         this.serviceManager.addSingleton<KernelSwitcher>(KernelSwitcher, KernelSwitcher);
+        this.serviceManager.addSingleton<KernelDependencyService>(KernelDependencyService, KernelDependencyService);
         this.serviceManager.addSingleton<IProductService>(IProductService, ProductService);
         this.serviceManager.addSingleton<IProductPathService>(
             IProductPathService,

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -8,10 +8,8 @@ import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { IApplicationShell } from '../../../../client/common/application/types';
 import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
 import { Common } from '../../../../client/common/utils/localize';
-import {
-    KernelDependencyService,
-    KernelInterpreterDependencyResponse
-} from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
+import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
+import { KernelInterpreterDependencyResponse } from '../../../../client/datascience/types';
 import { createPythonInterpreter } from '../../../utils/interpreters';
 
 // tslint:disable: no-any
@@ -61,9 +59,6 @@ suite('Data Science - Kernel Dependency Service', () => {
         const response = await dependencyService.installMissingDependencies(interpreter);
 
         assert.equal(response, KernelInterpreterDependencyResponse.ok);
-        verify(appShell.showErrorMessage(anything(), anything(), anything())).once();
-        verify(installer.install(Product.ipykernel, interpreter, anything())).once();
-        verify(installer.install(anything(), anything(), anything())).once();
     });
     test('Bubble installation errors', async () => {
         when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
@@ -75,8 +70,5 @@ suite('Data Science - Kernel Dependency Service', () => {
         const promise = dependencyService.installMissingDependencies(interpreter);
 
         await assert.isRejected(promise, 'Install failed - kaboom');
-        verify(appShell.showErrorMessage(anything(), anything(), anything())).once();
-        verify(installer.install(Product.ipykernel, interpreter, anything())).once();
-        verify(installer.install(anything(), anything(), anything())).once();
     });
 });

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { assert } from 'chai';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { IApplicationShell } from '../../../../client/common/application/types';
+import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
+import { Common } from '../../../../client/common/utils/localize';
+import {
+    KernelDepdencyService,
+    KernelInterpreterDependencyResponse
+} from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
+import { createPythonInterpreter } from '../../../utils/interpreters';
+
+// tslint:disable: no-any
+
+// tslint:disable-next-line: max-func-body-length
+suite('Data Science - Kernel Dependency Service', () => {
+    let dependencyService: KernelDepdencyService;
+    let appShell: IApplicationShell;
+    let installer: IInstaller;
+    const interpreter = createPythonInterpreter();
+    setup(() => {
+        appShell = mock<IApplicationShell>();
+        installer = mock<IInstaller>();
+        dependencyService = new KernelDepdencyService(instance(appShell), instance(installer));
+    });
+    test('Check if ipykernel is installed', async () => {
+        when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+
+        const response = await dependencyService.installMissingDependencies(interpreter);
+
+        assert.equal(response, KernelInterpreterDependencyResponse.ok);
+        verify(installer.isInstalled(Product.ipykernel, interpreter)).once();
+        verify(installer.isInstalled(anything(), anything())).once();
+    });
+    test('Do not prompt if if ipykernel is installed', async () => {
+        when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+
+        const response = await dependencyService.installMissingDependencies(interpreter);
+
+        assert.equal(response, KernelInterpreterDependencyResponse.ok);
+        verify(appShell.showErrorMessage(anything(), anything(), anything())).never();
+    });
+    test('Prompt if if ipykernel is not installed', async () => {
+        when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+        when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve();
+
+        const response = await dependencyService.installMissingDependencies(interpreter);
+
+        assert.equal(response, KernelInterpreterDependencyResponse.cancel);
+        verify(appShell.showErrorMessage(anything(), anything(), anything())).once();
+    });
+    test('Install ipykernel', async () => {
+        when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+        when(installer.install(Product.ipykernel, interpreter, anything())).thenResolve(InstallerResponse.Installed);
+        when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve(Common.ok() as any);
+
+        const response = await dependencyService.installMissingDependencies(interpreter);
+
+        assert.equal(response, KernelInterpreterDependencyResponse.ok);
+        verify(appShell.showErrorMessage(anything(), anything(), anything())).once();
+        verify(installer.install(Product.ipykernel, interpreter, anything())).once();
+        verify(installer.install(anything(), anything(), anything())).once();
+    });
+    test('Bubble installation errors', async () => {
+        when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+        when(installer.install(Product.ipykernel, interpreter, anything())).thenReject(
+            new Error('Install failed - kaboom')
+        );
+        when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve(Common.ok() as any);
+
+        const promise = dependencyService.installMissingDependencies(interpreter);
+
+        await assert.isRejected(promise, 'Install failed - kaboom');
+        verify(appShell.showErrorMessage(anything(), anything(), anything())).once();
+        verify(installer.install(Product.ipykernel, interpreter, anything())).once();
+        verify(installer.install(anything(), anything(), anything())).once();
+    });
+});

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -9,7 +9,7 @@ import { IApplicationShell } from '../../../../client/common/application/types';
 import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
 import { Common } from '../../../../client/common/utils/localize';
 import {
-    KernelDepdencyService,
+    KernelDependencyService,
     KernelInterpreterDependencyResponse
 } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { createPythonInterpreter } from '../../../utils/interpreters';
@@ -18,14 +18,14 @@ import { createPythonInterpreter } from '../../../utils/interpreters';
 
 // tslint:disable-next-line: max-func-body-length
 suite('Data Science - Kernel Dependency Service', () => {
-    let dependencyService: KernelDepdencyService;
+    let dependencyService: KernelDependencyService;
     let appShell: IApplicationShell;
     let installer: IInstaller;
     const interpreter = createPythonInterpreter();
     setup(() => {
         appShell = mock<IApplicationShell>();
         installer = mock<IInstaller>();
-        dependencyService = new KernelDepdencyService(instance(appShell), instance(installer));
+        dependencyService = new KernelDependencyService(instance(appShell), instance(installer));
     });
     test('Check if ipykernel is installed', async () => {
         when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -15,7 +15,7 @@ import { noop } from '../../../../client/common/utils/misc';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { StopWatch } from '../../../../client/common/utils/stopWatch';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
-import { KernelDepdencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
+import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelSelectionProvider } from '../../../../client/datascience/jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
@@ -33,7 +33,7 @@ suite('Data Science - KernelSelector', () => {
     let kernelSelector: KernelSelector;
     let interpreterService: IInterpreterService;
     let appShell: IApplicationShell;
-    let dependencyService: KernelDepdencyService;
+    let dependencyService: KernelDependencyService;
     const kernelSpec = {
         argv: [],
         display_name: 'Something',
@@ -57,7 +57,7 @@ suite('Data Science - KernelSelector', () => {
         kernelService = mock(KernelService);
         kernelSelectionProvider = mock(KernelSelectionProvider);
         appShell = mock(ApplicationShell);
-        dependencyService = mock(KernelDepdencyService);
+        dependencyService = mock(KernelDependencyService);
         interpreterService = mock(InterpreterService);
         kernelSelector = new KernelSelector(
             instance(kernelSelectionProvider),

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -9,13 +9,13 @@ import { CancellationToken } from 'vscode-jsonrpc';
 import { ApplicationShell } from '../../../../client/common/application/applicationShell';
 import { IApplicationShell } from '../../../../client/common/application/types';
 import { PYTHON_LANGUAGE } from '../../../../client/common/constants';
-import { ProductInstaller } from '../../../../client/common/installer/productInstaller';
-import { IInstaller, Product, Resource } from '../../../../client/common/types';
+import { Resource } from '../../../../client/common/types';
 import * as localize from '../../../../client/common/utils/localize';
 import { noop } from '../../../../client/common/utils/misc';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { StopWatch } from '../../../../client/common/utils/stopWatch';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
+import { KernelDepdencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelSelectionProvider } from '../../../../client/datascience/jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
@@ -33,7 +33,7 @@ suite('Data Science - KernelSelector', () => {
     let kernelSelector: KernelSelector;
     let interpreterService: IInterpreterService;
     let appShell: IApplicationShell;
-    let installer: IInstaller;
+    let dependencyService: KernelDepdencyService;
     const kernelSpec = {
         argv: [],
         display_name: 'Something',
@@ -57,14 +57,14 @@ suite('Data Science - KernelSelector', () => {
         kernelService = mock(KernelService);
         kernelSelectionProvider = mock(KernelSelectionProvider);
         appShell = mock(ApplicationShell);
-        installer = mock(ProductInstaller);
+        dependencyService = mock(KernelDepdencyService);
         interpreterService = mock(InterpreterService);
         kernelSelector = new KernelSelector(
             instance(kernelSelectionProvider),
             instance(appShell),
             instance(kernelService),
             instance(interpreterService),
-            instance(installer)
+            instance(dependencyService)
         );
     });
     teardown(() => sinon.restore());
@@ -338,7 +338,7 @@ suite('Data Science - KernelSelector', () => {
             verify(kernelService.findMatchingInterpreter(kernelSpec, anything())).once();
         });
         test('If seleted interpreter has ipykernel installed, then return matching kernelspec and interpreter', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             when(kernelService.findMatchingKernelSpec(interpreter, instance(sessionManager), anything())).thenResolve(
                 kernelSpec
             );
@@ -360,7 +360,7 @@ suite('Data Science - KernelSelector', () => {
             const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
-            verify(installer.isInstalled(Product.ipykernel, interpreter)).once();
+            verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(kernelService.findMatchingKernelSpec(interpreter, instance(sessionManager), anything())).once();
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
@@ -379,7 +379,7 @@ suite('Data Science - KernelSelector', () => {
             ).never();
         });
         test('If seleted interpreter has ipykernel installed and there is no matching kernelSpec, then register a new kernel and return the new kernelspec and interpreter', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             when(kernelService.findMatchingKernelSpec(interpreter, instance(sessionManager), anything())).thenResolve();
             when(kernelService.registerKernel(interpreter, anything(), anything())).thenResolve(kernelSpec);
             when(
@@ -401,7 +401,7 @@ suite('Data Science - KernelSelector', () => {
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
             assert.isOk(kernel.interpreter === interpreter);
-            verify(installer.isInstalled(Product.ipykernel, interpreter)).once();
+            verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(kernelService.findMatchingKernelSpec(interpreter, instance(sessionManager), anything())).once();
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
@@ -419,7 +419,7 @@ suite('Data Science - KernelSelector', () => {
             ).never();
         });
         test('If seleted interpreter does not have ipykernel installed and there is no matching kernelspec, then register a new kernel and return the new kernelspec and interpreter', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
             when(kernelService.registerKernel(interpreter, anything(), anything())).thenResolve(kernelSpec);
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
@@ -439,7 +439,7 @@ suite('Data Science - KernelSelector', () => {
             const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
-            verify(installer.isInstalled(Product.ipykernel, interpreter)).once();
+            verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
@@ -542,7 +542,7 @@ suite('Data Science - KernelSelector', () => {
             verify(kernelService.registerKernel(anything(), anything(), anything())).never();
         });
         test('If metadata contains kernel information, and there is matching kernelspec, then use current interpreter as a kernel', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
             when(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
             ).thenResolve(undefined);
@@ -592,7 +592,7 @@ suite('Data Science - KernelSelector', () => {
             ).once();
         });
         test('If metadata is empty, then use active interperter and find a kernel matching active interpreter', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
             when(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
             ).thenResolve(undefined);
@@ -621,7 +621,7 @@ suite('Data Science - KernelSelector', () => {
             verify(kernelService.registerKernel(anything(), anything())).never();
         });
         test('Remote search works', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
             when(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
             ).thenResolve(undefined);
@@ -669,7 +669,7 @@ suite('Data Science - KernelSelector', () => {
             verify(kernelService.registerKernel(anything(), anything(), anything())).never();
         });
         test('Remote search prefers same name as long as it is python', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
             when(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
             ).thenResolve(undefined);
@@ -724,7 +724,7 @@ suite('Data Science - KernelSelector', () => {
             verify(kernelService.registerKernel(anything(), anything())).never();
         });
         test('Remote search prefers same version', async () => {
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
             when(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
             ).thenResolve(undefined);

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -11,15 +11,18 @@ import * as sinon from 'sinon';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { CancellationToken } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../../../client/common/constants';
-import { ProductInstaller } from '../../../../client/common/installer/productInstaller';
 import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { PythonExecutionFactory } from '../../../../client/common/process/pythonExecutionFactory';
 import { IPythonExecutionFactory, IPythonExecutionService } from '../../../../client/common/process/types';
-import { IInstaller, InstallerResponse, Product, ReadWrite } from '../../../../client/common/types';
+import { ReadWrite } from '../../../../client/common/types';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
 import { JupyterKernelSpec } from '../../../../client/datascience/jupyter/kernels/jupyterKernelSpec';
+import {
+    KernelDepdencyService,
+    KernelInterpreterDependencyResponse
+} from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
 import {
     IJupyterKernelSpec,
@@ -41,7 +44,7 @@ suite('Data Science - KernelService', () => {
     let execFactory: IPythonExecutionFactory;
     let execService: IPythonExecutionService;
     let activationHelper: IEnvironmentActivationService;
-    let installer: IInstaller;
+    let dependencyService: KernelDepdencyService;
     let jupyterInterpreterExecutionService: IJupyterSubCommandExecutionService;
 
     function initialize() {
@@ -51,7 +54,7 @@ suite('Data Science - KernelService', () => {
         activationHelper = mock(EnvironmentActivationService);
         execFactory = mock(PythonExecutionFactory);
         execService = mock<IPythonExecutionService>();
-        installer = mock(ProductInstaller);
+        dependencyService = mock(KernelDepdencyService);
         jupyterInterpreterExecutionService = mock<IJupyterSubCommandExecutionService>();
         when(execFactory.createActivatedEnvironment(anything())).thenResolve(instance(execService));
         // tslint:disable-next-line: no-any
@@ -61,7 +64,7 @@ suite('Data Science - KernelService', () => {
             instance(jupyterInterpreterExecutionService),
             instance(execFactory),
             instance(interperterService),
-            instance(installer),
+            instance(dependencyService),
             instance(fs),
             instance(activationHelper)
         );
@@ -395,7 +398,7 @@ suite('Data Science - KernelService', () => {
         });
         test('Fail if installed kernel cannot be found', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             findMatchingKernelSpecStub.resolves(undefined);
             fakeTimer.install();
 
@@ -421,9 +424,9 @@ suite('Data Science - KernelService', () => {
         });
         test('If ipykernel is not installed, then prompt to install ipykernel', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
-            when(installer.promptToInstall(anything(), anything(), anything())).thenResolve(
-                InstallerResponse.Installed
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
+            when(dependencyService.installMissingDependencies(anything(), anything())).thenResolve(
+                KernelInterpreterDependencyResponse.ok
             );
             findMatchingKernelSpecStub.resolves(undefined);
             fakeTimer.install();
@@ -447,23 +450,25 @@ suite('Data Science - KernelService', () => {
                 promise,
                 `Kernel not created with the name ${kernelName}, display_name ${interpreter.displayName}. Output is `
             );
-            verify(installer.promptToInstall(anything(), anything(), anything())).once();
+            verify(dependencyService.installMissingDependencies(anything(), anything())).once();
         });
         test('If ipykernel is not installed, and ipykerne installation is canclled, then do not reigster kernel', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
-            when(installer.promptToInstall(anything(), anything(), anything())).thenResolve(InstallerResponse.Ignore);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(false);
+            when(dependencyService.installMissingDependencies(anything(), anything())).thenResolve(
+                KernelInterpreterDependencyResponse.cancel
+            );
             findMatchingKernelSpecStub.resolves(undefined);
 
             const kernel = await kernelService.registerKernel(interpreter);
 
             assert.isUndefined(kernel);
             verify(execService.execModule('ipykernel', anything(), anything())).never();
-            verify(installer.promptToInstall(anything(), anything(), anything())).once();
+            verify(dependencyService.installMissingDependencies(anything(), anything())).once();
         });
         test('Fail if installed kernel is not an instance of JupyterKernelSpec', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             // tslint:disable-next-line: no-any
             findMatchingKernelSpecStub.resolves({} as any);
 
@@ -480,7 +485,7 @@ suite('Data Science - KernelService', () => {
         });
         test('Fail if installed kernel spec does not have a specFile setup', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             // tslint:disable-next-line: no-any
             const kernel = new JupyterKernelSpec({} as any);
             findMatchingKernelSpecStub.resolves(kernel);
@@ -498,7 +503,7 @@ suite('Data Science - KernelService', () => {
         });
         test('Kernel is installed and spec file is updated with interpreter information in metadata and interpreter path in argv', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             const kernel = new JupyterKernelSpec(kernelSpecModel, kernelJsonFile);
             when(fs.readFile(kernelJsonFile)).thenResolve(JSON.stringify(kernelSpecModel));
             when(fs.writeFile(kernelJsonFile, anything())).thenResolve();
@@ -522,7 +527,7 @@ suite('Data Science - KernelService', () => {
         });
         test('Kernel is installed and spec file is updated with interpreter information in metadata along with environment variables', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             const kernel = new JupyterKernelSpec(kernelSpecModel, kernelJsonFile);
             when(fs.readFile(kernelJsonFile)).thenResolve(JSON.stringify(kernelSpecModel));
             when(fs.writeFile(kernelJsonFile, anything())).thenResolve();
@@ -549,7 +554,7 @@ suite('Data Science - KernelService', () => {
         });
         test('Kernel is found and spec file is updated with interpreter information in metadata along with environment variables', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             const kernel = new JupyterKernelSpec(kernelSpecModel, kernelJsonFile);
             when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve([kernel]);
             when(fs.readFile(kernelJsonFile)).thenResolve(JSON.stringify(kernelSpecModel));
@@ -577,7 +582,7 @@ suite('Data Science - KernelService', () => {
         });
         test('Kernel is found and spec file is not updated with interpreter information when user spec file', async () => {
             when(execService.execModule('ipykernel', anything(), anything())).thenResolve({ stdout: '' });
-            when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(true);
+            when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
             const kernel = new JupyterKernelSpec(userKernelSpecModel, kernelJsonFile);
             when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve([kernel]);
             when(fs.readFile(kernelJsonFile)).thenResolve(JSON.stringify(userKernelSpecModel));

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -20,7 +20,7 @@ import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
 import { JupyterKernelSpec } from '../../../../client/datascience/jupyter/kernels/jupyterKernelSpec';
 import {
-    KernelDepdencyService,
+    KernelDependencyService,
     KernelInterpreterDependencyResponse
 } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
@@ -44,7 +44,7 @@ suite('Data Science - KernelService', () => {
     let execFactory: IPythonExecutionFactory;
     let execService: IPythonExecutionService;
     let activationHelper: IEnvironmentActivationService;
-    let dependencyService: KernelDepdencyService;
+    let dependencyService: KernelDependencyService;
     let jupyterInterpreterExecutionService: IJupyterSubCommandExecutionService;
 
     function initialize() {
@@ -54,7 +54,7 @@ suite('Data Science - KernelService', () => {
         activationHelper = mock(EnvironmentActivationService);
         execFactory = mock(PythonExecutionFactory);
         execService = mock<IPythonExecutionService>();
-        dependencyService = mock(KernelDepdencyService);
+        dependencyService = mock(KernelDependencyService);
         jupyterInterpreterExecutionService = mock<IJupyterSubCommandExecutionService>();
         when(execFactory.createActivatedEnvironment(anything())).thenResolve(instance(execService));
         // tslint:disable-next-line: no-any

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -19,15 +19,13 @@ import { ReadWrite } from '../../../../client/common/types';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterSessionManager } from '../../../../client/datascience/jupyter/jupyterSessionManager';
 import { JupyterKernelSpec } from '../../../../client/datascience/jupyter/kernels/jupyterKernelSpec';
-import {
-    KernelDependencyService,
-    KernelInterpreterDependencyResponse
-} from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
+import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
 import {
     IJupyterKernelSpec,
     IJupyterSessionManager,
-    IJupyterSubCommandExecutionService
+    IJupyterSubCommandExecutionService,
+    KernelInterpreterDependencyResponse
 } from '../../../../client/datascience/types';
 import { EnvironmentActivationService } from '../../../../client/interpreter/activation/service';
 import { IEnvironmentActivationService } from '../../../../client/interpreter/activation/types';

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -10,13 +10,14 @@ import { ApplicationShell } from '../../../../client/common/application/applicat
 import { IApplicationShell } from '../../../../client/common/application/types';
 import { PythonSettings } from '../../../../client/common/configSettings';
 import { ConfigurationService } from '../../../../client/common/configuration/service';
-import { IConfigurationService, IInstaller, IPythonSettings } from '../../../../client/common/types';
-import { Common, DataScience, Installer } from '../../../../client/common/utils/localize';
+import { IConfigurationService, IPythonSettings } from '../../../../client/common/types';
+import { Common, DataScience } from '../../../../client/common/utils/localize';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterSessionStartError } from '../../../../client/datascience/baseJupyterSession';
 import { Commands } from '../../../../client/datascience/constants';
 import { JupyterNotebookBase } from '../../../../client/datascience/jupyter/jupyterNotebook';
 import { JupyterSessionManagerFactory } from '../../../../client/datascience/jupyter/jupyterSessionManagerFactory';
+import { KernelDepdencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../../../../client/datascience/jupyter/kernels/kernelSwitcher';
 import { LiveKernelModel } from '../../../../client/datascience/jupyter/kernels/types';
@@ -36,7 +37,6 @@ suite('Data Science - Kernel Switcher', () => {
     let sessionManagerFactory: IJupyterSessionManagerFactory;
     let kernelSelector: KernelSelector;
     let appShell: IApplicationShell;
-    let installer: IInstaller;
     let notebook: INotebook;
     let connection: IJupyterConnection;
     let currentKernel: IJupyterKernelSpec | LiveKernelModel;
@@ -80,7 +80,6 @@ suite('Data Science - Kernel Switcher', () => {
         sessionManagerFactory = mock(JupyterSessionManagerFactory);
         kernelSelector = mock(KernelSelector);
         appShell = mock(ApplicationShell);
-        installer = mock(Installer);
 
         // tslint:disable-next-line: no-any
         when(settings.datascience).thenReturn({} as any);
@@ -91,7 +90,7 @@ suite('Data Science - Kernel Switcher', () => {
             instance(sessionManagerFactory),
             instance(kernelSelector),
             instance(appShell),
-            instance(installer)
+            instance(mock(KernelDepdencyService))
         );
         when(appShell.withProgress(anything(), anything())).thenCall(async (_, cb: () => Promise<void>) => {
             await cb();

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -17,7 +17,7 @@ import { JupyterSessionStartError } from '../../../../client/datascience/baseJup
 import { Commands } from '../../../../client/datascience/constants';
 import { JupyterNotebookBase } from '../../../../client/datascience/jupyter/jupyterNotebook';
 import { JupyterSessionManagerFactory } from '../../../../client/datascience/jupyter/jupyterSessionManagerFactory';
-import { KernelDepdencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
+import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../../../../client/datascience/jupyter/kernels/kernelSwitcher';
 import { LiveKernelModel } from '../../../../client/datascience/jupyter/kernels/types';
@@ -90,7 +90,7 @@ suite('Data Science - Kernel Switcher', () => {
             instance(sessionManagerFactory),
             instance(kernelSelector),
             instance(appShell),
-            instance(mock(KernelDepdencyService))
+            instance(mock(KernelDependencyService))
         );
         when(appShell.withProgress(anything(), anything())).thenCall(async (_, cb: () => Promise<void>) => {
             await cb();


### PR DESCRIPTION
Use a single class that manages dependencies in kernels.
I.e. move both of the following into its own class.
* Is ipykernel installed
* Install ipykernel if required
