### PR TITLE
Fix export from the interactive window

### DIFF
--- a/news/2 Fixes/12460.md
+++ b/news/2 Fixes/12460.md
@@ -1,0 +1,1 @@
+Fix the export button from the interactive window to export again.

--- a/src/client/datascience/export/exportManagerFileOpener.ts
+++ b/src/client/datascience/export/exportManagerFileOpener.ts
@@ -1,12 +1,11 @@
 import { inject, injectable } from 'inversify';
 import { Position, Uri } from 'vscode';
-import { getLocString } from '../../../datascience-ui/react-common/locReactSide';
 import { IApplicationShell, IDocumentManager } from '../../common/application/types';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError } from '../../common/logger';
 import { IFileSystem } from '../../common/platform/types';
 import { IBrowserService } from '../../common/types';
-import { DataScience } from '../../common/utils/localize';
+import * as localize from '../../common/utils/localize';
 import { sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
 import { INotebookModel } from '../types';
@@ -33,7 +32,7 @@ export class ExportManagerFileOpener implements IExportManager {
             sendTelemetryEvent(Telemetry.ExportNotebookAsFailed, undefined, { format: format });
 
             if (format === ExportFormat.pdf) {
-                msg = DataScience.exportToPDFDependencyMessage();
+                msg = localize.DataScience.exportToPDFDependencyMessage();
             }
 
             this.showExportFailed(msg);
@@ -78,21 +77,18 @@ export class ExportManagerFileOpener implements IExportManager {
         this.applicationShell
             .showErrorMessage(
                 // tslint:disable-next-line: messages-must-be-localized
-                `${getLocString('DataScience.failedExportMessage', 'Export failed.')} ${msg}`
+                `${localize.DataScience.failedExportMessage()} ${msg}`
             )
             .then();
     }
 
     private async askOpenFile(uri: Uri): Promise<boolean> {
-        const yes = getLocString('DataScience.openExportFileYes', 'Yes');
-        const no = getLocString('DataScience.openExportFileNo', 'No');
+        const yes = localize.DataScience.openExportFileYes();
+        const no = localize.DataScience.openExportFileNo();
         const items = [yes, no];
 
         const selected = await this.applicationShell
-            .showInformationMessage(
-                getLocString('DataScience.openExportedFileMessage', 'Would you like to open the exported file?'),
-                ...items
-            )
+            .showInformationMessage(localize.DataScience.openExportedFileMessage(), ...items)
             .then((item) => item);
 
         if (selected === yes) {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -622,7 +622,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         if (this.model && selection === localize.DataScience.trustNotebook() && !this.model.isTrusted) {
             try {
                 const contents = this.model.getContent();
-                await this.trustService.trustNotebook(this.model.file.toString(), contents);
+                await this.trustService.trustNotebook(this.model.file, contents);
                 // Update model trust
                 this.model.update({
                     source: 'user',

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -100,7 +100,7 @@ export class NativeEditorStorage implements INotebookStorage {
         const contents = model.getContent();
         const parallelize = [this.fileSystem.writeFile(model.file.fsPath, contents, 'utf-8')];
         if (model.isTrusted) {
-            parallelize.push(this.trustService.trustNotebook(model.file.toString(), contents));
+            parallelize.push(this.trustService.trustNotebook(model.file, contents));
         }
         await Promise.all(parallelize);
         model.update({
@@ -116,7 +116,7 @@ export class NativeEditorStorage implements INotebookStorage {
         const contents = model.getContent();
         const parallelize = [this.fileSystem.writeFile(file.fsPath, contents, 'utf-8')];
         if (model.isTrusted) {
-            parallelize.push(this.trustService.trustNotebook(file.toString(), contents));
+            parallelize.push(this.trustService.trustNotebook(file, contents));
         }
         await Promise.all(parallelize);
         model.update({
@@ -356,7 +356,7 @@ export class NativeEditorStorage implements INotebookStorage {
         const isTrusted =
             contents === undefined || isUntitledFile(file)
                 ? true // If no contents or untitled, this is a newly created file, so it should be trusted
-                : await this.trustService.isNotebookTrusted(file.toString(), contentsToCheck!);
+                : await this.trustService.isNotebookTrusted(file, contentsToCheck!);
         return this.factory.createModel(
             {
                 trusted: isTrusted,

--- a/src/client/datascience/interactive-ipynb/trustService.ts
+++ b/src/client/datascience/interactive-ipynb/trustService.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'crypto';
 import { inject, injectable } from 'inversify';
-import { EventEmitter } from 'vscode';
+import { EventEmitter, Uri } from 'vscode';
 import { IConfigurationService } from '../../common/types';
 import { IDigestStorage, ITrustService } from '../types';
 
@@ -26,7 +26,7 @@ export class TrustService implements ITrustService {
      * Once a notebook is loaded in an untrusted state, no code will be executed and no
      * markdown will be rendered until notebook as a whole is marked trusted
      */
-    public async isNotebookTrusted(uri: string, notebookContents: string) {
+    public async isNotebookTrusted(uri: Uri, notebookContents: string) {
         if (this.alwaysTrustNotebooks) {
             return true; // User manually overrode our trust checking
         }
@@ -40,7 +40,7 @@ export class TrustService implements ITrustService {
      * It will add a new trusted checkpoint to the local database if it's safe to do so
      * I.e. if the notebook has already been trusted by the user
      */
-    public async trustNotebook(uri: string, notebookContents: string) {
+    public async trustNotebook(uri: Uri, notebookContents: string) {
         if (!this.alwaysTrustNotebooks) {
             // Only update digest store if the user wants us to check trust
             const digest = await this.computeDigest(notebookContents);

--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -24,7 +24,8 @@ import {
     IDataScienceErrorHandler,
     IJupyterExecution,
     INotebookEditorProvider,
-    INotebookExporter
+    INotebookExporter,
+    ITrustService
 } from '../types';
 
 @injectable()
@@ -37,7 +38,8 @@ export class JupyterExporter implements INotebookExporter {
         @inject(IPlatformService) private readonly platform: IPlatformService,
         @inject(IApplicationShell) private readonly applicationShell: IApplicationShell,
         @inject(INotebookEditorProvider) protected ipynbProvider: INotebookEditorProvider,
-        @inject(IDataScienceErrorHandler) protected errorHandler: IDataScienceErrorHandler
+        @inject(IDataScienceErrorHandler) protected errorHandler: IDataScienceErrorHandler,
+        @inject(ITrustService) private readonly trustService: ITrustService
     ) {}
 
     public dispose() {
@@ -56,6 +58,7 @@ export class JupyterExporter implements INotebookExporter {
         try {
             // tslint:disable-next-line: no-any
             const contents = JSON.stringify(notebook);
+            await this.trustService.trustNotebook(Uri.file(file.toLowerCase()), contents);
             await this.fileSystem.writeFile(file, contents, { encoding: 'utf8', flag: 'w' });
             const openQuestion1 = localize.DataScience.exportOpenQuestion1();
             const openQuestion2 = (await this.jupyterExecution.isSpawnSupported())

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1268,13 +1268,13 @@ export interface IJupyterUriProviderRegistration {
 export const IDigestStorage = Symbol('IDigestStorage');
 export interface IDigestStorage {
     readonly key: Promise<string>;
-    saveDigest(uri: string, digest: string): Promise<void>;
-    containsDigest(uri: string, digest: string): Promise<boolean>;
+    saveDigest(uri: Uri, digest: string): Promise<void>;
+    containsDigest(uri: Uri, digest: string): Promise<boolean>;
 }
 
 export const ITrustService = Symbol('ITrustService');
 export interface ITrustService {
     readonly onDidSetNotebookTrust: Event<void>;
-    isNotebookTrusted(uri: string, notebookContents: string): Promise<boolean>;
-    trustNotebook(uri: string, notebookContents: string): Promise<void>;
+    isNotebookTrusted(uri: Uri, notebookContents: string): Promise<boolean>;
+    trustNotebook(uri: Uri, notebookContents: string): Promise<void>;
 }

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -168,7 +168,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                         </ImageButton>
                         <ImageButton
                             baseTheme={this.props.baseTheme}
-                            onClick={this.props.exportAs}
+                            onClick={this.props.export}
                             disabled={this.props.cellVMs.length === 0 || this.props.busy}
                             tooltip={getLocString('DataScience.export', 'Export as Jupyter notebook')}
                         >

--- a/src/test/datascience/trustService.unit.test.ts
+++ b/src/test/datascience/trustService.unit.test.ts
@@ -29,6 +29,8 @@ suite('DataScience - TrustService', () => {
         });
         when(fileSystem.appendFile(anything(), anything())).thenCall((f, c) => fs.appendFile(f, c));
         when(fileSystem.readFile(anything())).thenCall((f) => fs.readFile(f));
+        when(fileSystem.createDirectory(anything())).thenCall((d) => fs.mkdir(d));
+        when(fileSystem.directoryExists(anything())).thenCall((d) => fs.pathExists(d));
 
         const digestStorage = new DigestStorage(instance(fileSystem), context.object);
         trustService = new TrustService(digestStorage, instance(configService));

--- a/src/test/datascience/trustService.unit.test.ts
+++ b/src/test/datascience/trustService.unit.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import { assert } from 'chai';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import { anything, instance, mock, when } from 'ts-mockito';
+import * as typemoq from 'typemoq';
+import { Uri } from 'vscode';
+import { ConfigurationService } from '../../client/common/configuration/service';
+import { FileSystem } from '../../client/common/platform/fileSystem';
+import { IExtensionContext } from '../../client/common/types';
+import { DigestStorage } from '../../client/datascience/interactive-ipynb/digestStorage';
+import { TrustService } from '../../client/datascience/interactive-ipynb/trustService';
+
+suite('DataScience - TrustService', () => {
+    let trustService: TrustService;
+    let alwaysTrustNotebooks: boolean = false;
+    setup(() => {
+        const configService = mock(ConfigurationService);
+        const fileSystem = mock(FileSystem);
+        const context = typemoq.Mock.ofType<IExtensionContext>();
+        context.setup((c) => c.globalStoragePath).returns(() => os.tmpdir());
+        when(configService.getSettings()).thenCall(() => {
+            // tslint:disable-next-line: no-any
+            return { datascience: { alwaysTrustNotebooks } } as any;
+        });
+        when(fileSystem.appendFile(anything(), anything())).thenCall((f, c) => fs.appendFile(f, c));
+        when(fileSystem.readFile(anything())).thenCall((f) => fs.readFile(f));
+
+        const digestStorage = new DigestStorage(instance(fileSystem), context.object);
+        trustService = new TrustService(digestStorage, instance(configService));
+    });
+
+    test('Trusting a notebook', async () => {
+        const uri = Uri.file('foo.ipynb');
+        await trustService.trustNotebook(uri, 'foobar');
+        assert.ok(await trustService.isNotebookTrusted(uri, 'foobar'), 'Notebook is not trusted');
+        assert.notOk(await trustService.isNotebookTrusted(uri, 'foobaz'));
+    });
+    test('Trusting a notebook with same path', async () => {
+        const uri = Uri.file('foo.ipynb');
+        const uri2 = Uri.file('FOO.ipynb');
+        if (os.platform() === 'win32') {
+            await trustService.trustNotebook(uri, 'foobar');
+            assert.ok(await trustService.isNotebookTrusted(uri2, 'foobar'), 'Notebook is not trusted');
+        }
+    });
+    test('Always trusting notebooks', async () => {
+        alwaysTrustNotebooks = true;
+        const uri = Uri.file('foo.ipynb');
+        assert.ok(await trustService.isNotebookTrusted(uri, 'foobar'), 'Notebook is not trusted when all should be');
+    });
+});

--- a/src/test/datascience/trustService.unit.test.ts
+++ b/src/test/datascience/trustService.unit.test.ts
@@ -18,6 +18,7 @@ suite('DataScience - TrustService', () => {
     let trustService: TrustService;
     let alwaysTrustNotebooks: boolean = false;
     setup(() => {
+        alwaysTrustNotebooks = false;
         const configService = mock(ConfigurationService);
         const fileSystem = mock(FileSystem);
         const context = typemoq.Mock.ofType<IExtensionContext>();


### PR DESCRIPTION
For #12460 

Export from the interactive window was broken because it was halfway switched to the new way. Switched it back.

Also made it so it would auto trust the notebook generated. 

Also changed the trust service to not care about file path case (on windows) and added some unit tests for the trust service.

Also fixed up a bug I noticed with loc in the exportFileManager.
