### PR TITLE
Add deprecation message for ptvsdDistPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1994,6 +1994,7 @@
                     "type": "string",
                     "default": "",
                     "description": "Path to ptvsd experimental bits for debugging cells.",
+                    "deprecationMessage": "This setting has been deprecated in favor of 'debugpyDistPath'.",
                     "scope": "resource"
                 },
                 "python.dataScience.stopOnFirstLineWhileDebugging": {


### PR DESCRIPTION
For #11993, #11996 

Precursor to #12105. This deprecation message is being included to alert users in the May release, following the example in #7382. We will fully deprecate `ptvsdDistPath` in the June release. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
