### PR TITLE
Fix #12705: Tests broken due to Prospector / Python 2.7 incompatibility

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -7,7 +7,7 @@ black ; python_version>='3.6'
 yapf
 pylint
 pycodestyle
-prospector
+prospector==1.2.0 # Last version of prospector with Python 2.7 support
 pydocstyle
 nose
 pytest==4.6.9 # Last version of pytest with Python 2.7 support


### PR DESCRIPTION
Pin prospector to 1.2.0 in test-requirements.txt.

For #12705
