### PR TITLE
Disable cdn tests again

### DIFF
--- a/src/test/datascience/ipywidgets/cdnWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/cdnWidgetScriptSourceProvider.unit.test.ts
@@ -40,7 +40,11 @@ suite('DataScience - ipywidget - CDN', () => {
     let fileSystem: IFileSystem;
     let webviewUriConverter: ILocalResourceUriConverter;
     let tempFileCount = 0;
-    setup(() => {
+    setup(function () {
+        // Nock seems to fail randomly on CI builds. See bug
+        // https://github.com/microsoft/vscode-python/issues/11442
+        // tslint:disable-next-line: no-invalid-this
+        this.skip();
         notebook = mock(JupyterNotebookBase);
         configService = mock(ConfigurationService);
         httpClient = mock(HttpClient);


### PR DESCRIPTION
For #11442

Tests are still failing. We might need something other than nock to mock an http request.