### PR TITLE
Move interpreter-info-related code to the py-envs component tree.

### DIFF
--- a/src/client/common/process/pythonEnvironment.ts
+++ b/src/client/common/process/pythonEnvironment.ts
@@ -68,7 +68,7 @@ class PythonEnvironment {
     private async getInterpreterInformationImpl(): Promise<InterpreterInformation | undefined> {
         try {
             const python = this.getExecutionInfo();
-            return getInterpreterInfo(python, this.deps.shellExec, { info: traceInfo, error: traceError });
+            return await getInterpreterInfo(python, this.deps.shellExec, { info: traceInfo, error: traceError });
         } catch (ex) {
             traceError(`Failed to get interpreter information for '${this.pythonPath}'`, ex);
         }

--- a/src/client/common/process/pythonEnvironment.ts
+++ b/src/client/common/process/pythonEnvironment.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 import { CondaEnvironmentInfo } from '../../pythonEnvironments/discovery/locators/services/conda';
-import { getPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
+import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { InterpreterInformation } from '../../pythonEnvironments/info';
+import { getExecutablePath } from '../../pythonEnvironments/info/executable';
 import { extractInterpreterInfo } from '../../pythonEnvironments/info/interpreter';
 import { traceError, traceInfo } from '../logger';
 import { IFileSystem } from '../platform/types';
@@ -29,11 +30,11 @@ class PythonEnvironment {
 
     public getExecutionInfo(pythonArgs: string[] = []): PythonExecInfo {
         const python = this.deps.getPythonArgv(this.pythonPath);
-        return getPythonExecInfo(python, pythonArgs);
+        return buildPythonExecInfo(python, pythonArgs);
     }
     public getExecutionObservableInfo(pythonArgs: string[] = []): PythonExecInfo {
         const python = this.deps.getObservablePythonArgv(this.pythonPath);
-        return getPythonExecInfo(python, pythonArgs);
+        return buildPythonExecInfo(python, pythonArgs);
     }
 
     public async getInterpreterInformation(): Promise<InterpreterInformation | undefined> {
@@ -49,11 +50,8 @@ class PythonEnvironment {
         if (await this.deps.isValidExecutable(this.pythonPath)) {
             return this.pythonPath;
         }
-
-        const [args, parse] = internalPython.getExecutable();
-        const info = this.getExecutionInfo(args);
-        const proc = await this.deps.exec(info.command, info.args);
-        return parse(proc.stdout);
+        const python = this.getExecutionInfo();
+        return getExecutablePath(python, this.deps.exec);
     }
 
     public async isModuleInstalled(moduleName: string): Promise<boolean> {

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// A representation of the information needed to run a Python executable.
+/**
+ * A representation of the information needed to run a Python executable.
+ *
+ * @prop command - the executable to execute in a new OS process
+ * @prop args - the full list of arguments with which to invoke the command
+ * @prop python - the command + the arguments needed just to invoke Python
+ * @prop pythonExecutable - the path the the Python executable
+ */
 export type PythonExecInfo = {
     command: string;
     args: string[];
@@ -10,7 +17,12 @@ export type PythonExecInfo = {
     pythonExecutable: string;
 };
 
-// Compose Python execution info for the given executable.
+/**
+ * Compose Python execution info for the given executable.
+ *
+ * @param python - the path (or command + arguments) to use to invoke Python
+ * @param pythonArgs - any extra arguments to use when running Python
+ */
 export function buildPythonExecInfo(python: string | string[], pythonArgs?: string[]): PythonExecInfo {
     if (Array.isArray(python)) {
         const args = python.slice(1);
@@ -33,7 +45,12 @@ export function buildPythonExecInfo(python: string | string[], pythonArgs?: stri
     }
 }
 
-// Create a copy, optionally adding to the args to pass to Python.
+/**
+ * Create a copy, optionally adding to the args to pass to Python.
+ *
+ * @param orig - the object to copy
+ * @param extraPythonArgs - any arguments to add to the end of orig.args
+ */
 export function copyPythonExecInfo(orig: PythonExecInfo, extraPythonArgs?: string[]): PythonExecInfo {
     const info = {
         command: orig.command,

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -11,7 +11,7 @@ export type PythonExecInfo = {
 };
 
 // Compose Python execution info for the given executable.
-export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, pythonArgs?: string[]): PythonExecInfo {
+export function buildPythonExecInfo(python: string | string[], pythonArgs?: string[]): PythonExecInfo {
     if (Array.isArray(python)) {
         const args = python.slice(1);
         if (pythonArgs) {
@@ -23,21 +23,6 @@ export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, 
             python,
             pythonExecutable: python[python.length - 1]
         };
-    } else if (python instanceof Object) {
-        const info = {
-            command: python.command,
-            args: [...python.args],
-            python: [...python.python],
-            pythonExecutable: python.pythonExecutable
-        };
-        if (pythonArgs) {
-            info.args.push(...pythonArgs);
-        }
-        if (info.pythonExecutable === undefined) {
-            // This isn't necessarily true...
-            info.pythonExecutable = info.python[info.python.length - 1];
-        }
-        return info;
     } else {
         return {
             command: python,
@@ -46,4 +31,22 @@ export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, 
             pythonExecutable: python
         };
     }
+}
+
+// Create a copy, optionally adding to the args to pass to Python.
+export function copyPythonExecInfo(orig: PythonExecInfo, extraPythonArgs?: string[]): PythonExecInfo {
+    const info = {
+        command: orig.command,
+        args: [...orig.args],
+        python: [...orig.python],
+        pythonExecutable: orig.pythonExecutable
+    };
+    if (extraPythonArgs) {
+        info.args.push(...extraPythonArgs);
+    }
+    if (info.pythonExecutable === undefined) {
+        // This isn't necessarily true...
+        info.pythonExecutable = info.python[info.python.length - 1];
+    }
+    return info;
 }

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -30,9 +30,9 @@ export function buildPythonExecInfo(python: string | string[], pythonArgs?: stri
             args.push(...pythonArgs);
         }
         return {
-            command: python[0],
             args,
-            python,
+            command: python[0],
+            python: [...python],
             pythonExecutable: python[python.length - 1]
         };
     } else {

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -49,7 +49,7 @@ export function buildPythonExecInfo(python: string | string[], pythonArgs?: stri
  * Create a copy, optionally adding to the args to pass to Python.
  *
  * @param orig - the object to copy
- * @param extraPythonArgs - any arguments to add to the end of orig.args
+ * @param extraPythonArgs - any arguments to add to the end of `orig.args`
  */
 export function copyPythonExecInfo(orig: PythonExecInfo, extraPythonArgs?: string[]): PythonExecInfo {
     const info = {

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -6,6 +6,7 @@ export type PythonExecInfo = {
     args: string[];
 
     python: string[];
+    pythonExecutable: string;
 };
 
 export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, pythonArgs?: string[]): PythonExecInfo {
@@ -14,14 +15,33 @@ export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, 
         if (pythonArgs) {
             args.push(...pythonArgs);
         }
-        return { command: python[0], args, python };
+        return {
+            command: python[0],
+            args,
+            python,
+            pythonExecutable: python[python.length - 1]
+        };
     } else if (python instanceof Object) {
-        const info = { command: python.command, args: [...python.args], python: [...python.python] };
+        const info = {
+            command: python.command,
+            args: [...python.args],
+            python: [...python.python],
+            pythonExecutable: python.pythonExecutable
+        };
         if (pythonArgs) {
             info.args.push(...pythonArgs);
         }
+        if (info.pythonExecutable === undefined) {
+            // This isn't necessarily true...
+            info.pythonExecutable = info.python[info.python.length - 1];
+        }
         return info;
     } else {
-        return { command: python, args: pythonArgs || [], python: [python] };
+        return {
+            command: python,
+            args: pythonArgs || [],
+            python: [python],
+            pythonExecutable: python
+        };
     }
 }

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -33,6 +33,8 @@ export function buildPythonExecInfo(python: string | string[], pythonArgs?: stri
             args,
             command: python[0],
             python: [...python],
+            // It isn't necessarily the last item but our supported
+            // cases it currently is.
             pythonExecutable: python[python.length - 1]
         };
     } else {
@@ -62,7 +64,8 @@ export function copyPythonExecInfo(orig: PythonExecInfo, extraPythonArgs?: strin
         info.args.push(...extraPythonArgs);
     }
     if (info.pythonExecutable === undefined) {
-        // This isn't necessarily true...
+        // It isn't necessarily the last item but our supported
+        // cases it currently is.
         info.pythonExecutable = info.python[info.python.length - 1];
     }
     return info;

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// A representation of the information needed to run a Python executable.
 export type PythonExecInfo = {
     command: string;
     args: string[];
@@ -9,6 +10,7 @@ export type PythonExecInfo = {
     pythonExecutable: string;
 };
 
+// Compose Python execution info for the given executable.
 export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, pythonArgs?: string[]): PythonExecInfo {
     if (Array.isArray(python)) {
         const args = python.slice(1);

--- a/src/client/pythonEnvironments/exec.ts
+++ b/src/client/pythonEnvironments/exec.ts
@@ -8,13 +8,19 @@ export type PythonExecInfo = {
     python: string[];
 };
 
-export function getPythonExecInfo(python: string | string[], pythonArgs?: string[]): PythonExecInfo {
+export function buildPythonExecInfo(python: string | string[] | PythonExecInfo, pythonArgs?: string[]): PythonExecInfo {
     if (Array.isArray(python)) {
         const args = python.slice(1);
         if (pythonArgs) {
             args.push(...pythonArgs);
         }
         return { command: python[0], args, python };
+    } else if (python instanceof Object) {
+        const info = { command: python.command, args: [...python.args], python: [...python.python] };
+        if (pythonArgs) {
+            info.args.push(...pythonArgs);
+        }
+        return info;
     } else {
         return { command: python, args: pythonArgs || [], python: [python] };
     }

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as internalPython from '../../common/process/internal/python';
+import { buildPythonExecInfo, PythonExecInfo } from '../exec';
+
+type ExecResult = {
+    stdout: string;
+};
+type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
+
+export async function getExecutablePath(python: PythonExecInfo, exec: ExecFunc): Promise<string> {
+    const [args, parse] = internalPython.getExecutable();
+    const info = buildPythonExecInfo(python, args);
+    const result = await exec(info.command, info.args);
+    return parse(result.stdout);
+}

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as internalPython from '../../common/process/internal/python';
+import { getExecutable as getPythonExecutableCommand } from '../../common/process/internal/python';
 import { buildPythonExecInfo, PythonExecInfo } from '../exec';
 
 type ExecResult = {
@@ -10,7 +10,7 @@ type ExecResult = {
 type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 
 export async function getExecutablePath(python: PythonExecInfo, exec: ExecFunc): Promise<string> {
-    const [args, parse] = internalPython.getExecutable();
+    const [args, parse] = getPythonExecutableCommand();
     const info = buildPythonExecInfo(python, args);
     const result = await exec(info.command, info.args);
     return parse(result.stdout);

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -9,7 +9,14 @@ type ExecResult = {
 };
 type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 
-// Find the filename for the corresponding Python executable (sys.executable).
+/**
+ * Find the filename for the corresponding Python executable.
+ *
+ * Effectively, we look up sys.executable.
+ *
+ * @param python - the information to use when running Python
+ * @param exec - the function to use to run Python
+ */
 export async function getExecutablePath(python: PythonExecInfo, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonExecutableCommand();
     const info = copyPythonExecInfo(python, args);

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -9,6 +9,7 @@ type ExecResult = {
 };
 type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 
+// Find the filename for the corresponding Python executable (sys.executable).
 export async function getExecutablePath(python: PythonExecInfo, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonExecutableCommand();
     const info = buildPythonExecInfo(python, args);

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -12,7 +12,7 @@ type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 /**
  * Find the filename for the corresponding Python executable.
  *
- * Effectively, we look up sys.executable.
+ * Effectively, we look up `sys.executable`.
  *
  * @param python - the information to use when running Python
  * @param exec - the function to use to run Python

--- a/src/client/pythonEnvironments/info/executable.ts
+++ b/src/client/pythonEnvironments/info/executable.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { getExecutable as getPythonExecutableCommand } from '../../common/process/internal/python';
-import { buildPythonExecInfo, PythonExecInfo } from '../exec';
+import { copyPythonExecInfo, PythonExecInfo } from '../exec';
 
 type ExecResult = {
     stdout: string;
@@ -12,7 +12,7 @@ type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 // Find the filename for the corresponding Python executable (sys.executable).
 export async function getExecutablePath(python: PythonExecInfo, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonExecutableCommand();
-    const info = buildPythonExecInfo(python, args);
+    const info = copyPythonExecInfo(python, args);
     const result = await exec(info.command, info.args);
     return parse(result.stdout);
 }

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -31,6 +31,7 @@ type ShellExecResult = {
     stderr?: string;
 };
 type ShellExecFunc = (command: string, timeout: number) => Promise<ShellExecResult>;
+
 type Logger = {
     info(msg: string): void;
     error(msg: string): void;

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -7,9 +7,14 @@ import { Architecture } from '../../common/utils/platform';
 import { copyPythonExecInfo, PythonExecInfo } from '../exec';
 import { parsePythonVersion } from './pythonVersion';
 
-// Composse full interpreter information based on the given data.
-//
-// The data format corresponds to the output of the interpreterInfo.py script.
+/**
+ * Compose full interpreter information based on the given data.
+ *
+ * The data format corresponds to the output of the interpreterInfo.py script.
+ *
+ * @param python - the path to the Python executable
+ * @param raw - the information returned by the interpreterInfo.py script
+ */
 export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
     return {
@@ -31,7 +36,13 @@ type Logger = {
     error(msg: string): void;
 };
 
-// Collect full interpreter information from the given Python executable.
+/**
+ * Collect full interpreter information from the given Python executable.
+ *
+ * @param python - the information to use when running Python
+ * @param shellExec - the function to use to exec Python
+ * @param logger - if provided, used to log failures or other info
+ */
 export async function getInterpreterInfo(
     python: PythonExecInfo,
     shellExec: ShellExecFunc,

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -7,6 +7,9 @@ import { Architecture } from '../../common/utils/platform';
 import { buildPythonExecInfo, PythonExecInfo } from '../exec';
 import { parsePythonVersion } from './pythonVersion';
 
+// Composse full interpreter information based on the given data.
+//
+// The data format corresponds to the output of the interpreterInfo.py script.
 export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
     return {
@@ -28,6 +31,7 @@ type Logger = {
     error(msg: string): void;
 };
 
+// Collect full interpreter information from the given Python executable.
 export async function getInterpreterInfo(
     python: PythonExecInfo,
     shellExec: ShellExecFunc,

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { InterpreterInformation } from '.';
-import { PythonEnvInfo } from '../../common/process/internal/scripts';
+//import * as internalScripts from '../../common/process/internal/scripts';
+import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../common/process/internal/scripts';
 import { Architecture } from '../../common/utils/platform';
+import { buildPythonExecInfo, PythonExecInfo } from '../exec';
+import { InterpreterInformation } from '.';
 import { parsePythonVersion } from './pythonVersion';
 
 export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
@@ -15,4 +17,46 @@ export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): Inte
         sysVersion: raw.sysVersion,
         sysPrefix: raw.sysPrefix
     };
+}
+
+type ShellExecResult = {
+    stdout: string;
+    stderr?: string;
+};
+type ShellExecFunc = (command: string, timeout: number) => Promise<ShellExecResult>;
+type Logger = {
+    info(msg: string): void;
+    error(msg: string): void;
+};
+
+export async function getInterpreterInfo(
+    python: PythonExecInfo,
+    shellExec: ShellExecFunc,
+    logger?: Logger
+): Promise<InterpreterInformation | undefined> {
+    const [args, parse] = getInterpreterInfoCommand();
+    const info = buildPythonExecInfo(python, args);
+    const argv = [info.command, ...info.args];
+
+    // Concat these together to make a set of quoted strings
+    const quoted = argv.reduce((p, c) => (p ? `${p} "${c}"` : `"${c.replace('\\', '\\\\')}"`), '');
+
+    // Try shell execing the command, followed by the arguments. This will make node kill the process if it
+    // takes too long.
+    // Sometimes the python path isn't valid, timeout if that's the case.
+    // See these two bugs:
+    // https://github.com/microsoft/vscode-python/issues/7569
+    // https://github.com/microsoft/vscode-python/issues/7760
+    const result = await shellExec(quoted, 15000);
+    if (result.stderr) {
+        if (logger) {
+            logger.error(`Failed to parse interpreter information for ${argv} stderr: ${result.stderr}`);
+        }
+        return;
+    }
+    const json = parse(result.stdout);
+    if (logger) {
+        logger.info(`Found interpreter for ${argv}`);
+    }
+    return extractInterpreterInfo(python.pythonExecutable, json);
 }

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -10,10 +10,10 @@ import { parsePythonVersion } from './pythonVersion';
 /**
  * Compose full interpreter information based on the given data.
  *
- * The data format corresponds to the output of the interpreterInfo.py script.
+ * The data format corresponds to the output of the `interpreterInfo.py` script.
  *
  * @param python - the path to the Python executable
- * @param raw - the information returned by the interpreterInfo.py script
+ * @param raw - the information returned by the `interpreterInfo.py` script
  */
 export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -4,7 +4,7 @@
 import { InterpreterInformation } from '.';
 import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../common/process/internal/scripts';
 import { Architecture } from '../../common/utils/platform';
-import { buildPythonExecInfo, PythonExecInfo } from '../exec';
+import { copyPythonExecInfo, PythonExecInfo } from '../exec';
 import { parsePythonVersion } from './pythonVersion';
 
 // Composse full interpreter information based on the given data.
@@ -38,7 +38,7 @@ export async function getInterpreterInfo(
     logger?: Logger
 ): Promise<InterpreterInformation | undefined> {
     const [args, parse] = getInterpreterInfoCommand();
-    const info = buildPythonExecInfo(python, args);
+    const info = copyPythonExecInfo(python, args);
     const argv = [info.command, ...info.args];
 
     // Concat these together to make a set of quoted strings

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//import * as internalScripts from '../../common/process/internal/scripts';
+import { InterpreterInformation } from '.';
 import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../common/process/internal/scripts';
 import { Architecture } from '../../common/utils/platform';
 import { buildPythonExecInfo, PythonExecInfo } from '../exec';
-import { InterpreterInformation } from '.';
 import { parsePythonVersion } from './pythonVersion';
 
 export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -72,7 +72,7 @@ type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 /**
  * Get the version string of the given Python executable by running it.
  *
- * Effectively, we look up sys.version.
+ * Effectively, we look up `sys.version`.
  *
  * @param pythonPath - the Python executable to exec
  * @param defaultValue - the value to return if anything goes wrong

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -5,6 +5,10 @@ import { SemVer } from 'semver';
 import '../../common/extensions'; // For string.splitLines()
 import { getVersion as getPythonVersionCommand } from '../../common/process/internal/python';
 
+// A representation of a Python runtime's version.
+//
+// Note that this is currently compatible with SemVer objects,
+// but we may change it to match the format of sys.version_info.
 export type PythonVersion = {
     raw: string;
     major: number;
@@ -18,6 +22,9 @@ export type PythonVersion = {
     prerelease: string[];
 };
 
+// Convert a Python version string.
+//
+// TBD: the supported formats are...
 export function parsePythonVersion(raw: string): PythonVersion | undefined {
     if (!raw || raw.trim().length === 0) {
         return;
@@ -53,6 +60,7 @@ type ExecResult = {
 };
 type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 
+// Get the version via the given Python executable (sys.version).
 export async function getPythonVersion(pythonPath: string, defaultValue: string, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonVersionCommand();
     // Use buildPythonExecInfo()...

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -55,6 +55,7 @@ type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 
 export async function getPythonVersion(pythonPath: string, defaultValue: string, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonVersionCommand();
+    // Use buildPythonExecInfo()...
     return exec(pythonPath, args)
         .then((result) => parse(result.stdout).splitLines()[0])
         .then((version) => (version.length === 0 ? defaultValue : version))

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -32,8 +32,18 @@ export type PythonVersion = {
 
 /**
  * Convert a Python version string.
+ *
+ * The supported formats are:
+ *
+ *  * MAJOR.MINOR.MICRO-RELEASE_LEVEL
+ *
+ *  (where RELEASE_LEVEL is one of {alpha,beta,candidate,final})
+ *
+ * Everything else, including an empty string, results in `undefined`.
  */
-// TBD: the supported formats are...
+// Eventually we will want to also support the release serial
+// (e.g. beta1, candidate3) and maybe even release abbreviations
+// (e.g. 3.9.2b1, 3.8.10rc3).
 export function parsePythonVersion(raw: string): PythonVersion | undefined {
     if (!raw || raw.trim().length === 0) {
         return;
@@ -80,7 +90,9 @@ type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
  */
 export async function getPythonVersion(pythonPath: string, defaultValue: string, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonVersionCommand();
-    // Use buildPythonExecInfo()...
+    // It may make sense eventually to use buildPythonExecInfo() here
+    // instead of using pythonPath and args directly.  That would allow
+    // buildPythonExecInfo() to assume any burden of flexibility.
     return exec(pythonPath, args)
         .then((result) => parse(result.stdout).splitLines()[0])
         .then((version) => (version.length === 0 ? defaultValue : version))

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -5,8 +5,16 @@ import { SemVer } from 'semver';
 import '../../common/extensions'; // For string.splitLines()
 import { getVersion as getPythonVersionCommand } from '../../common/process/internal/python';
 
-// A representation of a Python runtime's version.
-//
+/**
+ * A representation of a Python runtime's version.
+ *
+ * @prop raw - the original version string
+ * @prop major - the "major" version
+ * @prop minor - the "minor" version
+ * @prop patch - the "patch" (or "micro") version
+ * @prop build - the build ID of the executable
+ * @prop prerelease - identifies a tag in the release process (e.g. beta 1)
+ */
 // Note that this is currently compatible with SemVer objects,
 // but we may change it to match the format of sys.version_info.
 export type PythonVersion = {
@@ -22,8 +30,9 @@ export type PythonVersion = {
     prerelease: string[];
 };
 
-// Convert a Python version string.
-//
+/**
+ * Convert a Python version string.
+ */
 // TBD: the supported formats are...
 export function parsePythonVersion(raw: string): PythonVersion | undefined {
     if (!raw || raw.trim().length === 0) {
@@ -60,7 +69,15 @@ type ExecResult = {
 };
 type ExecFunc = (command: string, args: string[]) => Promise<ExecResult>;
 
-// Get the version via the given Python executable (sys.version).
+/**
+ * Get the version string of the given Python executable by running it.
+ *
+ * Effectively, we look up sys.version.
+ *
+ * @param pythonPath - the Python executable to exec
+ * @param defaultValue - the value to return if anything goes wrong
+ * @param exec - the function to call to run the Python executable
+ */
 export async function getPythonVersion(pythonPath: string, defaultValue: string, exec: ExecFunc): Promise<string> {
     const [args, parse] = getPythonVersionCommand();
     // Use buildPythonExecInfo()...

--- a/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
+++ b/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
@@ -11,7 +11,7 @@ import '../../common/extensions';
 import { IFileSystem, IPlatformService } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
-import { PythonExecInfo } from '../../pythonEnvironments/exec';
+import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { DjangoContextInitializer } from './djangoContext';
 import { TerminalCodeExecutionProvider } from './terminalCodeExecution';
 
@@ -33,7 +33,7 @@ export class DjangoShellCodeExecutionProvider extends TerminalCodeExecutionProvi
     }
 
     public async getExecutableInfo(resource?: Uri, args: string[] = []): Promise<PythonExecInfo> {
-        const { command, args: executableArgs, python } = await super.getExecutableInfo(resource, args);
+        const info = await super.getExecutableInfo(resource, args);
 
         const workspaceUri = resource ? this.workspace.getWorkspaceFolder(resource) : undefined;
         const defaultWorkspace =
@@ -43,14 +43,12 @@ export class DjangoShellCodeExecutionProvider extends TerminalCodeExecutionProvi
         const workspaceRoot = workspaceUri ? workspaceUri.uri.fsPath : defaultWorkspace;
         const managePyPath = workspaceRoot.length === 0 ? 'manage.py' : path.join(workspaceRoot, 'manage.py');
 
-        executableArgs.push(managePyPath.fileToCommandArgument());
-        executableArgs.push('shell');
-        return { command, args: executableArgs, python };
+        return buildPythonExecInfo(info, [managePyPath.fileToCommandArgument(), 'shell']);
     }
 
     public async getExecuteFileArgs(resource?: Uri, executeArgs: string[] = []): Promise<PythonExecInfo> {
         // We need the executable info but not the 'manage.py shell' args
-        const { command, args, python } = await super.getExecutableInfo(resource);
-        return { command, args: args.concat(executeArgs), python };
+        const info = await super.getExecutableInfo(resource);
+        return buildPythonExecInfo(info, executeArgs);
     }
 }

--- a/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
+++ b/src/client/terminals/codeExecution/djangoShellCodeExecution.ts
@@ -11,7 +11,7 @@ import '../../common/extensions';
 import { IFileSystem, IPlatformService } from '../../common/platform/types';
 import { ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
-import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
+import { copyPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { DjangoContextInitializer } from './djangoContext';
 import { TerminalCodeExecutionProvider } from './terminalCodeExecution';
 
@@ -43,12 +43,12 @@ export class DjangoShellCodeExecutionProvider extends TerminalCodeExecutionProvi
         const workspaceRoot = workspaceUri ? workspaceUri.uri.fsPath : defaultWorkspace;
         const managePyPath = workspaceRoot.length === 0 ? 'manage.py' : path.join(workspaceRoot, 'manage.py');
 
-        return buildPythonExecInfo(info, [managePyPath.fileToCommandArgument(), 'shell']);
+        return copyPythonExecInfo(info, [managePyPath.fileToCommandArgument(), 'shell']);
     }
 
     public async getExecuteFileArgs(resource?: Uri, executeArgs: string[] = []): Promise<PythonExecInfo> {
         // We need the executable info but not the 'manage.py shell' args
         const info = await super.getExecutableInfo(resource);
-        return buildPythonExecInfo(info, executeArgs);
+        return copyPythonExecInfo(info, executeArgs);
     }
 }

--- a/src/client/terminals/codeExecution/terminalCodeExecution.ts
+++ b/src/client/terminals/codeExecution/terminalCodeExecution.ts
@@ -11,7 +11,7 @@ import '../../common/extensions';
 import { IPlatformService } from '../../common/platform/types';
 import { ITerminalService, ITerminalServiceFactory } from '../../common/terminal/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
-import { PythonExecInfo } from '../../pythonEnvironments/exec';
+import { buildPythonExecInfo, PythonExecInfo } from '../../pythonEnvironments/exec';
 import { ICodeExecutionService } from '../../terminals/types';
 
 @injectable()
@@ -64,7 +64,7 @@ export class TerminalCodeExecutionProvider implements ICodeExecutionService {
             ? pythonSettings.pythonPath.replace(/\\/g, '/')
             : pythonSettings.pythonPath;
         const launchArgs = pythonSettings.terminal.launchArgs;
-        return { command, args: [...launchArgs, ...args], python: [command] };
+        return buildPythonExecInfo(command, [...launchArgs, ...args]);
     }
 
     // Overridden in subclasses, see djangoShellCodeExecution.ts

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -223,7 +223,7 @@ suite('PythonEnvironment', () => {
         const result = env.getExecutionInfo(args);
 
         expect(result).to.deep.equal(
-            { command: pythonPath, args, python: [pythonPath] },
+            { command: pythonPath, args, python: [pythonPath], pythonExecutable: pythonPath },
             'getExecutionInfo should return pythonPath and the command and execution arguments as is'
         );
     });
@@ -250,7 +250,8 @@ suite('CondaEnvironment', () => {
         expect(result).to.deep.equal({
             command: condaFile,
             args: ['run', '-n', condaInfo.name, 'python', ...args],
-            python: [condaFile, 'run', '-n', condaInfo.name, 'python']
+            python: [condaFile, 'run', '-n', condaInfo.name, 'python'],
+            pythonExecutable: 'python'
         });
     });
 
@@ -263,12 +264,13 @@ suite('CondaEnvironment', () => {
         expect(result).to.deep.equal({
             command: condaFile,
             args: ['run', '-p', condaInfo.path, 'python', ...args],
-            python: [condaFile, 'run', '-p', condaInfo.path, 'python']
+            python: [condaFile, 'run', '-p', condaInfo.path, 'python'],
+            pythonExecutable: 'python'
         });
     });
 
     test('getExecutionObservableInfo with a named environment should return execution info using pythonPath only', () => {
-        const expected = { command: pythonPath, args, python: [pythonPath] };
+        const expected = { command: pythonPath, args, python: [pythonPath], pythonExecutable: pythonPath };
         const condaInfo = { name: 'foo', path: 'bar' };
         const env = createCondaEnv(condaFile, condaInfo, pythonPath, processService.object, fileSystem.object);
 
@@ -278,7 +280,7 @@ suite('CondaEnvironment', () => {
     });
 
     test('getExecutionObservableInfo with a non-named environment should return execution info using pythonPath only', () => {
-        const expected = { command: pythonPath, args, python: [pythonPath] };
+        const expected = { command: pythonPath, args, python: [pythonPath], pythonExecutable: pythonPath };
         const condaInfo = { name: '', path: 'bar' };
         const env = createCondaEnv(condaFile, condaInfo, pythonPath, processService.object, fileSystem.object);
 

--- a/src/test/common/process/pythonEnvironment.unit.test.ts
+++ b/src/test/common/process/pythonEnvironment.unit.test.ts
@@ -117,7 +117,7 @@ suite('PythonEnvironment', () => {
         processService
             .setup((p) => p.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             // tslint:disable-next-line: no-any
-            .returns(() => Promise.resolve(undefined as any));
+            .returns(() => Promise.reject(new Error('timed out')));
         const env = createPythonEnv(pythonPath, processService.object, fileSystem.object);
 
         const result = await env.getInterpreterInformation();
@@ -173,7 +173,7 @@ suite('PythonEnvironment', () => {
 
         const result = env.getExecutablePath();
 
-        expect(result).to.eventually.be.rejectedWith(stderr);
+        await expect(result).to.eventually.be.rejectedWith(stderr);
     });
 
     test('isModuleInstalled should call processService.exec()', async () => {

--- a/src/test/datascience/executionServiceMock.ts
+++ b/src/test/datascience/executionServiceMock.ts
@@ -14,8 +14,8 @@ import {
     SpawnOptions
 } from '../../client/common/process/types';
 import { Architecture } from '../../client/common/utils/platform';
-import { InterpreterInformation } from '../../client/pythonEnvironments/info';
 import { buildPythonExecInfo } from '../../client/pythonEnvironments/exec';
+import { InterpreterInformation } from '../../client/pythonEnvironments/info';
 
 export class MockPythonExecutionService implements IPythonExecutionService {
     private procService: ProcessService;

--- a/src/test/datascience/executionServiceMock.ts
+++ b/src/test/datascience/executionServiceMock.ts
@@ -15,6 +15,7 @@ import {
 } from '../../client/common/process/types';
 import { Architecture } from '../../client/common/utils/platform';
 import { InterpreterInformation } from '../../client/pythonEnvironments/info';
+import { buildPythonExecInfo } from '../../client/pythonEnvironments/exec';
 
 export class MockPythonExecutionService implements IPythonExecutionService {
     private procService: ProcessService;
@@ -78,6 +79,6 @@ export class MockPythonExecutionService implements IPythonExecutionService {
         return result;
     }
     public getExecutionInfo(args: string[]) {
-        return { command: this.pythonPath, args, python: [this.pythonPath] };
+        return buildPythonExecInfo(this.pythonPath, args);
     }
 }

--- a/src/test/datascience/mockPythonService.ts
+++ b/src/test/datascience/mockPythonService.ts
@@ -8,6 +8,7 @@ import {
     SpawnOptions
 } from '../../client/common/process/types';
 import { InterpreterInformation, PythonInterpreter } from '../../client/pythonEnvironments/info';
+import { buildPythonExecInfo } from '../../client/pythonEnvironments/exec';
 import { MockProcessService } from './mockProcessService';
 
 export class MockPythonService implements IPythonExecutionService {
@@ -77,6 +78,6 @@ export class MockPythonService implements IPythonExecutionService {
     }
 
     public getExecutionInfo(args: string[]) {
-        return { command: this.interpreter.path, args, python: [this.interpreter.path] };
+        return buildPythonExecInfo(this.interpreter.path, args);
     }
 }

--- a/src/test/datascience/mockPythonService.ts
+++ b/src/test/datascience/mockPythonService.ts
@@ -7,8 +7,8 @@ import {
     ObservableExecutionResult,
     SpawnOptions
 } from '../../client/common/process/types';
-import { InterpreterInformation, PythonInterpreter } from '../../client/pythonEnvironments/info';
 import { buildPythonExecInfo } from '../../client/pythonEnvironments/exec';
+import { InterpreterInformation, PythonInterpreter } from '../../client/pythonEnvironments/info';
 import { MockProcessService } from './mockProcessService';
 
 export class MockPythonService implements IPythonExecutionService {

--- a/src/test/pythonEnvironments/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/info/executable.unit.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import * as path from 'path';
+import * as TypeMoq from 'typemoq';
+import { StdErrError } from '../../../client/common/process/types';
+import { buildPythonExecInfo } from '../../../client/pythonEnvironments/exec';
+import * as sut from '../../../client/pythonEnvironments/info/executable';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
+
+const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
+
+type ExecResult = {
+    stdout: string;
+};
+interface IDeps {
+    exec(command: string, args: string[]): Promise<ExecResult>;
+}
+
+suite('getExecutablePath()', () => {
+    let deps: TypeMoq.IMock<IDeps>;
+    const python = buildPythonExecInfo('path/to/python');
+
+    setup(() => {
+        deps = TypeMoq.Mock.ofType<IDeps>(undefined, TypeMoq.MockBehavior.Strict);
+    });
+    function verifyAll() {
+        deps.verifyAll();
+    }
+
+    test('should get the value by running python', async () => {
+        const expected = 'path/to/dummy/executable';
+        const argv = [isolated, '-c', 'import sys;print(sys.executable)'];
+        deps.setup((d) => d.exec(python.command, argv))
+            .returns(() => Promise.resolve({ stdout: expected }));
+        const exec = async (c: string, a: string[]) => deps.object.exec(c, a);
+
+        const result = await sut.getExecutablePath(python, exec);
+
+        expect(result).to.equal(expected, "getExecutablePath() sbould return get the value by running Python");
+        verifyAll();
+    });
+
+    test('should throw if the result of exec() writes to stderr', async () => {
+        const stderr = 'oops';
+        const argv = [isolated, '-c', 'import sys;print(sys.executable)'];
+        deps.setup((d) => d.exec(python.command, argv))
+            .returns(() => Promise.reject(new StdErrError(stderr)));
+        const exec = async (c: string, a: string[]) => deps.object.exec(c, a);
+
+        const result = sut.getExecutablePath(python, exec);
+
+        expect(result).to.eventually.be.rejectedWith(stderr);
+        verifyAll();
+    });
+});

--- a/src/test/pythonEnvironments/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/info/executable.unit.test.ts
@@ -42,7 +42,7 @@ suite('getExecutablePath()', () => {
         verifyAll();
     });
 
-    test('should throw if the result of exec() writes to stderr', async () => {
+    test('should throw if exec() fails', async () => {
         const stderr = 'oops';
         const argv = [isolated, '-c', 'import sys;print(sys.executable)'];
         deps.setup((d) => d.exec(python.command, argv))

--- a/src/test/pythonEnvironments/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/info/executable.unit.test.ts
@@ -33,12 +33,13 @@ suite('getExecutablePath()', () => {
         const expected = 'path/to/dummy/executable';
         const argv = [isolated, '-c', 'import sys;print(sys.executable)'];
         deps.setup((d) => d.exec(python.command, argv))
+            // Return the expected value.
             .returns(() => Promise.resolve({ stdout: expected }));
         const exec = async (c: string, a: string[]) => deps.object.exec(c, a);
 
         const result = await getExecutablePath(python, exec);
 
-        expect(result).to.equal(expected, "getExecutablePath() sbould return get the value by running Python");
+        expect(result).to.equal(expected, 'getExecutablePath() sbould return get the value by running Python');
         verifyAll();
     });
 
@@ -46,6 +47,7 @@ suite('getExecutablePath()', () => {
         const stderr = 'oops';
         const argv = [isolated, '-c', 'import sys;print(sys.executable)'];
         deps.setup((d) => d.exec(python.command, argv))
+            // Throw an error.
             .returns(() => Promise.reject(new StdErrError(stderr)));
         const exec = async (c: string, a: string[]) => deps.object.exec(c, a);
 

--- a/src/test/pythonEnvironments/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/info/executable.unit.test.ts
@@ -25,9 +25,6 @@ suite('getExecutablePath()', () => {
     setup(() => {
         deps = Mock.ofType<IDeps>(undefined, MockBehavior.Strict);
     });
-    function verifyAll() {
-        deps.verifyAll();
-    }
 
     test('should get the value by running python', async () => {
         const expected = 'path/to/dummy/executable';
@@ -40,7 +37,7 @@ suite('getExecutablePath()', () => {
         const result = await getExecutablePath(python, exec);
 
         expect(result).to.equal(expected, 'getExecutablePath() should return get the value by running Python');
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should throw if exec() fails', async () => {
@@ -54,6 +51,6 @@ suite('getExecutablePath()', () => {
         const result = getExecutablePath(python, exec);
 
         expect(result).to.eventually.be.rejectedWith(stderr);
-        verifyAll();
+        deps.verifyAll();
     });
 });

--- a/src/test/pythonEnvironments/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/info/executable.unit.test.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 import { expect } from 'chai';
-import * as path from 'path';
-import * as TypeMoq from 'typemoq';
+import { join as pathJoin } from 'path';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 import { StdErrError } from '../../../client/common/process/types';
 import { buildPythonExecInfo } from '../../../client/pythonEnvironments/exec';
-import * as sut from '../../../client/pythonEnvironments/info/executable';
+import { getExecutablePath } from '../../../client/pythonEnvironments/info/executable';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
 
-const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
+const isolated = pathJoin(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
 
 type ExecResult = {
     stdout: string;
@@ -19,11 +19,11 @@ interface IDeps {
 }
 
 suite('getExecutablePath()', () => {
-    let deps: TypeMoq.IMock<IDeps>;
+    let deps: IMock<IDeps>;
     const python = buildPythonExecInfo('path/to/python');
 
     setup(() => {
-        deps = TypeMoq.Mock.ofType<IDeps>(undefined, TypeMoq.MockBehavior.Strict);
+        deps = Mock.ofType<IDeps>(undefined, MockBehavior.Strict);
     });
     function verifyAll() {
         deps.verifyAll();
@@ -36,7 +36,7 @@ suite('getExecutablePath()', () => {
             .returns(() => Promise.resolve({ stdout: expected }));
         const exec = async (c: string, a: string[]) => deps.object.exec(c, a);
 
-        const result = await sut.getExecutablePath(python, exec);
+        const result = await getExecutablePath(python, exec);
 
         expect(result).to.equal(expected, "getExecutablePath() sbould return get the value by running Python");
         verifyAll();
@@ -49,7 +49,7 @@ suite('getExecutablePath()', () => {
             .returns(() => Promise.reject(new StdErrError(stderr)));
         const exec = async (c: string, a: string[]) => deps.object.exec(c, a);
 
-        const result = sut.getExecutablePath(python, exec);
+        const result = getExecutablePath(python, exec);
 
         expect(result).to.eventually.be.rejectedWith(stderr);
         verifyAll();

--- a/src/test/pythonEnvironments/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/info/executable.unit.test.ts
@@ -39,7 +39,7 @@ suite('getExecutablePath()', () => {
 
         const result = await getExecutablePath(python, exec);
 
-        expect(result).to.equal(expected, 'getExecutablePath() sbould return get the value by running Python');
+        expect(result).to.equal(expected, 'getExecutablePath() should return get the value by running Python');
         verifyAll();
     });
 

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -33,9 +33,6 @@ suite('getInterpreterInfo()', () => {
     setup(() => {
         deps = Mock.ofType<IDeps>(undefined, MockBehavior.Strict);
     });
-    function verifyAll() {
-        deps.verifyAll();
-    }
 
     test('should call exec() with the proper command and timeout', async () => {
         const json = {
@@ -53,7 +50,7 @@ suite('getInterpreterInfo()', () => {
 
         await getInterpreterInfo(python, shellExec);
 
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should quote spaces in the command', async () => {
@@ -73,7 +70,7 @@ suite('getInterpreterInfo()', () => {
 
         await getInterpreterInfo(_python, shellExec);
 
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should handle multi-command (e.g. conda)', async () => {
@@ -93,7 +90,7 @@ suite('getInterpreterInfo()', () => {
 
         await getInterpreterInfo(_python, shellExec);
 
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should return an object if exec() is successful', async () => {
@@ -119,7 +116,7 @@ suite('getInterpreterInfo()', () => {
         const result = await getInterpreterInfo(python, shellExec);
 
         expect(result).to.deep.equal(expected, 'broken');
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should return an object if the version info contains less than 4 items', async () => {
@@ -145,7 +142,7 @@ suite('getInterpreterInfo()', () => {
         const result = await getInterpreterInfo(python, shellExec);
 
         expect(result).to.deep.equal(expected, 'broken');
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should return an object with the architecture value set to x86 if json.is64bit is not 64bit', async () => {
@@ -171,7 +168,7 @@ suite('getInterpreterInfo()', () => {
         const result = await getInterpreterInfo(python, shellExec);
 
         expect(result).to.deep.equal(expected, 'broken');
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should return undefined if the result of exec() writes to stderr', async () => {
@@ -185,7 +182,7 @@ suite('getInterpreterInfo()', () => {
         const result = getInterpreterInfo(python, shellExec);
 
         await expect(result).to.eventually.be.rejectedWith(err);
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should fail if exec() fails (e.g. the script times out)', async () => {
@@ -199,7 +196,7 @@ suite('getInterpreterInfo()', () => {
         const result = getInterpreterInfo(python, shellExec);
 
         await expect(result).to.eventually.be.rejectedWith(err);
-        verifyAll();
+        deps.verifyAll();
     });
 
     test('should fail if the json value returned by interpreterInfo.py is not valid', async () => {
@@ -212,6 +209,6 @@ suite('getInterpreterInfo()', () => {
         const result = getInterpreterInfo(python, shellExec);
 
         await expect(result).to.eventually.be.rejected;
-        verifyAll();
+        deps.verifyAll();
     });
 });

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -1,6 +1,171 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { expect } from 'chai';
+import * as path from 'path';
+import { SemVer } from 'semver';
+import * as TypeMoq from 'typemoq';
+import { StdErrError } from '../../../client/common/process/types';
+import { Architecture } from '../../../client/common/utils/platform';
+import { buildPythonExecInfo } from '../../../client/pythonEnvironments/exec';
+import * as sut from '../../../client/pythonEnvironments/info/interpreter';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
+
+const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
+
 suite('extractInterpreterInfo()', () => {
     // Tests go here.
+});
+
+type ShellExecResult = {
+    stdout: string;
+    stderr?: string;
+};
+interface IDeps {
+    shellExec(command: string, timeout: number): Promise<ShellExecResult>;
+}
+
+suite('getInterpreterInfo()', () => {
+    let deps: TypeMoq.IMock<IDeps>;
+    const python = buildPythonExecInfo('path/to/python');
+
+    setup(() => {
+        deps = TypeMoq.Mock.ofType<IDeps>(undefined, TypeMoq.MockBehavior.Strict);
+    });
+    function verifyAll() {
+        deps.verifyAll();
+    }
+
+    test('should call exec() with the proper command and timeout', async () => {
+        const json = {
+            versionInfo: [3, 7, 5, 'candidate', 1],
+            sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
+            version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
+            is64Bit: true
+        };
+        const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
+        const cmd = `"${python}" "${isolated}" "${script}"`;
+        //const cmd = `${python} ${isolated} ${script}`;
+        deps.setup((d) => d.shellExec(cmd, 15000))
+            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        await sut.getInterpreterInfo(python, shellExec);
+
+        verifyAll();
+    });
+
+    test('should quote spaces in the command', async () => {
+    });
+
+    test('should handle multi-command (e.g. conda)', async () => {
+    });
+
+    test('should return an object if exec() is successful', async () => {
+        const expected = {
+            architecture: Architecture.x64,
+            path: python.command,
+            version: new SemVer('3.7.5-candidate.1'),
+            sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
+            sysVersion: undefined
+        };
+        const json = {
+            versionInfo: [3, 7, 5, 'candidate', 1],
+            sysPrefix: expected.sysPrefix,
+            version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
+            is64Bit: true
+        };
+        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = await sut.getInterpreterInfo(python, shellExec);
+
+        expect(result).to.deep.equal(expected, 'broken');
+        verifyAll();
+    });
+
+    test('should return an object if the version info contains less than 4 items', async () => {
+        const expected = {
+            architecture: Architecture.x64,
+            path: python.command,
+            version: new SemVer('3.7.5'),
+            sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
+            sysVersion: undefined
+        };
+        const json = {
+            versionInfo: [3, 7, 5],
+            sysPrefix: expected.sysPrefix,
+            version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
+            is64Bit: true
+        };
+        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = await sut.getInterpreterInfo(python, shellExec);
+
+        expect(result).to.deep.equal(expected, 'broken');
+        verifyAll();
+    });
+
+    test('should return an object with the architecture value set to x86 if json.is64bit is not 64bit', async () => {
+        const expected = {
+            architecture: Architecture.x86,
+            path: python.command,
+            version: new SemVer('3.7.5-candidate'),
+            sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
+            sysVersion: undefined
+        };
+        const json = {
+            versionInfo: [3, 7, 5, 'candidate'],
+            sysPrefix: expected.sysPrefix,
+            version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
+            is64Bit: false
+        };
+        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = await sut.getInterpreterInfo(python, shellExec);
+
+        expect(result).to.deep.equal(expected, 'broken');
+        verifyAll();
+    });
+
+    test('should return undefined if the result of exec() writes to stderr', async () => {
+        const stderr = 'oops';
+        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.reject(new StdErrError(stderr)));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = await sut.getInterpreterInfo(python, shellExec);
+
+        expect(result).to.equal(undefined, 'broken');
+        verifyAll();
+    });
+
+    test('should fail if exec() fails (e.g. the script times out)', async () => {
+        const err = new Error('oops');
+        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            // tslint:disable-next-line: no-any
+            .returns(() => Promise.reject(err));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = sut.getInterpreterInfo(python, shellExec);
+
+        expect(result).to.eventually.be.rejectedWith(err);
+        verifyAll();
+    });
+
+    test('should fail if the json value returned by interpreterInfo.py is not valid', async () => {
+        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve({ stdout: 'bad json' }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = sut.getInterpreterInfo(python, shellExec);
+
+        expect(result).to.eventually.be.rejectedWith('');
+        verifyAll();
+    });
 });

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -101,7 +101,6 @@ suite('getInterpreterInfo()', () => {
             architecture: Architecture.x64,
             path: python.command,
             version: new SemVer('3.7.5-candidate'),
-            //version: new SemVer('3.7.5-candidate.1'),
             sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
             sysVersion: undefined
         };

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -56,6 +56,48 @@ suite('getInterpreterInfo()', () => {
         verifyAll();
     });
 
+    test('should quote spaces in the command', async () => {
+        const json = {
+            versionInfo: [3, 7, 5, 'candidate', 1],
+            sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
+            version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
+            is64Bit: true
+        };
+        const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
+        const _python = buildPythonExecInfo(' path to /my python ');
+        const cmd = `" path to /my python " "${isolated}" "${script}"`;
+        deps
+            // Checking the args is the key point of this test.
+            .setup((d) => d.shellExec(cmd, 15000))
+            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        await sut.getInterpreterInfo(_python, shellExec);
+
+        verifyAll();
+    });
+
+    test('should handle multi-command (e.g. conda)', async () => {
+        const json = {
+            versionInfo: [3, 7, 5, 'candidate', 1],
+            sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
+            version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
+            is64Bit: true
+        };
+        const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
+        const _python = buildPythonExecInfo(['path/to/conda', 'run', '-n', 'my-env', 'python']);
+        const cmd = `"path/to/conda" "run" "-n" "my-env" "python" "${isolated}" "${script}"`;
+        deps
+            // Checking the args is the key point of this test.
+            .setup((d) => d.shellExec(cmd, 15000))
+            .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        await sut.getInterpreterInfo(_python, shellExec);
+
+        verifyAll();
+    });
+
     test('should return an object if exec() is successful', async () => {
         const expected = {
             architecture: Architecture.x64,

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -44,9 +44,10 @@ suite('getInterpreterInfo()', () => {
             is64Bit: true
         };
         const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
-        const cmd = `"${python}" "${isolated}" "${script}"`;
-        //const cmd = `${python} ${isolated} ${script}`;
-        deps.setup((d) => d.shellExec(cmd, 15000))
+        const cmd = `"${python.command}" "${isolated}" "${script}"`;
+        deps
+            // Checking the args is the key point of this test.
+            .setup((d) => d.shellExec(cmd, 15000))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
@@ -55,17 +56,12 @@ suite('getInterpreterInfo()', () => {
         verifyAll();
     });
 
-    test('should quote spaces in the command', async () => {
-    });
-
-    test('should handle multi-command (e.g. conda)', async () => {
-    });
-
     test('should return an object if exec() is successful', async () => {
         const expected = {
             architecture: Architecture.x64,
             path: python.command,
-            version: new SemVer('3.7.5-candidate.1'),
+            version: new SemVer('3.7.5-candidate'),
+            //version: new SemVer('3.7.5-candidate.1'),
             sysPrefix: '/path/of/sysprefix/versions/3.7.5rc1',
             sysVersion: undefined
         };
@@ -75,7 +71,9 @@ suite('getInterpreterInfo()', () => {
             version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
             is64Bit: true
         };
-        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+        deps
+            // We check the args in other tests.
+            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
@@ -99,7 +97,9 @@ suite('getInterpreterInfo()', () => {
             version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
             is64Bit: true
         };
-        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+        deps
+            // We check the args in other tests.
+            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
@@ -123,7 +123,9 @@ suite('getInterpreterInfo()', () => {
             version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
             is64Bit: false
         };
-        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+        deps
+            // We check the args in other tests.
+            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
@@ -134,38 +136,43 @@ suite('getInterpreterInfo()', () => {
     });
 
     test('should return undefined if the result of exec() writes to stderr', async () => {
-        const stderr = 'oops';
-        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns(() => Promise.reject(new StdErrError(stderr)));
-        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
-
-        const result = await sut.getInterpreterInfo(python, shellExec);
-
-        expect(result).to.equal(undefined, 'broken');
-        verifyAll();
-    });
-
-    test('should fail if exec() fails (e.g. the script times out)', async () => {
-        const err = new Error('oops');
-        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            // tslint:disable-next-line: no-any
+        const err = new StdErrError('oops!');
+        deps
+            // We check the args in other tests.
+            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.reject(err));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         const result = sut.getInterpreterInfo(python, shellExec);
 
-        expect(result).to.eventually.be.rejectedWith(err);
+        await expect(result).to.eventually.be.rejectedWith(err);
+        verifyAll();
+    });
+
+    test('should fail if exec() fails (e.g. the script times out)', async () => {
+        const err = new Error('oops');
+        deps
+            // We check the args in other tests.
+            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.reject(err));
+        const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
+
+        const result = sut.getInterpreterInfo(python, shellExec);
+
+        await expect(result).to.eventually.be.rejectedWith(err);
         verifyAll();
     });
 
     test('should fail if the json value returned by interpreterInfo.py is not valid', async () => {
-        deps.setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+        deps
+            // We check the args in other tests.
+            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve({ stdout: 'bad json' }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
         const result = sut.getInterpreterInfo(python, shellExec);
 
-        expect(result).to.eventually.be.rejectedWith('');
+        await expect(result).to.eventually.be.rejected;
         verifyAll();
     });
 });

--- a/src/test/pythonEnvironments/info/interpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/info/interpreter.unit.test.ts
@@ -2,16 +2,17 @@
 // Licensed under the MIT License.
 
 import { expect } from 'chai';
-import * as path from 'path';
+import { join as pathJoin } from 'path';
 import { SemVer } from 'semver';
-import * as TypeMoq from 'typemoq';
+import { IMock, It as TypeMoqIt, Mock, MockBehavior } from 'typemoq';
 import { StdErrError } from '../../../client/common/process/types';
 import { Architecture } from '../../../client/common/utils/platform';
 import { buildPythonExecInfo } from '../../../client/pythonEnvironments/exec';
-import * as sut from '../../../client/pythonEnvironments/info/interpreter';
+import { getInterpreterInfo } from '../../../client/pythonEnvironments/info/interpreter';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../constants';
 
-const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
+const isolated = pathJoin(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
+const script = pathJoin(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
 
 suite('extractInterpreterInfo()', () => {
     // Tests go here.
@@ -26,11 +27,11 @@ interface IDeps {
 }
 
 suite('getInterpreterInfo()', () => {
-    let deps: TypeMoq.IMock<IDeps>;
+    let deps: IMock<IDeps>;
     const python = buildPythonExecInfo('path/to/python');
 
     setup(() => {
-        deps = TypeMoq.Mock.ofType<IDeps>(undefined, TypeMoq.MockBehavior.Strict);
+        deps = Mock.ofType<IDeps>(undefined, MockBehavior.Strict);
     });
     function verifyAll() {
         deps.verifyAll();
@@ -43,7 +44,6 @@ suite('getInterpreterInfo()', () => {
             version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
             is64Bit: true
         };
-        const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
         const cmd = `"${python.command}" "${isolated}" "${script}"`;
         deps
             // Checking the args is the key point of this test.
@@ -51,7 +51,7 @@ suite('getInterpreterInfo()', () => {
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        await sut.getInterpreterInfo(python, shellExec);
+        await getInterpreterInfo(python, shellExec);
 
         verifyAll();
     });
@@ -63,7 +63,6 @@ suite('getInterpreterInfo()', () => {
             version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
             is64Bit: true
         };
-        const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
         const _python = buildPythonExecInfo(' path to /my python ');
         const cmd = `" path to /my python " "${isolated}" "${script}"`;
         deps
@@ -72,7 +71,7 @@ suite('getInterpreterInfo()', () => {
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        await sut.getInterpreterInfo(_python, shellExec);
+        await getInterpreterInfo(_python, shellExec);
 
         verifyAll();
     });
@@ -84,7 +83,6 @@ suite('getInterpreterInfo()', () => {
             version: '3.7.5rc1 (default, Oct 18 2019, 14:48:48) \n[Clang 11.0.0 (clang-1100.0.33.8)]',
             is64Bit: true
         };
-        const script = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'interpreterInfo.py');
         const _python = buildPythonExecInfo(['path/to/conda', 'run', '-n', 'my-env', 'python']);
         const cmd = `"path/to/conda" "run" "-n" "my-env" "python" "${isolated}" "${script}"`;
         deps
@@ -93,7 +91,7 @@ suite('getInterpreterInfo()', () => {
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        await sut.getInterpreterInfo(_python, shellExec);
+        await getInterpreterInfo(_python, shellExec);
 
         verifyAll();
     });
@@ -115,11 +113,11 @@ suite('getInterpreterInfo()', () => {
         };
         deps
             // We check the args in other tests.
-            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        const result = await sut.getInterpreterInfo(python, shellExec);
+        const result = await getInterpreterInfo(python, shellExec);
 
         expect(result).to.deep.equal(expected, 'broken');
         verifyAll();
@@ -141,11 +139,11 @@ suite('getInterpreterInfo()', () => {
         };
         deps
             // We check the args in other tests.
-            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        const result = await sut.getInterpreterInfo(python, shellExec);
+        const result = await getInterpreterInfo(python, shellExec);
 
         expect(result).to.deep.equal(expected, 'broken');
         verifyAll();
@@ -167,11 +165,11 @@ suite('getInterpreterInfo()', () => {
         };
         deps
             // We check the args in other tests.
-            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() => Promise.resolve({ stdout: JSON.stringify(json) }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        const result = await sut.getInterpreterInfo(python, shellExec);
+        const result = await getInterpreterInfo(python, shellExec);
 
         expect(result).to.deep.equal(expected, 'broken');
         verifyAll();
@@ -181,11 +179,11 @@ suite('getInterpreterInfo()', () => {
         const err = new StdErrError('oops!');
         deps
             // We check the args in other tests.
-            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() => Promise.reject(err));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        const result = sut.getInterpreterInfo(python, shellExec);
+        const result = getInterpreterInfo(python, shellExec);
 
         await expect(result).to.eventually.be.rejectedWith(err);
         verifyAll();
@@ -195,11 +193,11 @@ suite('getInterpreterInfo()', () => {
         const err = new Error('oops');
         deps
             // We check the args in other tests.
-            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() => Promise.reject(err));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        const result = sut.getInterpreterInfo(python, shellExec);
+        const result = getInterpreterInfo(python, shellExec);
 
         await expect(result).to.eventually.be.rejectedWith(err);
         verifyAll();
@@ -208,11 +206,11 @@ suite('getInterpreterInfo()', () => {
     test('should fail if the json value returned by interpreterInfo.py is not valid', async () => {
         deps
             // We check the args in other tests.
-            .setup((d) => d.shellExec(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((d) => d.shellExec(TypeMoqIt.isAny(), TypeMoqIt.isAny()))
             .returns(() => Promise.resolve({ stdout: 'bad json' }));
         const shellExec = async (c: string, t: number) => deps.object.shellExec(c, t);
 
-        const result = sut.getInterpreterInfo(python, shellExec);
+        const result = getInterpreterInfo(python, shellExec);
 
         await expect(result).to.eventually.be.rejected;
         verifyAll();


### PR DESCRIPTION
This change is part of the work to isolate a "component" for Python environments.  The focus here is on pulling code related to getting interpreter info out of unrelated modules and into the py-envs component.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [X] Title summarizes what is changing.
-   ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   ~[ ] Appropriate comments and documentation strings in the code.~
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] Unit tests & system/integration tests are added/updated.~
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
