### PR TITLE
Remove path from untitled files when using VSC NB

### DIFF
--- a/src/client/datascience/common.ts
+++ b/src/client/datascience/common.ts
@@ -132,17 +132,20 @@ export function translateKernelLanguageToMonaco(kernelLanguage: string): string 
     return kernelLanguage.toLowerCase();
 }
 
-export function generateNewNotebookUri(counter: number, title?: string): Uri {
-    // Because of this bug here:
-    // https://github.com/microsoft/vscode/issues/93441
-    // We can't create 'untitled' files anymore. The untitled scheme will just be ignored.
-    // Instead we need to create untitled files in the temp folder and force a saveas whenever they're
-    // saved.
-
+export function generateNewNotebookUri(counter: number, title?: string, forVSCodeNotebooks?: boolean): Uri {
     // However if there are files already on disk, we should be able to overwrite them because
     // they will only ever be used by 'open' editors. So just use the current counter for our untitled count.
     const fileName = title ? `${title}-${counter}.ipynb` : `${DataScience.untitledNotebookFileName()}-${counter}.ipynb`;
-    const filePath = Uri.file(path.join(os.tmpdir(), fileName));
     // Turn this back into an untitled
-    return filePath.with({ scheme: 'untitled', path: filePath.fsPath });
+    if (forVSCodeNotebooks) {
+        return Uri.file(fileName).with({ scheme: 'untitled', path: fileName });
+    } else {
+        // Because of this bug here:
+        // https://github.com/microsoft/vscode/issues/93441
+        // We can't create 'untitled' files anymore. The untitled scheme will just be ignored.
+        // Instead we need to create untitled files in the temp folder and force a saveas whenever they're
+        // saved.
+        const filePath = Uri.file(path.join(os.tmpdir(), fileName));
+        return filePath.with({ scheme: 'untitled', path: filePath.fsPath });
+    }
 }

--- a/src/client/datascience/interactive-ipynb/notebookStorageProvider.ts
+++ b/src/client/datascience/interactive-ipynb/notebookStorageProvider.ts
@@ -15,7 +15,7 @@ import { getNextUntitledCounter } from './nativeEditorStorage';
 
 export const INotebookStorageProvider = Symbol.for('INotebookStorageProvider');
 export interface INotebookStorageProvider extends INotebookStorage {
-    createNew(contents?: string): Promise<INotebookModel>;
+    createNew(contents?: string, forVSCodeNotebook?: boolean): Promise<INotebookModel>;
 }
 @injectable()
 export class NotebookStorageProvider implements INotebookStorageProvider {
@@ -80,16 +80,16 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
         }
     }
 
-    public async createNew(contents?: string): Promise<INotebookModel> {
+    public async createNew(contents?: string, forVSCodeNotebooks?: boolean): Promise<INotebookModel> {
         // Create a new URI for the dummy file using our root workspace path
-        const uri = this.getNextNewNotebookUri();
+        const uri = this.getNextNewNotebookUri(forVSCodeNotebooks);
 
         // Always skip loading from the hot exit file. When creating a new file we want a new file.
         return this.load(uri, contents, true);
     }
 
-    private getNextNewNotebookUri(): Uri {
-        return generateNewNotebookUri(NotebookStorageProvider.untitledCounter);
+    private getNextNewNotebookUri(forVSCodeNotebooks?: boolean): Uri {
+        return generateNewNotebookUri(NotebookStorageProvider.untitledCounter, undefined, forVSCodeNotebooks);
     }
 
     private trackModel(model: INotebookModel): INotebookModel {

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -131,7 +131,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         return;
     }
     public async createNew(contents?: string): Promise<INotebookEditor> {
-        const model = await this.storage.createNew(contents);
+        const model = await this.storage.createNew(contents, true);
         return this.open(model.file);
     }
     private onEditorOpened(editor: INotebookEditor): void {


### PR DESCRIPTION
For #10496

We don't need the fully qualified path for untitled notebooks.
However auto saving in untitiled nb doesn't work, VSC Master has a fix but we're waiting for insiders to get updated.