### PR TITLE
Skip debugger smoke test

### DIFF
--- a/src/test/smoke/debugger.smoke.test.ts
+++ b/src/test/smoke/debugger.smoke.test.ts
@@ -15,6 +15,8 @@ import { closeActiveWindows, initialize, initializeTest } from '../initialize';
 
 suite('Smoke Test: Debug file', () => {
     suiteSetup(async function () {
+        // https://github.com/microsoft/vscode-python/issues/11733
+        return this.skip();
         if (!IS_SMOKE_TEST) {
             return this.skip();
         }


### PR DESCRIPTION
For #11733

Debugger smoke tests are failing on GHA when using the old TS debug adapter. We'll re-enable these next week once we get rid of the old adapter. Based on discussions with @karthiknadig 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
