### PR TITLE
Support data tips over top of python files

### DIFF
--- a/news/3 Code Health/11659.md
+++ b/news/3 Code Health/11659.md
@@ -1,0 +1,1 @@
+Support data tips overtop of python files that have had cells run.

--- a/src/client/datascience/editor-integration/hoverProvider.ts
+++ b/src/client/datascience/editor-integration/hoverProvider.ts
@@ -82,6 +82,7 @@ export class HoverProvider implements INotebookExecutionLogger, vscode.HoverProv
         if (range) {
             const word = document.getText(range);
             if (word) {
+                // Only do this for the interactive window notebook
                 const notebook = await this.notebookProvider.getOrCreateNotebook(
                     {
                         getOnly: true,

--- a/src/client/datascience/editor-integration/hoverProvider.ts
+++ b/src/client/datascience/editor-integration/hoverProvider.ts
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+import { inject, injectable, named } from 'inversify';
+
+import * as vscode from 'vscode';
+import { PYTHON } from '../../common/constants';
+import { RunByLine } from '../../common/experimentGroups';
+import { traceError } from '../../common/logger';
+import { IExperimentsManager } from '../../common/types';
+import { noop } from '../../common/utils/misc';
+import { Identifiers } from '../constants';
+import { ICell, IJupyterVariables, INotebookExecutionLogger, INotebookProvider } from '../types';
+
+// This class provides hashes for debugging jupyter cells. Call getHashes just before starting debugging to compute all of the
+// hashes for cells.
+@injectable()
+export class HoverProvider implements INotebookExecutionLogger, vscode.HoverProvider {
+    private runFiles = new Set<string>();
+    private enabled = false;
+    private registeredHoverProvider = false;
+
+    constructor(
+        @inject(IExperimentsManager) experimentsManager: IExperimentsManager,
+        @inject(IJupyterVariables) @named(Identifiers.KERNEL_VARIABLES) private variableProvider: IJupyterVariables,
+        @inject(INotebookProvider) private notebookProvider: INotebookProvider
+    ) {
+        this.enabled = experimentsManager.inExperiment(RunByLine.experiment);
+    }
+
+    public dispose() {
+        noop();
+    }
+
+    // tslint:disable-next-line: no-any
+    public onKernelRestarted() {
+        this.runFiles.clear();
+    }
+
+    public async preExecute(cell: ICell, silent: boolean): Promise<void> {
+        try {
+            if (!silent && cell.file && cell.file !== Identifiers.EmptyFileName) {
+                const size = this.runFiles.size;
+                this.runFiles.add(cell.file.toLocaleLowerCase());
+                if (size !== this.runFiles.size) {
+                    this.initializeHoverProvider();
+                }
+            }
+        } catch (exc) {
+            // Don't let exceptions in a preExecute mess up normal operation
+            traceError(exc);
+        }
+    }
+
+    public async postExecute(_cell: ICell, _silent: boolean): Promise<void> {
+        noop();
+    }
+
+    public provideHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken
+    ): vscode.ProviderResult<vscode.Hover> {
+        return this.getVariableHover(document, position, token);
+    }
+
+    private initializeHoverProvider() {
+        if (!this.registeredHoverProvider) {
+            this.registeredHoverProvider = true;
+            if (this.enabled) {
+                vscode.languages.registerHoverProvider(PYTHON, this);
+            }
+        }
+    }
+
+    private async getVariableHover(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        token: vscode.CancellationToken
+    ): Promise<vscode.Hover | null> {
+        const range = document.getWordRangeAtPosition(position);
+        if (range) {
+            const word = document.getText(range);
+            if (word) {
+                const notebook = await this.notebookProvider.getOrCreateNotebook(
+                    {
+                        getOnly: true,
+                        identity: vscode.Uri.parse(Identifiers.InteractiveWindowIdentity)
+                    },
+                    token
+                );
+                if (notebook) {
+                    const match = await this.variableProvider.getMatchingVariableValue(notebook, word, token);
+                    if (match) {
+                        return {
+                            contents: [`${word} : ${match}`]
+                        };
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/client/datascience/editor-integration/hoverProvider.ts
+++ b/src/client/datascience/editor-integration/hoverProvider.ts
@@ -97,10 +97,10 @@ export class HoverProvider implements INotebookExecutionLogger, vscode.HoverProv
                         token: t
                     });
                     if (notebook) {
-                        const match = await this.variableProvider.getMatchingVariableValue(notebook, word, t);
+                        const match = await this.variableProvider.getMatchingVariable(notebook, word, t);
                         if (match) {
                             return {
-                                contents: [`${word} = ${match}`]
+                                contents: [`${word} = ${match.value}`]
                             };
                         }
                     }

--- a/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
@@ -755,10 +755,10 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         if (wordAtPosition) {
             const notebook = await this.getNotebook(token);
             if (notebook) {
-                const value = await this.variableProvider.getMatchingVariableValue(notebook, wordAtPosition, token);
+                const value = await this.variableProvider.getMatchingVariable(notebook, wordAtPosition, token);
                 if (value) {
                     return {
-                        contents: [`${wordAtPosition} = ${value}`]
+                        contents: [`${wordAtPosition}: ${value.type} = ${value.value}`]
                     };
                 }
             }

--- a/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
@@ -744,7 +744,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
 
     private async getNotebook(token: CancellationToken): Promise<INotebook | undefined> {
         return this.notebookIdentity
-            ? this.notebookProvider.getOrCreateNotebook({ identity: this.notebookIdentity, getOnly: true }, token)
+            ? this.notebookProvider.getOrCreateNotebook({ identity: this.notebookIdentity, getOnly: true, token })
             : undefined;
     }
 
@@ -758,7 +758,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
                 const value = await this.variableProvider.getMatchingVariableValue(notebook, wordAtPosition, token);
                 if (value) {
                     return {
-                        contents: [`${wordAtPosition} : ${value}`]
+                        contents: [`${wordAtPosition} = ${value}`]
                     };
                 }
             }

--- a/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
@@ -8,7 +8,6 @@ import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import {
-    CancellationToken,
     CancellationTokenSource,
     CompletionItem,
     Event,
@@ -18,6 +17,7 @@ import {
     TextDocumentContentChangeEvent,
     Uri
 } from 'vscode';
+import { CancellationToken } from 'vscode-jsonrpc';
 import * as vscodeLanguageClient from 'vscode-languageclient';
 import { concatMultilineStringInput } from '../../../../datascience-ui/common';
 import { ILanguageServer, ILanguageServerCache } from '../../../activation/types';
@@ -176,14 +176,14 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         return this.documentPromise.promise;
     }
 
-    protected async getLanguageServer(): Promise<ILanguageServer | undefined> {
+    protected async getLanguageServer(token: CancellationToken): Promise<ILanguageServer | undefined> {
         // Resource should be our potential resource if its set. Otherwise workspace root
         const resource =
             this.potentialResource ||
             (this.workspaceService.rootPath ? Uri.parse(this.workspaceService.rootPath) : undefined);
 
         // Interpreter should be the interpreter currently active in the notebook
-        const activeNotebook = await this.getNotebook();
+        const activeNotebook = await this.getNotebook(token);
         const interpreter = activeNotebook
             ? activeNotebook.getMatchingInterpreter()
             : await this.interpreterService.getActiveInterpreter(resource);
@@ -237,7 +237,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         cellId: string,
         token: CancellationToken
     ): Promise<monacoEditor.languages.CompletionList> {
-        const [languageServer, document] = await Promise.all([this.getLanguageServer(), this.getDocument()]);
+        const [languageServer, document] = await Promise.all([this.getLanguageServer(token), this.getDocument()]);
         if (languageServer && document) {
             const docPos = document.convertToDocumentPosition(cellId, position.lineNumber, position.column);
             const result = await languageServer.provideCompletionItems(document, docPos, token, context);
@@ -258,9 +258,9 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         token: CancellationToken
     ): Promise<monacoEditor.languages.Hover> {
         const [languageServer, document, variableHover] = await Promise.all([
-            this.getLanguageServer(),
+            this.getLanguageServer(token),
             this.getDocument(),
-            this.getVariableHover(wordAtPosition)
+            this.getVariableHover(wordAtPosition, token)
         ]);
         if (!variableHover && languageServer && document) {
             const docPos = document.convertToDocumentPosition(cellId, position.lineNumber, position.column);
@@ -282,7 +282,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         cellId: string,
         token: CancellationToken
     ): Promise<monacoEditor.languages.SignatureHelp> {
-        const [languageServer, document] = await Promise.all([this.getLanguageServer(), this.getDocument()]);
+        const [languageServer, document] = await Promise.all([this.getLanguageServer(token), this.getDocument()]);
         if (languageServer && document) {
             const docPos = document.convertToDocumentPosition(cellId, position.lineNumber, position.column);
             const result = await languageServer.provideSignatureHelp(
@@ -309,7 +309,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         cellId: string,
         token: CancellationToken
     ): Promise<monacoEditor.languages.CompletionItem> {
-        const [languageServer, document] = await Promise.all([this.getLanguageServer(), this.getDocument()]);
+        const [languageServer, document] = await Promise.all([this.getLanguageServer(token), this.getDocument()]);
         if (languageServer && languageServer.resolveCompletionItem && document) {
             const vscodeCompItem: CompletionItem = convertToVSCodeCompletionItem(item);
 
@@ -335,7 +335,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         // For the dot net language server, we have to send extra data to the language server
         if (document) {
             // Broadcast an update to the language server
-            const languageServer = await this.getLanguageServer();
+            const languageServer = await this.getLanguageServer(CancellationToken.None);
             if (languageServer && languageServer.handleChanges && languageServer.handleOpen) {
                 if (!this.sentOpenDocument) {
                     this.sentOpenDocument = true;
@@ -470,7 +470,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         cancelToken: CancellationToken
     ): Promise<monacoEditor.languages.CompletionList> {
         try {
-            const [activeNotebook, document] = await Promise.all([this.getNotebook(), this.getDocument()]);
+            const [activeNotebook, document] = await Promise.all([this.getNotebook(cancelToken), this.getDocument()]);
             if (activeNotebook && document) {
                 const data = document.getCellData(cellId);
 
@@ -742,17 +742,20 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         this.potentialResource = identity.owningResource ? identity.owningResource : this.potentialResource;
     }
 
-    private async getNotebook(): Promise<INotebook | undefined> {
+    private async getNotebook(token: CancellationToken): Promise<INotebook | undefined> {
         return this.notebookIdentity
-            ? this.notebookProvider.getOrCreateNotebook({ identity: this.notebookIdentity, getOnly: true })
+            ? this.notebookProvider.getOrCreateNotebook({ identity: this.notebookIdentity, getOnly: true }, token)
             : undefined;
     }
 
-    private async getVariableHover(wordAtPosition: string | undefined): Promise<Hover | undefined> {
+    private async getVariableHover(
+        wordAtPosition: string | undefined,
+        token: CancellationToken
+    ): Promise<Hover | undefined> {
         if (wordAtPosition) {
-            const notebook = await this.getNotebook();
+            const notebook = await this.getNotebook(token);
             if (notebook) {
-                const value = await this.variableProvider.getMatchingVariableValue(notebook, wordAtPosition);
+                const value = await this.variableProvider.getMatchingVariableValue(notebook, wordAtPosition, token);
                 if (value) {
                     return {
                         contents: [`${wordAtPosition} : ${value}`]

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -65,20 +65,17 @@ export class NotebookProvider implements INotebookProvider {
         if (await this.rawNotebookProvider.supported()) {
             return this.rawNotebookProvider.connect(token);
         } else {
-            return this.jupyterNotebookProvider.connect(options, token);
+            return this.jupyterNotebookProvider.connect(options);
         }
     }
 
-    public async getOrCreateNotebook(
-        options: GetNotebookOptions,
-        token?: CancellationToken
-    ): Promise<INotebook | undefined> {
+    public async getOrCreateNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
         const rawKernel = await this.rawNotebookProvider.supported();
 
         // Check to see if our provider already has this notebook
         const notebook = rawKernel
-            ? await this.rawNotebookProvider.getNotebook(options.identity, token)
-            : await this.jupyterNotebookProvider.getNotebook(options, token);
+            ? await this.rawNotebookProvider.getNotebook(options.identity, options.token)
+            : await this.jupyterNotebookProvider.getNotebook(options);
         if (notebook) {
             return notebook;
         }
@@ -92,7 +89,7 @@ export class NotebookProvider implements INotebookProvider {
         // but jupyterNotebookProvider.createNotebook can be undefined if the server is not available
         // so check for our connection here first
         if (!rawKernel) {
-            if (!(await this.jupyterNotebookProvider.connect(options, token))) {
+            if (!(await this.jupyterNotebookProvider.connect(options))) {
                 return undefined;
             }
         }
@@ -114,9 +111,9 @@ export class NotebookProvider implements INotebookProvider {
                   resource,
                   options.disableUI,
                   options.metadata,
-                  token
+                  options.token
               )
-            : this.jupyterNotebookProvider.createNotebook(options, token);
+            : this.jupyterNotebookProvider.createNotebook(options);
 
         this.cacheNotebookPromise(options.identity, promise);
 

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -76,10 +76,10 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
         return result;
     }
 
-    public async getMatchingVariableValue(_notebook: INotebook, name: string): Promise<string | undefined> {
+    public async getMatchingVariable(_notebook: INotebook, name: string): Promise<IJupyterVariable | undefined> {
         if (this.active) {
             // Note, full variable results isn't necessary for this call. It only really needs the variable value.
-            return this.lastKnownVariables.find((v) => v.name === name)?.value;
+            return this.lastKnownVariables.find((v) => v.name === name);
         }
     }
 

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
+import { CancellationToken } from 'vscode';
 import * as localize from '../../common/utils/localize';
 import {
     ConnectNotebookProviderOptions,
@@ -25,32 +26,41 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         return server?.dispose();
     }
 
-    public async connect(options: ConnectNotebookProviderOptions): Promise<IJupyterConnection | undefined> {
-        const server = await this.serverProvider.getOrCreateServer(options);
+    public async connect(
+        options: ConnectNotebookProviderOptions,
+        token?: CancellationToken
+    ): Promise<IJupyterConnection | undefined> {
+        const server = await this.serverProvider.getOrCreateServer(options, token);
         return server?.getConnectionInfo();
     }
 
-    public async createNotebook(options: GetNotebookOptions): Promise<INotebook> {
+    public async createNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook> {
         // Make sure we have a server
-        const server = await this.serverProvider.getOrCreateServer({
-            getOnly: options.getOnly,
-            disableUI: options.disableUI
-        });
+        const server = await this.serverProvider.getOrCreateServer(
+            {
+                getOnly: options.getOnly,
+                disableUI: options.disableUI
+            },
+            token
+        );
 
         if (server) {
-            return server.createNotebook(options.identity, options.identity, options.metadata);
+            return server.createNotebook(options.identity, options.identity, options.metadata, token);
         }
         // We want createNotebook to always return a notebook promise, so if we don't have a server
         // here throw our generic server disposed message that we use in server creatio n
         throw new Error(localize.DataScience.sessionDisposed());
     }
-    public async getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
-        const server = await this.serverProvider.getOrCreateServer({
-            getOnly: options.getOnly,
-            disableUI: options.disableUI
-        });
+    public async getNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook | undefined> {
+        const server = await this.serverProvider.getOrCreateServer(
+            {
+                getOnly: options.getOnly,
+                disableUI: options.disableUI
+            },
+            token
+        );
         if (server) {
-            return server.getNotebook(options.identity);
+            return server.getNotebook(options.identity, token);
         }
     }
 }

--- a/src/client/datascience/jupyter/jupyterNotebookProvider.ts
+++ b/src/client/datascience/jupyter/jupyterNotebookProvider.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { CancellationToken } from 'vscode';
 import * as localize from '../../common/utils/localize';
 import {
     ConnectNotebookProviderOptions,
@@ -26,41 +25,34 @@ export class JupyterNotebookProvider implements IJupyterNotebookProvider {
         return server?.dispose();
     }
 
-    public async connect(
-        options: ConnectNotebookProviderOptions,
-        token?: CancellationToken
-    ): Promise<IJupyterConnection | undefined> {
-        const server = await this.serverProvider.getOrCreateServer(options, token);
+    public async connect(options: ConnectNotebookProviderOptions): Promise<IJupyterConnection | undefined> {
+        const server = await this.serverProvider.getOrCreateServer(options);
         return server?.getConnectionInfo();
     }
 
-    public async createNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook> {
+    public async createNotebook(options: GetNotebookOptions): Promise<INotebook> {
         // Make sure we have a server
-        const server = await this.serverProvider.getOrCreateServer(
-            {
-                getOnly: options.getOnly,
-                disableUI: options.disableUI
-            },
-            token
-        );
+        const server = await this.serverProvider.getOrCreateServer({
+            getOnly: options.getOnly,
+            disableUI: options.disableUI,
+            token: options.token
+        });
 
         if (server) {
-            return server.createNotebook(options.identity, options.identity, options.metadata, token);
+            return server.createNotebook(options.identity, options.identity, options.metadata, options.token);
         }
         // We want createNotebook to always return a notebook promise, so if we don't have a server
         // here throw our generic server disposed message that we use in server creatio n
         throw new Error(localize.DataScience.sessionDisposed());
     }
-    public async getNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook | undefined> {
-        const server = await this.serverProvider.getOrCreateServer(
-            {
-                getOnly: options.getOnly,
-                disableUI: options.disableUI
-            },
-            token
-        );
+    public async getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined> {
+        const server = await this.serverProvider.getOrCreateServer({
+            getOnly: options.getOnly,
+            disableUI: options.disableUI,
+            token: options.token
+        });
         if (server) {
-            return server.getNotebook(options.identity, token);
+            return server.getNotebook(options.identity, options.token);
         }
     }
 }

--- a/src/client/datascience/jupyter/jupyterServerWrapper.ts
+++ b/src/client/datascience/jupyter/jupyterServerWrapper.ts
@@ -145,9 +145,9 @@ export class JupyterServerWrapper implements INotebookServer, ILiveShareHasRole 
         return undefined;
     }
 
-    public async getNotebook(resource: Uri): Promise<INotebook | undefined> {
+    public async getNotebook(resource: Uri, token?: CancellationToken): Promise<INotebook | undefined> {
         const server = await this.serverFactory.get();
-        return server.getNotebook(resource);
+        return server.getNotebook(resource, token);
     }
 
     public async waitForConnect(): Promise<INotebookServerLaunchInfo | undefined> {

--- a/src/client/datascience/jupyter/jupyterVariables.ts
+++ b/src/client/datascience/jupyter/jupyterVariables.ts
@@ -53,8 +53,8 @@ export class JupyterVariables implements IJupyterVariables {
         return this.realVariables.getVariables(notebook, request);
     }
 
-    public getMatchingVariableValue(notebook: INotebook, name: string): Promise<string | undefined> {
-        return this.realVariables.getMatchingVariableValue(notebook, name);
+    public getMatchingVariable(notebook: INotebook, name: string): Promise<IJupyterVariable | undefined> {
+        return this.realVariables.getMatchingVariable(notebook, name);
     }
 
     public async getDataFrameInfo(targetVariable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariable> {

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -62,11 +62,11 @@ export class KernelVariables implements IJupyterVariables {
         return this.getVariablesBasedOnKernel(notebook, request);
     }
 
-    public async getMatchingVariableValue(
+    public async getMatchingVariable(
         notebook: INotebook,
         name: string,
         token?: CancellationToken
-    ): Promise<string | undefined> {
+    ): Promise<IJupyterVariable | undefined> {
         // See if in the cache
         const cache = this.notebookState.get(notebook.identity);
         if (cache) {
@@ -74,14 +74,14 @@ export class KernelVariables implements IJupyterVariables {
             if (match && !match.value) {
                 match = await this.getVariableValueFromKernel(match, notebook, token);
             }
-            return match?.value;
+            return match;
         } else {
             // No items in the cache yet, just ask for the names
             const names = await this.getVariableNamesFromKernel(notebook, token);
             if (names) {
                 const matchName = names.find((n) => n === name);
                 if (matchName) {
-                    const match = await this.getVariableValueFromKernel(
+                    return this.getVariableValueFromKernel(
                         {
                             name,
                             value: undefined,
@@ -95,7 +95,6 @@ export class KernelVariables implements IJupyterVariables {
                         notebook,
                         token
                     );
-                    return match.value;
                 }
             }
         }

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -6,7 +6,7 @@ import { inject, injectable } from 'inversify';
 import stripAnsi from 'strip-ansi';
 import * as uuid from 'uuid/v4';
 
-import { Event, EventEmitter, Uri } from 'vscode';
+import { CancellationToken, Event, EventEmitter, Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError } from '../../common/logger';
 import { IConfigurationService, IDisposable } from '../../common/types';
@@ -62,18 +62,22 @@ export class KernelVariables implements IJupyterVariables {
         return this.getVariablesBasedOnKernel(notebook, request);
     }
 
-    public async getMatchingVariableValue(notebook: INotebook, name: string): Promise<string | undefined> {
+    public async getMatchingVariableValue(
+        notebook: INotebook,
+        name: string,
+        token?: CancellationToken
+    ): Promise<string | undefined> {
         // See if in the cache
         const cache = this.notebookState.get(notebook.identity);
         if (cache) {
             let match = cache.variables.find((v) => v.name === name);
             if (match && !match.value) {
-                match = await this.getVariableValueFromKernel(match, notebook);
+                match = await this.getVariableValueFromKernel(match, notebook, token);
             }
             return match?.value;
         } else {
             // No items in the cache yet, just ask for the names
-            const names = await this.getVariableNamesFromKernel(notebook);
+            const names = await this.getVariableNamesFromKernel(notebook, token);
             if (names) {
                 const matchName = names.find((n) => n === name);
                 if (matchName) {
@@ -88,7 +92,8 @@ export class KernelVariables implements IJupyterVariables {
                             shape: '',
                             truncated: true
                         },
-                        notebook
+                        notebook,
+                        token
                     );
                     return match.value;
                 }
@@ -142,7 +147,7 @@ export class KernelVariables implements IJupyterVariables {
         return this.deserializeJupyterResult(results);
     }
 
-    private async importDataFrameScripts(notebook: INotebook): Promise<void> {
+    private async importDataFrameScripts(notebook: INotebook, token?: CancellationToken): Promise<void> {
         const key = notebook.identity.toString();
         if (!this.importedDataFrameScripts.get(key)) {
             // Clear our flag if the notebook disposes or restarts
@@ -156,14 +161,18 @@ export class KernelVariables implements IJupyterVariables {
             disposables.push(notebook.onKernelRestarted(handler));
 
             const fullCode = `${DataFrameLoading.DataFrameSysImport}\n${DataFrameLoading.DataFrameInfoImport}\n${DataFrameLoading.DataFrameRowImport}\n${DataFrameLoading.VariableInfoImport}`;
-            await notebook.execute(fullCode, Identifiers.EmptyFileName, 0, uuid(), undefined, true);
+            await notebook.execute(fullCode, Identifiers.EmptyFileName, 0, uuid(), token, true);
             this.importedDataFrameScripts.set(notebook.identity.toString(), true);
         }
     }
 
-    private async getFullVariable(targetVariable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariable> {
+    private async getFullVariable(
+        targetVariable: IJupyterVariable,
+        notebook: INotebook,
+        token?: CancellationToken
+    ): Promise<IJupyterVariable> {
         // Import the data frame script directory if we haven't already
-        await this.importDataFrameScripts(notebook);
+        await this.importDataFrameScripts(notebook, token);
 
         // Then execute a call to get the info and turn it into JSON
         const results = await notebook.execute(
@@ -171,7 +180,7 @@ export class KernelVariables implements IJupyterVariables {
             Identifiers.EmptyFileName,
             0,
             uuid(),
-            undefined,
+            token,
             true
         );
 
@@ -356,13 +365,13 @@ export class KernelVariables implements IJupyterVariables {
         return result;
     }
 
-    private async getVariableNamesFromKernel(notebook: INotebook): Promise<string[]> {
+    private async getVariableNamesFromKernel(notebook: INotebook, token?: CancellationToken): Promise<string[]> {
         // Get our query and parser
         const query = this.getParser(notebook);
 
         // Now execute the query
         if (notebook) {
-            const cells = await notebook.execute(query.query, Identifiers.EmptyFileName, 0, uuid(), undefined, true);
+            const cells = await notebook.execute(query.query, Identifiers.EmptyFileName, 0, uuid(), token, true);
             const text = this.extractJupyterResultText(cells);
 
             // Apply the expression to it
@@ -379,11 +388,12 @@ export class KernelVariables implements IJupyterVariables {
 
     private async getVariableValueFromKernel(
         targetVariable: IJupyterVariable,
-        notebook: INotebook
+        notebook: INotebook,
+        token?: CancellationToken
     ): Promise<IJupyterVariable> {
         let result = { ...targetVariable };
         if (notebook) {
-            const output = await notebook.inspect(targetVariable.name);
+            const output = await notebook.inspect(targetVariable.name, token);
 
             // Should be a text/plain inside of it (at least IPython does this)
             if (output && output.hasOwnProperty('text/plain')) {

--- a/src/client/datascience/jupyter/oldJupyterVariables.ts
+++ b/src/client/datascience/jupyter/oldJupyterVariables.ts
@@ -71,7 +71,7 @@ export class OldJupyterVariables implements IJupyterVariables {
         return this.getVariablesBasedOnKernel(notebook, request);
     }
 
-    public async getMatchingVariableValue(_notebook: INotebook, _name: string): Promise<string | undefined> {
+    public async getMatchingVariable(_notebook: INotebook, _name: string): Promise<IJupyterVariable | undefined> {
         // Not supported with old method.
         return undefined;
     }

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -26,6 +26,7 @@ import { CodeLensFactory } from './editor-integration/codeLensFactory';
 import { DataScienceCodeLensProvider } from './editor-integration/codelensprovider';
 import { CodeWatcher } from './editor-integration/codewatcher';
 import { Decorator } from './editor-integration/decorator';
+import { HoverProvider } from './editor-integration/hoverProvider';
 import { DataScienceErrorHandler } from './errorHandler/errorHandler';
 import { GatherListener } from './gather/gatherListener';
 import { GatherLogger } from './gather/gatherLogger';
@@ -150,6 +151,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingletonInstance<boolean>(UseCustomEditorApi, useCustomEditorApi);
 
     serviceManager.add<ICellHashProvider>(ICellHashProvider, CellHashProvider, undefined, [INotebookExecutionLogger]);
+    serviceManager.add<INotebookExecutionLogger>(INotebookExecutionLogger, HoverProvider);
     serviceManager.add<ICodeWatcher>(ICodeWatcher, CodeWatcher);
     serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);
     serviceManager.add<IDataViewer>(IDataViewer, DataViewer);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -785,11 +785,11 @@ export interface IJupyterVariables {
         start: number,
         end: number
     ): Promise<JSONObject>;
-    getMatchingVariableValue(
+    getMatchingVariable(
         notebook: INotebook,
         name: string,
         cancelToken?: CancellationToken
-    ): Promise<string | undefined>;
+    ): Promise<IJupyterVariable | undefined>;
 }
 
 export interface IConditionalJupyterVariables extends IJupyterVariables {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -158,12 +158,9 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
 // Provides notebooks that talk to jupyter servers
 export const IJupyterNotebookProvider = Symbol('IJupyterNotebookProvider');
 export interface IJupyterNotebookProvider {
-    connect(
-        options: ConnectNotebookProviderOptions,
-        token?: CancellationToken
-    ): Promise<IJupyterConnection | undefined>;
-    createNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook>;
-    getNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook | undefined>;
+    connect(options: ConnectNotebookProviderOptions): Promise<IJupyterConnection | undefined>;
+    createNotebook(options: GetNotebookOptions): Promise<INotebook>;
+    getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
     disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
 }
 
@@ -236,6 +233,7 @@ export type ConnectNotebookProviderOptions = {
     getOnly?: boolean;
     disableUI?: boolean;
     localOnly?: boolean;
+    token?: CancellationToken;
 };
 
 export interface INotebookServerOptions {
@@ -1028,6 +1026,7 @@ export type GetServerOptions = {
     getOnly?: boolean;
     disableUI?: boolean;
     localOnly?: boolean;
+    token?: CancellationToken;
 };
 
 /**
@@ -1038,6 +1037,7 @@ export type GetNotebookOptions = {
     getOnly?: boolean;
     disableUI?: boolean;
     metadata?: nbformat.INotebookMetadata;
+    token?: CancellationToken;
 };
 
 export interface INotebookProvider {
@@ -1053,14 +1053,11 @@ export interface INotebookProvider {
     /**
      * Gets or creates a notebook, and manages the lifetime of notebooks.
      */
-    getOrCreateNotebook(options: GetNotebookOptions, cancelToken?: CancellationToken): Promise<INotebook | undefined>;
+    getOrCreateNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
     /**
      * Connect to a notebook provider to prepare its connection and to get connection information
      */
-    connect(
-        options: ConnectNotebookProviderOptions,
-        cancelToken?: CancellationToken
-    ): Promise<INotebookProviderConnection | undefined>;
+    connect(options: ConnectNotebookProviderOptions): Promise<INotebookProviderConnection | undefined>;
 
     /**
      * Disconnect from a notebook provider connection
@@ -1073,7 +1070,7 @@ export interface IJupyterServerProvider {
     /**
      * Gets the server used for starting notebooks
      */
-    getOrCreateServer(options: GetServerOptions, token?: CancellationToken): Promise<INotebookServer | undefined>;
+    getOrCreateServer(options: GetServerOptions): Promise<INotebookServer | undefined>;
 }
 
 export interface IKernelSocket {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -133,7 +133,7 @@ export interface INotebookServer extends IAsyncDisposable {
         notebookMetadata?: nbformat.INotebookMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook>;
-    getNotebook(identity: Uri): Promise<INotebook | undefined>;
+    getNotebook(identity: Uri, cancelToken?: CancellationToken): Promise<INotebook | undefined>;
     connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void>;
     getConnectionInfo(): IJupyterConnection | undefined;
     waitForConnect(): Promise<INotebookServerLaunchInfo | undefined>;
@@ -144,7 +144,7 @@ export interface INotebookServer extends IAsyncDisposable {
 export const IRawNotebookProvider = Symbol('IRawNotebookProvider');
 export interface IRawNotebookProvider extends IAsyncDisposable {
     supported(): Promise<boolean>;
-    connect(): Promise<IRawConnection>;
+    connect(token?: CancellationToken): Promise<IRawConnection>;
     createNotebook(
         identity: Uri,
         resource: Resource,
@@ -152,15 +152,18 @@ export interface IRawNotebookProvider extends IAsyncDisposable {
         notebookMetadata?: nbformat.INotebookMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook>;
-    getNotebook(identity: Uri): Promise<INotebook | undefined>;
+    getNotebook(identity: Uri, token?: CancellationToken): Promise<INotebook | undefined>;
 }
 
 // Provides notebooks that talk to jupyter servers
 export const IJupyterNotebookProvider = Symbol('IJupyterNotebookProvider');
 export interface IJupyterNotebookProvider {
-    connect(options: ConnectNotebookProviderOptions): Promise<IJupyterConnection | undefined>;
-    createNotebook(options: GetNotebookOptions): Promise<INotebook>;
-    getNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
+    connect(
+        options: ConnectNotebookProviderOptions,
+        token?: CancellationToken
+    ): Promise<IJupyterConnection | undefined>;
+    createNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook>;
+    getNotebook(options: GetNotebookOptions, token?: CancellationToken): Promise<INotebook | undefined>;
     disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
 }
 
@@ -784,7 +787,11 @@ export interface IJupyterVariables {
         start: number,
         end: number
     ): Promise<JSONObject>;
-    getMatchingVariableValue(notebook: INotebook, name: string): Promise<string | undefined>;
+    getMatchingVariableValue(
+        notebook: INotebook,
+        name: string,
+        cancelToken?: CancellationToken
+    ): Promise<string | undefined>;
 }
 
 export interface IConditionalJupyterVariables extends IJupyterVariables {
@@ -1046,16 +1053,19 @@ export interface INotebookProvider {
     /**
      * Gets or creates a notebook, and manages the lifetime of notebooks.
      */
-    getOrCreateNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;
+    getOrCreateNotebook(options: GetNotebookOptions, cancelToken?: CancellationToken): Promise<INotebook | undefined>;
     /**
      * Connect to a notebook provider to prepare its connection and to get connection information
      */
-    connect(options: ConnectNotebookProviderOptions): Promise<INotebookProviderConnection | undefined>;
+    connect(
+        options: ConnectNotebookProviderOptions,
+        cancelToken?: CancellationToken
+    ): Promise<INotebookProviderConnection | undefined>;
 
     /**
      * Disconnect from a notebook provider connection
      */
-    disconnect(options: ConnectNotebookProviderOptions): Promise<void>;
+    disconnect(options: ConnectNotebookProviderOptions, cancelToken?: CancellationToken): Promise<void>;
 }
 
 export const IJupyterServerProvider = Symbol('IJupyterServerProvider');
@@ -1063,7 +1073,7 @@ export interface IJupyterServerProvider {
     /**
      * Gets the server used for starting notebooks
      */
-    getOrCreateServer(options: GetServerOptions): Promise<INotebookServer | undefined>;
+    getOrCreateServer(options: GetServerOptions, token?: CancellationToken): Promise<INotebookServer | undefined>;
 }
 
 export interface IKernelSocket {

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -183,6 +183,7 @@ import { CellHashProvider } from '../../client/datascience/editor-integration/ce
 import { CodeLensFactory } from '../../client/datascience/editor-integration/codeLensFactory';
 import { DataScienceCodeLensProvider } from '../../client/datascience/editor-integration/codelensprovider';
 import { CodeWatcher } from '../../client/datascience/editor-integration/codewatcher';
+import { HoverProvider } from '../../client/datascience/editor-integration/hoverProvider';
 import { DataScienceErrorHandler } from '../../client/datascience/errorHandler/errorHandler';
 import { GatherProvider } from '../../client/datascience/gather/gather';
 import { GatherListener } from '../../client/datascience/gather/gatherListener';
@@ -790,6 +791,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.add<ICellHashProvider>(ICellHashProvider, CellHashProvider, undefined, [
             INotebookExecutionLogger
         ]);
+        this.serviceManager.add<INotebookExecutionLogger>(INotebookExecutionLogger, HoverProvider);
         this.serviceManager.add<IGatherProvider>(IGatherProvider, GatherProvider);
         this.serviceManager.add<IGatherLogger>(IGatherLogger, GatherLogger, undefined, [INotebookExecutionLogger]);
         this.serviceManager.addSingleton<ICodeLensFactory>(ICodeLensFactory, CodeLensFactory, undefined, [

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -539,7 +539,7 @@ Name: 0, dtype: float64`,
                 }
             },
             () => {
-                return ioc;
+                return Promise.resolve(ioc);
             }
         );
 


### PR DESCRIPTION
For #11659

Add support for hovering over top of python file variables when that file was used in the interactive window.

Didn't think a test was necessary here (nor simple to mimic as we don't have VS code in our test infrastructure.

It essentially adds another hover provider so that when it works, we get two values:

![image](https://user-images.githubusercontent.com/19672699/81625841-e394e500-93ae-11ea-9ba1-26ec790b0dce.png)

First one is the hover provider I added in this checkin and the second one is the language server.