### PR TITLE
Add tests for notebook cell manipulations

### DIFF
--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -86,6 +86,9 @@ export async function insertPythonCell(source: string, index: number = 0) {
 export async function insertPythonCellAndWait(source: string, index: number = 0) {
     await (await insertPythonCell(source, index)).waitForCellToGetAdded();
 }
+export async function insertMarkdownCellAndWait(source: string, index: number = 0) {
+    await (await insertMarkdownCell(source, index)).waitForCellToGetAdded();
+}
 export async function deleteCell(index: number = 0) {
     const { vscodeNotebook } = await getServices();
     const activeEditor = vscodeNotebook.activeNotebookEditor;


### PR DESCRIPTION
For #10496
* Added tests, to ensure changes to API will not break our code (the API used to handle/detect cell manipulations have changed a couple of times)
* Might have to add more tests (if the API changes and breaks our tests, I'll add more tests - only if API changes, which I believe will)