### PR TITLE
Fix the 'type code here' to disappear appropriately.

### DIFF
--- a/news/2 Fixes/11691.md
+++ b/news/2 Fixes/11691.md
@@ -1,0 +1,1 @@
+Watermark in the interactive window can appear on top of entered text.

--- a/src/datascience-ui/react-common/monacoEditor.tsx
+++ b/src/datascience-ui/react-common/monacoEditor.tsx
@@ -437,7 +437,7 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
 
     public setValue(text: string, cursorPos: CursorPos) {
         if (this.state.model && this.state.editor && this.state.model.getValue() !== text) {
-            this.forceValue(text, cursorPos);
+            this.forceValue(text, cursorPos, true);
         }
     }
 
@@ -469,19 +469,18 @@ export class MonacoEditor extends React.Component<IMonacoEditorProps, IMonacoEdi
         }
     }
 
-    private forceValue(text: string, cursorPos: CursorPos | monacoEditor.IPosition) {
+    private forceValue(text: string, cursorPos: CursorPos | monacoEditor.IPosition, allowNotifications?: boolean) {
         if (this.state.model && this.state.editor) {
             // Save current position. May need it to update after setting.
             const current = this.state.editor.getPosition();
 
-            // Disable change notifications as we know this
-            // is different.
-            this.skipNotifications = true;
+            // Disable change notifications if forcing this value should not allow them
+            this.skipNotifications = allowNotifications ? false : true;
 
             // Close any suggestions that are open
             this.closeSuggestWidget();
 
-            // Change our text. This shouldn't fire an update to the model
+            // Change our text.
             this.previousModelValue = text;
             this.state.model.setValue(text);
 


### PR DESCRIPTION
For #11691

Bug was caused by changes for the custom editor. In order to prevent updates when an undo fires (which would cause another edit), certain changes to the monaco editor did not fire events. 

This broke the input history (up/down arrow on interactive window) because it relies on the events firing to update the watermark.
