### PR TITLE
Skip another flaky Python daemon test

### DIFF
--- a/src/test/common/process/pythonDaemonPool.unit.test.ts
+++ b/src/test/common/process/pythonDaemonPool.unit.test.ts
@@ -100,7 +100,10 @@ suite('Daemon - Python Daemon Pool', () => {
         expect(sendRequestStub.callCount).equal(8);
         expect(listenStub.callCount).equal(8);
     });
-    test('Throw error if daemon does not respond to ping within 5s', async () => {
+    test('Throw error if daemon does not respond to ping within 5s', async function () {
+        // https://github.com/microsoft/vscode-python/issues/12567
+        // tslint:disable-next-line: no-invalid-this
+        return this.skip();
         sendRequestStub.reset();
         sendRequestStub.returns(sleep(6_000).then({ pong: 'hello' } as any));
         // Create and initialize the pool.


### PR DESCRIPTION
For #12567

Unit tests timeout is 2 seconds by default, and looks like this test may require 5 seconds to complete. Skipping it for now so @DonJayamanne can have a look later.