### PR TITLE
Give notebooks/interactive window a bit of time before showing

### DIFF
--- a/news/2 Fixes/11865.md
+++ b/news/2 Fixes/11865.md
@@ -1,0 +1,1 @@
+Give time to notebooks (or the interactive window) to load when opening them when the extension is loading.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -212,8 +212,10 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         // Verify a server that matches us hasn't started already
         this.checkForNotebookProviderConnection().ignoreErrors();
 
-        // Show our web panel.
-        return super.show(true);
+        setTimeout(async () => {
+            // Show our web panel.
+            return super.show(true);
+        }, 0);
     }
 
     // tslint:disable-next-line: no-any no-empty cyclomatic-complexity max-func-body-length


### PR DESCRIPTION
For #11865

This issue happened to me when working on the start page. Since it opened when the extension was loading, sometimes the webview would show empty, with the font-awesome css errors in the console log. 

We think this is an issue with VS code, but using a setTimeout of 0 prevented the issue with the start page. I think it should also work for when the notebooks try to load immediately.

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
