### PR TITLE
Jupyter kernelspec list doesn't always work

### DIFF
--- a/news/2 Fixes/11412.md
+++ b/news/2 Fixes/11412.md
@@ -1,0 +1,1 @@
+Get Jupyter connections to work with a Windows store installed Python/Jupyter combination.

--- a/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
+++ b/src/client/datascience/jupyter/interpreter/jupyterInterpreterSubCommandExecutionService.ts
@@ -239,7 +239,12 @@ export class JupyterInterpreterSubCommandExecutionService
                 stdoutFromFileExecPromise
             ]);
 
-            return parseKernelSpecs(stdoutFromDaemon || stdoutFromFileExec, this.fs, token).catch((parserError) => {
+            return parseKernelSpecs(
+                stdoutFromDaemon || stdoutFromFileExec,
+                this.fs,
+                this.pythonExecutionFactory,
+                token
+            ).catch((parserError) => {
                 traceError('Failed to parse kernelspecs', parserError);
                 // This is failing for some folks. In that case return nothing
                 return [];

--- a/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
+++ b/src/client/datascience/jupyter/kernels/jupyterKernelSpec.ts
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 'use strict';
 import type { Kernel } from '@jupyterlab/services';
+import * as os from 'os';
 import * as path from 'path';
 import { CancellationToken } from 'vscode';
 import { createPromiseFromCancellation } from '../../../common/cancellation';
 import { traceInfo } from '../../../common/logger';
 import { IFileSystem } from '../../../common/platform/types';
+import { IPythonExecutionFactory } from '../../../common/process/types';
 import { PythonInterpreter } from '../../../pythonEnvironments/info';
 import { IJupyterKernelSpec } from '../../types';
 
@@ -43,7 +45,12 @@ export class JupyterKernelSpec implements IJupyterKernelSpec {
  * @param {CancellationToken} [token]
  * @returns
  */
-export async function parseKernelSpecs(stdout: string, fs: IFileSystem, token?: CancellationToken) {
+export async function parseKernelSpecs(
+    stdout: string,
+    fs: IFileSystem,
+    execFactory: IPythonExecutionFactory,
+    token?: CancellationToken
+) {
     traceInfo('Parsing kernelspecs from jupyter');
     // This should give us back a key value pair we can parse
     const jsOut = JSON.parse(stdout.trim()) as {
@@ -54,22 +61,65 @@ export async function parseKernelSpecs(stdout: string, fs: IFileSystem, token?: 
     const specs = await Promise.race([
         Promise.all(
             Object.keys(kernelSpecs).map(async (kernelName) => {
-                const specFile = path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json');
-                const spec = kernelSpecs[kernelName].spec;
+                const spec = kernelSpecs[kernelName].spec as Kernel.ISpecModel;
                 // Add the missing name property.
                 const model = {
                     ...spec,
                     name: kernelName
                 };
-                // Check if the spec file exists.
-                if (await fs.fileExists(specFile)) {
+                const specFile = await getKernelSpecFile(
+                    fs,
+                    execFactory,
+                    spec.argv[0],
+                    path.join(kernelSpecs[kernelName].resource_dir, 'kernel.json')
+                );
+                if (specFile) {
                     return new JupyterKernelSpec(model as Kernel.ISpecModel, specFile);
-                } else {
-                    return;
                 }
             })
         ),
         createPromiseFromCancellation({ cancelAction: 'resolve', defaultValue: [], token })
     ]);
     return specs.filter((item) => !!item).map((item) => item as JupyterKernelSpec);
+}
+
+export async function getKernelSpecFile(
+    fs: IFileSystem,
+    execFactory: IPythonExecutionFactory,
+    pythonPath: string,
+    expectedPath: string
+): Promise<string | undefined> {
+    if (await fs.fileExists(expectedPath)) {
+        return expectedPath;
+    }
+
+    // On windows, a store installed python may not put kernel.json in the
+    // spot returned by jupyter kernelspec list. Detect this situation and look in the
+    // store cache location.
+    // Not super happy with this. It's basically working around a bug in jupyter kernelspec list
+    if (os.platform() === 'win32' && expectedPath.includes('Roaming')) {
+        // Run this python and ask for its USER_BASE. That should have the
+        // real location for jupyter kernels
+        const pythonRunner = await execFactory.create({ pythonPath });
+        const result = await pythonRunner.exec(['-c', 'import site;print(site.USER_BASE)'], {
+            throwOnStdErr: false,
+            encoding: 'utf-8'
+        });
+        if (result.stdout) {
+            // Path should be one up and under 'Roaming\jupyter\kernels'
+            const fileName = path.basename(expectedPath);
+            const baseDirName = path.basename(path.dirname(expectedPath));
+            const specFile = path.join(
+                path.normalize(path.join(result.stdout, '..')),
+                'Roaming',
+                'jupyter',
+                'kernels',
+                baseDirName,
+                fileName
+            );
+            if (await fs.fileExists(specFile)) {
+                return specFile;
+            }
+        }
+    }
 }


### PR DESCRIPTION
For #11412 

The root cause of this bug is that jupyter kernelspec is wrong. It returns paths that don't actually exist. Ipykernel install will also do the same thing (even though a file is installed in a different path, it will still return the %APPDATA% path.).

I checked and their code is doing this:

```
appdata = os.environ.get('APPDATA', None)
        if appdata:
            return pjoin(appdata, 'jupyter')
        else:
            return pjoin(jupyter_config_dir(), 'data')
```

Which when accessed from within the python executable (meaning a read of this path), it will return the real path. However when sent outside of the executable, it gives an invalid path.

Here's an example. Inside of the python executable, running this code:
```
os.listdir(os.environ.get('APPDATA'))
```
returns different values than running this:
```
dir %APPDATA%
```
