### PR TITLE
Don't modify LS settings if jediEnabled does not exist

### DIFF
--- a/src/client/testing/common/updateTestSettings.ts
+++ b/src/client/testing/common/updateTestSettings.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { applyEdits, Edit, findNodeAtLocation, FormattingOptions, getNodeValue, modify, parseTree } from 'jsonc-parser';
+import { applyEdits, findNodeAtLocation, getNodeValue, ModificationOptions, modify, parseTree } from 'jsonc-parser';
 import * as path from 'path';
 import { IExtensionActivationService, LanguageServerType } from '../../activation/types';
 import { IApplicationEnvironment, IWorkspaceService } from '../../common/application/types';
@@ -116,31 +116,38 @@ export class UpdateTestSettingService implements IExtensionActivationService {
             const ast = parseTree(fileContent);
 
             const jediEnabledNode = findNodeAtLocation(ast, jediEnabledPath);
+            const languageServerNode = findNodeAtLocation(ast, languageServerPath);
+
+            // If missing, do nothing.
             if (!jediEnabledNode) {
                 return fileContent;
             }
 
             const jediEnabled = getNodeValue(jediEnabledNode);
-            const languageServerNode = findNodeAtLocation(ast, languageServerPath);
-            const formattingOptions: FormattingOptions = {
-                tabSize: 4,
-                insertSpaces: true
-            };
-            let edits: Edit[] = [];
 
-            if (jediEnabled) {
-                // `jediEnabled` is missing or is true. Default is true, so assume Jedi.
-                edits = modify(fileContent, languageServerPath, LanguageServerType.Jedi, { formattingOptions });
-            } else {
-                // `jediEnabled` is false. if languageServer is missing, set it to Microsoft.
-                if (!languageServerNode) {
-                    edits = modify(fileContent, languageServerPath, LanguageServerType.Microsoft, {
-                        formattingOptions
-                    });
+            const modificationOptions: ModificationOptions = {
+                formattingOptions: {
+                    tabSize: 4,
+                    insertSpaces: true
                 }
+            };
+
+            // `jediEnabled` is true, set it to Jedi.
+            if (jediEnabled) {
+                return applyEdits(
+                    fileContent,
+                    modify(fileContent, languageServerPath, LanguageServerType.Jedi, modificationOptions)
+                );
             }
 
-            fileContent = applyEdits(fileContent, edits);
+            // `jediEnabled` is false. if languageServer is missing, set it to Microsoft.
+            if (!languageServerNode) {
+                return applyEdits(
+                    fileContent,
+                    modify(fileContent, languageServerPath, LanguageServerType.Microsoft, modificationOptions)
+                );
+            }
+
             // tslint:disable-next-line:no-empty
         } catch {}
         return fileContent;

--- a/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
+++ b/src/test/application/diagnostics/checks/updateTestSettings.unit.test.ts
@@ -217,9 +217,14 @@ suite('Application Diagnostics - Check Test Settings', () => {
 
     [
         {
-            testTitle: 'No jediEnabled setting.',
+            testTitle: 'No jediEnabled setting',
             contents: '{}',
-            expectedContent: '{ "python.languageServer": "Jedi" }'
+            expectedContent: '{}'
+        },
+        {
+            testTitle: 'jediEnabled setting in comment',
+            contents: '{\n // "python.jediEnabled": true\n }',
+            expectedContent: '{\n // "python.jediEnabled": true\n }'
         },
         {
             testTitle: 'jediEnabled: true, no languageServer setting',
@@ -250,6 +255,11 @@ suite('Application Diagnostics - Check Test Settings', () => {
             testTitle: 'jediEnabled: false, languageServer is Jedi',
             contents: '{ "python.jediEnabled": false, "python.languageServer": "Jedi" }',
             expectedContent: '{ "python.jediEnabled": false, "python.languageServer": "Jedi"}'
+        },
+        {
+            testTitle: 'jediEnabled not present, languageServer is Microsoft',
+            contents: '{ "python.languageServer": "Microsoft" }',
+            expectedContent: '{ "python.languageServer": "Microsoft" }'
         }
     ].forEach((item) => {
         test(item.testTitle, async () => {


### PR DESCRIPTION
For #12429

Not sure if I can add a news for this, given it's a bugfix for a bugfix...

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
