### PR TITLE
Variable Explorer saves state (height of window) persistently  

### DIFF
--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -11,6 +11,7 @@ import {
     CommonActionType,
     IAddCellAction,
     ILoadIPyWidgetClassFailureAction,
+    IVariableExplorerHeight,
     LoadIPyWidgetClassLoadAction,
     NotifyIPyWidgeWidgetVersionNotSupportedAction
 } from '../../../datascience-ui/interactive-common/redux/reducers/types';
@@ -132,7 +133,8 @@ export enum InteractiveWindowMessages {
     ShowContinue = 'show_continue',
     ShowBreak = 'show_break',
     ShowingIp = 'showing_ip',
-    KernelIdle = 'kernel_idle'
+    KernelIdle = 'kernel_idle',
+    VariableExplorerHeight = 'VariableExplorerHeight'
 }
 
 export enum IPyWidgetMessages {
@@ -546,6 +548,7 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.GetVariablesRequest]: IJupyterVariablesRequest;
     public [InteractiveWindowMessages.GetVariablesResponse]: IJupyterVariablesResponse;
     public [InteractiveWindowMessages.VariableExplorerToggle]: boolean;
+    public [InteractiveWindowMessages.VariableExplorerHeight]: IVariableExplorerHeight;
     public [CssMessages.GetCssRequest]: IGetCssRequest;
     public [CssMessages.GetCssResponse]: IGetCssResponse;
     public [CssMessages.GetMonacoThemeRequest]: IGetMonacoThemeRequest;

--- a/src/client/datascience/interactive-common/synchronization.ts
+++ b/src/client/datascience/interactive-common/synchronization.ts
@@ -83,7 +83,8 @@ const messageWithMessageTypes: MessageMapping<IInteractiveWindowMapping> & Messa
     [CommonActionType.TOGGLE_INPUT_BLOCK]: MessageType.syncAcrossSameNotebooks | MessageType.syncWithLiveShare,
     [CommonActionType.TOGGLE_LINE_NUMBERS]: MessageType.syncWithLiveShare,
     [CommonActionType.TOGGLE_OUTPUT]: MessageType.syncWithLiveShare,
-    [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: MessageType.syncWithLiveShare,
+    [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: MessageType.other,
+    [CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT]: MessageType.syncWithLiveShare,
     [CommonActionType.UNFOCUS_CELL]: MessageType.syncWithLiveShare,
     [CommonActionType.UNMOUNT]: MessageType.other,
     [CommonActionType.PostOutgoingMessage]: MessageType.other,
@@ -194,6 +195,7 @@ const messageWithMessageTypes: MessageMapping<IInteractiveWindowMapping> & Messa
     [InteractiveWindowMessages.UpdateDisplayData]: MessageType.syncWithLiveShare,
     [InteractiveWindowMessages.VariableExplorerToggle]: MessageType.other,
     [InteractiveWindowMessages.VariablesComplete]: MessageType.other,
+    [InteractiveWindowMessages.VariableExplorerHeight]: MessageType.other,
     [InteractiveWindowMessages.ConvertUriForUseInWebViewRequest]: MessageType.other,
     [InteractiveWindowMessages.ConvertUriForUseInWebViewResponse]: MessageType.other,
     // Types from CssMessages

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -313,6 +313,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             skipDefault: this.props.skipDefault,
             testMode: this.props.testMode,
             closeVariableExplorer: this.props.toggleVariableExplorer,
+            setVariableExplorerHeight: this.props.setVariableExplorerHeight,
             baseTheme: baseTheme,
             pageIn: this.pageInVariableData,
             fontSize: this.props.font.size,

--- a/src/datascience-ui/history-react/redux/actions.ts
+++ b/src/datascience-ui/history-react/redux/actions.ts
@@ -18,7 +18,8 @@ import {
     ILinkClickAction,
     IOpenSettingsAction,
     IScrollAction,
-    IShowDataViewerAction
+    IShowDataViewerAction,
+    IVariableExplorerHeight
 } from '../../interactive-common/redux/reducers/types';
 import { IMonacoModelContentChangeEvent } from '../../react-common/monacoHelpers';
 
@@ -73,6 +74,8 @@ export const actionCreators = {
     submitInput: (code: string, cellId: string): CommonAction<ICodeAction> =>
         createIncomingActionWithPayload(CommonActionType.SUBMIT_INPUT, { code, cellId }),
     toggleVariableExplorer: (): CommonAction => createIncomingAction(CommonActionType.TOGGLE_VARIABLE_EXPLORER),
+    setVariableExplorerHeight: (containerHeight: number, gridHeight: number): CommonAction<IVariableExplorerHeight> =>
+        createIncomingActionWithPayload(CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT, { containerHeight, gridHeight }),
     expandAll: (): CommonAction => createIncomingAction(InteractiveWindowMessages.ExpandAll),
     collapseAll: (): CommonAction => createIncomingAction(InteractiveWindowMessages.CollapseAll),
     export: (): CommonAction => createIncomingAction(CommonActionType.EXPORT),

--- a/src/datascience-ui/interactive-common/redux/reducers/types.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/types.ts
@@ -82,6 +82,7 @@ export enum CommonActionType {
     TOGGLE_LINE_NUMBERS = 'action.toggle_line_numbers',
     TOGGLE_OUTPUT = 'action.toggle_output',
     TOGGLE_VARIABLE_EXPLORER = 'action.toggle_variable_explorer',
+    SET_VARIABLE_EXPLORER_HEIGHT = 'action.set_variable_explorer_height',
     UNFOCUS_CELL = 'action.unfocus_cell',
     UNMOUNT = 'action.unmount'
 }
@@ -134,6 +135,7 @@ export type CommonActionTypeMapping = {
     [CommonActionType.CODE_CREATED]: ICodeCreatedAction;
     [CommonActionType.GET_VARIABLE_DATA]: IJupyterVariablesRequest;
     [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: never | undefined;
+    [CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT]: IVariableExplorerHeight;
     [CommonActionType.PostOutgoingMessage]: never | undefined;
     [CommonActionType.REFRESH_VARIABLES]: never | undefined;
     [CommonActionType.OPEN_SETTINGS]: IOpenSettingsAction;
@@ -147,7 +149,7 @@ export type CommonActionTypeMapping = {
     [CommonActionType.RUN_BY_LINE]: ICellAction;
 };
 
-export interface IShowDataViewerAction extends IShowDataViewer {}
+export interface IShowDataViewerAction extends IShowDataViewer { }
 
 export interface ILinkClickAction {
     href: string;
@@ -206,7 +208,7 @@ export interface IRefreshVariablesAction {
     newExecutionCount?: number;
 }
 
-export interface IShowDataViewerAction extends IShowDataViewer {}
+export interface IShowDataViewerAction extends IShowDataViewer { }
 
 export interface ISendCommandAction {
     command: NativeKeyboardCommandTelemetry | NativeMouseCommandTelemetry;
@@ -230,6 +232,12 @@ export interface ILoadIPyWidgetClassFailureAction {
     error: any;
     timedout: boolean;
 }
+
+export interface IVariableExplorerHeight {
+    containerHeight: number;
+    gridHeight: number;
+}
+
 export type LoadIPyWidgetClassDisabledAction = {
     className: string;
     moduleName: string;

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../client/datascience/types';
 import { combineReducers, QueuableAction, ReducerArg, ReducerFunc } from '../../../react-common/reduxUtils';
 import { postActionToExtension } from '../helpers';
-import { CommonActionType, CommonActionTypeMapping } from './types';
+import { CommonActionType, CommonActionTypeMapping, IVariableExplorerHeight } from './types';
 
 export type IVariableState = {
     currentExecutionCount: number;
@@ -24,6 +24,8 @@ export type IVariableState = {
     sortAscending: boolean;
     variables: IJupyterVariable[];
     pageSize: number;
+    containerHeight: number;
+    gridHeight: number;
 };
 
 type VariableReducerFunc<T = never | undefined> = ReducerFunc<
@@ -82,6 +84,10 @@ function toggleVariableExplorer(arg: VariableReducerArg): IVariableState {
     } else {
         return newState;
     }
+}
+
+function setVariableExplorerHeight(arg: VariableReducerArg<IVariableExplorerHeight>): IVariableState {
+    return arg.prevState;
 }
 
 function handleResponse(arg: VariableReducerArg<IJupyterVariablesResponse>): IVariableState {
@@ -219,6 +225,7 @@ const reducerMap: Partial<VariableActionMapping> = {
     [InteractiveWindowMessages.FinishCell]: handleFinishCell,
     [InteractiveWindowMessages.ForceVariableRefresh]: handleRefresh,
     [CommonActionType.TOGGLE_VARIABLE_EXPLORER]: toggleVariableExplorer,
+    [CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT]: setVariableExplorerHeight,
     [CommonActionType.GET_VARIABLE_DATA]: handleRequest,
     [InteractiveWindowMessages.GetVariablesResponse]: handleResponse
 };
@@ -231,7 +238,9 @@ export function generateVariableReducer(): Reducer<IVariableState, QueuableActio
         visible: false,
         sortAscending: true,
         sortColumn: 'name',
-        pageSize: 5
+        pageSize: 5,
+        containerHeight: 0,
+        gridHeight: 200
     };
 
     // Then combine that with our map of state change message to reducer

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -58,10 +58,22 @@ function handleRequest(arg: VariableReducerArg<IJupyterVariablesRequest>): IVari
 }
 
 function toggleVariableExplorer(arg: VariableReducerArg): IVariableState {
-    const newState: IVariableState = {
+    let newState: IVariableState = {
         ...arg.prevState,
         visible: !arg.prevState.visible
     };
+
+    const vscode = (window as any).acquireVSCodeApi;
+    if (vscode) {
+        const resizeState = vscode.getState();
+        if (resizeState && 'containerHeight' in resizeState && 'gridHeight' in resizeState) {
+            newState = {
+                ...newState,
+                containerHeight: resizeState.containerHeight,
+                gridHeight: resizeState.gridHeight
+            };
+        }
+    }
 
     postActionToExtension(arg, InteractiveWindowMessages.VariableExplorerToggle, newState.visible);
 
@@ -87,7 +99,16 @@ function toggleVariableExplorer(arg: VariableReducerArg): IVariableState {
 }
 
 function setVariableExplorerHeight(arg: VariableReducerArg<IVariableExplorerHeight>): IVariableState {
-    return arg.prevState;
+    const containerHeight = arg.payload.data.containerHeight;
+    const gridHeight = arg.payload.data.gridHeight;
+    const vscode = (window as any).acquireVSCodeApi;
+    vscode.setState({ containerHeight: containerHeight, gridHeight: gridHeight });
+
+    return {
+        ...arg.prevState,
+        containerHeight: containerHeight,
+        gridHeight: gridHeight
+    };
 }
 
 function handleResponse(arg: VariableReducerArg<IJupyterVariablesResponse>): IVariableState {

--- a/src/datascience-ui/interactive-common/variableExplorer.tsx
+++ b/src/datascience-ui/interactive-common/variableExplorer.tsx
@@ -106,6 +106,20 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
 
         this.gridColumns = [
             {
+                key: 'buttons',
+                name: '',
+                type: 'boolean',
+                width: 34,
+                sortable: false,
+                resizable: false,
+                formatter: (
+                    <VariableExplorerButtonCellFormatter
+                        showDataExplorer={this.props.showDataExplorer}
+                        baseTheme={this.props.baseTheme}
+                    />
+                )
+            },
+            {
                 key: 'name',
                 name: getLocString('DataScience.variableExplorerNameColumn', 'Name'),
                 type: 'string',
@@ -136,20 +150,6 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                 width: 300,
                 formatter: <VariableExplorerCellFormatter cellStyle={CellStyle.string} />,
                 headerRenderer: <VariableExplorerHeaderCellFormatter />
-            },
-            {
-                key: 'buttons',
-                name: '',
-                type: 'boolean',
-                width: 34,
-                sortable: false,
-                resizable: false,
-                formatter: (
-                    <VariableExplorerButtonCellFormatter
-                        showDataExplorer={this.props.showDataExplorer}
-                        baseTheme={this.props.baseTheme}
-                    />
-                )
             }
         ];
 

--- a/src/datascience-ui/interactive-common/variableExplorer.tsx
+++ b/src/datascience-ui/interactive-common/variableExplorer.tsx
@@ -103,6 +103,8 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
 
         this.handleResizeMouseMove = this.handleResizeMouseMove.bind(this);
         this.setInitialHeight = this.setInitialHeight.bind(this);
+        this.saveCurrentSize = this.saveCurrentSize.bind(this);
+        this.restorePreviousSize = this.restorePreviousSize.bind(this);
 
         this.gridColumns = [
             {
@@ -159,7 +161,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
     }
 
     public componentDidMount() {
-        this.setInitialHeight();
+        this.restorePreviousSize();
     }
 
     public shouldComponentUpdate(nextProps: IVariableExplorerProps): boolean {
@@ -186,7 +188,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
         }
 
         return (
-            <Draggable handle=".handle-resize" onDrag={this.handleResizeMouseMove}>
+            <Draggable handle=".handle-resize" onDrag={this.handleResizeMouseMove} onStop={this.saveCurrentSize}>
                 <span>
                     <div id="variable-panel" ref={this.variablePanelRef}>
                         <div id="variable-panel-padding">
@@ -255,6 +257,22 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
                     />
                 </div>
             );
+        }
+    }
+
+    private saveCurrentSize() {
+        //const vscode = acquireVsCodeApi();
+        //vscode.setState(this.state);
+    }
+
+    private restorePreviousSize() {
+        const acquireVsCodeApi = (window as any).acquireVsCodeApi as Function;
+        const vscode = acquireVsCodeApi();
+        const lastState = vscode.getState();
+        if (lastState) {
+            vscode.setState(lastState);
+        } else {
+            this.setInitialHeight();
         }
     }
 

--- a/src/datascience-ui/interactive-common/variableExplorer.tsx
+++ b/src/datascience-ui/interactive-common/variableExplorer.tsx
@@ -35,6 +35,7 @@ interface IVariableExplorerProps {
     offsetHeight: number;
     showDataExplorer(targetVariable: IJupyterVariable, numberOfColumns: number): void;
     closeVariableExplorer(): void;
+    setVariableExplorerHeight(containerHeight: number, gridHeight: number): any;
     pageIn(startIndex: number, pageSize: number): void;
 }
 
@@ -74,7 +75,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
     private pageSize: number = -1;
 
     // Used for handling resizing
-    private minGridHeight: number = 200;
+    private defaultGridHeight: number = 200;
 
     // These values keep track of variable requests so we don't make the same ones over and over again
     // Note: This isn't in the redux state because the requests will come before the state
@@ -98,7 +99,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
 
         this.state = {
             wrapHeight: 0,
-            gridHeight: this.minGridHeight
+            gridHeight: this.defaultGridHeight
         };
 
         this.handleResizeMouseMove = this.handleResizeMouseMove.bind(this);
@@ -162,6 +163,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
 
     public componentDidMount() {
         this.restorePreviousSize();
+        this.setInitialHeight();
     }
 
     public shouldComponentUpdate(nextProps: IVariableExplorerProps): boolean {
@@ -188,7 +190,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
         }
 
         return (
-            <Draggable handle=".handle-resize" onDrag={this.handleResizeMouseMove} onStop={this.saveCurrentSize}>
+            <Draggable handle=".handle-resize" onDrag={this.handleResizeMouseMove}>
                 <span>
                     <div id="variable-panel" ref={this.variablePanelRef}>
                         <div id="variable-panel-padding">
@@ -265,16 +267,7 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
         //vscode.setState(this.state);
     }
 
-    private restorePreviousSize() {
-        const acquireVsCodeApi = (window as any).acquireVsCodeApi as Function;
-        const vscode = acquireVsCodeApi();
-        const lastState = vscode.getState();
-        if (lastState) {
-            vscode.setState(lastState);
-        } else {
-            this.setInitialHeight();
-        }
-    }
+    private restorePreviousSize() {}
 
     private getRowHeight() {
         return this.props.fontSize + 9;

--- a/src/datascience-ui/interactive-common/variablePanel.tsx
+++ b/src/datascience-ui/interactive-common/variablePanel.tsx
@@ -20,6 +20,7 @@ export interface IVariablePanelProps {
     offsetHeight: number;
     showDataExplorer(targetVariable: IJupyterVariable, numberOfColumns: number): void;
     closeVariableExplorer(): void;
+    setVariableExplorerHeight(containerHeight: number, gridHeight: number): any;
     pageIn(startIndex: number, pageSize: number): void;
 }
 
@@ -39,6 +40,7 @@ export class VariablePanel extends React.Component<IVariablePanelProps> {
                 skipDefault={this.props.skipDefault}
                 showDataExplorer={this.props.showDataExplorer}
                 closeVariableExplorer={this.props.closeVariableExplorer}
+                setVariableExplorerHeight={this.props.setVariableExplorerHeight}
                 pageIn={this.props.pageIn}
                 executionCount={this.props.executionCount}
                 supportsDebugging={this.props.supportsDebugging}

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -172,6 +172,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             skipDefault: this.props.skipDefault,
             testMode: this.props.testMode,
             closeVariableExplorer: this.props.toggleVariableExplorer,
+            setVariableExplorerHeight: this.props.setVariableExplorerHeight,
             baseTheme: baseTheme,
             pageIn: this.pageInVariableData,
             fontSize: this.props.font.size,

--- a/src/datascience-ui/native-editor/redux/actions.ts
+++ b/src/datascience-ui/native-editor/redux/actions.ts
@@ -21,7 +21,8 @@ import {
     ILinkClickAction,
     IOpenSettingsAction,
     ISendCommandAction,
-    IShowDataViewerAction
+    IShowDataViewerAction,
+    IVariableExplorerHeight
 } from '../../interactive-common/redux/reducers/types';
 import { IMonacoModelContentChangeEvent } from '../../react-common/monacoHelpers';
 
@@ -67,6 +68,8 @@ export const actionCreators = {
     executeCellAndBelow: (cellId: string): CommonAction<ICellAction> =>
         createIncomingActionWithPayload(CommonActionType.EXECUTE_CELL_AND_BELOW, { cellId }),
     toggleVariableExplorer: (): CommonAction => createIncomingAction(CommonActionType.TOGGLE_VARIABLE_EXPLORER),
+    setVariableExplorerHeight: (containerHeight: number, gridHeight: number): CommonAction<IVariableExplorerHeight> =>
+        createIncomingActionWithPayload(CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT, { containerHeight, gridHeight }),
     restartKernel: (): CommonAction => createIncomingAction(CommonActionType.RESTART_KERNEL),
     interruptKernel: (): CommonAction => createIncomingAction(CommonActionType.INTERRUPT_KERNEL),
     clearAllOutputs: (): CommonAction => createIncomingAction(InteractiveWindowMessages.ClearAllOutputs),

--- a/src/datascience-ui/native-editor/toolbar.tsx
+++ b/src/datascience-ui/native-editor/toolbar.tsx
@@ -37,6 +37,7 @@ export type INativeEditorToolbarProps = INativeEditorDataProps & {
     save: typeof actionCreators.save;
     executeAllCells: typeof actionCreators.executeAllCells;
     toggleVariableExplorer: typeof actionCreators.toggleVariableExplorer;
+    setVariableExplorerHeight: typeof actionCreators.setVariableExplorerHeight;
     executeAbove: typeof actionCreators.executeAbove;
     executeCellAndBelow: typeof actionCreators.executeCellAndBelow;
     restartKernel: typeof actionCreators.restartKernel;

--- a/src/datascience-ui/react-common/postOffice.ts
+++ b/src/datascience-ui/react-common/postOffice.ts
@@ -77,6 +77,7 @@ export class PostOffice implements IDisposable {
         // tslint:disable-next-line:no-typeof-undefined
         if (!this.vscodeApi && typeof acquireVsCodeApi !== 'undefined') {
             this.vscodeApi = acquireVsCodeApi(); // NOSONAR
+            (window as any).acquireVSCodeApi = this.vscodeApi;
         }
         if (!this.registered) {
             this.registered = true;

--- a/src/test/datascience/interactivePanel.functional.test.tsx
+++ b/src/test/datascience/interactivePanel.functional.test.tsx
@@ -99,8 +99,11 @@ suite('DataScience Interactive Panel', () => {
                 sortAscending: true,
                 sortColumn: '',
                 variables: [],
-                visible: true
+                visible: true,
+                containerHeight: 0,
+                gridHeight: 200
             },
+            setVariableExplorerHeight: noopAny,
             editorOptions: {},
             settings: { showCellInputCode: true, allowInput: true, extraSettings: { editor: {} } } as any
         };

--- a/src/test/datascience/nativeEditor.toolbar.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.toolbar.functional.test.tsx
@@ -52,6 +52,7 @@ suite('DataScience Native Toolbar', () => {
             selectionFocusedInfo: {},
             sendCommand: noopAny,
             toggleVariableExplorer: sinon.stub(),
+            setVariableExplorerHeight: sinon.stub(),
             variablesVisible: false
         };
     });


### PR DESCRIPTION
For #

This pull request makes the variable explorer window save and restore its state after being toggled. Previously the height of the variable explorer would reset every time it was re-toggled (closed then opened).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file ~(remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
