### PR TITLE
Leave pipenv in a corner until the user decides to select an interpreter

### DIFF
--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -73,7 +73,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         this.experiments.sendTelemetryIfInExperiment(DeprecatePythonPath.control);
 
         // Get latest interpreter list in the background.
-        this.interpreterService.getInterpreters(resource, { onActivation: true }).ignoreErrors();
+        this.interpreterService.getInterpreters(resource).ignoreErrors();
 
         await sendActivationTelemetry(this.fileSystem, this.workspaceService, resource);
 

--- a/src/client/application/diagnostics/checks/macPythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/macPythonInterpreter.ts
@@ -101,7 +101,7 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
             return [];
         }
 
-        const interpreters = await this.interpreterService.getInterpreters(resource, { onActivation: true });
+        const interpreters = await this.interpreterService.getInterpreters(resource);
         if (interpreters.filter((i) => !this.helper.isMacDefaultPythonPath(i.path)).length === 0) {
             return [
                 new InvalidMacPythonInterpreterDiagnostic(

--- a/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
@@ -3,10 +3,16 @@
 
 'use strict';
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, named } from 'inversify';
 import { Uri } from 'vscode';
 import '../../../common/extensions';
-import { IInterpreterService, InterpreterType, IPipEnvService } from '../../../interpreter/contracts';
+import {
+    IInterpreterLocatorService,
+    IInterpreterService,
+    InterpreterType,
+    IPipEnvService,
+    PIPENV_SERVICE
+} from '../../../interpreter/contracts';
 import { IWorkspaceService } from '../../application/types';
 import { IFileSystem } from '../../platform/types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
@@ -15,7 +21,9 @@ import { ITerminalActivationCommandProvider, TerminalShellType } from '../types'
 export class PipEnvActivationCommandProvider implements ITerminalActivationCommandProvider {
     constructor(
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IPipEnvService) private readonly pipenvService: IPipEnvService,
+        @inject(IInterpreterLocatorService)
+        @named(PIPENV_SERVICE)
+        private readonly pipenvService: IPipEnvService,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IFileSystem) private readonly fs: IFileSystem
     ) {}

--- a/src/client/interpreter/autoSelection/rules/system.ts
+++ b/src/client/interpreter/autoSelection/rules/system.ts
@@ -25,7 +25,7 @@ export class SystemWideInterpretersAutoSelectionRule extends BaseRuleService {
         resource: Resource,
         manager?: IInterpreterAutoSelectionService
     ): Promise<NextAction> {
-        const interpreters = await this.interpreterService.getInterpreters(resource, { onActivation: true });
+        const interpreters = await this.interpreterService.getInterpreters(resource);
         // Exclude non-local interpreters.
         const filteredInterpreters = interpreters.filter(
             (int) =>

--- a/src/client/interpreter/configuration/interpreterSelector/interpreterSelector.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/interpreterSelector.ts
@@ -27,7 +27,7 @@ export class InterpreterSelector implements IInterpreterSelector {
     }
 
     public async getSuggestions(resource: Resource) {
-        let interpreters = await this.interpreterManager.getInterpreters(resource);
+        let interpreters = await this.interpreterManager.getInterpreters(resource, { onSuggestion: true });
         if (this.experimentsManager.inExperiment(DeprecatePythonPath.experiment)) {
             interpreters = interpreters.filter((item) => this.interpreterSecurityService.isSafe(item) !== false);
         }

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -126,7 +126,7 @@ export interface IInterpreterHelper {
 }
 
 export const IPipEnvService = Symbol('IPipEnvService');
-export interface IPipEnvService {
+export interface IPipEnvService extends IInterpreterLocatorService {
     executable: string;
     isRelatedPipEnvironment(dir: string, pythonPath: string): Promise<boolean>;
 }

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -38,6 +38,7 @@ export const IInterpreterLocatorService = Symbol('IInterpreterLocatorService');
 export interface IInterpreterLocatorService extends Disposable {
     readonly onLocating: Event<Promise<PythonInterpreter[]>>;
     readonly hasInterpreters: Promise<boolean>;
+    didTriggerInterpreterSuggestions?: boolean;
     getInterpreters(resource?: Uri, options?: GetInterpreterLocatorOptions): Promise<PythonInterpreter[]>;
 }
 

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -28,7 +28,6 @@ export interface IVirtualEnvironmentsSearchPathProvider {
 }
 
 export type GetInterpreterOptions = {
-    onActivation?: boolean;
     onSuggestion?: boolean;
 };
 

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -29,6 +29,7 @@ export interface IVirtualEnvironmentsSearchPathProvider {
 
 export type GetInterpreterOptions = {
     onActivation?: boolean;
+    onSuggestion?: boolean;
 };
 
 export type GetInterpreterLocatorOptions = GetInterpreterOptions & { ignoreCache?: boolean };

--- a/src/client/interpreter/locators/index.ts
+++ b/src/client/interpreter/locators/index.ts
@@ -34,6 +34,8 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
     private readonly platform: IPlatformService;
     private readonly interpreterLocatorHelper: IInterpreterLocatorHelper;
     private readonly _hasInterpreters: Deferred<boolean>;
+    private didTriggerInterpreterSuggestions: boolean;
+
     constructor(
         @inject(IServiceContainer) private serviceContainer: IServiceContainer,
         @inject(InterpreterFilter) private readonly interpreterFilter: IInterpreterFilter
@@ -42,6 +44,7 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
         serviceContainer.get<Disposable[]>(IDisposableRegistry).push(this);
         this.platform = serviceContainer.get<IPlatformService>(IPlatformService);
         this.interpreterLocatorHelper = serviceContainer.get<IInterpreterLocatorHelper>(IInterpreterLocatorHelper);
+        this.didTriggerInterpreterSuggestions = false;
     }
     /**
      * This class should never emit events when we're locating.
@@ -102,6 +105,8 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
      * The locators are pulled from the registry.
      */
     private getLocators(options?: GetInterpreterLocatorOptions): IInterpreterLocatorService[] {
+        this.didTriggerInterpreterSuggestions = options?.onSuggestion || false;
+
         // The order of the services is important.
         // The order is important because the data sources at the bottom of the list do not contain all,
         //  the information about the interpreters (e.g. type, environment name, etc).

--- a/src/client/interpreter/locators/index.ts
+++ b/src/client/interpreter/locators/index.ts
@@ -105,7 +105,10 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
      * The locators are pulled from the registry.
      */
     private getLocators(options?: GetInterpreterLocatorOptions): IInterpreterLocatorService[] {
-        this.didTriggerInterpreterSuggestions = options?.onSuggestion || false;
+        // Set it to true the first time the user selects an interpreter
+        if (!this.didTriggerInterpreterSuggestions && options?.onSuggestion === true) {
+            this.didTriggerInterpreterSuggestions = options?.onSuggestion;
+        }
 
         // The order of the services is important.
         // The order is important because the data sources at the bottom of the list do not contain all,
@@ -115,7 +118,7 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
             [WINDOWS_REGISTRY_SERVICE, OSType.Windows],
             [CONDA_ENV_SERVICE, undefined],
             [CONDA_ENV_FILE_SERVICE, undefined],
-            options?.onActivation ? [undefined, undefined] : [PIPENV_SERVICE, undefined],
+            this.didTriggerInterpreterSuggestions ? [PIPENV_SERVICE, undefined] : [undefined, undefined],
             [GLOBAL_VIRTUAL_ENV_SERVICE, undefined],
             [WORKSPACE_VIRTUAL_ENV_SERVICE, undefined],
             [KNOWN_PATH_SERVICE, undefined],

--- a/src/client/interpreter/locators/services/cacheableLocatorService.ts
+++ b/src/client/interpreter/locators/services/cacheableLocatorService.ts
@@ -70,6 +70,8 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
     private readonly handlersAddedToResource = new Set<string>();
     private readonly cacheKeyPrefix: string;
     private readonly locating = new EventEmitter<Promise<PythonInterpreter[]>>();
+    private _didTriggerInterpreterSuggestions: boolean;
+
     constructor(
         @unmanaged() private readonly name: string,
         @unmanaged() protected readonly serviceContainer: IServiceContainer,
@@ -77,6 +79,15 @@ export abstract class CacheableLocatorService implements IInterpreterLocatorServ
     ) {
         this._hasInterpreters = createDeferred<boolean>();
         this.cacheKeyPrefix = `INTERPRETERS_CACHE_v3_${name}`;
+        this._didTriggerInterpreterSuggestions = false;
+    }
+
+    public get didTriggerInterpreterSuggestions(): boolean {
+        return this._didTriggerInterpreterSuggestions;
+    }
+
+    public set didTriggerInterpreterSuggestions(value: boolean) {
+        this._didTriggerInterpreterSuggestions = value;
     }
 
     public get onLocating(): Event<Promise<PythonInterpreter[]>> {

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -60,7 +60,6 @@ import {
     IInterpreterWatcherBuilder,
     IKnownSearchPathsForInterpreters,
     INTERPRETER_LOCATOR_SERVICE,
-    IPipEnvService,
     IShebangCodeLensProvider,
     IVirtualEnvironmentsSearchPathProvider,
     KNOWN_PATH_SERVICE,
@@ -200,7 +199,6 @@ export function registerInterpreterTypes(serviceManager: IServiceManager) {
         WORKSPACE_VIRTUAL_ENV_SERVICE
     );
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
-    serviceManager.addSingleton<IInterpreterLocatorService>(IPipEnvService, PipEnvService);
 
     serviceManager.addSingleton<IInterpreterLocatorService>(
         IInterpreterLocatorService,

--- a/src/client/startupTelemetry.ts
+++ b/src/client/startupTelemetry.ts
@@ -129,9 +129,7 @@ async function getActivationTelemetryProps(serviceContainer: IServiceContainer):
             .then((ver) => (ver ? ver.raw : ''))
             .catch<string>(() => ''),
         interpreterService.getActiveInterpreter().catch<PythonInterpreter | undefined>(() => undefined),
-        interpreterService
-            .getInterpreters(mainWorkspaceUri, { onActivation: true })
-            .catch<PythonInterpreter[]>(() => [])
+        interpreterService.getInterpreters(mainWorkspaceUri).catch<PythonInterpreter[]>(() => [])
     ]);
     const workspaceFolderCount = workspaceService.hasWorkspaceFolders ? workspaceService.workspaceFolders!.length : 0;
     const pythonVersion = interpreter && interpreter.version ? interpreter.version.raw : undefined;

--- a/src/test/activation/activationManager.unit.test.ts
+++ b/src/test/activation/activationManager.unit.test.ts
@@ -198,7 +198,7 @@ suite('Activation Manager', () => {
             when(workspaceService.getWorkspaceFolder(resource)).thenReturn(folder2);
             when(activationService1.activate(resource)).thenResolve();
             when(activationService2.activate(resource)).thenResolve();
-            when(interpreterService.getInterpreters(anything(), anything())).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
             autoSelection
                 .setup((a) => a.autoSelectInterpreter(resource))
                 .returns(() => Promise.resolve())
@@ -232,7 +232,7 @@ suite('Activation Manager', () => {
             const resource = Uri.parse('two');
             when(activationService1.activate(resource)).thenResolve();
             when(activationService2.activate(resource)).thenResolve();
-            when(interpreterService.getInterpreters(anything(), anything())).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
             autoSelection
                 .setup((a) => a.autoSelectInterpreter(resource))
                 .returns(() => Promise.resolve())
@@ -252,7 +252,7 @@ suite('Activation Manager', () => {
             const resource = Uri.parse('two');
             when(activationService1.activate(resource)).thenResolve();
             when(activationService2.activate(resource)).thenResolve();
-            when(interpreterService.getInterpreters(anything(), anything())).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
             when(experiments.inExperiment(DeprecatePythonPath.experiment)).thenReturn(true);
             interpreterPathService
                 .setup((i) => i.copyOldInterpreterStorageValuesToNew(resource))
@@ -278,7 +278,7 @@ suite('Activation Manager', () => {
             const resource = Uri.parse('two');
             when(activationService1.activate(resource)).thenResolve();
             when(activationService2.activate(resource)).thenResolve();
-            when(interpreterService.getInterpreters(anything(), anything())).thenResolve();
+            when(interpreterService.getInterpreters(anything())).thenResolve();
             autoSelection
                 .setup((a) => a.autoSelectInterpreter(resource))
                 .returns(() => Promise.resolve())

--- a/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
@@ -174,7 +174,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .returns(() => Promise.resolve(true))
                 .verifiable(typemoq.Times.once());
             interpreterService
-                .setup((i) => i.getInterpreters(typemoq.It.isAny(), { onActivation: true }))
+                .setup((i) => i.getInterpreters(typemoq.It.isAny()))
                 .returns(() => Promise.resolve([{} as any]))
                 .verifiable(typemoq.Times.never());
             interpreterService
@@ -204,7 +204,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .returns(() => Promise.resolve(true))
                 .verifiable(typemoq.Times.once());
             interpreterService
-                .setup((i) => i.getInterpreters(typemoq.It.isAny(), { onActivation: true }))
+                .setup((i) => i.getInterpreters(typemoq.It.isAny()))
                 .returns(() => Promise.resolve([{} as any]))
                 .verifiable(typemoq.Times.never());
             interpreterService
@@ -235,7 +235,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .returns(() => false)
                 .verifiable(typemoq.Times.once());
             interpreterService
-                .setup((i) => i.getInterpreters(typemoq.It.isAny(), { onActivation: true }))
+                .setup((i) => i.getInterpreters(typemoq.It.isAny()))
                 .returns(() => Promise.resolve([{ path: pythonPath } as any, { path: pythonPath } as any]))
                 .verifiable(typemoq.Times.once());
             interpreterService
@@ -275,7 +275,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .returns(() => false)
                 .verifiable(typemoq.Times.once());
             interpreterService
-                .setup((i) => i.getInterpreters(typemoq.It.isAny(), { onActivation: true }))
+                .setup((i) => i.getInterpreters(typemoq.It.isAny()))
                 .returns(() =>
                     Promise.resolve([
                         { path: pythonPath } as any,

--- a/src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
@@ -106,7 +106,7 @@ suite('Interpreters - selector', () => {
                 return { ...info, ...item };
             });
             interpreterService
-                .setup((x) => x.getInterpreters(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .setup((x) => x.getInterpreters(TypeMoq.It.isAny(), { onSuggestion: true }))
                 .returns(() => new Promise((resolve) => resolve(initial)));
 
             const actual = await selector.getSuggestions(undefined);

--- a/src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
+++ b/src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
@@ -106,7 +106,7 @@ suite('Interpreters - selector', () => {
                 return { ...info, ...item };
             });
             interpreterService
-                .setup((x) => x.getInterpreters(TypeMoq.It.isAny()))
+                .setup((x) => x.getInterpreters(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
                 .returns(() => new Promise((resolve) => resolve(initial)));
 
             const actual = await selector.getSuggestions(undefined);
@@ -139,7 +139,9 @@ suite('Interpreters - selector', () => {
     test('When in Deprecate PythonPath experiment, remove unsafe interpreters from the suggested interpreters list', async () => {
         // tslint:disable-next-line: no-any
         const interpreterList = ['interpreter1', 'interpreter2', 'interpreter3'] as any;
-        interpreterService.setup((i) => i.getInterpreters(folder1.uri)).returns(() => interpreterList);
+        interpreterService
+            .setup((i) => i.getInterpreters(folder1.uri, { onSuggestion: true }))
+            .returns(() => interpreterList);
         // tslint:disable-next-line: no-any
         interpreterSecurityService.setup((i) => i.isSafe('interpreter1' as any)).returns(() => true);
         // tslint:disable-next-line: no-any

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -324,7 +324,6 @@ import {
     IKnownSearchPathsForInterpreters,
     INTERPRETER_LOCATOR_SERVICE,
     InterpreterType,
-    IPipEnvService,
     IShebangCodeLensProvider,
     IVirtualEnvironmentsSearchPathProvider,
     KNOWN_PATH_SERVICE,
@@ -1050,7 +1049,6 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
                 PipEnvService,
                 PIPENV_SERVICE
             );
-            this.serviceManager.addSingleton<IInterpreterLocatorService>(IPipEnvService, PipEnvService);
             this.serviceManager.addSingleton<IInterpreterLocatorService>(
                 IInterpreterLocatorService,
                 WindowsRegistryService,

--- a/src/test/interpreters/autoSelection/rules/currentPath.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/currentPath.unit.test.ts
@@ -69,7 +69,7 @@ suite('Interpreters - Auto Selection - Current Path Rule', () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
 
-        when(locator.getInterpreters(resource, anything())).thenResolve([]);
+        when(locator.getInterpreters(resource)).thenResolve([]);
 
         const nextAction = await rule.onAutoSelectInterpreter(resource, manager);
 

--- a/src/test/interpreters/autoSelection/rules/system.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/system.unit.test.ts
@@ -64,9 +64,8 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
     test('Invoke next rule if there are no interpreters in the current path', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
-        const options = { onActivation: true };
         let setGlobalInterpreterInvoked = false;
-        when(interpreterService.getInterpreters(resource, deepEqual(options))).thenResolve([]);
+        when(interpreterService.getInterpreters(resource)).thenResolve([]);
         when(helper.getBestInterpreter(deepEqual([]))).thenReturn(undefined);
         rule.setGlobalInterpreter = async (res: any) => {
             setGlobalInterpreterInvoked = true;
@@ -76,17 +75,16 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
 
         const nextAction = await rule.onAutoSelectInterpreter(resource, manager);
 
-        verify(interpreterService.getInterpreters(resource, deepEqual(options))).once();
+        verify(interpreterService.getInterpreters(resource)).once();
         expect(nextAction).to.be.equal(NextAction.runNextRule);
         expect(setGlobalInterpreterInvoked).to.be.equal(true, 'setGlobalInterpreter not invoked');
     });
     test('Invoke next rule if there interpreters in the current path but update fails', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
-        const options = { onActivation: true };
         let setGlobalInterpreterInvoked = false;
         const interpreterInfo = { path: '1', version: new SemVer('1.0.0') } as any;
-        when(interpreterService.getInterpreters(resource, deepEqual(options))).thenResolve([interpreterInfo]);
+        when(interpreterService.getInterpreters(resource)).thenResolve([interpreterInfo]);
         when(helper.getBestInterpreter(deepEqual([interpreterInfo]))).thenReturn(interpreterInfo);
         rule.setGlobalInterpreter = async (res: any) => {
             setGlobalInterpreterInvoked = true;
@@ -96,17 +94,16 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
 
         const nextAction = await rule.onAutoSelectInterpreter(resource, manager);
 
-        verify(interpreterService.getInterpreters(resource, deepEqual(options))).once();
+        verify(interpreterService.getInterpreters(resource)).once();
         expect(nextAction).to.be.equal(NextAction.runNextRule);
         expect(setGlobalInterpreterInvoked).to.be.equal(true, 'setGlobalInterpreter not invoked');
     });
     test('Do not Invoke next rule if there interpreters in the current path and update does not fail', async () => {
         const manager = mock(InterpreterAutoSelectionService);
         const resource = Uri.file('x');
-        const options = { onActivation: true };
         let setGlobalInterpreterInvoked = false;
         const interpreterInfo = { path: '1', version: new SemVer('1.0.0') } as any;
-        when(interpreterService.getInterpreters(resource, deepEqual(options))).thenResolve([interpreterInfo]);
+        when(interpreterService.getInterpreters(resource)).thenResolve([interpreterInfo]);
         when(helper.getBestInterpreter(deepEqual([interpreterInfo]))).thenReturn(interpreterInfo);
         rule.setGlobalInterpreter = async (res: any) => {
             setGlobalInterpreterInvoked = true;
@@ -116,7 +113,7 @@ suite('Interpreters - Auto Selection - System Interpreters Rule', () => {
 
         const nextAction = await rule.onAutoSelectInterpreter(resource, manager);
 
-        verify(interpreterService.getInterpreters(resource, deepEqual(options))).once();
+        verify(interpreterService.getInterpreters(resource)).once();
         expect(nextAction).to.be.equal(NextAction.exit);
         expect(setGlobalInterpreterInvoked).to.be.equal(true, 'setGlobalInterpreter not invoked');
     });

--- a/src/test/interpreters/locators/index.unit.test.ts
+++ b/src/test/interpreters/locators/index.unit.test.ts
@@ -68,6 +68,7 @@ suite('Interpreters - Locators Index', () => {
 
                 locatorsTypes.push(CONDA_ENV_SERVICE);
                 locatorsTypes.push(CONDA_ENV_FILE_SERVICE);
+                locatorsTypes.push(PIPENV_SERVICE);
                 locatorsTypes.push(GLOBAL_VIRTUAL_ENV_SERVICE);
                 locatorsTypes.push(WORKSPACE_VIRTUAL_ENV_SERVICE);
                 locatorsTypes.push(KNOWN_PATH_SERVICE);
@@ -89,10 +90,18 @@ suite('Interpreters - Locators Index', () => {
                         .setup((l) => l.hasInterpreters)
                         .returns(() => Promise.resolve(true))
                         .verifiable(TypeMoq.Times.once());
-                    typeLocator
-                        .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                        .returns(() => Promise.resolve([interpreter]))
-                        .verifiable(TypeMoq.Times.once());
+
+                    if (typeName === PIPENV_SERVICE) {
+                        typeLocator
+                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                            .returns(() => Promise.resolve([]))
+                            .verifiable(TypeMoq.Times.once());
+                    } else {
+                        typeLocator
+                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                            .returns(() => Promise.resolve([interpreter]))
+                            .verifiable(TypeMoq.Times.once());
+                    }
 
                     serviceContainer
                         .setup((c) =>
@@ -129,6 +138,7 @@ suite('Interpreters - Locators Index', () => {
 
                 locatorsTypes.push(CONDA_ENV_SERVICE);
                 locatorsTypes.push(CONDA_ENV_FILE_SERVICE);
+                locatorsTypes.push(PIPENV_SERVICE);
                 locatorsTypes.push(GLOBAL_VIRTUAL_ENV_SERVICE);
                 locatorsTypes.push(WORKSPACE_VIRTUAL_ENV_SERVICE);
                 locatorsTypes.push(KNOWN_PATH_SERVICE);
@@ -150,10 +160,18 @@ suite('Interpreters - Locators Index', () => {
                         .setup((l) => l.hasInterpreters)
                         .returns(() => Promise.resolve(true))
                         .verifiable(TypeMoq.Times.once());
-                    typeLocator
-                        .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                        .returns(() => Promise.resolve([interpreter]))
-                        .verifiable(TypeMoq.Times.once());
+
+                    if (typeName === PIPENV_SERVICE) {
+                        typeLocator
+                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                            .returns(() => Promise.resolve([]))
+                            .verifiable(TypeMoq.Times.once());
+                    } else {
+                        typeLocator
+                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                            .returns(() => Promise.resolve([interpreter]))
+                            .verifiable(TypeMoq.Times.once());
+                    }
 
                     serviceContainer
                         .setup((c) =>
@@ -179,153 +197,6 @@ suite('Interpreters - Locators Index', () => {
                 locatorsWithInterpreters.forEach((item) => item.locator.verifyAll());
                 helper.verifyAll();
                 expect(interpreters).to.be.lengthOf(locatorsTypes.length);
-                expect(interpreters).to.be.deep.equal(expectedInterpreters);
-            });
-
-            test(`The pipenv locator service is used when the onSuggestion option is true ${testSuffix}`, async () => {
-                const locatorsTypes: string[] = [];
-                if (osType.value === OSType.Windows) {
-                    locatorsTypes.push(WINDOWS_REGISTRY_SERVICE);
-                }
-                platformSvc.setup((p) => p.osType).returns(() => osType.value);
-                platformSvc.setup((p) => p.isWindows).returns(() => osType.value === OSType.Windows);
-                platformSvc.setup((p) => p.isLinux).returns(() => osType.value === OSType.Linux);
-                platformSvc.setup((p) => p.isMac).returns(() => osType.value === OSType.OSX);
-
-                locatorsTypes.push(CONDA_ENV_SERVICE);
-                locatorsTypes.push(CONDA_ENV_FILE_SERVICE);
-                locatorsTypes.push(PIPENV_SERVICE);
-                locatorsTypes.push(GLOBAL_VIRTUAL_ENV_SERVICE);
-                locatorsTypes.push(WORKSPACE_VIRTUAL_ENV_SERVICE);
-                locatorsTypes.push(KNOWN_PATH_SERVICE);
-                locatorsTypes.push(CURRENT_PATH_SERVICE);
-
-                const locatorsWithInterpreters = locatorsTypes.map((typeName) => {
-                    const interpreter: PythonInterpreter = {
-                        architecture: Architecture.Unknown,
-                        displayName: typeName,
-                        path: typeName,
-                        sysPrefix: typeName,
-                        sysVersion: typeName,
-                        type: InterpreterType.Unknown,
-                        version: new SemVer('0.0.0-alpha')
-                    };
-
-                    const typeLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
-                    typeLocator
-                        .setup((l) => l.hasInterpreters)
-                        .returns(() => Promise.resolve(true))
-                        .verifiable(TypeMoq.Times.once());
-                    typeLocator
-                        .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                        .returns(() => Promise.resolve([interpreter]))
-                        .verifiable(TypeMoq.Times.once());
-
-                    serviceContainer
-                        .setup((c) =>
-                            c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(typeName))
-                        )
-                        .returns(() => typeLocator.object);
-
-                    return {
-                        type: typeName,
-                        locator: typeLocator,
-                        interpreters: [interpreter]
-                    };
-                });
-
-                const expectedInterpreters = locatorsWithInterpreters.map((item) => item.interpreters[0]);
-                helper
-                    .setup((h) => h.mergeInterpreters(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve(expectedInterpreters))
-                    .verifiable(TypeMoq.Times.once());
-
-                const interpreters = await locator.getInterpreters(resource, { onSuggestion: true });
-
-                locatorsWithInterpreters.forEach((item) => item.locator.verifyAll());
-                helper.verifyAll();
-                expect(interpreters).to.be.deep.equal(expectedInterpreters);
-            });
-
-            test(`The pipenv locator service is not used when the onSuggestion option is false ${testSuffix}`, async () => {
-                const locatorsTypes: string[] = [];
-                if (osType.value === OSType.Windows) {
-                    locatorsTypes.push(WINDOWS_REGISTRY_SERVICE);
-                }
-                platformSvc.setup((p) => p.osType).returns(() => osType.value);
-                platformSvc.setup((p) => p.isWindows).returns(() => osType.value === OSType.Windows);
-                platformSvc.setup((p) => p.isLinux).returns(() => osType.value === OSType.Linux);
-                platformSvc.setup((p) => p.isMac).returns(() => osType.value === OSType.OSX);
-
-                locatorsTypes.push(CONDA_ENV_SERVICE);
-                locatorsTypes.push(CONDA_ENV_FILE_SERVICE);
-                locatorsTypes.push(PIPENV_SERVICE);
-                locatorsTypes.push(GLOBAL_VIRTUAL_ENV_SERVICE);
-                locatorsTypes.push(WORKSPACE_VIRTUAL_ENV_SERVICE);
-                locatorsTypes.push(KNOWN_PATH_SERVICE);
-                locatorsTypes.push(CURRENT_PATH_SERVICE);
-
-                const locatorsWithInterpreters = locatorsTypes.map((typeName) => {
-                    const interpreter: PythonInterpreter = {
-                        architecture: Architecture.Unknown,
-                        displayName: typeName,
-                        path: typeName,
-                        sysPrefix: typeName,
-                        sysVersion: typeName,
-                        type: InterpreterType.Unknown,
-                        version: new SemVer('0.0.0-alpha')
-                    };
-
-                    const typeLocator = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
-                    if (typeName === PIPENV_SERVICE) {
-                        typeLocator
-                            .setup((l) => l.hasInterpreters)
-                            .returns(() => Promise.resolve(true))
-                            .verifiable(TypeMoq.Times.never());
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([interpreter]))
-                            .verifiable(TypeMoq.Times.never());
-                    } else {
-                        typeLocator
-                            .setup((l) => l.hasInterpreters)
-                            .returns(() => Promise.resolve(true))
-                            .verifiable(TypeMoq.Times.once());
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([interpreter]))
-                            .verifiable(TypeMoq.Times.once());
-                    }
-
-                    serviceContainer
-                        .setup((c) =>
-                            c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(typeName))
-                        )
-                        .returns(() => typeLocator.object);
-
-                    return {
-                        type: typeName,
-                        locator: typeLocator,
-                        interpreters: [interpreter]
-                    };
-                });
-
-                const expectedInterpreters: PythonInterpreter[] = [];
-                locatorsWithInterpreters.forEach((item) => {
-                    if (item.type !== PIPENV_SERVICE) {
-                        expectedInterpreters.push(item.interpreters[0]);
-                    }
-                });
-
-                helper
-                    .setup((h) => h.mergeInterpreters(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve(expectedInterpreters))
-                    .verifiable(TypeMoq.Times.once());
-
-                const interpreters = await locator.getInterpreters(resource, { onSuggestion: false });
-
-                locatorsWithInterpreters.forEach((item) => item.locator.verifyAll());
-                helper.verifyAll();
                 expect(interpreters).to.be.deep.equal(expectedInterpreters);
             });
         });

--- a/src/test/interpreters/locators/index.unit.test.ts
+++ b/src/test/interpreters/locators/index.unit.test.ts
@@ -91,17 +91,10 @@ suite('Interpreters - Locators Index', () => {
                         .returns(() => Promise.resolve(true))
                         .verifiable(TypeMoq.Times.once());
 
-                    if (typeName === PIPENV_SERVICE) {
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([]))
-                            .verifiable(TypeMoq.Times.once());
-                    } else {
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([interpreter]))
-                            .verifiable(TypeMoq.Times.once());
-                    }
+                    typeLocator
+                        .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                        .returns(() => Promise.resolve([interpreter]))
+                        .verifiable(TypeMoq.Times.once());
 
                     serviceContainer
                         .setup((c) =>
@@ -161,17 +154,10 @@ suite('Interpreters - Locators Index', () => {
                         .returns(() => Promise.resolve(true))
                         .verifiable(TypeMoq.Times.once());
 
-                    if (typeName === PIPENV_SERVICE) {
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([]))
-                            .verifiable(TypeMoq.Times.once());
-                    } else {
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([interpreter]))
-                            .verifiable(TypeMoq.Times.once());
-                    }
+                    typeLocator
+                        .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                        .returns(() => Promise.resolve([interpreter]))
+                        .verifiable(TypeMoq.Times.once());
 
                     serviceContainer
                         .setup((c) =>
@@ -187,6 +173,7 @@ suite('Interpreters - Locators Index', () => {
                 });
 
                 const expectedInterpreters = locatorsWithInterpreters.map((item) => item.interpreters[0]);
+
                 helper
                     .setup((h) => h.mergeInterpreters(TypeMoq.It.isAny()))
                     .returns(() => Promise.resolve(expectedInterpreters))
@@ -196,7 +183,6 @@ suite('Interpreters - Locators Index', () => {
 
                 locatorsWithInterpreters.forEach((item) => item.locator.verifyAll());
                 helper.verifyAll();
-                expect(interpreters).to.be.lengthOf(locatorsTypes.length);
                 expect(interpreters).to.be.deep.equal(expectedInterpreters);
             });
             test(`didTriggerInterpreterSuggestions is set to true in the locators if onSuggestion is true ${testSuffix}`, async () => {
@@ -233,19 +219,11 @@ suite('Interpreters - Locators Index', () => {
                         .setup((l) => l.hasInterpreters)
                         .returns(() => Promise.resolve(true))
                         .verifiable(TypeMoq.Times.once());
-                    // typeLocator.setup((l) => l.didTriggerInterpreterSuggestions).verifiable(TypeMoq.Times.once());
 
-                    if (typeName === PIPENV_SERVICE) {
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([]))
-                            .verifiable(TypeMoq.Times.once());
-                    } else {
-                        typeLocator
-                            .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
-                            .returns(() => Promise.resolve([interpreter]))
-                            .verifiable(TypeMoq.Times.once());
-                    }
+                    typeLocator
+                        .setup((l) => l.getInterpreters(TypeMoq.It.isValue(resource)))
+                        .returns(() => Promise.resolve([interpreter]))
+                        .verifiable(TypeMoq.Times.once());
 
                     serviceContainer
                         .setup((c) =>
@@ -260,26 +238,19 @@ suite('Interpreters - Locators Index', () => {
                     };
                 });
 
-                const expectedInterpreters = locatorsWithInterpreters.map((item) => item.interpreters[0]);
-
                 helper
                     .setup((h) => h.mergeInterpreters(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve(expectedInterpreters))
-                    .verifiable(TypeMoq.Times.once());
+                    .returns(() => Promise.resolve(locatorsWithInterpreters.map((item) => item.interpreters[0])));
 
-                const interpreters = await locator.getInterpreters(resource, { onSuggestion: true });
+                await locator.getInterpreters(resource, { onSuggestion: true });
 
-                locatorsWithInterpreters.forEach((item) => item.locator.verifyAll());
                 locatorsWithInterpreters.forEach((item) =>
                     item.locator.verify((l) => (l.didTriggerInterpreterSuggestions = true), TypeMoq.Times.once())
                 );
-                helper.verifyAll();
                 expect(locator.didTriggerInterpreterSuggestions).to.equal(
                     true,
                     'didTriggerInterpreterSuggestions should be set to true.'
                 );
-                expect(interpreters).to.be.lengthOf(locatorsTypes.length);
-                expect(interpreters).to.be.deep.equal(expectedInterpreters);
             });
         });
     });

--- a/src/test/interpreters/pipEnvService.unit.test.ts
+++ b/src/test/interpreters/pipEnvService.unit.test.ts
@@ -60,6 +60,7 @@ suite('Interpreters - PipEnv', () => {
             let settings: TypeMoq.IMock<IPythonSettings>;
             let pipenvPathSetting: string;
             let pipEnvServiceHelper: IPipEnvServiceHelper;
+
             setup(() => {
                 serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
                 const workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
@@ -136,6 +137,11 @@ suite('Interpreters - PipEnv', () => {
                 pipenvPathSetting = 'pipenv';
 
                 pipEnvService = new PipEnvService(serviceContainer.object);
+                sinon.stub(pipEnvService, 'didTriggerInterpreterSuggestions').get(() => true);
+            });
+
+            teardown(() => {
+                sinon.restore();
             });
 
             test(`Should return an empty list'${testSuffix}`, () => {

--- a/src/test/interpreters/pipEnvService.unit.test.ts
+++ b/src/test/interpreters/pipEnvService.unit.test.ts
@@ -137,157 +137,204 @@ suite('Interpreters - PipEnv', () => {
                 pipenvPathSetting = 'pipenv';
 
                 pipEnvService = new PipEnvService(serviceContainer.object);
-                sinon.stub(pipEnvService, 'didTriggerInterpreterSuggestions').get(() => true);
             });
 
-            teardown(() => {
-                sinon.restore();
+            suite('With didTriggerInterpreterSuggestions set to true', () => {
+                setup(() => {
+                    sinon.stub(pipEnvService, 'didTriggerInterpreterSuggestions').get(() => true);
+                });
+
+                teardown(() => {
+                    sinon.restore();
+                });
+
+                test(`Should return an empty list'${testSuffix}`, () => {
+                    const environments = pipEnvService.getInterpreters(resource);
+                    expect(environments).to.be.eventually.deep.equal([]);
+                });
+                test(`Should return an empty list if there is no \'PipFile\'${testSuffix}`, async () => {
+                    const env = {};
+                    envVarsProvider
+                        .setup((e) => e.getEnvironmentVariables(TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({}))
+                        .verifiable(TypeMoq.Times.once());
+                    currentProcess.setup((c) => c.env).returns(() => env);
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
+                        .returns(() => Promise.resolve(false))
+                        .verifiable(TypeMoq.Times.once());
+                    const environments = await pipEnvService.getInterpreters(resource);
+
+                    expect(environments).to.be.deep.equal([]);
+                    fileSystem.verifyAll();
+                });
+                test(`Should display warning message if there is a \'PipFile\' but \'pipenv --version\' fails ${testSuffix}`, async () => {
+                    const env = {};
+                    currentProcess.setup((c) => c.env).returns(() => env);
+                    processService
+                        .setup((p) =>
+                            p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())
+                        )
+                        .returns(() => Promise.reject(''));
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
+                        .returns(() => Promise.resolve(true));
+                    const warningMessage =
+                        "Workspace contains Pipfile but 'pipenv' was not found. Make sure 'pipenv' is on the PATH.";
+                    appShell
+                        .setup((a) => a.showWarningMessage(warningMessage))
+                        .returns(() => Promise.resolve(''))
+                        .verifiable(TypeMoq.Times.once());
+                    const environments = await pipEnvService.getInterpreters(resource);
+
+                    expect(environments).to.be.deep.equal([]);
+                    appShell.verifyAll();
+                });
+                test(`Should display warning message if there is a \'PipFile\' but \'pipenv --venv\' fails with stderr ${testSuffix}`, async () => {
+                    const env = {};
+                    currentProcess.setup((c) => c.env).returns(() => env);
+                    processService
+                        .setup((p) =>
+                            p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())
+                        )
+                        .returns(() => Promise.resolve({ stderr: '', stdout: 'pipenv, version 2018.11.26' }));
+                    processService
+                        .setup((p) =>
+                            p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isValue(['--venv']), TypeMoq.It.isAny())
+                        )
+                        .returns(() => Promise.resolve({ stderr: 'Aborted!', stdout: '' }));
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
+                        .returns(() => Promise.resolve(true));
+                    const warningMessage =
+                        'Workspace contains Pipfile but the associated virtual environment has not been setup. Setup the virtual environment manually if needed.';
+                    appShell
+                        .setup((a) => a.showWarningMessage(warningMessage))
+                        .returns(() => Promise.resolve(''))
+                        .verifiable(TypeMoq.Times.once());
+                    const environments = await pipEnvService.getInterpreters(resource);
+
+                    expect(environments).to.be.deep.equal([]);
+                    appShell.verifyAll();
+                });
+                test(`Should return interpreter information${testSuffix}`, async () => {
+                    const env = {};
+                    const pythonPath = 'one';
+                    envVarsProvider
+                        .setup((e) => e.getEnvironmentVariables(TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({}))
+                        .verifiable(TypeMoq.Times.once());
+                    currentProcess.setup((c) => c.env).returns(() => env);
+                    processService
+                        .setup((p) => p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({ stdout: pythonPath }));
+                    interpreterHelper
+                        .setup((v) => v.getInterpreterInformation(TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({ version: new SemVer('1.0.0') }));
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
+                        .returns(() => Promise.resolve(true))
+                        .verifiable();
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(pythonPath)))
+                        .returns(() => Promise.resolve(true))
+                        .verifiable();
+
+                    const environments = await pipEnvService.getInterpreters(resource);
+
+                    expect(environments).to.be.lengthOf(1);
+                    fileSystem.verifyAll();
+                });
+                test(`Should return interpreter information using PipFile defined in Env variable${testSuffix}`, async () => {
+                    const envPipFile = 'XYZ';
+                    const env = {
+                        PIPENV_PIPFILE: envPipFile
+                    };
+                    const pythonPath = 'one';
+                    envVarsProvider
+                        .setup((e) => e.getEnvironmentVariables(TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({}))
+                        .verifiable(TypeMoq.Times.once());
+                    currentProcess.setup((c) => c.env).returns(() => env);
+                    processService
+                        .setup((p) => p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({ stdout: pythonPath }));
+                    interpreterHelper
+                        .setup((v) => v.getInterpreterInformation(TypeMoq.It.isAny()))
+                        .returns(() => Promise.resolve({ version: new SemVer('1.0.0') }));
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
+                        .returns(() => Promise.resolve(false))
+                        .verifiable(TypeMoq.Times.never());
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, envPipFile))))
+                        .returns(() => Promise.resolve(true))
+                        .verifiable(TypeMoq.Times.once());
+                    fileSystem
+                        .setup((fs) => fs.fileExists(TypeMoq.It.isValue(pythonPath)))
+                        .returns(() => Promise.resolve(true))
+                        .verifiable();
+                    const environments = await pipEnvService.getInterpreters(resource);
+
+                    expect(environments).to.be.lengthOf(1);
+                    fileSystem.verifyAll();
+                });
+                test("Must use 'python.pipenvPath' setting", async () => {
+                    pipenvPathSetting = 'spam-spam-pipenv-spam-spam';
+                    const pipenvExe = pipEnvService.executable;
+                    assert.equal(pipenvExe, 'spam-spam-pipenv-spam-spam', 'Failed to identify pipenv.exe');
+                });
+
+                test('Should send telemetry event when calling getInterpreters', async () => {
+                    const sendTelemetryStub = sinon.stub(Telemetry, 'sendTelemetryEvent');
+
+                    await pipEnvService.getInterpreters(resource);
+
+                    sinon.assert.calledWith(sendTelemetryStub, EventName.PIPENV_INTERPRETER_DISCOVERY);
+                    sinon.restore();
+                });
             });
 
-            test(`Should return an empty list'${testSuffix}`, () => {
-                const environments = pipEnvService.getInterpreters(resource);
-                expect(environments).to.be.eventually.deep.equal([]);
-            });
-            test(`Should return an empty list if there is no \'PipFile\'${testSuffix}`, async () => {
-                const env = {};
-                envVarsProvider
-                    .setup((e) => e.getEnvironmentVariables(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({}))
-                    .verifiable(TypeMoq.Times.once());
-                currentProcess.setup((c) => c.env).returns(() => env);
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
-                    .returns(() => Promise.resolve(false))
-                    .verifiable(TypeMoq.Times.once());
-                const environments = await pipEnvService.getInterpreters(resource);
+            suite('With didTriggerInterpreterSuggestions set to false', () => {
+                let didTriggerInterpreterSuggestionsStub: sinon.SinonStub;
 
-                expect(environments).to.be.deep.equal([]);
-                fileSystem.verifyAll();
-            });
-            test(`Should display warning message if there is a \'PipFile\' but \'pipenv --version\' fails ${testSuffix}`, async () => {
-                const env = {};
-                currentProcess.setup((c) => c.env).returns(() => env);
-                processService
-                    .setup((p) =>
-                        p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())
-                    )
-                    .returns(() => Promise.reject(''));
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
-                    .returns(() => Promise.resolve(true));
-                const warningMessage =
-                    "Workspace contains Pipfile but 'pipenv' was not found. Make sure 'pipenv' is on the PATH.";
-                appShell
-                    .setup((a) => a.showWarningMessage(warningMessage))
-                    .returns(() => Promise.resolve(''))
-                    .verifiable(TypeMoq.Times.once());
-                const environments = await pipEnvService.getInterpreters(resource);
+                setup(() => {
+                    didTriggerInterpreterSuggestionsStub = sinon
+                        .stub(pipEnvService, 'didTriggerInterpreterSuggestions')
+                        .get(() => false);
+                });
 
-                expect(environments).to.be.deep.equal([]);
-                appShell.verifyAll();
-            });
-            test(`Should display warning message if there is a \'PipFile\' but \'pipenv --venv\' fails with stderr ${testSuffix}`, async () => {
-                const env = {};
-                currentProcess.setup((c) => c.env).returns(() => env);
-                processService
-                    .setup((p) =>
-                        p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isValue(['--version']), TypeMoq.It.isAny())
-                    )
-                    .returns(() => Promise.resolve({ stderr: '', stdout: 'pipenv, version 2018.11.26' }));
-                processService
-                    .setup((p) =>
-                        p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isValue(['--venv']), TypeMoq.It.isAny())
-                    )
-                    .returns(() => Promise.resolve({ stderr: 'Aborted!', stdout: '' }));
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
-                    .returns(() => Promise.resolve(true));
-                const warningMessage =
-                    'Workspace contains Pipfile but the associated virtual environment has not been setup. Setup the virtual environment manually if needed.';
-                appShell
-                    .setup((a) => a.showWarningMessage(warningMessage))
-                    .returns(() => Promise.resolve(''))
-                    .verifiable(TypeMoq.Times.once());
-                const environments = await pipEnvService.getInterpreters(resource);
+                test('isRelatedPipEnvironment should exit early', async () => {
+                    processService
+                        .setup((p) => p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                        .verifiable(TypeMoq.Times.never());
 
-                expect(environments).to.be.deep.equal([]);
-                appShell.verifyAll();
-            });
-            test(`Should return interpreter information${testSuffix}`, async () => {
-                const env = {};
-                const pythonPath = 'one';
-                envVarsProvider
-                    .setup((e) => e.getEnvironmentVariables(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({}))
-                    .verifiable(TypeMoq.Times.once());
-                currentProcess.setup((c) => c.env).returns(() => env);
-                processService
-                    .setup((p) => p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({ stdout: pythonPath }));
-                interpreterHelper
-                    .setup((v) => v.getInterpreterInformation(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({ version: new SemVer('1.0.0') }));
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
-                    .returns(() => Promise.resolve(true))
-                    .verifiable();
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(pythonPath)))
-                    .returns(() => Promise.resolve(true))
-                    .verifiable();
+                    const result = await pipEnvService.isRelatedPipEnvironment('foo', 'some/python/path');
 
-                const environments = await pipEnvService.getInterpreters(resource);
+                    expect(result).to.be.equal(false, 'isRelatedPipEnvironment should return false.');
+                    processService.verifyAll();
+                });
 
-                expect(environments).to.be.lengthOf(1);
-                fileSystem.verifyAll();
-            });
-            test(`Should return interpreter information using PipFile defined in Env variable${testSuffix}`, async () => {
-                const envPipFile = 'XYZ';
-                const env = {
-                    PIPENV_PIPFILE: envPipFile
-                };
-                const pythonPath = 'one';
-                envVarsProvider
-                    .setup((e) => e.getEnvironmentVariables(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({}))
-                    .verifiable(TypeMoq.Times.once());
-                currentProcess.setup((c) => c.env).returns(() => env);
-                processService
-                    .setup((p) => p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({ stdout: pythonPath }));
-                interpreterHelper
-                    .setup((v) => v.getInterpreterInformation(TypeMoq.It.isAny()))
-                    .returns(() => Promise.resolve({ version: new SemVer('1.0.0') }));
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, 'Pipfile'))))
-                    .returns(() => Promise.resolve(false))
-                    .verifiable(TypeMoq.Times.never());
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(path.join(rootWorkspace, envPipFile))))
-                    .returns(() => Promise.resolve(true))
-                    .verifiable(TypeMoq.Times.once());
-                fileSystem
-                    .setup((fs) => fs.fileExists(TypeMoq.It.isValue(pythonPath)))
-                    .returns(() => Promise.resolve(true))
-                    .verifiable();
-                const environments = await pipEnvService.getInterpreters(resource);
+                test('Executable getter should return an empty string', () => {
+                    const executable = pipEnvService.executable;
 
-                expect(environments).to.be.lengthOf(1);
-                fileSystem.verifyAll();
-            });
-            test("Must use 'python.pipenvPath' setting", async () => {
-                pipenvPathSetting = 'spam-spam-pipenv-spam-spam';
-                const pipenvExe = pipEnvService.executable;
-                assert.equal(pipenvExe, 'spam-spam-pipenv-spam-spam', 'Failed to identify pipenv.exe');
-            });
+                    expect(executable).to.be.equal('', 'The executable getter should return an empty string.');
+                });
 
-            test('Should send telemetry event when calling getInterpreters', async () => {
-                const sendTelemetryStub = sinon.stub(Telemetry, 'sendTelemetryEvent');
+                test('getInterpreters should exit early', async () => {
+                    processService
+                        .setup((p) => p.exec(TypeMoq.It.isValue('pipenv'), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                        .verifiable(TypeMoq.Times.never());
 
-                await pipEnvService.getInterpreters(resource);
+                    const interpreters = await pipEnvService.getInterpreters(resource);
 
-                sinon.assert.calledWith(sendTelemetryStub, EventName.PIPENV_INTERPRETER_DISCOVERY);
-                sinon.restore();
+                    expect(interpreters).to.be.lengthOf(0);
+                    processService.verifyAll();
+                });
+
+                teardown(() => {
+                    sinon.restore();
+                });
             });
         });
     });

--- a/src/test/interpreters/pipEnvService.unit.test.ts
+++ b/src/test/interpreters/pipEnvService.unit.test.ts
@@ -296,12 +296,12 @@ suite('Interpreters - PipEnv', () => {
             });
 
             suite('With didTriggerInterpreterSuggestions set to false', () => {
-                let didTriggerInterpreterSuggestionsStub: sinon.SinonStub;
-
                 setup(() => {
-                    didTriggerInterpreterSuggestionsStub = sinon
-                        .stub(pipEnvService, 'didTriggerInterpreterSuggestions')
-                        .get(() => false);
+                    sinon.stub(pipEnvService, 'didTriggerInterpreterSuggestions').get(() => false);
+                });
+
+                teardown(() => {
+                    sinon.restore();
                 });
 
                 test('isRelatedPipEnvironment should exit early', async () => {

--- a/src/test/interpreters/pipEnvService.unit.test.ts
+++ b/src/test/interpreters/pipEnvService.unit.test.ts
@@ -331,10 +331,6 @@ suite('Interpreters - PipEnv', () => {
                     expect(interpreters).to.be.lengthOf(0);
                     processService.verifyAll();
                 });
-
-                teardown(() => {
-                    sinon.restore();
-                });
             });
         });
     });

--- a/src/test/interpreters/serviceRegistry.unit.test.ts
+++ b/src/test/interpreters/serviceRegistry.unit.test.ts
@@ -61,7 +61,6 @@ import {
     IInterpreterWatcherBuilder,
     IKnownSearchPathsForInterpreters,
     INTERPRETER_LOCATOR_SERVICE,
-    IPipEnvService,
     IShebangCodeLensProvider,
     IVirtualEnvironmentsSearchPathProvider,
     KNOWN_PATH_SERVICE,
@@ -148,7 +147,6 @@ suite('Interpreters - Service Registry', () => {
             [IInterpreterLocatorService, GlobalVirtualEnvService, GLOBAL_VIRTUAL_ENV_SERVICE],
             [IInterpreterLocatorService, WorkspaceVirtualEnvService, WORKSPACE_VIRTUAL_ENV_SERVICE],
             [IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE],
-            [IPipEnvService, PipEnvService],
 
             [IInterpreterLocatorService, WindowsRegistryService, WINDOWS_REGISTRY_SERVICE],
             [IInterpreterLocatorService, KnownPathsService, KNOWN_PATH_SERVICE],

--- a/src/test/interpreters/virtualEnvManager.unit.test.ts
+++ b/src/test/interpreters/virtualEnvManager.unit.test.ts
@@ -10,7 +10,7 @@ import { Uri, WorkspaceFolder } from 'vscode';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { IFileSystem } from '../../client/common/platform/types';
 import { IProcessServiceFactory } from '../../client/common/process/types';
-import { IPipEnvService } from '../../client/interpreter/contracts';
+import { IInterpreterLocatorService, IPipEnvService, PIPENV_SERVICE } from '../../client/interpreter/contracts';
 import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
 import { IServiceContainer } from '../../client/ioc/types';
 
@@ -41,7 +41,7 @@ suite('Virtual environment manager', () => {
         expect(name).to.be.equal(virtualEnvFolderName);
     });
 
-    test('Use workspacec name as env name', async () => {
+    test('Use workspace name as env name', async () => {
         const serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         const pipEnvService = TypeMoq.Mock.ofType<IPipEnvService>();
         pipEnvService
@@ -51,7 +51,9 @@ suite('Virtual environment manager', () => {
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IProcessServiceFactory)))
             .returns(() => TypeMoq.Mock.ofType<IProcessServiceFactory>().object);
-        serviceContainer.setup((s) => s.get(TypeMoq.It.isValue(IPipEnvService))).returns(() => pipEnvService.object);
+        serviceContainer
+            .setup((s) => s.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(PIPENV_SERVICE)))
+            .returns(() => pipEnvService.object);
         serviceContainer
             .setup((s) => s.get(TypeMoq.It.isValue(IFileSystem)))
             .returns(() => TypeMoq.Mock.ofType<IFileSystem>().object);
@@ -83,7 +85,9 @@ suite('Virtual environment manager', () => {
         pipEnvService
             .setup((w) => w.isRelatedPipEnvironment(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(isPipEnvironment));
-        serviceContainer.setup((s) => s.get(TypeMoq.It.isValue(IPipEnvService))).returns(() => pipEnvService.object);
+        serviceContainer
+            .setup((s) => s.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(PIPENV_SERVICE)))
+            .returns(() => pipEnvService.object);
         const workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         workspaceService.setup((w) => w.hasWorkspaceFolders).returns(() => false);
         if (resource) {

--- a/src/test/interpreters/virtualEnvs/index.unit.test.ts
+++ b/src/test/interpreters/virtualEnvs/index.unit.test.ts
@@ -14,7 +14,12 @@ import { IFileSystem, IPlatformService } from '../../../client/common/platform/t
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
 import { ITerminalActivationCommandProvider } from '../../../client/common/terminal/types';
 import { ICurrentProcess, IPathUtils } from '../../../client/common/types';
-import { InterpreterType, IPipEnvService } from '../../../client/interpreter/contracts';
+import {
+    IInterpreterLocatorService,
+    InterpreterType,
+    IPipEnvService,
+    PIPENV_SERVICE
+} from '../../../client/interpreter/contracts';
 import { VirtualEnvironmentManager } from '../../../client/interpreter/virtualEnvs';
 import { IServiceContainer } from '../../../client/ioc/types';
 
@@ -51,7 +56,9 @@ suite('Virtual Environment Manager', () => {
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IPathUtils))).returns(() => pathUtils.object);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fs.object);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IWorkspaceService))).returns(() => workspace.object);
-        serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IPipEnvService))).returns(() => pipEnvService.object);
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(PIPENV_SERVICE)))
+            .returns(() => pipEnvService.object);
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(ITerminalActivationCommandProvider), TypeMoq.It.isAny()))
             .returns(() => terminalActivation.object);

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -55,7 +55,6 @@ import {
     IInterpreterLocatorService,
     IInterpreterService,
     INTERPRETER_LOCATOR_SERVICE,
-    IPipEnvService,
     KNOWN_PATH_SERVICE,
     PIPENV_SERVICE,
     WINDOWS_REGISTRY_SERVICE,
@@ -379,7 +378,6 @@ export class IocContainer {
             KnownPathsService,
             KNOWN_PATH_SERVICE
         );
-        this.serviceManager.addSingleton<IInterpreterLocatorService>(IPipEnvService, PipEnvService);
 
         this.serviceManager.addSingleton<IInterpreterLocatorHelper>(
             IInterpreterLocatorHelper,


### PR DESCRIPTION
For #11127 

Instead of tracking all the places that call `getInterpreters` on activation, and passing `{ onActivation: true}` 15 levels deep, here's the new plan:
- remove:
   - the `onActivation` option
   - the registration of the `IPipEnvService` singleton
- add an `onSuggestion` option that will be `true` when the user clicks on the interpreter in the bottom-left corner or runs the select interpreter command. This will set a `didTriggerSuggestions` boolean to true the first time an interpreter is selected
- if `didTriggerSuggestions` is true -> set it to true inside the locators as well
- whenever a method from the pipenv locator is executed -> exit early if `didTriggerSuggestions` is not true

-----

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
