### PR TITLE
Give restarts a chance when running debugger tests

### DIFF
--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -337,7 +337,10 @@ suite('DataScience Debugger tests', () => {
                 disposables.push(jupyterDebuggerService!.onBreakpointHit(() => breakPromise.resolve()));
                 const targetUri = Uri.file(fileName);
                 const done = history.debugCode(code, targetUri.fsPath, 0, docManager.activeTextEditor);
-                await waitForPromise(Promise.race([done, breakPromise.promise]), 60000);
+                await waitForPromise(
+                    Promise.race([done, breakPromise.promise]),
+                    ioc.getSettings().datascience.jupyterLaunchTimeout * 2 // Give restarts a chance
+                );
                 assert.ok(breakPromise.resolved, 'Breakpoint event did not fire');
                 assert.ok(!lastErrorMessage, `Error occurred ${lastErrorMessage}`);
                 const stackFrames = await jupyterDebuggerService!.getStack();


### PR DESCRIPTION
The other failure on the nightly tests looks like a wait for idle problem.

https://dev.azure.com/ms/vscode-python/_build/results?buildId=91663&view=ms.vss-test-web.build-test-results-tab&runId=2487752&resultId=100095&paneView=debug

If you look at the log, you can see the wait for idle pattern that indicates jupyter didn't respond:

```
2020-07-01T08:50:06.1708093Z Starting WebSocket: ws://localhost:8888/api/kernels/0ac92d36-607f-4a99-b474-94ee6e5af0d1
2020-07-01T08:50:06.1726565Z Info 2020-07-01 08:50:06: Waiting for idle on (kernel): 0ac92d36-607f-4a99-b474-94ee6e5af0d1 -> unknown <--- This here indicates Jupyter didn't respond
2020-07-01T08:50:07.4265779Z Kernel: connected (0ac92d36-607f-4a99-b474-94ee6e5af0d1)
2020-07-01T08:51:03.6736680Z   [31m  1) Debug temporary file (interactive)[0m
2020-07-01T08:51:03.6757169Z Info 2020-07-01 08:51:03: Disposing HostJupyterExecution d892684d-8481-407a-a248-109590a9d798
```

In the test we only wait for 60 seconds for a breakpoint to appear. This isn't long enough if we go through the wait for idle loop when jupyter doesn't respond.
