### PR TITLE
Ensure our notebook cmds work with VSC Notebooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,62 @@
                 "command": "python.datascience.runcurrentcellandaddbelow",
                 "key": "alt+enter",
                 "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
+            },
+            {
+                "mac": "F",
+                "win": "F",
+                "linux": "F",
+                "key": "F",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "notebook.find"
+            },
+            {
+                "mac": "K",
+                "win": "K",
+                "linux": "K",
+                "key": "K",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "list.focusUp"
+            },
+            {
+                "mac": "J",
+                "win": "J",
+                "linux": "J",
+                "key": "J",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "list.focusDown"
+            },
+            {
+                "mac": "A",
+                "win": "A",
+                "linux": "A",
+                "key": "A",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "notebook.cell.insertCodeCellAbove"
+            },
+            {
+                "mac": "B",
+                "win": "B",
+                "linux": "B",
+                "key": "B",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "notebook.cell.insertCodeCellBelow"
+            },
+            {
+                "mac": "D D",
+                "win": "D D",
+                "linux": "D D",
+                "key": "D D",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "notebook.cell.delete"
+            },
+            {
+                "mac": "Z",
+                "win": "Z",
+                "linux": "Z",
+                "key": "Z",
+                "when": "notebookEditorFocused && !inputFocus",
+                "command": "notebook.undo"
             }
         ],
         "commands": [

--- a/package.json
+++ b/package.json
@@ -111,22 +111,22 @@
             {
                 "command": "python.datascience.execSelectionInteractive",
                 "key": "shift+enter",
-                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && python.datascience.ownsSelection && python.datascience.featureenabled"
+                "when": "editorTextFocus && editorLangId == python && !findInputFocussed && !replaceInputFocussed && python.datascience.ownsSelection && python.datascience.featureenabled && !notebookEditorFocused"
             },
             {
                 "command": "python.datascience.runcurrentcelladvance",
                 "key": "shift+enter",
-                "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled"
+                "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
             },
             {
                 "command": "python.datascience.runcurrentcell",
                 "key": "ctrl+enter",
-                "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled"
+                "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
             },
             {
                 "command": "python.datascience.runcurrentcellandaddbelow",
                 "key": "alt+enter",
-                "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled"
+                "when": "editorTextFocus && !editorHasSelection && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
             }
         ],
         "commands": [
@@ -661,52 +661,52 @@
                     "group": "Python"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled",
+                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.runallcells",
                     "group": "Python2"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled",
+                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.runcurrentcell",
                     "group": "Python2"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled",
+                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.runcurrentcelladvance",
                     "group": "Python2"
                 },
                 {
                     "command": "python.datascience.runFileInteractive",
                     "group": "Python2",
-                    "when": "editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "editorFocus && editorLangId == python && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.runfromline",
                     "group": "Python2",
-                    "when": "editorFocus && editorLangId == python && python.datascience.ownsSelection && python.datascience.featureenabled"
+                    "when": "editorFocus && editorLangId == python && python.datascience.ownsSelection && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.runtoline",
                     "group": "Python2",
-                    "when": "editorFocus && editorLangId == python && python.datascience.ownsSelection && python.datascience.featureenabled"
+                    "when": "editorFocus && editorLangId == python && python.datascience.ownsSelection && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.execSelectionInteractive",
                     "group": "Python2",
-                    "when": "editorFocus && editorLangId == python && python.datascience.featureenabled && python.datascience.ownsSelection"
+                    "when": "editorFocus && editorLangId == python && python.datascience.featureenabled && python.datascience.ownsSelection && !notebookEditorFocused"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && resourceLangId == jupyter && python.datascience.featureenabled",
+                    "when": "editorFocus && editorLangId == python && resourceLangId == jupyter && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.importnotebook",
                     "group": "Python3@1"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled",
+                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.exportfileasnotebook",
                     "group": "Python3@2"
                 },
                 {
-                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled",
+                    "when": "editorFocus && editorLangId == python && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.exportfileandoutputasnotebook",
                     "group": "Python3@3"
                 }
@@ -721,12 +721,12 @@
             ],
             "explorer/context": [
                 {
-                    "when": "resourceLangId == python && !busyTests",
+                    "when": "resourceLangId == python && !busyTests && !notebookEditorFocused",
                     "command": "python.runtests",
                     "group": "Python"
                 },
                 {
-                    "when": "resourceLangId == python && !busyTests",
+                    "when": "resourceLangId == python && !busyTests && !notebookEditorFocused",
                     "command": "python.debugtests",
                     "group": "Python"
                 },
@@ -736,7 +736,7 @@
                     "group": "Python"
                 },
                 {
-                    "when": "resourceLangId == python && python.datascience.featureenabled",
+                    "when": "resourceLangId == python && python.datascience.featureenabled && !notebookEditorFocused",
                     "command": "python.datascience.runFileInteractive",
                     "group": "Python2"
                 },
@@ -877,13 +877,13 @@
                     "command": "python.datascience.runFileInteractive",
                     "title": "%python.command.python.datascience.runFileInteractive.title%",
                     "category": "Python",
-                    "when": "editorLangId == python && python.datascience.featureenabled"
+                    "when": "editorLangId == python && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.debugFileInteractive",
                     "title": "%python.command.python.datascience.debugFileInteractive.title%",
                     "category": "Python",
-                    "when": "editorLangId == python && python.datascience.featureenabled"
+                    "when": "editorLangId == python && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.importnotebook",
@@ -899,25 +899,25 @@
                     "command": "python.datascience.exportfileasnotebook",
                     "title": "%python.command.python.datascience.exportfileasnotebook.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveeactive"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveeactive && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.exportfileandoutputasnotebook",
                     "title": "%python.command.python.datascience.exportfileandoutputasnotebook.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveeactive"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveeactive && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.undocells",
                     "title": "%python.command.python.datascience.undocells.title%",
                     "category": "Python",
-                    "when": "python.datascience.haveinteractivecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveeactive"
+                    "when": "python.datascience.haveinteractivecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveeactive && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.redocells",
                     "title": "%python.command.python.datascience.redocells.title%",
                     "category": "Python",
-                    "when": "python.datascience.haveredoablecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveornativeeactive"
+                    "when": "python.datascience.haveredoablecells && python.datascience.featureenabled && python.datascience.ispythonorinteractiveornativeeactive && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.removeallcells",
@@ -941,13 +941,13 @@
                     "command": "python.datascience.notebookeditor.undocells",
                     "title": "%python.command.python.datascience.undocells.title%",
                     "category": "Python",
-                    "when": "python.datascience.haveinteractivecells && python.datascience.featureenabled && python.datascience.isnativeactive"
+                    "when": "python.datascience.haveinteractivecells && python.datascience.featureenabled && python.datascience.isnativeactive && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.notebookeditor.redocells",
                     "title": "%python.command.python.datascience.redocells.title%",
                     "category": "Python",
-                    "when": "python.datascience.havenativeredoablecells && python.datascience.featureenabled && python.datascience.isnativeactive"
+                    "when": "python.datascience.havenativeredoablecells && python.datascience.featureenabled && python.datascience.isnativeactive && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.notebookeditor.removeallcells",
@@ -977,7 +977,13 @@
                     "command": "python.datascience.notebookeditor.runselectedcell",
                     "title": "%python.command.python.datascience.notebookeditor.runselectedcell.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.havecellselected"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.havecellselected && !notebookEditorFocused"
+                },
+                {
+                    "command": "python.datascience.notebookeditor.runselectedcell",
+                    "title": "%python.command.python.datascience.notebookeditor.runselectedcell.title%",
+                    "category": "Python",
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.notebookeditor.addcellbelow",
@@ -1057,7 +1063,7 @@
                 {
                     "command": "python.datascience.execSelectionInteractive",
                     "category": "Python",
-                    "when": "editorLangId == python && python.datascience.featureenabled"
+                    "when": "editorLangId == python && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.switchKernel",

--- a/src/client/common/application/notebook.ts
+++ b/src/client/common/application/notebook.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import {
     Disposable,
     Event,
@@ -13,12 +13,16 @@ import {
     NotebookEditor,
     NotebookKernel,
     NotebookOutputRenderer,
-    NotebookOutputSelector
+    NotebookOutputSelector,
+    TextDocument,
+    window
 } from 'vscode';
+import { UseProposedApi } from '../constants';
 import { IVSCodeNotebook } from './types';
 
 @injectable()
 export class VSCodeNotebook implements IVSCodeNotebook {
+    constructor(@inject(UseProposedApi) private readonly useProposedApi: boolean) {}
     public registerNotebookContentProvider(notebookType: string, provider: NotebookContentProvider): Disposable {
         return notebook.registerNotebookContentProvider(notebookType, provider);
     }
@@ -42,7 +46,26 @@ export class VSCodeNotebook implements IVSCodeNotebook {
     public get onDidChangeNotebookDocument(): Event<NotebookDocumentChangeEvent> {
         return notebook.onDidChangeNotebookDocument;
     }
+    public isCell(textDocument: TextDocument) {
+        return (
+            textDocument.fileName.toLowerCase().includes('.ipynb') &&
+            textDocument.uri.query.includes('notebook') &&
+            textDocument.uri.query.includes('cell')
+        );
+    }
     public get activeNotebookEditor(): NotebookEditor | undefined {
+        if (!this.useProposedApi) {
+            return;
+        }
+        // Temporary, currently VSC API doesn't work well.
+        // `notebook.activeNotebookEditor`  is not reset when opening another file.
+        if (!notebook.activeNotebookEditor) {
+            return;
+        }
+        // If we have a text editor opened and it is not a cell, then we know for certain a notebook is not open.
+        if (window.activeTextEditor && !this.isCell(window.activeTextEditor.document)) {
+            return;
+        }
         return notebook.activeNotebookEditor;
     }
 }

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -1457,6 +1457,10 @@ export interface IVSCodeNotebook {
 
     readonly onDidChangeNotebookDocument: Event<NotebookDocumentChangeEvent>;
     readonly activeNotebookEditor: NotebookEditor | undefined;
+    /**
+     * Whether the current document is aCell.
+     */
+    isCell(textDocument: TextDocument): boolean;
     registerNotebookContentProvider(notebookType: string, provider: NotebookContentProvider): Disposable;
 
     registerNotebookKernel(id: string, selectors: GlobPattern[], kernel: NotebookKernel): Disposable;

--- a/src/client/common/experiments.ts
+++ b/src/client/common/experiments.ts
@@ -13,6 +13,7 @@ import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import { IApplicationEnvironment } from './application/types';
 import { EXTENSION_ROOT_DIR, STANDARD_OUTPUT_CHANNEL } from './constants';
+import { NativeNotebook } from './experimentGroups';
 import { traceDecorators, traceError } from './logger';
 import { IFileSystem } from './platform/types';
 import {
@@ -150,6 +151,13 @@ export class ExperimentsManager implements IExperimentsManager {
         this.cleanUpExperimentsOptList();
         if (Array.isArray(this.experimentStorage.value)) {
             for (const experiment of this.experimentStorage.value) {
+                // User cannot belong to NotebookExperiment if they are not using Insiders.
+                if (
+                    (experiment.name === NativeNotebook.experiment || experiment.name === NativeNotebook.control) &&
+                    this.appEnvironment.channel !== 'insiders'
+                ) {
+                    continue;
+                }
                 try {
                     if (
                         this._experimentsOptedOutFrom.includes('All') ||

--- a/src/client/datascience/editor-integration/codelensprovider.ts
+++ b/src/client/datascience/editor-integration/codelensprovider.ts
@@ -4,7 +4,7 @@
 import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 
-import { ICommandManager, IDebugService, IDocumentManager } from '../../common/application/types';
+import { ICommandManager, IDebugService, IDocumentManager, IVSCodeNotebook } from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
 import { IFileSystem } from '../../common/platform/types';
 import { IConfigurationService, IDataScienceSettings, IDisposable, IDisposableRegistry } from '../../common/types';
@@ -28,7 +28,8 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
         @inject(ICommandManager) private commandManager: ICommandManager,
         @inject(IDisposableRegistry) disposableRegistry: IDisposableRegistry,
         @inject(IDebugService) private debugService: IDebugService,
-        @inject(IFileSystem) private fileSystem: IFileSystem
+        @inject(IFileSystem) private fileSystem: IFileSystem,
+        @inject(IVSCodeNotebook) private readonly vsCodeNotebook: IVSCodeNotebook
     ) {
         disposableRegistry.push(this);
         disposableRegistry.push(this.debugService.onDidChangeActiveDebugSession(this.onChangeDebugSession.bind(this)));
@@ -53,6 +54,9 @@ export class DataScienceCodeLensProvider implements IDataScienceCodeLensProvider
     // CodeLensProvider interface
     // Some implementation based on DonJayamanne's jupyter extension work
     public provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.CodeLens[] {
+        if (this.vsCodeNotebook.activeNotebookEditor) {
+            return [];
+        }
         // Get the list of code lens for this document.
         return this.getCodeLensTimed(document);
     }

--- a/src/client/datascience/editor-integration/decorator.ts
+++ b/src/client/datascience/editor-integration/decorator.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import * as vscode from 'vscode';
 
 import { IExtensionSingleActivationService } from '../../activation/types';
-import { IDocumentManager } from '../../common/application/types';
+import { IDocumentManager, IVSCodeNotebook } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { IConfigurationService, IDisposable, IDisposableRegistry } from '../../common/types';
 import { generateCellRangesFromDocument } from '../cellFactory';
@@ -20,7 +20,8 @@ export class Decorator implements IExtensionSingleActivationService, IDisposable
     constructor(
         @inject(IDocumentManager) private documentManager: IDocumentManager,
         @inject(IDisposableRegistry) disposables: IDisposableRegistry,
-        @inject(IConfigurationService) private configuration: IConfigurationService
+        @inject(IConfigurationService) private configuration: IConfigurationService,
+        @inject(IVSCodeNotebook) private vsCodeNotebook: IVSCodeNotebook
     ) {
         this.computeDecorations();
         disposables.push(this);
@@ -100,6 +101,7 @@ export class Decorator implements IExtensionSingleActivationService, IDisposable
             editor &&
             editor.document &&
             editor.document.languageId === PYTHON_LANGUAGE &&
+            !this.vsCodeNotebook.activeNotebookEditor &&
             this.activeCellTop &&
             this.cellSeparatorType &&
             this.activeCellBottom

--- a/src/client/datascience/notebook/integration.ts
+++ b/src/client/datascience/notebook/integration.ts
@@ -5,15 +5,11 @@ import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { ICommandManager, IVSCodeNotebook } from '../../common/application/types';
-import { UseProposedApi } from '../../common/constants';
 import { NativeNotebook } from '../../common/experimentGroups';
 import { IFileSystem } from '../../common/platform/types';
 import { IDisposableRegistry, IExperimentsManager, IExtensionContext } from '../../common/types';
 import { noop } from '../../common/utils/misc';
-import { IServiceManager } from '../../ioc/types';
-import { INotebookEditorProvider } from '../types';
 import { NotebookContentProvider } from './contentProvider';
-import { NotebookEditorProvider } from './notebookEditorProvider';
 import { NotebookKernel } from './notebookKernel';
 
 /**
@@ -31,9 +27,7 @@ export class NotebookIntegration implements IExtensionSingleActivationService {
         @inject(IExtensionContext) private readonly context: IExtensionContext,
         @inject(IFileSystem) private readonly fs: IFileSystem,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(NotebookKernel) private readonly notebookKernel: NotebookKernel,
-        @inject(IServiceManager) private readonly serviceManager: IServiceManager,
-        @inject(UseProposedApi) private readonly useProposedApi: boolean
+        @inject(NotebookKernel) private readonly notebookKernel: NotebookKernel
     ) {}
     public async activate(): Promise<void> {
         // This condition is temporary.
@@ -41,19 +35,6 @@ export class NotebookIntegration implements IExtensionSingleActivationService {
         // Once the API is final, we won't need to modify the package.json.
         if (!this.experiment.inExperiment(NativeNotebook.experiment)) {
             return;
-        }
-
-        // This condition is temporary.
-        // If user belongs to the experiment, then make the necessary changes to package.json.
-        // Once the API is final, we won't need to modify the package.json.
-        if (
-            this.serviceManager.get<IExperimentsManager>(IExperimentsManager).inExperiment(NativeNotebook.experiment) &&
-            this.useProposedApi
-        ) {
-            this.serviceManager.rebindSingleton<INotebookEditorProvider>(
-                INotebookEditorProvider,
-                NotebookEditorProvider
-            );
         }
 
         const packageJsonFile = path.join(this.context.extensionPath, 'package.json');

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -140,7 +140,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
 
         return this.open(model.file);
     }
-    protected openedEditor(editor: INotebookEditor): void {
+    private onEditorOpened(editor: INotebookEditor): void {
         this.openedNotebookCount += 1;
         if (!this.executedEditors.has(editor.file.fsPath)) {
             editor.executed(this.onExecuted.bind(this));
@@ -169,7 +169,11 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         const uri = isUri(doc) ? doc : doc.uri;
         const model = await this.storage.load(uri);
         // In open method we might be waiting.
-        const editor = this.notebookEditorsByUri.get(uri.toString()) || new NotebookEditor(model, this.vscodeNotebook);
+        let editor = this.notebookEditorsByUri.get(uri.toString());
+        if (!editor) {
+            editor = new NotebookEditor(model, this.vscodeNotebook);
+            this.onEditorOpened(editor);
+        }
         const deferred = this.notebooksWaitingToBeOpenedByUri.get(uri.toString());
         deferred?.resolve(editor); // NOSONAR
         if (!isUri(doc)) {

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -92,7 +92,7 @@ import { WebPanelProvider } from '../../client/common/application/webPanels/webP
 import { WorkspaceService } from '../../client/common/application/workspace';
 import { AsyncDisposableRegistry } from '../../client/common/asyncDisposableRegistry';
 import { PythonSettings } from '../../client/common/configSettings';
-import { EXTENSION_ROOT_DIR, UseCustomEditorApi } from '../../client/common/constants';
+import { EXTENSION_ROOT_DIR, UseCustomEditorApi, UseProposedApi } from '../../client/common/constants';
 import { CryptoUtils } from '../../client/common/crypto';
 import { DotNetCompatibilityService } from '../../client/common/dotnet/compatibilityService';
 import { IDotNetCompatibilityService } from '../../client/common/dotnet/types';
@@ -604,6 +604,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             IInteractiveWindowProvider,
             TestInteractiveWindowProvider
         );
+        this.serviceManager.addSingletonInstance(UseProposedApi, false);
         this.serviceManager.addSingletonInstance(UseCustomEditorApi, useCustomEditor);
         this.serviceManager.addSingleton<IDataViewerProvider>(IDataViewerProvider, DataViewerProvider);
         this.serviceManager.addSingleton<IPlotViewerProvider>(IPlotViewerProvider, PlotViewerProvider);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -68,6 +68,7 @@ import {
     IDiagnosticsService
 } from '../../client/application/diagnostics/types';
 import { ClipboardService } from '../../client/common/application/clipboard';
+import { VSCodeNotebook } from '../../client/common/application/notebook';
 import { TerminalManager } from '../../client/common/application/terminalManager';
 import {
     IApplicationShell,
@@ -79,6 +80,7 @@ import {
     ILiveShareApi,
     ILiveShareTestingApi,
     ITerminalManager,
+    IVSCodeNotebook,
     IWebPanel,
     IWebPanelMessageListener,
     IWebPanelOptions,
@@ -830,6 +832,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         this.serviceManager.addSingleton<IProductService>(IProductService, ProductService);
         this.serviceManager.addSingleton<KernelDaemonPool>(KernelDaemonPool, KernelDaemonPool);
         this.serviceManager.addSingleton<KernelDaemonPreWarmer>(KernelDaemonPreWarmer, KernelDaemonPreWarmer);
+        this.serviceManager.addSingleton<IVSCodeNotebook>(IVSCodeNotebook, VSCodeNotebook);
         this.serviceManager.addSingleton<IProductPathService>(
             IProductPathService,
             CTagsProductPathService,

--- a/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
+++ b/src/test/datascience/editor-integration/codelensprovider.unit.test.ts
@@ -4,7 +4,12 @@
 import * as TypeMoq from 'typemoq';
 import { CancellationTokenSource, Disposable, TextDocument } from 'vscode';
 
-import { ICommandManager, IDebugService, IDocumentManager } from '../../../client/common/application/types';
+import {
+    ICommandManager,
+    IDebugService,
+    IDocumentManager,
+    IVSCodeNotebook
+} from '../../../client/common/application/types';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IConfigurationService, IDataScienceSettings, IPythonSettings } from '../../../client/common/types';
 import { DataScienceCodeLensProvider } from '../../../client/datascience/editor-integration/codelensprovider';
@@ -24,6 +29,7 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
     let debugLocationTracker: TypeMoq.IMock<IDebugLocationTracker>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     let tokenSource: CancellationTokenSource;
+    let vscodeNotebook: TypeMoq.IMock<IVSCodeNotebook>;
     const disposables: Disposable[] = [];
 
     setup(() => {
@@ -37,9 +43,11 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
         pythonSettings = TypeMoq.Mock.ofType<IPythonSettings>();
         dataScienceSettings = TypeMoq.Mock.ofType<IDataScienceSettings>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
+        vscodeNotebook = TypeMoq.Mock.ofType<IVSCodeNotebook>();
         dataScienceSettings.setup((d) => d.enabled).returns(() => true);
         pythonSettings.setup((p) => p.datascience).returns(() => dataScienceSettings.object);
         configurationService.setup((c) => c.getSettings(TypeMoq.It.isAny())).returns(() => pythonSettings.object);
+        vscodeNotebook.setup((c) => c.activeNotebookEditor).returns(() => undefined);
         commandManager
             .setup((c) => c.executeCommand(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve());
@@ -53,7 +61,8 @@ suite('DataScienceCodeLensProvider Unit Tests', () => {
             commandManager.object,
             disposables,
             debugService.object,
-            fileSystem.object
+            fileSystem.object,
+            vscodeNotebook.object
         );
     });
 

--- a/src/test/datascience/editor-integration/codewatcher.unit.test.ts
+++ b/src/test/datascience/editor-integration/codewatcher.unit.test.ts
@@ -7,7 +7,12 @@ import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
 import { CancellationTokenSource, CodeLens, Disposable, Range, Selection, TextEditor, Uri } from 'vscode';
 
-import { ICommandManager, IDebugService, IDocumentManager } from '../../../client/common/application/types';
+import {
+    ICommandManager,
+    IDebugService,
+    IDocumentManager,
+    IVSCodeNotebook
+} from '../../../client/common/application/types';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IConfigurationService } from '../../../client/common/types';
 import { Commands, EditorContexts } from '../../../client/datascience/constants';
@@ -46,6 +51,7 @@ suite('DataScience Code Watcher Unit Tests', () => {
     let tokenSource: CancellationTokenSource;
     let debugService: TypeMoq.IMock<IDebugService>;
     let debugLocationTracker: TypeMoq.IMock<IDebugLocationTracker>;
+    let vscodeNotebook: TypeMoq.IMock<IVSCodeNotebook>;
     const contexts: Map<string, boolean> = new Map<string, boolean>();
     const pythonSettings = new MockPythonSettings(undefined, new MockAutoSelectionService());
     const disposables: Disposable[] = [];
@@ -63,6 +69,7 @@ suite('DataScience Code Watcher Unit Tests', () => {
         helper = TypeMoq.Mock.ofType<ICodeExecutionHelper>();
         commandManager = TypeMoq.Mock.ofType<ICommandManager>();
         debugService = TypeMoq.Mock.ofType<IDebugService>();
+        vscodeNotebook = TypeMoq.Mock.ofType<IVSCodeNotebook>();
 
         // Setup default settings
         pythonSettings.datascience = {
@@ -95,6 +102,7 @@ suite('DataScience Code Watcher Unit Tests', () => {
             widgetScriptSources: []
         };
         debugService.setup((d) => d.activeDebugSession).returns(() => undefined);
+        vscodeNotebook.setup((d) => d.activeNotebookEditor).returns(() => undefined);
 
         // Setup the service container to return code watchers
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
@@ -890,7 +898,8 @@ testing2`;
             commandManager.object,
             disposables,
             debugService.object,
-            fileSystem.object
+            fileSystem.object,
+            vscodeNotebook.object
         );
 
         let result = codeLensProvider.provideCodeLenses(document.object, tokenSource.token);


### PR DESCRIPTION
For #10496

* Hide commands related to interctive window when in VSCode Notebooks
	* This is required because VSC Notebooks host text editors with python code, and these are treated as standalone python editors.
* Ensure we initialize experiments before we register the DS types