### PR TITLE
Revert vscode-extension-telemetry changes for the release (#11602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,8 +91,6 @@
    ([#11221](https://github.com/Microsoft/vscode-python/issues/11221))
 1. Lazy load types from `jupyterlab/services` and similar `npm modules`.
    ([#11297](https://github.com/Microsoft/vscode-python/issues/11297))
-1. Update telemetry on errors and exceptions to use [vscode-extension-telemetry](https://www.npmjs.com/package/vscode-extension-telemetry).
-   ([#11436](https://github.com/Microsoft/vscode-python/issues/11436))
 1. Remove IJMPConnection implementation while maintaining tests written for it.
    ([#11470](https://github.com/Microsoft/vscode-python/issues/11470))
 1. Implement an IJupyterVariables provider for the debugger.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -287,9 +287,7 @@ function getAllowedWarningsForWebPack(buildConfig) {
                 'WARNING in ./node_modules/@jupyterlab/services/node_modules/ws/lib/validation.js',
                 'WARNING in ./node_modules/any-promise/register.js',
                 'WARNING in ./node_modules/log4js/lib/appenders/index.js',
-                'WARNING in ./node_modules/log4js/lib/clustering.js',
-                'WARNING in ./node_modules/diagnostic-channel-publishers/dist/src/azure-coretracing.pub.js',
-                'WARNING in ./node_modules/applicationinsights/out/AutoCollection/NativePerformance.js'
+                'WARNING in ./node_modules/log4js/lib/clustering.js'
             ];
         case 'extension':
             return [
@@ -302,16 +300,10 @@ function getAllowedWarningsForWebPack(buildConfig) {
                 'remove-files-plugin@1.4.0:',
                 'WARNING in ./node_modules/@jupyterlab/services/node_modules/ws/lib/buffer-util.js',
                 'WARNING in ./node_modules/@jupyterlab/services/node_modules/ws/lib/validation.js',
-                'WARNING in ./node_modules/@jupyterlab/services/node_modules/ws/lib/Validation.js',
-                'WARNING in ./node_modules/diagnostic-channel-publishers/dist/src/azure-coretracing.pub.js',
-                'WARNING in ./node_modules/applicationinsights/out/AutoCollection/NativePerformance.js'
+                'WARNING in ./node_modules/@jupyterlab/services/node_modules/ws/lib/Validation.js'
             ];
         case 'debugAdapter':
-            return [
-                'WARNING in ./node_modules/vscode-uri/lib/index.js',
-                'WARNING in ./node_modules/diagnostic-channel-publishers/dist/src/azure-coretracing.pub.js',
-                'WARNING in ./node_modules/applicationinsights/out/AutoCollection/NativePerformance.js'
-            ];
+            return ['WARNING in ./node_modules/vscode-uri/lib/index.js'];
         default:
             throw new Error('Unknown WebPack Configuration');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4657,14 +4657,13 @@
             }
         },
         "applicationinsights": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-            "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.0.6.tgz",
+            "integrity": "sha512-VQT3kBpJVPw5fCO5n+WUeSx0VHjxFtD7znYbILBlVgOS9/cMDuGFmV2Br3ObzFyZUDGNbEfW36fD1y2/vAiCKw==",
             "requires": {
-                "cls-hooked": "^4.2.2",
-                "continuation-local-storage": "^3.2.1",
                 "diagnostic-channel": "0.2.0",
-                "diagnostic-channel-publishers": "^0.3.3"
+                "diagnostic-channel-publishers": "0.2.1",
+                "zone.js": "0.7.6"
             }
         },
         "aproba": {
@@ -5231,27 +5230,10 @@
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
-        "async-hook-jl": {
-            "version": "1.7.6",
-            "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-            "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-            "requires": {
-                "stack-chain": "^1.3.7"
-            }
-        },
         "async-limiter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
             "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-        },
-        "async-listener": {
-            "version": "0.6.10",
-            "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-            "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-            "requires": {
-                "semver": "^5.3.0",
-                "shimmer": "^1.1.0"
-            }
         },
         "async-settle": {
             "version": "1.0.0",
@@ -6825,16 +6807,6 @@
                 }
             }
         },
-        "cls-hooked": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-            "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-            "requires": {
-                "async-hook-jl": "^1.7.6",
-                "emitter-listener": "^1.0.1",
-                "semver": "^5.4.1"
-            }
-        },
         "clsx": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
@@ -7175,15 +7147,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-        },
-        "continuation-local-storage": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-            "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-            "requires": {
-                "async-listener": "^0.6.0",
-                "emitter-listener": "^1.1.1"
-            }
         },
         "convert-source-map": {
             "version": "1.6.0",
@@ -8727,9 +8690,9 @@
             }
         },
         "diagnostic-channel-publishers": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
-            "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.2.1.tgz",
+            "integrity": "sha1-ji1geottef6IC1SLxYzGvrKIxPM="
         },
         "diagnostics": {
             "version": "1.1.1",
@@ -9094,14 +9057,6 @@
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0",
                 "minimalistic-crypto-utils": "^1.0.0"
-            }
-        },
-        "emitter-listener": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-            "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-            "requires": {
-                "shimmer": "^1.2.0"
             }
         },
         "emoji-regex": {
@@ -20713,11 +20668,6 @@
                 }
             }
         },
-        "shimmer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-            "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-        },
         "shortid": {
             "version": "2.2.14",
             "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
@@ -21309,11 +21259,6 @@
             "requires": {
                 "figgy-pudding": "^3.5.1"
             }
-        },
-        "stack-chain": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-            "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
         },
         "stack-trace": {
             "version": "0.0.10",
@@ -24618,11 +24563,11 @@
             "integrity": "sha512-+OMm11R1bGYbpIJ5eQIkwoDGFF4GvBz3Ztl6/VM+/RNNb2Gjk2c0Ku+oMmfhlTmTlPCpgHBsH4JqVCbUYhu5bA=="
         },
         "vscode-extension-telemetry": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.4.tgz",
-            "integrity": "sha512-9U2pUZ/YwZBfA8CkBrHwMxjnq9Ab+ng8daJWJzEQ6CAxlZyRhmck23bx2lqqpEwGWJCiuceQy4k0Me6llEB4zw==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.0.tgz",
+            "integrity": "sha512-WVCnP+uLxlqB6UD98yQNV47mR5Rf79LFxpuZhSPhEf0Sb4tPZed3a63n003/dchhOwyCTCBuNN4n8XKJkLEI1Q==",
             "requires": {
-                "applicationinsights": "1.7.4"
+                "applicationinsights": "1.0.6"
             }
         },
         "vscode-jsonrpc": {
@@ -25736,6 +25681,11 @@
                     }
                 }
             }
+        },
+        "zone.js": {
+            "version": "0.7.6",
+            "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.6.tgz",
+            "integrity": "sha1-+7w50+AmHQmG8boGMG6zrrDSIAk="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -2980,7 +2980,7 @@
         "untildify": "^3.0.2",
         "vscode-debugadapter": "^1.28.0",
         "vscode-debugprotocol": "^1.28.0",
-        "vscode-extension-telemetry": "0.1.4",
+        "vscode-extension-telemetry": "0.1.0",
         "vscode-jsonrpc": "^5.0.1",
         "vscode-languageclient": "^6.2.0-next.2",
         "vscode-languageserver": "^6.2.0-next.2",

--- a/src/client/telemetry/vscode-extension-telemetry.d.ts
+++ b/src/client/telemetry/vscode-extension-telemetry.d.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+declare module 'vscode-extension-telemetry' {
+    export default class TelemetryReporter {
+        /**
+         * Constructs a new telemetry reporter
+         * @param {string} extensionId All events will be prefixed with this event name
+         * @param {string} extensionVersion Extension version to be reported with each event
+         * @param {string} key The application insights key
+         */
+        // tslint:disable-next-line:no-empty
+        constructor(extensionId: string, extensionVersion: string, key: string);
+
+        /**
+         * Sends a telemetry event
+         * @param {string} eventName The event name
+         * @param {object} properties An associative array of strings
+         * @param {object} measures An associative array of numbers
+         */
+        // tslint:disable-next-line:member-access
+        public sendTelemetryEvent(
+            eventName: string,
+            properties?: {
+                [key: string]: string;
+            },
+            measures?: {
+                [key: string]: number;
+                // tslint:disable-next-line:no-empty
+            }
+        ): void;
+    }
+}

--- a/src/test/testing/helper.ts
+++ b/src/test/testing/helper.ts
@@ -32,7 +32,7 @@ export function lookForTestFile(tests: Tests, testFile: string) {
 // Only "/" (forward slash) in the given filename is affected.
 //
 // This helps with readability in test code.  It allows us to use
-// literals for filenames and dirnames instead of path.join().
+// literals for filenames and dirnames instead of oath.join().
 export function fixPath(filename: string): string {
     return filename.replace(/\//, sep);
 }


### PR DESCRIPTION
* Revert "Fix slashes in telemetry unit tests (#11572)"
This reverts commit 7431c9c53fa5f80fd440b47ae19a825286d3d760.
* Revert "Use vscode-extension-telemetry for our exceptions & error telemetry (#11524)"
This reverts commit d5065e6976ab8bf3289d70be4a34110a53b224c5.
* Remove from changelog