### PR TITLE
Changed session manager to account for bearer token

### DIFF
--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -257,6 +257,9 @@ export class JupyterSessionManager implements IJupyterSessionManager {
                 throw new Error(localize.DataScience.passwordFailure());
             }
         } else {
+            // pass in the bearer token as the request header
+            const bearerRequestHeader = {Authorization: 'Bearer <bearer_token_here>'};
+            requestInit = { ...requestInit, headers: bearerRequestHeader};
             serverSettings = { ...serverSettings, token: connInfo.token };
         }
 


### PR DESCRIPTION
Added bearer token as an authorization to send as part of the request object. We only want to do this when we pass in the bearer token as the session "token" as well (otherwise it cannot authenticate against the Jupyter server).