### PR TITLE
Simplify INotebookModel when using VSCode Notebooks

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -259,7 +259,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
             case InteractiveWindowMessages.Started:
                 if (this.model) {
                     // Load our cells, but don't wait for this to finish, otherwise the window won't load.
-                    this.sendInitialCellsToWebView(this.model.cells, this.model.isTrusted)
+                    this.sendInitialCellsToWebView([...this.model.cells], this.model.isTrusted)
                         .then(() => {
                             // May alread be dirty, if so send a message
                             if (this.model?.isDirty) {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProvider.ts
@@ -24,9 +24,9 @@ import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { generateNewNotebookUri } from '../common';
 import { Telemetry } from '../constants';
 import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
+import { NotebookModelEditEvent } from '../notebookStorage/notebookModelEditEvent';
 import { INotebookEditor, INotebookEditorProvider, INotebookModel } from '../types';
 import { getNextUntitledCounter } from './nativeEditorStorage';
-import { NotebookModelEditEvent } from './notebookModelEditEvent';
 import { INotebookStorageProvider } from './notebookStorageProvider';
 
 // Class that is registered as the custom editor provider for notebooks. VS code will call into this class when

--- a/src/client/datascience/notebook/contentProvider.ts
+++ b/src/client/datascience/notebook/contentProvider.ts
@@ -68,8 +68,8 @@ export class NotebookContentProvider implements INotebookContentProvider {
         }
         // If there's no backup id, then skip loading dirty contents.
         const model = await (openContext.backupId
-            ? this.notebookStorage.load(uri, undefined, openContext.backupId)
-            : this.notebookStorage.load(uri, undefined, true));
+            ? this.notebookStorage.load(uri, undefined, openContext.backupId, true)
+            : this.notebookStorage.load(uri, undefined, true, true));
 
         setSharedProperty('ds_notebookeditor', 'native');
         sendTelemetryEvent(Telemetry.CellCount, undefined, { count: model.cells.length });
@@ -77,7 +77,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
     }
     @captureTelemetry(Telemetry.Save, undefined, true)
     public async saveNotebook(document: NotebookDocument, cancellation: CancellationToken) {
-        const model = await this.notebookStorage.load(document.uri);
+        const model = await this.notebookStorage.load(document.uri, undefined, undefined, true);
         if (cancellation.isCancellationRequested) {
             return;
         }
@@ -93,7 +93,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
         document: NotebookDocument,
         cancellation: CancellationToken
     ): Promise<void> {
-        const model = await this.notebookStorage.load(document.uri);
+        const model = await this.notebookStorage.load(document.uri, undefined, undefined, true);
         if (!cancellation.isCancellationRequested) {
             await this.notebookStorage.saveAs(model, targetResource);
         }
@@ -106,7 +106,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
         _context: NotebookDocumentBackupContext,
         cancellation: CancellationToken
     ): Promise<NotebookDocumentBackup> {
-        const model = await this.notebookStorage.load(document.uri);
+        const model = await this.notebookStorage.load(document.uri, undefined, undefined, true);
         const id = this.notebookStorage.generateBackupId(model);
         await this.notebookStorage.backup(model, cancellation, id);
         return {

--- a/src/client/datascience/notebook/executionService.ts
+++ b/src/client/datascience/notebook/executionService.ts
@@ -146,7 +146,7 @@ export class NotebookExecutionService implements INotebookExecutionService {
         this.pendingExecutionCancellations.get(document.uri.fsPath)?.forEach((cancellation) => cancellation.cancel()); // NOSONAR
     }
     private async getNotebookAndModel(document: NotebookDocument): Promise<{ model: INotebookModel; nb: INotebook }> {
-        const model = await this.notebookStorage.load(document.uri, undefined, undned, true);
+        const model = await this.notebookStorage.load(document.uri, undefined, undefined, true);
         const nb = await this.notebookProvider.getOrCreateNotebook({
             identity: document.uri,
             resource: document.uri,

--- a/src/client/datascience/notebook/executionService.ts
+++ b/src/client/datascience/notebook/executionService.ts
@@ -146,7 +146,7 @@ export class NotebookExecutionService implements INotebookExecutionService {
         this.pendingExecutionCancellations.get(document.uri.fsPath)?.forEach((cancellation) => cancellation.cancel()); // NOSONAR
     }
     private async getNotebookAndModel(document: NotebookDocument): Promise<{ model: INotebookModel; nb: INotebook }> {
-        const model = await this.notebookStorage.load(document.uri);
+        const model = await this.notebookStorage.load(document.uri, undefined, undned, true);
         const nb = await this.notebookProvider.getOrCreateNotebook({
             identity: document.uri,
             resource: document.uri,

--- a/src/client/datascience/notebook/helpers/cellMappers.ts
+++ b/src/client/datascience/notebook/helpers/cellMappers.ts
@@ -74,7 +74,7 @@ export function findMappedNotebookCell(source: ICell, cells: NotebookCell[]): No
     return found[0];
 }
 
-export function findMappedNotebookCellModel(source: NotebookCell, cells: ICell[]): ICell {
+export function findMappedNotebookCellModel(source: NotebookCell, cells: readonly ICell[]): ICell {
     // If so, then we have a problem.
     const found = cells.filter((cell) => cell.id === getOriginalCellId(source));
     assert.ok(found.length, `ICell not found, for CellId = ${getOriginalCellId(source)} in ${source}`);

--- a/src/client/datascience/notebook/helpers/cellUpdateHelpers.ts
+++ b/src/client/datascience/notebook/helpers/cellUpdateHelpers.ts
@@ -120,7 +120,9 @@ function changeCellLanguage(change: NotebookCellLanguageChangeEvent, model: INot
 
     // Create a new cell & replace old one.
     const oldCellIndex = model.cells.indexOf(cellModel);
+    // tslint:disable-next-line: no-suspicious-comment
     // TODO: CHANGE.
+    // tslint:disable-next-line: no-any
     (model.cells as any)[oldCellIndex] = createCellFromVSCNotebookCell(change.cell, model);
     sendTelemetryEvent(
         change.cell.cellKind === vscodeNotebookEnums.CellKind.Markdown

--- a/src/client/datascience/notebook/helpers/cellUpdateHelpers.ts
+++ b/src/client/datascience/notebook/helpers/cellUpdateHelpers.ts
@@ -120,7 +120,8 @@ function changeCellLanguage(change: NotebookCellLanguageChangeEvent, model: INot
 
     // Create a new cell & replace old one.
     const oldCellIndex = model.cells.indexOf(cellModel);
-    model.cells[oldCellIndex] = createCellFromVSCNotebookCell(change.cell, model);
+    // TODO: CHANGE.
+    (model.cells as any)[oldCellIndex] = createCellFromVSCNotebookCell(change.cell, model);
     sendTelemetryEvent(
         change.cell.cellKind === vscodeNotebookEnums.CellKind.Markdown
             ? VSCodeNativeTelemetry.ChangeToMarkdown
@@ -176,8 +177,10 @@ function handleCellMove(change: NotebookCellsChangeEvent, model: INotebookModel)
     assert.notEqual(cellToSwap, cellToSwapWith, 'Cannot swap cell with the same cell');
 
     const indexOfCellToSwap = model.cells.indexOf(cellToSwap);
-    model.cells[insertChange.start] = cellToSwap;
-    model.cells[indexOfCellToSwap] = cellToSwapWith;
+    // tslint:disable-next-line: no-any
+    (model.cells as any)[insertChange.start] = cellToSwap;
+    // tslint:disable-next-line: no-any
+    (model.cells as any)[indexOfCellToSwap] = cellToSwapWith;
     // Get model to fire events.
     model.update({
         source: 'user',
@@ -194,7 +197,8 @@ function handleCellInsertion(change: NotebookCellsChangeEvent, model: INotebookM
     const insertChange = change.changes[0];
     const cell = change.changes[0].items[0];
     const newCell = createCellFromVSCNotebookCell(cell, model);
-    model.cells.splice(insertChange.start, 0, newCell);
+    // tslint:disable-next-line: no-any
+    (model.cells as any).splice(insertChange.start, 0, newCell);
     // Get model to fire events.
     model.update({
         source: 'user',
@@ -209,7 +213,8 @@ function handleCellDelete(change: NotebookCellsChangeEvent, model: INotebookMode
     assert.equal(change.changes.length, 1, 'When deleting cells we must have only 1 change');
     const deletionChange = change.changes[0];
     assert.equal(deletionChange.deletedCount, 1, 'Deleting more than one cell is not supported');
-    const cellToRemove = model.cells.splice(deletionChange.start, 1);
+    // tslint:disable-next-line: no-any
+    const cellToRemove = (model.cells as any).splice(deletionChange.start, 1);
     // Get model to fire events.
     model.update({
         source: 'user',

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -160,7 +160,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
             return;
         }
         const uri = doc.uri;
-        const model = await this.storage.load(uri);
+        const model = await this.storage.load(uri, undefined, undefined, true);
         mapVSCNotebookCellsToNotebookCellModels(doc, model);
         // In open method we might be waiting.
         let editor = this.notebookEditorsByUri.get(uri.toString());
@@ -231,7 +231,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         if (!isJupyterNotebook(e.document)) {
             return;
         }
-        const model = await this.storage.load(e.document.uri);
+        const model = await this.storage.load(e.document.uri, undefined, undefined, true);
         if (updateCellModelWithChangesToVSCCell(e, model)) {
             // If we have updated the notebook document, then trigger changes.
             this.contentProvider.notifyChangesToDocument(e.document);

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -21,7 +21,6 @@ import { createDeferred, Deferred } from '../../common/utils/async';
 import { IServiceContainer } from '../../ioc/types';
 import { captureTelemetry, setSharedProperty } from '../../telemetry';
 import { Commands, Telemetry } from '../constants';
-import { updateModelForUseWithVSCodeNotebook } from '../interactive-ipynb/nativeEditorStorage';
 import { INotebookStorageProvider } from '../interactive-ipynb/notebookStorageProvider';
 import { INotebookEditor, INotebookEditorProvider, INotebookProvider, IStatusProvider } from '../types';
 import { JupyterNotebookView } from './constants';
@@ -162,7 +161,6 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         }
         const uri = doc.uri;
         const model = await this.storage.load(uri);
-        updateModelForUseWithVSCodeNotebook(model); // take ownership of this model.
         mapVSCNotebookCellsToNotebookCellModels(doc, model);
         // In open method we might be waiting.
         let editor = this.notebookEditorsByUri.get(uri.toString());

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
+import { Event, EventEmitter, Uri } from 'vscode';
+import { PythonInterpreter } from '../../pythonEnvironments/info';
+import { pruneCell } from '../common';
+import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
+import { isUntitled } from '../interactive-ipynb/nativeEditorStorage';
+import { LiveKernelModel } from '../jupyter/kernels/types';
+import { ICell, IJupyterKernelSpec, INotebookModel } from '../types';
+
+export abstract class BaseNotebookModel implements INotebookModel {
+    public get onDidDispose() {
+        return this._disposed.event;
+    }
+    public get isDisposed() {
+        return this._isDisposed === true;
+    }
+    public get isDirty(): boolean {
+        return false;
+    }
+    public get changed(): Event<NotebookModelChange> {
+        return this._changedEmitter.event;
+    }
+    public get file(): Uri {
+        return this._file;
+    }
+
+    public get isUntitled(): boolean {
+        return isUntitled(this);
+    }
+    public get cells(): ICell[] {
+        return this._cells;
+    }
+    public get onDidEdit(): Event<NotebookModelChange> {
+        return this._editEventEmitter.event;
+    }
+    public get metadata(): nbformat.INotebookMetadata | undefined {
+        return this.notebookJson.metadata;
+    }
+    public get isTrusted() {
+        return this._isTrusted;
+    }
+
+    protected _disposed = new EventEmitter<void>();
+    protected _isDisposed?: boolean;
+    protected _changedEmitter = new EventEmitter<NotebookModelChange>();
+    protected _editEventEmitter = new EventEmitter<NotebookModelChange>();
+    constructor(
+        protected _isTrusted: boolean,
+        protected _file: Uri,
+        protected _cells: ICell[],
+        protected notebookJson: Partial<nbformat.INotebookContent> = {},
+        public readonly indentAmount: string = ' ',
+        private readonly pythonNumber: number = 3
+    ) {
+        this.ensureNotebookJson();
+    }
+    public dispose() {
+        this._isDisposed = true;
+        this._disposed.fire();
+    }
+    public update(change: NotebookModelChange): void {
+        this.handleModelChange(change);
+    }
+
+    public async applyEdits(edits: readonly NotebookModelChange[]): Promise<void> {
+        edits.forEach((e) => this.update({ ...e, source: 'redo' }));
+    }
+    public async undoEdits(edits: readonly NotebookModelChange[]): Promise<void> {
+        edits.forEach((e) => this.update({ ...e, source: 'undo' }));
+    }
+
+    public getContent(): string {
+        return this.generateNotebookContent();
+    }
+    protected handleUndo(_change: NotebookModelChange): boolean {
+        return false;
+    }
+
+    protected handleRedo(change: NotebookModelChange): boolean {
+        let changed = false;
+        switch (change.kind) {
+            case 'version':
+                changed = this.updateVersionInfo(change.interpreter, change.kernelSpec);
+                break;
+            default:
+                break;
+        }
+
+        return changed;
+    }
+
+    private handleModelChange(change: NotebookModelChange) {
+        const oldDirty = this.isDirty;
+        let changed = false;
+
+        switch (change.source) {
+            case 'redo':
+            case 'user':
+                changed = this.handleRedo(change);
+                break;
+            case 'undo':
+                changed = this.handleUndo(change);
+                break;
+            default:
+                break;
+        }
+
+        // Forward onto our listeners if necessary
+        if (changed || this.isDirty !== oldDirty) {
+            this._changedEmitter.fire({ ...change, newDirty: this.isDirty, oldDirty, model: this });
+        }
+        // Slightly different for the event we send to VS code. Skip version and file changes. Only send user events.
+        if ((changed || this.isDirty !== oldDirty) && change.kind !== 'version' && change.source === 'user') {
+            this._editEventEmitter.fire(change);
+        }
+    }
+
+    // tslint:disable-next-line: cyclomatic-complexity
+    private updateVersionInfo(
+        interpreter: PythonInterpreter | undefined,
+        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined
+    ): boolean {
+        let changed = false;
+        // Get our kernel_info and language_info from the current notebook
+        if (
+            interpreter &&
+            interpreter.version &&
+            this.notebookJson.metadata &&
+            this.notebookJson.metadata.language_info &&
+            this.notebookJson.metadata.language_info.version !== interpreter.version.raw
+        ) {
+            this.notebookJson.metadata.language_info.version = interpreter.version.raw;
+            changed = true;
+        }
+
+        if (kernelSpec && this.notebookJson.metadata && !this.notebookJson.metadata.kernelspec) {
+            // Add a new spec in this case
+            this.notebookJson.metadata.kernelspec = {
+                name: kernelSpec.name || kernelSpec.display_name || '',
+                display_name: kernelSpec.display_name || kernelSpec.name || ''
+            };
+            changed = true;
+        } else if (kernelSpec && this.notebookJson.metadata && this.notebookJson.metadata.kernelspec) {
+            // Spec exists, just update name and display_name
+            const name = kernelSpec.name || kernelSpec.display_name || '';
+            const displayName = kernelSpec.display_name || kernelSpec.name || '';
+            if (
+                this.notebookJson.metadata.kernelspec.name !== name ||
+                this.notebookJson.metadata.kernelspec.display_name !== displayName
+            ) {
+                changed = true;
+                this.notebookJson.metadata.kernelspec.name = name;
+                this.notebookJson.metadata.kernelspec.display_name = displayName;
+            }
+        }
+        return changed;
+    }
+
+    private ensureNotebookJson() {
+        if (!this.notebookJson || !this.notebookJson.metadata) {
+            // const pythonNumber = await this.extractPythonMainVersion(this._state.notebookJson);
+            const pythonNumber = this.pythonNumber;
+            // Use this to build our metadata object
+            // Use these as the defaults unless we have been given some in the options.
+            const metadata: nbformat.INotebookMetadata = {
+                language_info: {
+                    codemirror_mode: {
+                        name: 'ipython',
+                        version: pythonNumber
+                    },
+                    file_extension: '.py',
+                    mimetype: 'text/x-python',
+                    name: 'python',
+                    nbconvert_exporter: 'python',
+                    pygments_lexer: `ipython${pythonNumber}`,
+                    version: pythonNumber
+                },
+                orig_nbformat: 2
+            };
+
+            // Default notebook data.
+            this.notebookJson = {
+                metadata: metadata,
+                nbformat: 4,
+                nbformat_minor: 2
+            };
+        }
+    }
+
+    private generateNotebookContent(): string {
+        // Make sure we have some
+        this.ensureNotebookJson();
+
+        // Reuse our original json except for the cells.
+        const json = {
+            cells: this.cells.map((c) => pruneCell(c.data)),
+            metadata: this.notebookJson.metadata,
+            nbformat: this.notebookJson.nbformat,
+            nbformat_minor: this.notebookJson.nbformat_minor
+        };
+        return JSON.stringify(json, null, this.indentAmount);
+    }
+}

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -65,13 +65,6 @@ export abstract class BaseNotebookModel implements INotebookModel {
         this.handleModelChange(change);
     }
 
-    public async applyEdits(edits: readonly NotebookModelChange[]): Promise<void> {
-        edits.forEach((e) => this.update({ ...e, source: 'redo' }));
-    }
-    public async undoEdits(edits: readonly NotebookModelChange[]): Promise<void> {
-        edits.forEach((e) => this.update({ ...e, source: 'undo' }));
-    }
-
     public getContent(): string {
         return this.generateNotebookContent();
     }

--- a/src/client/datascience/notebookStorage/factory.ts
+++ b/src/client/datascience/notebookStorage/factory.ts
@@ -10,6 +10,7 @@ import { NativeEditorNotebookModel } from './notebookModel';
 import { INotebookModelFactory } from './types';
 import { VSCodeNotebookModel } from './vscNotebookModel';
 
+@injectable()
 export class NotebookModelFactory implements INotebookModelFactory {
     constructor(@inject(UseVSCodeNotebookEditorApi) private readonly useVSCodeNotebookEditorApi: boolean) {}
     public createModel(

--- a/src/client/datascience/notebookStorage/factory.ts
+++ b/src/client/datascience/notebookStorage/factory.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import { UseVSCodeNotebookEditorApi } from '../../common/constants';
 import { ICell, INotebookModel } from '../types';

--- a/src/client/datascience/notebookStorage/factory.ts
+++ b/src/client/datascience/notebookStorage/factory.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
+import { inject } from 'inversify';
+import { Uri } from 'vscode';
+import { UseVSCodeNotebookEditorApi } from '../../common/constants';
+import { ICell, INotebookModel } from '../types';
+import { NativeEditorNotebookModel } from './notebookModel';
+import { INotebookModelFactory } from './types';
+import { VSCodeNotebookModel } from './vscNotebookModel';
+
+export class NotebookModelFactory implements INotebookModelFactory {
+    constructor(@inject(UseVSCodeNotebookEditorApi) private readonly useVSCodeNotebookEditorApi: boolean) {}
+    public createModel(
+        options: {
+            trusted: boolean;
+            file: Uri;
+            cells: ICell[];
+            notebookJson?: Partial<nbformat.INotebookContent>;
+            indentAmount?: string;
+            pythonNumber?: number;
+            initiallyDirty?: boolean;
+        },
+        forVSCodeNotebook?: boolean
+    ): INotebookModel {
+        if (forVSCodeNotebook || this.useVSCodeNotebookEditorApi) {
+            return new VSCodeNotebookModel(
+                options.trusted,
+                options.file,
+                options.cells,
+                options.notebookJson,
+                options.indentAmount,
+                options.pythonNumber
+            );
+        }
+        return new NativeEditorNotebookModel(
+            options.trusted,
+            options.file,
+            options.cells,
+            options.notebookJson,
+            options.indentAmount,
+            options.pythonNumber,
+            options.initiallyDirty
+        );
+    }
+}

--- a/src/client/datascience/notebookStorage/notebookModel.ts
+++ b/src/client/datascience/notebookStorage/notebookModel.ts
@@ -1,0 +1,258 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
+import * as fastDeepEqual from 'fast-deep-equal';
+import * as uuid from 'uuid/v4';
+import { Uri } from 'vscode';
+import { concatMultilineStringInput, splitMultilineString } from '../../../datascience-ui/common';
+import { createCodeCell } from '../../../datascience-ui/common/cellFactory';
+import { Identifiers } from '../constants';
+import { IEditorContentChange, NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
+import { CellState, ICell } from '../types';
+import { BaseNotebookModel } from './baseModel';
+
+export class NativeEditorNotebookModel extends BaseNotebookModel {
+    public get id() {
+        return this._id;
+    }
+    private _id = uuid();
+    private saveChangeCount: number = 0;
+    private changeCount: number = 0;
+    public get isDirty(): boolean {
+        return this.changeCount !== this.saveChangeCount;
+    }
+    constructor(
+        isTrusted: boolean,
+        file: Uri,
+        cells: ICell[],
+        json: Partial<nbformat.INotebookContent> = {},
+        indentAmount: string = ' ',
+        pythonNumber: number = 3,
+        isInitiallyDirty: boolean = false
+    ) {
+        super(isTrusted, file, cells, json, indentAmount, pythonNumber);
+        if (isInitiallyDirty) {
+            // This means we're dirty. Indicate dirty and load from this content
+            this.saveChangeCount = -1;
+        }
+    }
+
+    public async applyEdits(edits: readonly NotebookModelChange[]): Promise<void> {
+        edits.forEach((e) => this.update({ ...e, source: 'redo' }));
+    }
+    public async undoEdits(edits: readonly NotebookModelChange[]): Promise<void> {
+        edits.forEach((e) => this.update({ ...e, source: 'undo' }));
+    }
+
+    protected handleRedo(change: NotebookModelChange): boolean {
+        let changed = false;
+        switch (change.kind) {
+            case 'clear':
+                changed = this.clearOutputs();
+                break;
+            case 'edit':
+                changed = this.editCell(change.forward, change.id);
+                break;
+            case 'insert':
+                changed = this.insertCell(change.cell, change.index);
+                break;
+            case 'changeCellType':
+                changed = this.changeCellType(change.cell);
+                break;
+            case 'modify':
+                changed = this.modifyCells(change.newCells);
+                break;
+            case 'remove':
+                changed = this.removeCell(change.cell);
+                break;
+            case 'remove_all':
+                changed = this.removeAllCells(change.newCellId);
+                break;
+            case 'swap':
+                changed = this.swapCells(change.firstCellId, change.secondCellId);
+                break;
+            case 'updateCellExecutionCount':
+                changed = this.updateCellExecutionCount(change.cellId, change.executionCount);
+                break;
+            case 'save':
+                this.saveChangeCount = this.changeCount;
+                break;
+            case 'saveAs':
+                this.saveChangeCount = this.changeCount;
+                this.changeCount = this.saveChangeCount = 0;
+                this._file = change.target;
+                break;
+            default:
+                changed = super.handleRedo(change);
+                break;
+        }
+
+        // Dirty state comes from undo. At least VS code will track it that way. However
+        // skip file changes as we don't forward those to VS code
+        if (change.kind !== 'save' && change.kind !== 'saveAs') {
+            this.changeCount += 1;
+        }
+
+        return changed;
+    }
+
+    protected handleUndo(change: NotebookModelChange): boolean {
+        let changed = false;
+        switch (change.kind) {
+            case 'clear':
+                changed = !fastDeepEqual(this.cells, change.oldCells);
+                this._cells = change.oldCells;
+                break;
+            case 'edit':
+                this.editCell(change.reverse, change.id);
+                changed = true;
+                break;
+            case 'changeCellType':
+                this.changeCellType(change.cell);
+                changed = true;
+                break;
+            case 'insert':
+                changed = this.removeCell(change.cell);
+                break;
+            case 'modify':
+                changed = this.modifyCells(change.oldCells);
+                break;
+            case 'remove':
+                changed = this.insertCell(change.cell, change.index);
+                break;
+            case 'remove_all':
+                this._cells = change.oldCells;
+                changed = true;
+                break;
+            case 'swap':
+                changed = this.swapCells(change.firstCellId, change.secondCellId);
+                break;
+            default:
+                break;
+        }
+
+        // Dirty state comes from undo. At least VS code will track it that way.
+        // Note unlike redo, 'file' and 'version' are not possible on undo as
+        // we don't send them to VS code.
+        this.changeCount -= 1;
+
+        return changed;
+    }
+
+    private removeAllCells(newCellId: string) {
+        this._cells = [];
+        this._cells.push(this.createEmptyCell(newCellId));
+        return true;
+    }
+
+    private applyCellContentChange(change: IEditorContentChange, id: string): boolean {
+        const normalized = change.text.replace(/\r/g, '');
+
+        // Figure out which cell we're editing.
+        const index = this.cells.findIndex((c) => c.id === id);
+        if (index >= 0) {
+            // This is an actual edit.
+            const contents = concatMultilineStringInput(this.cells[index].data.source);
+            const before = contents.substr(0, change.rangeOffset);
+            const after = contents.substr(change.rangeOffset + change.rangeLength);
+            const newContents = `${before}${normalized}${after}`;
+            if (contents !== newContents) {
+                const newCell = {
+                    ...this.cells[index],
+                    data: { ...this.cells[index].data, source: splitMultilineString(newContents) }
+                };
+                this._cells[index] = this.asCell(newCell);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private editCell(changes: IEditorContentChange[], id: string): boolean {
+        // Apply the changes to the visible cell list
+        if (changes && changes.length) {
+            return changes.map((c) => this.applyCellContentChange(c, id)).reduce((p, c) => p || c, false);
+        }
+
+        return false;
+    }
+
+    private swapCells(firstCellId: string, secondCellId: string) {
+        const first = this.cells.findIndex((v) => v.id === firstCellId);
+        const second = this.cells.findIndex((v) => v.id === secondCellId);
+        if (first >= 0 && second >= 0 && first !== second) {
+            const temp = { ...this.cells[first] };
+            this._cells[first] = this.asCell(this.cells[second]);
+            this._cells[second] = this.asCell(temp);
+            return true;
+        }
+        return false;
+    }
+
+    private updateCellExecutionCount(cellId: string, executionCount?: number) {
+        const index = this.cells.findIndex((v) => v.id === cellId);
+        if (index >= 0) {
+            this._cells[index].data.execution_count =
+                typeof executionCount === 'number' && executionCount > 0 ? executionCount : null;
+            return true;
+        }
+        return false;
+    }
+
+    private modifyCells(cells: ICell[]): boolean {
+        // Update these cells in our list
+        cells.forEach((c) => {
+            const index = this.cells.findIndex((v) => v.id === c.id);
+            this._cells[index] = this.asCell(c);
+        });
+        return true;
+    }
+
+    private changeCellType(cell: ICell): boolean {
+        // Update the cell in our list.
+        const index = this.cells.findIndex((v) => v.id === cell.id);
+        this._cells[index] = this.asCell(cell);
+        return true;
+    }
+
+    private removeCell(cell: ICell): boolean {
+        const index = this.cells.findIndex((c) => c.id === cell.id);
+        if (index >= 0) {
+            this.cells.splice(index, 1);
+            return true;
+        }
+        return false;
+    }
+
+    private clearOutputs(): boolean {
+        const newCells = this.cells.map((c) =>
+            this.asCell({ ...c, data: { ...c.data, execution_count: null, outputs: [] } })
+        );
+        const result = !fastDeepEqual(newCells, this.cells);
+        this._cells = newCells;
+        return result;
+    }
+
+    private insertCell(cell: ICell, index: number): boolean {
+        // Insert a cell into our visible list based on the index. They should be in sync
+        this._cells.splice(index, 0, cell);
+        return true;
+    }
+
+    // tslint:disable-next-line: no-any
+    private asCell(cell: any): ICell {
+        // Works around problems with setting a cell to another one in the nyc compiler.
+        return cell as ICell;
+    }
+
+    private createEmptyCell(id: string) {
+        return {
+            id,
+            line: 0,
+            file: Identifiers.EmptyFileName,
+            state: CellState.finished,
+            data: createCodeCell()
+        };
+    }
+}

--- a/src/client/datascience/notebookStorage/notebookModelEditEvent.ts
+++ b/src/client/datascience/notebookStorage/notebookModelEditEvent.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { CustomDocument, CustomDocumentEditEvent } from '../../common/application/types';
 import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
 import { INotebookModel } from '../types';

--- a/src/client/datascience/notebookStorage/notebookModelEditEvent.ts
+++ b/src/client/datascience/notebookStorage/notebookModelEditEvent.ts
@@ -4,6 +4,7 @@
 import { CustomDocument, CustomDocumentEditEvent } from '../../common/application/types';
 import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
 import { INotebookModel } from '../types';
+import { NativeEditorNotebookModel } from './notebookModel';
 export class NotebookModelEditEvent implements CustomDocumentEditEvent {
     public label?: string | undefined;
     constructor(
@@ -14,9 +15,9 @@ export class NotebookModelEditEvent implements CustomDocumentEditEvent {
         this.label = change.kind;
     }
     public undo(): void | Thenable<void> {
-        return this.model.undoEdits([{ ...this.change, source: 'undo' }]);
+        return (this.model as NativeEditorNotebookModel).undoEdits([{ ...this.change, source: 'undo' }]);
     }
     public redo(): void | Thenable<void> {
-        return this.model.applyEdits([{ ...this.change, source: 'redo' }]);
+        return (this.model as NativeEditorNotebookModel).applyEdits([{ ...this.change, source: 'redo' }]);
     }
 }

--- a/src/client/datascience/notebookStorage/types.ts
+++ b/src/client/datascience/notebookStorage/types.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { nbformat } from '@jupyterlab/coreutils/lib/nbformat';
+import { Uri } from 'vscode';
+import { ICell, INotebookModel } from '../types';
+
+export const INotebookModelFactory = Symbol('INotebookModelFactory');
+export interface INotebookModelFactory {
+    createModel(
+        options: {
+            trusted: boolean;
+            file: Uri;
+            cells: ICell[];
+            notebookJson?: Partial<nbformat.INotebookContent>;
+            indentAmount?: string;
+            pythonNumber?: number;
+            initiallyDirty?: boolean;
+        },
+        forVSCodeNotebook?: boolean
+    ): INotebookModel;
+}

--- a/src/client/datascience/notebookStorage/vscNotebookModel.ts
+++ b/src/client/datascience/notebookStorage/vscNotebookModel.ts
@@ -1,0 +1,42 @@
+import type { nbformat } from '@jupyterlab/coreutils';
+import { Uri } from 'vscode';
+import { NotebookDocument } from '../../../../types/vscode-proposed';
+import { NotebookModelChange } from '../interactive-common/interactiveWindowTypes';
+import { ICell } from '../types';
+import { BaseNotebookModel } from './baseModel';
+
+// Exported for test mocks
+export class VSCodeNotebookModel extends BaseNotebookModel {
+    private document?: NotebookDocument;
+    public get isDirty(): boolean {
+        return this.document?.isDirty === true;
+    }
+
+    constructor(
+        isTrusted: boolean,
+        file: Uri,
+        cells: ICell[],
+        json: Partial<nbformat.INotebookContent> = {},
+        indentAmount: string = ' ',
+        pythonNumber: number = 3
+    ) {
+        super(isTrusted, file, cells, json, indentAmount, pythonNumber);
+    }
+    /**
+     * Unfortunately Notebook models are created early, well before a VSC Notebook Document is created.
+     * We can associate an INotebookModel with a VSC Notebook, only after the Notebook has been opened.
+     */
+    public associateNotebookDocument(document: NotebookDocument) {
+        this.document = document;
+    }
+    public async applyEdits(_: readonly NotebookModelChange[]): Promise<void> {
+        throw new Error('INotebookModel.applyEdits Not supported when using VSCode Notebooks');
+    }
+    public async undoEdits(_: readonly NotebookModelChange[]): Promise<void> {
+        throw new Error('INotebookModel.applyEdits Not supported when using VSCode Notebooks');
+    }
+    protected handleRedo(change: NotebookModelChange): boolean {
+        super.handleRedo(change);
+        return true;
+    }
+}

--- a/src/client/datascience/notebookStorage/vscNotebookModel.ts
+++ b/src/client/datascience/notebookStorage/vscNotebookModel.ts
@@ -29,12 +29,6 @@ export class VSCodeNotebookModel extends BaseNotebookModel {
     public associateNotebookDocument(document: NotebookDocument) {
         this.document = document;
     }
-    public async applyEdits(_: readonly NotebookModelChange[]): Promise<void> {
-        throw new Error('INotebookModel.applyEdits Not supported when using VSCode Notebooks');
-    }
-    public async undoEdits(_: readonly NotebookModelChange[]): Promise<void> {
-        throw new Error('INotebookModel.applyEdits Not supported when using VSCode Notebooks');
-    }
     protected handleRedo(change: NotebookModelChange): boolean {
         super.handleRedo(change);
         return true;

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -116,6 +116,7 @@ import { NotebookEditorProviderWrapper } from './notebook/notebookEditorProvider
 import { registerTypes as registerNotebookTypes } from './notebook/serviceRegistry';
 import { NotebookAndInteractiveWindowUsageTracker } from './notebookAndInteractiveTracker';
 import { NotebookModelFactory } from './notebookStorage/factory';
+import { INotebookModelFactory } from './notebookStorage/types';
 import { PlotViewer } from './plotting/plotViewer';
 import { PlotViewerProvider } from './plotting/plotViewerProvider';
 import { PreWarmActivatedJupyterEnvironmentVariables } from './preWarmVariables';
@@ -172,7 +173,6 @@ import {
     IThemeFinder,
     ITrustService
 } from './types';
-import { INotebookModelFactory } from './notebookStorage/types';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -115,6 +115,7 @@ import { NotebookEditorProvider } from './notebook/notebookEditorProvider';
 import { NotebookEditorProviderWrapper } from './notebook/notebookEditorProviderWrapper';
 import { registerTypes as registerNotebookTypes } from './notebook/serviceRegistry';
 import { NotebookAndInteractiveWindowUsageTracker } from './notebookAndInteractiveTracker';
+import { NotebookModelFactory } from './notebookStorage/factory';
 import { PlotViewer } from './plotting/plotViewer';
 import { PlotViewerProvider } from './plotting/plotViewerProvider';
 import { PreWarmActivatedJupyterEnvironmentVariables } from './preWarmVariables';
@@ -171,7 +172,6 @@ import {
     IThemeFinder,
     ITrustService
 } from './types';
-import { NotebookModelFactory } from './notebookStorage/factory';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -171,6 +171,7 @@ import {
     IThemeFinder,
     ITrustService
 } from './types';
+import { NotebookModelFactory } from './notebookStorage/factory';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -197,6 +198,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     }
 
     serviceManager.add<ICellHashProvider>(ICellHashProvider, CellHashProvider, undefined, [INotebookExecutionLogger]);
+    serviceManager.addSingleton<NotebookModelFactory>(NotebookModelFactory, NotebookModelFactory);
     serviceManager.add<INotebookExecutionLogger>(INotebookExecutionLogger, HoverProvider);
     serviceManager.add<ICodeWatcher>(ICodeWatcher, CodeWatcher);
     serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -172,6 +172,7 @@ import {
     IThemeFinder,
     ITrustService
 } from './types';
+import { INotebookModelFactory } from './notebookStorage/types';
 
 // README: Did you make sure "dataScienceIocContainer.ts" has also been updated appropriately?
 
@@ -198,7 +199,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     }
 
     serviceManager.add<ICellHashProvider>(ICellHashProvider, CellHashProvider, undefined, [INotebookExecutionLogger]);
-    serviceManager.addSingleton<NotebookModelFactory>(NotebookModelFactory, NotebookModelFactory);
+    serviceManager.addSingleton<INotebookModelFactory>(INotebookModelFactory, NotebookModelFactory);
     serviceManager.add<INotebookExecutionLogger>(INotebookExecutionLogger, HoverProvider);
     serviceManager.add<ICodeWatcher>(ICodeWatcher, CodeWatcher);
     serviceManager.addSingleton<IDataScienceErrorHandler>(IDataScienceErrorHandler, DataScienceErrorHandler);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1039,9 +1039,14 @@ export interface INotebookStorage {
     save(model: INotebookModel, cancellation: CancellationToken): Promise<void>;
     saveAs(model: INotebookModel, targetResource: Uri): Promise<void>;
     backup(model: INotebookModel, cancellation: CancellationToken, backupId?: string): Promise<void>;
-    load(file: Uri, contents?: string, backupId?: string): Promise<INotebookModel>;
-    // tslint:disable-next-line: unified-signatures
-    load(file: Uri, contents?: string, skipDirtyContents?: boolean): Promise<INotebookModel>;
+    load(file: Uri, contents?: string, backupId?: string, forVSCodeNotebook?: boolean): Promise<INotebookModel>;
+    load(
+        file: Uri,
+        contents?: string,
+        // tslint:disable-next-line: unified-signatures
+        skipDirtyContents?: boolean,
+        forVSCodeNotebook?: boolean
+    ): Promise<INotebookModel>;
     revert(model: INotebookModel, cancellation: CancellationToken): Promise<void>;
     deleteBackup(model: INotebookModel, backupId?: string): Promise<void>;
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1013,7 +1013,7 @@ export interface INotebookModel {
     readonly isDirty: boolean;
     readonly isUntitled: boolean;
     readonly changed: Event<NotebookModelChange>;
-    readonly cells: Readonly<ICell>[];
+    readonly cells: readonly Readonly<ICell>[];
     readonly onDidEdit: Event<NotebookModelChange>;
     readonly isDisposed: boolean;
     readonly metadata: nbformat.INotebookMetadata | undefined;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1019,8 +1019,6 @@ export interface INotebookModel {
     readonly metadata: nbformat.INotebookMetadata | undefined;
     readonly isTrusted: boolean;
     getContent(): string;
-    applyEdits(edits: readonly NotebookModelChange[]): Thenable<void>;
-    undoEdits(edits: readonly NotebookModelChange[]): Thenable<void>;
     update(change: NotebookModelChange): void;
     /**
      * Dispose of the Notebook model.

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -206,14 +206,11 @@ import { ExportBase } from '../../client/datascience/export/exportBase';
 import { ExportManager } from '../../client/datascience/export/exportManager';
 import { ExportManagerDependencyChecker } from '../../client/datascience/export/exportManagerDependencyChecker';
 import { ExportManagerFileOpener } from '../../client/datascience/export/exportManagerFileOpener';
-import {
-    ExportManagerFilePicker,
-    IExportManagerFilePicker
-} from '../../client/datascience/export/exportManagerFilePicker';
+import { ExportManagerFilePicker } from '../../client/datascience/export/exportManagerFilePicker';
 import { ExportToHTML } from '../../client/datascience/export/exportToHTML';
 import { ExportToPDF } from '../../client/datascience/export/exportToPDF';
 import { ExportToPython } from '../../client/datascience/export/exportToPython';
-import { ExportFormat, IExport, IExportManager } from '../../client/datascience/export/types';
+import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker } from '../../client/datascience/export/types';
 import { GatherProvider } from '../../client/datascience/gather/gather';
 import { GatherListener } from '../../client/datascience/gather/gatherListener';
 import { GatherLogger } from '../../client/datascience/gather/gatherLogger';

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -271,6 +271,7 @@ import { KernelLauncher } from '../../client/datascience/kernel-launcher/kernelL
 import { IKernelFinder, IKernelLauncher } from '../../client/datascience/kernel-launcher/types';
 import { NotebookAndInteractiveWindowUsageTracker } from '../../client/datascience/notebookAndInteractiveTracker';
 import { NotebookModelFactory } from '../../client/datascience/notebookStorage/factory';
+import { INotebookModelFactory } from '../../client/datascience/notebookStorage/types';
 import { PlotViewer } from '../../client/datascience/plotting/plotViewer';
 import { PlotViewerProvider } from '../../client/datascience/plotting/plotViewerProvider';
 import { ProgressReporter } from '../../client/datascience/progress/progressReporter';
@@ -617,7 +618,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             ExportManagerDependencyChecker,
             ExportManagerDependencyChecker
         );
-        this.serviceManager.addSingleton<NotebookModelFactory>(NotebookModelFactory, NotebookModelFactory);
+        this.serviceManager.addSingleton<INotebookModelFactory>(INotebookModelFactory, NotebookModelFactory);
         this.serviceManager.addSingleton<IExportManager>(IExportManager, ExportManagerFileOpener);
         this.serviceManager.addSingleton<IExport>(IExport, ExportToPDF, ExportFormat.pdf);
         this.serviceManager.addSingleton<IExport>(IExport, ExportToHTML, ExportFormat.html);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -270,6 +270,7 @@ import { KernelFinder } from '../../client/datascience/kernel-launcher/kernelFin
 import { KernelLauncher } from '../../client/datascience/kernel-launcher/kernelLauncher';
 import { IKernelFinder, IKernelLauncher } from '../../client/datascience/kernel-launcher/types';
 import { NotebookAndInteractiveWindowUsageTracker } from '../../client/datascience/notebookAndInteractiveTracker';
+import { NotebookModelFactory } from '../../client/datascience/notebookStorage/factory';
 import { PlotViewer } from '../../client/datascience/plotting/plotViewer';
 import { PlotViewerProvider } from '../../client/datascience/plotting/plotViewerProvider';
 import { ProgressReporter } from '../../client/datascience/progress/progressReporter';
@@ -616,6 +617,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             ExportManagerDependencyChecker,
             ExportManagerDependencyChecker
         );
+        this.serviceManager.addSingleton<NotebookModelFactory>(NotebookModelFactory, NotebookModelFactory);
         this.serviceManager.addSingleton<IExportManager>(IExportManager, ExportManagerFileOpener);
         this.serviceManager.addSingleton<IExport>(IExport, ExportToPDF, ExportFormat.pdf);
         this.serviceManager.addSingleton<IExport>(IExport, ExportToHTML, ExportFormat.html);

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
@@ -40,6 +40,7 @@ import {
     NotebookStorageProvider
 } from '../../../client/datascience/interactive-ipynb/notebookStorageProvider';
 import { JupyterExecutionFactory } from '../../../client/datascience/jupyter/jupyterExecutionFactory';
+import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 import {
     IJupyterExecution,
     INotebookEditor,
@@ -55,7 +56,6 @@ import { concatMultilineStringInput } from '../../../datascience-ui/common';
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
 import { MockWorkspaceConfiguration } from '../mockWorkspaceConfig';
-import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 
 // tslint:disable: max-func-body-length
 suite('DataScience - Native Editor Provider', () => {

--- a/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorProvider.functional.test.ts
@@ -55,6 +55,7 @@ import { concatMultilineStringInput } from '../../../datascience-ui/common';
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
 import { MockWorkspaceConfiguration } from '../mockWorkspaceConfig';
+import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 
 // tslint:disable: max-func-body-length
 suite('DataScience - Native Editor Provider', () => {
@@ -207,7 +208,7 @@ suite('DataScience - Native Editor Provider', () => {
             globalMemento,
             localMemento,
             trustService,
-            false
+            new NotebookModelFactory(false)
         );
 
         storageProvider = new NotebookStorageProvider(notebookStorage, []);

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -47,6 +47,7 @@ import { concatMultilineStringInput } from '../../../datascience-ui/common';
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
 import { MockWorkspaceConfiguration } from '../mockWorkspaceConfig';
+import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 
 // tslint:disable: no-any chai-vague-errors no-unused-expression
 
@@ -337,7 +338,7 @@ suite('DataScience - Native Editor Storage', () => {
             globalMemento,
             localMemento,
             trustService,
-            false
+            new NotebookModelFactory(false)
         );
 
         return new NotebookStorageProvider(notebookStorage, []);
@@ -402,7 +403,7 @@ suite('DataScience - Native Editor Storage', () => {
             kind: 'remove_all',
             oldDirty: model.isDirty,
             newDirty: true,
-            oldCells: model.cells,
+            oldCells: [...model.cells],
             newCellId: '1'
         });
     }

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -34,6 +34,7 @@ import { NativeEditorStorage } from '../../../client/datascience/interactive-ipy
 import { NotebookStorageProvider } from '../../../client/datascience/interactive-ipynb/notebookStorageProvider';
 import { TrustService } from '../../../client/datascience/interactive-ipynb/trustService';
 import { JupyterExecutionFactory } from '../../../client/datascience/jupyter/jupyterExecutionFactory';
+import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 import {
     ICell,
     IJupyterExecution,
@@ -47,7 +48,6 @@ import { concatMultilineStringInput } from '../../../datascience-ui/common';
 import { createEmptyCell } from '../../../datascience-ui/interactive-common/mainState';
 import { MockMemento } from '../../mocks/mementos';
 import { MockWorkspaceConfiguration } from '../mockWorkspaceConfig';
-import { NotebookModelFactory } from '../../../client/datascience/notebookStorage/factory';
 
 // tslint:disable: no-any chai-vague-errors no-unused-expression
 

--- a/src/test/datascience/mockCustomEditorService.ts
+++ b/src/test/datascience/mockCustomEditorService.ts
@@ -14,7 +14,8 @@ import { noop } from '../../client/common/utils/misc';
 import { NotebookModelChange } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { NativeEditorProvider } from '../../client/datascience/interactive-ipynb/nativeEditorProvider';
 import { INotebookStorageProvider } from '../../client/datascience/interactive-ipynb/notebookStorageProvider';
-import { INotebookEditor, INotebookEditorProvider, INotebookModel } from '../../client/datascience/types';
+import { NativeEditorNotebookModel } from '../../client/datascience/notebookStorage/notebookModel';
+import { INotebookEditor, INotebookEditorProvider} from '../../client/datascience/types';
 import { createTemporaryFile } from '../utils/fs';
 
 @injectable()
@@ -134,10 +135,10 @@ export class MockCustomEditorService implements ICustomEditorService {
         };
     }
 
-    private async getModel(file: Uri): Promise<INotebookModel | undefined> {
+    private async getModel(file: Uri): Promise<NativeEditorNotebookModel | undefined> {
         const nativeProvider = this.provider as NativeEditorProvider;
         if (nativeProvider) {
-            return nativeProvider.loadModel(file);
+            return (nativeProvider.loadModel(file) as unknown) as Promise<NativeEditorNotebookModel | undefined>;
         }
         return undefined;
     }

--- a/src/test/datascience/mockCustomEditorService.ts
+++ b/src/test/datascience/mockCustomEditorService.ts
@@ -15,7 +15,7 @@ import { NotebookModelChange } from '../../client/datascience/interactive-common
 import { NativeEditorProvider } from '../../client/datascience/interactive-ipynb/nativeEditorProvider';
 import { INotebookStorageProvider } from '../../client/datascience/interactive-ipynb/notebookStorageProvider';
 import { NativeEditorNotebookModel } from '../../client/datascience/notebookStorage/notebookModel';
-import { INotebookEditor, INotebookEditorProvider} from '../../client/datascience/types';
+import { INotebookEditor, INotebookEditorProvider } from '../../client/datascience/types';
 import { createTemporaryFile } from '../utils/fs';
 
 @injectable()

--- a/src/test/datascience/nativeEditorViewTracker.unit.test.ts
+++ b/src/test/datascience/nativeEditorViewTracker.unit.test.ts
@@ -8,8 +8,8 @@ import { EventEmitter, Memento, Uri } from 'vscode';
 import { NotebookModelChange } from '../../client/datascience/interactive-common/interactiveWindowTypes';
 import { NativeEditor } from '../../client/datascience/interactive-ipynb/nativeEditor';
 import { NativeEditorProvider } from '../../client/datascience/interactive-ipynb/nativeEditorProvider';
-import { NativeEditorNotebookModel } from '../../client/datascience/interactive-ipynb/nativeEditorStorage';
 import { NativeEditorViewTracker } from '../../client/datascience/interactive-ipynb/nativeEditorViewTracker';
+import { NativeEditorNotebookModel } from '../../client/datascience/notebookStorage/notebookModel';
 import { INotebookEditor, INotebookEditorProvider, INotebookModel } from '../../client/datascience/types';
 import { MockMemento } from '../mocks/mementos';
 

--- a/src/test/datascience/notebook/contentProvider.unit.test.ts
+++ b/src/test/datascience/notebook/contentProvider.unit.test.ts
@@ -65,7 +65,7 @@ suite('Data Science - NativeNotebook ContentProvider', () => {
                 }
             ]
         };
-        when(storageProvider.load(anything(), anything(), anything())).thenResolve(
+        when(storageProvider.load(anything(), anything(), anything(), anything())).thenResolve(
             (model as unknown) as INotebookModel
         );
 
@@ -143,7 +143,7 @@ suite('Data Science - NativeNotebook ContentProvider', () => {
                 }
             ]
         };
-        when(storageProvider.load(anything(), anything(), anything())).thenResolve(
+        when(storageProvider.load(anything(), anything(), anything(), anything())).thenResolve(
             (model as unknown) as INotebookModel
         );
 

--- a/src/test/datascience/notebook/executionService.ds.test.ts
+++ b/src/test/datascience/notebook/executionService.ds.test.ts
@@ -58,7 +58,6 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await editorProvider.createNew();
     });
     setup(deleteAllCellsAndWait);
-    teardown(() => closeNotebooks(disposables));
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
 
     test('Execute cell using VSCode Command', async () => {

--- a/src/test/datascience/notebook/executionService.ds.test.ts
+++ b/src/test/datascience/notebook/executionService.ds.test.ts
@@ -23,7 +23,6 @@ import {
     assertNotHasTextOutputInVSCode,
     assertVSCCellHasErrors,
     canRunTests,
-    closeNotebooks,
     closeNotebooksAndCleanUpAfterTests,
     deleteAllCellsAndWait,
     insertPythonCellAndWait,


### PR DESCRIPTION
For #10496

* Two INotebookModels, one for existing Notebook and one for VS Code Notebooks
* VS Code Notebooks will not need a lot of the API in INotebookModel class (such as updates to cells, undo/redo, etc).
* VSC Notebooks will use INotebookModel as a mere mirror (readonly view) of the actual VSC NotebookDocument.

This PR just refactors stuff (moving stuff to accommodate the two new INotebook classes).

Will submit separate PR that cleans up updating INotebookModel for VS Code Notebooks (wanted to keep PR and easy for review, else it looks like there's a lot going on, when in fact there isn't much new).