### PR TITLE
Move remaining "virtual"-env-related code to the py-envs component tree.

### DIFF
--- a/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
@@ -12,7 +12,7 @@ import { ITerminalActivationCommandProvider, TerminalShellType } from '../types'
 
 @injectable()
 export abstract class BaseActivationCommandProvider implements ITerminalActivationCommandProvider {
-    constructor(protected readonly serviceContainer: IServiceContainer) {}
+    constructor(@inject(IServiceContainer) protected readonly serviceContainer: IServiceContainer) {}
 
     public abstract isShellSupported(targetShell: TerminalShellType): boolean;
     public getActivationCommands(
@@ -32,17 +32,11 @@ export abstract class BaseActivationCommandProvider implements ITerminalActivati
 export type ActivationScripts = Record<TerminalShellType, string[]>;
 
 export abstract class VenvBaseActivationCommandProvider extends BaseActivationCommandProvider {
-    constructor(
-        protected readonly scripts: ActivationScripts,
-        // This is passed through.
-        serviceContainer: IServiceContainer
-    ) {
-        super(serviceContainer);
-    }
-
     public isShellSupported(targetShell: TerminalShellType): boolean {
         return this.scripts[targetShell] !== undefined;
     }
+
+    protected abstract get scripts(): ActivationScripts;
 
     protected async findScriptFile(pythonPath: string, targetShell: TerminalShellType): Promise<string | undefined> {
         const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);

--- a/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
@@ -5,6 +5,7 @@ import { injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
+import { resolveVenvExecutable } from '../../../pythonEnvironments/discovery/subenv';
 import { IFileSystem } from '../../platform/types';
 import { IConfigurationService } from '../../types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
@@ -30,8 +31,10 @@ export abstract class BaseActivationCommandProvider implements ITerminalActivati
     protected async findScriptFile(pythonPath: string, scriptFileNames: string[]): Promise<string | undefined> {
         const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
         for (const scriptFileName of scriptFileNames) {
-            // Generate scripts are found in the same directory as the interpreter.
-            const scriptFile = path.join(path.dirname(pythonPath), scriptFileName);
+            const scriptFile = resolveVenvExecutable(pythonPath, scriptFileName, path);
+            if (!scriptFile) {
+                return;
+            }
             const found = await fs.fileExists(scriptFile);
             if (found) {
                 return scriptFile;

--- a/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/baseActivationProvider.ts
@@ -5,7 +5,7 @@ import { injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { IServiceContainer } from '../../../ioc/types';
-import { resolveVenvExecutable } from '../../../pythonEnvironments/discovery/subenv';
+import { findVenvExecutable } from '../../../pythonEnvironments/discovery/subenv';
 import { IFileSystem } from '../../platform/types';
 import { IConfigurationService } from '../../types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
@@ -27,18 +27,26 @@ export abstract class BaseActivationCommandProvider implements ITerminalActivati
         pythonPath: string,
         targetShell: TerminalShellType
     ): Promise<string[] | undefined>;
+}
 
-    protected async findScriptFile(pythonPath: string, scriptFileNames: string[]): Promise<string | undefined> {
+export type ActivationScripts = Record<TerminalShellType, string[]>;
+
+export abstract class VenvBaseActivationCommandProvider extends BaseActivationCommandProvider {
+    constructor(
+        protected readonly scripts: ActivationScripts,
+        // This is passed through.
+        serviceContainer: IServiceContainer
+    ) {
+        super(serviceContainer);
+    }
+
+    public isShellSupported(targetShell: TerminalShellType): boolean {
+        return this.scripts[targetShell] !== undefined;
+    }
+
+    protected async findScriptFile(pythonPath: string, targetShell: TerminalShellType): Promise<string | undefined> {
         const fs = this.serviceContainer.get<IFileSystem>(IFileSystem);
-        for (const scriptFileName of scriptFileNames) {
-            const scriptFile = resolveVenvExecutable(pythonPath, scriptFileName, path);
-            if (!scriptFile) {
-                return;
-            }
-            const found = await fs.fileExists(scriptFile);
-            if (found) {
-                return scriptFile;
-            }
-        }
+        const candidates = this.scripts[targetShell];
+        return findVenvExecutable(pythonPath, candidates || [], path, (n: string) => fs.fileExists(n));
     }
 }

--- a/src/client/common/terminal/environmentActivationProviders/bash.ts
+++ b/src/client/common/terminal/environmentActivationProviders/bash.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { inject, injectable } from 'inversify';
-import { IServiceContainer } from '../../../ioc/types';
+import { injectable } from 'inversify';
 import '../../extensions';
 import { TerminalShellType } from '../types';
 import { ActivationScripts, VenvBaseActivationCommandProvider } from './baseActivationProvider';
@@ -37,9 +36,8 @@ export function getAllScripts(): string[] {
 
 @injectable()
 export class Bash extends VenvBaseActivationCommandProvider {
-    constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
-        super(SCRIPTS, serviceContainer);
-    }
+    protected readonly scripts = SCRIPTS;
+
     public async getActivationCommandsForInterpreter(
         pythonPath: string,
         targetShell: TerminalShellType

--- a/src/client/common/terminal/environmentActivationProviders/bash.ts
+++ b/src/client/common/terminal/environmentActivationProviders/bash.ts
@@ -8,7 +8,7 @@ import { TerminalShellType } from '../types';
 import { ActivationScripts, VenvBaseActivationCommandProvider } from './baseActivationProvider';
 
 // For a given shell the scripts are in order of precedence.
-export const SCRIPTS: ActivationScripts = ({
+const SCRIPTS: ActivationScripts = ({
     // Group 1
     [TerminalShellType.wsl]: ['activate.sh', 'activate'],
     [TerminalShellType.ksh]: ['activate.sh', 'activate'],
@@ -21,6 +21,19 @@ export const SCRIPTS: ActivationScripts = ({
     // Group 3
     [TerminalShellType.fish]: ['activate.fish']
 } as unknown) as ActivationScripts;
+
+export function getAllScripts(): string[] {
+    const scripts: string[] = [];
+    for (const key of Object.keys(SCRIPTS)) {
+        const shell = key as TerminalShellType;
+        for (const name of SCRIPTS[shell]) {
+            if (!scripts.includes(name)) {
+                scripts.push(name);
+            }
+        }
+    }
+    return scripts;
+}
 
 @injectable()
 export class Bash extends VenvBaseActivationCommandProvider {

--- a/src/client/common/terminal/environmentActivationProviders/bash.ts
+++ b/src/client/common/terminal/environmentActivationProviders/bash.ts
@@ -5,55 +5,36 @@ import { inject, injectable } from 'inversify';
 import { IServiceContainer } from '../../../ioc/types';
 import '../../extensions';
 import { TerminalShellType } from '../types';
-import { BaseActivationCommandProvider } from './baseActivationProvider';
+import { ActivationScripts, VenvBaseActivationCommandProvider } from './baseActivationProvider';
+
+// For a given shell the scripts are in order of precedence.
+export const SCRIPTS: ActivationScripts = ({
+    // Group 1
+    [TerminalShellType.wsl]: ['activate.sh', 'activate'],
+    [TerminalShellType.ksh]: ['activate.sh', 'activate'],
+    [TerminalShellType.zsh]: ['activate.sh', 'activate'],
+    [TerminalShellType.gitbash]: ['activate.sh', 'activate'],
+    [TerminalShellType.bash]: ['activate.sh', 'activate'],
+    // Group 2
+    [TerminalShellType.tcshell]: ['activate.csh'],
+    [TerminalShellType.cshell]: ['activate.csh'],
+    // Group 3
+    [TerminalShellType.fish]: ['activate.fish']
+} as unknown) as ActivationScripts;
 
 @injectable()
-export class Bash extends BaseActivationCommandProvider {
+export class Bash extends VenvBaseActivationCommandProvider {
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
-        super(serviceContainer);
-    }
-    public isShellSupported(targetShell: TerminalShellType): boolean {
-        return (
-            targetShell === TerminalShellType.bash ||
-            targetShell === TerminalShellType.gitbash ||
-            targetShell === TerminalShellType.wsl ||
-            targetShell === TerminalShellType.ksh ||
-            targetShell === TerminalShellType.zsh ||
-            targetShell === TerminalShellType.cshell ||
-            targetShell === TerminalShellType.tcshell ||
-            targetShell === TerminalShellType.fish
-        );
+        super(SCRIPTS, serviceContainer);
     }
     public async getActivationCommandsForInterpreter(
         pythonPath: string,
         targetShell: TerminalShellType
     ): Promise<string[] | undefined> {
-        const scriptFile = await this.findScriptFile(pythonPath, this.getScriptsInOrderOfPreference(targetShell));
+        const scriptFile = await this.findScriptFile(pythonPath, targetShell);
         if (!scriptFile) {
             return;
         }
         return [`source ${scriptFile.fileToCommandArgument()}`];
-    }
-
-    private getScriptsInOrderOfPreference(targetShell: TerminalShellType): string[] {
-        switch (targetShell) {
-            case TerminalShellType.wsl:
-            case TerminalShellType.ksh:
-            case TerminalShellType.zsh:
-            case TerminalShellType.gitbash:
-            case TerminalShellType.bash: {
-                return ['activate.sh', 'activate'];
-            }
-            case TerminalShellType.tcshell:
-            case TerminalShellType.cshell: {
-                return ['activate.csh'];
-            }
-            case TerminalShellType.fish: {
-                return ['activate.fish'];
-            }
-            default: {
-                return [];
-            }
-        }
     }
 }

--- a/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
+++ b/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
@@ -37,8 +37,10 @@ export function getAllScripts(pathJoin: (...p: string[]) => string): string[] {
 
 @injectable()
 export class CommandPromptAndPowerShell extends VenvBaseActivationCommandProvider {
+    protected readonly scripts: ActivationScripts;
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
-        super(({} as unknown) as ActivationScripts, serviceContainer);
+        super(serviceContainer);
+        this.scripts = ({} as unknown) as ActivationScripts;
         for (const key of Object.keys(SCRIPTS)) {
             const shell = key as TerminalShellType;
             const scripts: string[] = [];
@@ -53,6 +55,7 @@ export class CommandPromptAndPowerShell extends VenvBaseActivationCommandProvide
             this.scripts[shell] = scripts;
         }
     }
+
     public async getActivationCommandsForInterpreter(
         pythonPath: string,
         targetShell: TerminalShellType

--- a/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
+++ b/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
@@ -6,26 +6,40 @@ import * as path from 'path';
 import { IServiceContainer } from '../../../ioc/types';
 import '../../extensions';
 import { TerminalShellType } from '../types';
-import { BaseActivationCommandProvider } from './baseActivationProvider';
+import { ActivationScripts, VenvBaseActivationCommandProvider } from './baseActivationProvider';
+
+// For a given shell the scripts are in order of precedence.
+export const SCRIPTS: ActivationScripts = ({
+    // Group 1
+    [TerminalShellType.commandPrompt]: ['activate.bat', 'Activate.ps1'],
+    // Group 2
+    [TerminalShellType.powershell]: ['Activate.ps1', 'activate.bat'],
+    [TerminalShellType.powershellCore]: ['Activate.ps1', 'activate.bat']
+} as unknown) as ActivationScripts;
 
 @injectable()
-export class CommandPromptAndPowerShell extends BaseActivationCommandProvider {
+export class CommandPromptAndPowerShell extends VenvBaseActivationCommandProvider {
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
-        super(serviceContainer);
-    }
-    public isShellSupported(targetShell: TerminalShellType): boolean {
-        return (
-            targetShell === TerminalShellType.commandPrompt ||
-            targetShell === TerminalShellType.powershell ||
-            targetShell === TerminalShellType.powershellCore
-        );
+        super(({} as unknown) as ActivationScripts, serviceContainer);
+        for (const key of Object.keys(SCRIPTS)) {
+            const shell = key as TerminalShellType;
+            const scripts: string[] = [];
+            for (const name of SCRIPTS[shell]) {
+                scripts.push(
+                    name,
+                    // We also add scripts in subdirs.
+                    path.join('Scripts', name),
+                    path.join('scripts', name)
+                );
+            }
+            this.scripts[shell] = scripts;
+        }
     }
     public async getActivationCommandsForInterpreter(
         pythonPath: string,
         targetShell: TerminalShellType
     ): Promise<string[] | undefined> {
-        // Dependending on the target shell, look for the preferred script file.
-        const scriptFile = await this.findScriptFile(pythonPath, this.getScriptsInOrderOfPreference(targetShell));
+        const scriptFile = await this.findScriptFile(pythonPath, targetShell);
         if (!scriptFile) {
             return;
         }
@@ -42,20 +56,6 @@ export class CommandPromptAndPowerShell extends BaseActivationCommandProvider {
             return [];
         } else {
             return;
-        }
-    }
-
-    private getScriptsInOrderOfPreference(targetShell: TerminalShellType): string[] {
-        const batchFiles = ['activate.bat', path.join('Scripts', 'activate.bat'), path.join('scripts', 'activate.bat')];
-        const powerShellFiles = [
-            'Activate.ps1',
-            path.join('Scripts', 'Activate.ps1'),
-            path.join('scripts', 'Activate.ps1')
-        ];
-        if (targetShell === TerminalShellType.commandPrompt) {
-            return batchFiles.concat(powerShellFiles);
-        } else {
-            return powerShellFiles.concat(batchFiles);
         }
     }
 }

--- a/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
+++ b/src/client/common/terminal/environmentActivationProviders/commandPrompt.ts
@@ -9,13 +9,31 @@ import { TerminalShellType } from '../types';
 import { ActivationScripts, VenvBaseActivationCommandProvider } from './baseActivationProvider';
 
 // For a given shell the scripts are in order of precedence.
-export const SCRIPTS: ActivationScripts = ({
+const SCRIPTS: ActivationScripts = ({
     // Group 1
     [TerminalShellType.commandPrompt]: ['activate.bat', 'Activate.ps1'],
     // Group 2
     [TerminalShellType.powershell]: ['Activate.ps1', 'activate.bat'],
     [TerminalShellType.powershellCore]: ['Activate.ps1', 'activate.bat']
 } as unknown) as ActivationScripts;
+
+export function getAllScripts(pathJoin: (...p: string[]) => string): string[] {
+    const scripts: string[] = [];
+    for (const key of Object.keys(SCRIPTS)) {
+        const shell = key as TerminalShellType;
+        for (const name of SCRIPTS[shell]) {
+            if (!scripts.includes(name)) {
+                scripts.push(
+                    name,
+                    // We also add scripts in subdirs.
+                    pathJoin('Scripts', name),
+                    pathJoin('scripts', name)
+                );
+            }
+        }
+    }
+    return scripts;
+}
 
 @injectable()
 export class CommandPromptAndPowerShell extends VenvBaseActivationCommandProvider {

--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -1,5 +1,4 @@
 import { inject, injectable } from 'inversify';
-import { compare } from 'semver';
 import { ConfigurationTarget, Uri } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../common/application/types';
 import { traceError } from '../common/logger';
@@ -7,8 +6,15 @@ import { FileSystemPaths } from '../common/platform/fs-paths';
 import { IPythonExecutionFactory } from '../common/process/types';
 import { IPersistentStateFactory, Resource } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
+import { isMacDefaultPythonPath } from '../pythonEnvironments/discovery';
 import { InterpeterHashProviderFactory } from '../pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterInformation, InterpreterType, PythonInterpreter } from '../pythonEnvironments/info';
+import {
+    getInterpreterTypeName,
+    InterpreterInformation,
+    InterpreterType,
+    PythonInterpreter,
+    sortInterpreters
+} from '../pythonEnvironments/info';
 import { IInterpreterHelper } from './contracts';
 import { IInterpreterHashProviderFactory } from './locators/types';
 
@@ -110,39 +116,16 @@ export class InterpreterHelper implements IInterpreterHelper {
         }
     }
     public isMacDefaultPythonPath(pythonPath: string) {
-        return pythonPath === 'python' || pythonPath === '/usr/bin/python';
+        return isMacDefaultPythonPath(pythonPath);
     }
     public getInterpreterTypeDisplayName(interpreterType: InterpreterType) {
-        switch (interpreterType) {
-            case InterpreterType.Conda: {
-                return 'conda';
-            }
-            case InterpreterType.Pipenv: {
-                return 'pipenv';
-            }
-            case InterpreterType.Pyenv: {
-                return 'pyenv';
-            }
-            case InterpreterType.Venv: {
-                return 'venv';
-            }
-            case InterpreterType.VirtualEnv: {
-                return 'virtualenv';
-            }
-            default: {
-                return '';
-            }
-        }
+        return getInterpreterTypeName(interpreterType);
     }
     public getBestInterpreter(interpreters?: PythonInterpreter[]): PythonInterpreter | undefined {
         if (!Array.isArray(interpreters) || interpreters.length === 0) {
             return;
         }
-        if (interpreters.length === 1) {
-            return interpreters[0];
-        }
-        const sorted = interpreters.slice();
-        sorted.sort((a, b) => (a.version && b.version ? compare(a.version.raw, b.version.raw) : 0));
+        const sorted = sortInterpreters(interpreters);
         return sorted[sorted.length - 1];
     }
 }

--- a/src/client/interpreter/virtualEnvs/index.ts
+++ b/src/client/interpreter/virtualEnvs/index.ts
@@ -7,24 +7,21 @@ import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../common/application/types';
 import { IFileSystem, IPlatformService } from '../../common/platform/types';
 import { IProcessServiceFactory } from '../../common/process/types';
-import { ITerminalActivationCommandProvider, TerminalShellType } from '../../common/terminal/types';
+import { getAllScripts as getNonWindowsScripts } from '../../common/terminal/environmentActivationProviders/bash';
+import { getAllScripts as getWindowsScripts } from '../../common/terminal/environmentActivationProviders/commandPrompt';
 import { ICurrentProcess, IPathUtils } from '../../common/types';
-import { getNamesAndValues } from '../../common/utils/enum';
-import { noop } from '../../common/utils/misc';
 import { IServiceContainer } from '../../ioc/types';
-import { getName as getEnvName } from '../../pythonEnvironments/discovery/subenv';
+import * as globalenvs from '../../pythonEnvironments/discovery/globalenv';
+import * as subenvs from '../../pythonEnvironments/discovery/subenv';
 import { InterpreterType } from '../../pythonEnvironments/info';
 import { IInterpreterLocatorService, IPipEnvService, PIPENV_SERVICE } from '../contracts';
 import { IVirtualEnvironmentManager } from './types';
-
-const PYENVFILES = ['pyvenv.cfg', path.join('..', 'pyvenv.cfg')];
 
 @injectable()
 export class VirtualEnvironmentManager implements IVirtualEnvironmentManager {
     private processServiceFactory: IProcessServiceFactory;
     private pipEnvService: IPipEnvService;
     private fs: IFileSystem;
-    private pyEnvRoot?: string;
     private workspaceService: IWorkspaceService;
     constructor(@inject(IServiceContainer) private readonly serviceContainer: IServiceContainer) {
         this.processServiceFactory = serviceContainer.get<IProcessServiceFactory>(IProcessServiceFactory);
@@ -35,114 +32,116 @@ export class VirtualEnvironmentManager implements IVirtualEnvironmentManager {
         ) as IPipEnvService;
         this.workspaceService = serviceContainer.get<IWorkspaceService>(IWorkspaceService);
     }
+
     public async getEnvironmentName(pythonPath: string, resource?: Uri): Promise<string> {
-        const workspaceRoot = this.getWorkspaceRoot(resource);
-        return getEnvName(
-            pythonPath,
-            workspaceRoot,
-            (d: string, p: string) => this.pipEnvService.isRelatedPipEnvironment(d, p),
-            path
+        const finders = subenvs.getNameFinders(
+            await this.getWorkspaceRoot(resource),
+            path.dirname,
+            path.basename,
+            // We use a closure on "this".
+            (d: string, p: string) => this.pipEnvService.isRelatedPipEnvironment(d, p)
         );
+        return (await subenvs.getName(pythonPath, finders)) || '';
     }
+
     public async getEnvironmentType(pythonPath: string, resource?: Uri): Promise<InterpreterType> {
-        if (await this.isVenvEnvironment(pythonPath)) {
-            return InterpreterType.Venv;
-        }
-
-        if (await this.isPyEnvEnvironment(pythonPath, resource)) {
-            return InterpreterType.Pyenv;
-        }
-
-        if (await this.isPipEnvironment(pythonPath, resource)) {
-            return InterpreterType.Pipenv;
-        }
-
-        if (await this.isVirtualEnvironment(pythonPath)) {
-            return InterpreterType.VirtualEnv;
-        }
-
-        // Lets not try to determine whether this is a conda environment or not.
-        return InterpreterType.Unknown;
-    }
-    public async isVenvEnvironment(pythonPath: string) {
-        const dir = path.dirname(pythonPath);
-        const pyEnvCfgFiles = PYENVFILES.map((file) => path.join(dir, file));
-        for (const file of pyEnvCfgFiles) {
-            if (await this.fs.fileExists(file)) {
-                return true;
-            }
-        }
-        return false;
-    }
-    public async isPyEnvEnvironment(pythonPath: string, resource?: Uri) {
-        const pyEnvRoot = await this.getPyEnvRoot(resource);
-        return pyEnvRoot && pythonPath.startsWith(pyEnvRoot);
-    }
-    public async isPipEnvironment(pythonPath: string, resource?: Uri) {
-        const defaultWorkspaceUri = this.workspaceService.hasWorkspaceFolders
-            ? this.workspaceService.workspaceFolders![0].uri
-            : undefined;
-        const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
-        const workspaceUri = workspaceFolder ? workspaceFolder.uri : defaultWorkspaceUri;
-        if (workspaceUri && (await this.pipEnvService.isRelatedPipEnvironment(workspaceUri.fsPath, pythonPath))) {
-            return true;
-        }
-        return false;
-    }
-    public async getPyEnvRoot(resource?: Uri): Promise<string | undefined> {
-        if (this.pyEnvRoot) {
-            return this.pyEnvRoot;
-        }
-
-        const currentProccess = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);
-        const pyenvRoot = currentProccess.env.PYENV_ROOT;
-        if (pyenvRoot) {
-            return (this.pyEnvRoot = pyenvRoot);
-        }
-
-        try {
-            const processService = await this.processServiceFactory.create(resource);
-            const output = await processService.exec('pyenv', ['root']);
-            if (output.stdout.trim().length > 0) {
-                return (this.pyEnvRoot = output.stdout.trim());
-            }
-        } catch {
-            noop();
-        }
         const pathUtils = this.serviceContainer.get<IPathUtils>(IPathUtils);
-        return (this.pyEnvRoot = path.join(pathUtils.home, '.pyenv'));
-    }
-    public async isVirtualEnvironment(pythonPath: string) {
-        const provider = this.getTerminalActivationProviderForVirtualEnvs();
-        const shells = getNamesAndValues<TerminalShellType>(TerminalShellType)
-            .filter((shell) => provider.isShellSupported(shell.value))
-            .map((shell) => shell.value);
-
-        for (const shell of shells) {
-            const cmds = await provider.getActivationCommandsForInterpreter!(pythonPath, shell);
-            if (cmds && cmds.length > 0) {
-                return true;
+        const plat = this.serviceContainer.get<IPlatformService>(IPlatformService);
+        const candidates = plat.isWindows ? getWindowsScripts(path.join) : getNonWindowsScripts();
+        const finders = subenvs.getTypeFinders(
+            pathUtils.home,
+            candidates,
+            path.sep,
+            path.join,
+            path.dirname,
+            () => this.getWorkspaceRoot(resource),
+            (d: string, p: string) => this.pipEnvService.isRelatedPipEnvironment(d, p),
+            (n: string) => {
+                const curProc = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);
+                return curProc.env[n];
+            },
+            (n: string) => this.fs.fileExists(n),
+            async (c: string, a: string[]) => {
+                const processService = await this.processServiceFactory.create(resource);
+                return processService.exec(c, a);
             }
-        }
-
-        return false;
+        );
+        return (await subenvs.getType(pythonPath, finders)) || InterpreterType.Unknown;
     }
 
-    private getWorkspaceRoot(resource?: Uri): string | undefined {
+    public async isVenvEnvironment(pythonPath: string) {
+        const find = subenvs.getVenvTypeFinder(
+            path.dirname,
+            path.join,
+            // We use a closure on "this".
+            (n: string) => this.fs.fileExists(n)
+        );
+        return (await find(pythonPath)) === InterpreterType.Venv;
+    }
+
+    public async isPyEnvEnvironment(pythonPath: string, resource?: Uri) {
+        const pathUtils = this.serviceContainer.get<IPathUtils>(IPathUtils);
+        const find = globalenvs.getPyenvTypeFinder(
+            pathUtils.home,
+            path.sep,
+            path.join,
+            (n: string) => {
+                const curProc = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);
+                return curProc.env[n];
+            },
+            async (c: string, a: string[]) => {
+                const processService = await this.processServiceFactory.create(resource);
+                return processService.exec(c, a);
+            }
+        );
+        return (await find(pythonPath)) === InterpreterType.Pyenv;
+    }
+
+    public async isPipEnvironment(pythonPath: string, resource?: Uri) {
+        const find = subenvs.getPipenvTypeFinder(
+            () => this.getWorkspaceRoot(resource),
+            // We use a closure on "this".
+            (d: string, p: string) => this.pipEnvService.isRelatedPipEnvironment(d, p)
+        );
+        return (await find(pythonPath)) === InterpreterType.Pipenv;
+    }
+
+    public async getPyEnvRoot(resource?: Uri): Promise<string | undefined> {
+        const pathUtils = this.serviceContainer.get<IPathUtils>(IPathUtils);
+        const find = globalenvs.getPyenvRootFinder(
+            pathUtils.home,
+            path.join,
+            (n: string) => {
+                const curProc = this.serviceContainer.get<ICurrentProcess>(ICurrentProcess);
+                return curProc.env[n];
+            },
+            async (c: string, a: string[]) => {
+                const processService = await this.processServiceFactory.create(resource);
+                return processService.exec(c, a);
+            }
+        );
+        return find();
+    }
+
+    public async isVirtualEnvironment(pythonPath: string) {
+        const plat = this.serviceContainer.get<IPlatformService>(IPlatformService);
+        const candidates = plat.isWindows ? getWindowsScripts(path.join) : getNonWindowsScripts();
+        const find = subenvs.getVirtualenvTypeFinder(
+            candidates,
+            path.dirname,
+            path.join,
+            // We use a closure on "this".
+            (n: string) => this.fs.fileExists(n)
+        );
+        return (await find(pythonPath)) === InterpreterType.VirtualEnv;
+    }
+
+    private async getWorkspaceRoot(resource?: Uri): Promise<string | undefined> {
         const defaultWorkspaceUri = this.workspaceService.hasWorkspaceFolders
             ? this.workspaceService.workspaceFolders![0].uri
             : undefined;
         const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
         const uri = workspaceFolder ? workspaceFolder.uri : defaultWorkspaceUri;
         return uri ? uri.fsPath : undefined;
-    }
-
-    private getTerminalActivationProviderForVirtualEnvs(): ITerminalActivationCommandProvider {
-        const isWindows = this.serviceContainer.get<IPlatformService>(IPlatformService).isWindows;
-        const serviceName = isWindows ? 'commandPromptAndPowerShell' : 'bashCShellFish';
-        return this.serviceContainer.get<ITerminalActivationCommandProvider>(
-            ITerminalActivationCommandProvider,
-            serviceName
-        );
     }
 }

--- a/src/client/pythonEnvironments/discovery/globalenv.ts
+++ b/src/client/pythonEnvironments/discovery/globalenv.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { logVerbose } from '../../logging';
 import { InterpreterType } from '../info';
 
 type ExecFunc = (cmd: string, args: string[]) => Promise<{ stdout: string }>;
@@ -62,8 +63,9 @@ export function getPyenvRootFinder(
             if (text.length > 0) {
                 return text;
             }
-        } catch {
-            // Ignore the error.  (log it?)
+        } catch (err) {
+            // Ignore the error.
+            logVerbose(`"pyenv root" failed (${err})`);
         }
         return pathJoin(homedir, '.pyenv');
     };

--- a/src/client/pythonEnvironments/discovery/globalenv.ts
+++ b/src/client/pythonEnvironments/discovery/globalenv.ts
@@ -8,6 +8,15 @@ type ExecFunc = (cmd: string, args: string[]) => Promise<{ stdout: string }>;
 type TypeFinderFunc = (python: string) => Promise<InterpreterType | undefined>;
 type RootFinderFunc = () => Promise<string | undefined>;
 
+/**
+ * Build a "type finder" function that identifies pyenv environments.
+ *
+ * @param homedir - the user's home directory (e.g. `$HOME`)
+ * @param pathSep - the path separator to use (typically `path.sep`)
+ * @param pathJoin - typically `path.join`
+ * @param getEnvVar - a function to look up a process environment variable (i,e. `process.env[name]`)
+ * @param exec - the function to use to run pyenv
+ */
 export function getPyenvTypeFinder(
     homedir: string,
     // <path>
@@ -27,6 +36,14 @@ export function getPyenvTypeFinder(
     };
 }
 
+/**
+ * Build a "root finder" function that finds pyenv environments.
+ *
+ * @param homedir - the user's home directory (e.g. `$HOME`)
+ * @param pathJoin - typically `path.join`
+ * @param getEnvVar - a function to look up a process environment variable (i,e. `process.env[name]`)
+ * @param exec - the function to use to run pyenv
+ */
 export function getPyenvRootFinder(
     homedir: string,
     pathJoin: (...parts: string[]) => string,

--- a/src/client/pythonEnvironments/discovery/globalenv.ts
+++ b/src/client/pythonEnvironments/discovery/globalenv.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InterpreterType } from '../info';
+
+type ExecFunc = (cmd: string, args: string[]) => Promise<{ stdout: string }>;
+
+type TypeFinderFunc = (python: string) => Promise<InterpreterType | undefined>;
+type RootFinderFunc = () => Promise<string | undefined>;
+
+export function getPyenvTypeFinder(
+    homedir: string,
+    // <path>
+    pathSep: string,
+    pathJoin: (...parts: string[]) => string,
+    // </path>
+    getEnvVar: (name: string) => string | undefined,
+    exec: ExecFunc
+): TypeFinderFunc {
+    const find = getPyenvRootFinder(homedir, pathJoin, getEnvVar, exec);
+    return async (python) => {
+        const root = await find();
+        if (root && python.startsWith(`${root}${pathSep}`)) {
+            return InterpreterType.Pyenv;
+        }
+        return undefined;
+    };
+}
+
+export function getPyenvRootFinder(
+    homedir: string,
+    pathJoin: (...parts: string[]) => string,
+    getEnvVar: (name: string) => string | undefined,
+    exec: ExecFunc
+): RootFinderFunc {
+    return async () => {
+        const root = getEnvVar('PYENV_ROOT');
+        if (root /* ...or empty... */) {
+            return root;
+        }
+
+        try {
+            const result = await exec('pyenv', ['root']);
+            const text = result.stdout.trim();
+            if (text.length > 0) {
+                return text;
+            }
+        } catch {
+            // Ignore the error.  (log it?)
+        }
+        return pathJoin(homedir, '.pyenv');
+    };
+}

--- a/src/client/pythonEnvironments/discovery/index.ts
+++ b/src/client/pythonEnvironments/discovery/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export function isMacDefaultPythonPath(pythonPath: string) {
+    return pythonPath === 'python' || pythonPath === '/usr/bin/python';
+}

--- a/src/client/pythonEnvironments/discovery/index.ts
+++ b/src/client/pythonEnvironments/discovery/index.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+/**
+ * Decide if the given Python executable looks like the MacOS default Python.
+ */
 export function isMacDefaultPythonPath(pythonPath: string) {
     return pythonPath === 'python' || pythonPath === '/usr/bin/python';
 }

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -25,8 +25,19 @@ interface IFSPathsForVenvExec {
     join(...parts: string[]): string;
 }
 
-export function resolveVenvExecutable(python: string, name: string, path: IFSPathsForVenvExec): string {
+export async function findVenvExecutable(
+    python: string,
+    basename: string | string[],
+    path: IFSPathsForVenvExec,
+    fileExists: (n: string) => Promise<boolean>
+): Promise<string | undefined> {
     // Generated scripts are found in the same directory as the interpreter.
     const binDir = path.dirname(python);
-    return path.join(binDir, name);
+    for (const name of typeof basename === 'string' ? [basename] : basename) {
+        const filename = path.join(binDir, name);
+        if (await fileExists(filename)) {
+            return filename;
+        }
+    }
+    // No matches so return undefined.
 }

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -217,20 +217,3 @@ export function getPipenvTypeFinder(
         return undefined;
     };
 }
-
-// XXX Drop everything below:
-
-interface IFSPathsForVenvExec {
-    dirname(filename: string): string;
-    join(...parts: string[]): string;
-}
-
-export async function findVenvExecutable(
-    python: string,
-    basename: string | string[],
-    path: IFSPathsForVenvExec,
-    fileExists: (n: string) => Promise<boolean>
-): Promise<string | undefined> {
-    const find = getVenvExecutableFinder(basename, path.dirname, path.join, fileExists);
-    return find(python);
-}

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -1,24 +1,158 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-interface IFSPathsForName {
-    dirname(filename: string): string;
-    basename(filename: string): string;
+import { InterpreterType } from '../info';
+import { getPyenvTypeFinder } from './globalenv';
+
+type ExecFunc = (cmd: string, args: string[]) => Promise<{ stdout: string }>;
+
+type NameFinderFunc = (python: string) => Promise<string>;
+type TypeFinderFunc = (python: string) => Promise<InterpreterType | undefined>;
+type ExecutableFinderFunc = (python: string) => Promise<string | undefined>;
+
+export async function getName(python: string, finders: NameFinderFunc[]): Promise<string | undefined> {
+    for (const find of finders) {
+        const found = await find(python);
+        if (found && found !== '') {
+            return found;
+        }
+    }
+    return undefined;
 }
 
-export async function getName(
-    python: string,
-    dirname: string | undefined,
-    isPipenvRoot: (dir: string, python: string) => Promise<boolean>,
-    path: IFSPathsForName
-): Promise<string> {
-    if (dirname && (await isPipenvRoot(dirname, python))) {
-        // In pipenv, return the folder name of the root dir.
-        return path.basename(dirname);
-    } else {
-        return path.basename(path.dirname(path.dirname(python)));
+export async function getType(python: string, finders: TypeFinderFunc[]): Promise<InterpreterType | undefined> {
+    for (const find of finders) {
+        const found = await find(python);
+        if (found && found !== InterpreterType.Unknown) {
+            return found;
+        }
     }
+    return undefined;
 }
+
+//======= default sets ========
+
+export function getNameFinders(
+    dirname: string | undefined,
+    // <path>
+    pathDirname: (filename: string) => string,
+    pathBasename: (filename: string) => string,
+    // </path>
+    isPipenvRoot: (dir: string, python: string) => Promise<boolean>
+): NameFinderFunc[] {
+    return [
+        async (python) => {
+            if (dirname && (await isPipenvRoot(dirname, python))) {
+                // In pipenv, return the folder name of the root dir.
+                return pathBasename(dirname);
+            } else {
+                return pathBasename(pathDirname(pathDirname(python)));
+            }
+        }
+    ];
+}
+
+export function getTypeFinders(
+    homedir: string,
+    scripts: string[],
+    // <path>
+    pathSep: string,
+    pathJoin: (...parts: string[]) => string,
+    pathDirname: (filename: string) => string,
+    // </path>
+    getCurDir: () => Promise<string | undefined>,
+    isPipenvRoot: (dir: string, python: string) => Promise<boolean>,
+    getEnvVar: (name: string) => string | undefined,
+    fileExists: (n: string) => Promise<boolean>,
+    exec: ExecFunc
+): TypeFinderFunc[] {
+    return [
+        getVenvTypeFinder(pathDirname, pathJoin, fileExists),
+        // For now we treat pyenv as a "virtual" environment (to keep compatibility)...
+        getPyenvTypeFinder(homedir, pathSep, pathJoin, getEnvVar, exec),
+        getPipenvTypeFinder(getCurDir, isPipenvRoot),
+        getVirtualenvTypeFinder(scripts, pathDirname, pathJoin, fileExists)
+        // Lets not try to determine whether this is a conda environment or not.
+    ];
+}
+
+//======= venv ========
+
+export function getVenvTypeFinder(
+    // <path>
+    pathDirname: (filename: string) => string,
+    pathJoin: (...parts: string[]) => string,
+    // </path>
+    fileExists: (n: string) => Promise<boolean>
+): TypeFinderFunc {
+    return async (python: string) => {
+        const dir = pathDirname(python);
+        const VENVFILES = ['pyvenv.cfg', pathJoin('..', 'pyvenv.cfg')];
+        const cfgFiles = VENVFILES.map((file) => pathJoin(dir, file));
+        for (const file of cfgFiles) {
+            if (await fileExists(file)) {
+                return InterpreterType.Venv;
+            }
+        }
+        return undefined;
+    };
+}
+
+export function getVenvExecutableFinder(
+    basename: string | string[],
+    // <path>
+    pathDirname: (filename: string) => string,
+    pathJoin: (...parts: string[]) => string,
+    // </path>
+    fileExists: (n: string) => Promise<boolean>
+): ExecutableFinderFunc {
+    const basenames = typeof basename === 'string' ? [basename] : basename;
+    return async (python: string) => {
+        // Generated scripts are found in the same directory as the interpreter.
+        const binDir = pathDirname(python);
+        for (const name of basenames) {
+            const filename = pathJoin(binDir, name);
+            if (await fileExists(filename)) {
+                return filename;
+            }
+        }
+        // No matches so return undefined.
+    };
+}
+
+//======= virtualenv ========
+
+export function getVirtualenvTypeFinder(
+    scripts: string[],
+    // <path>
+    pathDirname: (filename: string) => string,
+    pathJoin: (...parts: string[]) => string,
+    // </path>
+    fileExists: (n: string) => Promise<boolean>
+) {
+    const find = getVenvExecutableFinder(scripts, pathDirname, pathJoin, fileExists);
+    return async (python: string) => {
+        const found = await find(python);
+        return found !== undefined ? InterpreterType.VirtualEnv : undefined;
+    };
+}
+
+//======= pipenv ========
+
+export function getPipenvTypeFinder(
+    getCurDir: () => Promise<string | undefined>,
+    isPipenvRoot: (dir: string, python: string) => Promise<boolean>
+) {
+    return async (python: string) => {
+        const curDir = await getCurDir();
+        if (curDir && (await isPipenvRoot(curDir, python))) {
+            return InterpreterType.Pipenv;
+        }
+        return undefined;
+    };
+}
+
+// XXX Drop everything below:
 
 interface IFSPathsForVenvExec {
     dirname(filename: string): string;
@@ -31,13 +165,6 @@ export async function findVenvExecutable(
     path: IFSPathsForVenvExec,
     fileExists: (n: string) => Promise<boolean>
 ): Promise<string | undefined> {
-    // Generated scripts are found in the same directory as the interpreter.
-    const binDir = path.dirname(python);
-    for (const name of typeof basename === 'string' ? [basename] : basename) {
-        const filename = path.join(binDir, name);
-        if (await fileExists(filename)) {
-            return filename;
-        }
-    }
-    // No matches so return undefined.
+    const find = getVenvExecutableFinder(basename, path.dirname, path.join, fileExists);
+    return find(python);
 }

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-interface IFSPaths {
+interface IFSPathsForName {
     dirname(filename: string): string;
     basename(filename: string): string;
 }
@@ -10,7 +10,7 @@ export async function getName(
     python: string,
     dirname: string | undefined,
     isPipenvRoot: (dir: string, python: string) => Promise<boolean>,
-    path: IFSPaths
+    path: IFSPathsForName
 ): Promise<string> {
     if (dirname && (await isPipenvRoot(dirname, python))) {
         // In pipenv, return the folder name of the root dir.
@@ -18,4 +18,15 @@ export async function getName(
     } else {
         return path.basename(path.dirname(path.dirname(python)));
     }
+}
+
+interface IFSPathsForVenvExec {
+    dirname(filename: string): string;
+    join(...parts: string[]): string;
+}
+
+export function resolveVenvExecutable(python: string, name: string, path: IFSPathsForVenvExec): string {
+    // Generated scripts are found in the same directory as the interpreter.
+    const binDir = path.dirname(python);
+    return path.join(binDir, name);
 }

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+interface IFSPaths {
+    dirname(filename: string): string;
+    basename(filename: string): string;
+}
+
+export async function getName(
+    python: string,
+    dirname: string | undefined,
+    isPipenvRoot: (dir: string, python: string) => Promise<boolean>,
+    path: IFSPaths
+): Promise<string> {
+    if (dirname && (await isPipenvRoot(dirname, python))) {
+        // In pipenv, return the folder name of the root dir.
+        return path.basename(dirname);
+    } else {
+        return path.basename(path.dirname(path.dirname(python)));
+    }
+}

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -4,8 +4,8 @@
 'use strict';
 
 import * as semver from 'semver';
-import { Version } from '../../common/types';
 import { Architecture } from '../../common/utils/platform';
+import { PythonVersion } from './pythonVersion';
 
 /**
  * The supported Python environment types.
@@ -41,7 +41,7 @@ export type PythonVersionInfo = [number, number, number, ReleaseLevel];
  */
 export type InterpreterInformation = {
     path: string;
-    version?: Version;
+    version?: PythonVersion;
     sysVersion: string;
     architecture: Architecture;
     sysPrefix: string;

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import * as semver from 'semver';
 import { Version } from '../../common/types';
 import { Architecture } from '../../common/utils/platform';
 
@@ -36,3 +37,38 @@ export type PythonInterpreter = InterpreterInformation & {
     envPath?: string;
     cachedEntry?: boolean;
 };
+
+export function getInterpreterTypeName(interpreterType: InterpreterType) {
+    switch (interpreterType) {
+        case InterpreterType.Conda: {
+            return 'conda';
+        }
+        case InterpreterType.Pipenv: {
+            return 'pipenv';
+        }
+        case InterpreterType.Pyenv: {
+            return 'pyenv';
+        }
+        case InterpreterType.Venv: {
+            return 'venv';
+        }
+        case InterpreterType.VirtualEnv: {
+            return 'virtualenv';
+        }
+        default: {
+            return '';
+        }
+    }
+}
+
+export function sortInterpreters(interpreters: PythonInterpreter[]): PythonInterpreter[] {
+    if (interpreters.length === 0) {
+        return [];
+    }
+    if (interpreters.length === 1) {
+        return [interpreters[0]];
+    }
+    const sorted = interpreters.slice();
+    sorted.sort((a, b) => (a.version && b.version ? semver.compare(a.version.raw, b.version.raw) : 0));
+    return sorted;
+}

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -7,6 +7,9 @@ import * as semver from 'semver';
 import { Version } from '../../common/types';
 import { Architecture } from '../../common/utils/platform';
 
+/**
+ * The supported Python environment types.
+ */
 export enum InterpreterType {
     Unknown = 'Unknown',
     Conda = 'Conda',
@@ -18,8 +21,24 @@ export enum InterpreterType {
 }
 
 type ReleaseLevel = 'alpha' | 'beta' | 'candidate' | 'final' | 'unknown';
+
+/**
+ * The components of a Python version.
+ *
+ * These match the elements of `sys.version_info`.
+ */
 export type PythonVersionInfo = [number, number, number, ReleaseLevel];
 
+/**
+ * Details about a Python runtime.
+ *
+ * @prop path - the location of the executable file
+ * @prop version - the runtime version
+ * @prop sysVersion - the raw value of `sys.version`
+ * @prop architecture - of the host CPU (e.g. `x86`)
+ * @prop sysPrefix - the environment's install root (`sys.prefix`)
+ * @prop pipEnvWorkspaceFolder - the pipenv root, if applicable
+ */
 export type InterpreterInformation = {
     path: string;
     version?: Version;
@@ -29,6 +48,18 @@ export type InterpreterInformation = {
     pipEnvWorkspaceFolder?: string;
 };
 
+/**
+ * Details about a Python environment.
+ *
+ * @prop companyDisplayName - the user-facing name of the distro publisher
+ * @prop displayName - the user-facing name for the environment
+ * @prop type - the kind of Python environment
+ * @prop envName - the environment's name, if applicable (else `envPath` is set)
+ * @prop envPath - the environment's root dir, if applicable (else `envName`)
+ * @prop cachedEntry - whether or not the info came from a cache
+ */
+// Note that "cachedEntry" is specific to the caching machinery
+// and doesn't really belong here.
 export type PythonInterpreter = InterpreterInformation & {
     companyDisplayName?: string;
     displayName?: string;
@@ -38,6 +69,9 @@ export type PythonInterpreter = InterpreterInformation & {
     cachedEntry?: boolean;
 };
 
+/**
+ * Convert the Python environment type to a user-facing name.
+ */
 export function getInterpreterTypeName(interpreterType: InterpreterType) {
     switch (interpreterType) {
         case InterpreterType.Conda: {
@@ -61,6 +95,9 @@ export function getInterpreterTypeName(interpreterType: InterpreterType) {
     }
 }
 
+/**
+ * Build a version-sorted list from the given one, with lowest first.
+ */
 export function sortInterpreters(interpreters: PythonInterpreter[]): PythonInterpreter[] {
     if (interpreters.length === 0) {
         return [];

--- a/src/test/pythonEnvironments/discovery/globalenv.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/globalenv.unit.test.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+suite('getPyenvTypeFinder()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});
+
+suite('getPyenvRootFinder()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});

--- a/src/test/pythonEnvironments/discovery/subenv.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/subenv.unit.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { expect } from 'chai';
+import * as TypeMoq from 'typemoq';
+import * as sut from '../../../client/pythonEnvironments/discovery/subenv';
+import { InterpreterType } from '../../../client/pythonEnvironments/info';
+
+suite('getName()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});
+
+suite('getType()', () => {
+    interface IFinders {
+        venv(python: string): Promise<InterpreterType | undefined>;
+        pyenv(python: string): Promise<InterpreterType | undefined>;
+        pipenv(python: string): Promise<InterpreterType | undefined>;
+        virtualenv(python: string): Promise<InterpreterType | undefined>;
+    }
+    let finders: TypeMoq.IMock<IFinders>;
+    setup(() => {
+        finders = TypeMoq.Mock.ofType<IFinders>(undefined, TypeMoq.MockBehavior.Strict);
+    });
+    function verifyAll() {
+        finders.verifyAll();
+    }
+
+    test('detects the first type', async () => {
+        const python = 'x/y/z/bin/python';
+        finders
+            .setup((f) => f.venv(python))
+            // found
+            .returns(() => Promise.resolve(InterpreterType.Venv));
+
+        const result = await sut.getType(python, [
+            (p: string) => finders.object.venv(p),
+            (p: string) => finders.object.pyenv(p),
+            (p: string) => finders.object.pipenv(p),
+            (p: string) => finders.object.virtualenv(p)
+        ]);
+
+        expect(result).to.equal(InterpreterType.Venv, 'broken');
+        verifyAll();
+    });
+
+    test('detects the second type', async () => {
+        const python = 'x/y/z/bin/python';
+        finders
+            .setup((f) => f.venv(python))
+            // not found
+            .returns(() => Promise.resolve(undefined));
+        finders
+            .setup((f) => f.pyenv(python))
+            // found
+            .returns(() => Promise.resolve(InterpreterType.Pyenv));
+
+        const result = await sut.getType(python, [
+            (p: string) => finders.object.venv(p),
+            (p: string) => finders.object.pyenv(p),
+            (p: string) => finders.object.pipenv(p),
+            (p: string) => finders.object.virtualenv(p)
+        ]);
+
+        expect(result).to.equal(InterpreterType.Pyenv, 'broken');
+        verifyAll();
+    });
+
+    test('does not detect the type', async () => {
+        const python = 'x/y/z/bin/python';
+        finders
+            .setup((f) => f.venv(python))
+            // not found
+            .returns(() => Promise.resolve(undefined));
+        finders
+            .setup((f) => f.pyenv(python))
+            // not found
+            .returns(() => Promise.resolve(undefined));
+        finders
+            .setup((f) => f.pipenv(python))
+            // not found
+            .returns(() => Promise.resolve(undefined));
+        finders
+            .setup((f) => f.virtualenv(python))
+            // not found
+            .returns(() => Promise.resolve(undefined));
+
+        const result = await sut.getType(python, [
+            (p: string) => finders.object.venv(p),
+            (p: string) => finders.object.pyenv(p),
+            (p: string) => finders.object.pipenv(p),
+            (p: string) => finders.object.virtualenv(p)
+        ]);
+
+        expect(result).to.equal(undefined, 'broken');
+        verifyAll();
+    });
+});
+
+suite('getNameFinders()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});
+
+suite('getTypeFinders()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});
+
+suite('getVenvTypeFinder()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});
+
+suite('getVirtualenvTypeFinder()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});
+
+suite('getPipenvTypeFinder()', () => {
+    // We will pull tests over from src/test/interpreters/virtualEnvs/index.unit.test.ts at some point.
+});


### PR DESCRIPTION
This change is part of the work to isolate a "component" for Python environments. The focus here is on pulling over the remaining significant sections of code belonging to the "discovery" portion of the py-envs component.  There are a few pieces here and there but we'll get those pulled over in later phases.

For those most part this PR is just moving code between files.  In some cases this involves refactoring code so that part of it can be moved.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   ~[ ] Appropriate comments and documentation strings in the code.~
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] Unit tests & system/integration tests are added/updated.~
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
