### PR TITLE
Discard notebook changes when the user clicks don't save

### DIFF
--- a/news/2 Fixes/12180.md
+++ b/news/2 Fixes/12180.md
@@ -1,0 +1,1 @@
+Discard changes on Notebooks when the user selects 'Don't Save' on the save changes dialog.

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -174,6 +174,10 @@ export class NativeEditorOldWebView extends NativeEditor {
                     break;
 
                 case AskForSaveResult.No:
+                    // If there were changes, delete them
+                    if (this.model) {
+                        await this.storage.deleteBackup(this.model);
+                    }
                     // Close it
                     await super.close();
                     break;


### PR DESCRIPTION
For #12180

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
