### PR TITLE
More nightly fixes

### DIFF
--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -260,6 +260,10 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         traceInfo(`Killing server because of error ${err}`);
                         await result.dispose();
                     }
+                    // If this is occurring during shutdown, don't worry about it.
+                    if (this.disposed) {
+                        return;
+                    }
                     if (err instanceof JupyterWaitForIdleError && tryCount < maxTries) {
                         // Special case. This sometimes happens where jupyter doesn't ever connect. Cleanup after
                         // ourselves and propagate the failure outwards.

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -260,10 +260,6 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         traceInfo(`Killing server because of error ${err}`);
                         await result.dispose();
                     }
-                    // If this is occurring during shutdown, don't worry about it.
-                    if (this.disposed) {
-                        return;
-                    }
                     if (err instanceof JupyterWaitForIdleError && tryCount < maxTries) {
                         // Special case. This sometimes happens where jupyter doesn't ever connect. Cleanup after
                         // ourselves and propagate the failure outwards.
@@ -275,6 +271,11 @@ export class JupyterExecutionBase implements IJupyterExecution {
                         tryCount += 1;
                     } else if (connection) {
                         kernelSpecCancelSource.cancel();
+
+                        // If this is occurring during shutdown, don't worry about it.
+                        if (this.disposed) {
+                            return undefined;
+                        }
 
                         // Something else went wrong
                         if (!isLocalConnection) {

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -157,7 +157,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
             let tryCount = 0;
             const maxTries = this.configuration.getSettings(undefined).datascience.jupyterLaunchRetries;
             const stopWatch = new StopWatch();
-            while (tryCount < maxTries) {
+            while (tryCount < maxTries && !this.disposed) {
                 try {
                     // Start or connect to the process
                     [connection, kernelSpecInterpreter] = await Promise.all([

--- a/src/client/datascience/jupyter/liveshare/roleBasedFactory.ts
+++ b/src/client/datascience/jupyter/liveshare/roleBasedFactory.ts
@@ -73,7 +73,8 @@ export class RoleBasedFactory<T extends IRoleBasedObject, CtorType extends Class
         const oldDispose = obj.dispose.bind(obj);
         obj.dispose = () => {
             objDisposed = true;
-            this.createPromise = undefined;
+            // Make sure we don't destroy the create promise. Otherwise
+            // dispose will end up causing the creation code to run again.
             return oldDispose();
         };
 

--- a/src/client/datascience/jupyter/liveshare/roleBasedFactory.ts
+++ b/src/client/datascience/jupyter/liveshare/roleBasedFactory.ts
@@ -88,6 +88,7 @@ export class RoleBasedFactory<T extends IRoleBasedObject, CtorType extends Class
                         ? vsls.Role.Guest
                         : vsls.Role.Host;
                 if (newRole !== role) {
+                    this.createPromise = undefined;
                     obj.dispose().ignoreErrors();
                 }
 

--- a/src/client/datascience/jupyter/liveshare/roleBasedFactory.ts
+++ b/src/client/datascience/jupyter/liveshare/roleBasedFactory.ts
@@ -88,7 +88,10 @@ export class RoleBasedFactory<T extends IRoleBasedObject, CtorType extends Class
                         ? vsls.Role.Guest
                         : vsls.Role.Host;
                 if (newRole !== role) {
+                    // Also have to clear the create promise so we
+                    // run the create code again.
                     this.createPromise = undefined;
+
                     obj.dispose().ignoreErrors();
                 }
 

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -6,7 +6,7 @@ import { ChildProcess } from 'child_process';
 import * as tcpPortUsed from 'tcp-port-used';
 import * as tmp from 'tmp';
 import { Event, EventEmitter } from 'vscode';
-import { isTestExecution, PYTHON_LANGUAGE } from '../../common/constants';
+import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError, traceInfo, traceWarning } from '../../common/logger';
 import { IProcessServiceFactory, ObservableExecutionResult } from '../../common/process/types';
 import { Resource } from '../../common/types';
@@ -176,10 +176,13 @@ export class KernelProcess implements IKernelProcess {
         newConnectionArgs.push(`--shell=${this._connection.shell_port}`);
         newConnectionArgs.push(`--transport="${this._connection.transport}"`);
         newConnectionArgs.push(`--iopub=${this._connection.iopub_port}`);
-        if (isTestExecution()) {
-            // Extra logging for tests
-            newConnectionArgs.push(`--log-level=10`);
-        }
+
+        // Turn this on if you get desparate. It can cause crashes though as the
+        // logging code isn't that robust.
+        // if (isTestExecution()) {
+        //     // Extra logging for tests
+        //     newConnectionArgs.push(`--log-level=10`);
+        // }
 
         // We still put in the tmp name to make sure the kernel picks a valid connection file name. It won't read it as
         // we passed in the arguments, but it will use it as the file name so it doesn't clash with other kernels.

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -376,7 +376,7 @@ suite('DataScience notebook tests', () => {
                 const pythonService = await createPythonService(2);
 
                 // Skip test for older python and on windows. Getting E_PROTO on windows.
-                if (pythonService && os.platform() !== 'win32') {
+                if (pythonService) {
                     // We will only connect if we allow for self signed cert connections
                     ioc.getSettings().datascience.allowUnauthorizedRemoteConnection = true;
 


### PR DESCRIPTION
Some more fixes:

- Kernel logging can actually crash the kernel. Turn it off for now.
- If shutting down jupyter execution, don't bother throwing an error. This will only happen during tests or closing VS code.
- Reenable the remote self cert test for Windows. 
- Don't recreate a JupyterServer object during dispose. 