### PR TITLE
DS: Ensure atomic key creation for use with trusted notebooks

### DIFF
--- a/src/client/datascience/crossProcessLock.ts
+++ b/src/client/datascience/crossProcessLock.ts
@@ -1,0 +1,58 @@
+import { open, unlink } from 'fs-extra';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { sleep } from '../common/utils/async';
+
+export class CrossProcessLock {
+    private lockFilePath: string;
+    private acquired: boolean = false;
+
+    constructor(mutexName: string) {
+        this.lockFilePath = path.join(tmpdir(), `${mutexName}.tmp`);
+    }
+
+    public async lock(): Promise<boolean> {
+        const maxTries = 10;
+        let tries = 0;
+        while (!this.acquired && tries < maxTries) {
+            try {
+                await this.acquire();
+                if (this.acquired) {
+                    return true;
+                }
+                await sleep(100);
+            } catch (err) {
+                // Swallow the error and retry
+            }
+            tries += 1;
+        }
+        return false;
+    }
+
+    public async unlock() {
+        // Does nothing if the lock is not currently held
+        if (this.acquired) {
+            // Delete the lockfile
+            await unlink(this.lockFilePath);
+            this.acquired = false;
+        }
+    }
+
+    /*
+    One of the few atomicity guarantees that the node fs module appears to provide
+    is with fs.open(). With the 'wx' option flags, open() will error if the
+    file already exists, which tells us if it was already created in another process.
+    Hence we can use the existence of the file as a flag indicating whether we have
+    successfully acquired the right to create the keyfile.
+    */
+    private async acquire() {
+        try {
+            await open(this.lockFilePath, 'wx');
+            this.acquired = true;
+        } catch (err) {
+            if (err.code !== 'EEXIST') {
+                throw err;
+            }
+        }
+    }
+}

--- a/src/test/datascience/crossProcessLock.unit.test.ts
+++ b/src/test/datascience/crossProcessLock.unit.test.ts
@@ -1,8 +1,4 @@
 import { assert } from 'chai';
-import { unlink } from 'fs';
-import { tmpdir } from 'os';
-import * as path from 'path';
-import { traceError } from '../../client/common/logger';
 import { sleep } from '../../client/common/utils/async';
 import { CrossProcessLock } from '../../client/datascience/crossProcessLock';
 
@@ -18,9 +14,8 @@ suite('Cross process lock', async () => {
 
     suiteTeardown(async () => {
         // Delete the lockfile so it's clean for the next run
-        unlink(path.join(tmpdir(), 'crossProcessLockUnitTest.tmp'), (err) => {
-            traceError(err);
-        });
+        // Note that mutex2 should not have been acquired so there's no need to unlock it
+        await mutex1.unlock();
     });
 
     test('Lock guarantees in-process mutual exclusion', async () => {

--- a/src/test/datascience/crossProcessLock.unit.test.ts
+++ b/src/test/datascience/crossProcessLock.unit.test.ts
@@ -1,0 +1,32 @@
+import { assert } from 'chai';
+import { unlink } from 'fs';
+import { tmpdir } from 'os';
+import * as path from 'path';
+import { traceError } from '../../client/common/logger';
+import { sleep } from '../../client/common/utils/async';
+import { CrossProcessLock } from '../../client/datascience/crossProcessLock';
+
+suite('Cross process lock', async () => {
+    let mutex1: CrossProcessLock;
+    let mutex2: CrossProcessLock;
+
+    suiteSetup(() => {
+        // Create two named mutexes with the same name
+        mutex1 = new CrossProcessLock('crossProcessLockUnitTest');
+        mutex2 = new CrossProcessLock('crossProcessLockUnitTest');
+    });
+
+    suiteTeardown(async () => {
+        // Delete the lockfile so it's clean for the next run
+        unlink(path.join(tmpdir(), 'crossProcessLockUnitTest.tmp'), (err) => {
+            traceError(err);
+        });
+    });
+
+    test('Lock guarantees in-process mutual exclusion', async () => {
+        const result1 = await mutex1.lock();
+        assert.equal(result1, true); // Expect to successfully acquire the lock since it's not held
+        const result2 = await Promise.race([mutex2.lock(), sleep(1000)]);
+        assert.equal(result2, 1000); // Expect the sleep to resolve before the mutex is acquired
+    }).timeout(10000);
+});


### PR DESCRIPTION
For #12146 

# Summary

This PR introduces an implementation of a cross process lock for ensuring that only one keyfile is created on the user's system. The implementation uses the existence of a temporary lockfile as a flag for whether the process can safely proceed to read from and write to the actual keyfile. 

This only works assuming that Node's `fs.open` guarantees atomicity when in `wx` mode (will fail if the file already exists), which is what their documentation suggests.

# Why is this PR necessary?

Since each instance of VS Code runs in its own process, if two instances of VS Code are running, they may each attempt to initialize their own keyfile. For example, the following event interleaving is possible:

0. User has ipynbs open in 2 instances of VS Code, and does not already have a keyfile on their system (e.g. when we first ship this feature)
1. VS Code Instance A checks if keyfile exists, thinks it doesn't exist
2. VS Code Instance B checks if keyfile exists, thinks it doesn't exist
3. Instance A writes the keyfile with randomly generated key X
4. Instance A computes and stores a digest with randomly generated key X
5. Instance B writes the keyfile with randomly generated key Y

The consequence of this is that a digest could added to the trust store by Instance A that was computed with an overwritten key X. Therefore *notebooks which should be trusted will appear untrusted* when the notebook being edited in Instance A is opened again. (This is not as bad as untrusted notebooks appearing trusted, but is still incorrect behavior.)

Therefore the problem is that we need to coordinate the creation of a keyfile between potentially multiple VS Code instances, despite them operating in their own processes.

# Alternatives considered

1. One approach that probably won't work is to have each instance write the secret key to a temp file and copying it to the true destination, where the copy operation fails if the file already exists. Theoretically this would ensure that the first writer wins. However, we can't use this because Node's `fs` module [doesn't guarantee](https://nodejs.org/api/fs.html#fs_fspromises_copyfile_src_dest_mode) the atomicity of the copy operation across processes.

2. Another common approach is to use a named mutex (a mutex that can be identified between processes by a unique name). There are existing solutions like the `named-mutex` npm package. However, this package uses `flockSync` from `fs-ext`, which I believe (please correct if I'm wrong) is a native node module that does not appear to use napi, and which we would need to ship precompiled binaries for. This is why I've implemented our own named mutex. If it turns out that we can actually ship with `fs-ext` as a dependency we should probably use `named-mutex` instead.

3. There's a popular npm package called `write-file-atomic` which would have been nice to use, but it doesn't offer a way to specify that the write should fail if the file already exists, which is really the behavior we're after.

# Notes/known problems
- If a process crashes while holding the lock, there's currently no mechanism to free it. If this happens, it will result in all notebooks thereafter appearing untrusted. I.e. we need some heuristic to determine when it's safe to delete the lockfile (perhaps at startup if we can check that no other VS Code instances are running?).
- Atomicity isn't guaranteed in some NFS environments, as described [here](https://man7.org/linux/man-pages/man2/open.2.html).


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
