### PR TITLE
Update incorrect JSDoc annotations

### DIFF
--- a/news/3 Code Health/12101.md
+++ b/news/3 Code Health/12101.md
@@ -1,1 +1,1 @@
-Update JSDoc annotations for many of the APIs
+Update JSDoc annotations for many of the APIs (thanks [tonybaloney](https://github.com/tonybaloney))

--- a/news/3 Code Health/12101.md
+++ b/news/3 Code Health/12101.md
@@ -1,0 +1,1 @@
+Update JSDoc annotations for many of the APIs

--- a/src/client/common/process/pythonDaemonPool.ts
+++ b/src/client/common/process/pythonDaemonPool.ts
@@ -106,6 +106,7 @@ export class PythonDaemonExecutionServicePool extends PythonDaemonFactory implem
      * @private
      * @template T
      * @param {(daemon: IPythonExecutionService) => Promise<T>} cb
+     * @param daemonLogMessage
      * @returns {Promise<T>}
      * @memberof PythonDaemonExecutionServicePool
      */
@@ -130,6 +131,7 @@ export class PythonDaemonExecutionServicePool extends PythonDaemonFactory implem
      *
      * @private
      * @param {(daemon: IPythonExecutionService) => ObservableExecutionResult<string>} cb
+     * @param daemonLogMessage
      * @returns {ObservableExecutionResult<string>}
      * @memberof PythonDaemonExecutionServicePool
      */

--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -129,7 +129,7 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
      * This configuration is documented on Conda.
      * Extension will not attempt to work around issues by trying to setup shell for user.
      *
-     * @param {string} envName
+     * @param {string} condaEnv
      * @returns {(Promise<string[] | undefined>)}
      * @memberof CondaActivationCommandProvider
      */

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -570,6 +570,7 @@ export interface ICryptoUtils {
      * @returns hash as number, or string
      * @param data The string to hash
      * @param hashFormat Return format of the hash, number or string
+     * @param [algorithm]
      */
     createHash<E extends keyof IHashFormat>(
         data: string,

--- a/src/client/common/utils/cacheUtils.ts
+++ b/src/client/common/utils/cacheUtils.ts
@@ -25,7 +25,7 @@ const resourceSpecificCacheStores = new Map<string, Map<string, CacheData>>();
  *  used in a workspace will affect the cache key.
  * @param {Resource} resource
  * @param {VSCodeType} [vscode=require('vscode')]
- * @param {IServiceContainer} serviceContainer
+ * @param serviceContainer
  * @returns
  */
 function getCacheKey(

--- a/src/client/common/utils/cacheUtils.ts
+++ b/src/client/common/utils/cacheUtils.ts
@@ -23,9 +23,9 @@ const resourceSpecificCacheStores = new Map<string, Map<string, CacheData>>();
  * Get a cache key specific to a resource (i.e. workspace)
  * This key will be used to cache interpreter related data, hence the Python Path
  *  used in a workspace will affect the cache key.
- * @param {String} keyPrefix
  * @param {Resource} resource
  * @param {VSCodeType} [vscode=require('vscode')]
+ * @param {IServiceContainer} serviceContainer
  * @returns
  */
 function getCacheKey(
@@ -70,9 +70,9 @@ function getCacheKey(
 }
 /**
  * Gets the cache store for a resource that's specific to the interpreter.
- * @param {string} keyPrefix
  * @param {Resource} resource
  * @param {VSCodeType} [vscode=require('vscode')]
+ * @param serviceContainer
  * @returns
  */
 function getCacheStore(

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterDependencyService.ts
@@ -55,6 +55,7 @@ function sortProductsInOrderForInstallation(products: Product[]) {
  *
  * @export
  * @param {Product[]} products
+ * @param {string} [interpreterName]
  * @returns {string}
  */
 export function getMessageForLibrariesNotInstalled(products: Product[], interpreterName?: string): string {
@@ -288,7 +289,7 @@ export class JupyterInterpreterDependencyService {
      *
      * @private
      * @param {PythonInterpreter} interpreter
-     * @param {CancellationToken} [token]
+     * @param {CancellationToken} [_token]
      * @returns {Promise<boolean>}
      * @memberof JupyterInterpreterConfigurationService
      */

--- a/src/client/datascience/jupyter/jupyterDebugger.ts
+++ b/src/client/datascience/jupyter/jupyterDebugger.ts
@@ -243,7 +243,7 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
      * (temporary to hard-code and use these in here).
      * The old debugger will soon go away into oblivion...
      * @private
-     * @param {INotebook} notebook
+     * @param {INotebook} _notebook
      * @returns {Promise<string>}
      * @memberof JupyterDebugger
      */

--- a/src/client/datascience/jupyter/kernels/kernelSelections.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelections.ts
@@ -24,6 +24,7 @@ import { IKernelSelectionListProvider, IKernelSpecQuickPickItem, LiveKernelModel
  * Given a kernel spec, this will return a quick pick item with appropriate display names and the like.
  *
  * @param {IJupyterKernelSpec} kernelSpec
+ * @param pathUtils
  * @returns {IKernelSpecQuickPickItem}
  */
 function getQuickPickItemForKernelSpec(
@@ -42,6 +43,7 @@ function getQuickPickItemForKernelSpec(
  * Given an active kernel, this will return a quick pick item with appropriate display names and the like.
  *
  * @param {(LiveKernelModel)} kernel
+ * @param {IPathUtils} pathUtils
  * @returns {IKernelSpecQuickPickItem}
  */
 function getQuickPickItemForActiveKernel(kernel: LiveKernelModel, pathUtils: IPathUtils): IKernelSpecQuickPickItem {
@@ -190,6 +192,7 @@ export class KernelSelectionProvider {
     /**
      * Gets a selection of kernel specs from a remote session.
      *
+     * @param {Resource} resource
      * @param {IJupyterSessionManager} sessionManager
      * @param {CancellationToken} [cancelToken]
      * @returns {Promise<IKernelSpecQuickPickItem[]>}
@@ -227,6 +230,8 @@ export class KernelSelectionProvider {
     /**
      * Gets a selection of kernel specs for a local session.
      *
+     * @param {Resource} resource
+     * @param type
      * @param {IJupyterSessionManager} [sessionManager]
      * @param {CancellationToken} [cancelToken]
      * @returns {Promise<IKernelSelectionListProvider>}

--- a/src/client/datascience/jupyter/kernels/kernelSelections.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelections.ts
@@ -24,7 +24,7 @@ import { IKernelSelectionListProvider, IKernelSpecQuickPickItem, LiveKernelModel
  * Given a kernel spec, this will return a quick pick item with appropriate display names and the like.
  *
  * @param {IJupyterKernelSpec} kernelSpec
- * @param pathUtils
+ * @param {IPathUtils} pathUtils
  * @returns {IKernelSpecQuickPickItem}
  */
 function getQuickPickItemForKernelSpec(

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -87,8 +87,11 @@ export class KernelSelector {
     /**
      * Selects a kernel from a remote session.
      *
+     * @param {Resource} resource
+     * @param {StopWatch} stopWatch
      * @param {IJupyterSessionManager} session
      * @param {CancellationToken} [cancelToken]
+     * @param {IJupyterKernelSpec | LiveKernelModel} [currentKernel]
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
      */
@@ -119,8 +122,12 @@ export class KernelSelector {
     /**
      * Select a kernel from a local session.
      *
+     * @param {Resource} resource
+     * @param type
+     * @param {StopWatch} stopWatch
      * @param {IJupyterSessionManager} [session]
      * @param {CancellationToken} [cancelToken]
+     * @param {IJupyterKernelSpec | LiveKernelModel} [currentKernel]
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
      */
@@ -154,8 +161,11 @@ export class KernelSelector {
      * Gets a kernel that needs to be used with a local session.
      * (will attempt to find the best matching kernel, or prompt user to use current interpreter or select one).
      *
+     * @param {Resource} resource
+     * @param type
      * @param {IJupyterSessionManager} [sessionManager]
      * @param {nbformat.INotebookMetadata} [notebookMetadata]
+     * @param {boolean} [disableUI]
      * @param {CancellationToken} [cancelToken]
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector
@@ -212,6 +222,7 @@ export class KernelSelector {
      * Gets a kernel that needs to be used with a remote session.
      * (will attempt to find the best matching kernel, or prompt user to use current interpreter or select one).
      *
+     * @param {Resource} resource
      * @param {IJupyterSessionManager} [sessionManager]
      * @param {nbformat.INotebookMetadata} [notebookMetadata]
      * @param {CancellationToken} [cancelToken]
@@ -442,9 +453,12 @@ export class KernelSelector {
      * Otherwise, if not provided user is changing the kernel after starting a notebook.
      *
      * @private
+     * @param {Resource} resource
      * @param {PythonInterpreter} interpreter
+     * @param type
      * @param {string} [displayNameOfKernelNotFound]
      * @param {IJupyterSessionManager} [session]
+     * @param [disableUI]
      * @param {CancellationToken} [cancelToken]
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -458,7 +458,7 @@ export class KernelSelector {
      * @param type
      * @param {string} [displayNameOfKernelNotFound]
      * @param {IJupyterSessionManager} [session]
-     * @param [disableUI]
+     * @param {boolean} [disableUI]
      * @param {CancellationToken} [cancelToken]
      * @returns {Promise<KernelSpecInterpreter>}
      * @memberof KernelSelector

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -283,6 +283,7 @@ export class KernelService {
      * - env = Will have environment variables of the activated environment.
      *
      * @param {PythonInterpreter} interpreter
+     * @param {boolean} [disableUI]
      * @param {CancellationToken} [cancelToken]
      * @returns {Promise<IJupyterKernelSpec>}
      * @memberof KernelService

--- a/src/client/debugger/extension/configuration/launch.json/updaterService.ts
+++ b/src/client/debugger/extension/configuration/launch.json/updaterService.ts
@@ -68,9 +68,9 @@ export class LaunchJsonUpdaterServiceHelper {
     /**
      * Gets the string representation of the debug config for insertion in the document.
      * Adds necessary leading or trailing commas (remember the text is added into an array).
-     * @param {TextDocument} document
-     * @param {Position} position
      * @param {DebugConfiguration} config
+     * @param {PositionOfCursor} cursorPosition
+     * @param {PositionOfComma} [commaPosition]
      * @returns
      * @memberof LaunchJsonCompletionItemProvider
      */

--- a/src/client/interpreter/activation/wrapperEnvironmentActivationService.ts
+++ b/src/client/interpreter/activation/wrapperEnvironmentActivationService.ts
@@ -94,7 +94,7 @@ export class WrapperEnvironmentActivationService implements IEnvironmentActivati
      * If a cached entry already exists, then ignore the implementation.
      *
      * @private
-     * @param {string} key
+     * @param {string} cacheKey
      * @param {(() => Promise<NodeJS.ProcessEnv | undefined>)} implementation
      * @returns {(Promise<NodeJS.ProcessEnv | undefined>)}
      * @memberof WrapperEnvironmentActivationService

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -207,6 +207,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
      * The format is `Python <Version> <bitness> (<env name>: <env type>)`
      * E.g. `Python 3.5.1 32-bit (myenv2: virtualenv)`
      * @param {Partial<PythonInterpreter>} info
+     * @param {Uri} [resource]
      * @returns {string}
      * @memberof InterpreterService
      */

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -96,7 +96,7 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * Check if the linter itself is available in the workspace's Python environment or
      * not.
      *
-     * @param linterProduct Linter to check in the current workspace environment.
+     * @param linterInfo Linter to check in the current workspace environment.
      * @param resource Context information for workspace.
      */
     public async isLinterAvailable(linterInfo: ILinterInfo, resource: Resource): Promise<boolean | undefined> {

--- a/src/client/testing/common/services/discoveredTestParser.ts
+++ b/src/client/testing/common/services/discoveredTestParser.ts
@@ -218,6 +218,7 @@ export class TestDiscoveredTestParser implements discovery.ITestDiscoveredTestPa
      *
      * @protected
      * @param {TestFolder} rootFolder
+     * @param {TestFile | TestSuite} parent
      * @param {TestFunction} parentFunction
      * @param {DiscoveredTests} discoveredTests
      * @param {Tests} tests

--- a/src/client/testing/pytest/services/testMessageService.ts
+++ b/src/client/testing/pytest/services/testMessageService.ts
@@ -21,6 +21,7 @@ export class TestMessageService implements ITestMessageService {
      * Condense the test details down to just the potentially relevant information. Messages
      * should only be created for tests that were actually run.
      *
+     * @param rootDirectory
      * @param testResults Details about all known tests.
      */
     public async getFilteredTestMessages(rootDirectory: string, testResults: Tests): Promise<IPythonTestMessage[]> {

--- a/src/client/testing/unittest/services/parserService.ts
+++ b/src/client/testing/unittest/services/parserService.ts
@@ -56,7 +56,8 @@ export class TestsParser implements ITestsParser {
      * Where tone_test = folder, Failing2Tests = class/suite, test_failure = method.
      * @private
      * @param {string} rootDirectory
-     * @param {string[]} testIds
+     * @param {string} testId
+     * @param {TestFile[]} testFiles
      * @returns {Tests}
      * @memberof TestsParser
      */

--- a/src/ipywidgets/src/embed.ts
+++ b/src/ipywidgets/src/embed.ts
@@ -55,7 +55,7 @@ function moduleNameToCDNUrl(moduleName: string, moduleVersion: string): string {
  * Load an amd module locally and fall back to specified CDN if unavailable.
  *
  * @param moduleName The name of the module to load..
- * @param version The semver range for the module, if loaded from a CDN.
+ * @param moduleVersion The semver range for the module, if loaded from a CDN.
  *
  * By default, the CDN service used is unpkg.com. However, this default can be
  * overriden by specifying another URL via the HTML attribute

--- a/src/ipywidgets/src/libembed.ts
+++ b/src/ipywidgets/src/libembed.ts
@@ -42,6 +42,7 @@ export async function renderWidgets(
  *
  * @param element The DOM element to search for widget view state script tags
  * @param widgetState The widget manager state
+ * @param managerFactory The widget manager factory
  *
  * #### Notes
  *

--- a/src/test/mocks/vsc/uri.ts
+++ b/src/test/mocks/vsc/uri.ts
@@ -311,7 +311,7 @@ export namespace vscUri {
          * `file:///usr/home`, or `scheme:with/path`.
          *
          * @param value A string which represents an URI (see `URI#toString`).
-         * @param {boolean} _strict
+         * @param {boolean} [_strict=false]
          */
         static parse(value: string, _strict: boolean = false): URI {
             const match = _regexp.exec(value);

--- a/src/test/mocks/vsc/uri.ts
+++ b/src/test/mocks/vsc/uri.ts
@@ -311,6 +311,7 @@ export namespace vscUri {
          * `file:///usr/home`, or `scheme:with/path`.
          *
          * @param value A string which represents an URI (see `URI#toString`).
+         * @param {boolean} _strict
          */
         static parse(value: string, _strict: boolean = false): URI {
             const match = _regexp.exec(value);

--- a/src/test/testing/explorer/explorerTestData.ts
+++ b/src/test/testing/explorer/explorerTestData.ts
@@ -220,10 +220,11 @@ export function createMockWorkspaceService(): typemoq.IMock<IWorkspaceService> {
  * Create a testable mocked up version of the TestExplorerViewProvider. Creates any
  * mocked dependencies not provided in the parameters.
  *
- * @param testStore Test storage service, provides access to the Tests structure that the view is built from.
- * @param unitTestMgmtService Unit test management service that provides the 'onTestStatusUpdated' event.
- * @param workspaceService Workspace service used to determine the current workspace that the test view is showing.
- * @param disposableReg Disposable registry used to dispose of items in the view.
+ * @param {ITestCollectionStorageService} [testStore] Test storage service, provides access to the Tests structure that the view is built from.
+ * @param {Tests} [testsData]
+ * @param {ITestManagementService} [unitTestMgmtService] Unit test management service that provides the 'onTestStatusUpdated' event.
+ * @param {IWorkspaceService} [workspaceService] Workspace service used to determine the current workspace that the test view is showing.
+ * @param {ICommandManager} [commandManager]
  */
 export function createMockTestExplorer(
     testStore?: ITestCollectionStorageService,

--- a/src/test/testing/pytest/pytest.run.test.ts
+++ b/src/test/testing/pytest/pytest.run.test.ts
@@ -243,6 +243,7 @@ function getRelevantSkippedIssuesFromTestDetailsForFile(testDetails: ITestDetail
 /**
  * Get the FlattenedTestFunction from the test results that's associated with the given testDetails object.
  *
+ * @param ioc IOC Test Container
  * @param results Results of the test run.
  * @param testFileUri The Uri of the test file that was run.
  * @param testDetails The details of a particular test.

--- a/types/@msrvida-python-program-analysis/rewrite-magics.d.ts
+++ b/types/@msrvida-python-program-analysis/rewrite-magics.d.ts
@@ -34,7 +34,7 @@ export interface LineMagicRewriter {
      * Rewrite the line magic.
      * @param matchedText the original matched text from the program
      * @param magicStmt the line magic text with newlines and continuations removed
-     * @param postion ((start_line, start_col),(end_line, end_col)) of `matchedText` within the cell
+     * @param position ((start_line, start_col),(end_line, end_col)) of `matchedText` within the cell
      * @return rewrite operation. Leave text empty if you want to use default rewrites.
      */
     rewrite(matchedText: string, magicStmt: string, position: MatchPosition): Rewrite;


### PR DESCRIPTION
For #12101 

Code quality related. This change just updates a few of the JSDoc `@param` annotations for typescript and javascript files that are either incorrect (wrong argument name), missing, or had typos

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.

