### PR TITLE
Revert LS issue template changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_ds_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_ds_bug_report.md
@@ -33,6 +33,7 @@ _Please provide as much info as you readily know_
 -   **Jupyter server running:** Local | Remote | N/A
 -   **Extension version:** 20YY.MM.#####-xxx
 -   **VS Code version:** #.##
+-   **Setting python.jediEnabled:** true | false
 -   **Setting python.languageServer:** Jedi | Microsoft | None
 -   **Python and/or Anaconda version:** #.#.#
 -   **OS:** Windows | Mac | Linux (distro):

--- a/.github/ISSUE_TEMPLATE/2_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.md
@@ -15,6 +15,7 @@ labels: classify, type-bug
 -   Type of virtual environment used (N/A | venv | virtualenv | conda | ...): XXX
 -   Relevant/affected Python packages and their versions: XXX
 -   Relevant/affected Python-related VS Code extensions and their versions: XXX
+-   Jedi or Language Server? (i.e. what is `"python.jediEnabled"` set to; more info #3977): XXX
 -   Value of the `python.languageServer` setting: XXX
 
 ## Expected behaviour


### PR DESCRIPTION
Undoing the template change in #11834.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
