### PR TITLE
Ensure extension features are started when in Deprecate PythonPath experiment and opening a file without any folder opened

### DIFF
--- a/news/2 Fixes/12177.md
+++ b/news/2 Fixes/12177.md
@@ -1,0 +1,1 @@
+Ensure extension features are started when in `Deprecate PythonPath` experiment and opening a file without any folder opened.

--- a/src/client/common/interpreterPathService.ts
+++ b/src/client/common/interpreterPathService.ts
@@ -9,6 +9,7 @@ import { ConfigurationChangeEvent, ConfigurationTarget, Event, EventEmitter, Uri
 import { IWorkspaceService } from './application/types';
 import { PythonSettings } from './configSettings';
 import { isTestExecution } from './constants';
+import { traceError } from './logger';
 import { FileSystemPaths } from './platform/fs-paths';
 import {
     IDisposable,
@@ -105,7 +106,8 @@ export class InterpreterPathService implements IInterpreterPathService {
             return;
         }
         if (!resource) {
-            throw new Error('Cannot update workspace settings as no workspace is opened');
+            traceError('Cannot update workspace settings as no workspace is opened');
+            return;
         }
         const settingKey = this.getSettingKey(resource, configTarget);
         const persistentSetting = this.persistentStateFactory.createGlobalPersistentState<string | undefined>(
@@ -149,7 +151,10 @@ export class InterpreterPathService implements IInterpreterPathService {
 
     public async _copyWorkspaceFolderValueToNewStorage(resource: Resource, value: string | undefined): Promise<void> {
         // Copy workspace folder setting into the new storage if it hasn't been copied already
-        const workspaceFolderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource);
+        const workspaceFolderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource, '');
+        if (workspaceFolderKey === '') {
+            return;
+        }
         const flaggedWorkspaceFolderKeysStorage = this.persistentStateFactory.createGlobalPersistentState<string[]>(
             workspaceFolderKeysForWhichTheCopyIsDone_Key,
             []

--- a/src/client/common/interpreterPathService.ts
+++ b/src/client/common/interpreterPathService.ts
@@ -153,6 +153,7 @@ export class InterpreterPathService implements IInterpreterPathService {
         // Copy workspace folder setting into the new storage if it hasn't been copied already
         const workspaceFolderKey = this.workspaceService.getWorkspaceFolderIdentifier(resource, '');
         if (workspaceFolderKey === '') {
+            // No workspace folder is opened, simply return.
             return;
         }
         const flaggedWorkspaceFolderKeysStorage = this.persistentStateFactory.createGlobalPersistentState<string[]>(


### PR DESCRIPTION
For #12177

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
