### PR TITLE
Refactor ipywidget tests to use real kernel to wait for idle

### DIFF
--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -10,12 +10,14 @@ import { Event, EventEmitter } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { ServerStatus } from '../../datascience-ui/interactive-common/mainState';
 import { traceError, traceInfo, traceWarning } from '../common/logger';
-import { waitForPromise } from '../common/utils/async';
+import { sleep, waitForPromise } from '../common/utils/async';
 import * as localize from '../common/utils/localize';
 import { noop } from '../common/utils/misc';
 import { PythonInterpreter } from '../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../telemetry';
-import { Telemetry } from './constants';
+import { Identifiers, Telemetry } from './constants';
+import { JupyterInvalidKernelError } from './jupyter/jupyterInvalidKernelError';
+import { JupyterWaitForIdleError } from './jupyter/jupyterWaitForIdleError';
 import { JupyterKernelPromiseFailedError } from './jupyter/kernels/jupyterKernelPromiseFailedError';
 import { KernelSelector } from './jupyter/kernels/kernelSelector';
 import { LiveKernelModel } from './jupyter/kernels/types';
@@ -323,6 +325,79 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         timeoutMS: number,
         interpreter?: PythonInterpreter
     ): Promise<ISessionWithSocket>;
+
+    protected async waitForIdleOnSession(session: ISessionWithSocket | undefined, timeout: number): Promise<void> {
+        if (session && session.kernel) {
+            traceInfo(`Waiting for idle on (kernel): ${session.kernel.id} -> ${session.kernel.status}`);
+            // tslint:disable-next-line: no-any
+            const statusHandler = (resolve: () => void, reject: (exc: any) => void, e: Kernel.Status | undefined) => {
+                if (e === 'idle') {
+                    resolve();
+                } else if (e === 'dead') {
+                    traceError('Kernel died while waiting for idle');
+                    // If we throw an exception, make sure to shutdown the session as it's not usable anymore
+                    this.shutdownSession(session, this.statusHandler).ignoreErrors();
+                    reject(
+                        new JupyterInvalidKernelError({
+                            ...session.kernel,
+                            lastActivityTime: new Date(),
+                            numberOfConnections: 0,
+                            session: session.model
+                        })
+                    );
+                }
+            };
+
+            let statusChangeHandler: Slot<ISessionWithSocket, Kernel.Status> | undefined;
+            const kernelStatusChangedPromise = new Promise((resolve, reject) => {
+                statusChangeHandler = (_: ISessionWithSocket, e: Kernel.Status) => statusHandler(resolve, reject, e);
+                session.statusChanged.connect(statusChangeHandler);
+            });
+            let kernelChangedHandler: Slot<ISessionWithSocket, Session.IKernelChangedArgs> | undefined;
+            const statusChangedPromise = new Promise((resolve, reject) => {
+                kernelChangedHandler = (_: ISessionWithSocket, e: Session.IKernelChangedArgs) =>
+                    statusHandler(resolve, reject, e.newValue?.status);
+                session.kernelChanged.connect(kernelChangedHandler);
+            });
+            const checkStatusPromise = new Promise(async (resolve) => {
+                // This function seems to cause CI builds to timeout randomly on
+                // different tests. Waiting for status to go idle doesn't seem to work and
+                // in the past, waiting on the ready promise doesn't work either. Check status with a maximum of 5 seconds
+                const startTime = Date.now();
+                while (
+                    session &&
+                    session.kernel &&
+                    session.kernel.status !== 'idle' &&
+                    Date.now() - startTime < timeout
+                ) {
+                    await sleep(100);
+                }
+                resolve();
+            });
+            await Promise.race([kernelStatusChangedPromise, statusChangedPromise, checkStatusPromise]);
+            traceInfo(`Finished waiting for idle on (kernel): ${session.kernel.id} -> ${session.kernel.status}`);
+
+            if (statusChangeHandler && session && session.statusChanged) {
+                session.statusChanged.disconnect(statusChangeHandler);
+            }
+            if (kernelChangedHandler && session && session.kernelChanged) {
+                session.kernelChanged.disconnect(kernelChangedHandler);
+            }
+
+            // If we didn't make it out in ten seconds, indicate an error
+            if (session.kernel && session.kernel.status === 'idle') {
+                // So that we don't have problems with ipywidgets, always register the default ipywidgets comm target.
+                // Restart sessions and retries might make this hard to do correctly otherwise.
+                session.kernel.registerCommTarget(Identifiers.DefaultCommTarget, noop);
+
+                return;
+            }
+
+            // If we throw an exception, make sure to shutdown the session as it's not usable anymore
+            this.shutdownSession(session, this.statusHandler).ignoreErrors();
+            throw new JupyterWaitForIdleError(localize.DataScience.jupyterLaunchTimedOut());
+        }
+    }
 
     // Changes the current session.
     protected setSession(session: ISessionWithSocket | undefined) {

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -49,8 +49,12 @@ export class RawJupyterSession extends BaseJupyterSession {
     }
 
     @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
-    public async waitForIdle(_timeout: number): Promise<void> {
-        // RawKernels are good to go right away
+    public async waitForIdle(timeout: number): Promise<void> {
+        // Wait until status says idle.
+        if (this.session) {
+            return this.waitForIdleOnSession(this.session, timeout);
+        }
+        return Promise.resolve();
     }
     public async dispose(): Promise<void> {
         this._disposables.forEach((d) => d.dispose());

--- a/src/client/datascience/raw-kernel/rawSession.ts
+++ b/src/client/datascience/raw-kernel/rawSession.ts
@@ -26,13 +26,15 @@ export class RawSession implements ISessionWithSocket {
     private _clientID: string;
     private _kernel: RawKernel;
     private readonly _statusChanged: Signal<this, Kernel.Status>;
+    private readonly _kernelChanged: Signal<this, Session.IKernelChangedArgs>;
     private readonly exitHandler: IDisposable;
 
     // RawSession owns the lifetime of the kernel process and will dispose it
     constructor(public kernelProcess: IKernelProcess) {
         // tslint:disable-next-line: no-require-imports
-        const singaling = require('@phosphor/signaling') as typeof import('@phosphor/signaling');
-        this._statusChanged = new singaling.Signal<this, Kernel.Status>(this);
+        const signaling = require('@phosphor/signaling') as typeof import('@phosphor/signaling');
+        this._statusChanged = new signaling.Signal<this, Kernel.Status>(this);
+        this._kernelChanged = new signaling.Signal<this, Session.IKernelChangedArgs>(this);
         // Unique ID for this session instance
         this._id = uuid();
 
@@ -93,7 +95,7 @@ export class RawSession implements ISessionWithSocket {
         throw new Error('Not yet implemented');
     }
     get kernelChanged(): ISignal<this, Session.IKernelChangedArgs> {
-        throw new Error('Not yet implemented');
+        return this._kernelChanged;
     }
     get propertyChanged(): ISignal<this, 'path' | 'name' | 'type'> {
         throw new Error('Not yet implemented');

--- a/src/test/datascience/uiTests/notebookUi.ts
+++ b/src/test/datascience/uiTests/notebookUi.ts
@@ -6,6 +6,7 @@
 import { assert } from 'chai';
 import { ElementHandle } from 'playwright-chromium';
 import { InteractiveWindowMessages } from '../../../client/datascience/interactive-common/interactiveWindowTypes';
+import { INotebookEditor } from '../../../client/datascience/types';
 import { BaseWebUI } from './helpers';
 
 enum CellToolbarButton {
@@ -17,6 +18,10 @@ enum MainToolbarButton {
 }
 
 export class NotebookEditorUI extends BaseWebUI {
+    private _editor: INotebookEditor | undefined;
+    public _setEditor(editor: INotebookEditor) {
+        this._editor = editor;
+    }
     public async getCellCount(): Promise<number> {
         const items = await this.page!.$$('.cell-wrapper');
         return items.length;
@@ -29,6 +34,10 @@ export class NotebookEditorUI extends BaseWebUI {
 
     public async executeCell(cellIndex: number): Promise<void> {
         const renderedPromise = this.waitForMessage(InteractiveWindowMessages.ExecutionRendered);
+        // Make sure to wait for idle so that the button is clickable.
+        await this.waitForIdle();
+
+        // Click the run button.
         const runButton = await this.getToolbarButton(cellIndex, CellToolbarButton.run);
         await Promise.all([runButton.click({ button: 'left', force: true, timeout: 0 }), renderedPromise]);
     }
@@ -58,6 +67,14 @@ export class NotebookEditorUI extends BaseWebUI {
         const items = await this.page!.$$('.cell-wrapper');
         return items[cellIndex];
     }
+
+    private waitForIdle(): Promise<void> {
+        if (this._editor && this._editor.notebook) {
+            return this._editor.notebook.waitForIdle(60_000);
+        }
+        return Promise.resolve();
+    }
+
     private async getMainToolbarButton(button: MainToolbarButton): Promise<ElementHandle<Element>> {
         // First wait for the toolbar button to be visible.
         await this.page!.waitForFunction(


### PR DESCRIPTION
Last night's flake run had two failures:
https://dev.azure.com/ms/vscode-python/_build/results?buildId=91663&view=ms.vss-test-web.build-test-results-tab&runId=2487498&resultId=100344&paneView=debug

The Mac failure was ipywidgets failing again. This PR is an attempt to alleviate the problems with clicking on run buttons. My guess is that the run button is still busy and that's why it sometimes fails to run anything. 

In the log you can see that the 4th cell never even started:

```
2020-07-01T09:01:53.9625310Z Info 2020-07-01 09:01:53: Cell Execution for NotebookImport#3 : 
2020-07-01T09:01:53.9625920Z BoxGeometry(
2020-07-01T09:01:53.9626210Z     width=5,
2020-07-01T09:01:53.9626490Z     height=10,
2020-07-01T09:01:53.9626810Z     depth=15,
2020-07-01T09:01:53.9627090Z     widthSegments=5,
2020-07-01T09:01:53.9627430Z     heightSegments=10,
2020-07-01T09:01:53.9627750Z     depthSegments=15)
2020-07-01T09:01:53.9627980Z 
2020-07-01T09:01:53.9705840Z Info 2020-07-01 09:01:53: Kernel switching to busy
2020-07-01T09:01:54.0399670Z Info 2020-07-01 09:01:54: Kernel switching to idle
2020-07-01T09:01:54.0486070Z Info 2020-07-01 09:01:54: Cell Execution complete for NotebookImport#3
2020-07-01T09:01:54.0494720Z  Output: {"text/plain":"Preview(child=BoxGeometry(depth=15.0, depthSegments=15, height=10.0, heightSegments=10, width=5.0, widthSegmen…","application/vnd.jupyter.widget-view+json":{"version_major":2,"version_minor":0,"model_id":"pythree_example_model_002"}}
2020-07-01T09:01:54.0496860Z Info 2020-07-01 09:01:54: Finished execution for NotebookImport#3
2020-07-01T09:01:54.0527980Z Info 2020-07-01 09:01:54: Finished executing cell NotebookImport#3
2020-07-01T09:03:09.8675560Z   [31m  1) Render pythreejs[0m
2020-07-01T09:03:09.8676960Z Info 2020-07-01 09:03:09: Disposing HostJupyterExecution c4f3255e-aaab-4a82-b07a-424fb7f37b5a
```

The last cell executed was the 3rd one and then it took a minute for the test to fail after that. With no logging at all for the 4th cell I can only surmise that the button wasn't even clicked. 

I'll enter a separate PR for the debug breakpoint failure that happened on windows (assuming I can figure that out).