### PR TITLE
DS: Fixes for trusted notebooks UI

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -612,7 +612,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
     private async launchNotebookTrustPrompt() {
         const prompts = [localize.DataScience.trustNotebook(), localize.DataScience.doNotTrustNotebook()];
-        const selection = await this.applicationShell.showInformationMessage(
+        const selection = await this.applicationShell.showErrorMessage(
             localize.DataScience.launchNotebookTrustPrompt(),
             ...prompts
         );

--- a/src/datascience-ui/interactive-common/cellInput.tsx
+++ b/src/datascience-ui/interactive-common/cellInput.tsx
@@ -139,6 +139,7 @@ export class CellInput extends React.Component<ICellInputProps> {
                 <div className="cell-input">
                     <Markdown
                         editorOptions={this.props.editorOptions}
+                        readOnly={!this.props.isNotebookTrusted}
                         markdown={source}
                         codeTheme={this.props.codeTheme}
                         testMode={this.props.testMode ? true : false}
@@ -158,7 +159,6 @@ export class CellInput extends React.Component<ICellInputProps> {
                         font={this.props.font}
                         disableUndoStack={this.props.disableUndoStack}
                         version={this.props.codeVersion}
-                        isNotebookTrusted={this.props.isNotebookTrusted}
                     />
                 </div>
             );

--- a/src/datascience-ui/interactive-common/editor.tsx
+++ b/src/datascience-ui/interactive-common/editor.tsx
@@ -82,6 +82,10 @@ export class Editor extends React.Component<IEditorProps> {
                 }
             }
         }
+        if (prevProps.readOnly === true && this.props.readOnly === false && this.editorRef) {
+            this.subscriptions.push(this.editorRef.onKeyDown(this.onKeyDown));
+            this.subscriptions.push(this.editorRef.onKeyUp(this.onKeyUp));
+        }
     }
 
     public render() {

--- a/src/datascience-ui/interactive-common/markdown.tsx
+++ b/src/datascience-ui/interactive-common/markdown.tsx
@@ -24,7 +24,7 @@ export interface IMarkdownProps {
     hasFocus: boolean;
     cursorPos: CursorPos | monacoEditor.IPosition;
     disableUndoStack: boolean;
-    isNotebookTrusted: boolean;
+    readOnly: boolean;
     onCreated(code: string, modelId: string): void;
     onChange(e: IMonacoModelContentChangeEvent): void;
     focused?(): void;
@@ -47,7 +47,7 @@ export class Markdown extends React.Component<IMarkdownProps> {
             <div className={classes}>
                 <Editor
                     codeTheme={this.props.codeTheme}
-                    readOnly={!this.props.isNotebookTrusted}
+                    readOnly={this.props.readOnly}
                     history={undefined}
                     onCreated={this.props.onCreated}
                     onChange={this.props.onChange}

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -146,12 +146,8 @@ export class NativeCell extends React.Component<INativeCellProps> {
     };
 
     private renderNormalCell() {
-        const cellOuterClass =
-            this.props.cellVM.editable && this.props.isNotebookTrusted ? 'cell-outer-editable' : 'cell-outer';
-        let cellWrapperClass =
-            this.props.cellVM.editable && this.props.isNotebookTrusted
-                ? 'cell-wrapper'
-                : 'cell-wrapper cell-wrapper-noneditable';
+        const cellOuterClass = this.props.cellVM.editable ? 'cell-outer-editable' : 'cell-outer';
+        let cellWrapperClass = this.props.cellVM.editable ? 'cell-wrapper' : 'cell-wrapper cell-wrapper-noneditable';
         if (this.isSelected() && !this.isFocused()) {
             cellWrapperClass += ' cell-wrapper-selected';
         }

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -245,7 +245,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
     };
 
     private isShowingMarkdownEditor = (): boolean => {
-        return this.isMarkdownCell() && this.props.cellVM.focused;
+        return this.isMarkdownCell() && (this.props.cellVM.focused || !this.isNotebookTrusted());
     };
 
     private shouldRenderInput(): boolean {
@@ -265,7 +265,10 @@ export class NativeCell extends React.Component<INativeCellProps> {
     };
 
     private shouldRenderOutput(): boolean {
-        if (this.isCodeCell() && this.props.isNotebookTrusted) {
+        if (!this.isNotebookTrusted()) {
+            return false;
+        }
+        if (this.isCodeCell()) {
             const cell = this.getCodeCell();
             return (
                 this.hasOutput() &&
@@ -275,16 +278,13 @@ export class NativeCell extends React.Component<INativeCellProps> {
                 cell.outputs.length !== 0
             );
         } else if (this.isMarkdownCell()) {
-            return !this.isShowingMarkdownEditor() && this.isNotebookTrusted();
+            return !this.isShowingMarkdownEditor();
         }
         return false;
     }
 
     // tslint:disable-next-line: cyclomatic-complexity max-func-body-length
     private keyDownInput = (cellId: string, e: IKeyboardEvent) => {
-        if (!this.isNotebookTrusted()) {
-            return; // Disable keyboard interaction with untrusted notebooks
-        }
         const isFocusedWhenNotSuggesting = this.isFocused() && e.editorInfo && !e.editorInfo.isSuggesting;
         switch (e.code) {
             case 'ArrowUp':

--- a/src/datascience-ui/native-editor/nativeEditor.less
+++ b/src/datascience-ui/native-editor/nativeEditor.less
@@ -105,7 +105,7 @@
 .markdown-editor-area {
     position: relative;
     width:100%;
-    padding-right: 10px;
+    padding-right: 8px;
     margin-bottom: 0px;
     padding-left: 2px;
     padding-top: 2px;


### PR DESCRIPTION
Fixes #12148

+ Display prompt as error message so it doesn't dismiss on its own
+ Show markdown editor source per Graham's feedback at demo
+ Fix bug where shift+enter wasn't working on code cells after trusting a previously untrusted notebook
![image](https://user-images.githubusercontent.com/30305945/86184819-c4325280-bae9-11ea-817f-a54ce3a16a89.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
