### PR TITLE
Kernel finder optimization

### DIFF
--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -194,14 +194,14 @@ export class KernelFinder implements IKernelFinder {
             this.cache = this.cache.concat(result);
         });
 
-        try {
-            const kernelJsonFile = this.cache.filter((kernelPath) => kernelPath.includes(kernelName));
+        const kernelJsonFile = this.cache.filter((kernelPath) => kernelPath.includes(kernelName));
+
+        if (kernelJsonFile[0]) {
             const kernelJson = JSON.parse(await this.file.readFile(kernelJsonFile[0]));
             return new JupyterKernelSpec(kernelJson, kernelJsonFile[0]);
-        } catch (e) {
-            traceError('Invalid kernel.json', e);
-            return undefined;
         }
+
+        return undefined;
     }
 
     private async getDefaultKernelSpec(resource: Resource): Promise<IJupyterKernelSpec> {
@@ -229,8 +229,9 @@ export class KernelFinder implements IKernelFinder {
 
     private async readCache(): Promise<string[]> {
         try {
-            const x = await this.file.readFile(path.join(this.context.globalStoragePath, 'kernelSpecCache.json'));
-            return JSON.parse(x) as string[];
+            return JSON.parse(
+                await this.file.readFile(path.join(this.context.globalStoragePath, 'kernelSpecCache.json'))
+            ) as string[];
         } catch {
             traceInfo('No kernelSpec cache found.');
             return [];

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -234,15 +234,7 @@ export class KernelFinder implements IKernelFinder {
     }
 
     private async searchCache(kernelName: string): Promise<IJupyterKernelSpec | undefined> {
-        const kernelJsonFile = this.cache.find((kernelPath) => {
-            const slash = this.platformService.isWindows ? '\\' : '/';
-            const startKeyword = path.join(slash, 'kernels', slash);
-            const startIndex = kernelPath.indexOf(startKeyword) + startKeyword.length;
-            const endIndex = kernelPath.indexOf(path.join(slash, 'kernel.json'));
-
-            const name = kernelPath.substring(startIndex, endIndex);
-            return name === kernelName;
-        });
+        const kernelJsonFile = this.cache.find((kernelPath) => path.basename(path.dirname(kernelPath)) === kernelName);
 
         if (kernelJsonFile) {
             const kernelJson = JSON.parse(await this.file.readFile(kernelJsonFile));

--- a/src/test/datascience/kernelFinder.unit.test.ts
+++ b/src/test/datascience/kernelFinder.unit.test.ts
@@ -4,6 +4,7 @@
 
 import * as assert from 'assert';
 import { expect } from 'chai';
+import * as path from 'path';
 import { anything, instance, mock, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 
@@ -42,7 +43,7 @@ suite('Kernel Finder', () => {
         metadata: {},
         env: {},
         argv: ['<python path>', '-m', 'ipykernel_launcher', '-f', '{connection_file}'],
-        specFile: 'testKernel'
+        specFile: path.join('kernels', kernelName, 'kernel.json')
     };
 
     function setupFileSystem() {
@@ -52,7 +53,7 @@ suite('Kernel Finder', () => {
         fileSystem.setup((fs) => fs.getSubDirectories(typemoq.It.isAnyString())).returns(() => Promise.resolve(['']));
         fileSystem
             .setup((fs) => fs.search(typemoq.It.isAnyString(), typemoq.It.isAnyString()))
-            .returns(() => Promise.resolve([kernel.name]));
+            .returns(() => Promise.resolve([path.join('kernels', kernel.name, 'kernel.json')]));
     }
 
     setup(() => {
@@ -222,7 +223,7 @@ suite('Kernel Finder', () => {
                 }
                 return Promise.resolve(JSON.stringify(spec));
             })
-            .verifiable(typemoq.Times.exactly(2));
+            .verifiable(typemoq.Times.once());
 
         // get the same kernel, but from cache
         const spec2 = await kernelFinder.findKernelSpec(resource, spec.name);


### PR DESCRIPTION
Cache the kernel path, instead of the content of the file.
Save all found kernels on the cache, instead of only the one we are returning.

For #11452

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
