### PR TITLE
Fix shift tab to work again

### DIFF
--- a/news/2 Fixes/11495.md
+++ b/news/2 Fixes/11495.md
@@ -1,0 +1,1 @@
+Make shift+tab work again in the interactive window. Escaping focus from the prompt is now relegated to 'Shift+Esc'.


### PR DESCRIPTION
For #11495 

Make shift+tab work again in the interactive window. Use shift+esc instead to lose focus
