### PR TITLE
Fix nightly flake tests

### DIFF
--- a/src/client/datascience/themeFinder.ts
+++ b/src/client/datascience/themeFinder.ts
@@ -172,7 +172,7 @@ export class ThemeFinder implements IThemeFinder {
         // Search through all package.json files in the directory and below, looking
         // for the themeName in them.
         const foundPackages = await this.fs.search('**/package.json', rootPath);
-        if (foundPackages.length > 0) {
+        if (foundPackages && foundPackages.length > 0) {
             // For each one, open it up and look for the theme name.
             for (const f of foundPackages) {
                 const fpath = path.join(rootPath, f);

--- a/src/test/datascience/uiTests/helpers.ts
+++ b/src/test/datascience/uiTests/helpers.ts
@@ -69,7 +69,8 @@ export class BaseWebUI implements IAsyncDisposable {
                 this.waitForMessage(CommonActionType.EDITOR_LOADED),
                 this.waitForMessage(CommonActionType.CODE_CREATED), // When a cell has been created.
                 this.waitForMessage(CssMessages.GetMonacoThemeResponse),
-                this.waitForMessage(CssMessages.GetCssResponse)
+                this.waitForMessage(CssMessages.GetCssResponse),
+                this.page?.waitForLoadState()
             ])
         );
     }

--- a/src/test/datascience/uiTests/notebookUi.ts
+++ b/src/test/datascience/uiTests/notebookUi.ts
@@ -59,6 +59,11 @@ export class NotebookEditorUI extends BaseWebUI {
         return items[cellIndex];
     }
     private async getMainToolbarButton(button: MainToolbarButton): Promise<ElementHandle<Element>> {
+        // First wait for the toolbar button to be visible.
+        await this.page!.waitForFunction(
+            `document.querySelectorAll('.toolbar-menu-bar button[role=button]').length && document.querySelectorAll('.toolbar-menu-bar button[role=button]')[${button}].clientHeight != 0`
+        );
+        // Then eval the button
         const buttons = await this.page!.$$('.toolbar-menu-bar button[role=button]');
         if (buttons.length === 0) {
             assert.fail('Main toolbar Buttons not available');


### PR DESCRIPTION
Flake failed last night with this:
https://dev.azure.com/ms/vscode-python/_build/results?buildId=88563&view=ms.vss-test-web.build-test-results-tab&runId=2441774&resultId=100356&paneView=debug

IPyWidget failure I looked up on the internets. Seems like we're not waiting for items to be visible before attempting to click them. Hopefully the wait I added will work.

Fixed live share bug. Not sure what broke this but essentially the mocked file system was being created too early and the web view for the exported notebook wasn't being mounted.