### PR TITLE
Hook up kernel selection to the kernel finder (part 1)

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1062,7 +1062,11 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                 // If we get an invalid kernel error, make sure to ask the user to switch
                 if (e instanceof JupyterInvalidKernelError && serverConnection && serverConnection.localLaunch) {
                     // Ask the user for a new local kernel
-                    const newKernel = await this.switcher.askForLocalKernel(resource, e.kernelSpec);
+                    const newKernel = await this.switcher.askForLocalKernel(
+                        resource,
+                        serverConnection.type,
+                        e.kernelSpec
+                    );
                     if (newKernel?.kernelSpec) {
                         // Update the notebook metadata
                         await this.updateNotebookOptions(newKernel.kernelSpec, newKernel.interpreter);

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -231,6 +231,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                                     const sessionManager = await sessionManagerFactory.create(connection);
                                     const kernelInterpreter = await this.kernelSelector.selectLocalKernel(
                                         undefined,
+                                        'jupyter',
                                         new StopWatch(),
                                         sessionManager,
                                         cancelToken,

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -104,6 +104,7 @@ export class KernelSelector {
         suggestions = suggestions.filter((item) => !this.kernelIdsToHide.has(item.selection.kernelModel?.id || ''));
         return this.selectKernel(
             resource,
+            'jupyter',
             stopWatch,
             Telemetry.SelectRemoteJupyterKernel,
             suggestions,
@@ -122,6 +123,7 @@ export class KernelSelector {
      */
     public async selectLocalKernel(
         resource: Resource,
+        type: 'raw' | 'jupyter' | 'unknown',
         stopWatch: StopWatch,
         session?: IJupyterSessionManager,
         cancelToken?: CancellationToken,
@@ -129,12 +131,14 @@ export class KernelSelector {
     ): Promise<KernelSpecInterpreter> {
         let suggestions = await this.selectionProvider.getKernelSelectionsForLocalSession(
             resource,
+            type,
             session,
             cancelToken
         );
         suggestions = suggestions.filter((item) => !this.kernelIdsToHide.has(item.selection.kernelModel?.id || ''));
         return this.selectKernel(
             resource,
+            type,
             stopWatch,
             Telemetry.SelectLocalJupyterKernel,
             suggestions,
@@ -169,7 +173,9 @@ export class KernelSelector {
         };
         // When this method is called, we know we've started a local jupyter server.
         // Lets pre-warm the list of local kernels.
-        this.selectionProvider.getKernelSelectionsForLocalSession(resource, sessionManager, cancelToken).ignoreErrors();
+        this.selectionProvider
+            .getKernelSelectionsForLocalSession(resource, 'jupyter', sessionManager, cancelToken)
+            .ignoreErrors();
 
         let selection: KernelSpecInterpreter = {};
         if (notebookMetadata?.kernelspec) {
@@ -198,6 +204,7 @@ export class KernelSelector {
                     selection = await this.useInterpreterAsKernel(
                         resource,
                         activeInterpreter,
+                        'jupyter',
                         notebookMetadata.kernelspec.display_name,
                         sessionManager,
                         disableUI,
@@ -205,7 +212,13 @@ export class KernelSelector {
                     );
                 } else {
                     telemetryProps.promptedToSelect = true;
-                    selection = await this.selectLocalKernel(resource, stopWatch, sessionManager, cancelToken);
+                    selection = await this.selectLocalKernel(
+                        resource,
+                        'jupyter',
+                        stopWatch,
+                        sessionManager,
+                        cancelToken
+                    );
                 }
             }
         } else {
@@ -302,6 +315,7 @@ export class KernelSelector {
     }
     private async selectKernel(
         resource: Resource,
+        type: 'raw' | 'jupyter' | 'unknown',
         stopWatch: StopWatch,
         telemetryEvent: Telemetry,
         suggestions: IKernelSpecQuickPickItem[],
@@ -323,6 +337,7 @@ export class KernelSelector {
             return this.useInterpreterAsKernel(
                 resource,
                 selection.selection.interpreter,
+                type,
                 undefined,
                 session,
                 false,
@@ -371,6 +386,7 @@ export class KernelSelector {
     private async useInterpreterAsKernel(
         resource: Resource,
         interpreter: PythonInterpreter,
+        type: 'raw' | 'jupyter' | 'unknown',
         displayNameOfKernelNotFound?: string,
         session?: IJupyterSessionManager,
         disableUI?: boolean,
@@ -426,7 +442,7 @@ export class KernelSelector {
 
         // When this method is called, we know a new kernel may have been registered.
         // Lets pre-warm the list of local kernels (with the new list).
-        this.selectionProvider.getKernelSelectionsForLocalSession(resource, session, cancelToken).ignoreErrors();
+        this.selectionProvider.getKernelSelectionsForLocalSession(resource, type, session, cancelToken).ignoreErrors();
 
         return { kernelSpec, interpreter };
     }

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -43,6 +43,7 @@ export class KernelSwitcher {
 
     public async askForLocalKernel(
         resource: Resource,
+        type: 'raw' | 'jupyter' | 'unknown',
         kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined
     ): Promise<KernelSpecInterpreter | undefined> {
         const displayName = kernelSpec?.display_name || kernelSpec?.name || '';
@@ -51,7 +52,7 @@ export class KernelSwitcher {
         const cancel = Common.cancel();
         const selection = await this.appShell.showErrorMessage(message, selectKernel, cancel);
         if (selection === selectKernel) {
-            return this.selectLocalJupyterKernel(resource, kernelSpec);
+            return this.selectLocalJupyterKernel(resource, type, kernelSpec);
         }
     }
 
@@ -64,7 +65,11 @@ export class KernelSwitcher {
             settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
 
         if (isLocalConnection) {
-            kernel = await this.selectLocalJupyterKernel(notebook.resource, notebook?.getKernelSpec());
+            kernel = await this.selectLocalJupyterKernel(
+                notebook.resource,
+                notebook.connection?.type || 'unknown',
+                notebook?.getKernelSpec()
+            );
         } else if (notebook) {
             const connInfo = notebook.connection;
             const currentKernel = notebook.getKernelSpec();
@@ -77,9 +82,17 @@ export class KernelSwitcher {
 
     private async selectLocalJupyterKernel(
         resource: Resource,
+        type: 'raw' | 'jupyter' | 'unknown',
         currentKernel?: IJupyterKernelSpec | LiveKernelModel
     ): Promise<KernelSpecInterpreter> {
-        return this.kernelSelector.selectLocalKernel(resource, new StopWatch(), undefined, undefined, currentKernel);
+        return this.kernelSelector.selectLocalKernel(
+            resource,
+            type,
+            new StopWatch(),
+            undefined,
+            undefined,
+            currentKernel
+        );
     }
 
     private async selectRemoteJupyterKernel(
@@ -119,6 +132,7 @@ export class KernelSwitcher {
                     // At this point we have a valid jupyter server.
                     const potential = await this.askForLocalKernel(
                         notebook.resource,
+                        notebook.connection?.type || 'unknown',
                         kernel.kernelSpec || kernel.kernelModel
                     );
                     if (potential && Object.keys(potential).length > 0) {

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -105,6 +105,11 @@ export class KernelFinder implements IKernelFinder {
         return this.verifyIpyKernel(foundKernel, cancelToken);
     }
 
+    // Search all our local file system locations for installed kernel specs and return them
+    public async listKernelSpecs(_cancelToken?: CancellationToken): Promise<IJupyterKernelSpec[]> {
+        throw new Error('Not yet implmented');
+    }
+
     // For the given kernelspec return back the kernelspec with ipykernel installed into it or error
     private async verifyIpyKernel(
         kernelSpec: IJupyterKernelSpec,

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -49,6 +49,7 @@ export interface IKernelFinder {
         kernelName?: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterKernelSpec>;
+    listKernelSpecs(cancelToken?: CancellationToken): Promise<IJupyterKernelSpec[]>;
 }
 
 /**

--- a/src/test/datascience/jupyter/kernels/kernelSelections.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelections.unit.test.ts
@@ -16,6 +16,7 @@ import { JupyterSessionManager } from '../../../../client/datascience/jupyter/ju
 import { KernelSelectionProvider } from '../../../../client/datascience/jupyter/kernels/kernelSelections';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
 import { IKernelSpecQuickPickItem } from '../../../../client/datascience/jupyter/kernels/types';
+import { IKernelFinder } from '../../../../client/datascience/kernel-launcher/types';
 import { IJupyterKernel, IJupyterKernelSpec, IJupyterSessionManager } from '../../../../client/datascience/types';
 import { InterpreterSelector } from '../../../../client/interpreter/configuration/interpreterSelector/interpreterSelector';
 import { IInterpreterQuickPickItem, IInterpreterSelector } from '../../../../client/interpreter/configuration/types';
@@ -25,6 +26,7 @@ import { InterpreterType } from '../../../../client/interpreter/contracts';
 suite('Data Science - KernelSelections', () => {
     let kernelSelectionProvider: KernelSelectionProvider;
     let kernelService: KernelService;
+    let kernelFinder: IKernelFinder;
     let interpreterSelector: IInterpreterSelector;
     let pathUtils: IPathUtils;
     let fs: IFileSystem;
@@ -132,6 +134,7 @@ suite('Data Science - KernelSelections', () => {
         interpreterSelector = mock(InterpreterSelector);
         sessionManager = mock(JupyterSessionManager);
         kernelService = mock(KernelService);
+        kernelFinder = mock(IKernelFinder);
         fs = mock(FileSystem);
         pathUtils = mock(PathUtils);
         when(pathUtils.getDisplayName(anything())).thenReturn('<user friendly path>');
@@ -140,7 +143,8 @@ suite('Data Science - KernelSelections', () => {
             instance(kernelService),
             instance(interpreterSelector),
             instance(fs),
-            instance(pathUtils)
+            instance(pathUtils),
+            instance(kernelFinder)
         );
     });
 
@@ -248,6 +252,7 @@ suite('Data Science - KernelSelections', () => {
 
         const items = await kernelSelectionProvider.getKernelSelectionsForLocalSession(
             undefined,
+            'jupyter',
             instance(sessionManager)
         );
 

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -99,18 +99,25 @@ suite('Data Science - KernelSelector', () => {
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
             ).thenResolve([]);
             when(appShell.showQuickPick(anything(), anything(), anything())).thenResolve();
 
-            const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
+            const kernel = await kernelSelector.selectLocalKernel(
+                undefined,
+                'jupyter',
+                new StopWatch(),
+                instance(sessionManager)
+            );
 
             assert.isEmpty(kernel);
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -280,6 +287,7 @@ suite('Data Science - KernelSelector', () => {
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -290,12 +298,18 @@ suite('Data Science - KernelSelector', () => {
             kernelSelector.addKernelToIgnoreList({ id: 'id2' } as any);
             // tslint:disable-next-line: no-any
             kernelSelector.addKernelToIgnoreList({ clientId: 'id4' } as any);
-            const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
+            const kernel = await kernelSelector.selectLocalKernel(
+                undefined,
+                'jupyter',
+                new StopWatch(),
+                instance(sessionManager)
+            );
 
             assert.isEmpty(kernel);
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -313,6 +327,7 @@ suite('Data Science - KernelSelector', () => {
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -323,13 +338,19 @@ suite('Data Science - KernelSelector', () => {
                 // tslint:disable-next-line: no-any
             } as any);
 
-            const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
+            const kernel = await kernelSelector.selectLocalKernel(
+                undefined,
+                'jupyter',
+                new StopWatch(),
+                instance(sessionManager)
+            );
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
             assert.isOk(kernel.interpreter === interpreter);
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -345,6 +366,7 @@ suite('Data Science - KernelSelector', () => {
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -357,7 +379,12 @@ suite('Data Science - KernelSelector', () => {
                 // tslint:disable-next-line: no-any
             } as any);
 
-            const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
+            const kernel = await kernelSelector.selectLocalKernel(
+                undefined,
+                'jupyter',
+                new StopWatch(),
+                instance(sessionManager)
+            );
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
             verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
@@ -365,6 +392,7 @@ suite('Data Science - KernelSelector', () => {
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -385,6 +413,7 @@ suite('Data Science - KernelSelector', () => {
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -397,7 +426,12 @@ suite('Data Science - KernelSelector', () => {
                 // tslint:disable-next-line: no-any
             } as any);
 
-            const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
+            const kernel = await kernelSelector.selectLocalKernel(
+                undefined,
+                'jupyter',
+                new StopWatch(),
+                instance(sessionManager)
+            );
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
             assert.isOk(kernel.interpreter === interpreter);
@@ -406,6 +440,7 @@ suite('Data Science - KernelSelector', () => {
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -424,6 +459,7 @@ suite('Data Science - KernelSelector', () => {
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -436,13 +472,19 @@ suite('Data Science - KernelSelector', () => {
                 // tslint:disable-next-line: no-any
             } as any);
 
-            const kernel = await kernelSelector.selectLocalKernel(undefined, new StopWatch(), instance(sessionManager));
+            const kernel = await kernelSelector.selectLocalKernel(
+                undefined,
+                'jupyter',
+                new StopWatch(),
+                instance(sessionManager)
+            );
 
             assert.isOk(kernel.kernelSpec === kernelSpec);
             verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
+                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )
@@ -468,6 +510,7 @@ suite('Data Science - KernelSelector', () => {
         let selectLocalKernelStub: sinon.SinonStub<
             [
                 Resource,
+                'raw' | 'jupyter' | 'unknown',
                 StopWatch,
                 (IJupyterSessionManager | undefined)?,
                 (CancellationToken | undefined)?,
@@ -497,7 +540,12 @@ suite('Data Science - KernelSelector', () => {
             ).thenResolve(kernelSpec);
             when(kernelService.findMatchingInterpreter(kernelSpec, anything())).thenResolve(interpreter);
             when(
-                kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything(), anything())
+                kernelSelectionProvider.getKernelSelectionsForLocalSession(
+                    anything(),
+                    anything(),
+                    anything(),
+                    anything()
+                )
             ).thenResolve();
 
             const kernel = await kernelSelector.getKernelForLocalConnection(
@@ -522,7 +570,12 @@ suite('Data Science - KernelSelector', () => {
             ).thenResolve(kernelSpec);
             when(kernelService.findMatchingInterpreter(kernelSpec, anything())).thenResolve();
             when(
-                kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything(), anything())
+                kernelSelectionProvider.getKernelSelectionsForLocalSession(
+                    anything(),
+                    anything(),
+                    anything(),
+                    anything()
+                )
             ).thenResolve();
 
             const kernel = await kernelSelector.getKernelForLocalConnection(
@@ -559,7 +612,12 @@ suite('Data Science - KernelSelector', () => {
                 )
             ).thenResolve();
             when(
-                kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything(), anything())
+                kernelSelectionProvider.getKernelSelectionsForLocalSession(
+                    anything(),
+                    anything(),
+                    anything(),
+                    anything()
+                )
             ).thenResolve();
 
             const kernel = await kernelSelector.getKernelForLocalConnection(
@@ -599,7 +657,12 @@ suite('Data Science - KernelSelector', () => {
             when(interpreterService.getActiveInterpreter(undefined)).thenResolve(interpreter);
             when(kernelService.searchAndRegisterKernel(interpreter, anything(), anything())).thenResolve(kernelSpec);
             when(
-                kernelSelectionProvider.getKernelSelectionsForLocalSession(anything(), anything(), anything())
+                kernelSelectionProvider.getKernelSelectionsForLocalSession(
+                    anything(),
+                    anything(),
+                    anything(),
+                    anything()
+                )
             ).thenResolve();
 
             const kernel = await kernelSelector.getKernelForLocalConnection(

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -137,6 +137,7 @@ suite('Data Science - Kernel Switcher', () => {
                                 kernelSelector.selectLocalKernel(
                                     anything(),
                                     anything(),
+                                    anything(),
                                     undefined,
                                     undefined,
                                     currentKernelInfo.currentKernel
@@ -160,6 +161,7 @@ suite('Data Science - Kernel Switcher', () => {
                             kernelSelector.selectLocalKernel(
                                 anything(),
                                 anything(),
+                                anything(),
                                 undefined,
                                 undefined,
                                 currentKernelInfo.currentKernel
@@ -176,6 +178,7 @@ suite('Data Science - Kernel Switcher', () => {
                             if (isLocalConnection) {
                                 when(
                                     kernelSelector.selectLocalKernel(
+                                        anything(),
                                         anything(),
                                         anything(),
                                         undefined,
@@ -315,6 +318,7 @@ suite('Data Science - Kernel Switcher', () => {
                                     kernelSelector.selectLocalKernel(
                                         anything(),
                                         anything(),
+                                        anything(),
                                         undefined,
                                         anything(),
                                         anything()
@@ -352,6 +356,7 @@ suite('Data Science - Kernel Switcher', () => {
                                 // first time when user select a kernel, second time is when user selects after failing to switch to the first kernel.
                                 verify(
                                     kernelSelector.selectLocalKernel(
+                                        anything(),
                                         anything(),
                                         anything(),
                                         anything(),

--- a/src/test/datascience/mockKernelFinder.ts
+++ b/src/test/datascience/mockKernelFinder.ts
@@ -20,6 +20,10 @@ export class MockKernelFinder implements IKernelFinder {
         return this.realFinder.findKernelSpec(interpreterUri, kernelName);
     }
 
+    public async listKernelSpecs(): Promise<IJupyterKernelSpec[]> {
+        throw new Error('Not yet implemented');
+    }
+
     public addKernelSpec(pythonPathOrResource: string, spec: IJupyterKernelSpec) {
         this.dummySpecs.set(pythonPathOrResource, spec);
     }


### PR DESCRIPTION
This is the first part of making kernel selection independent from jupyter. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
