### PR TITLE
Skip more flaky CI tests

### DIFF
--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -953,6 +953,9 @@ suite('FileSystem', () => {
             });
 
             test('for symlinks, gets the info for the linked file', async function () {
+                // https://github.com/microsoft/vscode-python/issues/10294
+                // tslint:disable-next-line:no-invalid-this
+                this.skip();
                 if (!SUPPORTS_SYMLINKS) {
                     // tslint:disable-next-line:no-invalid-this
                     this.skip();

--- a/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
+++ b/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
@@ -20,7 +20,7 @@ import {
     updateSetting,
     waitForCondition
 } from '../../../common';
-import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
+import { EXTENSION_ROOT_DIR_FOR_TESTS, TEST_TIMEOUT } from '../../../constants';
 import { sleep } from '../../../core';
 import { initialize, initializeTest } from '../../../initialize';
 
@@ -192,5 +192,5 @@ suite('Activation of Environments in Terminal', () => {
         );
         await pythonSettings.update('condaPath', envPaths.condaExecPath, vscode.ConfigurationTarget.Workspace);
         await testActivation(envPaths.condaPath);
-    });
+    }).timeout(TEST_TIMEOUT * 2);
 });

--- a/src/test/format/extension.format.test.ts
+++ b/src/test/format/extension.format.test.ts
@@ -149,6 +149,7 @@ suite('Formatting - General', () => {
     test('Black', async function () {
         // https://github.com/microsoft/vscode-python/issues/12564
         // tslint:disable-next-line: no-invalid-this
+        return this.skip();
         if (!(await formattingTestIsBlackSupported())) {
             // Skip for versions of python below 3.6, as Black doesn't support them at all.
             // tslint:disable-next-line:no-invalid-this

--- a/src/test/format/extension.format.test.ts
+++ b/src/test/format/extension.format.test.ts
@@ -147,6 +147,8 @@ suite('Formatting - General', () => {
     });
     // tslint:disable-next-line:no-function-expression
     test('Black', async function () {
+        // https://github.com/microsoft/vscode-python/issues/12564
+        // tslint:disable-next-line: no-invalid-this
         if (!(await formattingTestIsBlackSupported())) {
             // Skip for versions of python below 3.6, as Black doesn't support them at all.
             // tslint:disable-next-line:no-invalid-this

--- a/src/test/testing/argsService.test.ts
+++ b/src/test/testing/argsService.test.ts
@@ -19,6 +19,7 @@ import { ArgumentsService as PyTestArgumentsService } from '../../client/testing
 import { IArgumentsHelper, IArgumentsService } from '../../client/testing/types';
 import { ArgumentsService as UnitTestArgumentsService } from '../../client/testing/unittest/services/argsService';
 import { PYTHON_PATH } from '../common';
+import { TEST_TIMEOUT } from '../constants';
 
 suite('ArgsService: Common', () => {
     UNIT_TEST_PRODUCTS.forEach((product) => {
@@ -33,7 +34,7 @@ suite('ArgsService: Common', () => {
             setup(function () {
                 // Take the spawning of process into account.
                 // tslint:disable-next-line:no-invalid-this
-                this.timeout(5000);
+                this.timeout(TEST_TIMEOUT * 2);
                 const serviceContainer = typeMoq.Mock.ofType<IServiceContainer>();
 
                 const argsHelper = new ArgumentsHelper();


### PR DESCRIPTION
For #12564 #10294

I have the skipped the very common flaky tests after investigating several failed builds. I have also increased timeouts for often failing hooks, and some tests which are only timing out by a second or two.