### PR TITLE
Clarify that using a custom jedi also means a custom parso

### DIFF
--- a/package.json
+++ b/package.json
@@ -2071,7 +2071,7 @@
                 "python.jediPath": {
                     "type": "string",
                     "default": "",
-                    "description": "Path to directory containing the Jedi library (this path will contain the 'Jedi' sub directory).",
+                    "description": "Path to directory containing the Jedi library (this path will contain the 'Jedi' sub directory). Note: since Jedi depends on Parso, if using this setting you will need to ensure a suitable version of Parso is available.",
                     "scope": "resource"
                 },
                 "python.languageServer": {


### PR DESCRIPTION
Even with a good understanding of both VSCode-Python and Jedi, this is easy to overlook.

Doesn't feel worth a news entry, but happy to add one if you disagree.