### PR TITLE
Fix more nightly test failures

### DIFF
--- a/src/client/common/process/baseDaemon.ts
+++ b/src/client/common/process/baseDaemon.ts
@@ -166,6 +166,9 @@ export abstract class BasePythonDaemon {
         return Promise.race([this.connection.sendRequest(type), this.connectionClosedDeferred.promise]);
     }
     protected sendRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, params?: P): Thenable<R> {
+        if (!this.isAlive) {
+            traceError('Daemon is handling a request after death.');
+        }
         // Throw an error if the connection has been closed.
         return Promise.race([this.connection.sendRequest(type, params), this.connectionClosedDeferred.promise]);
     }

--- a/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
@@ -755,11 +755,15 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
         if (wordAtPosition) {
             const notebook = await this.getNotebook(token);
             if (notebook) {
-                const value = await this.variableProvider.getMatchingVariable(notebook, wordAtPosition, token);
-                if (value) {
-                    return {
-                        contents: [`${wordAtPosition}: ${value.type} = ${value.value}`]
-                    };
+                try {
+                    const value = await this.variableProvider.getMatchingVariable(notebook, wordAtPosition, token);
+                    if (value) {
+                        return {
+                            contents: [`${wordAtPosition}: ${value.type} = ${value.value}`]
+                        };
+                    }
+                } catch (exc) {
+                    traceError(`Exception attempting to retrieve hover for variables`, exc);
                 }
             }
         }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1132,16 +1132,13 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     private async listenToNotebookEvents(notebook: INotebook): Promise<void> {
         const statusChangeHandler = async (status: ServerStatus) => {
             const kernelSpec = notebook.getKernelSpec();
+            const name = kernelSpec?.display_name || kernelSpec?.name || '';
 
-            if (kernelSpec) {
-                const name = kernelSpec.display_name || kernelSpec.name;
-
-                await this.postMessage(InteractiveWindowMessages.UpdateKernel, {
-                    jupyterServerStatus: status,
-                    localizedUri: this.getServerUri(notebook.connection),
-                    displayName: name
-                });
-            }
+            await this.postMessage(InteractiveWindowMessages.UpdateKernel, {
+                jupyterServerStatus: status,
+                localizedUri: this.getServerUri(notebook.connection),
+                displayName: name
+            });
         };
         notebook.onSessionStatusChanged(statusChangeHandler);
         this.disposables.push(notebook.onKernelChanged(this.kernelChangeHandler.bind(this)));

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -131,7 +131,8 @@ export enum InteractiveWindowMessages {
     Continue = 'continue',
     ShowContinue = 'show_continue',
     ShowBreak = 'show_break',
-    ShowingIp = 'showing_ip'
+    ShowingIp = 'showing_ip',
+    KernelIdle = 'kernel_idle'
 }
 
 export enum IPyWidgetMessages {
@@ -618,4 +619,5 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.ShowContinue]: ICell;
     public [InteractiveWindowMessages.Step]: never | undefined;
     public [InteractiveWindowMessages.ShowingIp]: never | undefined;
+    public [InteractiveWindowMessages.KernelIdle]: never | undefined;
 }

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -88,6 +88,11 @@ export class NotebookProvider implements INotebookProvider {
             return this.notebooks.get(options.identity.fsPath)!!;
         }
 
+        // If get only, don't create a notebook
+        if (options.getOnly) {
+            return undefined;
+        }
+
         // We want to cache a Promise<INotebook> from the create functions
         // but jupyterNotebookProvider.createNotebook can be undefined if the server is not available
         // so check for our connection here first

--- a/src/client/datascience/interactive-common/synchronization.ts
+++ b/src/client/datascience/interactive-common/synchronization.ts
@@ -126,6 +126,7 @@ const messageWithMessageTypes: MessageMapping<IInteractiveWindowMapping> & Messa
     [InteractiveWindowMessages.IPyWidgetRenderFailure]: MessageType.other,
     [InteractiveWindowMessages.IPyWidgetUnhandledKernelMessage]: MessageType.other,
     [InteractiveWindowMessages.IPyWidgetWidgetVersionNotSupported]: MessageType.other,
+    [InteractiveWindowMessages.KernelIdle]: MessageType.other,
     [InteractiveWindowMessages.LoadAllCells]: MessageType.other,
     [InteractiveWindowMessages.LoadAllCellsComplete]: MessageType.other,
     [InteractiveWindowMessages.LoadOnigasmAssemblyRequest]: MessageType.other,

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -234,9 +234,6 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // relative files next to the notebook.
         await super.loadWebPanel(path.dirname(this.file.fsPath), webViewPanel);
 
-        // Start the server as soon as we open
-        this.ensureConnectionAndNotebook().ignoreErrors();
-
         // Sign up for dirty events
         model.changed(this.modelChanged.bind(this));
     }

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -234,6 +234,9 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // relative files next to the notebook.
         await super.loadWebPanel(path.dirname(this.file.fsPath), webViewPanel);
 
+        // Start the server as soon as we open
+        this.ensureConnectionAndNotebook().ignoreErrors();
+
         // Sign up for dirty events
         model.changed(this.modelChanged.bind(this));
     }

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -323,7 +323,7 @@ export class JupyterNotebookBase implements INotebook {
             }
         );
 
-        if (cancelToken) {
+        if (cancelToken && cancelToken.onCancellationRequested) {
             this.disposableRegistry.push(
                 cancelToken.onCancellationRequested(() => deferred.reject(new CancellationError()))
             );

--- a/src/client/datascience/kernel-launcher/kernelDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemon.ts
@@ -63,6 +63,9 @@ export class PythonKernelDaemon extends BasePythonDaemon implements IPythonKerne
         args: string[],
         options: SpawnOptions
     ): Promise<ObservableExecutionResult<string>> {
+        if (this.killed) {
+            throw new Error('Restarting a dead daemon');
+        }
         if (options.throwOnStdErr) {
             throw new Error("'throwOnStdErr' not supported in spawnOptions for KernelDaemon.start");
         }

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -181,7 +181,8 @@ export class KernelProcess implements IKernelProcess {
             newConnectionArgs.push(`--log-level=10`);
         }
 
-        // We still put in the tmp name to make sure the kernel picks a valid connection file name.
+        // We still put in the tmp name to make sure the kernel picks a valid connection file name. It won't read it as
+        // we passed in the arguments, but it will use it as the file name so it doesn't clash with other kernels.
         newConnectionArgs.push(`--f=${tmp.tmpNameSync({ postfix: '.json' })}`);
 
         return newConnectionArgs;

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -4,8 +4,9 @@
 
 import { ChildProcess } from 'child_process';
 import * as tcpPortUsed from 'tcp-port-used';
+import * as tmp from 'tmp';
 import { Event, EventEmitter } from 'vscode';
-import { PYTHON_LANGUAGE } from '../../common/constants';
+import { isTestExecution, PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError, traceInfo, traceWarning } from '../../common/logger';
 import { IProcessServiceFactory, ObservableExecutionResult } from '../../common/process/types';
 import { Resource } from '../../common/types';
@@ -175,6 +176,13 @@ export class KernelProcess implements IKernelProcess {
         newConnectionArgs.push(`--shell=${this._connection.shell_port}`);
         newConnectionArgs.push(`--transport="${this._connection.transport}"`);
         newConnectionArgs.push(`--iopub=${this._connection.iopub_port}`);
+        if (isTestExecution()) {
+            // Extra logging for tests
+            newConnectionArgs.push(`--log-level=10`);
+        }
+
+        // We still put in the tmp name to make sure the kernel picks a valid connection file name.
+        newConnectionArgs.push(`--f=${tmp.tmpNameSync({ postfix: '.json' })}`);
 
         return newConnectionArgs;
     }

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -228,6 +228,16 @@ function createTestMiddleware(): Redux.Middleware<{}, IStore> {
             sendMessage(InteractiveWindowMessages.ShowingIp);
         }
 
+        // Kernel state changing
+        const afterKernel = afterState.main.kernel;
+        const prevKernel = prevState.main.kernel;
+        if (
+            afterKernel.jupyterServerStatus !== prevKernel.jupyterServerStatus &&
+            afterKernel.jupyterServerStatus === ServerStatus.Idle
+        ) {
+            sendMessage(InteractiveWindowMessages.KernelIdle);
+        }
+
         if (action.type !== 'action.postOutgoingMessage') {
             sendMessage(`DISPATCHED_ACTION_${action.type}`, {});
         }

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -1024,6 +1024,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             this.jupyterMock = new MockJupyterManagerFactory(this.serviceManager);
             // When using mocked Jupyter, default to using default kernel.
             when(this.kernelServiceMock.searchAndRegisterKernel(anything(), anything())).thenResolve(undefined);
+            when(this.kernelServiceMock.getKernelSpecs(anything(), anything())).thenResolve([]);
             this.serviceManager.addSingletonInstance<KernelService>(KernelService, instance(this.kernelServiceMock));
 
             this.serviceManager.addSingleton<InterpeterHashProviderFactory>(
@@ -1523,7 +1524,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             debugJustMyCode: true,
             variableQueries: [],
             jupyterCommandLineArguments: [],
-            disableJupyterAutoStart: true,
+            disableJupyterAutoStart: false,
             widgetScriptSources: ['jsdelivr.com', 'unpkg.com']
         };
         pythonSettings.jediEnabled = false;

--- a/src/test/datascience/intellisense.functional.test.tsx
+++ b/src/test/datascience/intellisense.functional.test.tsx
@@ -9,6 +9,7 @@ import { Disposable } from 'vscode';
 import { nbformat } from '@jupyterlab/coreutils';
 import { LanguageServerType } from '../../client/activation/types';
 import { createDeferred } from '../../client/common/utils/async';
+import { InteractiveWindowMessages } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { IInterpreterService } from '../../client/interpreter/contracts';
 import { MonacoEditor } from '../../datascience-ui/react-common/monacoEditor';
 import { noop } from '../core';
@@ -16,7 +17,14 @@ import { DataScienceIocContainer } from './dataScienceIocContainer';
 import { takeSnapshot, writeDiffSnapshot } from './helpers';
 import * as InteractiveHelpers from './interactiveWindowTestHelpers';
 import * as NativeHelpers from './nativeEditorTestHelpers';
-import { addMockData, enterEditorKey, getInteractiveEditor, getNativeEditor, typeCode } from './testHelpers';
+import {
+    addMockData,
+    enterEditorKey,
+    getInteractiveEditor,
+    getNativeEditor,
+    typeCode,
+    waitForMessage
+} from './testHelpers';
 
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
 [LanguageServerType.Microsoft, LanguageServerType.Node].forEach((languageServerType) => {
@@ -449,8 +457,10 @@ import { addMockData, enterEditorKey, getInteractiveEditor, getNativeEditor, typ
             'Hover on notebook',
             async (wrapper) => {
                 // Create an notebook so that it listens to the results.
+                const kernelIdle = waitForMessage(ioc, InteractiveWindowMessages.KernelIdle);
                 const notebook = await NativeHelpers.openEditor(ioc, JSON.stringify(notebookJSON));
                 await notebook.show();
+                await kernelIdle;
 
                 // Cause a hover event over the first character
                 await waitForHover('Native', wrapper, 1, 1);

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -31,6 +31,7 @@ export class MockJupyterSession implements IJupyterSession {
     private forceRestartTimeout: boolean = false;
     private completionTimeout: number = 1;
     private lastRequest: MockJupyterRequest | undefined;
+    private _status = ServerStatus.Busy;
     constructor(
         cellDictionary: Record<string, ICell>,
         timedelay: number,
@@ -39,6 +40,8 @@ export class MockJupyterSession implements IJupyterSession {
     ) {
         this.dict = cellDictionary;
         this.timedelay = timedelay;
+        // Switch to idle after a timeout
+        setTimeout(() => this.changeStatus(ServerStatus.Idle), 100);
     }
 
     public get onRestarted(): Event<void> {
@@ -53,7 +56,7 @@ export class MockJupyterSession implements IJupyterSession {
     }
 
     public get status(): ServerStatus {
-        return ServerStatus.Idle;
+        return this._status;
     }
 
     public async restart(_timeout: number): Promise<void> {
@@ -268,6 +271,11 @@ export class MockJupyterSession implements IJupyterSession {
         _hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
     ): void {
         noop();
+    }
+
+    private changeStatus(newStatus: ServerStatus) {
+        this._status = newStatus;
+        this.onStatusChangedEvent.fire(newStatus);
     }
 
     private findCell = (code: string): ICell => {

--- a/src/test/datascience/uiTests/helpers.ts
+++ b/src/test/datascience/uiTests/helpers.ts
@@ -73,6 +73,10 @@ export class BaseWebUI implements IAsyncDisposable {
             ])
         );
     }
+
+    public waitForMessageAfterServer(message: string, options?: WaitForMessageOptions): Promise<void> {
+        return this.webServerPromise.promise.then(() => this.waitForMessage(message, options));
+    }
     public async waitForMessage(message: string, options?: WaitForMessageOptions): Promise<void> {
         if (!this.webServer) {
             throw new Error('WebServer not yet started');

--- a/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
@@ -55,6 +55,13 @@ use(chaiAsPromised);
             }
 
             ioc.registerDataScienceTypes();
+
+            // Make sure we force auto start (we wait for kernel idle before running)
+            ioc.forceSettingsChanged(undefined, ioc.getSettings().pythonPath, {
+                ...ioc.getSettings().datascience,
+                disableJupyterAutoStart: false
+            });
+
             await ioc.activate();
         });
         teardown(async () => {

--- a/src/test/datascience/uiTests/notebookHelpers.ts
+++ b/src/test/datascience/uiTests/notebookHelpers.ts
@@ -16,7 +16,6 @@ import { traceInfo } from '../../../client/logging';
 import { createTemporaryFile } from '../../utils/fs';
 import { mockedVSCodeNamespaces } from '../../vscode-mock';
 import { DataScienceIocContainer } from '../dataScienceIocContainer';
-import { waitForMessage } from '../testHelpers';
 import { NotebookEditorUI } from './notebookUi';
 import { WebServer } from './webBrowserPanel';
 

--- a/src/test/datascience/uiTests/notebookHelpers.ts
+++ b/src/test/datascience/uiTests/notebookHelpers.ts
@@ -10,11 +10,13 @@ import * as sinon from 'sinon';
 import * as TypeMoq from 'typemoq';
 import { EventEmitter, Uri, ViewColumn, WebviewPanel } from 'vscode';
 import { noop } from '../../../client/common/utils/misc';
+import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
 import { INotebookEditor, INotebookEditorProvider } from '../../../client/datascience/types';
 import { traceInfo } from '../../../client/logging';
 import { createTemporaryFile } from '../../utils/fs';
 import { mockedVSCodeNamespaces } from '../../vscode-mock';
 import { DataScienceIocContainer } from '../dataScienceIocContainer';
+import { waitForMessage } from '../testHelpers';
 import { NotebookEditorUI } from './notebookUi';
 import { WebServer } from './webBrowserPanel';
 
@@ -116,9 +118,14 @@ export async function openNotebook(
     const webViewPanel = createWebViewPanel();
     traceInfo(`Notebook UI Tests: about to open editor`);
 
+    const kernelIdle = notebookUI.waitForMessageAfterServer(InteractiveWindowMessages.KernelIdle);
     const notebookEditor = await openNotebookEditor(ioc, notebookFileContents, notebookFile);
     traceInfo(`Notebook UI Tests: have editor`);
     await uiLoaded;
     traceInfo(`Notebook UI Tests: UI complete`);
+
+    // Wait for kernel to be idle before finishing. (Prevents early shutdown problems in tests)
+    await kernelIdle;
+
     return { notebookEditor, webViewPanel, notebookUI };
 }


### PR DESCRIPTION
We were getting random raw kernel failures with nightly tests that looked like the connection file was being reused after shutdown.

The fix was to pass a connection file name, but not create one. This allows us to control the name so there aren't any conflicts. 

Also noticed that we seemed to create 4 sessions for every test that creates a notebook. It turned out to be a bug in the notebook provider where it would always create a notebook even with just a 'get' request.