### PR TITLE
Track notebook/interactive start dates

### DIFF
--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -13,7 +13,7 @@ import { sendTelemetryEvent } from '../telemetry';
 import { JupyterDaemonModule, Telemetry } from './constants';
 import { ActiveEditorContextService } from './context/activeEditorContext';
 import { JupyterInterpreterService } from './jupyter/interpreter/jupyterInterpreterService';
-import { INotebookEditor, INotebookEditorProvider } from './types';
+import { INotebookAndInteractiveWindowUsageTracker, INotebookEditor, INotebookEditorProvider } from './types';
 
 @injectable()
 export class Activation implements IExtensionSingleActivationService {
@@ -23,12 +23,15 @@ export class Activation implements IExtensionSingleActivationService {
         @inject(JupyterInterpreterService) private readonly jupyterInterpreterService: JupyterInterpreterService,
         @inject(IPythonExecutionFactory) private readonly factory: IPythonExecutionFactory,
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
-        @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService
+        @inject(ActiveEditorContextService) private readonly contextService: ActiveEditorContextService,
+        @inject(INotebookAndInteractiveWindowUsageTracker)
+        private readonly tracker: INotebookAndInteractiveWindowUsageTracker
     ) {}
     public async activate(): Promise<void> {
         this.disposables.push(this.notebookEditorProvider.onDidOpenNotebookEditor(this.onDidOpenNotebookEditor, this));
         this.disposables.push(this.jupyterInterpreterService.onDidChangeInterpreter(this.onDidChangeInterpreter, this));
         this.contextService.activate().ignoreErrors();
+        this.tracker.startTracking();
     }
 
     private onDidOpenNotebookEditor(_: INotebookEditor) {

--- a/src/client/datascience/notebookAndInteractiveTracker.ts
+++ b/src/client/datascience/notebookAndInteractiveTracker.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject, injectable, named } from 'inversify';
+import { Memento } from 'vscode';
+import { IDisposableRegistry, IMemento, WORKSPACE_MEMENTO } from '../common/types';
+import {
+    IInteractiveWindowProvider,
+    INotebookAndInteractiveWindowUsageTracker,
+    INotebookEditorProvider
+} from './types';
+
+const LastNotebookOpenedTimeKey = 'last-notebook-start-time';
+const LastInteractiveWindowStartTimeKey = 'last-interactive-window-start-time';
+
+@injectable()
+export class NotebookAndInteractiveWindowUsageTracker implements INotebookAndInteractiveWindowUsageTracker {
+    public get lastNotebookOpened() {
+        const time = this.mementoStorage.get<number | undefined>(LastNotebookOpenedTimeKey);
+        return time ? new Date(time) : undefined;
+    }
+    public get lastInteractiveWindowOpened() {
+        const time = this.mementoStorage.get<number | undefined>(LastInteractiveWindowStartTimeKey);
+        return time ? new Date(time) : undefined;
+    }
+    constructor(
+        @inject(IMemento) @named(WORKSPACE_MEMENTO) private mementoStorage: Memento,
+        @inject(INotebookEditorProvider) private readonly notebookEditorProvider: INotebookEditorProvider,
+        @inject(IInteractiveWindowProvider) private readonly interactiveWindowProvider: IInteractiveWindowProvider,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry
+    ) {}
+    public async startTracking(): Promise<void> {
+        this.disposables.push(
+            this.notebookEditorProvider.onDidOpenNotebookEditor(() =>
+                this.mementoStorage.update(LastNotebookOpenedTimeKey, Date.now())
+            )
+        );
+        this.disposables.push(
+            this.interactiveWindowProvider.onDidChangeActiveInteractiveWindow(() =>
+                this.mementoStorage.update(LastInteractiveWindowStartTimeKey, Date.now())
+            )
+        );
+    }
+}

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -126,8 +126,10 @@ import {
     IPlotViewerProvider,
     IRawNotebookProvider,
     IStatusProvider,
-    IThemeFinder
+    IThemeFinder,
+    INotebookAndInteractiveWindowUsageTracker
 } from './types';
+import { NotebookAndInteractiveWindowUsageTracker } from './notebookAndInteractiveTracker';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -212,6 +214,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IJupyterInterpreterDependencyManager>(IJupyterInterpreterDependencyManager, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<IJupyterSubCommandExecutionService>(IJupyterSubCommandExecutionService, JupyterInterpreterSubCommandExecutionService);
     serviceManager.addSingleton<IKernelDependencyService>(IKernelDependencyService, KernelDependencyService);
+    serviceManager.addSingleton<INotebookAndInteractiveWindowUsageTracker>(INotebookAndInteractiveWindowUsageTracker, NotebookAndInteractiveWindowUsageTracker);
 
     registerGatherTypes(serviceManager);
 }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -76,6 +76,7 @@ import { JupyterServerSelector } from './jupyter/serverSelector';
 import { KernelFinder } from './kernel-launcher/kernelFinder';
 import { KernelLauncher } from './kernel-launcher/kernelLauncher';
 import { IKernelFinder, IKernelLauncher } from './kernel-launcher/types';
+import { NotebookAndInteractiveWindowUsageTracker } from './notebookAndInteractiveTracker';
 import { PlotViewer } from './plotting/plotViewer';
 import { PlotViewerProvider } from './plotting/plotViewerProvider';
 import { PreWarmActivatedJupyterEnvironmentVariables } from './preWarmVariables';
@@ -114,6 +115,7 @@ import {
     IJupyterSubCommandExecutionService,
     IJupyterVariables,
     IKernelDependencyService,
+    INotebookAndInteractiveWindowUsageTracker,
     INotebookEditor,
     INotebookEditorProvider,
     INotebookExecutionLogger,
@@ -126,10 +128,8 @@ import {
     IPlotViewerProvider,
     IRawNotebookProvider,
     IStatusProvider,
-    IThemeFinder,
-    INotebookAndInteractiveWindowUsageTracker
+    IThemeFinder
 } from './types';
-import { NotebookAndInteractiveWindowUsageTracker } from './notebookAndInteractiveTracker';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1151,3 +1151,10 @@ export interface IKernelDependencyService {
     ): Promise<KernelInterpreterDependencyResponse>;
     areDependenciesInstalled(interpreter: PythonInterpreter, _token?: CancellationToken): Promise<boolean>;
 }
+
+export const INotebookAndInteractiveWindowUsageTracker = Symbol('INotebookAndInteractiveWindowUsageTracker');
+export interface INotebookAndInteractiveWindowUsageTracker {
+    readonly lastNotebookOpened?: Date;
+    readonly lastInteractiveWindowOpened?: Date;
+    startTracking(): void;
+}

--- a/src/test/datascience/activation.unit.test.ts
+++ b/src/test/datascience/activation.unit.test.ts
@@ -15,7 +15,11 @@ import { ActiveEditorContextService } from '../../client/datascience/context/act
 import { NativeEditor } from '../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorProvider } from '../../client/datascience/interactive-ipynb/nativeEditorProvider';
 import { JupyterInterpreterService } from '../../client/datascience/jupyter/interpreter/jupyterInterpreterService';
-import { INotebookEditor, INotebookEditorProvider } from '../../client/datascience/types';
+import {
+    INotebookAndInteractiveWindowUsageTracker,
+    INotebookEditor,
+    INotebookEditorProvider
+} from '../../client/datascience/types';
 import { PythonInterpreter } from '../../client/interpreter/contracts';
 import { FakeClock } from '../common';
 import { createPythonInterpreter } from '../utils/interpreters';
@@ -35,6 +39,7 @@ suite('Data Science - Activation', () => {
         fakeTimer = new FakeClock();
         openedEventEmitter = new EventEmitter<INotebookEditor>();
         interpreterEventEmitter = new EventEmitter<PythonInterpreter>();
+        const tracker = mock<INotebookAndInteractiveWindowUsageTracker>();
 
         notebookEditorProvider = mock(NativeEditorProvider);
         jupyterInterpreterService = mock(JupyterInterpreterService);
@@ -49,7 +54,8 @@ suite('Data Science - Activation', () => {
             instance(jupyterInterpreterService),
             instance(executionFactory),
             [],
-            instance(contextService)
+            instance(contextService),
+            instance(tracker)
         );
         when(jupyterInterpreterService.getSelectedInterpreter()).thenResolve(interpreter);
         when(jupyterInterpreterService.getSelectedInterpreter(anything())).thenResolve(interpreter);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -274,7 +274,8 @@ import {
     IPlotViewerProvider,
     IRawNotebookProvider,
     IStatusProvider,
-    IThemeFinder
+    IThemeFinder,
+    INotebookAndInteractiveWindowUsageTracker
 } from '../../client/datascience/types';
 import { ProtocolParser } from '../../client/debugger/debugAdapter/Common/protocolParser';
 import { IProtocolParser } from '../../client/debugger/debugAdapter/types';
@@ -389,6 +390,7 @@ import { TestInteractiveWindowProvider } from './testInteractiveWindowProvider';
 import { TestNativeEditorProvider } from './testNativeEditorProvider';
 import { TestPersistentStateFactory } from './testPersistentStateFactory';
 import { WebBrowserPanelProvider } from './uiTests/webBrowserPanelProvider';
+import { NotebookAndInteractiveWindowUsageTracker } from '../../client/datascience/notebookAndInteractiveTracker';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {
@@ -754,6 +756,10 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<KernelSelectionProvider>(KernelSelectionProvider, KernelSelectionProvider);
         this.serviceManager.addSingleton<KernelSwitcher>(KernelSwitcher, KernelSwitcher);
         this.serviceManager.addSingleton<IKernelDependencyService>(IKernelDependencyService, KernelDependencyService);
+        this.serviceManager.addSingleton<INotebookAndInteractiveWindowUsageTracker>(
+            INotebookAndInteractiveWindowUsageTracker,
+            NotebookAndInteractiveWindowUsageTracker
+        );
         this.serviceManager.addSingleton<IProductService>(IProductService, ProductService);
         this.serviceManager.addSingleton<IProductPathService>(
             IProductPathService,

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -225,6 +225,7 @@ import { JupyterServerSelector } from '../../client/datascience/jupyter/serverSe
 import { KernelFinder } from '../../client/datascience/kernel-launcher/kernelFinder';
 import { KernelLauncher } from '../../client/datascience/kernel-launcher/kernelLauncher';
 import { IKernelFinder, IKernelLauncher } from '../../client/datascience/kernel-launcher/types';
+import { NotebookAndInteractiveWindowUsageTracker } from '../../client/datascience/notebookAndInteractiveTracker';
 import { PlotViewer } from '../../client/datascience/plotting/plotViewer';
 import { PlotViewerProvider } from '../../client/datascience/plotting/plotViewerProvider';
 import { ProgressReporter } from '../../client/datascience/progress/progressReporter';
@@ -262,6 +263,7 @@ import {
     IJupyterSubCommandExecutionService,
     IJupyterVariables,
     IKernelDependencyService,
+    INotebookAndInteractiveWindowUsageTracker,
     INotebookEditor,
     INotebookEditorProvider,
     INotebookExecutionLogger,
@@ -274,8 +276,7 @@ import {
     IPlotViewerProvider,
     IRawNotebookProvider,
     IStatusProvider,
-    IThemeFinder,
-    INotebookAndInteractiveWindowUsageTracker
+    IThemeFinder
 } from '../../client/datascience/types';
 import { ProtocolParser } from '../../client/debugger/debugAdapter/Common/protocolParser';
 import { IProtocolParser } from '../../client/debugger/debugAdapter/types';
@@ -390,7 +391,6 @@ import { TestInteractiveWindowProvider } from './testInteractiveWindowProvider';
 import { TestNativeEditorProvider } from './testNativeEditorProvider';
 import { TestPersistentStateFactory } from './testPersistentStateFactory';
 import { WebBrowserPanelProvider } from './uiTests/webBrowserPanelProvider';
-import { NotebookAndInteractiveWindowUsageTracker } from '../../client/datascience/notebookAndInteractiveTracker';
 
 export class DataScienceIocContainer extends UnitTestIocContainer {
     public get workingInterpreter() {


### PR DESCRIPTION
Move tracking of dates when notebook/interactive windows were opened, into a separate class (for use in pre-warming servers and raw kernels).