### PR TITLE
Minor refactoring to notebook model

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -131,15 +131,6 @@ export class NativeEditorNotebookModel implements INotebookModel {
         this._isDisposed = true;
         this._disposed.fire();
     }
-    public clone(file: Uri) {
-        return new NativeEditorNotebookModel(
-            this.useNativeEditorApi,
-            file,
-            cloneDeep(this._state.cells),
-            cloneDeep(this._state.notebookJson),
-            this.indentAmount
-        );
-    }
     public update(change: NotebookModelChange): void {
         this.handleModelChange(change);
     }
@@ -495,7 +486,8 @@ export class NativeEditorNotebookModel implements INotebookModel {
 }
 
 /**
- * Temporary hack to ensure we can use VS Code notebooks along with our standard notbooked editors.
+ * Marks a model as being used solely by VS Code Notebooks editor.
+ * (this is required, because at the time of loading a notebook its not always possible to know what editor will use it).
  */
 export function updateModelForUseWithVSCodeNotebook(model: INotebookModel) {
     if (!(model instanceof NativeEditorNotebookModel)) {

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -19,8 +19,6 @@ import { CellState, ICell, IJupyterExecution, IJupyterKernelSpec, INotebookModel
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 import detectIndent = require('detect-indent');
-// tslint:disable-next-line:no-require-imports no-var-requires
-import cloneDeep = require('lodash/cloneDeep');
 import { UseVSCodeNotebookEditorApi } from '../../common/constants';
 import { isFileNotFoundError } from '../../common/platform/errors';
 import { sendTelemetryEvent } from '../../telemetry';

--- a/src/client/datascience/notebook/contentProvider.ts
+++ b/src/client/datascience/notebook/contentProvider.ts
@@ -15,11 +15,10 @@ import type {
     NotebookDocumentOpenContext
 } from 'vscode-proposed';
 import { ICommandManager } from '../../common/application/types';
-import { MARKDOWN_LANGUAGE, UseVSCodeNotebookEditorApi } from '../../common/constants';
+import { MARKDOWN_LANGUAGE } from '../../common/constants';
 import { DataScience } from '../../common/utils/localize';
 import { captureTelemetry } from '../../telemetry';
 import { Telemetry } from '../constants';
-import { updateModelForUseWithVSCodeNotebook } from '../interactive-ipynb/nativeEditorStorage';
 import { INotebookStorageProvider } from '../interactive-ipynb/notebookStorageProvider';
 import { notebookModelToVSCNotebookData } from './helpers/helpers';
 import { NotebookEditorCompatibilitySupport } from './notebookEditorCompatibilitySupport';
@@ -43,7 +42,6 @@ export class NotebookContentProvider implements VSCodeNotebookContentProvider {
     constructor(
         @inject(INotebookStorageProvider) private readonly notebookStorage: INotebookStorageProvider,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(UseVSCodeNotebookEditorApi) private readonly useVSCodeNotebookEditorApi: boolean,
         @inject(NotebookEditorCompatibilitySupport)
         private readonly compatibilitySupport: NotebookEditorCompatibilitySupport
     ) {}
@@ -69,10 +67,6 @@ export class NotebookContentProvider implements VSCodeNotebookContentProvider {
         const model = await (openContext.backupId
             ? this.notebookStorage.load(uri, undefined, openContext.backupId)
             : this.notebookStorage.load(uri, undefined, true));
-        // If experiment is not enabled, then this method was invoked as user opted to try and open using the new API.
-        if (!this.useVSCodeNotebookEditorApi) {
-            updateModelForUseWithVSCodeNotebook(model);
-        }
         return notebookModelToVSCNotebookData(model);
     }
     @captureTelemetry(Telemetry.Save, undefined, true)

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -20,6 +20,7 @@ import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import { createDeferred, Deferred } from '../../common/utils/async';
 import { IServiceContainer } from '../../ioc/types';
 import { Commands } from '../constants';
+import { updateModelForUseWithVSCodeNotebook } from '../interactive-ipynb/nativeEditorStorage';
 import { INotebookStorageProvider } from '../interactive-ipynb/notebookStorageProvider';
 import { INotebookEditor, INotebookEditorProvider, INotebookProvider, IStatusProvider } from '../types';
 import { JupyterNotebookView } from './constants';
@@ -152,6 +153,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         }
         const uri = doc.uri;
         const model = await this.storage.load(uri);
+        updateModelForUseWithVSCodeNotebook(model); // take ownership of this model.
         mapVSCNotebookCellsToNotebookCellModels(doc, model);
         // In open method we might be waiting.
         let editor = this.notebookEditorsByUri.get(uri.toString());

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1017,7 +1017,6 @@ export interface INotebookModel {
     applyEdits(edits: readonly NotebookModelChange[]): Thenable<void>;
     undoEdits(edits: readonly NotebookModelChange[]): Thenable<void>;
     update(change: NotebookModelChange): void;
-    clone(file: Uri): INotebookModel;
     /**
      * Dispose of the Notebook model.
      *

--- a/src/test/datascience/notebook/contentProvider.unit.test.ts
+++ b/src/test/datascience/notebook/contentProvider.unit.test.ts
@@ -30,7 +30,6 @@ suite('Data Science - NativeNotebook ContentProvider', () => {
         contentProvider = new NotebookContentProvider(
             instance(storageProvider),
             instance(commandManager),
-            true,
             instance(compatSupport)
         );
     });


### PR DESCRIPTION
For #10496

* Take ownership of a notebook model when it is opened (not when it is created)
* Delete `clone` method.