### PR TITLE
Allow azure files and only nest scrolling in notebooks

### DIFF
--- a/news/2 Fixes/11393.md
+++ b/news/2 Fixes/11393.md
@@ -1,0 +1,1 @@
+Support opening other URI schemes besides 'file' and 'vsls'.

--- a/news/2 Fixes/11421.md
+++ b/news/2 Fixes/11421.md
@@ -1,0 +1,1 @@
+Force interactive window to always scroll long output. Don't allow scrollbars within scrollbars.

--- a/package.json
+++ b/package.json
@@ -1758,7 +1758,7 @@
                 "python.dataScience.maxOutputSize": {
                     "type": "number",
                     "default": 400,
-                    "description": "Maximum size (in pixels) of text output in the Python Interactive window and Notebook Editor before a scrollbar appears. First enable scrolling for cell outputs in settings.",
+                    "description": "Maximum size (in pixels) of text output in the Notebook Editor before a scrollbar appears. First enable scrolling for cell outputs in settings.",
                     "scope": "resource"
                 },
                 "python.dataScience.alwaysScrollOnNewCell": {
@@ -1770,7 +1770,7 @@
                 "python.dataScience.enableScrollingForCellOutputs": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Enables scrolling for large cell outputs.",
+                    "description": "Enables scrolling for large cell outputs in the Notebook Editor. This setting does not apply to the Python Interactive Window.",
                     "scope": "resource"
                 },
                 "python.dataScience.errorBackgroundColor": {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -235,7 +235,6 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
         // Look for other editors with the same file name that have a scheme of file/git and same viewcolumn.
         const fileSchemeEditor = this.documentManager.visibleTextEditors.find(
             (editorUri) =>
-                (editorUri.document.uri.scheme === 'file' || editorUri.document.uri.scheme === 'git') &&
                 editorUri !== gitSchemeEditor &&
                 this.fileSystem.arePathsSame(editorUri.document.uri.fsPath, editor.document.uri.fsPath) &&
                 editorUri.viewColumn === gitSchemeEditor.viewColumn
@@ -251,7 +250,7 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
     private isNotebook(document: TextDocument) {
         // Only support file uris (we don't want to automatically open any other ipynb file from another resource as a notebook).
         // E.g. when opening a document for comparison, the scheme is `git`, in live share the scheme is `vsls`.
-        const validUriScheme = document.uri.scheme === 'file' || document.uri.scheme === 'vsls';
+        const validUriScheme = document.uri.scheme !== 'git';
         return (
             validUriScheme &&
             (document.languageId === JUPYTER_LANGUAGE ||

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -248,8 +248,7 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
         return gitSchemeEditor === editor || fileSchemeEditor === editor;
     }
     private isNotebook(document: TextDocument) {
-        // Only support file uris (we don't want to automatically open any other ipynb file from another resource as a notebook).
-        // E.g. when opening a document for comparison, the scheme is `git`, in live share the scheme is `vsls`.
+        // Skip opening anything from git as we should use the git viewer.
         const validUriScheme = document.uri.scheme !== 'git';
         return (
             validUriScheme &&

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -19,6 +19,8 @@ import { InteractiveCellComponent } from './interactiveCell';
 import './interactivePanel.less';
 import { actionCreators } from './redux/actions';
 
+// tslint:disable: no-suspicious-comment
+
 export type IInteractivePanelProps = IMainWithVariables & typeof actionCreators;
 
 function mapStateToProps(state: IStore): IMainWithVariables {
@@ -257,8 +259,8 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                     <InteractiveCellComponent
                         role="form"
                         editorOptions={this.props.editorOptions}
-                        maxTextSize={this.getMaxTextSize(this.props.settings.maxOutputSize)}
-                        enableScroll={this.props.settings.enableScrollingForCellOutputs}
+                        maxTextSize={undefined}
+                        enableScroll={false}
                         autoFocus={document.hasFocus()}
                         testMode={this.props.testMode}
                         cellVM={this.props.editCellVM}
@@ -326,6 +328,8 @@ ${buildSettingsCss(this.props.settings)}`}</style>
         _index: number,
         containerRef?: React.RefObject<HTMLDivElement>
     ): JSX.Element | null => {
+        // Note: MaxOutputSize and enableScrollingForCellOutputs is being ignored on purpose for
+        // the interactive window. See bug: https://github.com/microsoft/vscode-python/issues/11421
         if (this.props.settings && this.props.editorOptions) {
             return (
                 <div key={cellVM.cell.id} id={cellVM.cell.id} ref={containerRef}>
@@ -333,8 +337,8 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                         <InteractiveCellComponent
                             role="listitem"
                             editorOptions={this.props.editorOptions}
-                            maxTextSize={this.getMaxTextSize(this.props.settings.maxOutputSize)}
-                            enableScroll={this.props.settings.enableScrollingForCellOutputs}
+                            maxTextSize={undefined}
+                            enableScroll={false}
                             autoFocus={false}
                             testMode={this.props.testMode}
                             cellVM={cellVM}
@@ -383,11 +387,6 @@ ${buildSettingsCss(this.props.settings)}`}</style>
     private linkClick = (ev: MouseEvent) => {
         handleLinkClick(ev, this.props.linkClick);
     };
-
-    private getMaxTextSize(maxOutputSize: number): number | undefined {
-        const outputSizeLimit = 10000;
-        return maxOutputSize && maxOutputSize < outputSizeLimit && maxOutputSize > 0 ? maxOutputSize : undefined;
-    }
 }
 
 // Main export, return a redux connected editor

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -295,7 +295,11 @@ ${buildSettingsCss(this.props.settings)}`}</style>
         const maxOutputSize = this.props.settings.maxOutputSize;
         const outputSizeLimit = 10000;
         const maxTextSize =
-            maxOutputSize && maxOutputSize < outputSizeLimit && maxOutputSize > 0 ? maxOutputSize : undefined;
+            maxOutputSize && maxOutputSize < outputSizeLimit && maxOutputSize > 0
+                ? maxOutputSize
+                : this.props.settings.enableScrollingForCellOutputs
+                ? 400
+                : undefined;
 
         return (
             <div key={cellVM.cell.id} id={cellVM.cell.id}>


### PR DESCRIPTION
For #11421, #11393

Change scrolling behavior to never allow nested scrollbars in the interactive window (might be some backlash from this as we added this setting for the interactive window)

Also don't skip opening files if they're not vsls or file scheme. The only one we don't support is 'git'.