### PR TITLE
Log diagnosis info and Increase timeout for flaky tests & hooks

### DIFF
--- a/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
+++ b/src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
@@ -81,7 +81,9 @@ suite('Activation of Environments in Terminal', () => {
         outputFilesCreated.push(outputFile);
     });
 
-    suiteTeardown(async () => {
+    suiteTeardown(async function () {
+        // tslint:disable-next-line: no-invalid-this
+        this.timeout(TEST_TIMEOUT * 2);
         await revertSettings();
 
         // remove all created log files.

--- a/src/test/format/extension.sort.test.ts
+++ b/src/test/format/extension.sort.test.ts
@@ -160,7 +160,7 @@ suite('Sorting', () => {
         const originalContent = textDocument.getText();
         await commands.executeCommand(Commands.Sort_Imports);
         assert.notEqual(originalContent, textDocument.getText(), 'Contents have not changed');
-    });
+    }).timeout(TEST_TIMEOUT * 2);
 
     test('With Changes and Config implicit from cwd', async () => {
         const textDocument = await workspace.openTextDocument(fileToFormatWithConfig);

--- a/src/test/testing/pytest/pytest.run.test.ts
+++ b/src/test/testing/pytest/pytest.run.test.ts
@@ -519,7 +519,10 @@ suite('Unit Tests - pytest - run with mocked process output', () => {
             let testManager: ITestManager;
             let results: Tests;
             let diagnostics: readonly vscode.Diagnostic[];
-            suiteSetup(async () => {
+            suiteSetup(async function () {
+                // This "before all" hook is doing way more than normal
+                // tslint:disable-next-line: no-invalid-this
+                this.timeout(TEST_TIMEOUT * 2);
                 await initializeTest();
                 initializeDI();
                 await injectTestDiscoveryOutput(scenario.discoveryOutput);


### PR DESCRIPTION
Details provided in the comments. Until we figure out the root cause, I choose to increase timeouts rather than disabling these useful tests.