### PR TITLE
Remove TS debug adapter subprocess support

### DIFF
--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -1,6 +1,6 @@
 variables:
   PythonVersion: '3.8' # Always use latest version.
-  NodeVersion: '12.4.0' # Check version of node used in VS Code.
+  NodeVersion: '12.8.1' # Check version of node used in VS Code.
   NpmVersion: '6.13.4'
   MOCHA_FILE: '$(Build.ArtifactStagingDirectory)/test-junit.xml' # All test files will write their JUnit xml output to this file, clobbering the last time it was written.
   MOCHA_REPORTER_JUNIT: true # Use the mocha-multi-reporters and send output to both console (spec) and JUnit (mocha-junit-reporter).

--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -1,6 +1,6 @@
 variables:
   PythonVersion: '3.8' # Always use latest version.
-  NodeVersion: '12.8.1' # Check version of node used in VS Code.
+  NodeVersion: '12.4.0' # Check version of node used in VS Code.
   NpmVersion: '6.13.4'
   MOCHA_FILE: '$(Build.ArtifactStagingDirectory)/test-junit.xml' # All test files will write their JUnit xml output to this file, clobbering the last time it was written.
   MOCHA_REPORTER_JUNIT: true # Use the mocha-multi-reporters and send output to both console (spec) and JUnit (mocha-junit-reporter).

--- a/src/client/debugger/extension/hooks/childProcessAttachHandler.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachHandler.ts
@@ -8,7 +8,7 @@ import { DebugConfiguration, DebugSessionCustomEvent } from 'vscode';
 import { swallowExceptions } from '../../../common/utils/decorators';
 import { AttachRequestArguments } from '../../types';
 import { DebuggerEvents } from './constants';
-import { ChildProcessLaunchData, IChildProcessAttachService, IDebugSessionEventHandlers } from './types';
+import { IChildProcessAttachService, IDebugSessionEventHandlers } from './types';
 
 /**
  * This class is responsible for automatically attaching the debugger to any
@@ -29,10 +29,8 @@ export class ChildProcessAttachEventHandler implements IDebugSessionEventHandler
             return;
         }
 
-        let data: ChildProcessLaunchData | (AttachRequestArguments & DebugConfiguration);
-        if (event.event === DebuggerEvents.ChildProcessLaunched) {
-            data = event.body! as ChildProcessLaunchData;
-        } else if (
+        let data: AttachRequestArguments & DebugConfiguration;
+        if (
             event.event === DebuggerEvents.PtvsdAttachToSubprocess ||
             event.event === DebuggerEvents.DebugpyAttachToSubprocess
         ) {

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -7,11 +7,10 @@ import { inject, injectable } from 'inversify';
 import { DebugConfiguration, DebugSession, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../../common/application/types';
 import { noop } from '../../../common/utils/misc';
-import { SystemVariables } from '../../../common/variables/systemVariables';
 import { captureTelemetry } from '../../../telemetry';
 import { EventName } from '../../../telemetry/constants';
-import { AttachRequestArguments, LaunchRequestArguments } from '../../types';
-import { ChildProcessLaunchData, IChildProcessAttachService } from './types';
+import { AttachRequestArguments } from '../../types';
+import { IChildProcessAttachService } from './types';
 
 /**
  * This class is responsible for attaching the debugger to any
@@ -29,49 +28,16 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
     ) {}
 
     @captureTelemetry(EventName.DEBUGGER_ATTACH_TO_CHILD_PROCESS)
-    public async attach(
-        data: ChildProcessLaunchData | (AttachRequestArguments & DebugConfiguration),
-        parentSession: DebugSession
-    ): Promise<void> {
-        let debugConfig: AttachRequestArguments & DebugConfiguration;
-        let processId: number;
-        if (this.isChildProcessLaunchData(data)) {
-            processId = data.processId;
-            debugConfig = this.getAttachConfiguration(data);
-        } else {
-            debugConfig = data;
-            processId = debugConfig.subProcessId!;
-        }
+    public async attach(data: AttachRequestArguments & DebugConfiguration, parentSession: DebugSession): Promise<void> {
+        const debugConfig: AttachRequestArguments & DebugConfiguration = data;
+        const processId = debugConfig.subProcessId!;
         const folder = this.getRelatedWorkspaceFolder(debugConfig);
         const launched = await this.debugService.startDebugging(folder, debugConfig, parentSession);
         if (!launched) {
             this.appShell.showErrorMessage(`Failed to launch debugger for child process ${processId}`).then(noop, noop);
         }
     }
-    /**
-     * Since we're attaching we need to provide path mappings.
-     * If not provided, we cannot add breakpoints as we don't have mappings to the actual source.
-     * This is because attach automatically assumes remote debugging.
-     * Also remember, this code gets executed only when dynamically attaching to child processes.
-     * Resolves https://github.com/microsoft/vscode-python/issues/3568
-     */
-    public fixPathMappings(config: LaunchRequestArguments & AttachRequestArguments & DebugConfiguration) {
-        if (!config.workspaceFolder) {
-            return;
-        }
-        if (Array.isArray(config.pathMappings) && config.pathMappings.length > 0) {
-            return;
-        }
-        // If user has provided a `cwd` in their `launch.json`, then we need to use
-        // the `cwd` as the localRoot.
-        // We cannot expect the debugger to assume remote root is the same as the cwd,
-        // As debugger doesn't necessarily know whether the process being attached to is
-        // a child process or not.
-        const systemVariables = new SystemVariables(undefined, config.workspaceFolder);
-        const localRoot =
-            config.cwd && config.cwd.length > 0 ? systemVariables.resolveAny(config.cwd) : config.workspaceFolder;
-        config.pathMappings = [{ remoteRoot: '.', localRoot }];
-    }
+
     private getRelatedWorkspaceFolder(
         config: AttachRequestArguments & DebugConfiguration
     ): WorkspaceFolder | undefined {
@@ -80,22 +46,5 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
             return;
         }
         return this.workspaceService.workspaceFolders!.find((ws) => ws.uri.fsPath === workspaceFolder);
-    }
-    private getAttachConfiguration(data: ChildProcessLaunchData): AttachRequestArguments & DebugConfiguration {
-        const args = data.rootStartRequest.arguments;
-        // tslint:disable-next-line:no-any
-        const config = (JSON.parse(JSON.stringify(args)) as any) as AttachRequestArguments & DebugConfiguration;
-        // tslint:disable-next-line: no-any
-        this.fixPathMappings(config as any);
-        config.host = args.request === 'attach' ? args.host! : 'localhost';
-        config.port = data.port;
-        config.name = `Child Process ${data.processId}`;
-        config.request = 'attach';
-        return config;
-    }
-    private isChildProcessLaunchData(
-        data: ChildProcessLaunchData | (AttachRequestArguments & DebugConfiguration)
-    ): data is ChildProcessLaunchData {
-        return data.rootStartRequest !== undefined;
     }
 }

--- a/src/client/debugger/extension/hooks/constants.ts
+++ b/src/client/debugger/extension/hooks/constants.ts
@@ -5,7 +5,6 @@
 
 export enum DebuggerEvents {
     // Event sent by PTVSD when a child process is launched and ready to be attached to for multi-proc debugging.
-    ChildProcessLaunched = 'ptvsd_subprocess',
     PtvsdAttachToSubprocess = 'ptvsd_attach',
     DebugpyAttachToSubprocess = 'debugpyAttach'
 }

--- a/src/client/debugger/extension/hooks/types.ts
+++ b/src/client/debugger/extension/hooks/types.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { DebugConfiguration, DebugSession, DebugSessionCustomEvent } from 'vscode';
-import { AttachRequestArguments, LaunchRequestArguments } from '../../types';
+import { AttachRequestArguments } from '../../types';
 
 export const IDebugSessionEventHandlers = Symbol('IDebugSessionEventHandlers');
 export interface IDebugSessionEventHandlers {
@@ -12,53 +12,7 @@ export interface IDebugSessionEventHandlers {
     handleTerminateEvent?(e: DebugSession): Promise<void>;
 }
 
-export type ChildProcessLaunchData = {
-    /**
-     * The main process (that in turn starts child processes).
-     * @type {number}
-     */
-    rootProcessId: number;
-    /**
-     * The immediate parent of the current process (identified by `processId`).
-     * This could be the same as `parentProcessId`, or something else.
-     * @type {number}
-     */
-    parentProcessId: number;
-    /**
-     * The process id of the child process launched.
-     * @type {number}
-     */
-    processId: number;
-    /**
-     * Port on which the child process is listening and waiting for the debugger to attach.
-     * @type {number}
-     */
-    port: number;
-    /**
-     * The request object sent to the PTVSD by the main process.
-     * If main process was launched, then `arguments` would be the launch request arsg,
-     * else it would be the attach request args.
-     * @type {({
-     *         // tslint:disable-next-line:no-banned-terms
-     *         arguments: LaunchRequestArguments | AttachRequestArguments;
-     *         command: 'attach' | 'request';
-     *         seq: number;
-     *         type: string;
-     *     })}
-     */
-    rootStartRequest: {
-        // tslint:disable-next-line:no-banned-terms
-        arguments: LaunchRequestArguments | AttachRequestArguments;
-        command: 'attach' | 'request';
-        seq: number;
-        type: string;
-    };
-};
-
 export const IChildProcessAttachService = Symbol('IChildProcessAttachService');
 export interface IChildProcessAttachService {
-    attach(
-        data: ChildProcessLaunchData | (AttachRequestArguments & DebugConfiguration),
-        parentSession: DebugSession
-    ): Promise<void>;
+    attach(data: AttachRequestArguments & DebugConfiguration, parentSession: DebugSession): Promise<void>;
 }

--- a/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
+++ b/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
@@ -6,7 +6,6 @@
 // tslint:disable:no-any max-func-body-length
 
 import { expect } from 'chai';
-import * as path from 'path';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
 import { Uri, WorkspaceFolder } from 'vscode';
 import { ApplicationShell } from '../../../../client/common/application/applicationShell';
@@ -14,7 +13,6 @@ import { DebugService } from '../../../../client/common/application/debugService
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../../../client/common/application/types';
 import { WorkspaceService } from '../../../../client/common/application/workspace';
 import { ChildProcessAttachService } from '../../../../client/debugger/extension/hooks/childProcessAttachService';
-import { ChildProcessLaunchData } from '../../../../client/debugger/extension/hooks/types';
 import { AttachRequestArguments, LaunchRequestArguments } from '../../../../client/debugger/types';
 
 suite('Debug - Attach to Child Process', () => {
@@ -35,22 +33,12 @@ suite('Debug - Attach to Child Process', () => {
     });
 
     test('Message is not displayed if debugger is launched', async () => {
-        const args: LaunchRequestArguments | AttachRequestArguments = {
-            request: 'launch',
+        const data: AttachRequestArguments = {
+            name: 'Attach',
             type: 'python',
-            name: ''
-        };
-        const data: ChildProcessLaunchData = {
-            rootProcessId: 1,
-            parentProcessId: 1,
+            request: 'attach',
             port: 1234,
-            processId: 2,
-            rootStartRequest: {
-                seq: 1,
-                type: 'python',
-                arguments: args,
-                command: 'request'
-            }
+            subProcessId: 2
         };
         const session: any = {};
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
@@ -60,22 +48,12 @@ suite('Debug - Attach to Child Process', () => {
         verify(debugService.startDebugging(anything(), anything(), anything())).once();
     });
     test('Message is displayed if debugger is not launched', async () => {
-        const args: LaunchRequestArguments | AttachRequestArguments = {
-            request: 'launch',
+        const data: AttachRequestArguments = {
+            name: 'Attach',
             type: 'python',
-            name: ''
-        };
-        const data: ChildProcessLaunchData = {
-            rootProcessId: 1,
-            parentProcessId: 1,
+            request: 'attach',
             port: 1234,
-            processId: 2,
-            rootStartRequest: {
-                seq: 1,
-                type: 'python',
-                arguments: args,
-                command: 'request'
-            }
+            subProcessId: 2
         };
 
         const session: any = {};
@@ -94,23 +72,13 @@ suite('Debug - Attach to Child Process', () => {
         const wkspace1: WorkspaceFolder = { name: '0', index: 0, uri: Uri.file('0') };
         const wkspace2: WorkspaceFolder = { name: '2', index: 2, uri: Uri.file('2') };
 
-        const args: LaunchRequestArguments | AttachRequestArguments = {
-            request: 'launch',
+        const data: AttachRequestArguments = {
+            name: 'Attach',
             type: 'python',
-            name: '',
-            workspaceFolder: rightWorkspaceFolder.uri.fsPath
-        };
-        const data: ChildProcessLaunchData = {
-            rootProcessId: 1,
-            parentProcessId: 1,
+            request: 'attach',
             port: 1234,
-            processId: 2,
-            rootStartRequest: {
-                seq: 1,
-                type: 'python',
-                arguments: args,
-                command: 'request'
-            }
+            subProcessId: 2,
+            workspaceFolder: rightWorkspaceFolder.uri.fsPath
         };
 
         const session: any = {};
@@ -129,23 +97,13 @@ suite('Debug - Attach to Child Process', () => {
         const wkspace1: WorkspaceFolder = { name: '0', index: 0, uri: Uri.file('0') };
         const wkspace2: WorkspaceFolder = { name: '2', index: 2, uri: Uri.file('2') };
 
-        const args: LaunchRequestArguments | AttachRequestArguments = {
-            request: 'launch',
+        const data: AttachRequestArguments = {
+            name: 'Attach',
             type: 'python',
-            name: '',
-            workspaceFolder: rightWorkspaceFolder.uri.fsPath
-        };
-        const data: ChildProcessLaunchData = {
-            rootProcessId: 1,
-            parentProcessId: 1,
+            request: 'attach',
             port: 1234,
-            processId: 2,
-            rootStartRequest: {
-                seq: 1,
-                type: 'python',
-                arguments: args,
-                command: 'request'
-            }
+            subProcessId: 2,
+            workspaceFolder: rightWorkspaceFolder.uri.fsPath
         };
 
         const session: any = {};
@@ -159,30 +117,18 @@ suite('Debug - Attach to Child Process', () => {
         verify(debugService.startDebugging(undefined, anything(), anything())).once();
         verify(shell.showErrorMessage(anything())).never();
     });
-    test('Validate debug config when parent/root parent was launched', async () => {
-        const args: LaunchRequestArguments | AttachRequestArguments = {
-            request: 'launch',
+    test('Validate debug config is passed as is', async () => {
+        const data: LaunchRequestArguments | AttachRequestArguments = {
+            request: 'attach',
             type: 'python',
-            name: ''
-        };
-        const data: ChildProcessLaunchData = {
-            rootProcessId: 1,
-            parentProcessId: 1,
+            name: 'Attach',
             port: 1234,
-            processId: 2,
-            rootStartRequest: {
-                seq: 1,
-                type: 'python',
-                arguments: args,
-                command: 'request'
-            }
+            subProcessId: 2,
+            host: 'localhost'
         };
 
-        const debugConfig = JSON.parse(JSON.stringify(args));
+        const debugConfig = JSON.parse(JSON.stringify(data));
         debugConfig.host = 'localhost';
-        debugConfig.port = data.port;
-        debugConfig.name = `Child Process ${data.processId}`;
-        debugConfig.request = 'attach';
         const session: any = {};
 
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
@@ -219,29 +165,18 @@ suite('Debug - Attach to Child Process', () => {
         verify(shell.showErrorMessage(anything())).never();
     });
     test('Validate debug config when parent/root parent was attached', async () => {
-        const args: AttachRequestArguments = {
+        const data: AttachRequestArguments = {
             request: 'attach',
             type: 'python',
-            name: '',
-            host: '123.123.123.123'
-        };
-        const data: ChildProcessLaunchData = {
-            rootProcessId: 1,
-            parentProcessId: 1,
+            name: 'Attach',
+            host: '123.123.123.123',
             port: 1234,
-            processId: 2,
-            rootStartRequest: {
-                seq: 1,
-                type: 'python',
-                arguments: args,
-                command: 'request'
-            }
+            subProcessId: 2
         };
 
-        const debugConfig = JSON.parse(JSON.stringify(args));
-        debugConfig.host = args.host!;
+        const debugConfig = JSON.parse(JSON.stringify(data));
+        debugConfig.host = data.host;
         debugConfig.port = data.port;
-        debugConfig.name = `Child Process ${data.processId}`;
         debugConfig.request = 'attach';
         const session: any = {};
 
@@ -256,87 +191,5 @@ suite('Debug - Attach to Child Process', () => {
         expect(secondArg).to.deep.equal(debugConfig);
         expect(thirdArg).to.deep.equal(session);
         verify(shell.showErrorMessage(anything())).never();
-    });
-    test('Path mappings are not set when there is no workspace folder', async () => {
-        const args: LaunchRequestArguments & AttachRequestArguments = {
-            request: 'launch',
-            type: 'python',
-            name: '',
-            pythonPath: '',
-            args: [],
-            envFile: ''
-        };
-
-        attachService.fixPathMappings(args);
-
-        expect(args.pathMappings).to.equal(undefined, 'Not undefined');
-    });
-    test('Path mappings are left untouched when they are provided', async () => {
-        const pathMappings = [{ localRoot: '1', remoteRoot: '2' }];
-        const args: LaunchRequestArguments & AttachRequestArguments = {
-            request: 'launch',
-            type: 'python',
-            name: '',
-            workspaceFolder: __dirname,
-            pythonPath: '',
-            args: [],
-            envFile: '',
-            pathMappings: pathMappings
-        };
-
-        attachService.fixPathMappings(args);
-
-        expect(args.pathMappings).to.deep.equal(pathMappings);
-    });
-    test('Path mappings default to workspace folder', async () => {
-        const expectedPathMappings = [{ localRoot: __dirname, remoteRoot: '.' }];
-        const args: LaunchRequestArguments & AttachRequestArguments = {
-            request: 'launch',
-            type: 'python',
-            name: '',
-            workspaceFolder: __dirname,
-            pythonPath: '',
-            args: [],
-            envFile: ''
-        };
-
-        attachService.fixPathMappings(args);
-
-        expect(args.pathMappings).to.deep.equal(expectedPathMappings);
-    });
-    test('Path mappings default to cwd folder', async () => {
-        const expectedPathMappings = [{ localRoot: path.join('hello', 'world'), remoteRoot: '.' }];
-        const args: LaunchRequestArguments & AttachRequestArguments = {
-            request: 'launch',
-            type: 'python',
-            name: '',
-            cwd: path.join('hello', 'world'),
-            workspaceFolder: __dirname,
-            pythonPath: '',
-            args: [],
-            envFile: ''
-        };
-
-        attachService.fixPathMappings(args);
-
-        expect(args.pathMappings).to.deep.equal(expectedPathMappings);
-    });
-    test('Path mappings default to cwd folder relative to workspace folder', async () => {
-        const expectedPathMappings = [{ localRoot: path.join(__dirname, 'hello', 'world'), remoteRoot: '.' }];
-        const args: LaunchRequestArguments & AttachRequestArguments = {
-            request: 'launch',
-            type: 'python',
-            name: '',
-            // tslint:disable-next-line: no-invalid-template-strings
-            cwd: path.join('${workspaceFolder}', 'hello', 'world'),
-            workspaceFolder: __dirname,
-            pythonPath: '',
-            args: [],
-            envFile: ''
-        };
-
-        attachService.fixPathMappings(args);
-
-        expect(args.pathMappings).to.deep.equal(expectedPathMappings);
     });
 });

--- a/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
+++ b/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
@@ -43,9 +43,13 @@ suite('Debug - Attach to Child Process', () => {
         const session: any = {};
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
         when(debugService.startDebugging(anything(), anything(), anything())).thenResolve(true as any);
+        when(shell.showErrorMessage(anything())).thenResolve();
+
         await attachService.attach(data, session);
+
         verify(workspaceService.hasWorkspaceFolders).once();
         verify(debugService.startDebugging(anything(), anything(), anything())).once();
+        verify(shell.showErrorMessage(anything())).never();
     });
     test('Message is displayed if debugger is not launched', async () => {
         const data: AttachRequestArguments = {


### PR DESCRIPTION
This is now replaced by python debug adapter sub-process handler.

Note: This does support the `ptvsd == 4.*` version of the subprocess event. The behavior of those is same as `debugpy` subprocess event. It is left as is, since it is possible that people will have containers with old ptvsd installed. They will get a prompt to update the debugger.