### PR TITLE
Faster node unit tests

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -34,6 +34,13 @@ steps:
       compile: 'false'
       sqlite: $(NeedsIPythonReqs)
 
+  # When running unit tests, we need to just compile extension code (not webviews & the like).
+  - task: Gulp@0
+    displayName: 'gulp compile'
+    inputs:
+      targets: 'compile'
+    condition: and(succeeded(), contains(variables['TestsToRun'], 'testUnitTests'))
+
   # Run the `prePublishNonBundle` gulp task to build the binaries we will be testing.
   # This produces the .js files required into the out/ folder.
   # Example command line (windows pwsh):
@@ -42,7 +49,7 @@ steps:
     displayName: 'gulp prePublishNonBundle'
     inputs:
       targets: 'prePublishNonBundle'
-    condition: and(succeeded(), not(contains(variables['TestsToRun'], 'testSmoke')))
+    condition: and(succeeded(), not(contains(variables['TestsToRun'], 'testSmoke')), not(contains(variables['TestsToRun'], 'testUnitTests')))
 
   # Run the typescript unit tests.
   #

--- a/news/3 Code Health/12027.md
+++ b/news/3 Code Health/12027.md
@@ -1,0 +1,1 @@
+Faster node unit tests on Azure pipeline.

--- a/src/test/datascience/ipywidgets/cdnWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/cdnWidgetScriptSourceProvider.unit.test.ts
@@ -40,11 +40,13 @@ suite('DataScience - ipywidget - CDN', () => {
     let fileSystem: IFileSystem;
     let webviewUriConverter: ILocalResourceUriConverter;
     let tempFileCount = 0;
-    setup(function () {
+    suiteSetup(function () {
         // Nock seems to fail randomly on CI builds. See bug
         // https://github.com/microsoft/vscode-python/issues/11442
         // tslint:disable-next-line: no-invalid-this
-        this.skip();
+        return this.skip();
+    });
+    setup(() => {
         notebook = mock(JupyterNotebookBase);
         configService = mock(ConfigurationService);
         httpClient = mock(HttpClient);


### PR DESCRIPTION
For #11999
* When running unit tests we don't need to compile the webviews (no need to compile react, etc).
* Total time to compile code down from 6 minutes to 1 minute (i.e. 5 minutes faster CI to know whether tests passed/failed)

Note the drop in compile times from ~7minutes to ~50s. (**basically 6 minutes faster**)

| Before        | After           | 
| ------------- |:-------------:| 
| ![Screen Shot 2020-05-27 at 16 31 19](https://user-images.githubusercontent.com/1948812/83082224-a760b600-a037-11ea-807f-01666fc2f157.png) | ![Screen Shot 2020-05-27 at 16 31 34](https://user-images.githubusercontent.com/1948812/83082231-ad569700-a037-11ea-9bd8-38b8110ac70b.png) |
