### PR TITLE
Fix raw kernel running other languages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,5 +55,6 @@
         // Match what black does.
         "--max-line-length=88"
     ],
-    "typescript.preferences.importModuleSpecifier": "relative"
+    "typescript.preferences.importModuleSpecifier": "relative",
+    "debug.javascript.usePreview": false
 }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -168,7 +168,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.RunCurrentCellAndAddBelow]: [string];
     [DSCommands.ScrollToCell]: [string, string];
     [DSCommands.ViewJupyterOutput]: [];
-    [DSCommands.SwitchJupyterKernel]: [INotebook | undefined];
+    [DSCommands.SwitchJupyterKernel]: [INotebook | undefined, 'raw' | 'jupyter'];
     [DSCommands.SelectJupyterCommandLine]: [undefined | Uri];
     [DSCommands.SaveNotebookNonCustomEditor]: [Uri];
     [DSCommands.SaveAsNotebookNonCustomEditor]: [Uri, Uri];

--- a/src/client/datascience/commands/kernelSwitcher.ts
+++ b/src/client/datascience/commands/kernelSwitcher.ts
@@ -5,7 +5,6 @@
 
 import { inject, injectable } from 'inversify';
 import { ICommandManager } from '../../common/application/types';
-import { traceError } from '../../common/logger';
 import { IDisposable } from '../../common/types';
 import { Commands } from '../constants';
 import { KernelSpecInterpreter } from '../jupyter/kernels/kernelSelector';
@@ -29,7 +28,10 @@ export class KernelSwitcherCommand implements IDisposable {
     public dispose() {
         this.disposables.forEach((d) => d.dispose());
     }
-    private async switchKernel(notebook?: INotebook): Promise<KernelSpecInterpreter | undefined> {
+    private async switchKernel(
+        notebook: INotebook | undefined,
+        type: 'raw' | 'jupyter'
+    ): Promise<KernelSpecInterpreter | undefined> {
         // If notebook isn't know, then user invoked this command from command palette or similar.
         // We need to identify the current notebook (active native editor or interactive window).
         if (!notebook) {
@@ -37,10 +39,6 @@ export class KernelSwitcherCommand implements IDisposable {
                 this.notebookEditorProvider.activeEditor?.notebook ??
                 this.interactiveWindowProvider.getActive()?.notebook;
         }
-        if (!notebook) {
-            traceError('No active notebook');
-            return;
-        }
-        return this.kernelSwitcher.switchKernel(notebook);
+        return this.kernelSwitcher.switchKernel(notebook, type);
     }
 }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -66,6 +66,7 @@ import {
 } from '../interactive-common/interactiveWindowTypes';
 import { JupyterInvalidKernelError } from '../jupyter/jupyterInvalidKernelError';
 import { JupyterKernelPromiseFailedError } from '../jupyter/kernels/jupyterKernelPromiseFailedError';
+import { KernelSpecInterpreter } from '../jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../jupyter/kernels/kernelSwitcher';
 import { LiveKernelModel } from '../jupyter/kernels/types';
 import { CssMessages, SharedMessages } from '../messages';
@@ -1436,12 +1437,28 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     }
 
     private async selectKernel() {
-        if (!this._notebook) {
-            return;
-        }
         try {
             this.startProgress();
-            await this.commandManager.executeCommand(Commands.SwitchJupyterKernel, this._notebook);
+            const kernel = (await this.commandManager.executeCommand(
+                Commands.SwitchJupyterKernel,
+                this._notebook,
+                this._notebook?.connection?.type || this.notebookProvider.type
+            )) as KernelSpecInterpreter;
+            if (!this._notebook && kernel?.kernelSpec) {
+                // No notebook, send update to UI anyway
+                this.postMessage(InteractiveWindowMessages.UpdateKernel, {
+                    jupyterServerStatus: ServerStatus.NotStarted,
+                    localizedUri: '',
+                    displayName: kernel.kernelSpec.display_name || kernel.kernelSpec.name || '',
+                    language: translateKernelLanguageToMonaco(kernel.kernelSpec.language ?? PYTHON_LANGUAGE)
+                }).ignoreErrors();
+
+                // Update our model
+                this.updateNotebookOptions(kernel.kernelSpec, kernel.interpreter).ignoreErrors();
+
+                // Try creating a notebook again with this new kernel.
+                this.ensureConnectionAndNotebook().ignoreErrors();
+            }
         } finally {
             this.stopProgress();
         }

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -47,10 +47,10 @@ export class NotebookProvider implements INotebookProvider {
         disposables.push(
             interactiveWindowProvider.onDidChangeActiveInteractiveWindow(this.checkAndDisposeNotebook, this)
         );
-        // this.rawNotebookProvider
-        //     .supported()
-        //     .then((b) => (this._type = b ? 'raw' : 'jupyter'))
-        //     .ignoreErrors();
+        this.rawNotebookProvider
+            .supported()
+            .then((b) => (this._type = b ? 'raw' : 'jupyter'))
+            .ignoreErrors();
     }
     public get onNotebookCreated() {
         return this._notebookCreated.event;

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -28,6 +28,7 @@ import {
 export class NotebookProvider implements INotebookProvider {
     private readonly notebooks = new Map<string, Promise<INotebook>>();
     private _notebookCreated = new EventEmitter<{ identity: Uri; notebook: INotebook }>();
+    private _type: 'jupyter' | 'raw' = 'jupyter';
     public get activeNotebooks() {
         return [...this.notebooks.values()];
     }
@@ -46,9 +47,17 @@ export class NotebookProvider implements INotebookProvider {
         disposables.push(
             interactiveWindowProvider.onDidChangeActiveInteractiveWindow(this.checkAndDisposeNotebook, this)
         );
+        // this.rawNotebookProvider
+        //     .supported()
+        //     .then((b) => (this._type = b ? 'raw' : 'jupyter'))
+        //     .ignoreErrors();
     }
     public get onNotebookCreated() {
         return this._notebookCreated.event;
+    }
+
+    public get type(): 'jupyter' | 'raw' {
+        return this._type;
     }
 
     // Disconnect from the specified provider

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -154,10 +154,10 @@ export class JupyterExecutionBase implements IJupyterExecution {
             }
 
             // Try to connect to our jupyter process. Check our setting for the number of tries
-            let tryCount = 0;
+            let tryCount = 1;
             const maxTries = this.configuration.getSettings(undefined).datascience.jupyterLaunchRetries;
             const stopWatch = new StopWatch();
-            while (tryCount < maxTries && !this.disposed) {
+            while (tryCount <= maxTries && !this.disposed) {
                 try {
                     // Start or connect to the process
                     [connection, kernelSpecInterpreter] = await Promise.all([

--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -6,6 +6,7 @@ import { inject, injectable } from 'inversify';
 import * as portfinder from 'portfinder';
 import { promisify } from 'util';
 import * as uuid from 'uuid/v4';
+import { IFileSystem } from '../../common/platform/types';
 import { IProcessServiceFactory } from '../../common/process/types';
 import { Resource } from '../../common/types';
 import { PythonInterpreter } from '../../interpreter/contracts';
@@ -26,6 +27,7 @@ export class KernelLauncher implements IKernelLauncher {
     private static nextFreePortToTryAndUse = PortToStartFrom;
     constructor(
         @inject(IProcessServiceFactory) private processExecutionFactory: IProcessServiceFactory,
+        @inject(IFileSystem) private readonly fileSystem: IFileSystem,
         @inject(KernelDaemonPool) private readonly daemonPool: KernelDaemonPool
     ) {}
 
@@ -41,6 +43,7 @@ export class KernelLauncher implements IKernelLauncher {
             this.daemonPool,
             connection,
             kernelSpec,
+            this.fileSystem,
             resource,
             interpreter
         );

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -21,6 +21,7 @@ import { IKernelConnection, IKernelProcess, IPythonKernelDaemon, PythonKernelDie
 
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
+import { IFileSystem } from '../../common/platform/types';
 import { KernelDaemonPool } from './kernelDaemonPool';
 
 // Launches and disposes a kernel process given a kernelspec and a resource or python interpreter.
@@ -46,11 +47,13 @@ export class KernelProcess implements IKernelProcess {
     private kernelDaemon?: IPythonKernelDaemon;
     private readonly _kernelSpec: IJupyterKernelSpec;
     private readonly originalKernelSpec: IJupyterKernelSpec;
+    private connectionFile?: string;
     constructor(
         private readonly processExecutionFactory: IProcessServiceFactory,
         private readonly daemonPool: KernelDaemonPool,
         private readonly _connection: IKernelConnection,
         kernelSpec: IJupyterKernelSpec,
+        private readonly file: IFileSystem,
         private readonly resource: Resource,
         private readonly interpreter?: PythonInterpreter
     ) {
@@ -71,7 +74,7 @@ export class KernelProcess implements IKernelProcess {
         this.launchedOnce = true;
 
         // Update our connection arguments in the kernel spec
-        this.updateConnectionArgs();
+        await this.updateConnectionArgs();
 
         const exeObs = await this.launchAsObservable();
 
@@ -126,6 +129,7 @@ export class KernelProcess implements IKernelProcess {
             this.exitEvent.fire();
         });
         swallowExceptions(() => this.pythonKernelLauncher?.dispose());
+        swallowExceptions(async () => (this.connectionFile ? this.file.deleteFile(this.connectionFile) : noop()));
     }
 
     // Make sure that the heartbeat channel is open for connections
@@ -144,27 +148,48 @@ export class KernelProcess implements IKernelProcess {
 
     // Instead of having to use a connection file update our local copy of the kernelspec to launch
     // directly with command line arguments
-    private updateConnectionArgs() {
+    private async updateConnectionArgs() {
         // First check to see if we have a kernelspec that expects a connection file,
         // Error if we don't have one. We expect '-f', '{connectionfile}' in our launch args
         const indexOfConnectionFile = findIndexOfConnectionFile(this._kernelSpec);
+        if (indexOfConnectionFile === -1) {
+            throw new Error(`Connection file not found in kernelspec json args, ${this._kernelSpec.argv.join(' ')}`);
+        }
         if (
-            indexOfConnectionFile === -1 ||
-            indexOfConnectionFile === 0 ||
+            this.isPythonKernel &&
+            indexOfConnectionFile === 0 &&
             this._kernelSpec.argv[indexOfConnectionFile - 1] !== '-f'
         ) {
             throw new Error(`Connection file not found in kernelspec json args, ${this._kernelSpec.argv.join(' ')}`);
         }
 
-        // Slice out -f and the connection file from the args
-        this._kernelSpec.argv.splice(indexOfConnectionFile - 1, 2);
+        // Python kernels are special. Handle the extra arguments.
+        if (this.isPythonKernel) {
+            // Slice out -f and the connection file from the args
+            this._kernelSpec.argv.splice(indexOfConnectionFile - 1, 2);
 
-        // Add in our connection command line args
-        this._kernelSpec.argv.push(...this.addConnectionArgs());
+            // Add in our connection command line args
+            this._kernelSpec.argv.push(...this.addPythonConnectionArgs());
+        } else {
+            // For other kernels, just write to the connection file.
+            // Note: We have to dispose the temp file and recreate it because otherwise the file
+            // system will hold onto the file with an open handle. THis doesn't work so well when
+            // a different process tries to open it.
+            const tempFile = await this.file.createTemporaryFile('.json');
+            this.connectionFile = tempFile.filePath;
+            await tempFile.dispose();
+            await this.file.writeFile(this.connectionFile, JSON.stringify(this._connection), {
+                encoding: 'utf-8',
+                flag: 'w'
+            });
+
+            // Then replace the connection file argument with this file
+            this._kernelSpec.argv[indexOfConnectionFile] = this.connectionFile;
+        }
     }
 
     // Add the command line arguments
-    private addConnectionArgs(): string[] {
+    private addPythonConnectionArgs(): string[] {
         const newConnectionArgs: string[] = [];
 
         newConnectionArgs.push(`--ip=${this._connection.ip}`);
@@ -218,6 +243,12 @@ export class KernelProcess implements IKernelProcess {
                     return;
                 }
                 this.exitEvent.fire({ exitCode: exitCode || undefined });
+            });
+            exeObs.proc.stdout.on('data', (data: any) => {
+                traceInfo(`KernelProcess output: ${data}`);
+            });
+            exeObs.proc.stderr.on('data', (data: any) => {
+                traceInfo(`KernelProcess error: ${data}`);
             });
         } else {
             throw new Error('KernelProcess failed to launch');

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -244,9 +244,11 @@ export class KernelProcess implements IKernelProcess {
                 }
                 this.exitEvent.fire({ exitCode: exitCode || undefined });
             });
+            // tslint:disable-next-line: no-any
             exeObs.proc.stdout.on('data', (data: any) => {
                 traceInfo(`KernelProcess output: ${data}`);
             });
+            // tslint:disable-next-line: no-any
             exeObs.proc.stderr.on('data', (data: any) => {
                 traceInfo(`KernelProcess error: ${data}`);
             });

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1063,6 +1063,7 @@ export type GetNotebookOptions = {
 };
 
 export interface INotebookProvider {
+    readonly type: 'raw' | 'jupyter';
     /**
      * Fired when a notebook has been created for a given Uri/Identity
      */

--- a/src/datascience-ui/interactive-common/kernelSelection.tsx
+++ b/src/datascience-ui/interactive-common/kernelSelection.tsx
@@ -17,7 +17,6 @@ export interface IKernelSelectionProps {
 export class KernelSelection extends React.Component<IKernelSelectionProps> {
     private get isKernelSelectionAllowed() {
         return (
-            this.props.kernel.jupyterServerStatus !== ServerStatus.NotStarted &&
             this.props.kernel.jupyterServerStatus !== ServerStatus.Restarting &&
             this.props.kernel.jupyterServerStatus !== ServerStatus.Starting
         );

--- a/src/test/datascience/commands/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/commands/kernelSwitcher.unit.test.ts
@@ -47,10 +47,10 @@ suite('Data Science - KernelSwitcher Command', () => {
             commandHandler = capture(commandManager.registerCommand as any).first()[1] as Function;
             commandHandler = commandHandler.bind(kernelSwitcherCommand);
         });
-        test('Should do nothing if there is no active notebook and no interactive window', async () => {
+        test('Should switch even if no active notebook', async () => {
             await commandHandler.bind(kernelSwitcherCommand)();
 
-            verify(kernelSwitcher.switchKernel(anything(), anything())).never();
+            verify(kernelSwitcher.switchKernel(anything(), anything())).once();
         });
         test('Should switch kernel using the provided notebook', async () => {
             const notebook = mock(JupyterNotebookBase);

--- a/src/test/datascience/commands/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/commands/kernelSwitcher.unit.test.ts
@@ -50,14 +50,14 @@ suite('Data Science - KernelSwitcher Command', () => {
         test('Should do nothing if there is no active notebook and no interactive window', async () => {
             await commandHandler.bind(kernelSwitcherCommand)();
 
-            verify(kernelSwitcher.switchKernel(anything())).never();
+            verify(kernelSwitcher.switchKernel(anything(), anything())).never();
         });
         test('Should switch kernel using the provided notebook', async () => {
             const notebook = mock(JupyterNotebookBase);
 
             await commandHandler.bind(kernelSwitcherCommand)(instance(notebook));
 
-            verify(kernelSwitcher.switchKernel(instance(notebook))).once();
+            verify(kernelSwitcher.switchKernel(instance(notebook), anything())).once();
         });
         test('Should switch kernel using the active Native Editor', async () => {
             const nativeEditor = mock(JupyterNotebookBase);
@@ -66,7 +66,7 @@ suite('Data Science - KernelSwitcher Command', () => {
 
             await commandHandler.bind(kernelSwitcherCommand)();
 
-            verify(kernelSwitcher.switchKernel(instance(nativeEditor))).once();
+            verify(kernelSwitcher.switchKernel(instance(nativeEditor), anything())).once();
         });
         test('Should switch kernel using the active Interactive Window', async () => {
             const interactiveWindow = mock(JupyterNotebookBase);
@@ -75,7 +75,7 @@ suite('Data Science - KernelSwitcher Command', () => {
 
             await commandHandler.bind(kernelSwitcherCommand)();
 
-            verify(kernelSwitcher.switchKernel(instance(interactiveWindow))).once();
+            verify(kernelSwitcher.switchKernel(instance(interactiveWindow), anything())).once();
         });
         test('Should switch kernel using the active Native editor even if an Interactive Window is available', async () => {
             const interactiveWindow = mock(JupyterNotebookBase);
@@ -87,7 +87,7 @@ suite('Data Science - KernelSwitcher Command', () => {
 
             await commandHandler.bind(kernelSwitcherCommand)();
 
-            verify(kernelSwitcher.switchKernel(instance(nativeEditor))).once();
+            verify(kernelSwitcher.switchKernel(instance(nativeEditor), anything())).once();
         });
     });
 });

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -60,6 +60,7 @@ suite('Data Science - NotebookProvider', () => {
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
         when(dataScienceSettings.jupyterServerURI).thenReturn('local');
         when(dataScienceSettings.useDefaultConfigForJupyter).thenReturn(true);
+        when(rawNotebookProvider.supported).thenReturn(() => Promise.resolve(false));
 
         notebookProvider = new NotebookProvider(
             instance(fileSystem),

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -94,7 +94,6 @@ suite('Data Science - Kernel Switcher', () => {
             instance(kernelSelector),
             instance(appShell),
             instance(mock(KernelDependencyService))
-            //instance(notebookProvider)
         );
         when(appShell.withProgress(anything(), anything())).thenCall(async (_, cb: () => Promise<void>) => {
             await cb();

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -15,6 +15,7 @@ import { Common, DataScience } from '../../../../client/common/utils/localize';
 import { Architecture } from '../../../../client/common/utils/platform';
 import { JupyterSessionStartError } from '../../../../client/datascience/baseJupyterSession';
 import { Commands } from '../../../../client/datascience/constants';
+import { NotebookProvider } from '../../../../client/datascience/interactive-common/notebookProvider';
 import { JupyterNotebookBase } from '../../../../client/datascience/jupyter/jupyterNotebook';
 import { JupyterSessionManagerFactory } from '../../../../client/datascience/jupyter/jupyterSessionManagerFactory';
 import { KernelDependencyService } from '../../../../client/datascience/jupyter/kernels/kernelDependencyService';
@@ -80,6 +81,8 @@ suite('Data Science - Kernel Switcher', () => {
         sessionManagerFactory = mock(JupyterSessionManagerFactory);
         kernelSelector = mock(KernelSelector);
         appShell = mock(ApplicationShell);
+        const notebookProvider = mock(NotebookProvider);
+        when(notebookProvider.type).thenReturn('jupyter');
 
         // tslint:disable-next-line: no-any
         when(settings.datascience).thenReturn({} as any);
@@ -91,6 +94,7 @@ suite('Data Science - Kernel Switcher', () => {
             instance(kernelSelector),
             instance(appShell),
             instance(mock(KernelDependencyService))
+            //instance(notebookProvider)
         );
         when(appShell.withProgress(anything(), anything())).thenCall(async (_, cb: () => Promise<void>) => {
             await cb();
@@ -168,7 +172,7 @@ suite('Data Science - Kernel Switcher', () => {
                             )
                         ).thenResolve({});
 
-                        const selection = await kernelSwitcher.switchKernel(instance(notebook));
+                        const selection = await kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                         assert.isUndefined(selection);
                     });
@@ -214,7 +218,7 @@ suite('Data Science - Kernel Switcher', () => {
                         test('Switch to the selected kernel', async () => {
                             when(notebook.setKernelSpec(anything(), anything(), anything())).thenResolve();
 
-                            const selection = await kernelSwitcher.switchKernel(instance(notebook));
+                            const selection = await kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                             assert.isOk(selection);
                             assert.deepEqual(selection?.kernelModel, selectedKernel);
@@ -226,7 +230,7 @@ suite('Data Science - Kernel Switcher', () => {
                             const ex = new Error('Kaboom');
                             when(notebook.setKernelSpec(anything(), anything(), anything())).thenReject(ex);
 
-                            const selection = kernelSwitcher.switchKernel(instance(notebook));
+                            const selection = kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                             await assert.isRejected(selection, ex.message);
                         });
@@ -242,7 +246,7 @@ suite('Data Science - Kernel Switcher', () => {
                                 when(notebook.setKernelSpec(anything(), anything(), anything())).thenReject(ex);
                                 when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve();
 
-                                const selection = kernelSwitcher.switchKernel(instance(notebook));
+                                const selection = kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                                 await assert.isRejected(selection, ex.message);
                                 const message = DataScience.sessionStartFailedWithKernel().format(
@@ -262,7 +266,7 @@ suite('Data Science - Kernel Switcher', () => {
                                 when(notebook.setKernelSpec(anything(), anything(), anything())).thenReject(ex);
                                 when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve();
 
-                                const selection = kernelSwitcher.switchKernel(instance(notebook));
+                                const selection = kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                                 await assert.isRejected(selection, ex.message);
                                 const message = DataScience.sessionStartFailedWithKernel().format(
@@ -285,7 +289,7 @@ suite('Data Science - Kernel Switcher', () => {
                                     Common.cancel() as any
                                 );
 
-                                const selection = kernelSwitcher.switchKernel(instance(notebook));
+                                const selection = kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                                 await assert.isRejected(selection, ex.message);
                                 const message = DataScience.sessionStartFailedWithKernel().format(
@@ -339,7 +343,7 @@ suite('Data Science - Kernel Switcher', () => {
                                     DataScience.selectDifferentKernel() as any
                                 );
 
-                                const selection = await kernelSwitcher.switchKernel(instance(notebook));
+                                const selection = await kernelSwitcher.switchKernel(instance(notebook), 'jupyter');
 
                                 assert.isOk(selection);
                                 assert.deepEqual(selection?.kernelModel, selectedKernelSecondTime);

--- a/src/test/datascience/kernelLauncher.functional.test.ts
+++ b/src/test/datascience/kernelLauncher.functional.test.ts
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 
 import { KernelMessage } from '@jupyterlab/services';
 import * as uuid from 'uuid/v4';
+import { IFileSystem } from '../../client/common/platform/types';
 import { IProcessServiceFactory } from '../../client/common/process/types';
 import { createDeferred } from '../../client/common/utils/async';
 import { JupyterZMQBinariesNotFoundError } from '../../client/datascience/jupyter/jupyterZMQBinariesNotFoundError';
@@ -40,7 +41,8 @@ suite('DataScience - Kernel Launcher', () => {
         kernelFinder = new MockKernelFinder(ioc.serviceContainer.get<IKernelFinder>(IKernelFinder));
         const processServiceFactory = ioc.serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
         const daemonPool = ioc.serviceContainer.get<KernelDaemonPool>(KernelDaemonPool);
-        kernelLauncher = new KernelLauncher(processServiceFactory, daemonPool);
+        const fileSystem = ioc.serviceContainer.get<IFileSystem>(IFileSystem);
+        kernelLauncher = new KernelLauncher(processServiceFactory, fileSystem, daemonPool);
         await ioc.activate();
         if (!ioc.mockJupyter) {
             pythonInterpreter = await ioc.getJupyterCapableInterpreter();

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -286,6 +286,36 @@ suite('DataScience Native Editor', () => {
                 );
 
                 runMountedTest(
+                    'Invalid kernel can be switched',
+                    async (wrapper, context) => {
+                        if (ioc.mockJupyter) {
+                            // Can only do this with the mock. Have to force the first call to idle on the
+                            // the jupyter session to fail
+                            ioc.mockJupyter.forcePendingIdleFailure();
+
+                            // Create an editor so something is listening to messages
+                            const editor = (await createNewEditor(ioc)) as NativeEditorWebView;
+
+                            // Run a cell. It should fail.
+                            await addCell(wrapper, ioc, 'a=1\na');
+
+                            // Now switch to another kernel
+                            editor.onMessage(InteractiveWindowMessages.SelectKernel, undefined);
+
+                            // Verify we picked the valid kernel.
+                            await addCell(wrapper, ioc, 'a=1\na');
+
+                            verifyHtmlOnCell(wrapper, 'NativeCell', '<span>1</span>', 1);
+                        } else {
+                            context.skip();
+                        }
+                    },
+                    () => {
+                        return ioc;
+                    }
+                );
+
+                runMountedTest(
                     'Mime Types',
                     async (wrapper) => {
                         // Create an editor so something is listening to messages

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -289,6 +289,12 @@ suite('DataScience Native Editor', () => {
                     'Invalid kernel can be switched',
                     async (wrapper, context) => {
                         if (ioc.mockJupyter) {
+                            ioc.forceSettingsChanged(undefined, ioc.getSettings().pythonPath, {
+                                ...ioc.getSettings().datascience,
+                                jupyterLaunchRetries: 1,
+                                disableJupyterAutoStart: true
+                            });
+
                             // Can only do this with the mock. Have to force the first call to idle on the
                             // the jupyter session to fail
                             ioc.mockJupyter.forcePendingIdleFailure();
@@ -298,6 +304,7 @@ suite('DataScience Native Editor', () => {
 
                             // Run a cell. It should fail.
                             await addCell(wrapper, ioc, 'a=1\na');
+                            verifyHtmlOnCell(wrapper, 'NativeCell', undefined, 1);
 
                             // Now switch to another kernel
                             editor.onMessage(InteractiveWindowMessages.SelectKernel, undefined);
@@ -305,7 +312,7 @@ suite('DataScience Native Editor', () => {
                             // Verify we picked the valid kernel.
                             await addCell(wrapper, ioc, 'a=1\na');
 
-                            verifyHtmlOnCell(wrapper, 'NativeCell', '<span>1</span>', 1);
+                            verifyHtmlOnCell(wrapper, 'NativeCell', '<span>1</span>', 2);
                         } else {
                             context.skip();
                         }

--- a/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
+++ b/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
@@ -4,6 +4,7 @@
 import { assert } from 'chai';
 import { noop } from 'jquery';
 import * as uuid from 'uuid/v4';
+import { IFileSystem } from '../../../client/common/platform/types';
 import { IProcessServiceFactory } from '../../../client/common/process/types';
 import { createDeferred, sleep } from '../../../client/common/utils/async';
 import { KernelDaemonPool } from '../../../client/datascience/kernel-launcher/kernelDaemonPool';
@@ -79,6 +80,7 @@ suite('DataScience raw kernel tests', () => {
             ioc.get<KernelDaemonPool>(KernelDaemonPool),
             connectionInfo as any,
             kernelSpec,
+            ioc.get<IFileSystem>(IFileSystem),
             undefined,
             interpreter
         );


### PR DESCRIPTION
For #11919 

This finishes the work to support other languages. Note, there's no tests for it. (other than some basic unit tests for kernel picking). We don't install dotnet on the azure machine nor do we test the language tokenization.

I feel like this is okay at this time as we're not _officially_ supporting any other languages yet.

I'm going to add another issue for 'testing' other languages. 
https://github.com/microsoft/vscode-python/issues/12112
