### PR TITLE
Disable all stream tests

### DIFF
--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -239,6 +239,15 @@ suite('FileSystem - raw', () => {
     });
 
     suite('createReadStream', () => {
+        setup(function () {
+            // tslint:disable-next-line: no-suspicious-comment
+            // TODO(GH-10031) This appears to be producing
+            // false negative test results, so we're skipping
+            // it for now.
+            // tslint:disable-next-line:no-invalid-this
+            this.skip();
+        });
+
         test('returns the correct ReadStream', async () => {
             const filename = await fix.createFile('x/y/z/spam.py', '...');
             const expected = fs.createReadStream(filename);
@@ -258,14 +267,12 @@ suite('FileSystem - raw', () => {
 
     suite('createWriteStream', () => {
         setup(function () {
-            if (OSX) {
-                // tslint:disable-next-line:no-suspicious-comment
-                // TODO(GH-10031) This appears to be producing
-                // false negative test results, so we're skipping
-                // it for now.
-                // tslint:disable-next-line:no-invalid-this
-                this.skip();
-            }
+            // tslint:disable-next-line: no-suspicious-comment
+            // TODO(GH-10031) This appears to be producing
+            // false negative test results, so we're skipping
+            // it for now.
+            // tslint:disable-next-line:no-invalid-this
+            this.skip();
         });
 
         async function writeToStream(filename: string, write: (str: fs.WriteStream) => void) {

--- a/src/test/common/platform/filesystem.functional.test.ts
+++ b/src/test/common/platform/filesystem.functional.test.ts
@@ -16,7 +16,6 @@ import {
     DOES_NOT_EXIST,
     fixPath,
     FSFixture,
-    OSX,
     SUPPORTS_SOCKETS,
     SUPPORTS_SYMLINKS,
     WINDOWS


### PR DESCRIPTION
For #10031 

These tests are randomly failing (see this example: https://dev.azure.com/ms/vscode-python/_build/results?buildId=83213&view=logs&j=99939364-d097-5982-f38a-b129fc7cd898&t=53d73250-60f3-5636-6a69-89bd47a8a385&l=114)