### PR TITLE
Remove all other version of debugpy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-          # We need to have debugpy available in wheels/ so that tests relying on it keep passing, but we don't need install_debugpy's logic in the test phase.
+          # We need to have debugpy so that tests relying on it keep passing, but we don't need install_debugpy's logic in the test phase.
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
 
       - name: Install test requirements
@@ -270,13 +270,19 @@ jobs:
           python -m pip install --upgrade -r ./build/ipython-test-requirements.txt
         if: matrix.test-suite == 'python-unit'
 
-      - name: Install debugpy wheels
+      - name: Install debugpy wheels (python 3.8)
         run: |
           python -m pip install wheel
           python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
           python ./pythonFiles/install_debugpy.py
         shell: bash
         if: matrix.test-suite == 'debugger' && matrix.python == 3.8
+
+      - name: Install debugpy (python 2.7)
+        run: |
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+        shell: bash
+        if: matrix.test-suite == 'debugger' && matrix.python == 2.7
 
       - name: Install functional test requirements
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
 
       - name: Install debugpy wheels
         run: |
@@ -259,9 +258,8 @@ jobs:
         run: |
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
           # We need to have debugpy available in wheels/ so that tests relying on it keep passing, but we don't need install_debugpy's logic in the test phase.
-          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
 
       - name: Install test requirements
         run: python -m pip install --upgrade -r build/test-requirements.txt
@@ -454,7 +452,7 @@ jobs:
           python -m pip install --upgrade -r build/test-requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
           python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+          python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
         shell: bash
 
       - name: pip install ipython requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,6 +301,9 @@ Steps to build the extension on your machine once you've cloned the repo:
 > npm ci
 > python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
 > python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
+# For python 3.6 and lower use this command to install the debugger
+> python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
+# For python 3.7 and greater use this command to install the debugger
 > python3 -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
 > python3 ./pythonFiles/install_debugpy.py
 > npm run clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,7 +301,6 @@ Steps to build the extension on your machine once you've cloned the repo:
 > npm ci
 > python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
 > python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-> python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
 > python3 -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
 > python3 ./pythonFiles/install_debugpy.py
 > npm run clean

--- a/build/ci/templates/steps/build.yml
+++ b/build/ci/templates/steps/build.yml
@@ -21,7 +21,6 @@ steps:
   - bash: |
       python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
       python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-      python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
     failOnStderr: true
     displayName: 'pip install requirements'
 

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -82,7 +82,7 @@ steps:
   - template: steps/generate_upload_coverage.yml
 
   # Install the requirements for the Python or the system tests. This includes the supporting libs that
-  # we ship in our extension such as PTVSD and Jedi.
+  # we ship in our extension such as PTVSD, DEBUGPY and Jedi.
   #
   # This task will only run if variable `NeedsPythonTestReqs` is true.
   #
@@ -94,6 +94,7 @@ steps:
       python -m pip install --upgrade -r build/test-requirements.txt
       python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
       python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
+      python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
     displayName: 'pip install system test requirements'
     condition: and(succeeded(), eq(variables['NeedsPythonTestReqs'], 'true'))
 
@@ -202,7 +203,7 @@ steps:
       python ./pythonFiles/install_debugpy.py
     failOnStderr: true
     displayName: 'Install DEBUGPY wheels'
-    condition: and(succeeded(), eq(variables['NeedsPythonTestReqs'], 'true'))
+    condition: and(eq(variables['NeedsPythonTestReqs'], 'true'), eq(variables['PythonVersion'], '3.7'))
 
   # Run the Python unit tests in our codebase. Produces a JUnit-style log file that
   # will be uploaded after all tests are complete.

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -82,7 +82,7 @@ steps:
   - template: steps/generate_upload_coverage.yml
 
   # Install the requirements for the Python or the system tests. This includes the supporting libs that
-  # we ship in our extension such as PTVSD, DEBUGPY and Jedi.
+  # we ship in our extension such as PTVSD and Jedi.
   #
   # This task will only run if variable `NeedsPythonTestReqs` is true.
   #
@@ -94,7 +94,6 @@ steps:
       python -m pip install --upgrade -r build/test-requirements.txt
       python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
       python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/old_ptvsd --no-cache-dir --implementation py --no-deps --upgrade 'ptvsd==4.3.2'
-      python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python/debugpy/no_wheels --no-cache-dir --implementation py --no-deps --upgrade --pre debugpy
     displayName: 'pip install system test requirements'
     condition: and(succeeded(), eq(variables['NeedsPythonTestReqs'], 'true'))
 
@@ -161,7 +160,7 @@ steps:
   # Run the pip installs in the 3 environments (windows)
   - script: |
       call activate base
-      conda install --quiet -y --file build/ci/conda_base.yml      
+      conda install --quiet -y --file build/ci/conda_base.yml
       python -m pip install --upgrade -r build/conda-functional-requirements.txt
       call activate conda_env_1
       python -m pip install --upgrade -r build/conda-functional-requirements.txt
@@ -203,7 +202,7 @@ steps:
       python ./pythonFiles/install_debugpy.py
     failOnStderr: true
     displayName: 'Install DEBUGPY wheels'
-    condition: and(eq(variables['NeedsPythonTestReqs'], 'true'), eq(variables['PythonVersion'], '3.7'))
+    condition: and(succeeded(), eq(variables['NeedsPythonTestReqs'], 'true'))
 
   # Run the Python unit tests in our codebase. Produces a JUnit-style log file that
   # will be uploaded after all tests are complete.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -405,37 +405,6 @@ gulp.task('installNewDebugpy', async () => {
     }
 
     rmrf.sync('./pythonFiles/lib/temp');
-
-    // Install source only version of new DEBUGPY for use with all other python versions.
-    const args = [
-        '-m',
-        'pip',
-        '--disable-pip-version-check',
-        'install',
-        '-t',
-        './pythonFiles/lib/python/debugpy/no_wheels',
-        '--no-cache-dir',
-        '--implementation',
-        'py',
-        '--no-deps',
-        '--upgrade',
-        '--pre',
-        'debugpy'
-    ];
-    const successWithoutWheels = await spawnAsync(process.env.CI_PYTHON_PATH || 'python3', args, undefined, true)
-        .then(() => true)
-        .catch((ex) => {
-            console.error("Failed to install DEBUGPY using 'python3'", ex);
-            return false;
-        });
-    if (!successWithoutWheels) {
-        console.info(
-            "Failed to install source only version of new DEBUGPY using 'python3', attempting to install using 'python'"
-        );
-        await spawnAsync('python', args).catch((ex) =>
-            console.error("Failed to install source only DEBUGPY using 'python'", ex)
-        );
-    }
 });
 
 // Install the last stable version of old PTVSD (which includes a middle layer adapter and requires ptvsd_launcher.py)

--- a/news/2 Fixes/11686.md
+++ b/news/2 Fixes/11686.md
@@ -1,0 +1,1 @@
+Fixes issue with importing `debupy` in interactive window.

--- a/pythonFiles/install_debugpy.py
+++ b/pythonFiles/install_debugpy.py
@@ -8,7 +8,7 @@ from packaging.version import parse as version_parser
 
 EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEBUGGER_DEST = os.path.join(
-    EXTENSION_ROOT, "pythonFiles", "lib", "python", "debugpy", "wheels"
+    EXTENSION_ROOT, "pythonFiles", "lib", "python"
 )
 DEBUGGER_PACKAGE = "debugpy"
 DEBUGGER_PYTHON_VERSIONS = ("cp37",)

--- a/pythonFiles/install_debugpy.py
+++ b/pythonFiles/install_debugpy.py
@@ -7,9 +7,7 @@ from packaging.version import parse as version_parser
 
 
 EXTENSION_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DEBUGGER_DEST = os.path.join(
-    EXTENSION_ROOT, "pythonFiles", "lib", "python"
-)
+DEBUGGER_DEST = os.path.join(EXTENSION_ROOT, "pythonFiles", "lib", "python")
 DEBUGGER_PACKAGE = "debugpy"
 DEBUGGER_PYTHON_VERSIONS = ("cp37",)
 

--- a/src/client/datascience/jupyter/jupyterDebugger.ts
+++ b/src/client/datascience/jupyter/jupyterDebugger.ts
@@ -238,20 +238,13 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
      * @returns {Promise<string>}
      * @memberof JupyterDebugger
      */
-    private async getDebuggerPath(notebook: INotebook): Promise<string> {
+    private async getDebuggerPath(_notebook: INotebook): Promise<string> {
         if (this.debuggerPackage === 'ptvsd') {
             return path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'old_ptvsd');
         }
-        const pythonVersion = await this.getKernelPythonVersion(notebook);
-        // The new debug adapter with wheels is only supported in 3.7
-        // Code can be found here (src/client/debugger/extension/adapter/factory.ts).
-        if (pythonVersion && pythonVersion.major === 3 && pythonVersion.minor === 7) {
-            // Return debugger with wheels
-            return path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'debugpy', 'wheels');
-        }
 
         // We are here so this is NOT python 3.7, return debugger without wheels
-        return path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'debugpy', 'no_wheels');
+        return path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python');
     }
     private async calculateDebuggerPathList(notebook: INotebook): Promise<string | undefined> {
         const extraPaths: string[] = [];
@@ -326,11 +319,6 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
 
     private executeSilently(notebook: INotebook, code: string): Promise<ICell[]> {
         return notebook.execute(code, Identifiers.EmptyFileName, 0, uuid(), undefined, true);
-    }
-
-    private async getKernelPythonVersion(notebook: INotebook): Promise<Version | undefined> {
-        const execResults = await this.executeSilently(notebook, 'import sys;print(sys.version)');
-        return this.parseVersionInfo(execResults, 'pythonVersionInfo');
     }
 
     private async debuggerCheck(notebook: INotebook): Promise<Version | undefined> {

--- a/src/client/debugger/extension/adapter/factory.ts
+++ b/src/client/debugger/extension/adapter/factory.ts
@@ -75,23 +75,17 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
                     return new DebugAdapterExecutable(pythonPath, [configuration.debugAdapterPath, ...logArgs]);
                 }
 
-                const debuggerPathToUse = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'debugpy');
+                const debuggerAdapterPathToUse = path.join(
+                    EXTENSION_ROOT_DIR,
+                    'pythonFiles',
+                    'lib',
+                    'python',
+                    'debugpy',
+                    'adapter'
+                );
 
-                if (await this.useNewDebugger(pythonPath)) {
-                    sendTelemetryEvent(EventName.DEBUG_ADAPTER_USING_WHEELS_PATH, undefined, { usingWheels: true });
-                    return new DebugAdapterExecutable(pythonPath, [
-                        path.join(debuggerPathToUse, 'wheels', 'debugpy', 'adapter'),
-                        ...logArgs
-                    ]);
-                } else {
-                    sendTelemetryEvent(EventName.DEBUG_ADAPTER_USING_WHEELS_PATH, undefined, {
-                        usingWheels: false
-                    });
-                    return new DebugAdapterExecutable(pythonPath, [
-                        path.join(debuggerPathToUse, 'no_wheels', 'debugpy', 'adapter'),
-                        ...logArgs
-                    ]);
-                }
+                sendTelemetryEvent(EventName.DEBUG_ADAPTER_USING_WHEELS_PATH, undefined, { usingWheels: true });
+                return new DebugAdapterExecutable(pythonPath, [debuggerAdapterPathToUse, ...logArgs]);
             }
         } else {
             this.experimentsManager.sendTelemetryIfInExperiment(DebugAdapterNewPtvsd.control);
@@ -103,22 +97,6 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
         }
         // Unlikely scenario.
         throw new Error('Debug Adapter Executable not provided');
-    }
-
-    /**
-     * Check and return whether the user should and can use the new Debugger wheels or not.
-     *
-     * @param {string} pythonPath Path to the python executable used to launch the Python Debug Adapter (result of `this.getPythonPath()`)
-     * @returns {Promise<boolean>} Whether the user should and can use the new Debugger wheels or not.
-     * @memberof DebugAdapterDescriptorFactory
-     */
-    private async useNewDebugger(pythonPath: string): Promise<boolean> {
-        const interpreterInfo = await this.interpreterService.getInterpreterDetails(pythonPath);
-        if (!interpreterInfo || !interpreterInfo.version || !interpreterInfo.version.raw.startsWith('3.7')) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/client/debugger/extension/adapter/remoteLaunchers.ts
+++ b/src/client/debugger/extension/adapter/remoteLaunchers.ts
@@ -9,7 +9,7 @@ import '../../../common/extensions';
 
 const pathToPythonLibDir = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python');
 const pathToScript = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py');
-const pathToDebugger = path.join(pathToPythonLibDir, 'debugpy', 'no_wheels', 'debugpy');
+const pathToDebugger = path.join(pathToPythonLibDir, 'debugpy');
 
 export type RemoteDebugOptions = {
     host: string;

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -22,15 +22,7 @@ suite('Extension API', () => {
     const expectedLauncherPath = path
         .join(EXTENSION_ROOT_DIR, 'pythonFiles', 'ptvsd_launcher.py')
         .fileToCommandArgument();
-    const debuggerPath = path.join(
-        EXTENSION_ROOT_DIR,
-        'pythonFiles',
-        'lib',
-        'python',
-        'debugpy',
-        'no_wheels',
-        'debugpy'
-    );
+    const debuggerPath = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'debugpy');
     const ptvsdHost = 'somehost';
     const ptvsdPort = 12345;
 
@@ -167,15 +159,7 @@ suite('Extension API', () => {
             instance(serviceContainer)
         ).debug.getDebuggerPackagePath();
 
-        const expected = path.join(
-            EXTENSION_ROOT_DIR,
-            'pythonFiles',
-            'lib',
-            'python',
-            'debugpy',
-            'no_wheels',
-            'debugpy'
-        );
+        const expected = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python', 'debugpy');
         assert.equal(pkgPath, expected);
     });
 });

--- a/src/test/debugger/extension/adapter/factory.unit.test.ts
+++ b/src/test/debugger/extension/adapter/factory.unit.test.ts
@@ -50,8 +50,6 @@ suite('Debugging - Adapter Factory', () => {
         'lib',
         'python',
         'debugpy',
-        'wheels',
-        'debugpy',
         'adapter'
     );
     const ptvsdAdapterPathWithoutWheels = path.join(
@@ -59,8 +57,6 @@ suite('Debugging - Adapter Factory', () => {
         'pythonFiles',
         'lib',
         'python',
-        'debugpy',
-        'no_wheels',
         'debugpy',
         'adapter'
     );
@@ -429,7 +425,7 @@ suite('Debugging - Adapter Factory', () => {
             EventName.PYTHON_EXPERIMENTS,
             EventName.DEBUG_ADAPTER_USING_WHEELS_PATH
         ]);
-        assert.deepEqual(Reporter.properties, [{ expName: DebugAdapterNewPtvsd.experiment }, { usingWheels: 'false' }]);
+        assert.deepEqual(Reporter.properties, [{ expName: DebugAdapterNewPtvsd.experiment }, { usingWheels: 'true' }]);
     });
 
     test('Send attach to local process telemetry if inside the DA experiment and attaching to a local process', async () => {

--- a/src/test/debugger/extension/adapter/remoteLaunchers.unit.test.ts
+++ b/src/test/debugger/extension/adapter/remoteLaunchers.unit.test.ts
@@ -105,7 +105,7 @@ suite('Path To Debugger Package', () => {
     const pathToPythonLibDir = path.join(EXTENSION_ROOT_DIR, 'pythonFiles', 'lib', 'python');
     test('Path to debugpy debugger package', () => {
         const actual = launchers.getDebugpyPackagePath();
-        const expected = path.join(pathToPythonLibDir, 'debugpy', 'no_wheels', 'debugpy');
+        const expected = path.join(pathToPythonLibDir, 'debugpy');
         expect(actual).to.be.deep.equal(expected);
     });
 });


### PR DESCRIPTION
For #10945, #11686

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.

It was easier to get rid of the two versions of the debuggers (which we wanted to do anyway #10945). Since this issue occurs with the current stable release as well, I am not sure we should push this to release branch immediately. We could take this in the bug fix release, and it will give this change enough bake time.
