### PR TITLE
Moved all logging into the Python output channel

### DIFF
--- a/news/3 Code Health/9837.md
+++ b/news/3 Code Health/9837.md
@@ -1,0 +1,1 @@
+Move all logging to the Python output channel.

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -48,6 +48,7 @@ import { IServiceContainer, IServiceManager } from './ioc/types';
 import { getLanguageConfiguration } from './language/languageConfiguration';
 import { LinterCommands } from './linters/linterCommands';
 import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
+import { setPythonOutputChannelTransport } from './logging/transports';
 import { PythonCodeActionProvider } from './providers/codeActionProvider/pythonCodeActionProvider';
 import { PythonFormattingEditProvider } from './providers/formatProvider';
 import { ReplProvider } from './providers/replProvider';
@@ -89,6 +90,7 @@ async function activateLegacy(
     // register "services"
 
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    setPythonOutputChannelTransport(standardOutputChannel);
     const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
     const jupyterOutputChannel = window.createOutputChannel(OutputChannelNames.jupyter());
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -48,7 +48,7 @@ import { IServiceContainer, IServiceManager } from './ioc/types';
 import { getLanguageConfiguration } from './language/languageConfiguration';
 import { LinterCommands } from './linters/linterCommands';
 import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
-import { setPythonOutputChannelTransport } from './logging/transports';
+import { addOutputChannelLogging } from './logging';
 import { PythonCodeActionProvider } from './providers/codeActionProvider/pythonCodeActionProvider';
 import { PythonFormattingEditProvider } from './providers/formatProvider';
 import { ReplProvider } from './providers/replProvider';
@@ -90,7 +90,7 @@ async function activateLegacy(
     // register "services"
 
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
-    setPythonOutputChannelTransport(standardOutputChannel);
+    addOutputChannelLogging(standardOutputChannel);
     const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
     const jupyterOutputChannel = window.createOutputChannel(OutputChannelNames.jupyter());
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -70,6 +70,7 @@ function initialize() {
     }
 }
 
+// Register the output channel transport the logger will log into
 export function addOutputChannelLogging(channel: IOutputChannel) {
     const formatter = getFormatter();
     const transport = getPythonOutputChannelTransport(channel, formatter);

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -39,16 +39,16 @@ function initialize() {
     const config: LoggerConfig = {};
     let nonConsole = false;
 
-    if (!isTestExecution()) {
-        // Do not log to console if running tests and we're not
-        // asked to do so.
-        if (process.env.VSC_PYTHON_FORCE_LOGGING) {
-            config.console = {};
-            // In CI there's no need for the label.
-            if (!isCI) {
-                config.console.label = 'Python Extension:';
-            }
+    // Do not log to console if running tests and we're not
+    // asked to do so.
+    if (!isTestExecution() || process.env.VSC_PYTHON_FORCE_LOGGING) {
+        config.console = {};
+        // In CI there's no need for the label.
+        if (!isCI) {
+            config.console.label = 'Python Extension:';
         }
+    }
+    if (!isTestExecution()) {
         config.pythonOutputChannel = true;
     }
     if (process.env.VSC_PYTHON_LOG_FILE) {

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -41,7 +41,7 @@ function initialize() {
 
     // Do not log to console if running tests and we're not
     // asked to do so.
-    if (!isTestExecution() || process.env.VSC_PYTHON_FORCE_LOGGING) {
+    if (process.env.VSC_PYTHON_FORCE_LOGGING) {
         config.console = {};
         // In CI there's no need for the label.
         if (!isCI) {

--- a/src/client/logging/_global.ts
+++ b/src/client/logging/_global.ts
@@ -39,14 +39,17 @@ function initialize() {
     const config: LoggerConfig = {};
     let nonConsole = false;
 
-    // Do not log to console if running tests and we're not
-    // asked to do so.
-    if (!isTestExecution() || process.env.VSC_PYTHON_FORCE_LOGGING) {
-        config.console = {};
-        // In CI there's no need for the label.
-        if (!isCI) {
-            config.console.label = 'Python Extension:';
+    if (!isTestExecution()) {
+        // Do not log to console if running tests and we're not
+        // asked to do so.
+        if (process.env.VSC_PYTHON_FORCE_LOGGING) {
+            config.console = {};
+            // In CI there's no need for the label.
+            if (!isCI) {
+                config.console.label = 'Python Extension:';
+            }
         }
+        config.pythonOutputChannel = true;
     }
     if (process.env.VSC_PYTHON_LOG_FILE) {
         config.file = {

--- a/src/client/logging/index.ts
+++ b/src/client/logging/index.ts
@@ -5,6 +5,7 @@
 export {
     // aliases
     // (for convenience)
+    addOutputChannelLogging,
     logError,
     logInfo,
     logVerbose,

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -7,12 +7,7 @@ import * as winston from 'winston';
 import * as Transport from 'winston-transport';
 import { getFormatter } from './formatters';
 import { LogLevel, resolveLevelName } from './levels';
-import {
-    getConsoleTransport,
-    getFileTransport,
-    getPythonOutputChannelTransport,
-    isConsoleTransport
-} from './transports';
+import { getConsoleTransport, getFileTransport, isConsoleTransport } from './transports';
 import { Arguments } from './util';
 
 export type LoggerConfig = {
@@ -23,7 +18,6 @@ export type LoggerConfig = {
     console?: {
         label?: string;
     };
-    pythonOutputChannel?: boolean;
 };
 
 // Create a logger just the way we like it.
@@ -59,11 +53,6 @@ export function configureLogger(logger: IConfigurableLogger, config: LoggerConfi
     if (config.console) {
         const formatter = getFormatter({ label: config.console.label });
         const transport = getConsoleTransport(formatter);
-        logger.add(transport);
-    }
-    if (config.pythonOutputChannel) {
-        const formatter = getFormatter();
-        const transport = getPythonOutputChannelTransport(formatter);
         logger.add(transport);
     }
 }

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -7,7 +7,12 @@ import * as winston from 'winston';
 import * as Transport from 'winston-transport';
 import { getFormatter } from './formatters';
 import { LogLevel, resolveLevelName } from './levels';
-import { getConsoleTransport, getFileTransport, isConsoleTransport } from './transports';
+import {
+    getConsoleTransport,
+    getFileTransport,
+    getPythonOutputChannelTransport,
+    isConsoleTransport
+} from './transports';
 import { Arguments } from './util';
 
 export type LoggerConfig = {
@@ -18,6 +23,7 @@ export type LoggerConfig = {
     console?: {
         label?: string;
     };
+    pythonOutputChannel?: boolean;
 };
 
 // Create a logger just the way we like it.
@@ -53,6 +59,11 @@ export function configureLogger(logger: IConfigurableLogger, config: LoggerConfi
     if (config.console) {
         const formatter = getFormatter({ label: config.console.label });
         const transport = getConsoleTransport(formatter);
+        logger.add(transport);
+    }
+    if (config.pythonOutputChannel) {
+        const formatter = getFormatter();
+        const transport = getPythonOutputChannelTransport(formatter);
         logger.add(transport);
     }
 }

--- a/src/client/logging/transports.ts
+++ b/src/client/logging/transports.ts
@@ -87,7 +87,7 @@ class PythonOutputChannelTransport extends Transport {
     }
 }
 
-// Create a Python output channel targeting transport ;that can be added to a winston logger.
+// Create a Python output channel targeting transport that can be added to a winston logger.
 export function getPythonOutputChannelTransport(channel: IOutputChannel, formatter: logform.Format) {
     return new PythonOutputChannelTransport(channel, {
         // We minimize customization.


### PR DESCRIPTION
For #9837 

- [x] (src/client/logging/transports.ts) add transport
- [x] (src/client/logging/logger.ts) use transport
- [x] do not use transport when running tests
- [ ] drop console transport from logger upon adding output panel to logger (I've removed logging to console when not running tests, is that what this means, @ericsnowcurrently ?)

For the trace decorators, this requires that the logger remain global and that the transport be added during extension init (due to DI).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
