### PR TITLE
Pin py to 1.8.1 (CI failure - Windows unit tests)

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -11,6 +11,7 @@ prospector
 pydocstyle
 nose
 pytest==4.6.9 # Last version of pytest with Python 2.7 support
+py==1.8.1
 rope
 flask
 django


### PR DESCRIPTION
For #12372 

Will create a backlog item for fixing the pytest tests to not be dependent on pytest output: https://github.com/microsoft/vscode-python/issues/12416

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
