### PR TITLE
Fix #12446: Stock launch.json "attach" configs should be using "connect"

### DIFF
--- a/news/1 Enhancements/12446.md
+++ b/news/1 Enhancements/12446.md
@@ -1,0 +1,1 @@
+Change stock launch.json "attach" config to use "connect".

--- a/src/client/debugger/extension/configuration/providers/remoteAttach.ts
+++ b/src/client/debugger/extension/configuration/providers/remoteAttach.ts
@@ -25,8 +25,10 @@ export class RemoteAttachDebugConfigurationProvider implements IDebugConfigurati
             name: DebugConfigStrings.attach.snippet.name(),
             type: DebuggerTypeName,
             request: 'attach',
-            port: defaultPort,
-            host: defaultHost,
+            connect: {
+                host: defaultHost,
+                port: defaultPort
+            },
             pathMappings: [
                 {
                     // tslint:disable-next-line:no-invalid-template-strings
@@ -36,37 +38,40 @@ export class RemoteAttachDebugConfigurationProvider implements IDebugConfigurati
             ]
         };
 
-        config.host = await input.showInputBox({
+        const connect = config.connect!;
+        connect.host = await input.showInputBox({
             title: DebugConfigStrings.attach.enterRemoteHost.title(),
             step: 1,
             totalSteps: 2,
-            value: config.host || defaultHost,
+            value: connect.host || defaultHost,
             prompt: DebugConfigStrings.attach.enterRemoteHost.prompt(),
             validate: (value) =>
                 Promise.resolve(
                     value && value.trim().length > 0 ? undefined : DebugConfigStrings.attach.enterRemoteHost.invalid()
                 )
         });
-        if (!config.host) {
-            config.host = defaultHost;
+        if (!connect.host) {
+            connect.host = defaultHost;
         }
 
         sendTelemetryEvent(EventName.DEBUGGER_CONFIGURATION_PROMPTS, undefined, {
             configurationType: DebugConfigurationType.remoteAttach,
-            manuallyEnteredAValue: config.host !== defaultHost
+            manuallyEnteredAValue: connect.host !== defaultHost
         });
         Object.assign(state.config, config);
         return (_) => this.configurePort(input, state.config);
     }
+
     protected async configurePort(
         input: MultiStepInput<DebugConfigurationState>,
         config: Partial<AttachRequestArguments>
     ) {
+        const connect = config.connect || (config.connect = {});
         const port = await input.showInputBox({
             title: DebugConfigStrings.attach.enterRemotePort.title(),
             step: 2,
             totalSteps: 2,
-            value: (config.port || defaultPort).toString(),
+            value: (connect.port || defaultPort).toString(),
             prompt: DebugConfigStrings.attach.enterRemotePort.prompt(),
             validate: (value) =>
                 Promise.resolve(
@@ -76,14 +81,14 @@ export class RemoteAttachDebugConfigurationProvider implements IDebugConfigurati
                 )
         });
         if (port && /^\d+$/.test(port.trim())) {
-            config.port = parseInt(port, 10);
+            connect.port = parseInt(port, 10);
         }
-        if (!config.port) {
-            config.port = defaultPort;
+        if (!connect.port) {
+            connect.port = defaultPort;
         }
         sendTelemetryEvent(EventName.DEBUGGER_CONFIGURATION_PROMPTS, undefined, {
             configurationType: DebugConfigurationType.remoteAttach,
-            manuallyEnteredAValue: config.port !== defaultPort
+            manuallyEnteredAValue: connect.port !== defaultPort
         });
     }
 }

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -27,8 +27,8 @@ export type PathMapping = {
     remoteRoot: string;
 };
 export type Connection = {
-    host: string;
-    port: number;
+    host?: string;
+    port?: number;
 };
 
 interface ICommonDebugArguments {

--- a/src/test/debugger/extension/configuration/providers/remoteAttach.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/remoteAttach.unit.test.ts
@@ -40,31 +40,31 @@ suite('Debugging - Configuration Provider Remote Attach', () => {
         verify(input.showInputBox(anything())).once();
     });
     test('Configure port will default to 5678 if entered value is not a number', async () => {
-        const config: { port?: number } = {};
+        const config: { connect?: { port?: number } } = {};
         when(input.showInputBox(anything())).thenResolve('xyz');
 
         await provider.configurePort(instance(input), config);
 
         verify(input.showInputBox(anything())).once();
-        expect(config.port).to.equal(5678);
+        expect(config).to.be.deep.equal({ connect: { port: 5678 } });
     });
     test('Configure port will default to 5678', async () => {
-        const config: { port?: number } = {};
+        const config: { connect?: { port?: number } } = {};
         when(input.showInputBox(anything())).thenResolve();
 
         await provider.configurePort(instance(input), config);
 
         verify(input.showInputBox(anything())).once();
-        expect(config.port).to.equal(5678);
+        expect(config).to.be.deep.equal({ connect: { port: 5678 } });
     });
     test('Configure port will use user selected value', async () => {
-        const config: { port?: number } = {};
+        const config: { connect?: { port?: number } } = {};
         when(input.showInputBox(anything())).thenResolve('1234');
 
         await provider.configurePort(instance(input), config);
 
         verify(input.showInputBox(anything())).once();
-        expect(config.port).to.equal(1234);
+        expect(config).to.be.deep.equal({ connect: { port: 1234 } });
     });
     test('Launch JSON with default host name', async () => {
         const folder = { uri: Uri.parse(path.join('one', 'two')), name: '1', index: 0 };
@@ -85,8 +85,10 @@ suite('Debugging - Configuration Provider Remote Attach', () => {
             name: DebugConfigStrings.attach.snippet.name(),
             type: DebuggerTypeName,
             request: 'attach',
-            port: 5678,
-            host: 'localhost',
+            connect: {
+                host: 'localhost',
+                port: 5678
+            },
             pathMappings: [
                 {
                     localRoot: '${workspaceFolder}',
@@ -105,7 +107,7 @@ suite('Debugging - Configuration Provider Remote Attach', () => {
         when(input.showInputBox(anything())).thenResolve('Hello');
         provider.configurePort = (_, cfg) => {
             portConfigured = true;
-            cfg.port = 9999;
+            cfg.connect!.port = 9999;
             return Promise.resolve();
         };
 
@@ -118,8 +120,10 @@ suite('Debugging - Configuration Provider Remote Attach', () => {
             name: DebugConfigStrings.attach.snippet.name(),
             type: DebuggerTypeName,
             request: 'attach',
-            port: 9999,
-            host: 'Hello',
+            connect: {
+                host: 'Hello',
+                port: 9999
+            },
             pathMappings: [
                 {
                     localRoot: '${workspaceFolder}',


### PR DESCRIPTION
Change RemoteAttachDebugConfigurationProvider to generate configs with "connect".

For #12446

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
