### PR TITLE
Enable logging in DS tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3115,7 +3115,7 @@
         "testDebugger": "node ./out/test/testBootstrap.js ./out/test/debuggerTest.js",
         "testSingleWorkspace": "node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "pretestDataScience": "node ./out/test/datascience/dsTestSetup.js",
-        "testDataScience": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_PYTHON_CI_TEST_VSC_CHANNEL=insiders TEST_FILES_SUFFIX=ds.test VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
+        "testDataScience": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_PYTHON_CI_TEST_VSC_CHANNEL=insiders TEST_FILES_SUFFIX=ds.test VSC_PYTHON_FORCE_LOGGING=1 VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "testMultiWorkspace": "node ./out/test/testBootstrap.js ./out/test/multiRootTest.js",
         "testPerformance": "node ./out/test/testBootstrap.js ./out/test/performanceTest.js",
         "testSmoke": "node ./out/test/smokeTest.js",

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -23,5 +23,6 @@
     // Ensure auto save is off.
     "files.autoSave": "off",
     // We don't want jupyter to start when testing (DS functionality or anything else).
-    "python.dataScience.disableJupyterAutoStart": true
+    "python.dataScience.disableJupyterAutoStart": true,
+    "python.logging.level": "debug"
 }

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -24,5 +24,5 @@
     "files.autoSave": "off",
     // We don't want jupyter to start when testing (DS functionality or anything else).
     "python.dataScience.disableJupyterAutoStart": true,
-    "python.logging.level": "trace"
+    "python.logging.level": "debug"
 }

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -24,5 +24,5 @@
     "files.autoSave": "off",
     // We don't want jupyter to start when testing (DS functionality or anything else).
     "python.dataScience.disableJupyterAutoStart": true,
-    "python.logging.level": "debug"
+    "python.logging.level": "trace"
 }

--- a/src/test/datascience/dsTestSetup.ts
+++ b/src/test/datascience/dsTestSetup.ts
@@ -58,5 +58,6 @@ if (
 
 // Update package.json to pick experiments from our custom settings.json file.
 content.contributes.configuration.properties['python.experiments.optInto'].scope = 'resource';
+content.contributes.configuration.properties['python.logging.level'].scope = 'resource';
 
 fs.writeFileSync(packageJsonFile, JSON.stringify(content, undefined, 4));


### PR DESCRIPTION
For #10496
Looks like we've lost all logging in tests, this brings it back for DS tests.
Some tests are failing on CI in VSC Insiders, need the logs.

~@rchiodo not sure if we need the same for our PR tests as well.~