### PR TITLE
Register services before we return from activation

### DIFF
--- a/news/2 Fixes/12227.md
+++ b/news/2 Fixes/12227.md
@@ -1,0 +1,1 @@
+Register services before extension activates.

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -102,7 +102,7 @@ async function activateUnsafe(
     const [serviceManager, serviceContainer] = initializeGlobals(context);
     activatedServiceContainer = serviceContainer;
     initializeComponents(context, serviceManager, serviceContainer);
-    const activationPromise = activateComponents(context, serviceManager, serviceContainer);
+    const { activationPromise } = await activateComponents(context, serviceManager, serviceContainer);
 
     //===============================================
     // activation ends here

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -209,5 +209,5 @@ async function activateLegacy(
 
     serviceContainer.get<IDebuggerBanner>(IDebuggerBanner).initialize();
 
-    return activationPromise;
+    return { activationPromise };
 }


### PR DESCRIPTION
For #12227

Fix - Ensure we register our code before we tell VSC that extension has activted.
Else VSC might assume that extension doesn't provide intellisense, etc & other providers because none of those functionality has been registered when extension has activated.