### PR TITLE
Fix ipywidget and other test flakiness (hopefully)

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -239,6 +239,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // Indicate we have our identity
         this.loadedPromise.resolve();
 
+        traceInfo(`Loading web panel for ${model.file}`);
+
         // Load the web panel using our file path so it can find
         // relative files next to the notebook.
         await super.loadWebPanel(path.dirname(this.file.fsPath), webViewPanel);

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -632,6 +632,8 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
                 await this.submitCode(code, Identifiers.EmptyFileName, 0, cell.id, cell.data, undefined, cancelToken);
             }
         } catch (exc) {
+            traceInfo(`Exception executing cell ${cell.id}: `, exc);
+
             // Make this error our cell output
             this.sendCellsToWebView([
                 {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -135,7 +135,8 @@ export class NativeEditorProvider
 
     public async resolveCustomEditor(document: CustomDocument, panel: WebviewPanel) {
         this.customDocuments.set(document.uri.fsPath, document);
-        await this.createNotebookEditor(document.uri, panel);
+        const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
+        await this.loadNotebookEditor(editor, document.uri, panel);
     }
 
     public async resolveCustomDocument(document: CustomDocument): Promise<void> {
@@ -208,13 +209,10 @@ export class NativeEditorProvider
         });
     }
 
-    protected async createNotebookEditor(resource: Uri, panel?: WebviewPanel) {
+    protected async loadNotebookEditor(editor: INotebookEditor, resource: Uri, panel?: WebviewPanel) {
         try {
             // Get the model
             const model = await this.loadModel(resource);
-
-            // Create a new editor
-            const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
 
             // Load it (should already be visible)
             return editor

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -149,8 +149,10 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
     }
 
     private async create(file: Uri): Promise<INotebookEditor> {
-        const editor = await this.createNotebookEditor(file);
+        const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
+        this.activeEditors.set(file.fsPath, editor);
         this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
+        await this.loadNotebookEditor(editor, file);
         await this.showEditor(editor);
         return editor;
     }

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -149,11 +149,14 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
     }
 
     private async create(file: Uri): Promise<INotebookEditor> {
-        const editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
-        this.activeEditors.set(file.fsPath, editor);
-        this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
-        await this.loadNotebookEditor(editor, file);
-        await this.showEditor(editor);
+        let editor = this.activeEditors.get(file.fsPath);
+        if (!editor) {
+            editor = this.serviceContainer.get<INotebookEditor>(INotebookEditor);
+            this.activeEditors.set(file.fsPath, editor);
+            this.disposables.push(editor.closed(this.onClosedEditor.bind(this)));
+            await this.loadNotebookEditor(editor, file);
+            await this.showEditor(editor);
+        }
         return editor;
     }
 

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -1242,7 +1242,13 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             .setup((a) =>
                 a.showInformationMessage(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny())
             )
-            .returns((_a1: string, a2: string, _a3: string, _a4: string) => Promise.resolve(a2));
+            .returns((_a1: string, a2: any, _a3: string, a4: string) => {
+                if (typeof a2 === 'string') {
+                    return Promise.resolve(a2);
+                } else {
+                    return Promise.resolve(a4);
+                }
+            });
         appShell
             .setup((a) => a.showSaveDialog(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(Uri.file('test.ipynb')));
@@ -1526,7 +1532,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         pythonSettings.pythonPath = this.defaultPythonPath!;
         pythonSettings.datascience = {
             allowImportFromNotebook: true,
-            jupyterLaunchTimeout: 20000,
+            jupyterLaunchTimeout: 60000,
             jupyterLaunchRetries: 3,
             enabled: true,
             jupyterServerURI: 'local',

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -2545,6 +2545,7 @@ df.head()`;
                         saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
                         await waitForMessageResponse(ioc, () => saveButton!.simulate('click'));
                         await saved;
+                        await sleep(1000); // Make sure file finishes writing.
 
                         const nb = JSON.parse(
                             await fs.readFile(notebookFile.filePath, 'utf8')

--- a/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
+++ b/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
@@ -3,6 +3,7 @@
 'use strict';
 import { assert } from 'chai';
 import { noop } from 'jquery';
+import * as portfinder from 'portfinder';
 import * as uuid from 'uuid/v4';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { IProcessServiceFactory } from '../../../client/common/process/types';
@@ -41,7 +42,8 @@ suite('DataScience raw kernel tests', () => {
             // tslint:disable-next-line: no-invalid-this
             this.skip();
         } else {
-            rawKernel = await connectToKernel(57718);
+            const port = await portfinder.getPortPromise({ startPort: 57718 });
+            rawKernel = await connectToKernel(port);
         }
     });
 
@@ -157,7 +159,8 @@ suite('DataScience raw kernel tests', () => {
         assert.ok(executeResult, 'Result not found');
         await shutdown();
         await sleep(2500); // Give time for the shutdown to go across
-        rawKernel = await connectToKernel(57418);
+        const port = await portfinder.getPortPromise({ startPort: 57418 });
+        rawKernel = await connectToKernel(port);
         replies = await requestExecute(rawKernel, 'a=1\na');
         executeResult = replies.find((r) => r.header.msg_type === 'execute_result');
         assert.ok(executeResult, 'Result not found');

--- a/src/test/datascience/uiTests/notebookHelpers.ts
+++ b/src/test/datascience/uiTests/notebookHelpers.ts
@@ -26,6 +26,7 @@ async function openNotebookEditor(
 ): Promise<INotebookEditor> {
     const uri = Uri.file(filePath);
     iocC.setFileContents(uri, contents);
+    traceInfo(`NotebookHelper: opening notebook file ${filePath}`);
     const notebookEditorProvider = iocC.get<INotebookEditorProvider>(INotebookEditorProvider);
     return uri ? notebookEditorProvider.open(uri) : notebookEditorProvider.createNew();
 }
@@ -85,7 +86,7 @@ export async function openNotebook(
 ) {
     traceInfo(`Opening notebook for UI tests...`);
     const notebookFile = await createNotebookFileWithContents(notebookFileContents, disposables);
-    traceInfo(`Notebook UI Tests: have file`);
+    traceInfo(`Notebook UI Tests: have file ${notebookFile}`);
 
     const notebookUI = new NotebookEditorUI();
     disposables.push(notebookUI);


### PR DESCRIPTION
Made some changes to 
- How editors are found. Made sure the file map was created before the promise finishes. 
- During tests that closing an editor doesn't reopen it
- During tests, we use a full 60 seconds for jupyter idle timeout. 
- During raw kernel tests, we don't assume ports are open


Last test was full green. Hopefully once this is in, subsequent runs will be green too:
https://dev.azure.com/ms/vscode-python/_build/results?buildId=86631&view=results