### PR TITLE
Disable old approach of hot exit for VSC NB

### DIFF
--- a/src/client/datascience/interactive-ipynb/notebookStorageProvider.ts
+++ b/src/client/datascience/interactive-ipynb/notebookStorageProvider.ts
@@ -110,7 +110,7 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
 
     private modelChanged(model: INotebookModel, e: NotebookModelChange) {
         // VSC Notebooks will have their own hotexit.
-        if (!this.experiment.inExperiment(NativeNotebook.experiment)) {
+        if (this.experiment.inExperiment(NativeNotebook.experiment)) {
             return;
         }
         const actualModel = e.model || model; // Test mocks can screw up bound values.

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
@@ -28,7 +28,7 @@ import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { CryptoUtils } from '../../../client/common/crypto';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { IConfigurationService, ICryptoUtils, IExtensionContext } from '../../../client/common/types';
+import { IConfigurationService, ICryptoUtils, IExtensionContext, IExperimentsManager } from '../../../client/common/types';
 import { sleep } from '../../../client/common/utils/async';
 import { noop } from '../../../client/common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
@@ -210,7 +210,8 @@ suite('DataScience - Native Editor Provider', () => {
             localMemento
         );
 
-        const storage = new NotebookStorageProvider(notebookStorage, [], instance(workspace));
+        const experiment = mock<IExperimentsManager>();
+        const storage = new NotebookStorageProvider(notebookStorage, [], instance(workspace), instance(experiment));
 
         registeredProvider = new NativeEditorProvider(
             instance(svcContainer),

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
@@ -28,7 +28,12 @@ import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { CryptoUtils } from '../../../client/common/crypto';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { IConfigurationService, ICryptoUtils, IExtensionContext, IExperimentsManager } from '../../../client/common/types';
+import {
+    IConfigurationService,
+    ICryptoUtils,
+    IExperimentsManager,
+    IExtensionContext
+} from '../../../client/common/types';
 import { sleep } from '../../../client/common/utils/async';
 import { noop } from '../../../client/common/utils/misc';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -23,7 +23,13 @@ import { PythonSettings } from '../../../client/common/configSettings';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { CryptoUtils } from '../../../client/common/crypto';
 import { IFileSystem } from '../../../client/common/platform/types';
-import { IConfigurationService, ICryptoUtils, IDisposable, IExtensionContext } from '../../../client/common/types';
+import {
+    IConfigurationService,
+    ICryptoUtils,
+    IDisposable,
+    IExperimentsManager,
+    IExtensionContext
+} from '../../../client/common/types';
 import { sleep } from '../../../client/common/utils/async';
 import { EXTENSION_ROOT_DIR } from '../../../client/constants';
 import {
@@ -328,8 +334,8 @@ suite('DataScience - Native Editor Storage', () => {
             globalMemento,
             localMemento
         );
-
-        return new NotebookStorageProvider(notebookStorage, [], instance(workspace));
+        const experiment = mock<IExperimentsManager>();
+        return new NotebookStorageProvider(notebookStorage, [], instance(workspace), instance(experiment));
     }
 
     teardown(() => {


### PR DESCRIPTION
For #10496 
* Disabling to ensure this is not supported until we have VSC API
* Else we end up with issues such as https://github.com/microsoft/vscode-python/issues/12180