### PR TITLE
LSP version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4041,9 +4041,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.45.1",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.1.tgz",
-            "integrity": "sha512-0NO9qrrEJBO8FsqHCrFMgR2suKnwCsKBWvRSb2OzH5gs4i3QO5AhEMQYrSzDbU/wLPt7N617/rN9lPY213gmwg==",
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.46.0.tgz",
+            "integrity": "sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==",
             "dev": true
         },
         "@types/webpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25266,9 +25266,9 @@
             }
         },
         "vscode-jsonrpc": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-            "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+            "version": "6.0.0-next.3",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.3.tgz",
+            "integrity": "sha512-bkAtRMXbTwU1pAXnlbkAMnrqXZX3q2/zttkcnPZOsDqgoycO2L7GK2aN3K5qCMZmhItwBU185T78Q9YH0v5jEA=="
         },
         "vscode-languageclient": {
             "version": "7.0.0-next.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25271,49 +25271,89 @@
             "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
         },
         "vscode-languageclient": {
-            "version": "6.2.0-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-6.2.0-next.2.tgz",
-            "integrity": "sha512-RqOrj+OCZmiMcLgmQSx581O+3rHb/AIFpEL+yoBcqFkqfIwMkoowCChEJGwVe/I8FeEphZ4dzlMm0MPW+p/DNA==",
+            "version": "7.0.0-next.6",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0-next.6.tgz",
+            "integrity": "sha512-3CPGOXCSxpPGONNVg+ZhY4AYyJrjLDJSKJT2acJ6L5mSlzKACFkFd3yQEGVHS/O0v4n/9i/KRNpBGVSR8ngw7Q==",
             "requires": {
                 "semver": "^6.3.0",
-                "vscode-languageserver-protocol": "3.16.0-next.2"
+                "vscode-languageserver-protocol": "3.16.0-next.5"
             },
             "dependencies": {
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                },
+                "vscode-jsonrpc": {
+                    "version": "6.0.0-next.3",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.3.tgz",
+                    "integrity": "sha512-bkAtRMXbTwU1pAXnlbkAMnrqXZX3q2/zttkcnPZOsDqgoycO2L7GK2aN3K5qCMZmhItwBU185T78Q9YH0v5jEA=="
+                },
+                "vscode-languageserver-protocol": {
+                    "version": "3.16.0-next.5",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.5.tgz",
+                    "integrity": "sha512-MVuLT4d5tdDo/14laViyZY+p1HT7wYDwJdvGmo8mCfkgON5c10AABhtqjD+LccidBcwdbKy+4dwwUUxiNg/8PA==",
+                    "requires": {
+                        "vscode-jsonrpc": "6.0.0-next.3",
+                        "vscode-languageserver-types": "3.16.0-next.2"
+                    }
+                },
+                "vscode-languageserver-types": {
+                    "version": "3.16.0-next.2",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+                    "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
                 }
             }
         },
         "vscode-languageserver": {
-            "version": "6.2.0-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-6.2.0-next.2.tgz",
-            "integrity": "sha512-UCXULa/RmT2zxcb6auNezl9ZIPwYHS15+a0XzybrpT2+xA0RbHEYQCsIQkTRYjGv8cm3yS9iPJMmxLilP+y1Xw==",
+            "version": "7.0.0-next.4",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0-next.4.tgz",
+            "integrity": "sha512-yyFMuKLNkSKYb//6dQHCo0wlDYWkgRPEXoV+/aYXHp9ziIBqQxKJJFrf/rnXYReCz1TroxYMcFGdO5UrBsLAaA==",
             "requires": {
-                "vscode-languageserver-protocol": "3.16.0-next.2"
-            }
-        },
-        "vscode-languageserver-protocol": {
-            "version": "3.16.0-next.2",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.2.tgz",
-            "integrity": "sha512-atmkGT/W6tF0cx4SaWFYtFs2UeSeC28RPiap9myv2YZTaTCFvTBEPNWrU5QRKfkyM0tbgtGo6T3UCQ8tkDpjzA==",
-            "requires": {
-                "vscode-jsonrpc": "5.1.0-next.1",
-                "vscode-languageserver-types": "3.16.0-next.1"
+                "vscode-languageserver-protocol": "3.16.0-next.5"
             },
             "dependencies": {
                 "vscode-jsonrpc": {
-                    "version": "5.1.0-next.1",
-                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.1.0-next.1.tgz",
-                    "integrity": "sha512-mwLDojZkbmpizSJSmp690oa9FB9jig18SIDGZeBCvFc2/LYSRvMm/WwWtMBJuJ1MfFh7rZXfQige4Uje5Z9NzA=="
+                    "version": "6.0.0-next.3",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.3.tgz",
+                    "integrity": "sha512-bkAtRMXbTwU1pAXnlbkAMnrqXZX3q2/zttkcnPZOsDqgoycO2L7GK2aN3K5qCMZmhItwBU185T78Q9YH0v5jEA=="
+                },
+                "vscode-languageserver-protocol": {
+                    "version": "3.16.0-next.5",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.5.tgz",
+                    "integrity": "sha512-MVuLT4d5tdDo/14laViyZY+p1HT7wYDwJdvGmo8mCfkgON5c10AABhtqjD+LccidBcwdbKy+4dwwUUxiNg/8PA==",
+                    "requires": {
+                        "vscode-jsonrpc": "6.0.0-next.3",
+                        "vscode-languageserver-types": "3.16.0-next.2"
+                    }
+                },
+                "vscode-languageserver-types": {
+                    "version": "3.16.0-next.2",
+                    "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+                    "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
+                }
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.16.0-next.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0-next.5.tgz",
+            "integrity": "sha512-MVuLT4d5tdDo/14laViyZY+p1HT7wYDwJdvGmo8mCfkgON5c10AABhtqjD+LccidBcwdbKy+4dwwUUxiNg/8PA==",
+            "requires": {
+                "vscode-jsonrpc": "6.0.0-next.3",
+                "vscode-languageserver-types": "3.16.0-next.2"
+            },
+            "dependencies": {
+                "vscode-jsonrpc": {
+                    "version": "6.0.0-next.3",
+                    "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0-next.3.tgz",
+                    "integrity": "sha512-bkAtRMXbTwU1pAXnlbkAMnrqXZX3q2/zttkcnPZOsDqgoycO2L7GK2aN3K5qCMZmhItwBU185T78Q9YH0v5jEA=="
                 }
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0-next.1",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.1.tgz",
-            "integrity": "sha512-tZFUSbyjUcrh+qQf13ALX4QDdOfDX0cVaBFgy7ktJ0VwS7AW/yRKgGPSxVqqP9OCMNPdqP57O5q47w2pEwfaUg=="
+            "version": "3.16.0-next.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz",
+            "integrity": "sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q=="
         },
         "vscode-tas-client": {
             "version": "0.0.864",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.45.0"
+        "vscode": "^1.46.0"
     },
     "keywords": [
         "python",
@@ -3125,9 +3125,9 @@
         "vscode-debugprotocol": "^1.28.0",
         "vscode-extension-telemetry": "0.1.4",
         "vscode-jsonrpc": "^5.0.1",
-        "vscode-languageclient": "^6.2.0-next.2",
-        "vscode-languageserver": "^6.2.0-next.2",
-        "vscode-languageserver-protocol": "^3.16.0-next.2",
+        "vscode-languageclient": "^7.0.0-next.6",
+        "vscode-languageserver": "^7.0.0-next.4",
+        "vscode-languageserver-protocol": "^3.16.0-next.5",
         "vscode-tas-client": "^0.0.864",
         "vsls": "^0.3.1291",
         "winreg": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -3208,7 +3208,7 @@
         "@types/tmp": "0.0.33",
         "@types/untildify": "^3.0.0",
         "@types/uuid": "^3.4.3",
-        "@types/vscode": "^1.45.0",
+        "@types/vscode": "^1.46.0",
         "@types/webpack-bundle-analyzer": "^2.13.0",
         "@types/winreg": "^1.2.30",
         "@types/ws": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -3124,7 +3124,7 @@
         "vscode-debugadapter": "^1.28.0",
         "vscode-debugprotocol": "^1.28.0",
         "vscode-extension-telemetry": "0.1.4",
-        "vscode-jsonrpc": "^5.0.1",
+        "vscode-jsonrpc": "^6.0.0-next.3",
         "vscode-languageclient": "^7.0.0-next.6",
         "vscode-languageserver": "^7.0.0-next.4",
         "vscode-languageserver-protocol": "^3.16.0-next.5",

--- a/pythonFiles/vscode_datascience_helpers/daemon/README.md
+++ b/pythonFiles/vscode_datascience_helpers/daemon/README.md
@@ -2,7 +2,7 @@
 
 ```javascript
 const cp  = require('child_process');
-const rpc = require('vscode-jsonrpc');
+const rpc = require('vscode-jsonrpc/node');
 const env = {
     PYTHONUNBUFFERED: '1',
     PYTHONPATH: '<extension dir>/pythonFiles:<extension dir>/pythonFiles/lib/python'

--- a/src/client/activation/common/activatorBase.ts
+++ b/src/client/activation/common/activatorBase.ts
@@ -22,7 +22,7 @@ import {
     TextDocumentContentChangeEvent,
     WorkspaceEdit
 } from 'vscode';
-import * as vscodeLanguageClient from 'vscode-languageclient';
+import * as vscodeLanguageClient from 'vscode-languageclient/node';
 
 import { injectable } from 'inversify';
 import { IWorkspaceService } from '../../common/application/types';

--- a/src/client/activation/common/analysisOptions.ts
+++ b/src/client/activation/common/analysisOptions.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { injectable } from 'inversify';
 import { Disposable, Event, EventEmitter, WorkspaceFolder } from 'vscode';
-import { DocumentFilter, LanguageClientOptions, RevealOutputChannelOn } from 'vscode-languageclient';
+import { DocumentFilter, LanguageClientOptions, RevealOutputChannelOn } from 'vscode-languageclient/node';
 
 import { PYTHON, PYTHON_LANGUAGE } from '../../common/constants';
 import { traceDecorators } from '../../common/logger';

--- a/src/client/activation/languageClientMiddleware.ts
+++ b/src/client/activation/languageClientMiddleware.ts
@@ -56,9 +56,9 @@ import {
     ResolveCompletionItemSignature,
     ResolveDocumentLinkSignature,
     ResponseError
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 
-import { ProvideDeclarationSignature } from 'vscode-languageclient/lib/declaration';
+import { ProvideDeclarationSignature } from 'vscode-languageclient/lib/common/declaration';
 import { HiddenFilePrefix } from '../common/constants';
 import { CollectLSRequestTiming, CollectNodeLSRequestTiming } from '../common/experiments/groups';
 import { IConfigurationService, IExperimentsManager, IPythonExtensionBanner } from '../common/types';

--- a/src/client/activation/languageServer/analysisOptions.ts
+++ b/src/client/activation/languageServer/analysisOptions.ts
@@ -3,7 +3,7 @@
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { ConfigurationChangeEvent, WorkspaceFolder } from 'vscode';
-import { DocumentFilter } from 'vscode-languageclient';
+import { DocumentFilter } from 'vscode-languageclient/node';
 
 import { IWorkspaceService } from '../../common/application/types';
 import { traceDecorators, traceError } from '../../common/logger';

--- a/src/client/activation/languageServer/languageClientFactory.ts
+++ b/src/client/activation/languageServer/languageClientFactory.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable, unmanaged } from 'inversify';
 import * as path from 'path';
-import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 
 import { EXTENSION_ROOT_DIR, PYTHON_LANGUAGE } from '../../common/constants';
 import { IConfigurationService, Resource } from '../../common/types';
@@ -40,7 +40,7 @@ export class DotNetDownloadedLanguageClientFactory implements ILanguageClientFac
             run: { command: serverModule, args: [], options },
             debug: { command: serverModule, args: ['--debug'], options }
         };
-        const vscodeLanguageClient = require('vscode-languageclient') as typeof import('vscode-languageclient');
+        const vscodeLanguageClient = require('vscode-languageclient/node') as typeof import('vscode-languageclient/node');
         return new vscodeLanguageClient.LanguageClient(
             PYTHON_LANGUAGE,
             languageClientName,
@@ -69,7 +69,7 @@ export class DotNetSimpleLanguageClientFactory implements ILanguageClientFactory
             run: { command: dotNetCommand, args: [serverModule], options },
             debug: { command: dotNetCommand, args: [serverModule, '--debug'], options }
         };
-        const vscodeLanguageClient = require('vscode-languageclient') as typeof import('vscode-languageclient');
+        const vscodeLanguageClient = require('vscode-languageclient/node') as typeof import('vscode-languageclient/node');
         return new vscodeLanguageClient.LanguageClient(
             PYTHON_LANGUAGE,
             languageClientName,

--- a/src/client/activation/languageServer/languageServerProxy.ts
+++ b/src/client/activation/languageServer/languageServerProxy.ts
@@ -3,7 +3,7 @@
 import '../../common/extensions';
 
 import { inject, injectable } from 'inversify';
-import { Disposable, LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
+import { Disposable, LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
 
 import { traceDecorators, traceError } from '../../common/logger';
 import { IConfigurationService, Resource } from '../../common/types';

--- a/src/client/activation/node/activator.ts
+++ b/src/client/activation/node/activator.ts
@@ -3,9 +3,9 @@
 import { inject, injectable } from 'inversify';
 
 import { CancellationToken, CompletionItem, ProviderResult } from 'vscode';
-import * as vscodeLanguageClient from 'vscode-languageclient';
+import ProtocolCompletionItem from 'vscode-languageclient/lib/common/ProtocolCompletionItem';
+import * as vscodeLanguageClient from 'vscode-languageclient/node';
 // tslint:disable-next-line: import-name
-import ProtocolCompletionItem from 'vscode-languageclient/lib/protocolCompletionItem';
 import { IWorkspaceService } from '../../common/application/types';
 import { traceDecorators } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';

--- a/src/client/activation/node/activator.ts
+++ b/src/client/activation/node/activator.ts
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
-
 import { CancellationToken, CompletionItem, ProviderResult } from 'vscode';
 // tslint:disable-next-line: import-name
 import ProtocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import { CompletionResolveRequest } from 'vscode-languageclient/node';
-
-// tslint:disable-next-line: import-name
 import { IWorkspaceService } from '../../common/application/types';
 import { traceDecorators } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';

--- a/src/client/activation/node/activator.ts
+++ b/src/client/activation/node/activator.ts
@@ -3,8 +3,10 @@
 import { inject, injectable } from 'inversify';
 
 import { CancellationToken, CompletionItem, ProviderResult } from 'vscode';
-import ProtocolCompletionItem from 'vscode-languageclient/lib/common/ProtocolCompletionItem';
-import * as vscodeLanguageClient from 'vscode-languageclient/node';
+// tslint:disable-next-line: import-name
+import ProtocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
+import { CompletionResolveRequest } from 'vscode-languageclient/node';
+
 // tslint:disable-next-line: import-name
 import { IWorkspaceService } from '../../common/application/types';
 import { traceDecorators } from '../../common/logger';
@@ -56,11 +58,7 @@ export class NodeLanguageServerActivator extends LanguageServerActivatorBase {
             Object.assign(protoItem, item);
 
             const args = languageClient.code2ProtocolConverter.asCompletionItem(protoItem);
-            const result = await languageClient.sendRequest(
-                vscodeLanguageClient.CompletionResolveRequest.type,
-                args,
-                token
-            );
+            const result = await languageClient.sendRequest(CompletionResolveRequest.type, args, token);
 
             if (result) {
                 return languageClient.protocol2CodeConverter.asCompletionItem(result);

--- a/src/client/activation/node/cancellationUtils.ts
+++ b/src/client/activation/node/cancellationUtils.ts
@@ -16,7 +16,7 @@ import {
     CancellationStrategy,
     Disposable,
     MessageConnection
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 
 type CancellationId = string | number;
 

--- a/src/client/activation/node/languageClientFactory.ts
+++ b/src/client/activation/node/languageClientFactory.ts
@@ -3,7 +3,7 @@
 
 import { inject, injectable } from 'inversify';
 import * as path from 'path';
-import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
 
 import { EXTENSION_ROOT_DIR, PYTHON_LANGUAGE } from '../../common/constants';
 import { IFileSystem } from '../../common/platform/types';
@@ -59,7 +59,7 @@ export class NodeLanguageClientFactory implements ILanguageClientFactory {
             }
         };
 
-        const vscodeLanguageClient = require('vscode-languageclient') as typeof import('vscode-languageclient');
+        const vscodeLanguageClient = require('vscode-languageclient/node') as typeof import('vscode-languageclient/node');
         return new vscodeLanguageClient.LanguageClient(
             PYTHON_LANGUAGE,
             languageClientName,

--- a/src/client/activation/node/languageServerProxy.ts
+++ b/src/client/activation/node/languageServerProxy.ts
@@ -8,7 +8,7 @@ import {
     Disposable,
     LanguageClient,
     LanguageClientOptions
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 
 import { DeprecatePythonPath } from '../../common/experiments/groups';
 import { traceDecorators, traceError } from '../../common/logger';

--- a/src/client/activation/progress.ts
+++ b/src/client/activation/progress.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { Progress, ProgressLocation, window } from 'vscode';
-import { Disposable, LanguageClient } from 'vscode-languageclient';
+import { Disposable, LanguageClient } from 'vscode-languageclient/node';
 import { createDeferred, Deferred } from '../common/utils/async';
 
 export class ProgressReporting implements Disposable {

--- a/src/client/activation/types.ts
+++ b/src/client/activation/types.ts
@@ -17,7 +17,7 @@ import {
     TextDocument,
     TextDocumentContentChangeEvent
 } from 'vscode';
-import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
 import { NugetPackage } from '../common/nuget/types';
 import { IDisposable, IOutputChannel, LanguageServerDownloadChannels, Resource } from '../common/types';
 import { PythonInterpreter } from '../pythonEnvironments/info';

--- a/src/client/common/process/pythonDaemonFactory.ts
+++ b/src/client/common/process/pythonDaemonFactory.ts
@@ -8,7 +8,7 @@ import {
     RequestType,
     StreamMessageReader,
     StreamMessageWriter
-} from 'vscode-jsonrpc';
+} from 'vscode-jsonrpc/node';
 
 import { EXTENSION_ROOT_DIR } from '../../constants';
 import { PYTHON_WARNINGS } from '../constants';

--- a/src/client/datascience/interactive-common/intellisense/conversion.ts
+++ b/src/client/datascience/interactive-common/intellisense/conversion.ts
@@ -5,7 +5,7 @@ import '../../../common/extensions';
 
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
 import * as vscode from 'vscode';
-import * as vscodeLanguageClient from 'vscode-languageclient';
+import * as vscodeLanguageClient from 'vscode-languageclient/node';
 
 // See the comment on convertCompletionItemKind below
 // Here's the monaco enum:

--- a/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseDocument.ts
@@ -4,7 +4,7 @@
 import '../../../common/extensions';
 
 import { EndOfLine, Position, Range, TextDocument, TextDocumentContentChangeEvent, TextLine, Uri } from 'vscode';
-import * as vscodeLanguageClient from 'vscode-languageclient';
+import * as vscodeLanguageClient from 'vscode-languageclient/node';
 
 import { PYTHON_LANGUAGE } from '../../../common/constants';
 import { Identifiers } from '../../constants';

--- a/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
@@ -18,7 +18,7 @@ import {
     Uri
 } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
-import * as vscodeLanguageClient from 'vscode-languageclient';
+import * as vscodeLanguageClient from 'vscode-languageclient/node';
 import { concatMultilineStringInput } from '../../../../datascience-ui/common';
 import { ILanguageServer, ILanguageServerCache } from '../../../activation/types';
 import { IWorkspaceService } from '../../../common/application/types';

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -4,7 +4,7 @@
 import { inject, injectable } from 'inversify';
 import * as uuid from 'uuid/v4';
 import { Disposable, Event, EventEmitter, Uri, WebviewPanel } from 'vscode';
-import { CancellationToken } from 'vscode-languageclient';
+import { CancellationToken } from 'vscode-languageclient/node';
 import { arePathsSame } from '../../../datascience-ui/react-common/arePathsSame';
 import {
     CustomDocument,

--- a/src/client/providers/symbolProvider.ts
+++ b/src/client/providers/symbolProvider.ts
@@ -11,7 +11,7 @@ import {
     TextDocument,
     Uri
 } from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { IFileSystem } from '../common/platform/types';
 import { createDeferred, Deferred } from '../common/utils/async';
 import { IServiceContainer } from '../ioc/types';

--- a/src/test/activation/languageServer/analysisOptions.unit.test.ts
+++ b/src/test/activation/languageServer/analysisOptions.unit.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { ConfigurationChangeEvent, Uri, WorkspaceFolder } from 'vscode';
-import { DocumentFilter } from 'vscode-languageclient';
+import { DocumentFilter } from 'vscode-languageclient/node';
 
 import { DotNetLanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
 import { DotNetLanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';

--- a/src/test/activation/languageServer/languageClientFactory.unit.test.ts
+++ b/src/test/activation/languageServer/languageClientFactory.unit.test.ts
@@ -11,7 +11,7 @@ import rewiremock from 'rewiremock';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
-import { LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
+import { LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 import {
     DotNetDownloadedLanguageClientFactory,
     DotNetLanguageClientFactory,
@@ -126,7 +126,7 @@ suite('Language Server - LanguageClient Factory', () => {
                 expect(serverOptions).to.be.deep.equal(expectedServerOptions);
             }
         }
-        rewiremock('vscode-languageclient').with({ LanguageClient: MockClass });
+        rewiremock('vscode-languageclient/node').with({ LanguageClient: MockClass });
 
         const client = await factory.createLanguageClient(uri, undefined, options, { FOO: 'bar' });
 
@@ -171,7 +171,7 @@ suite('Language Server - LanguageClient Factory', () => {
                 expect(serverOptions).to.be.deep.equal(expectedServerOptions);
             }
         }
-        rewiremock('vscode-languageclient').with({ LanguageClient: MockClass });
+        rewiremock('vscode-languageclient/node').with({ LanguageClient: MockClass });
 
         const client = await factory.createLanguageClient(uri, undefined, options, { FOO: 'bar' });
 

--- a/src/test/activation/languageServer/languageServer.unit.test.ts
+++ b/src/test/activation/languageServer/languageServer.unit.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
-import { Disposable, LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
+import { Disposable, LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
 import { DotNetLanguageClientFactory } from '../../../client/activation/languageServer/languageClientFactory';
 import { DotNetLanguageServerProxy } from '../../../client/activation/languageServer/languageServerProxy';
 import { ILanguageClientFactory } from '../../../client/activation/types';

--- a/src/test/activation/languageServer/manager.unit.test.ts
+++ b/src/test/activation/languageServer/manager.unit.test.ts
@@ -4,7 +4,7 @@ import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import { instance, mock, verify, when } from 'ts-mockito';
 import { Uri } from 'vscode';
-import { LanguageClientOptions } from 'vscode-languageclient';
+import { LanguageClientOptions } from 'vscode-languageclient/node';
 import { DotNetLanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
 import { LanguageServerExtension } from '../../../client/activation/languageServer/languageServerExtension';
 import { DotNetLanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';

--- a/src/test/common/process/pythonDaemon.functional.test.ts
+++ b/src/test/common/process/pythonDaemon.functional.test.ts
@@ -17,7 +17,7 @@ import {
     RequestType,
     StreamMessageReader,
     StreamMessageWriter
-} from 'vscode-jsonrpc';
+} from 'vscode-jsonrpc/node';
 import { PythonDaemonExecutionService } from '../../../client/common/process/pythonDaemon';
 import { IPythonExecutionService } from '../../../client/common/process/types';
 import { IDisposable } from '../../../client/common/types';

--- a/src/test/common/process/pythonDaemonPool.functional.test.ts
+++ b/src/test/common/process/pythonDaemonPool.functional.test.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { Observable } from 'rxjs/Observable';
 import * as sinon from 'sinon';
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito';
-import { createMessageConnection, StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc';
+import { createMessageConnection, StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc/node';
 import { ProcessLogger } from '../../../client/common/process/logger';
 import { PythonDaemonExecutionServicePool } from '../../../client/common/process/pythonDaemonPool';
 import {

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
@@ -11,7 +11,7 @@ import { anything, instance, mock, when } from 'ts-mockito';
 import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 import * as typemoq from 'typemoq';
 import { ConfigurationChangeEvent, EventEmitter, FileType, TextEditor, Uri, WebviewPanel } from 'vscode';
-import { CancellationToken } from 'vscode-languageclient';
+import { CancellationToken } from 'vscode-languageclient/node';
 import { DocumentManager } from '../../../client/common/application/documentManager';
 import {
     CustomDocument,

--- a/src/test/datascience/mockCode2ProtocolConverter.ts
+++ b/src/test/datascience/mockCode2ProtocolConverter.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import * as code from 'vscode';
-import { Code2ProtocolConverter } from 'vscode-languageclient';
+import { Code2ProtocolConverter } from 'vscode-languageclient/node';
 import * as proto from 'vscode-languageserver-protocol';
 
 // tslint:disable:no-any unified-signatures

--- a/src/test/datascience/mockCustomEditorService.ts
+++ b/src/test/datascience/mockCustomEditorService.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { inject, injectable } from 'inversify';
 import { CancellationTokenSource, Disposable, Uri, WebviewPanel, WebviewPanelOptions } from 'vscode';
-import { CancellationToken } from 'vscode-languageclient';
+import { CancellationToken } from 'vscode-languageclient/node';
 import {
     CustomDocument,
     CustomEditorProvider,

--- a/src/test/datascience/mockLanguageClient.ts
+++ b/src/test/datascience/mockLanguageClient.ts
@@ -12,6 +12,7 @@ import {
     InitializeResult,
     LanguageClient,
     LanguageClientOptions,
+    MessageSignature,
     MessageTransports,
     NotificationHandler,
     NotificationHandler0,
@@ -216,6 +217,9 @@ export class MockLanguageClient extends LanguageClient {
         throw new Error('Method not implemented.');
     }
     public registerFeature(_feature: StaticFeature | DynamicFeature<any>): void {
+        throw new Error('Method not implemented.');
+    }
+    public handleFailedRequest<T>(_type: MessageSignature, _error: any, _defaultValue: T): T {
         throw new Error('Method not implemented.');
     }
     protected handleConnectionClosed(): void {

--- a/src/test/datascience/mockLanguageClient.ts
+++ b/src/test/datascience/mockLanguageClient.ts
@@ -24,7 +24,6 @@ import {
     RequestHandler0,
     RequestType,
     RequestType0,
-    RPCMessageType,
     ServerOptions,
     StateChangeEvent,
     StaticFeature,
@@ -33,7 +32,7 @@ import {
     TextDocumentSyncKind,
     Trace,
     VersionedTextDocumentIdentifier
-} from 'vscode-languageclient';
+} from 'vscode-languageclient/node';
 
 import { LanguageServerType } from '../../client/activation/types';
 import { createDeferred, Deferred } from '../../client/common/utils/async';
@@ -219,10 +218,6 @@ export class MockLanguageClient extends LanguageClient {
     public registerFeature(_feature: StaticFeature | DynamicFeature<any>): void {
         throw new Error('Method not implemented.');
     }
-    public logFailedRequest(_type: RPCMessageType, _error: any): void {
-        throw new Error('Method not implemented.');
-    }
-
     protected handleConnectionClosed(): void {
         throw new Error('Method not implemented.');
     }

--- a/src/test/datascience/mockLanguageServerAnalysisOptions.ts
+++ b/src/test/datascience/mockLanguageServerAnalysisOptions.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { injectable } from 'inversify';
 import { Event, EventEmitter } from 'vscode';
-import { LanguageClientOptions } from 'vscode-languageclient';
+import { LanguageClientOptions } from 'vscode-languageclient/node';
 
 import { ILanguageServerAnalysisOptions } from '../../client/activation/types';
 import { Resource } from '../../client/common/types';

--- a/src/test/datascience/mockLanguageServerProxy.ts
+++ b/src/test/datascience/mockLanguageServerProxy.ts
@@ -3,7 +3,7 @@
 'use strict';
 import { injectable } from 'inversify';
 import { Uri } from 'vscode';
-import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient';
+import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
 
 import { ILanguageServerProxy } from '../../client/activation/types';
 import { PythonInterpreter } from '../../client/pythonEnvironments/info';

--- a/src/test/datascience/mockProtocol2CodeConverter.ts
+++ b/src/test/datascience/mockProtocol2CodeConverter.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 'use strict';
 import * as code from 'vscode';
-import { Protocol2CodeConverter } from 'vscode-languageclient';
+import { Protocol2CodeConverter } from 'vscode-languageclient/node';
 // tslint:disable-next-line: match-default-export-name
-import protocolCompletionItem from 'vscode-languageclient/lib/protocolCompletionItem';
+import protocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import * as proto from 'vscode-languageserver-protocol';
 
 // tslint:disable:no-any unified-signatures

--- a/src/test/datascience/mockProtocol2CodeConverter.ts
+++ b/src/test/datascience/mockProtocol2CodeConverter.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 'use strict';
 import * as code from 'vscode';
+// tslint:disable-next-line: import-name
+import ProtocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import { Protocol2CodeConverter } from 'vscode-languageclient/node';
-// tslint:disable-next-line: match-default-export-name
-import protocolCompletionItem from 'vscode-languageclient/lib/common/protocolCompletionItem';
 import * as proto from 'vscode-languageserver-protocol';
 
 // tslint:disable:no-any unified-signatures
@@ -69,8 +69,8 @@ export class MockProtocol2CodeConverter implements Protocol2CodeConverter {
         const list = <proto.CompletionList>result;
         return new code.CompletionList(list.items.map(this.asCompletionItem.bind(this)), list.isIncomplete);
     }
-    public asCompletionItem(item: proto.CompletionItem): protocolCompletionItem {
-        const result = new protocolCompletionItem(item.label);
+    public asCompletionItem(item: proto.CompletionItem): ProtocolCompletionItem {
+        const result = new ProtocolCompletionItem(item.label);
         if (item.detail) {
             result.detail = item.detail;
         }

--- a/src/test/languageServers/jedi/symbolProvider.unit.test.ts
+++ b/src/test/languageServers/jedi/symbolProvider.unit.test.ts
@@ -19,7 +19,7 @@ import {
     TextDocument,
     Uri
 } from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { IFileSystem } from '../../../client/common/platform/types';
 import { parseRange } from '../../../client/common/utils/text';
 import { IServiceContainer } from '../../../client/ioc/types';


### PR DESCRIPTION

vscode-languageclient folder structure changed now we append "node" to imports

updating packages
 - vscode-languageclient
 - vscode-languageserver
 - vscode-languageserver-protocol
 - types/vscode
 - engines/vscode

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
