### PR TITLE
Changed variable explorer grid column header order

### DIFF
--- a/src/datascience-ui/interactive-common/variableExplorer.tsx
+++ b/src/datascience-ui/interactive-common/variableExplorer.tsx
@@ -106,6 +106,20 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
 
         this.gridColumns = [
             {
+                key: 'buttons',
+                name: '',
+                type: 'boolean',
+                width: 34,
+                sortable: false,
+                resizable: false,
+                formatter: (
+                    <VariableExplorerButtonCellFormatter
+                        showDataExplorer={this.props.showDataExplorer}
+                        baseTheme={this.props.baseTheme}
+                    />
+                )
+            },
+            {
                 key: 'name',
                 name: getLocString('DataScience.variableExplorerNameColumn', 'Name'),
                 type: 'string',
@@ -136,20 +150,6 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                 width: 300,
                 formatter: <VariableExplorerCellFormatter cellStyle={CellStyle.string} />,
                 headerRenderer: <VariableExplorerHeaderCellFormatter />
-            },
-            {
-                key: 'buttons',
-                name: '',
-                type: 'boolean',
-                width: 34,
-                sortable: false,
-                resizable: false,
-                formatter: (
-                    <VariableExplorerButtonCellFormatter
-                        showDataExplorer={this.props.showDataExplorer}
-                        baseTheme={this.props.baseTheme}
-                    />
-                )
             }
         ];
 


### PR DESCRIPTION
For #

This PR modified the order of the headers for the variable explorer data grid. It simply moved the "buttons" column (which is actually unnamed in the UI) to the far left side. This means the column order now looks like:
+--+------+------+-------+-------+
|      | Name | Type | Count | Value |
+--+------+------+-------+-------+

This is a change from the original that looked like this:
+------+------+-------+-------+--+
| Name | Type | Count | Value  |      |
+------+------+-------+-------+--+

Now you can expand the "Value" column as far right as you'd like and the accessibility of the buttons that may appear is not compromised.

Notes:
- The blank column (aka buttons column) is not resizable

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
