### PR TITLE
Ensure uses of isolate script in combination with sendCommand is correctly quoted

### DIFF
--- a/src/client/common/installer/moduleInstaller.ts
+++ b/src/client/common/installer/moduleInstaller.ts
@@ -45,7 +45,7 @@ export abstract class ModuleInstaller implements IModuleInstaller {
                     ? await interpreterService.getActiveInterpreter(resource)
                     : resource;
                 const pythonPath = isResource(resource) ? settings.pythonPath : resource.path;
-                const args = internalPython.execModule(executionInfo.moduleName, executionInfoArgs, true, true);
+                const args = internalPython.execModule(executionInfo.moduleName, executionInfoArgs);
                 if (!interpreter || interpreter.type !== InterpreterType.Unknown) {
                     await terminalService.sendCommand(pythonPath, args, token);
                 } else if (settings.globalModuleInstallation) {

--- a/src/client/common/process/internal/python.ts
+++ b/src/client/common/process/internal/python.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import '../../extensions';
 import { _ISOLATED as ISOLATED } from './scripts';
 
 // "python" contains functions corresponding to the various ways that
@@ -26,15 +25,10 @@ export function execCode(code: string, isolated = true): string[] {
     return args;
 }
 
-export function execModule(
-    name: string,
-    moduleArgs: string[],
-    isolated = true,
-    useAsCommandArgument = false
-): string[] {
+export function execModule(name: string, moduleArgs: string[], isolated = true): string[] {
     const args = ['-m', name, ...moduleArgs];
     if (isolated) {
-        args[0] = useAsCommandArgument ? ISOLATED.fileToCommandArgument() : ISOLATED; // replace
+        args[0] = ISOLATED; // replace
     }
     // "code" isn't specific enough to know how to parse it,
     // so we only return the args.

--- a/src/client/common/terminal/helper.ts
+++ b/src/client/common/terminal/helper.ts
@@ -61,7 +61,9 @@ export class TerminalHelper implements ITerminalHelper {
             terminalShellType === TerminalShellType.powershell ||
             terminalShellType === TerminalShellType.powershellCore;
         const commandPrefix = isPowershell ? '& ' : '';
-        return `${commandPrefix}${command.fileToCommandArgument()} ${args.join(' ')}`.trim();
+        const formattedArgs = args.map((a) => a.toCommandArgument());
+
+        return `${commandPrefix}${command.fileToCommandArgument()} ${formattedArgs.join(' ')}`.trim();
     }
     public async getEnvironmentActivationCommands(
         terminalShellType: TerminalShellType,

--- a/src/client/interpreter/locators/services/currentPathService.ts
+++ b/src/client/interpreter/locators/services/currentPathService.ts
@@ -93,10 +93,10 @@ export class CurrentPathService extends CacheableLocatorService {
     private async getInterpreter(options: { command: string; args?: string[] }) {
         try {
             const processService = await this.processServiceFactory.create();
+            const pyArgs = Array.isArray(options.args) ? options.args : [];
             const [args, parse] = internalPython.getExecutable();
-            const pyArgs = Array.isArray(options.args) ? options.args.concat(args) : args;
             return processService
-                .exec(options.command, pyArgs, {})
+                .exec(options.command, pyArgs.concat(args), {})
                 .then((output) => parse(output.stdout))
                 .then(async (value) => {
                     if (value.length > 0 && (await this.fs.fileExists(value))) {

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -22,7 +22,6 @@ import {
 } from 'vscode';
 import { IApplicationShell, IWorkspaceService } from '../../../client/common/application/types';
 import { STANDARD_OUTPUT_CHANNEL } from '../../../client/common/constants';
-import '../../../client/common/extensions';
 import { CondaInstaller } from '../../../client/common/installer/condaInstaller';
 import { ModuleInstaller } from '../../../client/common/installer/moduleInstaller';
 import { PipEnvInstaller, pipenvName } from '../../../client/common/installer/pipEnvInstaller';
@@ -52,15 +51,13 @@ import {
 import { IServiceContainer } from '../../../client/ioc/types';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
 
-const isolated = path
-    .join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py')
-    .fileToCommandArgument();
+const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
 
 /* Complex test to ensure we cover all combinations:
 We could have written separate tests for each installer, but we'd be replicate code.
-Both approaches have their benefits.
+Both approachs have their benefits.
 
-Combinations of:
+Comnbinations of:
 1. With and without a workspace.
 2. Http Proxy configuration.
 3. All products.
@@ -467,7 +464,7 @@ suite('Module Installer', () => {
                                         interpreterService.verifyAll();
                                         terminalService.verifyAll();
                                     });
-                                    test(`If 'python.globalModuleInstallation' is not set to true, concatenate arguments with '--user' flag and send command to terminal`, async () => {
+                                    test(`If 'python.globalModuleInstallation' is not set to true, concanate arguments with '--user' flag and send command to terminal`, async () => {
                                         const info = TypeMoq.Mock.ofType<PythonInterpreter>();
                                         info.setup((t: any) => t.then).returns(() => undefined);
                                         info.setup((t) => t.type).returns(() => InterpreterType.Unknown);

--- a/src/test/common/installer/moduleInstaller.unit.test.ts
+++ b/src/test/common/installer/moduleInstaller.unit.test.ts
@@ -55,9 +55,9 @@ const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-r
 
 /* Complex test to ensure we cover all combinations:
 We could have written separate tests for each installer, but we'd be replicate code.
-Both approachs have their benefits.
+Both approaches have their benefits.
 
-Comnbinations of:
+Combinations of:
 1. With and without a workspace.
 2. Http Proxy configuration.
 3. All products.
@@ -464,7 +464,7 @@ suite('Module Installer', () => {
                                         interpreterService.verifyAll();
                                         terminalService.verifyAll();
                                     });
-                                    test(`If 'python.globalModuleInstallation' is not set to true, concanate arguments with '--user' flag and send command to terminal`, async () => {
+                                    test(`If 'python.globalModuleInstallation' is not set to true, concatenate arguments with '--user' flag and send command to terminal`, async () => {
                                         const info = TypeMoq.Mock.ofType<PythonInterpreter>();
                                         info.setup((t: any) => t.then).returns(() => undefined);
                                         info.setup((t) => t.type).returns(() => InterpreterType.Unknown);

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -37,7 +37,6 @@ import { ConfigurationService } from '../../client/common/configuration/service'
 import { CryptoUtils } from '../../client/common/crypto';
 import { EditorUtils } from '../../client/common/editor';
 import { ExperimentsManager } from '../../client/common/experiments';
-import '../../client/common/extensions';
 import { FeatureDeprecationManager } from '../../client/common/featureDeprecationManager';
 import {
     ExtensionInsidersDailyChannelRule,
@@ -144,9 +143,7 @@ import { closeActiveWindows, initializeTest } from './../initialize';
 
 chai_use(chaiAsPromised);
 
-const isolated = path
-    .join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py')
-    .fileToCommandArgument();
+const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
 
 const info: PythonInterpreter = {
     architecture: Architecture.Unknown,

--- a/src/test/common/terminals/helper.unit.test.ts
+++ b/src/test/common/terminals/helper.unit.test.ts
@@ -124,6 +124,20 @@ suite('Terminal Service helpers', () => {
                 expect(terminalCommand).to.equal(expectedTerminalCommand, `Incorrect command for Shell ${item.name}`);
             });
         });
+        test('Ensure spaces in args are quoted', async () => {
+            getNamesAndValues<TerminalShellType>(TerminalShellType).forEach((item) => {
+                const command = 'python3.7.exe';
+                const args = ['a file.py', '1', '2'];
+                const commandPrefix =
+                    item.value === TerminalShellType.powershell || item.value === TerminalShellType.powershellCore
+                        ? '& '
+                        : '';
+                const expectedTerminalCommand = `${commandPrefix}${command} "a file.py" 1 2`;
+
+                const terminalCommand = helper.buildCommandForTerminal(item.value, command, args);
+                expect(terminalCommand).to.equal(expectedTerminalCommand, `Incorrect command for Shell ${item.name}`);
+            });
+        });
 
         test('Ensure empty args are ignored', async () => {
             getNamesAndValues<TerminalShellType>(TerminalShellType).forEach((item) => {


### PR DESCRIPTION
For #11449

- Reverted https://github.com/microsoft/vscode-python/pull/11447
- Actual changes in `helper.ts` and `helper.unit.test.ts`

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
