### PR TITLE
Cache full ZMQ check promise, not just the result of the import

### DIFF
--- a/news/2 Fixes/12585.md
+++ b/news/2 Fixes/12585.md
@@ -1,0 +1,1 @@
+Correctly check for ZMQ support, previously it could allow ZMQ to be supported when zmq could not be imported.

--- a/src/client/datascience/raw-kernel/rawNotebookSupportedService.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookSupportedService.ts
@@ -13,7 +13,6 @@ import { IRawNotebookSupportedService } from '../types';
 @injectable()
 export class RawNotebookSupportedService implements IRawNotebookSupportedService {
     // Keep track of our ZMQ import check, this doesn't change with settings so we only want to do this once
-    //private _zmqSupported: boolean | undefined;
     private _zmqSupportedPromise: Promise<boolean> | undefined;
 
     constructor(

--- a/src/client/datascience/raw-kernel/rawNotebookSupportedService.ts
+++ b/src/client/datascience/raw-kernel/rawNotebookSupportedService.ts
@@ -13,7 +13,8 @@ import { IRawNotebookSupportedService } from '../types';
 @injectable()
 export class RawNotebookSupportedService implements IRawNotebookSupportedService {
     // Keep track of our ZMQ import check, this doesn't change with settings so we only want to do this once
-    private _zmqSupported: boolean | undefined;
+    //private _zmqSupported: boolean | undefined;
+    private _zmqSupportedPromise: Promise<boolean> | undefined;
 
     constructor(
         @inject(IConfigurationService) private readonly configuration: IConfigurationService,
@@ -48,21 +49,24 @@ export class RawNotebookSupportedService implements IRawNotebookSupportedService
 
     // Check to see if this machine supports our local ZMQ launching
     private async zmqSupported(): Promise<boolean> {
-        if (this._zmqSupported !== undefined) {
-            return this._zmqSupported;
+        if (!this._zmqSupportedPromise) {
+            this._zmqSupportedPromise = this.zmqSupportedImpl();
         }
 
+        return this._zmqSupportedPromise;
+    }
+
+    private async zmqSupportedImpl(): Promise<boolean> {
         try {
             await import('zeromq');
             traceInfo(`ZMQ install verified.`);
             sendTelemetryEvent(Telemetry.ZMQSupported);
-            this._zmqSupported = true;
         } catch (e) {
             traceError(`Exception while attempting zmq :`, e);
             sendTelemetryEvent(Telemetry.ZMQNotSupported);
-            this._zmqSupported = false;
+            return false;
         }
 
-        return this._zmqSupported;
+        return true;
     }
 }


### PR DESCRIPTION
For #12585 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
