### PR TITLE
make sure we use our resource to get interpreter details

### DIFF
--- a/news/2 Fixes/11469.md
+++ b/news/2 Fixes/11469.md
@@ -1,0 +1,1 @@
+When using a kernelspec without a fully qualified python path make sure we use the resource to get the active interpreter.

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -76,7 +76,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
         const logger = this.serviceContainer.get<IProcessLogger>(IProcessLogger);
 
-        const interpreter = await interpreterService.getInterpreterDetails(pythonPath);
+        const interpreter = await interpreterService.getInterpreterDetails(pythonPath, options.resource);
         const activatedProcPromise = this.createActivatedEnvironment({
             allowEnvironmentFetchExceptions: true,
             interpreter: interpreter,

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -224,6 +224,8 @@ export class KernelFinder implements IKernelFinder {
             this.activeInterpreter = await this.interpreterService.getActiveInterpreter(resource);
         }
 
+        // This creates a default kernel spec. When launched, 'python' argument will map to using the interpreter
+        // associated with the current resource for launching.
         const defaultSpec: Kernel.ISpecModel = {
             name: `python_defaultSpec_${Date.now()}`,
             language: 'python',

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -229,13 +229,7 @@ export class KernelFinder implements IKernelFinder {
             language: 'python',
             display_name: this.activeInterpreter?.displayName ? this.activeInterpreter.displayName : 'Python 3',
             metadata: {},
-            argv: [
-                this.activeInterpreter?.path || 'python',
-                '-m',
-                'ipykernel_launcher',
-                '-f',
-                connectionFilePlaceholder
-            ],
+            argv: ['python', '-m', 'ipykernel_launcher', '-f', connectionFilePlaceholder],
             env: {},
             resources: {}
         };

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -431,7 +431,7 @@ suite('Process - PythonExecutionFactory', () => {
                 when(pythonSettings.pythonPath).thenReturn('HELLO');
                 when(configService.getSettings(anything())).thenReturn(instance(pythonSettings));
                 reset(interpreterService);
-                when(interpreterService.getInterpreterDetails(anything())).thenResolve({
+                when(interpreterService.getInterpreterDetails(anything(), anything())).thenResolve({
                     version: parse('2.7.14')
                 } as any);
                 factory.createActivatedEnvironment = () => Promise.resolve(executionService.object);


### PR DESCRIPTION
For #11469 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
