### PR TITLE
Start restart session after first cell execution

### DIFF
--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -71,20 +71,6 @@ export class JupyterSession extends BaseJupyterSession {
         await this.waitForIdleOnSession(this.session, timeout);
     }
 
-    public requestExecute(
-        content: KernelMessage.IExecuteRequestMsg['content'],
-        disposeOnDone?: boolean,
-        metadata?: JSONObject
-    ): Kernel.IShellFuture<KernelMessage.IExecuteRequestMsg, KernelMessage.IExecuteReplyMsg> | undefined {
-        const result = super.requestExecute(content, disposeOnDone, metadata);
-        // It has been observed that starting the restart session slows down first time to execute a cell.
-        // Solution is to start the restart session after the first execution of user code.
-        if (!content.silent && result && !isTestExecution()) {
-            result.done.finally(() => this.startRestartSession()).ignoreErrors();
-        }
-        return result;
-    }
-
     public async connect(cancelToken?: CancellationToken): Promise<void> {
         if (!this.connInfo) {
             throw new Error(localize.DataScience.sessionDisposed());

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -5,17 +5,14 @@ import type {
     Contents,
     ContentsManager,
     Kernel,
-    KernelMessage,
     ServerConnection,
     Session,
     SessionManager
 } from '@jupyterlab/services';
-import type { JSONObject } from '@phosphor/coreutils';
 import type { Slot } from '@phosphor/signaling';
 import * as uuid from 'uuid/v4';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { Cancellation } from '../../common/cancellation';
-import { isTestExecution } from '../../common/constants';
 import { traceError, traceInfo } from '../../common/logger';
 import { IOutputChannel } from '../../common/types';
 import { sleep } from '../../common/utils/async';

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -124,9 +124,6 @@ export class RawJupyterSession extends BaseJupyterSession {
             throw error;
         }
 
-        // Start our restart session at this point
-        this.startRestartSession();
-
         this.connected = true;
         return (newSession as RawSession).kernelProcess.kernelSpec;
     }


### PR DESCRIPTION
For #12009 

Found that we weren't starting the restart kernel in the right place.
We used to start restart kernel after first cell has been executed else this impact time to execute first cell.

Moved code to base class as it applies to both.