### PR TITLE
Faster pipelines, split node unit tests from python unit tests

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -32,7 +32,7 @@ steps:
       PythonVersion: $(PythonVersion)
       workingDirectory: $(Build.SourcesDirectory)
       compile: 'false'
-      sqlite: 'true'
+      sqlite: $(NeedsIPythonReqs)
 
   # Run the `prePublishNonBundle` gulp task to build the binaries we will be testing.
   # This produces the .js files required into the out/ folder.

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -34,8 +34,12 @@ stages:
         dependsOn: []
         strategy:
           matrix:
+            'NodeUnit':
+              TestsToRun: 'testUnitTests'
+              NeedsPythonTestReqs: false
+              NeedsIPythonReqs: false
             'Unit':
-              TestsToRun: 'testUnitTests, pythonUnitTests, pythonInternalTools, pythonIPythonTests'
+              TestsToRun: 'pythonUnitTests, pythonInternalTools, pythonIPythonTests'
               NeedsPythonTestReqs: true
               NeedsIPythonReqs: true
             'Functional':
@@ -64,7 +68,7 @@ stages:
             'Unit':
               PythonVersion: '2.7'
               # Note: "pythonInternalTools" tests are 3.7+.
-              TestsToRun: 'testUnitTests, pythonUnitTests'
+              TestsToRun: 'pythonUnitTests'
               NeedsPythonTestReqs: true
             'Functional':
               PythonVersion: '2.7'

--- a/news/3 Code Health/12017.md
+++ b/news/3 Code Health/12017.md
@@ -1,0 +1,1 @@
+Faster unit tests on CI Pipeline.


### PR DESCRIPTION
For #12017
**Faster & fewer resources used on CI even though we have more jobs**

* When running python unit tests we don't need node (saving time on npm, and compilation - saving 8 minutes)
* When running node unit tests we don't need python (asving time on setting up python, saving 3 minutes)
* When running unit tests on Python 2.7, we only run Python tests, but we still setup node, install node modules and compile (unnecessarily slowing a whole Job by around 8 minutes)

* Over all we save 8 minutes
* Py2.7 was previously 17 minutes, now 7 minutes

PR https://github.com/microsoft/vscode-python/pull/12012 has also sped up some other builds.

| Before        | After           | 
| ------------- |:-------------:| 
| ![Screen Shot 2020-05-27 at 10 25 08](https://user-images.githubusercontent.com/1948812/83052721-92b6fa80-a004-11ea-9dc9-5f3efcbd7bbe.png)  | ![Screen Shot 2020-05-27 at 11 17 43](https://user-images.githubusercontent.com/1948812/83057414-ba5d9100-a00b-11ea-82f9-f6045b1479eb.png)
 |    


