### PR TITLE
Double-check for interpreters when running diagnostics

### DIFF
--- a/news/2 Fixes/11870.md
+++ b/news/2 Fixes/11870.md
@@ -1,0 +1,1 @@
+Double-check for interpreters when running diagnostics before displaying the "Python is not installed" message.

--- a/src/client/application/diagnostics/checks/pythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/pythonInterpreter.ts
@@ -67,17 +67,16 @@ export class InvalidPythonInterpreterService extends BaseDiagnosticsService {
         }
 
         const interpreterService = this.serviceContainer.get<IInterpreterService>(IInterpreterService);
-        let hasInterpreters = await interpreterService.hasInterpreters;
+        // hasInterpreters being false can mean one of 2 things:
+        // 1. getInterpreters hasn't returned any interpreters;
+        // 2. getInterpreters hasn't run yet.
+        // We want to make sure that false comes from 1, so we're adding this fix until we refactor interpreter discovery.
+        // Also see https://github.com/microsoft/vscode-python/issues/3023.
+        const hasInterpreters =
+            (await interpreterService.hasInterpreters) ||
+            (await interpreterService.getInterpreters(resource)).length > 0;
 
         if (!hasInterpreters) {
-            // hasInterpreters being false can mean one of 2 things:
-            // 1. getInterpreters hasn't returned any interpreters;
-            // 2. getInterpreters hasn't run yet.
-            // We want to make sure that false comes from 1, so we're adding this fix until we refactor interpreter discovery.
-            // Also see https://github.com/microsoft/vscode-python/issues/3023.
-            interpreterService.getInterpreters(resource).ignoreErrors();
-            hasInterpreters = await interpreterService.hasInterpreters;
-
             return [new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic, resource)];
         }
 

--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -175,6 +175,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .verifiable(typemoq.Times.once());
 
             const diagnostics = await diagnosticService.diagnose(undefined);
+
             expect(diagnostics).to.be.deep.equal([], 'not the same');
             settings.verifyAll();
             interpreterService.verifyAll();

--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -31,7 +31,7 @@ import { IConfigurationService, IDisposableRegistry, IPythonSettings } from '../
 import { noop } from '../../../../client/common/utils/misc';
 import { IInterpreterHelper, IInterpreterService } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
-import { InterpreterType } from '../../../../client/pythonEnvironments/discovery/types';
+import { InterpreterType, PythonInterpreter } from '../../../../client/pythonEnvironments/discovery/types';
 
 suite('Application Diagnostics - Checks Python Interpreter', () => {
     let diagnosticService: IDiagnosticsService;
@@ -153,6 +153,8 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             interpreterService.verifyAll();
         });
         test('Should return empty diagnostics if there are interpreters after double-checking', async () => {
+            const interpreter: PythonInterpreter = { type: InterpreterType.Unknown } as any;
+
             settings
                 .setup((s) => s.disableInstallationChecks)
                 .returns(() => false)
@@ -163,7 +165,13 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .verifiable(typemoq.Times.once());
             interpreterService
                 .setup((i) => i.getInterpreters(undefined))
-                .returns(() => Promise.resolve([{ type: InterpreterType.Unknown } as any]))
+                .returns(() => Promise.resolve([interpreter]))
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup((i) => i.getActiveInterpreter(typemoq.It.isAny()))
+                .returns(() => {
+                    return Promise.resolve(interpreter);
+                })
                 .verifiable(typemoq.Times.once());
 
             const diagnostics = await diagnosticService.diagnose(undefined);

--- a/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/pythonInterpreter.unit.test.ts
@@ -130,7 +130,7 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
             expect(diagnostics).to.be.deep.equal([]);
             settings.verifyAll();
         });
-        test('Should return diagnostics if there are no interpreters', async () => {
+        test('Should return diagnostics if there are no interpreters after double-checking', async () => {
             settings
                 .setup((s) => s.disableInstallationChecks)
                 .returns(() => false)
@@ -139,12 +139,35 @@ suite('Application Diagnostics - Checks Python Interpreter', () => {
                 .setup((i) => i.hasInterpreters)
                 .returns(() => Promise.resolve(false))
                 .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup((i) => i.getInterpreters(undefined))
+                .returns(() => Promise.resolve([]))
+                .verifiable(typemoq.Times.once());
 
             const diagnostics = await diagnosticService.diagnose(undefined);
             expect(diagnostics).to.be.deep.equal(
                 [new InvalidPythonInterpreterDiagnostic(DiagnosticCodes.NoPythonInterpretersDiagnostic, undefined)],
                 'not the same'
             );
+            settings.verifyAll();
+            interpreterService.verifyAll();
+        });
+        test('Should return empty diagnostics if there are interpreters after double-checking', async () => {
+            settings
+                .setup((s) => s.disableInstallationChecks)
+                .returns(() => false)
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup((i) => i.hasInterpreters)
+                .returns(() => Promise.resolve(false))
+                .verifiable(typemoq.Times.once());
+            interpreterService
+                .setup((i) => i.getInterpreters(undefined))
+                .returns(() => Promise.resolve([{ type: InterpreterType.Unknown } as any]))
+                .verifiable(typemoq.Times.once());
+
+            const diagnostics = await diagnosticService.diagnose(undefined);
+            expect(diagnostics).to.be.deep.equal([], 'not the same');
             settings.verifyAll();
             interpreterService.verifyAll();
         });


### PR DESCRIPTION
For #11870

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
