### PR TITLE
Skip venv tests for 2.7 and disable fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,7 @@ jobs:
     if: github.repository == 'microsoft/vscode-python'
     needs: [python-deps, js-ts-deps]
     strategy:
+      fail-fast: false
       matrix:
         # We're not running CI on macOS for now because it's one less matrix entry to lower the number of runners used,
         # macOS runners are expensive, and we assume that Ubuntu is enough to cover the UNIX case.
@@ -381,6 +382,7 @@ jobs:
       - name: Run venv tests
         env:
           TEST_FILES_SUFFIX: testvirtualenvs
+          CI_PYTHON_VERSION: ${{matrix.python}}
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm run testSingleWorkspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,6 @@ jobs:
       - name: Run venv tests
         env:
           TEST_FILES_SUFFIX: testvirtualenvs
-          CI_PYTHON_VERSION: ${{matrix.python}}
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm run testSingleWorkspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
       - name: Run venv tests
         env:
           TEST_FILES_SUFFIX: testvirtualenvs
+          CI_PYTHON_VERSION: ${{matrix.python}}
         uses: GabrielBB/xvfb-action@v1.0
         with:
           run: npm run testSingleWorkspace

--- a/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
+++ b/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
@@ -171,7 +171,11 @@ suite('Activation of Environments in Terminal', () => {
         expect(fileSystem.arePathsSame(content, PYTHON_PATH)).to.equal(false, 'Environment not activated');
     });
 
-    test('Should activate with venv', async () => {
+    test('Should activate with venv', async function () {
+        if (process.env.CI_PYTHON_VERSION && process.env.CI_PYTHON_VERSION.startsWith('2.')) {
+            // tslint:disable-next-line: no-invalid-this
+            this.skip();
+        }
         await testActivation(envPaths.venvPath);
     });
     test('Should activate with pipenv', async () => {

--- a/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
+++ b/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
@@ -12,6 +12,7 @@ import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { IExperimentsManager } from '../../../../client/common/types';
 import { PYTHON_VIRTUAL_ENVS_LOCATION } from '../../../ciConstants';
 import {
+    isPythonVersion,
     PYTHON_PATH,
     resetGlobalInterpreterPathSetting,
     restorePythonPathInWorkspaceRoot,
@@ -172,9 +173,9 @@ suite('Activation of Environments in Terminal', () => {
     });
 
     test('Should activate with venv', async function () {
-        if (process.env.CI_PYTHON_VERSION && process.env.CI_PYTHON_VERSION.startsWith('2.')) {
-            // tslint:disable-next-line: no-invalid-this
-            this.skip();
+        if (await isPythonVersion('2')) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
         }
         await testActivation(envPaths.venvPath);
     });

--- a/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
+++ b/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
@@ -12,7 +12,6 @@ import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { IExperimentsManager } from '../../../../client/common/types';
 import { PYTHON_VIRTUAL_ENVS_LOCATION } from '../../../ciConstants';
 import {
-    isPythonVersion,
     PYTHON_PATH,
     resetGlobalInterpreterPathSetting,
     restorePythonPathInWorkspaceRoot,
@@ -173,9 +172,9 @@ suite('Activation of Environments in Terminal', () => {
     });
 
     test('Should activate with venv', async function () {
-        if (await isPythonVersion('2')) {
-            // tslint:disable-next-line:no-invalid-this
-            return this.skip();
+        if (process.env.CI_PYTHON_VERSION && process.env.CI_PYTHON_VERSION.startsWith('2.')) {
+            // tslint:disable-next-line: no-invalid-this
+            this.skip();
         }
         await testActivation(envPaths.venvPath);
     });


### PR DESCRIPTION
We should not be running `venv` tests for 2.7, since `venv` is not supported on 2.7.