### PR TITLE
Added tests for export notebook to PDF

### DIFF
--- a/src/test/datascience/export/exportManagerFileOpener.unit.test.ts
+++ b/src/test/datascience/export/exportManagerFileOpener.unit.test.ts
@@ -80,4 +80,32 @@ suite('Data Science - Export File Opener', () => {
 
         verify(browserService.launch(anything())).never();
     });
+    test('Exporting to PDF displays message if operation fails', async () => {
+        when(exporter.export(anything(), anything())).thenThrow(new Error('Export failed...'));
+        when(applicationShell.showErrorMessage(anything())).thenResolve();
+        await fileOpener.export(ExportFormat.pdf, model);
+        verify(applicationShell.showErrorMessage(anything())).once();
+    });
+    test('PDF File opened if yes button pressed', async () => {
+        const uri = Uri.file('test.pdf');
+        when(exporter.export(anything(), anything())).thenResolve(uri);
+        when(applicationShell.showInformationMessage(anything(), anything(), anything())).thenReturn(
+            Promise.resolve(getLocString('DataScience.openExportFileYes', 'Yes'))
+        );
+
+        await fileOpener.export(ExportFormat.pdf, model);
+
+        verify(browserService.launch(anything())).once();
+    });
+    test('PDF File not opened if no button button pressed', async () => {
+        const uri = Uri.file('test.pdf');
+        when(exporter.export(anything(), anything())).thenResolve(uri);
+        when(applicationShell.showInformationMessage(anything(), anything(), anything())).thenReturn(
+            Promise.resolve(getLocString('DataScience.openExportFileNo', 'No'))
+        );
+
+        await fileOpener.export(ExportFormat.pdf, model);
+
+        verify(browserService.launch(anything())).never();
+    });
 });


### PR DESCRIPTION
Added some more unit tests for the file opener to make sure that when exporting to pdf an error message appears if the operation fails. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
