### PR TITLE
Fix problems with a python kernel not handling json with numbers

### DIFF
--- a/news/2 Fixes/11749.md
+++ b/news/2 Fixes/11749.md
@@ -1,0 +1,1 @@
+Jupyter can fail to run a kernel if the user's environment contains non string values.

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -8,6 +8,11 @@ import { JupyterKernelSpec } from './jupyterKernelSpec';
 // tslint:disable-next-line: no-var-requires no-require-imports
 const NamedRegexp = require('named-js-regexp') as typeof import('named-js-regexp');
 
+import { JSONObject } from '@phosphor/coreutils';
+
+// tslint:disable-next-line: no-require-imports
+import cloneDeep = require('lodash/cloneDeep');
+
 // Helper functions for dealing with kernels and kernelspecs
 
 export const defaultKernelSpecName = 'python_defaultSpec_';
@@ -41,4 +46,24 @@ export function createDefaultKernelSpec(displayName?: string): IJupyterKernelSpe
 export function detectDefaultKernelName(name: string) {
     const regEx = NamedRegexp('python\\s*(?<version>(\\d+))', 'g');
     return regEx.exec(name.toLowerCase());
+}
+
+export function cleanEnvironment<T>(spec: T): T {
+    const copy = cloneDeep(spec) as { env?: JSONObject };
+
+    if (copy.env) {
+        // Scrub the environment of the spec to make sure it has allowed values (they all must be strings)
+        // See this issue here: https://github.com/microsoft/vscode-python/issues/11749
+        const keys = Object.keys(copy.env);
+        keys.forEach((k) => {
+            if (copy.env) {
+                const value = copy.env[k];
+                if (value !== null && value !== undefined) {
+                    copy.env[k] = value.toString();
+                }
+            }
+        });
+    }
+
+    return copy as T;
 }

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -8,8 +8,6 @@ import { JupyterKernelSpec } from './jupyterKernelSpec';
 // tslint:disable-next-line: no-var-requires no-require-imports
 const NamedRegexp = require('named-js-regexp') as typeof import('named-js-regexp');
 
-import { JSONObject } from '@phosphor/coreutils';
-
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
 
@@ -49,7 +47,8 @@ export function detectDefaultKernelName(name: string) {
 }
 
 export function cleanEnvironment<T>(spec: T): T {
-    const copy = cloneDeep(spec) as { env?: JSONObject };
+    // tslint:disable-next-line: no-any
+    const copy = cloneDeep(spec) as { env?: any };
 
     if (copy.env) {
         // Scrub the environment of the spec to make sure it has allowed values (they all must be strings)

--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -32,7 +32,7 @@ import {
     IKernelDependencyService,
     KernelInterpreterDependencyResponse
 } from '../../types';
-import { detectDefaultKernelName } from './helpers';
+import { cleanEnvironment, detectDefaultKernelName } from './helpers';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { LiveKernelModel } from './types';
 
@@ -396,7 +396,7 @@ export class KernelService {
     ) {
         const specedKernel = kernel as JupyterKernelSpec;
         if (specedKernel.specFile) {
-            const specModel: ReadWrite<Kernel.ISpecModel> = JSON.parse(
+            let specModel: ReadWrite<Kernel.ISpecModel> = JSON.parse(
                 await this.fileSystem.readFile(specedKernel.specFile)
             );
             let shouldUpdate = false;
@@ -446,15 +446,7 @@ export class KernelService {
             // Scrub the environment of the specmodel to make sure it has allowed values (they all must be strings)
             // See this issue here: https://github.com/microsoft/vscode-python/issues/11749
             if (specModel.env) {
-                const keys = Object.keys(specModel.env);
-                keys.forEach((k) => {
-                    if (specModel.env) {
-                        const value = specModel.env[k];
-                        if (value !== null && value !== undefined) {
-                            specModel.env[k] = value.toString();
-                        }
-                    }
-                });
+                specModel = cleanEnvironment(specModel);
                 shouldUpdate = true;
             }
 

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -58,7 +58,7 @@ export class KernelProcess implements IKernelProcess {
         private readonly interpreter?: PythonInterpreter
     ) {
         this.originalKernelSpec = kernelSpec;
-        this._kernelSpec = cloneDeep(kernelSpec);
+        this._kernelSpec = this.clean(kernelSpec);
     }
     public async interrupt(): Promise<void> {
         if (this.kernelDaemon) {
@@ -258,5 +258,24 @@ export class KernelProcess implements IKernelProcess {
 
         this._process = exeObs.proc;
         return exeObs;
+    }
+
+    private clean(kernelSpec: IJupyterKernelSpec): IJupyterKernelSpec {
+        const copy = cloneDeep(kernelSpec);
+        if (copy.env) {
+            // Scrub the environment of the spec to make sure it has allowed values (they all must be strings)
+            // See this issue here: https://github.com/microsoft/vscode-python/issues/11749
+            const keys = Object.keys(copy.env);
+            keys.forEach((k) => {
+                if (copy.env) {
+                    const value = copy.env[k];
+                    if (value !== null && value !== undefined) {
+                        copy.env[k] = value.toString();
+                    }
+                }
+            });
+        }
+
+        return copy;
     }
 }

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -596,7 +596,6 @@ suite('Data Science - KernelService', () => {
 
             // tslint:disable-next-line: no-any
             assert.deepEqual(kernel, installedKernel as any);
-            verify(fs.writeFile(anything(), anything(), anything())).never();
         });
     });
 });

--- a/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelService.unit.test.ts
@@ -585,7 +585,11 @@ suite('Data Science - KernelService', () => {
             const kernel = new JupyterKernelSpec(userKernelSpecModel, kernelJsonFile);
             when(jupyterInterpreterExecutionService.getKernelSpecs(anything())).thenResolve([kernel]);
             when(fs.readFile(kernelJsonFile)).thenResolve(JSON.stringify(userKernelSpecModel));
-            when(fs.writeFile(kernelJsonFile, anything())).thenResolve();
+            let contents: string | undefined;
+            when(fs.writeFile(kernelJsonFile, anything(), anything())).thenCall((_f, c) => {
+                contents = c;
+                return Promise.resolve();
+            });
             const envVariables = { MYVAR: '1' };
             when(activationHelper.getActivatedEnvironmentVariables(undefined, interpreter, true)).thenResolve(
                 envVariables
@@ -596,6 +600,9 @@ suite('Data Science - KernelService', () => {
 
             // tslint:disable-next-line: no-any
             assert.deepEqual(kernel, installedKernel as any);
+            assert.ok(contents, 'Env not updated');
+            const obj = JSON.parse(contents!);
+            assert.notOk(obj.metadata.interpreter, 'MetaData should not have been written');
         });
     });
 });


### PR DESCRIPTION
For #11749

Essentially if you have this:

```
{
  "argv": [
    "C:\\Users\\rchiodo.REDMOND\\AppData\\Local\\Continuum\\miniconda3\\envs\\test36\\python.exe",
    "-m",
    "ipykernel_launcher",
    "-f",
    "{connection_file}"
  ],
  "display_name": "Python Test",
  "language": "python",
  "env": {
    "GOOFY_VAR_2": 2222
  }
}
```

A kernel will fail on startup saying non string environment is not allowed. THis might only happen with 3.7 and earlier, but easier to just prevent this.
