### PR TITLE
Performance improvements to executing cells without Ipywidget

### DIFF
--- a/news/2 Fixes/11576.md
+++ b/news/2 Fixes/11576.md
@@ -1,0 +1,1 @@
+Performance improvements when executing multiple cells in `Notebook` and `Interactive Window`.

--- a/src/client/datascience/ipywidgets/constants.ts
+++ b/src/client/datascience/ipywidgets/constants.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const WIDGET_MIMETYPE = 'application/vnd.jupyter.widget-view+json';

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -25,6 +25,7 @@ const ansiToHtml = require('ansi-to-html');
 const cloneDeep = require('lodash/cloneDeep');
 import { Widget } from '@phosphor/widgets';
 import { noop } from '../../client/common/utils/misc';
+import { WIDGET_MIMETYPE } from '../../client/datascience/ipywidgets/constants';
 import { concatMultilineStringInput, concatMultilineStringOutput } from '../common';
 import { TrimmedOutputMessage } from './trimmedOutputLink';
 
@@ -555,7 +556,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
     private renderWidget(widgetOutput: ICellOutputData) {
         // Create a view for this widget if we haven't already
         // tslint:disable-next-line: no-any
-        const widgetData: any = widgetOutput.mimeBundle['application/vnd.jupyter.widget-view+json'];
+        const widgetData: any = widgetOutput.mimeBundle[WIDGET_MIMETYPE];
         if (widgetData.model_id) {
             if (!this.renderedViews.has(widgetData.model_id)) {
                 this.renderedViews.set(widgetData.model_id, this.createWidgetView(widgetData));

--- a/src/datascience-ui/ipywidgets/manager.ts
+++ b/src/datascience-ui/ipywidgets/manager.ts
@@ -18,6 +18,7 @@ import {
     InteractiveWindowMessages,
     IPyWidgetMessages
 } from '../../client/datascience/interactive-common/interactiveWindowTypes';
+import { WIDGET_MIMETYPE } from '../../client/datascience/ipywidgets/constants';
 import { KernelSocketOptions } from '../../client/datascience/types';
 import { IMessageHandler, PostOffice } from '../react-common/postOffice';
 import { create as createKernel } from './kernel';
@@ -184,13 +185,9 @@ export class WidgetManager implements IIPyWidgetManager, IMessageHandler {
         }
         const displayMsg = payload as KernelMessage.IDisplayDataMsg;
 
-        if (
-            displayMsg.content &&
-            displayMsg.content.data &&
-            displayMsg.content.data['application/vnd.jupyter.widget-view+json']
-        ) {
+        if (displayMsg.content && displayMsg.content.data && displayMsg.content.data[WIDGET_MIMETYPE]) {
             // tslint:disable-next-line: no-any
-            const data = displayMsg.content.data['application/vnd.jupyter.widget-view+json'] as any;
+            const data = displayMsg.content.data[WIDGET_MIMETYPE] as any;
             const modelId = data.model_id;
             let deferred = this.modelIdsToBeDisplayed.get(modelId);
             if (!deferred) {


### PR DESCRIPTION
For #11576 
Basically defer waiting on messages to be processed by UI kernel until we know it is required, i.e. until we have widgets being created on the UI side.