### PR TITLE
Fix regression caused by multiple language support around indentation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -307,7 +307,8 @@
                 "--recursive",
                 "--colors",
                 //"--grep", "<suite name>",
-                "--timeout=300000"
+                "--timeout=300000",
+                "--exit"
             ],
             "env": {
                 // Remove `X` prefix to test with real browser to host DS ui (for DS functional tests).

--- a/news/2 Fixes/12389.md
+++ b/news/2 Fixes/12389.md
@@ -1,0 +1,1 @@
+Auto indentation no longer working for notebooks and interactive window.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -97,6 +97,7 @@ import {
 } from '../types';
 import { WebViewHost } from '../webViewHost';
 import { InteractiveWindowMessageListener } from './interactiveWindowMessageListener';
+import { serializeLanguageConfiguration } from './serialization';
 
 @injectable()
 export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapping> implements IInteractiveBase {
@@ -1401,7 +1402,9 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         // Get the contents of the appropriate tmLanguage file.
         traceInfo('Request for tmlanguage file.');
         const languageJson = await this.themeFinder.findTmLanguage(languageId);
-        const languageConfiguration = await this.themeFinder.findLanguageConfiguration(languageId);
+        const languageConfiguration = serializeLanguageConfiguration(
+            await this.themeFinder.findLanguageConfiguration(languageId)
+        );
         const extensions = languageId === PYTHON_LANGUAGE ? ['.py'] : [];
         const scopeName = `scope.${languageId}`; // This works for python, not sure about c# etc.
         this.postMessage(InteractiveWindowMessages.LoadTmLanguageResponse, {

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -32,6 +32,7 @@ import {
     INotebookModel,
     KernelSocketOptions
 } from '../types';
+import { ILanguageConfigurationDto } from './serialization';
 import { BaseReduxActionPayload } from './types';
 
 export enum InteractiveWindowMessages {
@@ -514,7 +515,7 @@ export interface ILoadTmLanguageResponse {
     languageId: string;
     scopeName: string; // Name in the tmlanguage scope file (scope.python instead of python)
     // tslint:disable-next-line: no-any
-    languageConfiguration: any; // Should actually be of type monacoEditor.languages.LanguageConfiguration but don't want to pull in all those types here.
+    languageConfiguration: ILanguageConfigurationDto;
     languageJSON: string; // Contents of the tmLanguage.json file
     extensions: string[]; // Array of file extensions that map to this language
 }

--- a/src/client/datascience/interactive-common/serialization.ts
+++ b/src/client/datascience/interactive-common/serialization.ts
@@ -123,27 +123,22 @@ export function serializeLanguageConfiguration(
     configuration: LanguageConfiguration | undefined
 ): ILanguageConfigurationDto {
     return {
-        comments: configuration?.comments,
-        brackets: configuration?.brackets,
+        ...configuration,
         wordPattern: configuration?.wordPattern ? _serializeRegExp(configuration.wordPattern) : undefined,
         indentationRules: configuration?.indentationRules
             ? _serializeIndentationRule(configuration.indentationRules)
             : undefined,
-        onEnterRules: configuration?.onEnterRules ? _serializeOnEnterRules(configuration.onEnterRules) : undefined,
-        __electricCharacterSupport: configuration?.__electricCharacterSupport,
-        __characterPairSupport: configuration?.__characterPairSupport
+        onEnterRules: configuration?.onEnterRules ? _serializeOnEnterRules(configuration.onEnterRules) : undefined
     };
 }
 
 export function deserializeLanguageConfiguration(configuration: ILanguageConfigurationDto): LanguageConfiguration {
     return {
-        comments: configuration.comments,
-        brackets: configuration.brackets,
+        ...configuration,
         wordPattern: configuration.wordPattern ? _reviveRegExp(configuration.wordPattern) : undefined,
         indentationRules: configuration.indentationRules
             ? _reviveIndentationRule(configuration.indentationRules)
             : undefined,
-        onEnterRules: configuration.onEnterRules ? _reviveOnEnterRules(configuration.onEnterRules) : undefined,
-        __electricCharacterSupport: undefined
+        onEnterRules: configuration.onEnterRules ? _reviveOnEnterRules(configuration.onEnterRules) : undefined
     };
 }

--- a/src/client/datascience/interactive-common/serialization.ts
+++ b/src/client/datascience/interactive-common/serialization.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { CharacterPair, CommentRule, EnterAction, IndentationRule, LanguageConfiguration, OnEnterRule } from 'vscode';
+
+// tslint:disable: no-any
+
+export interface IRegExpDto {
+    pattern: string;
+    flags?: string;
+}
+export interface IIndentationRuleDto {
+    decreaseIndentPattern: IRegExpDto;
+    increaseIndentPattern: IRegExpDto;
+    indentNextLinePattern?: IRegExpDto;
+    unIndentedLinePattern?: IRegExpDto;
+}
+export interface IOnEnterRuleDto {
+    beforeText: IRegExpDto;
+    afterText?: IRegExpDto;
+    oneLineAboveText?: IRegExpDto;
+    action: EnterAction;
+}
+export interface ILanguageConfigurationDto {
+    comments?: CommentRule;
+    brackets?: CharacterPair[];
+    wordPattern?: IRegExpDto;
+    indentationRules?: IIndentationRuleDto;
+    onEnterRules?: IOnEnterRuleDto[];
+    __electricCharacterSupport?: {
+        brackets?: any;
+        docComment?: {
+            scope: string;
+            open: string;
+            lineStart: string;
+            close?: string;
+        };
+    };
+    __characterPairSupport?: {
+        autoClosingPairs: {
+            open: string;
+            close: string;
+            notIn?: string[];
+        }[];
+    };
+}
+// Copied most of this from VS code directly.
+
+function regExpFlags(regexp: RegExp): string {
+    return (
+        (regexp.global ? 'g' : '') +
+        (regexp.ignoreCase ? 'i' : '') +
+        (regexp.multiline ? 'm' : '') +
+        ((regexp as any) /* standalone editor compilation */.unicode ? 'u' : '')
+    );
+}
+
+function _serializeRegExp(regExp: RegExp): IRegExpDto {
+    return {
+        pattern: regExp.source,
+        flags: regExpFlags(regExp)
+    };
+}
+
+function _serializeIndentationRule(indentationRule: IndentationRule): IIndentationRuleDto {
+    return {
+        decreaseIndentPattern: _serializeRegExp(indentationRule.decreaseIndentPattern),
+        increaseIndentPattern: _serializeRegExp(indentationRule.increaseIndentPattern),
+        indentNextLinePattern: indentationRule.indentNextLinePattern
+            ? _serializeRegExp(indentationRule.indentNextLinePattern)
+            : undefined,
+        unIndentedLinePattern: indentationRule.unIndentedLinePattern
+            ? _serializeRegExp(indentationRule.unIndentedLinePattern)
+            : undefined
+    };
+}
+
+function _serializeOnEnterRule(onEnterRule: OnEnterRule): IOnEnterRuleDto {
+    return {
+        beforeText: _serializeRegExp(onEnterRule.beforeText),
+        afterText: onEnterRule.afterText ? _serializeRegExp(onEnterRule.afterText) : undefined,
+        oneLineAboveText: (onEnterRule as any).oneLineAboveText
+            ? _serializeRegExp((onEnterRule as any).oneLineAboveText)
+            : undefined,
+        action: onEnterRule.action
+    };
+}
+
+function _serializeOnEnterRules(onEnterRules: OnEnterRule[]): IOnEnterRuleDto[] {
+    return onEnterRules.map(_serializeOnEnterRule);
+}
+
+function _reviveRegExp(regExp: IRegExpDto): RegExp {
+    return new RegExp(regExp.pattern, regExp.flags);
+}
+
+function _reviveIndentationRule(indentationRule: IIndentationRuleDto): IndentationRule {
+    return {
+        decreaseIndentPattern: _reviveRegExp(indentationRule.decreaseIndentPattern),
+        increaseIndentPattern: _reviveRegExp(indentationRule.increaseIndentPattern),
+        indentNextLinePattern: indentationRule.indentNextLinePattern
+            ? _reviveRegExp(indentationRule.indentNextLinePattern)
+            : undefined,
+        unIndentedLinePattern: indentationRule.unIndentedLinePattern
+            ? _reviveRegExp(indentationRule.unIndentedLinePattern)
+            : undefined
+    };
+}
+
+function _reviveOnEnterRule(onEnterRule: IOnEnterRuleDto): OnEnterRule {
+    return {
+        beforeText: _reviveRegExp(onEnterRule.beforeText),
+        afterText: onEnterRule.afterText ? _reviveRegExp(onEnterRule.afterText) : undefined,
+        oneLineAboveText: onEnterRule.oneLineAboveText ? _reviveRegExp(onEnterRule.oneLineAboveText) : undefined,
+        action: onEnterRule.action
+    } as any;
+}
+
+function _reviveOnEnterRules(onEnterRules: IOnEnterRuleDto[]): OnEnterRule[] {
+    return onEnterRules.map(_reviveOnEnterRule);
+}
+
+export function serializeLanguageConfiguration(
+    configuration: LanguageConfiguration | undefined
+): ILanguageConfigurationDto {
+    return {
+        comments: configuration?.comments,
+        brackets: configuration?.brackets,
+        wordPattern: configuration?.wordPattern ? _serializeRegExp(configuration.wordPattern) : undefined,
+        indentationRules: configuration?.indentationRules
+            ? _serializeIndentationRule(configuration.indentationRules)
+            : undefined,
+        onEnterRules: configuration?.onEnterRules ? _serializeOnEnterRules(configuration.onEnterRules) : undefined,
+        __electricCharacterSupport: configuration?.__electricCharacterSupport,
+        __characterPairSupport: configuration?.__characterPairSupport
+    };
+}
+
+export function deserializeLanguageConfiguration(configuration: ILanguageConfigurationDto): LanguageConfiguration {
+    return {
+        comments: configuration.comments,
+        brackets: configuration.brackets,
+        wordPattern: configuration.wordPattern ? _reviveRegExp(configuration.wordPattern) : undefined,
+        indentationRules: configuration.indentationRules
+            ? _reviveIndentationRule(configuration.indentationRules)
+            : undefined,
+        onEnterRules: configuration.onEnterRules ? _reviveOnEnterRules(configuration.onEnterRules) : undefined,
+        __electricCharacterSupport: undefined
+    };
+}

--- a/src/datascience-ui/interactive-common/redux/reducers/monaco.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/monaco.ts
@@ -15,6 +15,7 @@ import {
     IProvideSignatureHelpResponse,
     IResolveCompletionItemResponse
 } from '../../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { deserializeLanguageConfiguration } from '../../../../client/datascience/interactive-common/serialization';
 import { BaseReduxActionPayload } from '../../../../client/datascience/interactive-common/types';
 import { CssMessages } from '../../../../client/datascience/messages';
 import { IGetMonacoThemeResponse } from '../../../../client/datascience/monacoMessages';
@@ -111,7 +112,7 @@ function handleLoadTmLanguageResponse(arg: MonacoReducerArg<ILoadTmLanguageRespo
                     arg.payload.data.languageId,
                     arg.payload.data.extensions,
                     arg.payload.data.scopeName,
-                    arg.payload.data.languageConfiguration,
+                    deserializeLanguageConfiguration(arg.payload.data.languageConfiguration),
                     arg.payload.data.languageJSON
                 );
             }

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -922,6 +922,13 @@ for i in range(0, 100):
             addMockData(ioc, 'print("hello")', 'hello');
             await enterInput(wrapper, ioc, 'print("hello', 'InteractiveCell');
             verifyHtmlOnCell(wrapper, 'InteractiveCell', 'hello', CellPosition.Last);
+
+            // Verify auto indent is working
+            const editor = getInteractiveEditor(wrapper);
+            typeCode(editor, 'if (True):\n');
+            typeCode(editor, 'print("true")');
+            const reactEditor = editor.instance() as MonacoEditor;
+            assert.equal(reactEditor.state.model?.getValue().replace(/\r/g, ''), `if (True):\n    print("true")`);
         },
         () => {
             return ioc;


### PR DESCRIPTION
For #12389

The root cause of this bug was the change made to pull language configuration information from the extension instead of embedding it in the UI. 

The transfer of the language configuration from the extension to the UI loses all regular expressions this way, breaking the regex parsing. This is used for things like determining when to auto-ident.

Fix was to serialize the contents of the regular expressions.

