### PR TITLE
Make Jedi the default LS

### DIFF
--- a/news/2 Fixes/12225.md
+++ b/news/2 Fixes/12225.md
@@ -1,0 +1,1 @@
+Make Jedi the Default value for the python.languageServer setting.

--- a/package.json
+++ b/package.json
@@ -2153,7 +2153,7 @@
                         "Microsoft",
                         "None"
                     ],
-                    "default": "Microsoft",
+                    "default": "Jedi",
                     "description": "Defines type of the language server.",
                     "scope": "resource"
                 },


### PR DESCRIPTION
For #12225 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).

