### PR TITLE
Fix smoke tests & correctly running tests using Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
 
-      - name: Install IPython test requirements
+      - name: pip install ipython requirements
         run: |
           python -m pip install numpy
           python -m pip install --upgrade -r ./build/ipython-test-requirements.txt
@@ -329,7 +329,7 @@ jobs:
         shell: pwsh
         if: matrix.test-suite == 'venv'
 
-      - name: Set CI_PYTHON_PATH and disable autoselection
+      - name: Set CI_PYTHON_PATH and CI_DISABLE_AUTO_SELECTION
         run: |
           echo "::set-env name=CI_PYTHON_PATH::python"
           echo "::set-env name=CI_DISABLE_AUTO_SELECTION::1"
@@ -411,6 +411,11 @@ jobs:
           printenv
         shell: bash
 
+      - name: Use Python ${{matrix.python}}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python}}
+
       - name: Retrieve cached npm files
         uses: actions/cache@v1
         with:
@@ -420,7 +425,15 @@ jobs:
       - name: Install dependencies (npm ci)
         run: npm ci --prefer-offline
 
-      - name: Install IPython test requirements
+      - name: pip install system test requirements
+        run: |
+          python -m pip install --upgrade -r build/test-requirements.txt
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+        shell: bash
+
+      - name: pip install ipython requirements
         run: |
           python -m pip install numpy
           python -m pip install --upgrade -r ./build/ipython-test-requirements.txt
@@ -441,6 +454,12 @@ jobs:
           mv ${{env.ARTIFACT_NAME_VSIX}}/* .
           rm -r ${{env.ARTIFACT_NAME_VSIX}}
           npx tsc -p ./
+        shell: bash
+
+      - name: Set CI_PYTHON_PATH and CI_DISABLE_AUTO_SELECTION
+        run: |
+          echo "::set-env name=CI_PYTHON_PATH::python"
+          echo "::set-env name=CI_DISABLE_AUTO_SELECTION::1"
         shell: bash
 
       - name: Run smoke tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Show all env vars
+        run: |
+          printenv
+        shell: bash
+
       - name: Use Python ${{env.PYTHON_VERSION}}
         uses: actions/setup-python@v1
         with:
@@ -91,6 +96,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Show all env vars
+        run: |
+          printenv
+        shell: bash
 
       - name: Retrieve cached npm files
         uses: actions/cache@v1
@@ -200,6 +210,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Show all env vars
+        run: |
+          printenv
+        shell: bash
 
       - name: Retrieve cached npm files
         uses: actions/cache@v1
@@ -314,6 +329,13 @@ jobs:
         shell: pwsh
         if: matrix.test-suite == 'venv'
 
+      - name: Set CI_PYTHON_PATH and disable autoselection
+        run: |
+          echo "::set-env name=CI_PYTHON_PATH::python"
+          echo "::set-env name=CI_DISABLE_AUTO_SELECTION::1"
+        shell: bash
+        if: matrix.test-suite != 'ts-unit'
+
       # Run TypeScript unit tests only for Python 3.X.
       - name: Run TypeScript unit tests
         run: npm run test:unittests:cover
@@ -384,6 +406,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Show all env vars
+        run: |
+          printenv
+        shell: bash
+
       - name: Retrieve cached npm files
         uses: actions/cache@v1
         with:
@@ -392,6 +419,15 @@ jobs:
 
       - name: Install dependencies (npm ci)
         run: npm ci --prefer-offline
+
+      - name: Install IPython test requirements
+        run: |
+          python -m pip install numpy
+          python -m pip install --upgrade -r ./build/ipython-test-requirements.txt
+
+      - name: pip install jupyter
+        run: |
+          python -m pip install --upgrade jupyter
 
       - name: Download VSIX
         uses: actions/download-artifact@v1

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -605,7 +605,7 @@ export class PythonSettings implements IPythonSettings {
                 ? this.interpreterPathService.get(this.workspaceRoot)
                 : pythonSettings.get<string>('pythonPath')
         )!;
-        if (this.pythonPath.length === 0 || this.pythonPath === 'python') {
+        if (!process.env.CI_DISABLE_AUTO_SELECTION && (this.pythonPath.length === 0 || this.pythonPath === 'python')) {
             const autoSelectedPythonInterpreter = this.interpreterAutoSelectionService.getAutoSelectedInterpreter(
                 this.workspaceRoot
             );


### PR DESCRIPTION
For #11480 and more

Environment variable `CI_PYTHON_PATH` was not set, due to which tests were being run with the autoselected interpreter Python36 instead of Python 2.7 which was present in path.