### PR TITLE
Fix memleaks during tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -266,7 +266,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                //"--grep", "<suite name>",
+                "--grep", "DataScience Interactive",
                 "--timeout=300000"
             ],
             "env": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -266,7 +266,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                "--grep", "DataScience Interactive",
+                // "--grep", "<suite name>",
                 "--timeout=300000"
             ],
             "env": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -266,7 +266,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                // "--grep", "<suite name>",
+                //"--grep", "<suite name>",
                 "--timeout=300000"
             ],
             "env": {

--- a/build/conda-functional-requirements.txt
+++ b/build/conda-functional-requirements.txt
@@ -21,3 +21,4 @@ ipyvolume
 beakerx
 bqplot
 K3D
+debugpy

--- a/package-lock.json
+++ b/package-lock.json
@@ -3120,6 +3120,24 @@
                 }
             }
         },
+        "@raghb1/node-memwatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@raghb1/node-memwatch/-/node-memwatch-3.0.1.tgz",
+            "integrity": "sha512-35KIUjB0llg8N13yf4zQ4RCLBPB7BrqLQ9w1oXde70MjoAu9plnMTH4iJBUihZtumLc9OMhViEX0deaI+XRo+w==",
+            "dev": true,
+            "requires": {
+                "bindings": "^1.5.0",
+                "nan": "^2.14.1"
+            },
+            "dependencies": {
+                "nan": {
+                    "version": "2.14.1",
+                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+                    "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+                    "dev": true
+                }
+            }
+        },
         "@sheerun/mutationobserver-shim": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
@@ -5768,7 +5786,6 @@
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
@@ -10077,8 +10094,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "filemanager-webpack-plugin-fixed": {
             "version": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -2913,6 +2913,7 @@
         "test:unittests:cover": "nyc --no-clean --nycrc-path build/.nycrc mocha --opts ./build/.mocha.unittests.ts.opts",
         "test:functional": "mocha --require source-map-support/register --opts ./build/.mocha.functional.opts",
         "test:functional:perf": "node --inspect-brk ./node_modules/mocha/bin/_mocha --require source-map-support/register --opts ./build/.mocha.functional.perf.opts",
+        "test:functional:memleak": "node --inspect-brk ./node_modules/mocha/bin/_mocha --require source-map-support/register --opts ./build/.mocha.functional.opts",
         "test:functional:cover": "npm run test:functional",
         "test:cover:report": "nyc --nycrc-path build/.nycrc  report --reporter=text --reporter=html --reporter=text-summary --reporter=cobertura",
         "testDebugger": "node ./out/test/testBootstrap.js ./out/test/debuggerTest.js",

--- a/package.json
+++ b/package.json
@@ -3023,6 +3023,7 @@
         "@nteract/transform-vega": "^6.0.3",
         "@nteract/transforms": "^4.4.4",
         "@phosphor/widgets": "^1.9.3",
+        "@raghb1/node-memwatch": "^3.0.1",
         "@testing-library/react": "^9.4.0",
         "@types/ansi-regex": "^4.0.0",
         "@types/chai": "^4.1.2",

--- a/src/client/datascience/jupyter/jupyterConnection.ts
+++ b/src/client/datascience/jupyter/jupyterConnection.ts
@@ -41,7 +41,7 @@ export class JupyterConnectionWaiter implements IDisposable {
     private fileSystem: IFileSystem;
     private stderr: string[] = [];
     private connectionDisposed = false;
-    private disposables: Subscription[] = [];
+    private subscriptions: Subscription[] = [];
 
     constructor(
         private readonly launchResult: ObservableExecutionResult<string>,
@@ -76,7 +76,7 @@ export class JupyterConnectionWaiter implements IDisposable {
         }
         let stderr = '';
         // Listen on stderr for its connection information
-        this.disposables.push(
+        this.subscriptions.push(
             launchResult.out.subscribe(
                 (output: Output<string>) => {
                     if (output.source === 'stderr') {
@@ -96,7 +96,7 @@ export class JupyterConnectionWaiter implements IDisposable {
     public dispose() {
         // tslint:disable-next-line: no-any
         clearTimeout(this.launchTimeout as any);
-        this.disposables.forEach((d) => d.unsubscribe());
+        this.subscriptions.forEach((d) => d.unsubscribe());
     }
 
     public waitForConnection(): Promise<IJupyterConnection> {

--- a/src/client/datascience/jupyter/jupyterConnection.ts
+++ b/src/client/datascience/jupyter/jupyterConnection.ts
@@ -4,6 +4,7 @@
 import '../../common/extensions';
 
 import { ChildProcess } from 'child_process';
+import { Subscription } from 'rxjs';
 import { CancellationToken, Disposable, Event, EventEmitter } from 'vscode';
 import { Cancellation, CancellationError } from '../../common/cancellation';
 import { traceInfo, traceWarning } from '../../common/logger';
@@ -40,13 +41,14 @@ export class JupyterConnectionWaiter implements IDisposable {
     private fileSystem: IFileSystem;
     private stderr: string[] = [];
     private connectionDisposed = false;
+    private disposables: Subscription[] = [];
 
     constructor(
         private readonly launchResult: ObservableExecutionResult<string>,
         private readonly notebookDir: string,
         private readonly getServerInfo: (cancelToken?: CancellationToken) => Promise<JupyterServerInfo[] | undefined>,
         serviceContainer: IServiceContainer,
-        private readonly cancelToken?: CancellationToken
+        private cancelToken?: CancellationToken
     ) {
         this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
         this.fileSystem = serviceContainer.get<IFileSystem>(IFileSystem);
@@ -74,24 +76,27 @@ export class JupyterConnectionWaiter implements IDisposable {
         }
         let stderr = '';
         // Listen on stderr for its connection information
-        launchResult.out.subscribe(
-            (output: Output<string>) => {
-                if (output.source === 'stderr') {
-                    stderr += output.out;
-                    this.stderr.push(output.out);
-                    this.extractConnectionInformation(stderr);
-                } else {
-                    this.output(output.out);
-                }
-            },
-            (e) => this.rejectStartPromise(e.message),
-            // If the process dies, we can't extract connection information.
-            () => this.rejectStartPromise(localize.DataScience.jupyterServerCrashed().format(exitCode))
+        this.disposables.push(
+            launchResult.out.subscribe(
+                (output: Output<string>) => {
+                    if (output.source === 'stderr') {
+                        stderr += output.out;
+                        this.stderr.push(output.out);
+                        this.extractConnectionInformation(stderr);
+                    } else {
+                        this.output(output.out);
+                    }
+                },
+                (e) => this.rejectStartPromise(e.message),
+                // If the process dies, we can't extract connection information.
+                () => this.rejectStartPromise(localize.DataScience.jupyterServerCrashed().format(exitCode))
+            )
         );
     }
     public dispose() {
         // tslint:disable-next-line: no-any
         clearTimeout(this.launchTimeout as any);
+        this.disposables.forEach((d) => d.unsubscribe());
     }
 
     public waitForConnection(): Promise<IJupyterConnection> {
@@ -104,11 +109,11 @@ export class JupyterConnectionWaiter implements IDisposable {
     }
 
     // tslint:disable-next-line:no-any
-    private output = (data: any) => {
+    private output(data: any) {
         if (!this.connectionDisposed) {
             traceInfo(data.toString('utf8'));
         }
-    };
+    }
 
     // From a list of jupyter server infos try to find the matching jupyter that we launched
     // tslint:disable-next-line:no-any

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -291,8 +291,6 @@ export namespace Transfer {
         postActionToExtension(arg, CssMessages.GetMonacoThemeRequest, {
             isDark: arg.prevState.baseTheme !== 'vscode-light'
         });
-        postActionToExtension(arg, InteractiveWindowMessages.LoadOnigasmAssemblyRequest);
-        postActionToExtension(arg, InteractiveWindowMessages.LoadTmLanguageRequest);
         return arg.prevState;
     }
 

--- a/src/datascience-ui/interactive-common/tokenizer.ts
+++ b/src/datascience-ui/interactive-common/tokenizer.ts
@@ -59,7 +59,7 @@ export function registerMonacoLanguage() {
 
 // Loading the tokenizer is process wide, so don't bother doing it more than once. Creates memory leaks
 // when running tests.
-const loaded: boolean = false;
+let loaded: boolean = false;
 
 // tslint:disable: no-any
 export async function initializeTokenizer(
@@ -68,6 +68,7 @@ export async function initializeTokenizer(
     loadingFinished: (e?: any) => void
 ): Promise<void> {
     if (!loaded) {
+        loaded = true;
         try {
             // Register the language first
             registerMonacoLanguage();

--- a/src/datascience-ui/interactive-common/tokenizer.ts
+++ b/src/datascience-ui/interactive-common/tokenizer.ts
@@ -57,40 +57,48 @@ export function registerMonacoLanguage() {
     });
 }
 
+// Loading the tokenizer is process wide, so don't bother doing it more than once. Creates memory leaks
+// when running tests.
+const loaded: boolean = false;
+
 // tslint:disable: no-any
 export async function initializeTokenizer(
     onigasm: ArrayBuffer,
     tmlanguageJSON: string,
     loadingFinished: (e?: any) => void
 ): Promise<void> {
-    try {
-        // Register the language first
-        registerMonacoLanguage();
+    if (!loaded) {
+        try {
+            // Register the language first
+            registerMonacoLanguage();
 
-        // Load the web assembly if necessary
-        if (onigasm && onigasm.byteLength > 0) {
-            await loadWASM(onigasm);
+            // Load the web assembly if necessary
+            if (onigasm && onigasm.byteLength > 0) {
+                await loadWASM(onigasm);
 
-            // Setup our registry of different
-            const registry = new Registry({
-                getGrammarDefinition: async (_scopeName) => {
-                    return {
-                        format: 'json',
-                        content: tmlanguageJSON
-                    };
-                }
-            });
+                // Setup our registry of different
+                const registry = new Registry({
+                    getGrammarDefinition: async (_scopeName) => {
+                        return {
+                            format: 'json',
+                            content: tmlanguageJSON
+                        };
+                    }
+                });
 
-            // map of monaco "language id's" to TextMate scopeNames
-            const grammars = new Map();
-            grammars.set('python', 'source.python');
+                // map of monaco "language id's" to TextMate scopeNames
+                const grammars = new Map();
+                grammars.set('python', 'source.python');
 
-            // Wire everything together.
-            await wireTmGrammars(monacoEditor, registry, grammars);
+                // Wire everything together.
+                await wireTmGrammars(monacoEditor, registry, grammars);
+            }
+            // Indicate to the callback that we're done.
+            loadingFinished();
+        } catch (e) {
+            loadingFinished(e);
         }
-        // Indicate to the callback that we're done.
+    } else {
         loadingFinished();
-    } catch (e) {
-        loadingFinished(e);
     }
 }

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -492,7 +492,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         try {
             // Make sure to delete any temp files written by native editor storage
             const globPr = promisify(glob);
-            const tempLocation = this.serviceManager.get<IExtensionContext>(IExtensionContext).globalStoragePath;
+            const tempLocation = os.tmpdir;
             const tempFiles = await globPr(`${tempLocation}/*.ipynb`);
             if (tempFiles && tempFiles.length) {
                 await Promise.all(tempFiles.map((t) => fs.remove(t)));

--- a/src/test/datascience/dataviewer.functional.test.tsx
+++ b/src/test/datascience/dataviewer.functional.test.tsx
@@ -19,6 +19,7 @@ import { MainPanel } from '../../datascience-ui/data-explorer/mainPanel';
 import { ReactSlickGrid } from '../../datascience-ui/data-explorer/reactSlickGrid';
 import { noop, sleep } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import { waitForMessage } from './testHelpers';
 
 // import { asyncDump } from '../common/asyncDump';
@@ -27,6 +28,7 @@ suite('DataScience DataViewer tests', () => {
     let dataProvider: IDataViewerProvider;
     let ioc: DataScienceIocContainer;
     let notebook: INotebook | undefined;
+    const snapshot = takeSnapshot();
 
     suiteSetup(function () {
         // DataViewer tests require jupyter to run. Othewrise can't
@@ -38,6 +40,10 @@ suite('DataScience DataViewer tests', () => {
             // tslint:disable-next-line:no-invalid-this
             this.skip();
         }
+    });
+
+    suiteTeardown(() => {
+        writeDiffSnapshot(snapshot, 'DataViewer');
     });
 
     setup(async () => {

--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -46,9 +46,12 @@ suite('DataScience Debugger tests', () => {
     let ioc: DataScienceIocContainer;
     let lastErrorMessage: string | undefined;
     let jupyterDebuggerService: IJupyterDebugService | undefined;
-    const snapshot = takeSnapshot();
+    // tslint:disable-next-line: no-any
+    let snapshot: any;
 
     suiteSetup(function () {
+        snapshot = takeSnapshot();
+
         // Debugger tests require jupyter to run. Othewrise can't not really testing them
         const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
 

--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../client/datascience/types';
 import { ImageButton } from '../../datascience-ui/react-common/imageButton';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import { getInteractiveCellResults, getOrCreateInteractiveWindow } from './interactiveWindowTestHelpers';
 import { MockDocument } from './mockDocument';
 import { MockDocumentManager } from './mockDocumentManager';
@@ -45,6 +46,7 @@ suite('DataScience Debugger tests', () => {
     let ioc: DataScienceIocContainer;
     let lastErrorMessage: string | undefined;
     let jupyterDebuggerService: IJupyterDebugService | undefined;
+    const snapshot = takeSnapshot();
 
     suiteSetup(function () {
         // Debugger tests require jupyter to run. Othewrise can't not really testing them
@@ -56,6 +58,10 @@ suite('DataScience Debugger tests', () => {
             // tslint:disable-next-line:no-invalid-this
             this.skip();
         }
+    });
+
+    suiteTeardown(() => {
+        writeDiffSnapshot(snapshot, 'Debugger');
     });
 
     setup(async () => {

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -3,7 +3,10 @@
 
 'use strict';
 
+import * as fs from 'fs-extra';
+import * as path from 'path';
 import { IDataScienceSettings } from '../../client/common/types';
+import { EXTENSION_ROOT_DIR } from '../../client/constants';
 
 // The default base set of data science settings to use
 export function defaultDataScienceSettings(): IDataScienceSettings {
@@ -36,4 +39,19 @@ export function defaultDataScienceSettings(): IDataScienceSettings {
         jupyterCommandLineArguments: [],
         widgetScriptSources: []
     };
+}
+
+export function takeSnapshot() {
+    // tslint:disable-next-line: no-require-imports
+    const memwatch = require('@raghb1/node-memwatch');
+    return new memwatch.HeapDiff();
+}
+
+let snapshotCounter = 1;
+// tslint:disable-next-line: no-any
+export function writeDiffSnapshot(snapshot: any, prefix: string) {
+    const diff = snapshot.end();
+    const file = path.join(EXTENSION_ROOT_DIR, 'tmp', `SD-${snapshotCounter}-${prefix}.json`);
+    snapshotCounter += 1;
+    fs.writeFile(file, JSON.stringify(diff), { encoding: 'utf-8' }).ignoreErrors();
 }

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import { noop } from 'lodash';
 import { IDataScienceSettings } from '../../client/common/types';
 
 // The default base set of data science settings to use
@@ -39,18 +40,20 @@ export function defaultDataScienceSettings(): IDataScienceSettings {
 }
 
 export function takeSnapshot() {
+    // If you're investigating memory leaks in the tests, using the node-memwatch
+    // code below can be helpful. It will at least write out what objects are taking up the most
+    // memory.
+    // Alternatively, using the test:functional:memleak task and sticking breakpoints here and in
+    // writeDiffSnapshot can be used as convenient locations to create heap snapshots and diff them.
     // tslint:disable-next-line: no-require-imports
     //const memwatch = require('@raghb1/node-memwatch');
-    // tslint:disable-next-line: no-console
-    console.log('Snapshot now');
     return {}; //new memwatch.HeapDiff();
 }
 
 //let snapshotCounter = 1;
 // tslint:disable-next-line: no-any
 export function writeDiffSnapshot(_snapshot: any, _prefix: string) {
-    // tslint:disable-next-line: no-console
-    console.log('Diff now');
+    noop(); // Stick breakpoint here when generating heap snapshots
     // const diff = snapshot.end();
     // const file = path.join(EXTENSION_ROOT_DIR, 'tmp', `SD-${snapshotCounter}-${prefix}.json`);
     // snapshotCounter += 1;

--- a/src/test/datascience/helpers.ts
+++ b/src/test/datascience/helpers.ts
@@ -3,10 +3,7 @@
 
 'use strict';
 
-import * as fs from 'fs-extra';
-import * as path from 'path';
 import { IDataScienceSettings } from '../../client/common/types';
-import { EXTENSION_ROOT_DIR } from '../../client/constants';
 
 // The default base set of data science settings to use
 export function defaultDataScienceSettings(): IDataScienceSettings {
@@ -43,15 +40,19 @@ export function defaultDataScienceSettings(): IDataScienceSettings {
 
 export function takeSnapshot() {
     // tslint:disable-next-line: no-require-imports
-    const memwatch = require('@raghb1/node-memwatch');
-    return new memwatch.HeapDiff();
+    //const memwatch = require('@raghb1/node-memwatch');
+    // tslint:disable-next-line: no-console
+    console.log('Snapshot now');
+    return {}; //new memwatch.HeapDiff();
 }
 
-let snapshotCounter = 1;
+//let snapshotCounter = 1;
 // tslint:disable-next-line: no-any
-export function writeDiffSnapshot(snapshot: any, prefix: string) {
-    const diff = snapshot.end();
-    const file = path.join(EXTENSION_ROOT_DIR, 'tmp', `SD-${snapshotCounter}-${prefix}.json`);
-    snapshotCounter += 1;
-    fs.writeFile(file, JSON.stringify(diff), { encoding: 'utf-8' }).ignoreErrors();
+export function writeDiffSnapshot(_snapshot: any, _prefix: string) {
+    // tslint:disable-next-line: no-console
+    console.log('Diff now');
+    // const diff = snapshot.end();
+    // const file = path.join(EXTENSION_ROOT_DIR, 'tmp', `SD-${snapshotCounter}-${prefix}.json`);
+    // snapshotCounter += 1;
+    // fs.writeFile(file, JSON.stringify(diff), { encoding: 'utf-8' }).ignoreErrors();
 }

--- a/src/test/datascience/intellisense.functional.test.tsx
+++ b/src/test/datascience/intellisense.functional.test.tsx
@@ -13,6 +13,7 @@ import { IInterpreterService } from '../../client/interpreter/contracts';
 import { MonacoEditor } from '../../datascience-ui/react-common/monacoEditor';
 import { noop } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import * as InteractiveHelpers from './interactiveWindowTestHelpers';
 import * as NativeHelpers from './nativeEditorTestHelpers';
 import { addMockData, enterEditorKey, getInteractiveEditor, getNativeEditor, typeCode } from './testHelpers';
@@ -22,11 +23,16 @@ import { addMockData, enterEditorKey, getInteractiveEditor, getNativeEditor, typ
     suite(`DataScience Intellisense tests with ${languageServerType} LanguageServer mocked`, () => {
         const disposables: Disposable[] = [];
         let ioc: DataScienceIocContainer;
+        const snapshot = takeSnapshot();
 
         setup(async () => {
             ioc = new DataScienceIocContainer();
             ioc.registerDataScienceTypes(false, languageServerType);
             return ioc.activate();
+        });
+
+        suiteTeardown(() => {
+            writeDiffSnapshot(snapshot, 'Intellisense');
         });
 
         teardown(async () => {

--- a/src/test/datascience/intellisense.functional.test.tsx
+++ b/src/test/datascience/intellisense.functional.test.tsx
@@ -23,7 +23,11 @@ import { addMockData, enterEditorKey, getInteractiveEditor, getNativeEditor, typ
     suite(`DataScience Intellisense tests with ${languageServerType} LanguageServer mocked`, () => {
         const disposables: Disposable[] = [];
         let ioc: DataScienceIocContainer;
-        const snapshot = takeSnapshot();
+        let snapshot: any;
+
+        suiteSetup(() => {
+            snapshot = takeSnapshot();
+        });
 
         setup(async () => {
             ioc = new DataScienceIocContainer();

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -28,7 +28,7 @@ import { ImageButton } from '../../datascience-ui/react-common/imageButton';
 import { MonacoEditor } from '../../datascience-ui/react-common/monacoEditor';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 import { createDocument } from './editor-integration/helpers';
-import { defaultDataScienceSettings } from './helpers';
+import { defaultDataScienceSettings, takeSnapshot, writeDiffSnapshot } from './helpers';
 import {
     addCode,
     closeInteractiveWindow,
@@ -67,11 +67,16 @@ suite('DataScience Interactive Window output tests', () => {
     const disposables: Disposable[] = [];
     let ioc: DataScienceIocContainer;
     const defaultCellMarker = '# %%';
+    const snapshot = takeSnapshot();
 
     setup(async () => {
         ioc = new DataScienceIocContainer();
         ioc.registerDataScienceTypes();
         return ioc.activate();
+    });
+
+    suiteTeardown(() => {
+        writeDiffSnapshot(snapshot, 'Interactive Window');
     });
 
     teardown(async () => {

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -67,7 +67,11 @@ suite('DataScience Interactive Window output tests', () => {
     const disposables: Disposable[] = [];
     let ioc: DataScienceIocContainer;
     const defaultCellMarker = '# %%';
-    const snapshot = takeSnapshot();
+    let snapshot: any;
+
+    suiteSetup(() => {
+        snapshot = takeSnapshot();
+    });
 
     setup(async () => {
         ioc = new DataScienceIocContainer();

--- a/src/test/datascience/kernelLauncher.functional.test.ts
+++ b/src/test/datascience/kernelLauncher.functional.test.ts
@@ -28,7 +28,12 @@ suite('DataScience - Kernel Launcher', () => {
     let pythonInterpreter: PythonInterpreter | undefined;
     let kernelSpec: IJupyterKernelSpec;
     let kernelFinder: MockKernelFinder;
-    const snapshot = takeSnapshot();
+    // tslint:disable-next-line: no-any
+    let snapshot: any;
+
+    suiteSetup(() => {
+        snapshot = takeSnapshot();
+    });
 
     setup(async () => {
         ioc = new DataScienceIocContainer();

--- a/src/test/datascience/kernelLauncher.functional.test.ts
+++ b/src/test/datascience/kernelLauncher.functional.test.ts
@@ -18,6 +18,7 @@ import { IJupyterKernelSpec } from '../../client/datascience/types';
 import { PythonInterpreter } from '../../client/interpreter/contracts';
 import { sleep, waitForCondition } from '../common';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import { MockKernelFinder } from './mockKernelFinder';
 import { requestExecute } from './raw-kernel/rawKernelTestHelpers';
 
@@ -27,6 +28,7 @@ suite('DataScience - Kernel Launcher', () => {
     let pythonInterpreter: PythonInterpreter | undefined;
     let kernelSpec: IJupyterKernelSpec;
     let kernelFinder: MockKernelFinder;
+    const snapshot = takeSnapshot();
 
     setup(async () => {
         ioc = new DataScienceIocContainer();
@@ -48,6 +50,10 @@ suite('DataScience - Kernel Launcher', () => {
                 env: undefined
             };
         }
+    });
+
+    suiteTeardown(() => {
+        writeDiffSnapshot(snapshot, 'KernelLauncher');
     });
 
     test('Launch from kernelspec', async function () {

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -44,7 +44,7 @@ import { IMonacoEditorState, MonacoEditor } from '../../datascience-ui/react-com
 import { waitForCondition } from '../common';
 import { createTemporaryFile } from '../utils/fs';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
-import { defaultDataScienceSettings } from './helpers';
+import { defaultDataScienceSettings, takeSnapshot, writeDiffSnapshot } from './helpers';
 import { MockCustomEditorService } from './mockCustomEditorService';
 import { MockDocumentManager } from './mockDocumentManager';
 import {
@@ -101,6 +101,7 @@ suite('DataScience Native Editor', () => {
 
     [false, true].forEach((useCustomEditorApi) => {
         //import { asyncDump } from '../common/asyncDump';
+        const snapshot = takeSnapshot();
         suite(`${useCustomEditorApi ? 'With' : 'Without'} Custom Editor API`, () => {
             function createFileCell(cell: any, data: any): ICell {
                 const newCell = {
@@ -122,6 +123,9 @@ suite('DataScience Native Editor', () => {
 
                 return newCell;
             }
+            suiteTeardown(() => {
+                writeDiffSnapshot(snapshot, `Native ${useCustomEditorApi}`);
+            });
             suite('Editor tests', () => {
                 const disposables: Disposable[] = [];
                 let ioc: DataScienceIocContainer;

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -101,7 +101,7 @@ suite('DataScience Native Editor', () => {
 
     [false, true].forEach((useCustomEditorApi) => {
         //import { asyncDump } from '../common/asyncDump';
-        const snapshot = takeSnapshot();
+        let snapshot: any;
         suite(`${useCustomEditorApi ? 'With' : 'Without'} Custom Editor API`, () => {
             function createFileCell(cell: any, data: any): ICell {
                 const newCell = {
@@ -123,6 +123,9 @@ suite('DataScience Native Editor', () => {
 
                 return newCell;
             }
+            suiteSetup(() => {
+                snapshot = takeSnapshot();
+            });
             suiteTeardown(() => {
                 writeDiffSnapshot(snapshot, `Native ${useCustomEditorApi}`);
             });

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -55,6 +55,7 @@ import { concatMultilineStringInput } from '../../datascience-ui/common';
 import { generateTestState, ICellViewModel } from '../../datascience-ui/interactive-common/mainState';
 import { sleep } from '../core';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import { getConnectionInfo, getIPConnectionInfo } from './jupyterHelpers';
 import { SupportedCommands } from './mockJupyterManager';
 import { MockPythonService } from './mockPythonService';
@@ -70,6 +71,7 @@ suite('DataScience notebook tests', () => {
             let ioc: DataScienceIocContainer;
             let modifiedConfig = false;
             const baseUri = Uri.file('foo.py');
+            const snapshot = takeSnapshot();
 
             // tslint:disable-next-line: no-function-expression
             setup(async function () {
@@ -85,6 +87,10 @@ suite('DataScience notebook tests', () => {
                 await ioc.activate();
                 notebookProvider = ioc.get<INotebookProvider>(INotebookProvider);
                 pythonFactory = ioc.get<IPythonExecutionFactory>(IPythonExecutionFactory);
+            });
+
+            suiteTeardown(() => {
+                writeDiffSnapshot(snapshot, `Notebook ${useRawKernel}`);
             });
 
             teardown(async () => {

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -71,7 +71,7 @@ suite('DataScience notebook tests', () => {
             let ioc: DataScienceIocContainer;
             let modifiedConfig = false;
             const baseUri = Uri.file('foo.py');
-            const snapshot = takeSnapshot();
+            let snapshot: any;
 
             // tslint:disable-next-line: no-function-expression
             setup(async function () {
@@ -87,6 +87,10 @@ suite('DataScience notebook tests', () => {
                 await ioc.activate();
                 notebookProvider = ioc.get<INotebookProvider>(INotebookProvider);
                 pythonFactory = ioc.get<IPythonExecutionFactory>(IPythonExecutionFactory);
+            });
+
+            suiteSetup(() => {
+                snapshot = takeSnapshot();
             });
 
             suiteTeardown(() => {

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -31,9 +31,10 @@ const rangeInclusive = require('range-inclusive');
         const disposables: Disposable[] = [];
         let ioc: DataScienceIocContainer;
         let createdNotebook = false;
-        const snapshot = takeSnapshot();
+        let snapshot: any;
 
         suiteSetup(function () {
+            snapshot = takeSnapshot();
             // These test require python, so only run with a non-mocked jupyter
             const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
             if (!isRollingBuild) {

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -10,6 +10,7 @@ import { RunByLine } from '../../client/common/experimentGroups';
 import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IJupyterVariable } from '../../client/datascience/types';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
+import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import { addCode, getOrCreateInteractiveWindow } from './interactiveWindowTestHelpers';
 import { addCell, createNewEditor } from './nativeEditorTestHelpers';
 import {
@@ -30,6 +31,7 @@ const rangeInclusive = require('range-inclusive');
         const disposables: Disposable[] = [];
         let ioc: DataScienceIocContainer;
         let createdNotebook = false;
+        const snapshot = takeSnapshot();
 
         suiteSetup(function () {
             // These test require python, so only run with a non-mocked jupyter
@@ -65,9 +67,10 @@ const rangeInclusive = require('range-inclusive');
         });
 
         // Uncomment this to debug hangs on exit
-        //suiteTeardown(() => {
-        //      asyncDump();
-        //});
+        suiteTeardown(() => {
+            //      asyncDump();
+            writeDiffSnapshot(snapshot, `Variable Explorer ${runByLine}`);
+        });
 
         async function addCodeImpartial(
             wrapper: ReactWrapper<any, Readonly<{}>, React.Component>,

--- a/src/test/unittests.ts
+++ b/src/test/unittests.ts
@@ -22,6 +22,7 @@ if ((Reflect as any).metadata === undefined) {
 
 process.env.VSC_PYTHON_CI_TEST = '1';
 process.env.VSC_PYTHON_UNIT_TEST = '1';
+process.env.NODE_ENV = 'production'; // Make sure react is using production bits or we can run out of memory.
 
 import { setUpDomEnvironment, setupTranspile } from './datascience/reactHelpers';
 import { initialize } from './vscode-mock';


### PR DESCRIPTION
Half the time the nightly flake tests are just crashing with no results. Turns out we had more memory leaks.

These fixes address some of the memory leaks. The biggest being don't fetch the onigasm bundle (which expands into 150mb) if it's already been fetched. Since this data is stored in a global variable in the onigasm code, we can't free it. 

Additionally react when not in production mode retains a lot more objects than normal. Unmounting controls does not free them. So force react to be in production mode when running tests.


This also seems to speedup the tests as we don't need to send the onigasm requests more than once.
