### PR TITLE
Changed public API for execution to return an object and provide a callback which is called when interpreter setting changes

### DIFF
--- a/news/1 Enhancements/12596.md
+++ b/news/1 Enhancements/12596.md
@@ -1,0 +1,1 @@
+Changed public API for execution to return an object and provide a callback which is called when interpreter setting changes.

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -3,11 +3,13 @@
 
 'use strict';
 
+import { Event, Uri } from 'vscode';
 import { isTestExecution } from './common/constants';
 import { traceError } from './common/logger';
 import { IConfigurationService, Resource } from './common/types';
 import { IDataViewerDataProvider, IDataViewerFactory } from './datascience/data-viewing/types';
 import { getDebugpyLauncherArgs, getDebugpyPackagePath } from './debugger/extension/adapter/remoteLaunchers';
+import { IInterpreterService } from './interpreter/contracts';
 import { IServiceContainer, IServiceManager } from './ioc/types';
 
 /*
@@ -45,20 +47,32 @@ export interface IExtensionApi {
      */
     settings: {
         /**
-         * Returns the Python execution command corresponding to the specified resource, taking into account
+         * An event that is emitted when the interpreter configuration changes.
+         */
+        readonly onDidChangeExecDetails: Event<Uri | undefined>;
+        /**
+         * Returns the Python execution object corresponding to the specified resource, taking into account
          * any workspace-specific settings for the workspace to which this resource belongs.
-         * E.g of execution commands returned could be,
-         * * `['<path to the interpreter set in settings>']`
-         * * `['<path to the interpreter selected by the extension when setting is not set>']`
-         * * `['conda', 'run', 'python']` which is used to run from within Conda environments.
-         * or something similar for some other Python environments.
          * @param {Resource} [resource] A resource for which the setting is asked for.
          * * When no resource is provided, the setting scoped to the first workspace folder is returned.
          * * If no folder is present, it returns the global setting.
-         * @returns {(string[] | undefined)} When return value is `undefined`, it means no interpreter is set.
-         * Otherwise, join the items returned using space to construct the full execution command.
+         * @returns {({ execCommand: string[] | undefined })}
          */
-        getExecutionCommand(resource?: Resource): string[] | undefined;
+        getExecutionDetails(
+            resource?: Resource
+        ): {
+            /**
+             * E.g of execution commands returned could be,
+             * * `['<path to the interpreter set in settings>']`
+             * * `['<path to the interpreter selected by the extension when setting is not set>']`
+             * * `['conda', 'run', 'python']` which is used to run from within Conda environments.
+             * or something similar for some other Python environments.
+             *
+             * @type {(string[] | undefined)} When return value is `undefined`, it means no interpreter is set.
+             * Otherwise, join the items returned using space to construct the full execution command.
+             */
+            execCommand: string[] | undefined;
+        };
     };
     datascience: {
         /**
@@ -77,7 +91,8 @@ export function buildApi(
     serviceContainer: IServiceContainer
 ): IExtensionApi {
     const configurationService = serviceContainer.get<IConfigurationService>(IConfigurationService);
-    const api = {
+    const interpreterService = serviceContainer.get<IInterpreterService>(IInterpreterService);
+    const api: IExtensionApi = {
         // 'ready' will propagate the exception, but we must log it here first.
         ready: ready.catch((ex) => {
             traceError('Failure during activation.', ex);
@@ -100,10 +115,11 @@ export function buildApi(
             }
         },
         settings: {
-            getExecutionCommand(resource?: Resource) {
+            onDidChangeExecDetails: interpreterService.onDidChangeInterpreterConfiguration,
+            getExecutionDetails(resource?: Resource) {
                 const pythonPath = configurationService.getSettings(resource).pythonPath;
                 // If pythonPath equals an empty string, no interpreter is set.
-                return pythonPath === '' ? undefined : [pythonPath];
+                return { execCommand: pythonPath === '' ? undefined : [pythonPath] };
             }
         },
         datascience: {

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -47,12 +47,13 @@ export interface IExtensionApi {
      */
     settings: {
         /**
-         * An event that is emitted when the interpreter configuration changes.
+         * An event that is emitted when execution details (for a resource) change. For instance, when interpreter configuration changes.
          */
-        readonly onDidChangeExecDetails: Event<Uri | undefined>;
+        readonly onDidChangeExecutionDetails: Event<Uri | undefined>;
         /**
-         * Returns the Python execution object corresponding to the specified resource, taking into account
-         * any workspace-specific settings for the workspace to which this resource belongs.
+         * Returns all the details the consumer needs to execute code within the selected environment,
+         * corresponding to the specified resource taking into account any workspace-specific settings
+         * for the workspace to which this resource belongs.
          * @param {Resource} [resource] A resource for which the setting is asked for.
          * * When no resource is provided, the setting scoped to the first workspace folder is returned.
          * * If no folder is present, it returns the global setting.
@@ -115,7 +116,7 @@ export function buildApi(
             }
         },
         settings: {
-            onDidChangeExecDetails: interpreterService.onDidChangeInterpreterConfiguration,
+            onDidChangeExecutionDetails: interpreterService.onDidChangeInterpreterConfiguration,
             getExecutionDetails(resource?: Resource) {
                 const pythonPath = configurationService.getSettings(resource).pythonPath;
                 // If pythonPath equals an empty string, no interpreter is set.

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -57,6 +57,7 @@ export interface ICondaService {
 
 export const IInterpreterService = Symbol('IInterpreterService');
 export interface IInterpreterService {
+    onDidChangeInterpreterConfiguration: Event<Uri | undefined>;
     onDidChangeInterpreter: Event<void>;
     onDidChangeInterpreterInformation: Event<PythonInterpreter>;
     hasInterpreters: Promise<boolean>;

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -53,7 +53,11 @@ export class InterpreterService implements Disposable, IInterpreterService {
     public get onDidChangeInterpreterInformation(): Event<PythonInterpreter> {
         return this.didChangeInterpreterInformation.event;
     }
+    public get onDidChangeInterpreterConfiguration(): Event<Uri | undefined> {
+        return this.didChangeInterpreterConfigurationEmitter.event;
+    }
     public _pythonPathSetting: string = '';
+    private readonly didChangeInterpreterConfigurationEmitter = new EventEmitter<Uri | undefined>();
     private readonly locator: IInterpreterLocatorService;
     private readonly persistentStateFactory: IPersistentStateFactory;
     private readonly configService: IConfigurationService;
@@ -262,6 +266,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
         return store;
     }
     public _onConfigChanged = (resource?: Uri) => {
+        this.didChangeInterpreterConfigurationEmitter.fire(resource);
         // Check if we actually changed our python path
         const pySettings = this.configService.getSettings(resource);
         if (this._pythonPathSetting === '' || this._pythonPathSetting !== pySettings.pythonPath) {

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -8,11 +8,14 @@
 import { assert, expect } from 'chai';
 import * as path from 'path';
 import { instance, mock, when } from 'ts-mockito';
-import { Uri } from 'vscode';
+import * as Typemoq from 'typemoq';
+import { Event, Uri } from 'vscode';
 import { buildApi } from '../client/api';
 import { ConfigurationService } from '../client/common/configuration/service';
 import { EXTENSION_ROOT_DIR } from '../client/common/constants';
 import { IConfigurationService } from '../client/common/types';
+import { IInterpreterService } from '../client/interpreter/contracts';
+import { InterpreterService } from '../client/interpreter/interpreterService';
 import { ServiceContainer } from '../client/ioc/container';
 import { ServiceManager } from '../client/ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
@@ -25,41 +28,54 @@ suite('Extension API', () => {
     let serviceContainer: IServiceContainer;
     let serviceManager: IServiceManager;
     let configurationService: IConfigurationService;
+    let interpreterService: IInterpreterService;
 
     setup(() => {
         serviceContainer = mock(ServiceContainer);
         serviceManager = mock(ServiceManager);
         configurationService = mock(ConfigurationService);
+        interpreterService = mock(InterpreterService);
 
         when(serviceContainer.get<IConfigurationService>(IConfigurationService)).thenReturn(
             instance(configurationService)
         );
+        when(serviceContainer.get<IInterpreterService>(IInterpreterService)).thenReturn(instance(interpreterService));
     });
 
-    test('Execution command settings API returns expected array if interpreter is set', async () => {
+    test('Execution details settings API returns expected object if interpreter is set', async () => {
         const resource = Uri.parse('a');
         when(configurationService.getSettings(resource)).thenReturn({ pythonPath: 'settingValue' } as any);
 
-        const interpreterPath = buildApi(
+        const execDetails = buildApi(
             Promise.resolve(),
             instance(serviceManager),
             instance(serviceContainer)
-        ).settings.getExecutionCommand(resource);
+        ).settings.getExecutionDetails(resource);
 
-        assert.deepEqual(interpreterPath, ['settingValue']);
+        assert.deepEqual(execDetails, { execCommand: ['settingValue'] });
     });
 
-    test('Execution command settings API returns `undefined` if interpreter is set', async () => {
+    test('Execution details settings API returns `undefined` if interpreter is set', async () => {
         const resource = Uri.parse('a');
         when(configurationService.getSettings(resource)).thenReturn({ pythonPath: '' } as any);
 
-        const interpreterPath = buildApi(
+        const execDetails = buildApi(
             Promise.resolve(),
             instance(serviceManager),
             instance(serviceContainer)
-        ).settings.getExecutionCommand(resource);
+        ).settings.getExecutionDetails(resource);
 
-        expect(interpreterPath).to.equal(undefined, '');
+        assert.deepEqual(execDetails, { execCommand: undefined });
+    });
+
+    test('Provide a callback which is called when interpreter setting changes', async () => {
+        const expectedEvent = Typemoq.Mock.ofType<Event<Uri | undefined>>().object;
+        when(interpreterService.onDidChangeInterpreterConfiguration).thenReturn(expectedEvent);
+
+        const result = buildApi(Promise.resolve(), instance(serviceManager), instance(serviceContainer)).settings
+            .onDidChangeExecDetails;
+
+        assert.deepEqual(result, expectedEvent);
     });
 
     test('Test debug launcher args (no-wait)', async () => {

--- a/src/test/api.functional.test.ts
+++ b/src/test/api.functional.test.ts
@@ -73,7 +73,7 @@ suite('Extension API', () => {
         when(interpreterService.onDidChangeInterpreterConfiguration).thenReturn(expectedEvent);
 
         const result = buildApi(Promise.resolve(), instance(serviceManager), instance(serviceContainer)).settings
-            .onDidChangeExecDetails;
+            .onDidChangeExecutionDetails;
 
         assert.deepEqual(result, expectedEvent);
     });

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -610,6 +610,9 @@ suite('DataScience notebook tests', () => {
                         public get hasInterpreters(): Promise<boolean> {
                             return Promise.resolve(true);
                         }
+                        public onDidChangeInterpreterConfiguration(): Disposable {
+                            return { dispose: noop };
+                        }
                         public onDidChangeInterpreter(
                             _listener: (e: void) => any,
                             _thisArgs?: any,


### PR DESCRIPTION
For #12596

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
