### PR TITLE
Fixes bugs #11777 and #11726, 'outputPrepend' needed to be cleared on each cell execute.

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -589,6 +589,13 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                 // Clear the result if we've run before
                 await this.clearResult(cell.id);
 
+                // Clear 'per run' data passed to WebView before execution
+                if (cell.data.metadata.tags !== undefined) {
+                    const idx = cell.data.metadata.tags.indexOf('outputPrepend', 0);
+                    if (idx > -1) {
+                        cell.data.metadata.tags.splice(idx, 1);
+                    }
+                }
                 const code = concatMultilineStringInput(cell.data.source);
                 // Send to ourselves.
                 await this.submitCode(code, Identifiers.EmptyFileName, 0, cell.id, cell.data, undefined, cancelToken);

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -1283,8 +1283,8 @@ export class JupyterNotebookBase implements INotebook {
         trimFunc: (str: string) => string
     ) {
         const data: nbformat.ICodeCell = cell.data as nbformat.ICodeCell;
-        let originalTextLenght = 0;
-        let trimmedTextLenght = 0;
+        let originalTextLength = 0;
+        let trimmedTextLength = 0;
 
         // Clear output if waiting for a clear
         if (clearState.value) {
@@ -1301,12 +1301,12 @@ export class JupyterNotebookBase implements INotebook {
             // tslint:disable-next-line:restrict-plus-operands
             existing.text = existing.text + msg.content.text;
             const originalText = formatStreamText(concatMultilineStringOutput(existing.text));
-            originalTextLenght = originalText.length;
+            originalTextLength = originalText.length;
             existing.text = trimFunc(originalText);
-            trimmedTextLenght = existing.text.length;
+            trimmedTextLength = existing.text.length;
         } else {
             const originalText = formatStreamText(concatMultilineStringOutput(msg.content.text));
-            originalTextLenght = originalText.length;
+            originalTextLength = originalText.length;
             // Create a new stream entry
             const output: nbformat.IStream = {
                 output_type: 'stream',
@@ -1314,14 +1314,14 @@ export class JupyterNotebookBase implements INotebook {
                 text: trimFunc(originalText)
             };
             data.outputs = [...data.outputs, output];
-            trimmedTextLenght = output.text.length;
+            trimmedTextLength = output.text.length;
             cell.data = data;
         }
 
         // If the output was trimmed, we add the 'outputPrepend' metadata tag.
         // Later, the react side will display a message letting the user know
         // the output is trimmed and what setting changes that.
-        if (trimmedTextLenght < originalTextLenght) {
+        if (trimmedTextLength < originalTextLength) {
             if (!data.metadata.tags) {
                 data.metadata.tags = ['outputPrepend'];
             } else {

--- a/src/datascience-ui/interactive-common/kernelSelection.tsx
+++ b/src/datascience-ui/interactive-common/kernelSelection.tsx
@@ -96,9 +96,9 @@ export class KernelSelection extends React.Component<IKernelSelectionProps> {
             : ImageName.JupyterServerConnected;
     }
 
-    private getMaxWidth(charLenght: number): string {
+    private getMaxWidth(charLength: number): string {
         // This comes from a linear regression
-        const width = 0.57674 * charLenght + 1.70473;
+        const width = 0.57674 * charLength + 1.70473;
         const unit = 'em';
         return Math.round(width).toString() + unit;
     }


### PR DESCRIPTION
Changed 'outputPrepend' to be a per 'execution' tag instead of a per 'session' tag.  Once it got saved in the ipynb file, it never went away, thus always showing the truncation message.  All fixed an egregious spelling error.

-   [x] ~Has unit tests & system/integration tests~
-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
