### PR TITLE
Fix #12595: Opt out of process tree compacting

### DIFF
--- a/src/client/common/application/debugService.ts
+++ b/src/client/common/application/debugService.ts
@@ -13,6 +13,7 @@ import {
     DebugConsole,
     DebugSession,
     DebugSessionCustomEvent,
+    DebugSessionOptions,
     Disposable,
     Event,
     WorkspaceFolder
@@ -57,9 +58,9 @@ export class DebugService implements IDebugService {
     public startDebugging(
         folder: WorkspaceFolder | undefined,
         nameOrConfiguration: string | DebugConfiguration,
-        parentSession?: DebugSession
+        options?: DebugSessionOptions
     ): Thenable<boolean> {
-        return debug.startDebugging(folder, nameOrConfiguration, parentSession);
+        return debug.startDebugging(folder, nameOrConfiguration, options);
     }
     public addBreakpoints(breakpoints: Breakpoint[]): void {
         debug.addBreakpoints(breakpoints);

--- a/src/client/common/application/types.ts
+++ b/src/client/common/application/types.ts
@@ -14,6 +14,7 @@ import {
     DebugConsole,
     DebugSession,
     DebugSessionCustomEvent,
+    DebugSessionOptions,
     DecorationRenderOptions,
     Disposable,
     DocumentSelector,
@@ -70,7 +71,6 @@ import type {
     NotebookOutputSelector
 } from 'vscode-proposed';
 import * as vsls from 'vsls/vscode';
-
 import { IAsyncDisposable, Resource } from '../types';
 import { ICommandNameArgumentTypeMapping } from './commands';
 
@@ -927,7 +927,7 @@ export interface IDebugService {
     startDebugging(
         folder: WorkspaceFolder | undefined,
         nameOrConfiguration: string | DebugConfiguration,
-        parentSession?: DebugSession
+        options?: DebugSessionOptions
     ): Thenable<boolean>;
 
     /**

--- a/src/client/datascience/jupyterDebugService.ts
+++ b/src/client/datascience/jupyterDebugService.ts
@@ -14,6 +14,7 @@ import {
     DebugConsole,
     DebugSession,
     DebugSessionCustomEvent,
+    DebugSessionOptions,
     Disposable,
     Event,
     EventEmitter,
@@ -167,7 +168,7 @@ export class JupyterDebugService implements IJupyterDebugService, IDisposable {
     public startDebugging(
         _folder: WorkspaceFolder | undefined,
         nameOrConfiguration: string | DebugConfiguration,
-        _parentSession?: DebugSession | undefined
+        _options?: DebugSessionOptions
     ): Thenable<boolean> {
         // Should have a port number. We'll assume it's local
         const config = nameOrConfiguration as DebugConfiguration; // NOSONAR

--- a/src/client/datascience/multiplexingDebugService.ts
+++ b/src/client/datascience/multiplexingDebugService.ts
@@ -11,6 +11,7 @@ import {
     DebugConsole,
     DebugSession,
     DebugSessionCustomEvent,
+    DebugSessionOptions,
     Disposable,
     Event,
     EventEmitter,
@@ -106,10 +107,10 @@ export class MultiplexingDebugService implements IJupyterDebugService {
     public startDebugging(
         folder: WorkspaceFolder | undefined,
         nameOrConfiguration: string | DebugConfiguration,
-        parentSession?: DebugSession | undefined
+        options?: DebugSessionOptions
     ): Thenable<boolean> {
         this.lastStartedService = this.vscodeDebugService;
-        return this.vscodeDebugService.startDebugging(folder, nameOrConfiguration, parentSession);
+        return this.vscodeDebugService.startDebugging(folder, nameOrConfiguration, options);
     }
     public addBreakpoints(breakpoints: Breakpoint[]): void {
         return this.activeService.addBreakpoints(breakpoints);

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { DebugConfiguration, DebugSession, WorkspaceFolder } from 'vscode';
+import { DebugConfiguration, DebugSession, DebugSessionOptions, WorkspaceFolder } from 'vscode';
 import { IApplicationShell, IDebugService, IWorkspaceService } from '../../../common/application/types';
 import { noop } from '../../../common/utils/misc';
 import { captureTelemetry } from '../../../telemetry';
@@ -32,7 +32,10 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
         const debugConfig: AttachRequestArguments & DebugConfiguration = data;
         const processId = debugConfig.subProcessId!;
         const folder = this.getRelatedWorkspaceFolder(debugConfig);
-        const launched = await this.debugService.startDebugging(folder, debugConfig, parentSession);
+        const launched = await this.debugService.startDebugging(folder, debugConfig, {
+            parentSession,
+            noCompact: true
+        } as DebugSessionOptions);
         if (!launched) {
             this.appShell.showErrorMessage(`Failed to launch debugger for child process ${processId}`).then(noop, noop);
         }

--- a/src/test/datascience/mockDebugService.ts
+++ b/src/test/datascience/mockDebugService.ts
@@ -11,6 +11,7 @@ import {
     DebugConsole,
     DebugSession,
     DebugSessionCustomEvent,
+    DebugSessionOptions,
     Disposable,
     Event,
     WorkspaceFolder
@@ -72,9 +73,9 @@ export class MockDebuggerService implements IJupyterDebugService {
     public startDebugging(
         folder: WorkspaceFolder | undefined,
         nameOrConfiguration: string | DebugConfiguration,
-        parentSession?: DebugSession | undefined
+        options?: DebugSessionOptions
     ): Thenable<boolean> {
-        return this.activeService.startDebugging(folder, nameOrConfiguration, parentSession);
+        return this.activeService.startDebugging(folder, nameOrConfiguration, options);
     }
     public addBreakpoints(breakpoints: Breakpoint[]): void {
         return this.activeService.addBreakpoints(breakpoints);

--- a/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
+++ b/src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
@@ -144,7 +144,8 @@ suite('Debug - Attach to Child Process', () => {
         verify(debugService.startDebugging(undefined, anything(), anything())).once();
         const [, secondArg, thirdArg] = capture(debugService.startDebugging).last();
         expect(secondArg).to.deep.equal(debugConfig);
-        expect(thirdArg).to.deep.equal(session);
+        expect(thirdArg).to.have.property('parentSession', session);
+        expect(thirdArg).to.have.property('noCompact', true, 'Sessions must not be compacted');
         verify(shell.showErrorMessage(anything())).never();
     });
     test('Pass data as is if data is attach debug configuration', async () => {
@@ -165,7 +166,8 @@ suite('Debug - Attach to Child Process', () => {
         verify(debugService.startDebugging(undefined, anything(), anything())).once();
         const [, secondArg, thirdArg] = capture(debugService.startDebugging).last();
         expect(secondArg).to.deep.equal(debugConfig);
-        expect(thirdArg).to.deep.equal(session);
+        expect(thirdArg).to.have.property('parentSession', session);
+        expect(thirdArg).to.have.property('noCompact', true, 'Sessions must not be compacted');
         verify(shell.showErrorMessage(anything())).never();
     });
     test('Validate debug config when parent/root parent was attached', async () => {
@@ -193,7 +195,8 @@ suite('Debug - Attach to Child Process', () => {
         verify(debugService.startDebugging(undefined, anything(), anything())).once();
         const [, secondArg, thirdArg] = capture(debugService.startDebugging).last();
         expect(secondArg).to.deep.equal(debugConfig);
-        expect(thirdArg).to.deep.equal(session);
+        expect(thirdArg).to.have.property('parentSession', session);
+        expect(thirdArg).to.have.property('noCompact', true, 'Sessions must not be compacted');
         verify(shell.showErrorMessage(anything())).never();
     });
 });


### PR DESCRIPTION
Change IDebugService.startDebugging() to use DebugSessionOptions.

Use {noCompact: true} option for child sessions.

For #12595

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
