### PR TITLE
Fix layout causing repaints and rescrolls when unnecessary.

### DIFF
--- a/news/2 Fixes/11584.md
+++ b/news/2 Fixes/11584.md
@@ -1,0 +1,1 @@
+Make layout of markdown editors much faster to open.


### PR DESCRIPTION
For #11584

Root cause of the problem is the state having the visible line count in it. this causes a complete refresh as the editor goes through it's layout changes to reach a steady state.

Fix was to move visible line count to a variable and then adjust scrolling to not occur until a key has been pressed (although 1 scroll will happen to the current position once layout is complete).