### PR TITLE
Added `workspaceContains:pyproject.toml` to activationEvents

### DIFF
--- a/news/1 Enhancements/12056.md
+++ b/news/1 Enhancements/12056.md
@@ -1,0 +1,1 @@
+The extension will now automatically load if a `pyproject.toml` file is present in the workspace root directory. (@BrandonLWhite)

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
         "onCommand:python.enableSourceMapSupport",
         "onCustomEditor:NativeEditorProvider.ipynb",
         "onNotebookEditor:jupyter-notebook",
-        "workspaceContains:**/mspythonconfig.json"
+        "workspaceContains:**/mspythonconfig.json",
+        "workspaceContains:pyproject.toml"
     ],
     "main": "./out/client/extension",
     "contributes": {


### PR DESCRIPTION
(for #4765)

This PR adds triggering off of 'pyproject.toml' in the workspace root to load the extension.

I'm hoping that using this standard file is easier to get merged vs. the "kitchen-sink" approach that has stalled another PR due to debates and disagreements.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [ ] The wiki is updated with any design decisions/details.
