### PR TITLE
Set max height for variable explorer

### DIFF
--- a/src/datascience-ui/interactive-common/variableExplorer.tsx
+++ b/src/datascience-ui/interactive-common/variableExplorer.tsx
@@ -306,8 +306,9 @@ export class VariableExplorer extends React.Component<IVariableExplorerProps, IV
 
         // min height is one row of visible data
         const minHeight = this.getRowHeight() * 2 + variableExplorerMenuBar.clientHeight;
+        const maxHeight = document.body.scrollHeight - this.props.offsetHeight - variableExplorerMenuBar.clientHeight;
 
-        if (updatedHeight >= minHeight) {
+        if (updatedHeight >= minHeight && updatedHeight <= maxHeight) {
             this.setState({
                 containerHeight: updatedHeight
             });


### PR DESCRIPTION
Previously you could resize the variable explorer off the screen. Now it does not let you resize it off the screen (will stop right at the bottom). 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
