### PR TITLE
Fix the package json not being read on second run

### DIFF
--- a/news/2 Fixes/12231.md
+++ b/news/2 Fixes/12231.md
@@ -1,0 +1,1 @@
+Infinite loop of asking to reload the extension when enabling custom editor.


### PR DESCRIPTION
For #12231

Root cause is the applicationEnvironment.packageJson is the package json in the webpack bundle, not the one on disk.