### PR TITLE
add quotes around some arguments, fix #11562

### DIFF
--- a/news/2 Fixes/11562.md
+++ b/news/2 Fixes/11562.md
@@ -1,0 +1,1 @@
+Fixed an edge case where debugging tests would fail if the default shell was zsh and the test pattern contains a "*"

--- a/src/client/testing/unittest/runner.ts
+++ b/src/client/testing/unittest/runner.ts
@@ -128,7 +128,7 @@ export class TestManagerRunner implements ITestManagerRunner {
                 testArgs.push(`-t${testId}`);
             }
             if (testFile.length > 0) {
-                testArgs.push(`--testFile=${testFile}`);
+                testArgs.push(`--testFile="${testFile}"`);
             }
             if (options.debug === true) {
                 const debugLauncher = this.serviceContainer.get<ITestDebugLauncher>(ITestDebugLauncher);
@@ -219,7 +219,9 @@ export class TestManagerRunner implements ITestManagerRunner {
         }
         const failFast = args.some((arg) => arg.trim() === '-f' || arg.trim() === '--failfast');
         const verbosity = args.some((arg) => arg.trim().indexOf('-v') === 0) ? 2 : 1;
-        const testArgs = [`--us=${startTestDiscoveryDirectory}`, `--up=${pattern}`, `--uvInt=${verbosity}`];
+        // Quotes are required around paths and other strings because if zsh is parsing the command,
+        // it will see * as a regular expression, and try to evaluate it to all the files in the current working directory.
+        const testArgs = [`--us="${startTestDiscoveryDirectory}"`, `--up="${pattern}"`, `--uvInt=${verbosity}`];
         if (failFast) {
             testArgs.push('--uf');
         }


### PR DESCRIPTION
For #11562

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [x] The wiki is updated with any design decisions/details.
