### PR TITLE
Debug and variable test failures on nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,7 +495,7 @@ jobs:
           DISPLAY: 10
         uses: GabrielBB/xvfb-action@v1.0
         with:
-          run: node ./out/test/smokeTest.js
+          run: node --no-force-async-hooks-checks ./out/test/smokeTest.js
 
   coverage:
     name: Coverage reports upload

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -506,7 +506,7 @@ steps:
       npm run package
       npx gulp clean:cleanExceptTests
       cp -r ./tmp/test ./out/test
-      node ./out/test/smokeTest.js
+      node --no-force-async-hooks-checks ./out/test/smokeTest.js
     displayName: 'Run Smoke Tests'
     condition: and(succeeded(), contains(variables['TestsToRun'], 'testSmoke'))
     env:

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -115,7 +115,7 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
         end: number
     ): Promise<{}> {
         // Run the get dataframe rows script
-        if (!this.debugService.activeDebugSession) {
+        if (!this.debugService.activeDebugSession || targetVariable.columns === undefined) {
             // No active server just return no rows
             return {};
         }
@@ -161,7 +161,7 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
         // When the initialize response comes back, indicate we have started.
         if (message.type === 'response' && message.command === 'initialize') {
             this.debuggingStarted = true;
-        } else if (message.type === 'response' && message.command === 'variables') {
+        } else if (message.type === 'response' && message.command === 'variables' && message.body) {
             // If using the interactive debugger, update our variables.
             // tslint:disable-next-line: no-suspicious-comment
             // TODO: Figure out what resource to use

--- a/src/client/datascience/jupyterDebugService.ts
+++ b/src/client/datascience/jupyterDebugService.ts
@@ -337,14 +337,14 @@ export class JupyterDebugService implements IJupyterDebugService, IDisposable {
 
     private sendMessage(command: string, args?: any): Promise<any> {
         const response = createDeferred<any>();
-        const disposable = this.sessionTerminatedEvent.event(() => response.resolve());
+        const disposable = this.sessionTerminatedEvent.event(() => response.resolve({ body: {} }));
         this.protocolParser.once(`response_${command}`, (resp: any) => {
             this.sendToTrackers(resp);
             traceInfo(`Received response from debugger: ${JSON.stringify(args)}`);
             disposable.dispose();
             response.resolve(resp.body);
         });
-        this.socket!.on('error', (err) => response.reject(err)); // NOSONAR
+        this.socket?.on('error', (err) => response.reject(err)); // NOSONAR
         this.emitMessage(command, args).catch((exc) => {
             traceError(`Exception attempting to emit ${command} to debugger: `, exc);
         });

--- a/src/client/datascience/jupyterDebugService.ts
+++ b/src/client/datascience/jupyterDebugService.ts
@@ -349,9 +349,7 @@ export class JupyterDebugService implements IJupyterDebugService, IDisposable {
                 response.resolve(resp.body);
             }
         });
-        this.socket?.on('error', (err) => {
-            response.reject(err); // NOSONAR
-        });
+        this.socket?.on('error', (err) => response.reject(err)); // NOSONAR
         this.emitMessage(command, args).catch((exc) => {
             traceError(`Exception attempting to emit ${command} to debugger: `, exc);
         });

--- a/src/client/datascience/jupyterDebugService.ts
+++ b/src/client/datascience/jupyterDebugService.ts
@@ -337,14 +337,21 @@ export class JupyterDebugService implements IJupyterDebugService, IDisposable {
 
     private sendMessage(command: string, args?: any): Promise<any> {
         const response = createDeferred<any>();
-        const disposable = this.sessionTerminatedEvent.event(() => response.resolve({ body: {} }));
-        this.protocolParser.once(`response_${command}`, (resp: any) => {
-            this.sendToTrackers(resp);
-            traceInfo(`Received response from debugger: ${JSON.stringify(args)}`);
-            disposable.dispose();
-            response.resolve(resp.body);
+        const disposable = this.sessionTerminatedEvent.event(() => {
+            response.resolve({ body: {} });
         });
-        this.socket?.on('error', (err) => response.reject(err)); // NOSONAR
+        const sequenceNumber = this.sequence;
+        this.protocolParser.on(`response_${command}`, (resp: any) => {
+            if (resp.request_seq === sequenceNumber) {
+                this.sendToTrackers(resp);
+                traceInfo(`Received response from debugger: ${JSON.stringify(args)}`);
+                disposable.dispose();
+                response.resolve(resp.body);
+            }
+        });
+        this.socket?.on('error', (err) => {
+            response.reject(err); // NOSONAR
+        });
         this.emitMessage(command, args).catch((exc) => {
             traceError(`Exception attempting to emit ${command} to debugger: `, exc);
         });

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -147,7 +147,7 @@ function handleRestarted(arg: VariableReducerArg): IVariableState {
     });
     return {
         ...result,
-        currentExecutionCount: 0,
+        currentExecutionCount: -1,
         variables: []
     };
 }

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -183,7 +183,11 @@ function createTestMiddleware(): Redux.Middleware<{}, IStore> {
         }
 
         // Indicate variables complete
-        if (!fastDeepEqual(prevState.variables.variables, afterState.variables.variables)) {
+        if (
+            (!fastDeepEqual(prevState.variables.variables, afterState.variables.variables) ||
+                prevState.variables.currentExecutionCount !== afterState.variables.currentExecutionCount) &&
+            action.type === InteractiveWindowMessages.GetVariablesResponse
+        ) {
             sendMessage(InteractiveWindowMessages.VariablesComplete);
         }
 

--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -181,10 +181,11 @@ suite('DataScience Debugger tests', () => {
                 if (stepAndVerify && ioc.wrapper && !ioc.mockJupyter) {
                     // Verify variables work
                     openVariableExplorer(ioc.wrapper);
-                    const variableRefresh = waitForMessage(ioc, InteractiveWindowMessages.VariablesComplete);
                     breakPromise = createDeferred<void>();
                     await jupyterDebuggerService?.step();
                     await breakPromise.promise;
+                    await waitForMessage(ioc, InteractiveWindowMessages.VariablesComplete);
+                    const variableRefresh = waitForMessage(ioc, InteractiveWindowMessages.VariablesComplete);
                     await jupyterDebuggerService?.requestVariables();
                     await variableRefresh;
 

--- a/src/test/datascience/variableTestHelpers.ts
+++ b/src/test/datascience/variableTestHelpers.ts
@@ -37,7 +37,7 @@ export async function verifyAfterStep(
     docManager.addDocument('a=1\na', file.fsPath);
     const debugPromise = interactive.debugCode('a=1\na', file.fsPath, 1, undefined, undefined);
     await debuggerBroke.promise;
-    const variableRefresh = waitForVariablesUpdated(ioc, 2); // Two times. Once for the initial refresh and another for the values.
+    const variableRefresh = waitForVariablesUpdated(ioc);
     await jupyterDebugger.requestVariables(); // This is necessary because not running inside of VS code. Normally it would do this.
     await variableRefresh;
     wrapper.update();

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -325,6 +325,7 @@ myDict = {'a': 1}`;
 
                 // Restart the kernel and repeat
                 const interactive = await getOrCreateInteractiveWindow(ioc);
+
                 const variablesComplete = waitForMessage(ioc, InteractiveWindowMessages.VariablesComplete);
                 await interactive.restartKernel();
                 await variablesComplete; // Restart should cause a variable refresh


### PR DESCRIPTION
More intermittent failures for flake tests

Debugger can respond to requests async. I initially thought it would always handle requests in order. This caused problems with evals coming back out of order. 

Then on top of that, the variable complete response was firing too many times.

Oh and also noticed the smoke test would randomly throw an async hook not cleaned up failure. The internets said to just disable the hook check (vscode actually said to do this).

I still have problems with ipywidgets failing (looks like modules aren't installed somehow). Looking at that next.