### PR TITLE
Move all logging to the Python output channel

### DIFF
--- a/news/3 Code Health/9837.md
+++ b/news/3 Code Health/9837.md
@@ -1,0 +1,1 @@
+Move all logging to the Python output channel.

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -48,6 +48,7 @@ import { IServiceContainer, IServiceManager } from './ioc/types';
 import { getLanguageConfiguration } from './language/languageConfiguration';
 import { LinterCommands } from './linters/linterCommands';
 import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
+import { setPythonOutputChannelTransport } from './logging/transports';
 import { PythonCodeActionProvider } from './providers/codeActionProvider/pythonCodeActionProvider';
 import { PythonFormattingEditProvider } from './providers/formatProvider';
 import { ReplProvider } from './providers/replProvider';
@@ -89,6 +90,7 @@ async function activateLegacy(
     // register "services"
 
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    setPythonOutputChannelTransport(standardOutputChannel);
     const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
     const jupyterOutputChannel = window.createOutputChannel(OutputChannelNames.jupyter());
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -75,10 +75,9 @@ function initializeConsoleLogger() {
         // In CI there's no need for the label.
         label: process.env.TF_BUILD ? undefined : 'Python Extension:'
     });
-    const transport =
-        process.env.VSC_PYTHON_LOG_FILE && process.env.TF_BUILD
-            ? getConsoleTransport(logToConsole, formatter)
-            : getPythonOutputChannelTransport(formatter);
+    const transport = process.env.VSC_PYTHON_FORCE_LOGGING
+        ? getConsoleTransport(logToConsole, formatter)
+        : getPythonOutputChannelTransport(formatter);
     consoleLogger.add(transport as any);
 }
 

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -9,7 +9,7 @@ import { createLogger } from 'winston';
 import { isTestExecution } from '../common/constants';
 import { logToConsole, monkeypatchConsole } from './_console';
 import { getFormatter } from './formatters';
-import { getConsoleTransport, getFileTransport } from './transports';
+import { getConsoleTransport, getFileTransport, getPythonOutputChannelTransport } from './transports';
 import { LogLevel } from './types';
 
 // Initialize the loggers as soon as this module is imported.
@@ -75,7 +75,10 @@ function initializeConsoleLogger() {
         // In CI there's no need for the label.
         label: process.env.TF_BUILD ? undefined : 'Python Extension:'
     });
-    const transport = getConsoleTransport(logToConsole, formatter);
+    const transport =
+        process.env.VSC_PYTHON_LOG_FILE && process.env.TF_BUILD
+            ? getConsoleTransport(logToConsole, formatter)
+            : getPythonOutputChannelTransport(formatter);
     consoleLogger.add(transport as any);
 }
 


### PR DESCRIPTION
For #9837

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
