### PR TITLE
Add test that validates interactive and notebook editor at the same time

### DIFF
--- a/news/3 Code Health/11445.md
+++ b/news/3 Code Health/11445.md
@@ -1,0 +1,1 @@
+Add a functional test that opens both the interactive window and a notebook at the same time.

--- a/src/test/datascience/intellisense.functional.test.tsx
+++ b/src/test/datascience/intellisense.functional.test.tsx
@@ -480,7 +480,7 @@ import { addMockData, enterEditorKey, getInteractiveEditor, getNativeEditor, typ
                 await waitForHover('Interactive', wrapper, 1, 1);
                 verifyHoverVisible('Interactive', wrapper, 'a=1\na\nb=2\nb');
 
-                await InteractiveHelpers.closeInteractiveWindow(window, wrapper);
+                await InteractiveHelpers.closeInteractiveWindow(ioc, window);
             },
             () => {
                 return ioc;

--- a/src/test/datascience/interactiveWindowTestHelpers.tsx
+++ b/src/test/datascience/interactiveWindowTestHelpers.tsx
@@ -26,13 +26,9 @@ export async function getOrCreateInteractiveWindow(ioc: DataScienceIocContainer)
     return (await interactiveWindowProvider.getOrCreateActive()) as InteractiveWindow;
 }
 
-export function closeInteractiveWindow(
-    window: IInteractiveWindow,
-    // tslint:disable-next-line: no-any
-    wrapper: ReactWrapper<any, Readonly<{}>, React.Component>
-) {
+export function closeInteractiveWindow(ioc: DataScienceIocContainer, window: IInteractiveWindow) {
     const promise = window.dispose();
-    wrapper.unmount();
+    ioc.getWebPanel('default').dispose();
     return promise;
 }
 

--- a/src/test/datascience/testHelpers.tsx
+++ b/src/test/datascience/testHelpers.tsx
@@ -230,7 +230,7 @@ export function getLastOutputCell(
 
 export function verifyHtmlOnCell(
     wrapper: ReactWrapper<any, Readonly<{}>, React.Component>,
-    cellType: string,
+    cellType: 'NativeCell' | 'InteractiveCell',
     html: string | undefined | RegExp,
     cellIndex: number | CellPosition
 ) {


### PR DESCRIPTION
For #11445

This the follow up to the new infrastructure. A test that opens both interactive and native editor at the same time.
