### PR TITLE
Streamline DS Dependency installs

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -489,7 +489,7 @@
     "DataScience.unhandledMessage": "Unhandled kernel message from a widget: {0} : {1}",
     "DataScience.qgridWidgetScriptVersionCompatibilityWarning": "Unable to load a compatible version of the widget 'qgrid'. Consider downgrading to version 1.1.1.",
     "DataScience.kernelStarted": "Started kernel {0}",
-    "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter": "Data Science library {1} is not installed in interpreter {0}. Install?",
+    "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter": "{0} requires {1} to be installed.",
     "DataScience.runByLine": "Run by line",
     "DataScience.continueRunByLine": "Stop"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -491,5 +491,6 @@
     "DataScience.kernelStarted": "Started kernel {0}",
     "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter": "{0} requires {1} to be installed.",
     "DataScience.runByLine": "Run by line",
-    "DataScience.continueRunByLine": "Stop"
+    "DataScience.continueRunByLine": "Stop",
+    "DataScience.couldNotInstallLibrary": "Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.",
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -492,5 +492,5 @@
     "DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter": "{0} requires {1} to be installed.",
     "DataScience.runByLine": "Run by line",
     "DataScience.continueRunByLine": "Stop",
-    "DataScience.couldNotInstallLibrary": "Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.",
+    "DataScience.couldNotInstallLibrary": "Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment."
 }

--- a/src/client/common/installer/productInstaller.ts
+++ b/src/client/common/installer/productInstaller.ts
@@ -6,7 +6,7 @@ import { CancellationToken, OutputChannel, Uri } from 'vscode';
 import '../../common/extensions';
 import * as localize from '../../common/utils/localize';
 import { Telemetry } from '../../datascience/constants';
-import { IInterpreterService } from '../../interpreter/contracts';
+import { IInterpreterService, PythonInterpreter } from '../../interpreter/contracts';
 import { IServiceContainer } from '../../ioc/types';
 import { LinterId } from '../../linters/types';
 import { sendTelemetryEvent } from '../../telemetry';
@@ -30,7 +30,13 @@ import {
 import { isResource } from '../utils/misc';
 import { StopWatch } from '../utils/stopWatch';
 import { ProductNames } from './productNames';
-import { IInstallationChannelManager, InterpreterUri, IProductPathService, IProductService } from './types';
+import {
+    IInstallationChannelManager,
+    IModuleInstaller,
+    InterpreterUri,
+    IProductPathService,
+    IProductService
+} from './types';
 
 export { Product } from '../types';
 
@@ -346,6 +352,46 @@ export class RefactoringLibraryInstaller extends BaseInstaller {
 }
 
 export class DataScienceInstaller extends BaseInstaller {
+    // Override base installer to support a more DS-friendly streamlined installation.
+    public async install(
+        product: Product,
+        interpreterUri?: InterpreterUri,
+        cancel?: CancellationToken
+    ): Promise<InstallerResponse> {
+        // Get a list of known installation channels, pip, conda, etc.
+        const channels: IModuleInstaller[] = await this.serviceContainer
+            .get<IInstallationChannelManager>(IInstallationChannelManager)
+            .getInstallationChannels();
+
+        // Assume the Uri is actually a full PythonInterpreter...
+        const interpreter = interpreterUri as PythonInterpreter;
+
+        // Pick an installerModule based on whether the interpreter is conda or not.
+        let installerModule;
+        if (!interpreter || !interpreter.hasOwnProperty('type')) {
+            return InstallerResponse.Ignore; // All data science packages require an interpreter be passed in.
+        } else {
+            // If conda-based interpreter use it. If not, just use pip.
+            if (interpreter.type === 'Conda') {
+                installerModule = channels.find((v) => v.name === 'Conda');
+            } else {
+                installerModule = channels.find((v) => v.name === 'Pip');
+            }
+        }
+
+        if (!installerModule) {
+            return InstallerResponse.Ignore;
+        }
+
+        const moduleName = translateProductToModule(product, ModuleNamePurpose.install);
+        await installerModule
+            .installModule(moduleName, interpreter, cancel)
+            .catch((ex) => traceError(`Error in installing the module '${moduleName}', ${ex}`));
+
+        return this.isInstalled(product, interpreter).then((isInstalled) =>
+            isInstalled ? InstallerResponse.Installed : InstallerResponse.Ignore
+        );
+    }
     protected async promptToInstallImplementation(
         product: Product,
         resource?: InterpreterUri,

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -349,15 +349,15 @@ export namespace DataScience {
     );
     export const libraryRequiredToLaunchJupyterNotInstalledInterpreter = localize(
         'DataScience.libraryRequiredToLaunchJupyterNotInstalledInterpreter',
-        'Data Science library {1} is not installed in interpreter {0}.'
+        '{0} requires {1} to be installed.'
     );
     export const libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter = localize(
         'DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter',
-        'Data Science library {1} is not installed in interpreter {0}. Install?'
+        '{0} requires {1} to be installed.'
     );
     export const librariesRequiredToLaunchJupyterNotInstalledInterpreter = localize(
         'DataScience.librariesRequiredToLaunchJupyterNotInstalledInterpreter',
-        'Data Science libraries {1} are not installed in interpreter {0}.'
+        '{0} requires {1} to be installed.'
     );
     export const selectJupyterInterpreter = localize(
         'DataScience.selectJupyterInterpreter',

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -339,6 +339,10 @@ export namespace DataScience {
         'DataScience.libraryNotInstalled',
         'Data Science library {0} is not installed. Install?'
     );
+    export const couldNotInstallLibrary = localize(
+        'DataScience.couldNotInstallLibrary',
+        'Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.'
+    );
     export const libraryRequiredToLaunchJupyterNotInstalled = localize(
         'DataScience.libraryRequiredToLaunchJupyterNotInstalled',
         'Data Science library {0} is not installed.'

--- a/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelDependencyService.ts
@@ -45,15 +45,16 @@ export class KernelDependencyService implements IKernelDependencyService {
             ProductNames.get(Product.ipykernel)!
         );
         const installerToken = wrapCancellationTokens(token);
+
         const selection = await Promise.race([
-            this.appShell.showErrorMessage(message, Common.ok(), Common.cancel()),
+            this.appShell.showErrorMessage(message, Common.install()),
             promptCancellationPromise
         ]);
         if (installerToken.isCancellationRequested) {
             return KernelInterpreterDependencyResponse.cancel;
         }
 
-        if (selection === Common.ok()) {
+        if (selection === Common.install()) {
             const cancellatonPromise = createPromiseFromCancellation({
                 cancelAction: 'resolve',
                 defaultValue: InstallerResponse.Ignore,

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -408,7 +408,8 @@ suite('Installer', () => {
                 prod.value === Product.notebook ||
                 prod.value === Product.pandas ||
                 prod.value === Product.ipykernel ||
-                prod.value === Product.kernelspec
+                prod.value === Product.kernelspec ||
+                prod.value === Product.nbconvert
             ) {
                 return;
             }

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -407,7 +407,8 @@ suite('Installer', () => {
                 prod.value === Product.jupyter ||
                 prod.value === Product.notebook ||
                 prod.value === Product.pandas ||
-                prod.value === Product.ipykernel
+                prod.value === Product.ipykernel ||
+                prod.value === Product.kernelspec
             ) {
                 return;
             }

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -325,14 +325,8 @@ suite('Module Installer only', () => {
                                 try {
                                     await installer.install(product.value, resource);
                                 } catch (ex) {
-                                    moduleInstaller.verify(
-                                        (m) =>
-                                            m.installModule(
-                                                TypeMoq.It.isValue(moduleName),
-                                                TypeMoq.It.isValue(resource),
-                                                TypeMoq.It.isValue(undefined)
-                                            ),
-                                        TypeMoq.Times.once()
+                                    expect(ex.message).to.be.equal(
+                                        'All data science packages require an interpreter be passed in'
                                     );
                                 }
                             });

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -297,6 +297,48 @@ suite('Module Installer only', () => {
                         });
                         break;
                     }
+                    case Product.jupyter:
+                    case Product.pandas:
+                    case Product.nbconvert:
+                    case Product.ipykernel:
+                    case Product.kernelspec:
+                    case Product.notebook:
+                        {
+                            test(`Ensure resource info is passed into the module installer ${product.name} (${
+                                resource ? 'With a resource' : 'without a resource'
+                            })`, async () => {
+                                const moduleName = installer.translateProductToModuleName(
+                                    product.value,
+                                    ModuleNamePurpose.install
+                                );
+
+                                moduleInstaller
+                                    .setup((m) =>
+                                        m.installModule(
+                                            TypeMoq.It.isValue(moduleName),
+                                            TypeMoq.It.isValue(resource),
+                                            TypeMoq.It.isValue(undefined)
+                                        )
+                                    )
+                                    .returns(() => Promise.reject(new Error('UnitTesting')));
+
+                                try {
+                                    await installer.install(product.value, resource);
+                                } catch (ex) {
+                                    moduleInstaller.verify(
+                                        (m) =>
+                                            m.installModule(
+                                                TypeMoq.It.isValue(moduleName),
+                                                TypeMoq.It.isValue(resource),
+                                                TypeMoq.It.isValue(undefined)
+                                            ),
+                                        TypeMoq.Times.once()
+                                    );
+                                }
+                            });
+                        }
+                        break;
+
                     default:
                         {
                             test(`Ensure the prompt is displayed only once, until the prompt is closed, ${
@@ -547,6 +589,7 @@ suite('Module Installer only', () => {
                                 );
                             }
                         });
+
                         test(`Return InstallerResponse.Ignore for the module installer ${product.name} (${
                             resource ? 'With a resource' : 'without a resource'
                         }) if installation channel is not defined`, async () => {

--- a/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelDependencyService.unit.test.ts
@@ -44,17 +44,17 @@ suite('Data Science - Kernel Dependency Service', () => {
     });
     test('Prompt if if ipykernel is not installed', async () => {
         when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
-        when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve();
+        when(appShell.showErrorMessage(anything(), anything())).thenResolve(Common.install() as any);
 
         const response = await dependencyService.installMissingDependencies(interpreter);
 
         assert.equal(response, KernelInterpreterDependencyResponse.cancel);
-        verify(appShell.showErrorMessage(anything(), anything(), anything())).once();
+        verify(appShell.showErrorMessage(anything(), anything(), anything())).never();
     });
     test('Install ipykernel', async () => {
         when(installer.isInstalled(Product.ipykernel, interpreter)).thenResolve(false);
         when(installer.install(Product.ipykernel, interpreter, anything())).thenResolve(InstallerResponse.Installed);
-        when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve(Common.ok() as any);
+        when(appShell.showErrorMessage(anything(), anything())).thenResolve(Common.install() as any);
 
         const response = await dependencyService.installMissingDependencies(interpreter);
 
@@ -65,7 +65,7 @@ suite('Data Science - Kernel Dependency Service', () => {
         when(installer.install(Product.ipykernel, interpreter, anything())).thenReject(
             new Error('Install failed - kaboom')
         );
-        when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve(Common.ok() as any);
+        when(appShell.showErrorMessage(anything(), anything())).thenResolve(Common.install() as any);
 
         const promise = dependencyService.installMissingDependencies(interpreter);
 


### PR DESCRIPTION
#11650 Streamline how we prompt to install ipykernel. 

There are two options represented in this branch:
1. Ask for Conda/Pip in the when we prompt that ipykernel needs to be installed.
2. Just allow the user to decide whether ipykernel should be installed and automatically choose conda or pip.

The latest version of this PR represents the second option, which I think is the better choice.  The first option is represented in the first commit of this branch. 

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   ~[x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   ~[x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[x] The wiki is updated with any design decisions/details.~
