### PR TITLE
Don't use cached requirements installation when running the tests on GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Install debugpy wheels
         run: |
+          python -m pip install wheel
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py
 
@@ -252,22 +253,15 @@ jobs:
       - name: curl PyPI to get debugpy versions
         run: curl --output debugpy.json https://pypi.org/pypi/debugpy/json
 
-      - name: Retrieve cached pythonFiles/ directory
-        uses: actions/cache@v1
-        # Use an id for this step so that its cache-hit output can be accessed and checked in the next step.
-        id: pythonFiles-cache
-        with:
-          path: ./pythonFiles/lib/python
-          key: ${{runner.os}}-${{env.CACHE_PYTHONFILES}}-pythonFiles-${{env.PYTHON_VERSION}}-${{hashFiles('requirements.txt')}}-${{hashFiles('build/debugger-install-requirements.txt')}}-${{hashFiles('debugpy.json')}}
-
-      - name: Install Python requirements if not cached
+        # We're intentionally not retrieving cached Python requirements installation, as it appears that pulling the cache pulls in some extra libraries as well,
+        # which causes problems with the tests. Also, running the installation seems much faster than retrieving it from cache.
+      - name: Install Python requirements
         run: |
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
           # We need to have debugpy available in wheels/ so that tests relying on it keep passing, but we don't need install_debugpy's logic in the test phase.
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
-        if: steps.pythonFiles-cache.outputs.cache-hit == false
 
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
@@ -278,7 +272,7 @@ jobs:
           python -m pip install --upgrade -r ./build/ipython-test-requirements.txt
         if: matrix.test-suite == 'python-unit'
 
-      - name: Install Debugpy wheels
+      - name: Install debugpy wheels
         run: |
           python -m pip install wheel
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt


### PR DESCRIPTION
We're intentionally not retrieving cached Python requirements installation, as it appears that pulling the cache pulls in some extra libraries as well, which causes problems with the tests. Also, running the installation seems much faster than retrieving it from cache.
For instance, `copyreg` module was being copied into `pythonFiles/lib` when pulling installation requirements from cache, but it was not part of requirements. It was leading in the following error when running tests with Python 3.8:
```

  File "d:\a\vscode-python\vscode-python\pythonFiles\lib\python\isort\__init__.py", line 25, in <module>

    from . import settings  # noqa: F401

  File "d:\a\vscode-python\vscode-python\pythonFiles\lib\python\isort\settings.py", line 27, in <module>

    import fnmatch

  File "C:\hostedtoolcache\windows\Python\3.8.2\x64\lib\fnmatch.py", line 14, in <module>

    import re

  File "C:\hostedtoolcache\windows\Python\3.8.2\x64\lib\re.py", line 335, in <module>

    import copyreg

  File "d:\a\vscode-python\vscode-python\pythonFiles\lib\python\copyreg\__init__.py", line 7, in <module>

    raise ImportError('This package should not be accessible on Python 3. '

ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
```

This was because the `copyreg` module copied into the directory was actually a package from Python 2, so it cannot be accessed when running tests with Python 3.

I've also commented out the coverage step as that is not something we initially need to churn out insiders build. It would be set up as a second thing once we can reliably generate insiders builds from github actions.
