### PR TITLE
Do not execute shebang as an interpreter until user has clicked on the codelens enclosing the shebang

### DIFF
--- a/news/2 Fixes/11687.md
+++ b/news/2 Fixes/11687.md
@@ -1,0 +1,1 @@
+Do not execute shebang as an interpreter until user has clicked on the codelens enclosing the shebang.

--- a/src/client/interpreter/configuration/interpreterSelector/commands/setShebangInterpreter.ts
+++ b/src/client/interpreter/configuration/interpreterSelector/commands/setShebangInterpreter.ts
@@ -37,7 +37,8 @@ export class SetShebangInterpreterCommand extends BaseInterpreterSelectorCommand
 
     protected async setShebangInterpreter(): Promise<void> {
         const shebang = await this.shebangCodeLensProvider.detectShebang(
-            this.documentManager.activeTextEditor!.document
+            this.documentManager.activeTextEditor!.document,
+            true
         );
         if (!shebang) {
             return;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -114,7 +114,7 @@ export interface IInterpreterDisplay {
 
 export const IShebangCodeLensProvider = Symbol('IShebangCodeLensProvider');
 export interface IShebangCodeLensProvider extends CodeLensProvider {
-    detectShebang(document: TextDocument, resolveSheBangAsInterpreter?: boolean): Promise<string | undefined>;
+    detectShebang(document: TextDocument, resolveShebangAsInterpreter?: boolean): Promise<string | undefined>;
 }
 
 export const IInterpreterHelper = Symbol('IInterpreterHelper');

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -114,7 +114,7 @@ export interface IInterpreterDisplay {
 
 export const IShebangCodeLensProvider = Symbol('IShebangCodeLensProvider');
 export interface IShebangCodeLensProvider extends CodeLensProvider {
-    detectShebang(document: TextDocument): Promise<string | undefined>;
+    detectShebang(document: TextDocument, resolveSheBangAsInterpreter?: boolean): Promise<string | undefined>;
 }
 
 export const IInterpreterHelper = Symbol('IInterpreterHelper');

--- a/src/client/interpreter/display/shebangCodeLensProvider.ts
+++ b/src/client/interpreter/display/shebangCodeLensProvider.ts
@@ -19,7 +19,10 @@ export class ShebangCodeLensProvider implements IShebangCodeLensProvider {
         // tslint:disable-next-line:no-any
         this.onDidChangeCodeLenses = (workspaceService.onDidChangeConfiguration as any) as Event<void>;
     }
-    public async detectShebang(document: TextDocument): Promise<string | undefined> {
+    public async detectShebang(
+        document: TextDocument,
+        resolveSheBangAsInterpreter: boolean = false
+    ): Promise<string | undefined> {
         const firstLine = document.lineAt(0);
         if (firstLine.isEmptyOrWhitespace) {
             return;
@@ -30,8 +33,12 @@ export class ShebangCodeLensProvider implements IShebangCodeLensProvider {
         }
 
         const shebang = firstLine.text.substr(2).trim();
-        const pythonPath = await this.getFullyQualifiedPathToInterpreter(shebang, document.uri);
-        return typeof pythonPath === 'string' && pythonPath.length > 0 ? pythonPath : undefined;
+        if (resolveSheBangAsInterpreter) {
+            const pythonPath = await this.getFullyQualifiedPathToInterpreter(shebang, document.uri);
+            return typeof pythonPath === 'string' && pythonPath.length > 0 ? pythonPath : undefined;
+        } else {
+            return typeof shebang === 'string' && shebang.length > 0 ? shebang : undefined;
+        }
     }
     public async provideCodeLenses(document: TextDocument, _token?: CancellationToken): Promise<CodeLens[]> {
         return this.createShebangCodeLens(document);

--- a/src/client/interpreter/display/shebangCodeLensProvider.ts
+++ b/src/client/interpreter/display/shebangCodeLensProvider.ts
@@ -21,7 +21,7 @@ export class ShebangCodeLensProvider implements IShebangCodeLensProvider {
     }
     public async detectShebang(
         document: TextDocument,
-        resolveSheBangAsInterpreter: boolean = false
+        resolveShebangAsInterpreter: boolean = false
     ): Promise<string | undefined> {
         const firstLine = document.lineAt(0);
         if (firstLine.isEmptyOrWhitespace) {
@@ -33,7 +33,7 @@ export class ShebangCodeLensProvider implements IShebangCodeLensProvider {
         }
 
         const shebang = firstLine.text.substr(2).trim();
-        if (resolveSheBangAsInterpreter) {
+        if (resolveShebangAsInterpreter) {
             const pythonPath = await this.getFullyQualifiedPathToInterpreter(shebang, document.uri);
             return typeof pythonPath === 'string' && pythonPath.length > 0 ? pythonPath : undefined;
         } else {

--- a/src/test/providers/shebangCodeLenseProvider.unit.test.ts
+++ b/src/test/providers/shebangCodeLenseProvider.unit.test.ts
@@ -88,7 +88,7 @@ suite('Shebang detection', () => {
 
         document.verifyAll();
         line.verifyAll();
-        expect(shebang).to.be.equal('HELLO', 'Shebang should be undefined');
+        expect(shebang).to.be.equal('HELLO', 'Shebang should be HELLO');
     });
     test('Shebang should be empty when python path is invalid in shebang', async () => {
         const [document, line] = createDocument('#!HELLO');

--- a/src/test/providers/shebangCodeLenseProvider.unit.test.ts
+++ b/src/test/providers/shebangCodeLenseProvider.unit.test.ts
@@ -63,14 +63,32 @@ suite('Shebang detection', () => {
 
         return [doc, line];
     }
-    test('Shebang should be empty when first line is empty', async () => {
+    test('Shebang should be empty when first line is empty when resolving shebang as interpreter', async () => {
         const [document, line] = createDocument('');
 
-        const shebang = await provider.detectShebang(document.object);
+        const shebang = await provider.detectShebang(document.object, true);
 
         document.verifyAll();
         line.verifyAll();
         expect(shebang).to.be.equal(undefined, 'Shebang should be undefined');
+    });
+    test('Shebang should be empty when first line is empty when not resolving shebang as interpreter', async () => {
+        const [document, line] = createDocument('');
+
+        const shebang = await provider.detectShebang(document.object, true);
+
+        document.verifyAll();
+        line.verifyAll();
+        expect(shebang).to.be.equal(undefined, 'Shebang should be undefined');
+    });
+    test('Shebang should be returned as it is when not resolving shebang as interpreter', async () => {
+        const [document, line] = createDocument('#!HELLO');
+
+        const shebang = await provider.detectShebang(document.object, false);
+
+        document.verifyAll();
+        line.verifyAll();
+        expect(shebang).to.be.equal('HELLO', 'Shebang should be undefined');
     });
     test('Shebang should be empty when python path is invalid in shebang', async () => {
         const [document, line] = createDocument('#!HELLO');
@@ -80,7 +98,7 @@ suite('Shebang detection', () => {
             .returns(() => Promise.reject())
             .verifiable(typemoq.Times.once());
 
-        const shebang = await provider.detectShebang(document.object);
+        const shebang = await provider.detectShebang(document.object, true);
 
         document.verifyAll();
         line.verifyAll();
@@ -95,7 +113,7 @@ suite('Shebang detection', () => {
             .returns(() => Promise.resolve({ stdout: 'THIS_IS_IT' }))
             .verifiable(typemoq.Times.once());
 
-        const shebang = await provider.detectShebang(document.object);
+        const shebang = await provider.detectShebang(document.object, true);
 
         document.verifyAll();
         line.verifyAll();
@@ -113,7 +131,7 @@ suite('Shebang detection', () => {
             .returns(() => Promise.resolve({ stdout: 'THIS_IS_IT' }))
             .verifiable(typemoq.Times.once());
 
-        const shebang = await provider.detectShebang(document.object);
+        const shebang = await provider.detectShebang(document.object, true);
 
         document.verifyAll();
         line.verifyAll();
@@ -132,7 +150,7 @@ suite('Shebang detection', () => {
             .returns(() => Promise.resolve({ stdout: 'THIS_IS_IT' }))
             .verifiable(typemoq.Times.once());
 
-        const shebang = await provider.detectShebang(document.object);
+        const shebang = await provider.detectShebang(document.object, true);
 
         document.verifyAll();
         line.verifyAll();

--- a/src/test/providers/shebangCodeLenseProvider.unit.test.ts
+++ b/src/test/providers/shebangCodeLenseProvider.unit.test.ts
@@ -75,7 +75,7 @@ suite('Shebang detection', () => {
     test('Shebang should be empty when first line is empty when not resolving shebang as interpreter', async () => {
         const [document, line] = createDocument('');
 
-        const shebang = await provider.detectShebang(document.object, true);
+        const shebang = await provider.detectShebang(document.object, false);
 
         document.verifyAll();
         line.verifyAll();


### PR DESCRIPTION
For #11687

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
