### PR TITLE
Monkeypatch console.* calls on CI if we are asked to

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -524,12 +524,15 @@ steps:
       npm install -g vsce
       npm run clean
       npx tsc -p ./
+      mkdir -p ./tmp/client/logging
+      cp -r ./out/client/logging ./tmp/client/logging
       npx gulp clean:cleanExceptTests
-      mkdir -p ./tmp
       cp -r ./out/test ./tmp/test
       npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
       npm run package
       npx gulp clean:cleanExceptTests
+      mkdir -p ./out/client/logging
+      cp -r ./tmp/client/logging ./out/client/logging
       cp -r ./tmp/test ./out/test
       node ./out/test/smokeTest.js
     displayName: 'Run Smoke Tests'

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -525,14 +525,14 @@ steps:
       npm run clean
       npx tsc -p ./
       mkdir -p ./tmp/client/logging
-      cp -r ./out/client/logging ./tmp/client/logging
+      cp -r ./out/client/logging ./tmp/client
       npx gulp clean:cleanExceptTests
       cp -r ./out/test ./tmp/test
       npm run updateBuildNumber -- --buildNumber $BUILD_BUILDID
       npm run package
       npx gulp clean:cleanExceptTests
       mkdir -p ./out/client/logging
-      cp -r ./tmp/client/logging ./out/client/logging
+      cp -r ./tmp/client/logging ./out/client
       cp -r ./tmp/test ./out/test
       node ./out/test/smokeTest.js
     displayName: 'Run Smoke Tests'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,7 +99,13 @@ gulp.task('hygiene-branch', (done) => run({ mode: 'diffMaster' }, done));
 
 gulp.task('output:clean', () => del(['coverage']));
 
-gulp.task('clean:cleanExceptTests', () => del(['clean:vsix', 'out/client', 'out/datascience-ui', 'out/server']));
+gulp.task('clean:cleanExceptTests', async () => {
+    // Monkeypatching on CI requires 'out/client/logging' directory to exist, so delete everything in 'out/client' except that.
+    await fsExtra.move('out/client/logging', 'out/tmp');
+    await del(['clean:vsix', 'out/client', 'out/datascience-ui', 'out/server']);
+    await fsExtra.mkdir('out/client').then(() => fsExtra.mkdir('out/client/logging'));
+    await fsExtra.move('out/tmp', 'out/client/logging');
+});
 gulp.task('clean:vsix', () => del(['*.vsix']));
 gulp.task('clean:out', () => del(['out']));
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,13 +99,7 @@ gulp.task('hygiene-branch', (done) => run({ mode: 'diffMaster' }, done));
 
 gulp.task('output:clean', () => del(['coverage']));
 
-gulp.task('clean:cleanExceptTests', async () => {
-    // Monkeypatching on CI requires 'out/client/logging' directory to exist, so delete everything in 'out/client' except that.
-    await fsExtra.move('out/client/logging', 'out/tmp');
-    await del(['clean:vsix', 'out/client', 'out/datascience-ui', 'out/server']);
-    await fsExtra.mkdir('out/client').then(() => fsExtra.mkdir('out/client/logging'));
-    await fsExtra.move('out/tmp', 'out/client/logging');
-});
+gulp.task('clean:cleanExceptTests', () => del(['clean:vsix', 'out/client', 'out/datascience-ui', 'out/server']));
 gulp.task('clean:vsix', () => del(['*.vsix']));
 gulp.task('clean:out', () => del(['out']));
 

--- a/news/3 Code Health/11896.md
+++ b/news/3 Code Health/11896.md
@@ -1,1 +1,1 @@
-Monkeypatch `console.*` calls on CI if we are asked to.
+Monkeypatch `console.*` calls to the logger only in CI.

--- a/news/3 Code Health/11896.md
+++ b/news/3 Code Health/11896.md
@@ -1,0 +1,1 @@
+Monkeypatch `console.*` calls on CI if we are asked to.

--- a/src/client/logging/levels.ts
+++ b/src/client/logging/levels.ts
@@ -4,6 +4,7 @@
 
 // IMPORTANT: This file should only be importing from the '../client/logging' directory, as we
 // delete everything in '../client' except for '../client/logging' before running smoke tests.
+
 import * as winston from 'winston';
 
 //======================

--- a/src/client/logging/levels.ts
+++ b/src/client/logging/levels.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 'use strict';
 
+// IMPORTANT: This file should only be importing from the '../client/logging' directory, as we
+// delete everything in '../client' except for '../client/logging' before running smoke tests.
 import * as winston from 'winston';
 
 //======================

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -38,6 +38,13 @@ interface IConfigurableLogger {
     add(transport: Transport): void;
 }
 
+// tslint:disable-next-line: no-suspicious-comment
+/**
+ * TODO: We should actually have this method in `./_global.ts` as this is exported globally.
+ * But for some reason, importing '../client/logging/_global' fails when launching the tests.
+ * More details in the comment https://github.com/microsoft/vscode-python/pull/11897#discussion_r433954993
+ * https://github.com/microsoft/vscode-python/issues/12137
+ */
 export function getPreDefinedConfiguration(): LoggerConfig {
     const config: LoggerConfig = {};
 

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -5,6 +5,7 @@
 import * as util from 'util';
 import * as winston from 'winston';
 import * as Transport from 'winston-transport';
+import { isCI } from '../common/constants';
 import { getFormatter } from './formatters';
 import { LogLevel, resolveLevelName } from './levels';
 import { getConsoleTransport, getFileTransport, isConsoleTransport } from './transports';
@@ -34,6 +35,26 @@ export function createLogger(config?: LoggerConfig) {
 interface IConfigurableLogger {
     level: string;
     add(transport: Transport): void;
+}
+
+export function getPreDefinedConfiguration(): LoggerConfig {
+    const config: LoggerConfig = {};
+
+    // Do not log to console if running tests and we're not
+    // asked to do so.
+    if (process.env.VSC_PYTHON_FORCE_LOGGING) {
+        config.console = {};
+        // In CI there's no need for the label.
+        if (!isCI) {
+            config.console.label = 'Python Extension:';
+        }
+    }
+    if (process.env.VSC_PYTHON_LOG_FILE) {
+        config.file = {
+            logfile: process.env.VSC_PYTHON_LOG_FILE
+        };
+    }
+    return config;
 }
 
 // Set up a logger just the way we like it.

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 'use strict';
 
+// IMPORTANT: This file should only be importing from the '../client/logging' directory, as we
+// delete everything in '../client' except for '../client/logging' before running smoke tests.
 import * as util from 'util';
 import * as winston from 'winston';
 import * as Transport from 'winston-transport';
-import { isCI } from '../common/constants';
 import { getFormatter } from './formatters';
 import { LogLevel, resolveLevelName } from './levels';
 import { getConsoleTransport, getFileTransport, isConsoleTransport } from './transports';
@@ -45,6 +46,7 @@ export function getPreDefinedConfiguration(): LoggerConfig {
     if (process.env.VSC_PYTHON_FORCE_LOGGING) {
         config.console = {};
         // In CI there's no need for the label.
+        const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined;
         if (!isCI) {
             config.console.label = 'Python Extension:';
         }

--- a/src/client/logging/logger.ts
+++ b/src/client/logging/logger.ts
@@ -4,6 +4,7 @@
 
 // IMPORTANT: This file should only be importing from the '../client/logging' directory, as we
 // delete everything in '../client' except for '../client/logging' before running smoke tests.
+
 import * as util from 'util';
 import * as winston from 'winston';
 import * as Transport from 'winston-transport';

--- a/src/client/logging/transports.ts
+++ b/src/client/logging/transports.ts
@@ -2,16 +2,21 @@
 // Licensed under the MIT License.
 'use strict';
 
+// IMPORTANT: This file should only be importing from the '../client/logging' directory, as we
+// delete everything in '../client' except for '../client/logging' before running smoke tests.
+
 import * as logform from 'logform';
 import * as path from 'path';
+import { OutputChannel } from 'vscode';
 import * as winston from 'winston';
 import * as Transport from 'winston-transport';
-import { IOutputChannel } from '../common/types';
-import { EXTENSION_ROOT_DIR } from '../constants';
 import { LogLevel, resolveLevel } from './levels';
 import { Arguments } from './util';
 
-const formattedMessage = Symbol.for('message');
+const folderPath = path.dirname(__dirname);
+const folderName = path.basename(folderPath);
+const EXTENSION_ROOT_DIR =
+    folderName === 'client' ? path.join(folderPath, '..', '..') : path.join(folderPath, '..', '..', '..', '..');
 
 export function isConsoleTransport(transport: unknown): boolean {
     // tslint:disable-next-line:no-any
@@ -74,7 +79,7 @@ export function getConsoleTransport(formatter: logform.Format): Transport {
 
 class PythonOutputChannelTransport extends Transport {
     // tslint:disable-next-line: no-any
-    constructor(private readonly channel: IOutputChannel, options?: any) {
+    constructor(private readonly channel: OutputChannel, options?: any) {
         super(options);
     }
     // tslint:disable-next-line: no-any
@@ -88,7 +93,7 @@ class PythonOutputChannelTransport extends Transport {
 }
 
 // Create a Python output channel targeting transport that can be added to a winston logger.
-export function getPythonOutputChannelTransport(channel: IOutputChannel, formatter: logform.Format) {
+export function getPythonOutputChannelTransport(channel: OutputChannel, formatter: logform.Format) {
     return new PythonOutputChannelTransport(channel, {
         // We minimize customization.
         format: formatter

--- a/src/client/logging/transports.ts
+++ b/src/client/logging/transports.ts
@@ -17,6 +17,7 @@ const folderPath = path.dirname(__dirname);
 const folderName = path.basename(folderPath);
 const EXTENSION_ROOT_DIR =
     folderName === 'client' ? path.join(folderPath, '..', '..') : path.join(folderPath, '..', '..', '..', '..');
+const formattedMessage = Symbol.for('message');
 
 export function isConsoleTransport(transport: unknown): boolean {
     // tslint:disable-next-line:no-any

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -23,6 +23,9 @@ import {
     TEST_TIMEOUT
 } from './constants';
 import { initialize } from './initialize';
+import { initializeLogger } from './testLogger';
+
+initializeLogger();
 
 type SetupOptions = Mocha.MochaOptions & {
     testFilesSuffix: string;

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -23,9 +23,11 @@ import {
     TEST_TIMEOUT
 } from './constants';
 import { initialize } from './initialize';
-import { initializeLogger } from './testLogger';
 
-initializeLogger();
+if (!process.env.VSC_PYTHON_SMOKE_TEST) {
+    const initializeLogger = require('./testLogger');
+    initializeLogger();
+}
 
 type SetupOptions = Mocha.MochaOptions & {
     testFilesSuffix: string;

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -23,11 +23,9 @@ import {
     TEST_TIMEOUT
 } from './constants';
 import { initialize } from './initialize';
+import { initializeLogger } from './testLogger';
 
-if (!process.env.VSC_PYTHON_SMOKE_TEST) {
-    const initializeLogger = require('./testLogger');
-    initializeLogger();
-}
+initializeLogger();
 
 type SetupOptions = Mocha.MochaOptions & {
     testFilesSuffix: string;

--- a/src/test/multiRootTest.ts
+++ b/src/test/multiRootTest.ts
@@ -3,10 +3,13 @@
 import * as path from 'path';
 import { runTests } from 'vscode-test';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
+import { initializeLogger } from './testLogger';
 
 const workspacePath = path.join(__dirname, '..', '..', 'src', 'testMultiRootWkspc', 'multi.code-workspace');
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '';
 process.env.VSC_PYTHON_CI_TEST = '1';
+
+initializeLogger();
 
 function start() {
     console.log('*'.repeat(100));

--- a/src/test/performanceTest.ts
+++ b/src/test/performanceTest.ts
@@ -24,6 +24,9 @@ import * as path from 'path';
 import * as request from 'request';
 import { EXTENSION_ROOT_DIR, PVSC_EXTENSION_ID } from '../client/common/constants';
 import { unzip } from './common';
+import { initializeLogger } from './testLogger';
+
+initializeLogger();
 
 const NamedRegexp = require('named-js-regexp');
 const del = require('del');

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -3,6 +3,9 @@
 import * as path from 'path';
 import { runTests } from 'vscode-test';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
+import { initializeLogger } from './testLogger';
+
+initializeLogger();
 
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '';
 process.env.VSC_PYTHON_CI_TEST = '1';

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -3,9 +3,12 @@
 import * as path from 'path';
 import { runTests } from 'vscode-test';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
-import { initializeLogger } from './testLogger';
 
-initializeLogger();
+if (!process.env.VSC_PYTHON_SMOKE_TEST) {
+    // tslint:disable-next-line: no-require-imports no-var-requires
+    const initializeLogger = require('./testLogger');
+    initializeLogger();
+}
 
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '';
 process.env.VSC_PYTHON_CI_TEST = '1';

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -3,12 +3,9 @@
 import * as path from 'path';
 import { runTests } from 'vscode-test';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from './constants';
+import { initializeLogger } from './testLogger';
 
-if (!process.env.VSC_PYTHON_SMOKE_TEST) {
-    // tslint:disable-next-line: no-require-imports no-var-requires
-    const initializeLogger = require('./testLogger');
-    initializeLogger();
-}
+initializeLogger();
 
 process.env.IS_CI_SERVER_TEST_DEBUGGER = '';
 process.env.VSC_PYTHON_CI_TEST = '1';

--- a/src/test/testBootstrap.ts
+++ b/src/test/testBootstrap.ts
@@ -9,6 +9,9 @@ import { AddressInfo, createServer, Server } from 'net';
 import * as path from 'path';
 import { EXTENSION_ROOT_DIR } from '../client/constants';
 import { noop, sleep } from './core';
+import { initializeLogger } from './testLogger';
+
+initializeLogger();
 
 // tslint:disable:no-console
 

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -24,9 +24,6 @@ export function initializeLogger() {
     }
 }
 
-// Ensure that the console functions are bound before monkeypatching.
-import '../client/logging/transports';
-
 /**
  * What we're doing here is monkey patching the console.log so we can
  * send everything sent to console window into our logs.  This is only

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -3,10 +3,10 @@
 
 'use strict';
 
-import { isCI } from '../client/common/constants';
 import { LogLevel } from '../client/logging/levels';
 import { configureLogger, createLogger, getPreDefinedConfiguration, logToAll } from '../client/logging/logger';
 
+const isCI = process.env.TRAVIS === 'true' || process.env.TF_BUILD !== undefined;
 const monkeyPatchLogger = createLogger();
 
 export function initializeLogger() {
@@ -28,7 +28,7 @@ import '../client/logging/transports';
  * What we're doing here is monkey patching the console.log so we can
  * send everything sent to console window into our logs.  This is only
  * required when we're directly writing to `console.log` or not using
- * our `winston logger`.  This is something we'd generally turn on, only
+ * our `winston logger`.  This is something we'd generally turn on only
  * on CI so we can see everything logged to the console window
  * (via the logs).
  */
@@ -57,5 +57,3 @@ function monkeypatchConsole() {
         };
     }
 }
-
-module.exports = initializeLogger;

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -3,6 +3,9 @@
 
 'use strict';
 
+// IMPORTANT: This file should only be importing from the '../client/logging' directory, as we
+// delete everything in '../client' except for '../client/logging' before running smoke tests.
+
 import { LogLevel } from '../client/logging/levels';
 import { configureLogger, createLogger, getPreDefinedConfiguration, logToAll } from '../client/logging/logger';
 

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { isCI } from '../client/common/constants';
+import { LogLevel } from '../client/logging/levels';
+import { configureLogger, createLogger, getPreDefinedConfiguration, logToAll } from '../client/logging/logger';
+
+const monkeyPatchLogger = createLogger();
+
+export function initializeLogger() {
+    const config = getPreDefinedConfiguration();
+    if (isCI && process.env.VSC_PYTHON_LOG_FILE) {
+        delete config.console;
+        // This is a separate logger that matches our config but
+        // does not do any console logging.
+        configureLogger(monkeyPatchLogger, config);
+        // Send console.*() to the non-console loggers.
+        monkeypatchConsole();
+    }
+}
+
+// Ensure that the console functions are bound before monkeypatching.
+import '../client/logging/transports';
+
+/**
+ * What we're doing here is monkey patching the console.log so we can
+ * send everything sent to console window into our logs.  This is only
+ * required when we're directly writing to `console.log` or not using
+ * our `winston logger`.  This is something we'd generally turn on, only
+ * on CI so we can see everything logged to the console window
+ * (via the logs).
+ */
+function monkeypatchConsole() {
+    // The logging "streams" (methods) of the node console.
+    const streams = ['log', 'error', 'warn', 'info', 'debug', 'trace'];
+    const levels: { [key: string]: LogLevel } = {
+        error: LogLevel.Error,
+        warn: LogLevel.Warn
+    };
+    // tslint:disable-next-line:no-any
+    const consoleAny: any = console;
+    for (const stream of streams) {
+        // Using symbols guarantee the properties will be unique & prevents
+        // clashing with names other code/library may create or have created.
+        // We could use a closure but it's a bit trickier.
+        const sym = Symbol.for(stream);
+        consoleAny[sym] = consoleAny[stream];
+        // tslint:disable-next-line: no-function-expression
+        consoleAny[stream] = function () {
+            const args = Array.prototype.slice.call(arguments);
+            const fn = consoleAny[sym];
+            fn(...args);
+            const level = levels[stream] || LogLevel.Info;
+            logToAll([monkeyPatchLogger], level, args);
+        };
+    }
+}

--- a/src/test/testLogger.ts
+++ b/src/test/testLogger.ts
@@ -57,3 +57,5 @@ function monkeypatchConsole() {
         };
     }
 }
+
+module.exports = initializeLogger;


### PR DESCRIPTION
@ericsnowcurrently I've not done monkeypatching for smoke tests because `out` directory isn't available while running it and we've to copy all of the logging code to `test` directory for it to work. Let me know if you think I should still do it, or if there's a better way.

For #11896

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
