### PR TITLE
Skip incoming message processing if the ZMQ socket was closed

### DIFF
--- a/src/client/datascience/raw-kernel/rawSocket.ts
+++ b/src/client/datascience/raw-kernel/rawSocket.ts
@@ -173,8 +173,10 @@ export class RawSocket implements IWebSocketLike, IKernelSocket, IDisposable {
     }
 
     private onIncomingMessage(channel: string, data: any) {
-        // Decode the message
-        const message = wireProtocol.decode(data, this.connection.key, this.connection.signature_scheme) as any;
+        // Decode the message if still possible.
+        const message = this.closed
+            ? {}
+            : (wireProtocol.decode(data, this.connection.key, this.connection.signature_scheme) as any);
 
         // Make sure it has a channel on it
         message.channel = channel;


### PR DESCRIPTION
According to the ZMQ [docs](http://api.zeromq.org/2-1:zmq-setsockopt) (linger option), partial messages can be sent after closing a socket. This might have been the cause of this problem I recently saw in a functional test:

```
Starting WebSocket: RAW/api/kernels/a1bcf488-6d56-4446-a207-9abfc7c43d70
2020-05-21T17:20:01.3107191Z Kernel: connected (a1bcf488-6d56-4446-a207-9abfc7c43d70)
2020-05-21T17:20:01.4344246Z Error 2020-05-21 17:20:01: Error: Message Decoding: Incorrect;
2020-05-21T17:20:01.4348584Z Obtained "046c6c3aa9c0680249bcf5b86074aa0b0c5beebc35f160d2e077d75d8f3c5f91"
2020-05-21T17:20:01.4349344Z Expected "52142932a254e3539e52369b11ad5e48591b933cebab433ebe854e11f85ce0d7"
2020-05-21T17:20:01.4349972Z     at Object.decode (D:\a\1\s\node_modules\@nteract\messaging\lib\wire-protocol.js:72:19)
2020-05-21T17:20:01.4350680Z     at RawSocketWrapper.onIncomingMessage (D:\a\1\s\out\client\datascience\raw-kernel\rawSocket.js:132:38)
2020-05-21T17:20:01.4351433Z     at RawSocketWrapper.processSocketMessages (D:\a\1\s\out\client\datascience\raw-kernel\rawSocket.js:110:18)
2020-05-21T17:20:01.4359758Z Info 2020-05-21 17:20:01: Python Daemon (pid: 3916): write to stderr: [IPKernelApp] ERROR | Invalid Message
2020-05-21T17:20:01.4360461Z 
2020-05-21T17:20:01.4470523Z Error 2020-05-21 17:20:01: Kernel died StdErrError: [IPKernelApp] ERROR | Invalid Message
```

Looking at our process messages function, it had the potential to process partial messages after shutdown.