### PR TITLE
Fixed bug in exporting notebook to HTML

### DIFF
--- a/src/client/datascience/export/exportManagerFileOpener.ts
+++ b/src/client/datascience/export/exportManagerFileOpener.ts
@@ -31,7 +31,7 @@ export class ExportManagerFileOpener implements IExportManager {
             uri = await this.manager.export(format, model);
         } catch (e) {
             traceError('Export failed', e);
-            await this.showExportFailed(e);
+            this.showExportFailed(e);
             sendTelemetryEvent(Telemetry.ExportNotebookAsFailed, undefined, { format: format });
             return;
         } finally {
@@ -68,11 +68,13 @@ export class ExportManagerFileOpener implements IExportManager {
         await this.documentManager.showTextDocument(doc);
     }
 
-    private async showExportFailed(msg: string) {
-        await this.applicationShell.showErrorMessage(
-            // tslint:disable-next-line: messages-must-be-localized
-            `${getLocString('DataScience.failedExportMessage', 'Export failed')} ${msg}`
-        );
+    private showExportFailed(msg: string) {
+        this.applicationShell
+            .showErrorMessage(
+                // tslint:disable-next-line: messages-must-be-localized
+                `${getLocString('DataScience.failedExportMessage', 'Export failed')} ${msg}`
+            )
+            .then();
     }
 
     private async askOpenFile(uri: Uri): Promise<boolean> {

--- a/src/client/datascience/export/exportToHTML.ts
+++ b/src/client/datascience/export/exportToHTML.ts
@@ -15,6 +15,6 @@ export class ExportToHTML extends ExportBase {
             '--output-dir',
             path.dirname(target.fsPath)
         ];
-        await this.executeCommand(source, args);
+        await this.executeCommand(source, target, args);
     }
 }


### PR DESCRIPTION
There are some notebooks that contain special lines or cells that cause NBConvert to fail to export them. If you'd like an example of such notebook I've attached a link to one. Previously when attempting to export this notebooks no error message would be displayed. In other words, I had not handled some edge cases where the export fails in one specific method (check files to see where). This PR simply handles the case where the export fails and displays the appropriate error message to the user.

Link to download notebook you can use to Repro: https://microsoft.sharepoint.com/teams/python/Shared%20Documents/test%20.ipynb%20notebooks/Core_Learning_Algorithms.ipynb

Simply open the notebook and try to export it to .html (you will need the latest master branch changes).

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~


