### PR TITLE
Add ability to pass interpreter into kernel launcher

### DIFF
--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -9,6 +9,7 @@ import * as uuid from 'uuid/v4';
 import { IFileSystem } from '../../common/platform/types';
 import { IProcessServiceFactory, IPythonExecutionFactory } from '../../common/process/types';
 import { Resource } from '../../common/types';
+import { PythonInterpreter } from '../../interpreter/contracts';
 import { captureTelemetry } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { IJupyterKernelSpec } from '../types';
@@ -30,7 +31,11 @@ export class KernelLauncher implements IKernelLauncher {
     ) {}
 
     @captureTelemetry(Telemetry.KernelLauncherPerf)
-    public async launch(kernelSpec: IJupyterKernelSpec, resource: Resource): Promise<IKernelProcess> {
+    public async launch(
+        kernelSpec: IJupyterKernelSpec,
+        resource: Resource,
+        interpreter?: PythonInterpreter
+    ): Promise<IKernelProcess> {
         const connection = await this.getKernelConnection();
         const kernelProcess = new KernelProcess(
             this.pythonExecutionFactory,
@@ -38,7 +43,8 @@ export class KernelLauncher implements IKernelLauncher {
             this.file,
             connection,
             kernelSpec,
-            resource
+            resource,
+            interpreter
         );
         await kernelProcess.launch();
         return kernelProcess;

--- a/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
@@ -9,6 +9,7 @@ import { IDisposable } from 'monaco-editor';
 import { IPythonExecutionFactory, ObservableExecutionResult } from '../../common/process/types';
 import { Resource } from '../../common/types';
 import { noop } from '../../common/utils/misc';
+import { PythonInterpreter } from '../../interpreter/contracts';
 import { KernelLauncherDaemonModule } from '../constants';
 import { IJupyterKernelSpec } from '../types';
 import { PythonKernelDaemon } from './kernelDaemon';
@@ -25,12 +26,12 @@ export class PythonKernelLauncherDaemon implements IDisposable {
     constructor(@inject(IPythonExecutionFactory) private readonly pythonExecutionFactory: IPythonExecutionFactory) {}
     public async launch(
         resource: Resource,
-        kernelSpec: IJupyterKernelSpec
+        kernelSpec: IJupyterKernelSpec,
+        interpreter?: PythonInterpreter
     ): Promise<{ observableResult: ObservableExecutionResult<string>; daemon: IPythonKernelDaemon }> {
-        const pythonPath = kernelSpec.argv[0];
         const daemon = await this.pythonExecutionFactory.createDaemon<IPythonKernelDaemon>({
             daemonModule: KernelLauncherDaemonModule,
-            pythonPath: pythonPath,
+            pythonPath: interpreter?.path,
             daemonClass: PythonKernelDaemon,
             dedicated: true,
             resource

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -10,6 +10,7 @@ import { IFileSystem, TemporaryFile } from '../../common/platform/types';
 import { IProcessServiceFactory, IPythonExecutionFactory, ObservableExecutionResult } from '../../common/process/types';
 import { Resource } from '../../common/types';
 import { noop, swallowExceptions } from '../../common/utils/misc';
+import { PythonInterpreter } from '../../interpreter/contracts';
 import { IJupyterKernelSpec } from '../types';
 import { findIndexOfConnectionFile } from './kernelFinder';
 import { PythonKernelLauncherDaemon } from './kernelLauncherDaemon';
@@ -48,7 +49,8 @@ export class KernelProcess implements IKernelProcess {
         private readonly file: IFileSystem,
         private readonly _connection: IKernelConnection,
         kernelSpec: IJupyterKernelSpec,
-        private readonly resource: Resource
+        private readonly resource: Resource,
+        private readonly interpreter?: PythonInterpreter
     ) {
         this.originalKernelSpec = kernelSpec;
         this._kernelSpec = cloneDeep(kernelSpec);
@@ -131,7 +133,8 @@ export class KernelProcess implements IKernelProcess {
             this.pythonKernelLauncher = new PythonKernelLauncherDaemon(this.pythonExecutionFactory);
             const { observableResult, daemon } = await this.pythonKernelLauncher.launch(
                 this.resource,
-                this._kernelSpec
+                this._kernelSpec,
+                this.interpreter
             );
             this.kernelDaemon = daemon;
             exeObs = observableResult;

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -7,11 +7,16 @@ import { CancellationToken, Event } from 'vscode';
 import { InterpreterUri } from '../../common/installer/types';
 import { ObservableExecutionResult } from '../../common/process/types';
 import { IAsyncDisposable, IDisposable, Resource } from '../../common/types';
+import { PythonInterpreter } from '../../interpreter/contracts';
 import { IJupyterKernelSpec } from '../types';
 
 export const IKernelLauncher = Symbol('IKernelLauncher');
 export interface IKernelLauncher {
-    launch(kernelSpec: IJupyterKernelSpec, resource: Resource): Promise<IKernelProcess>;
+    launch(
+        kernelSpec: IJupyterKernelSpec,
+        resource: Resource,
+        interpreter?: PythonInterpreter
+    ): Promise<IKernelProcess>;
 }
 
 export interface IKernelConnection {


### PR DESCRIPTION
As discussed with @IanMatthewHuff @rchiodo 
Allow passing interpreter information into kernel launcher, if not passed, then spin up current interpreter as the kernel.