### PR TITLE
Add Telemetry for VSC Notebooks

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -534,5 +534,6 @@
     "DataScience.reloadCustomEditor": "Please reload VS Code to use the custom editor API",
     "DataScience.reloadVSCodeNotebookEditor": "Please reload VS Code to use the Notebook Editor",
     "DataScience.step": "Run next line (F10)",
-    "DataScience.usingPreviewNotebookWithOtherNotebookWarning": "Using the Preview Notebook Editor along with the stable Notebook Editor is not recommended. Doing so could result in data loss or corruption of notebooks."
+    "DataScience.usingPreviewNotebookWithOtherNotebookWarning": "Using the Preview Notebook Editor along with the stable Notebook Editor is not recommended. Doing so could result in data loss or corruption of notebooks.",
+    "DataScience.previewNotebookOnlySupportedInVSCInsiders": "The Preview Notebook Editor is supported only in the Insiders version of Visual Studio Code."
 }

--- a/src/client/common/experiments/telemetry.ts
+++ b/src/client/common/experiments/telemetry.ts
@@ -9,7 +9,9 @@ import { sendTelemetryEvent, setSharedProperty } from '../../telemetry';
 export class ExperimentationTelemetry implements IExperimentationTelemetry {
     public setSharedProperty(name: string, value: string): void {
         // Add the shared property to all telemetry being sent, not just events being sent by the experimentation package.
-        setSharedProperty(name, value);
+        // We are not in control of these props, just cast to `any`, i.e. we cannot strongly type these external props.
+        // tslint:disable-next-line: no-any
+        setSharedProperty(name as any, value as any);
     }
 
     public postEvent(eventName: string, properties: Map<string, string>): void {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -983,6 +983,10 @@ export namespace DataScience {
         'DataScience.usingPreviewNotebookWithOtherNotebookWarning',
         'Using the Preview Notebook Editor along with the stable Notebook Editor is not recommended. Doing so could result in data loss or corruption of notebooks.'
     );
+    export const previewNotebookOnlySupportedInVSCInsiders = localize(
+        'DataScience.previewNotebookOnlySupportedInVSCInsiders',
+        'The Preview Notebook Editor is supported only in the Insiders version of Visual Studio Code.'
+    );
 }
 
 export namespace StartPage {

--- a/src/client/datascience/activation.ts
+++ b/src/client/datascience/activation.ts
@@ -9,7 +9,7 @@ import '../common/extensions';
 import { IPythonDaemonExecutionService, IPythonExecutionFactory } from '../common/process/types';
 import { IDisposableRegistry } from '../common/types';
 import { debounceAsync, swallowExceptions } from '../common/utils/decorators';
-import { sendTelemetryEvent } from '../telemetry';
+import { sendTelemetryEvent, setSharedProperty } from '../telemetry';
 import { JupyterDaemonModule, Telemetry } from './constants';
 import { ActiveEditorContextService } from './context/activeEditorContext';
 import { JupyterInterpreterService } from './jupyter/interpreter/jupyterInterpreterService';
@@ -37,9 +37,10 @@ export class Activation implements IExtensionSingleActivationService {
         this.tracker.startTracking();
     }
 
-    private onDidOpenNotebookEditor(_: INotebookEditor) {
+    private onDidOpenNotebookEditor(e: INotebookEditor) {
         this.notebookOpened = true;
         this.PreWarmDaemonPool().ignoreErrors();
+        setSharedProperty('ds_notebookeditor', e.type);
         sendTelemetryEvent(Telemetry.OpenNotebookAll);
         // Warm up our selected interpreter for the extension
         this.jupyterInterpreterService.setInitialInterpreter().ignoreErrors();

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -395,6 +395,21 @@ export enum NativeMouseCommandTelemetry {
     ToggleVariableExplorer = 'DATASCIENCE.NATIVE.MOUSE.TOGGLE_VARIABLE_EXPLORER'
 }
 
+/**
+ * Notebook editing in VS Code Notebooks is handled by VSC.
+ * There's no way for us to know whether user added a cell using keyboard or not.
+ * Similarly a cell could have been added as part of an undo operation.
+ * All we know is previously user had n # of cells and now they have m # of cells.
+ */
+export enum VSCodeNativeTelemetry {
+    AddCell = 'DATASCIENCE.VSCODE_NATIVE.INSERT_CELL',
+    RunAllCells = 'DATASCIENCE.VSCODE_NATIVE.RUN_ALL',
+    DeleteCell = 'DATASCIENCE.VSCODE_NATIVE.DELETE_CELL',
+    MoveCell = 'DATASCIENCE.VSCODE_NATIVE.MOVE_CELL',
+    ChangeToCode = 'DATASCIENCE.VSCODE_NATIVE.CHANGE_TO_CODE', // Not guaranteed to work see, https://github.com/microsoft/vscode/issues/100042
+    ChangeToMarkdown = 'DATASCIENCE.VSCODE_NATIVE.CHANGE_TO_MARKDOWN' // Not guaranteed to work see, https://github.com/microsoft/vscode/issues/100042
+}
+
 export namespace HelpLinks {
     export const PythonInteractiveHelpLink = 'https://aka.ms/pyaiinstall';
     export const JupyterDataRateHelpLink = 'https://aka.ms/AA5ggm0'; // This redirects here: https://jupyter-notebook.readthedocs.io/en/stable/config.html

--- a/src/client/datascience/context/activeEditorContext.ts
+++ b/src/client/datascience/context/activeEditorContext.ts
@@ -11,6 +11,7 @@ import { PYTHON_LANGUAGE } from '../../common/constants';
 import { ContextKey } from '../../common/contextKey';
 import { NotebookEditorSupport } from '../../common/experiments/groups';
 import { IDisposable, IDisposableRegistry, IExperimentsManager } from '../../common/types';
+import { setSharedProperty } from '../../telemetry';
 import { EditorContexts } from '../constants';
 import { IInteractiveWindow, IInteractiveWindowProvider, INotebookEditor, INotebookEditorProvider } from '../types';
 
@@ -86,6 +87,9 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.updateMergedContexts();
     }
     private onDidChangeActiveNotebookEditor(e?: INotebookEditor) {
+        // This will ensure all subsequent telemetry will get the context of whether it is a custom/native/old notebook editor.
+        // This is temporary, and once we ship native editor this needs to be removed.
+        setSharedProperty('ds_notebookeditor', e?.type);
         this.nativeContext.set(!!e).ignoreErrors();
         this.updateMergedContexts();
     }

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -96,6 +96,7 @@ import { KernelSwitcher } from '../jupyter/kernels/kernelSwitcher';
 const nativeEditorDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', 'notebook');
 @injectable()
 export class NativeEditor extends InteractiveBase implements INotebookEditor {
+    public readonly type: 'old' | 'custom' = 'custom';
     public get onDidChangeViewState(): Event<void> {
         return this._onDidChangeViewState.event;
     }

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -62,6 +62,7 @@ enum AskForSaveResult {
 
 @injectable()
 export class NativeEditorOldWebView extends NativeEditor {
+    public readonly type = 'old';
     public get visible(): boolean {
         return this.viewState.visible;
     }

--- a/src/client/datascience/notebook/contentProvider.ts
+++ b/src/client/datascience/notebook/contentProvider.ts
@@ -16,7 +16,7 @@ import type {
 import { ICommandManager } from '../../common/application/types';
 import { MARKDOWN_LANGUAGE } from '../../common/constants';
 import { DataScience } from '../../common/utils/localize';
-import { captureTelemetry } from '../../telemetry';
+import { captureTelemetry, sendTelemetryEvent, setSharedProperty } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { INotebookStorageProvider } from '../interactive-ipynb/notebookStorageProvider';
 import { notebookModelToVSCNotebookData } from './helpers/helpers';
@@ -70,6 +70,9 @@ export class NotebookContentProvider implements INotebookContentProvider {
         const model = await (openContext.backupId
             ? this.notebookStorage.load(uri, undefined, openContext.backupId)
             : this.notebookStorage.load(uri, undefined, true));
+
+        setSharedProperty('ds_notebookeditor', 'native');
+        sendTelemetryEvent(Telemetry.CellCount, undefined, { count: model.cells.length });
         return notebookModelToVSCNotebookData(model);
     }
     @captureTelemetry(Telemetry.Save, undefined, true)

--- a/src/client/datascience/notebook/executionService.ts
+++ b/src/client/datascience/notebook/executionService.ts
@@ -17,7 +17,7 @@ import { noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
-import { Commands, Telemetry } from '../constants';
+import { Commands, Telemetry, VSCodeNativeTelemetry } from '../constants';
 import { INotebookStorageProvider } from '../interactive-ipynb/notebookStorageProvider';
 import { IDataScienceErrorHandler, INotebook, INotebookModel, INotebookProvider } from '../types';
 import { findMappedNotebookCellModel } from './helpers/cellMappers';
@@ -81,6 +81,7 @@ export class NotebookExecutionService implements INotebookExecutionService {
         await this.executeIndividualCell(notebookAndModel, document, cell, token, stopWatch);
     }
     @captureTelemetry(Telemetry.ExecuteNativeCell, undefined, true)
+    @captureTelemetry(VSCodeNativeTelemetry.RunAllCells, undefined, true)
     public async executeAllCells(document: NotebookDocument, token: CancellationToken): Promise<void> {
         const stopWatch = new StopWatch();
         const notebookAndModel = this.getNotebookAndModel(document);

--- a/src/client/datascience/notebook/notebookEditor.ts
+++ b/src/client/datascience/notebook/notebookEditor.ts
@@ -25,6 +25,7 @@ import { getDefaultCodeLanguage } from './helpers/helpers';
 import { INotebookExecutionService } from './types';
 
 export class NotebookEditor implements INotebookEditor {
+    public readonly type = 'native';
     public get onDidChangeViewState(): Event<void> {
         return this.changedViewState.event;
     }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -536,6 +536,11 @@ export interface INotebookEditorProvider {
 // For native editing, the INotebookEditor acts like a TextEditor and a TextDocument together
 export const INotebookEditor = Symbol('INotebookEditor');
 export interface INotebookEditor extends IInteractiveBase {
+    /**
+     * Type of editor, whether it is the old, custom or native notebook editor.
+     * Once VSC Notebook is stable, this property can be removed.
+     */
+    readonly type: 'old' | 'custom' | 'native';
     readonly onDidChangeViewState: Event<void>;
     readonly closed: Event<INotebookEditor>;
     readonly executed: Event<INotebookEditor>;

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -9,7 +9,7 @@ import TelemetryReporter from 'vscode-extension-telemetry/lib/telemetryReporter'
 import { LanguageServerType } from '../activation/types';
 import { DiagnosticCodes } from '../application/diagnostics/constants';
 import { IWorkspaceService } from '../common/application/types';
-import { AppinsightsKey, isTestExecution, PVSC_EXTENSION_ID } from '../common/constants';
+import { AppinsightsKey, isTestExecution, isUnitTestExecution, PVSC_EXTENSION_ID } from '../common/constants';
 import { traceError, traceInfo } from '../common/logger';
 import { TerminalShellType } from '../common/terminal/types';
 import { Architecture } from '../common/utils/platform';
@@ -67,6 +67,10 @@ const sharedProperties: Record<string, string> = {};
  * (overload as necessary to ensure we have strongly typed telemetry props, this way we do not leak any PII inadvertently).
  */
 export function setSharedProperty(name: 'ds_notebookeditor', value?: 'old' | 'custom' | 'native'): void {
+    // Ignore such shared telemetry during unit tests.
+    if (isUnitTestExecution() && name === 'ds_notebookeditor') {
+        return;
+    }
     if (value === undefined) {
         delete sharedProperties[name];
     } else {

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -61,20 +61,20 @@ export function isTelemetryDisabled(workspaceService: IWorkspaceService): boolea
 }
 
 // Shared properties set by the IExperimentationTelemetry implementation.
-const sharedProperties: Record<string, string> = {};
+const sharedProperties: Record<string, any> = {};
 /**
  * Set shared properties for all telemetry events.
- * (overload as necessary to ensure we have strongly typed telemetry props, this way we do not leak any PII inadvertently).
  */
-export function setSharedProperty(name: 'ds_notebookeditor', value?: 'old' | 'custom' | 'native'): void {
+export function setSharedProperty<P extends ISharedPropertyMapping, E extends keyof P>(name: E, value?: P[E]): void {
+    const propertyName = name as string;
     // Ignore such shared telemetry during unit tests.
-    if (isUnitTestExecution() && name === 'ds_notebookeditor') {
+    if (isUnitTestExecution() && propertyName.startsWith('ds_')) {
         return;
     }
     if (value === undefined) {
-        delete sharedProperties[name];
+        delete sharedProperties[propertyName];
     } else {
-        sharedProperties[name] = value;
+        sharedProperties[propertyName] = value;
     }
 }
 
@@ -325,6 +325,16 @@ function getCallsite(frame: stackTrace.StackFrame) {
         }
     }
     return parts.join('.');
+}
+
+/**
+ * Map all shared properties to their data types.
+ */
+export interface ISharedPropertyMapping {
+    /**
+     * For every DS telemetry we would like to know the type of Notebook Editor used when doing something.
+     */
+    ['ds_notebookeditor']: undefined | 'old' | 'custom' | 'native';
 }
 
 // Map all events to their properties

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -60,7 +60,6 @@ export function isTelemetryDisabled(workspaceService: IWorkspaceService): boolea
     return settings.globalValue === false ? true : false;
 }
 
-// Shared properties set by the IExperimentationTelemetry implementation.
 const sharedProperties: Record<string, any> = {};
 /**
  * Set shared properties for all telemetry events.
@@ -106,9 +105,6 @@ function getTelemetryReporter() {
 export function clearTelemetryReporter() {
     telemetryReporter = undefined;
 }
-
-// These properties are sent with every telemetry for DataScience.
-const sharedDataScienceProperties = ['notebookeditor'];
 
 export function sendTelemetryEvent<P extends IEventNamePropertyMapping, E extends keyof P>(
     eventName: E,
@@ -159,9 +155,10 @@ export function sendTelemetryEvent<P extends IEventNamePropertyMapping, E extend
         Object.assign(customProperties, sharedProperties);
 
         // Remove shared DS properties from core extension telemetry.
-        sharedDataScienceProperties.forEach((shareProperty) => {
+        Object.keys(sharedProperties).forEach((shareProperty) => {
             if (
                 customProperties[shareProperty] &&
+                shareProperty.startsWith('ds_') &&
                 !(eventNameSent.startsWith('DS_') || eventNameSent.startsWith('DATASCIENCE'))
             ) {
                 delete customProperties[shareProperty];

--- a/src/test/telemetry/index.unit.test.ts
+++ b/src/test/telemetry/index.unit.test.ts
@@ -128,7 +128,7 @@ suite('Telemetry', () => {
         const measures = { start: 123, end: 987 };
         const expectedProperties = { ...properties, one: 'two' };
 
-        setSharedProperty('one', 'two');
+        setSharedProperty('one' as any, 'two' as any);
 
         // tslint:disable-next-line:no-any
         sendTelemetryEvent(eventName as any, measures, properties as any);
@@ -146,7 +146,7 @@ suite('Telemetry', () => {
         const measures = { start: 123, end: 987 };
         const expectedProperties = { ...properties, foo: 'baz' };
 
-        setSharedProperty('foo', 'baz');
+        setSharedProperty('foo' as any, 'baz' as any);
 
         // tslint:disable-next-line:no-any
         sendTelemetryEvent(eventName as any, measures, properties as any);


### PR DESCRIPTION
For #10496

* Added some missing telemetry for VS Code Notebooks
* Track the type of notebook used in various operations (running cell, interrupting kernels, etc, determine whether user is performing such operations while in Native/Custom/Old editor)
* Added a `type` for `INobteookEditor` (temporary, until VSC Notebook is stable)
* Ensure users cannot opt into VSC Notebook Editor experiment when in VSC Stable.