### PR TITLE
DS: Hide commands for interacting with notebooks when active notebook is untrusted

### DIFF
--- a/package.json
+++ b/package.json
@@ -2941,6 +2941,12 @@
                     "description": "When debugging, debug just my code.",
                     "scope": "resource"
                 },
+                "python.dataScience.alwaysTrustNotebooks": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Automatically trust all notebooks that are opened. Warning: only enable this setting if you are absolutely certain that you wish to trust all notebooks.",
+                    "scope": "machine"
+                },
                 "python.insidersChannel": {
                     "type": "string",
                     "default": "off",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "onCommand:python.datascience.selectjupytercommandline",
         "onCommand:python.enableSourceMapSupport",
         "onNotebookEditor:jupyter-notebook",
-        "workspaceContains:**/mspythonconfig.json",
+        "workspaceContains:mspythonconfig.json",
         "workspaceContains:pyproject.toml"
     ],
     "main": "./out/client/extension",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "onCommand:python.datascience.selectjupytercommandline",
         "onCommand:python.enableSourceMapSupport",
         "onNotebookEditor:jupyter-notebook",
-        "workspaceContains:mspythonconfig.json",
+        "workspaceContains:**/mspythonconfig.json",
         "workspaceContains:pyproject.toml"
     ],
     "main": "./out/client/extension",
@@ -1081,55 +1081,55 @@
                     "command": "python.datascience.notebookeditor.undocells",
                     "title": "%python.command.python.datascience.undocells.title%",
                     "category": "Python",
-                    "when": "python.datascience.haveinteractivecells && python.datascience.featureenabled && python.datascience.isnativeactive && !notebookEditorFocused"
+                    "when": "python.datascience.haveinteractivecells && python.datascience.featureenabled && python.datascience.isnativeactive && !notebookEditorFocused && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.redocells",
                     "title": "%python.command.python.datascience.redocells.title%",
                     "category": "Python",
-                    "when": "python.datascience.havenativeredoablecells && python.datascience.featureenabled && python.datascience.isnativeactive && !notebookEditorFocused"
+                    "when": "python.datascience.havenativeredoablecells && python.datascience.featureenabled && python.datascience.isnativeactive && !notebookEditorFocused&& python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.removeallcells",
                     "title": "%python.command.python.datascience.notebookeditor.removeallcells.title%",
                     "category": "Python",
-                    "when": "python.datascience.havenativecells && python.datascience.featureenabled && python.datascience.isnativeactive"
+                    "when": "python.datascience.havenativecells && python.datascience.featureenabled && python.datascience.isnativeactive && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.interruptkernel",
                     "title": "%python.command.python.datascience.interruptkernel.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.restartkernel",
                     "title": "%python.command.python.datascience.restartkernel.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.runallcells",
                     "title": "%python.command.python.datascience.notebookeditor.runallcells.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.runselectedcell",
                     "title": "%python.command.python.datascience.notebookeditor.runselectedcell.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.havecellselected && !notebookEditorFocused"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.havecellselected && !notebookEditorFocused && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.runselectedcell",
                     "title": "%python.command.python.datascience.notebookeditor.runselectedcell.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && notebookEditorFocused"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && notebookEditorFocused && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.notebookeditor.addcellbelow",
                     "title": "%python.command.python.datascience.notebookeditor.addcellbelow.title%",
                     "category": "Python",
-                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled"
+                    "when": "python.datascience.isnativeactive && python.datascience.featureenabled && python.datascience.isnotebooktrusted"
                 },
                 {
                     "command": "python.datascience.expandallcells",
@@ -2940,12 +2940,6 @@
                     "default": true,
                     "description": "When debugging, debug just my code.",
                     "scope": "resource"
-                },
-                "python.dataScience.alwaysTrustNotebooks": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Automatically trust all notebooks that are opened. Warning: only enable this setting if you are absolutely certain that you wish to trust all notebooks.",
-                    "scope": "machine"
                 },
                 "python.insidersChannel": {
                     "type": "string",

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -118,6 +118,7 @@ export namespace EditorContexts {
     export const IsPythonOrInteractiveActive = 'python.datascience.ispythonorinteractiveeactive';
     export const IsPythonOrInteractiveOrNativeActive = 'python.datascience.ispythonorinteractiveornativeeactive';
     export const HaveCellSelected = 'python.datascience.havecellselected';
+    export const IsNotebookTrusted = 'python.datascience.isnotebooktrusted';
 }
 
 export namespace RegExpValues {

--- a/src/client/datascience/context/activeEditorContext.ts
+++ b/src/client/datascience/context/activeEditorContext.ts
@@ -110,8 +110,11 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.udpateNativeNotebookCellContext();
         this.updateMergedContexts();
     }
-    private onDidSetNotebookTrust(e: boolean) {
-        this.isNotebookTrusted.set(e).ignoreErrors();
+    // When trust service says trust has changed, update context with whether the currently active notebook is trusted
+    private onDidSetNotebookTrust() {
+        if (this.notebookEditorProvider.activeEditor?.model !== undefined) {
+            this.isNotebookTrusted.set(this.notebookEditorProvider.activeEditor?.model?.isTrusted).ignoreErrors();
+        }
     }
     private updateMergedContexts() {
         this.interactiveOrNativeContext

--- a/src/client/datascience/context/activeEditorContext.ts
+++ b/src/client/datascience/context/activeEditorContext.ts
@@ -13,7 +13,13 @@ import { NotebookEditorSupport } from '../../common/experiments/groups';
 import { IDisposable, IDisposableRegistry, IExperimentsManager } from '../../common/types';
 import { setSharedProperty } from '../../telemetry';
 import { EditorContexts } from '../constants';
-import { IInteractiveWindow, IInteractiveWindowProvider, INotebookEditor, INotebookEditorProvider, ITrustService } from '../types';
+import {
+    IInteractiveWindow,
+    IInteractiveWindowProvider,
+    INotebookEditor,
+    INotebookEditorProvider,
+    ITrustService
+} from '../types';
 
 @injectable()
 export class ActiveEditorContextService implements IExtensionSingleActivationService, IDisposable {
@@ -70,11 +76,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
             this,
             this.disposables
         );
-        this.trustService.onDidSetNotebookTrust(
-            this.onDidSetNotebookTrust,
-            this,
-            this.disposables
-        );
+        this.trustService.onDidSetNotebookTrust(this.onDidSetNotebookTrust, this, this.disposables);
 
         // Do we already have python file opened.
         if (this.docManager.activeTextEditor?.document.languageId === PYTHON_LANGUAGE) {
@@ -124,7 +126,7 @@ export class ActiveEditorContextService implements IExtensionSingleActivationSer
         this.pythonOrInteractiveOrNativeContext
             .set(
                 this.nativeContext.value === true ||
-                (this.interactiveContext.value === true && this.isPythonFileActive === true)
+                    (this.interactiveContext.value === true && this.isPythonFileActive === true)
             )
             .ignoreErrors();
     }

--- a/src/client/datascience/interactive-ipynb/trustService.ts
+++ b/src/client/datascience/interactive-ipynb/trustService.ts
@@ -1,18 +1,23 @@
 import { createHmac } from 'crypto';
 import { inject, injectable } from 'inversify';
 import { IConfigurationService } from '../../common/types';
+import { EventEmitter } from 'vscode';
 import { IDigestStorage, ITrustService } from '../types';
 
 @injectable()
 export class TrustService implements ITrustService {
+    public get onDidSetNotebookTrust() {
+        return this._onDidSetNotebookTrust.event;
+    }
     private get alwaysTrustNotebooks() {
         return this.configService.getSettings().datascience.alwaysTrustNotebooks;
     }
+    protected readonly _onDidSetNotebookTrust = new EventEmitter<boolean>();
     constructor(
         // @inject(IExperimentsManager) private readonly experiment: IExperimentsManager,
         @inject(IDigestStorage) private readonly digestStorage: IDigestStorage,
         @inject(IConfigurationService) private configService: IConfigurationService
-    ) {}
+    ) { }
 
     /**
      * When a notebook is opened, we check the database to see if a trusted checkpoint
@@ -27,7 +32,9 @@ export class TrustService implements ITrustService {
         }
         // Compute digest and see if notebook is trusted
         const digest = await this.computeDigest(notebookContents);
-        return this.digestStorage.containsDigest(uri, digest);
+        const isTrusted = await this.digestStorage.containsDigest(uri, digest);
+        this._onDidSetNotebookTrust.fire(isTrusted);
+        return isTrusted;
     }
 
     /**
@@ -39,7 +46,8 @@ export class TrustService implements ITrustService {
         if (!this.alwaysTrustNotebooks) {
             // Only update digest store if the user wants us to check trust
             const digest = await this.computeDigest(notebookContents);
-            return this.digestStorage.saveDigest(uri, digest);
+            await this.digestStorage.saveDigest(uri, digest);
+            this._onDidSetNotebookTrust.fire(true);
         }
     }
 

--- a/src/client/datascience/interactive-ipynb/trustService.ts
+++ b/src/client/datascience/interactive-ipynb/trustService.ts
@@ -1,7 +1,7 @@
 import { createHmac } from 'crypto';
 import { inject, injectable } from 'inversify';
-import { IConfigurationService } from '../../common/types';
 import { EventEmitter } from 'vscode';
+import { IConfigurationService } from '../../common/types';
 import { IDigestStorage, ITrustService } from '../types';
 
 @injectable()
@@ -17,7 +17,7 @@ export class TrustService implements ITrustService {
         // @inject(IExperimentsManager) private readonly experiment: IExperimentsManager,
         @inject(IDigestStorage) private readonly digestStorage: IDigestStorage,
         @inject(IConfigurationService) private configService: IConfigurationService
-    ) { }
+    ) {}
 
     /**
      * When a notebook is opened, we check the database to see if a trusted checkpoint

--- a/src/client/datascience/interactive-ipynb/trustService.ts
+++ b/src/client/datascience/interactive-ipynb/trustService.ts
@@ -12,7 +12,7 @@ export class TrustService implements ITrustService {
     private get alwaysTrustNotebooks() {
         return this.configService.getSettings().datascience.alwaysTrustNotebooks;
     }
-    protected readonly _onDidSetNotebookTrust = new EventEmitter<boolean>();
+    protected readonly _onDidSetNotebookTrust = new EventEmitter<void>();
     constructor(
         // @inject(IExperimentsManager) private readonly experiment: IExperimentsManager,
         @inject(IDigestStorage) private readonly digestStorage: IDigestStorage,
@@ -32,9 +32,7 @@ export class TrustService implements ITrustService {
         }
         // Compute digest and see if notebook is trusted
         const digest = await this.computeDigest(notebookContents);
-        const isTrusted = await this.digestStorage.containsDigest(uri, digest);
-        this._onDidSetNotebookTrust.fire(isTrusted);
-        return isTrusted;
+        return this.digestStorage.containsDigest(uri, digest);
     }
 
     /**
@@ -47,7 +45,7 @@ export class TrustService implements ITrustService {
             // Only update digest store if the user wants us to check trust
             const digest = await this.computeDigest(notebookContents);
             await this.digestStorage.saveDigest(uri, digest);
-            this._onDidSetNotebookTrust.fire(true);
+            this._onDidSetNotebookTrust.fire();
         }
     }
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -22,7 +22,7 @@ import {
     WebviewPanel
 } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import type { Data as WebSocketData, EventEmitter } from 'ws';
+import type { Data as WebSocketData } from 'ws';
 import { ServerStatus } from '../../datascience-ui/interactive-common/mainState';
 import { ICommandManager, IDebugService } from '../common/application/types';
 import { ExecutionResult, ObservableExecutionResult, SpawnOptions } from '../common/process/types';

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1246,7 +1246,7 @@ export interface IDigestStorage {
 
 export const ITrustService = Symbol('ITrustService');
 export interface ITrustService {
-    readonly onDidSetNotebookTrust: Event<boolean>;
+    readonly onDidSetNotebookTrust: Event<void>;
     isNotebookTrusted(uri: string, notebookContents: string): Promise<boolean>;
     trustNotebook(uri: string, notebookContents: string): Promise<void>;
 }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -22,7 +22,7 @@ import {
     WebviewPanel
 } from 'vscode';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import type { Data as WebSocketData } from 'ws';
+import type { Data as WebSocketData, EventEmitter } from 'ws';
 import { ServerStatus } from '../../datascience-ui/interactive-common/mainState';
 import { ICommandManager, IDebugService } from '../common/application/types';
 import { ExecutionResult, ObservableExecutionResult, SpawnOptions } from '../common/process/types';
@@ -1246,6 +1246,7 @@ export interface IDigestStorage {
 
 export const ITrustService = Symbol('ITrustService');
 export interface ITrustService {
+    readonly onDidSetNotebookTrust: Event<boolean>;
     isNotebookTrusted(uri: string, notebookContents: string): Promise<boolean>;
     trustNotebook(uri: string, notebookContents: string): Promise<void>;
 }


### PR DESCRIPTION
For #12148 

First half of the GIF illustrates commands being hidden for an untrusted notebook.
Second half of the GIF illustrates the same commands becoming available when a trusted notebook is opened.
![commands](https://user-images.githubusercontent.com/30305945/86069443-b5d33080-ba2e-11ea-899d-04706fa1372c.gif)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
