### PR TITLE
Added export to PDF, HTML and python to interactive window

### DIFF
--- a/news/1 Enhancements/12732.md
+++ b/news/1 Enhancements/12732.md
@@ -1,0 +1,1 @@
+Added exporting to python, HTML and PDF from the interative window.

--- a/package.nls.json
+++ b/package.nls.json
@@ -125,7 +125,7 @@
     "DataScience.exportDialogFailed": "Failed to export notebook. {0}",
     "DataScience.exportOpenQuestion": "Open in browser",
     "DataScience.exportOpenQuestion1": "Open in editor",
-    "DataScience.notebookExportAs": "Convert and save to a python script",
+    "DataScience.notebookExportAs": "Export As",
     "DataScience.exportAsQuickPickPlaceholder": "Export As...",
     "DataScience.exportPythonQuickPickLabel": "Python Script",
     "DataScience.collapseInputTooltip": "Collapse input block",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -815,7 +815,7 @@ export namespace DataScience {
         'DataScience.remoteDebuggerNotSupported',
         'Debugging while attached to a remote server is not currently supported.'
     );
-    export const notebookExportAs = localize('DataScience.notebookExportAs', 'Convert and save to a python script');
+    export const notebookExportAs = localize('DataScience.notebookExportAs', 'Export As');
     export const exportAsPythonFileTitle = localize('DataScience.exportAsPythonFileTitle', 'Save As Python File');
     export const exportAsQuickPickPlaceholder = localize('DataScience.exportAsQuickPickPlaceholder', 'Export As...');
     export const openExportedFileMessage = localize(

--- a/src/client/datascience/export/exportManager.ts
+++ b/src/client/datascience/export/exportManager.ts
@@ -53,8 +53,8 @@ export class ExportManager implements IExportManager {
                     break;
             }
         } finally {
-            await this.exportUtil.deleteDirectory(path.dirname(tempFilePath));
             reporter.dispose();
+            this.exportUtil.deleteDirectory(path.dirname(tempFilePath)).then().catch();
         }
 
         return target;

--- a/src/client/datascience/export/exportToPDF.ts
+++ b/src/client/datascience/export/exportToPDF.ts
@@ -19,17 +19,8 @@ export class ExportToPDF extends ExportBase {
     }
 
     public async export(source: Uri, target: Uri): Promise<void> {
-        const tempFile = await this.fileSystem.createTemporaryFile('.ipynb');
-        const directoryPath = path.join(
-            path.dirname(tempFile.filePath),
-            path.basename(tempFile.filePath, path.extname(tempFile.filePath))
-        );
-        tempFile.dispose();
-        const newFileName = path.basename(target.fsPath, path.extname(target.fsPath));
-        const newSource = Uri.file(await this.createNewFile(directoryPath, newFileName, source));
-
         const args = [
-            newSource.fsPath,
+            source.fsPath,
             '--to',
             'pdf',
             '--output',
@@ -37,37 +28,6 @@ export class ExportToPDF extends ExportBase {
             '--output-dir',
             path.dirname(target.fsPath)
         ];
-        try {
-            await this.executeCommand(newSource, target, args);
-        } finally {
-            await this.deleteNewDirectory(directoryPath);
-        }
-    }
-
-    private async createNewFile(dirPath: string, newName: string, source: Uri): Promise<string> {
-        // When exporting to PDF we need to change the source files name to match
-        // what the title of the pdf should be.
-        // To ensure the new file path is unique we will create a directory and
-        // save the new file there
-        try {
-            await this.fileSystem.createDirectory(dirPath);
-            const newFilePath = path.join(dirPath, newName);
-            await this.fileSystem.copyFile(source.fsPath, newFilePath);
-            return newFilePath;
-        } catch (e) {
-            await this.deleteNewDirectory(dirPath);
-            throw e;
-        }
-    }
-
-    private async deleteNewDirectory(dirPath: string) {
-        if (!(await this.fileSystem.directoryExists(dirPath))) {
-            return;
-        }
-        const files = await this.fileSystem.getFiles(dirPath);
-        for (const file of files) {
-            await this.fileSystem.deleteFile(file);
-        }
-        await this.fileSystem.deleteDirectory(dirPath);
+        await this.executeCommand(source, target, args);
     }
 }

--- a/src/client/datascience/export/exportUtil.ts
+++ b/src/client/datascience/export/exportUtil.ts
@@ -1,40 +1,71 @@
 import { inject, injectable } from 'inversify';
+import * as os from 'os';
 import * as path from 'path';
+import * as uuid from 'uuid/v4';
 import { Uri } from 'vscode';
-import { IFileSystem } from '../../common/platform/types';
+import { IFileSystem, TemporaryDirectory } from '../../common/platform/types';
+import { ICell, IDataScienceErrorHandler, INotebookExporter, INotebookModel, INotebookStorage } from '../types';
 
 @injectable()
 export class ExportUtil {
-    constructor(@inject(IFileSystem) private fileSystem: IFileSystem) {}
+    constructor(
+        @inject(IFileSystem) private fileSystem: IFileSystem,
+        @inject(IDataScienceErrorHandler) private readonly errorHandler: IDataScienceErrorHandler,
+        @inject(INotebookStorage) private notebookStorage: INotebookStorage,
+        @inject(INotebookExporter) private jupyterExporter: INotebookExporter
+    ) {}
 
-    public async createFileInDirectory(dirPath: string, fileName: string, source: Uri): Promise<string> {
+    public async generateTempDir(): Promise<TemporaryDirectory> {
+        const resultDir = path.join(os.tmpdir(), uuid());
+        await this.fileSystem.createDirectory(resultDir);
+
+        return {
+            path: resultDir,
+            dispose: async () => {
+                // Try ten times. Process may still be up and running.
+                // We don't want to do async as async dispose means it may never finish and then we don't
+                // delete
+                let count = 0;
+                while (count < 10) {
+                    try {
+                        await this.fileSystem.deleteDirectory(resultDir);
+                        count = 10;
+                    } catch {
+                        count += 1;
+                    }
+                }
+            }
+        };
+    }
+
+    public async makeFileInDirectory(model: INotebookModel, fileName: string, dirPath: string): Promise<string> {
+        const newFilePath = path.join(dirPath, fileName);
+
         try {
-            await this.fileSystem.createDirectory(dirPath);
-            const newFilePath = path.join(dirPath, fileName);
-            await this.fileSystem.copyFile(source.fsPath, newFilePath);
-            return newFilePath;
+            const content = model ? model.getContent() : '';
+            await this.fileSystem.writeFile(newFilePath, content, 'utf-8');
         } catch (e) {
-            await this.deleteDirectory(dirPath);
-            throw e;
+            await this.errorHandler.handleError(e);
         }
+
+        return newFilePath;
     }
 
-    public async createUniqueDirectoryPath(): Promise<string> {
+    public async getModelFromCells(cells: ICell[]): Promise<INotebookModel> {
+        const tempDir = await this.generateTempDir();
         const tempFile = await this.fileSystem.createTemporaryFile('.ipynb');
-        const filePath = tempFile.filePath;
-        const dirPath = path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
-        tempFile.dispose();
-        return dirPath;
-    }
+        let model: INotebookModel;
 
-    public async deleteDirectory(dirPath: string) {
-        if (!(await this.fileSystem.directoryExists(dirPath))) {
-            return;
+        try {
+            await this.jupyterExporter.exportToFile(cells, tempFile.filePath, false);
+            const newPath = path.join(tempDir.path, '.ipynb');
+            await this.fileSystem.copyFile(tempFile.filePath, newPath);
+            model = await this.notebookStorage.load(Uri.file(newPath));
+        } finally {
+            tempFile.dispose();
+            tempDir.dispose();
         }
-        const files = await this.fileSystem.getFiles(dirPath);
-        for (const file of files) {
-            await this.fileSystem.deleteFile(file);
-        }
-        await this.fileSystem.deleteDirectory(dirPath);
+
+        return model;
     }
 }

--- a/src/client/datascience/export/exportUtil.ts
+++ b/src/client/datascience/export/exportUtil.ts
@@ -1,0 +1,33 @@
+import { inject, injectable } from 'inversify';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import { IFileSystem } from '../../common/platform/types';
+import { IExportUtil } from './types';
+
+@injectable()
+export class ExportUtil implements IExportUtil {
+    constructor(@inject(IFileSystem) private fileSystem: IFileSystem) {}
+
+    public async createFileInDirectory(dirPath: string, fileName: string, source: Uri): Promise<string> {
+        try {
+            await this.fileSystem.createDirectory(dirPath);
+            const newFilePath = path.join(dirPath, fileName);
+            await this.fileSystem.copyFile(source.fsPath, newFilePath);
+            return newFilePath;
+        } catch (e) {
+            await this.deleteDirectory(dirPath);
+            throw e;
+        }
+    }
+
+    public async deleteDirectory(dirPath: string) {
+        if (!(await this.fileSystem.directoryExists(dirPath))) {
+            return;
+        }
+        const files = await this.fileSystem.getFiles(dirPath);
+        for (const file of files) {
+            await this.fileSystem.deleteFile(file);
+        }
+        await this.fileSystem.deleteDirectory(dirPath);
+    }
+}

--- a/src/client/datascience/export/exportUtil.ts
+++ b/src/client/datascience/export/exportUtil.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { Uri } from 'vscode';
 import { IFileSystem, TemporaryDirectory } from '../../common/platform/types';
+import { sleep } from '../../common/utils/async';
 import { ICell, IDataScienceErrorHandler, INotebookExporter, INotebookModel, INotebookStorage } from '../types';
 
 @injectable()
@@ -31,6 +32,7 @@ export class ExportUtil {
                         await this.fileSystem.deleteDirectory(resultDir);
                         count = 10;
                     } catch {
+                        await sleep(3000);
                         count += 1;
                     }
                 }

--- a/src/client/datascience/export/exportUtil.ts
+++ b/src/client/datascience/export/exportUtil.ts
@@ -2,10 +2,9 @@ import { inject, injectable } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { IFileSystem } from '../../common/platform/types';
-import { IExportUtil } from './types';
 
 @injectable()
-export class ExportUtil implements IExportUtil {
+export class ExportUtil {
     constructor(@inject(IFileSystem) private fileSystem: IFileSystem) {}
 
     public async createFileInDirectory(dirPath: string, fileName: string, source: Uri): Promise<string> {
@@ -18,6 +17,14 @@ export class ExportUtil implements IExportUtil {
             await this.deleteDirectory(dirPath);
             throw e;
         }
+    }
+
+    public async createUniqueDirectoryPath(): Promise<string> {
+        const tempFile = await this.fileSystem.createTemporaryFile('.ipynb');
+        const filePath = tempFile.filePath;
+        const dirPath = path.join(path.dirname(filePath), path.basename(filePath, path.extname(filePath)));
+        tempFile.dispose();
+        return dirPath;
     }
 
     public async deleteDirectory(dirPath: string) {

--- a/src/client/datascience/export/types.ts
+++ b/src/client/datascience/export/types.ts
@@ -21,9 +21,3 @@ export const IExportManagerFilePicker = Symbol('IExportManagerFilePicker');
 export interface IExportManagerFilePicker {
     getExportFileLocation(format: ExportFormat, source: Uri): Promise<Uri | undefined>;
 }
-
-export const IExportUtil = Symbol('IExportUitl');
-export interface IExportUtil {
-    deleteDirectory(dirPath: string): Promise<void>;
-    createFileInDirectory(dirPath: string, fileName: string, source: Uri): Promise<string>;
-}

--- a/src/client/datascience/export/types.ts
+++ b/src/client/datascience/export/types.ts
@@ -21,3 +21,9 @@ export const IExportManagerFilePicker = Symbol('IExportManagerFilePicker');
 export interface IExportManagerFilePicker {
     getExportFileLocation(format: ExportFormat, source: Uri): Promise<Uri | undefined>;
 }
+
+export const IExportUtil = Symbol('IExportUitl');
+export interface IExportUtil {
+    deleteDirectory(dirPath: string): Promise<void>;
+    createFileInDirectory(dirPath: string, fileName: string, source: Uri): Promise<string>;
+}

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -574,7 +574,7 @@ export class IInteractiveWindowMapping {
     public [InteractiveWindowMessages.SelectJupyterServer]: never | undefined;
     public [InteractiveWindowMessages.OpenSettings]: string | undefined;
     public [InteractiveWindowMessages.Export]: ICell[];
-    public [InteractiveWindowMessages.ExportNotebookAs]: never | undefined;
+    public [InteractiveWindowMessages.ExportNotebookAs]: ICell[];
     public [InteractiveWindowMessages.GetAllCells]: never | undefined;
     public [InteractiveWindowMessages.ReturnAllCells]: ICell[];
     public [InteractiveWindowMessages.DeleteAllCells]: IAddCellAction;

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -35,7 +35,7 @@ import { PythonInterpreter } from '../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { Commands, EditorContexts, Identifiers, Telemetry } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
-import { IExportUtil } from '../export/types';
+import { ExportUtil } from '../export/exportUtil';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
 import {
     INotebookIdentity,
@@ -120,7 +120,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         @inject(UseCustomEditorApi) useCustomEditorApi: boolean,
         @inject(IExperimentService) expService: IExperimentService,
         @inject(INotebookStorage) private notebookStorage: INotebookStorage,
-        @inject(IExportUtil) private exportUtil: IExportUtil
+        @inject(ExportUtil) private exportUtil: ExportUtil
     ) {
         super(
             listeners,
@@ -432,12 +432,9 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
     private async exportAs(cells: ICell[]) {
         const tempFile = await this.fileSystem.createTemporaryFile('.ipynb');
         const uri = Uri.file(tempFile.filePath);
-        let model: INotebookModel;
-        const directoryPath = path.join(
-            path.dirname(tempFile.filePath),
-            path.basename(tempFile.filePath, path.extname(tempFile.filePath))
-        );
+        const directoryPath = await this.exportUtil.createUniqueDirectoryPath();
 
+        let model: INotebookModel;
         this.startProgress();
         try {
             await this.jupyterExporter.exportToFile(cells, uri.fsPath, false);

--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -46,7 +46,7 @@ export class JupyterExporter implements INotebookExporter {
         noop();
     }
 
-    public async exportToFile(cells: ICell[], file: string): Promise<void> {
+    public async exportToFile(cells: ICell[], file: string, showOpenPrompt?: boolean): Promise<void> {
         let directoryChange;
         const settings = this.configService.getSettings();
         if (settings.datascience.changeDirOnImportExport) {
@@ -60,6 +60,9 @@ export class JupyterExporter implements INotebookExporter {
             const contents = JSON.stringify(notebook);
             await this.trustService.trustNotebook(Uri.file(file.toLowerCase()), contents);
             await this.fileSystem.writeFile(file, contents, { encoding: 'utf8', flag: 'w' });
+            if (showOpenPrompt !== undefined && !showOpenPrompt) {
+                return;
+            }
             const openQuestion1 = localize.DataScience.exportOpenQuestion1();
             const openQuestion2 = (await this.jupyterExecution.isSpawnSupported())
                 ? localize.DataScience.exportOpenQuestion()

--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -46,7 +46,7 @@ export class JupyterExporter implements INotebookExporter {
         noop();
     }
 
-    public async exportToFile(cells: ICell[], file: string, showOpenPrompt?: boolean): Promise<void> {
+    public async exportToFile(cells: ICell[], file: string, showOpenPrompt: boolean = true): Promise<void> {
         let directoryChange;
         const settings = this.configService.getSettings();
         if (settings.datascience.changeDirOnImportExport) {
@@ -60,7 +60,7 @@ export class JupyterExporter implements INotebookExporter {
             const contents = JSON.stringify(notebook);
             await this.trustService.trustNotebook(Uri.file(file.toLowerCase()), contents);
             await this.fileSystem.writeFile(file, contents, { encoding: 'utf8', flag: 'w' });
-            if (showOpenPrompt !== undefined && !showOpenPrompt) {
+            if (!showOpenPrompt) {
                 return;
             }
             const openQuestion1 = localize.DataScience.exportOpenQuestion1();

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -43,7 +43,8 @@ import { ExportManagerFilePicker } from './export/exportManagerFilePicker';
 import { ExportToHTML } from './export/exportToHTML';
 import { ExportToPDF } from './export/exportToPDF';
 import { ExportToPython } from './export/exportToPython';
-import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker } from './export/types';
+import { ExportUtil } from './export/exportUtil';
+import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker, IExportUtil } from './export/types';
 import { GatherListener } from './gather/gatherListener';
 import { GatherLogger } from './gather/gatherLogger';
 import { DebugListener } from './interactive-common/debugListener';
@@ -298,6 +299,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExport>(IExport, ExportToHTML, ExportFormat.html);
     serviceManager.addSingleton<IExport>(IExport, ExportToPython, ExportFormat.python);
     serviceManager.addSingleton<IExport>(IExport, ExportBase, 'Export Base');
+    serviceManager.addSingleton<IExportUtil>(IExportUtil, ExportUtil);
     serviceManager.addSingleton<ExportCommands>(ExportCommands, ExportCommands);
     serviceManager.addSingleton<IExportManagerFilePicker>(IExportManagerFilePicker, ExportManagerFilePicker);
     serviceManager.addSingleton<IJupyterUriProviderRegistration>(IJupyterUriProviderRegistration, JupyterUriProviderRegistration);

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -44,7 +44,7 @@ import { ExportToHTML } from './export/exportToHTML';
 import { ExportToPDF } from './export/exportToPDF';
 import { ExportToPython } from './export/exportToPython';
 import { ExportUtil } from './export/exportUtil';
-import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker, IExportUtil } from './export/types';
+import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker } from './export/types';
 import { GatherListener } from './gather/gatherListener';
 import { GatherLogger } from './gather/gatherLogger';
 import { DebugListener } from './interactive-common/debugListener';
@@ -299,7 +299,7 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExport>(IExport, ExportToHTML, ExportFormat.html);
     serviceManager.addSingleton<IExport>(IExport, ExportToPython, ExportFormat.python);
     serviceManager.addSingleton<IExport>(IExport, ExportBase, 'Export Base');
-    serviceManager.addSingleton<IExportUtil>(IExportUtil, ExportUtil);
+    serviceManager.addSingleton<ExportUtil>(ExportUtil, ExportUtil);
     serviceManager.addSingleton<ExportCommands>(ExportCommands, ExportCommands);
     serviceManager.addSingleton<IExportManagerFilePicker>(IExportManagerFilePicker, ExportManagerFilePicker);
     serviceManager.addSingleton<IJupyterUriProviderRegistration>(IJupyterUriProviderRegistration, JupyterUriProviderRegistration);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -440,7 +440,7 @@ export interface INotebookImporter extends Disposable {
 export const INotebookExporter = Symbol('INotebookExporter');
 export interface INotebookExporter extends Disposable {
     translateToNotebook(cells: ICell[], directoryChange?: string): Promise<nbformat.INotebookContent | undefined>;
-    exportToFile(cells: ICell[], file: string): Promise<void>;
+    exportToFile(cells: ICell[], file: string, showOpenPrompt?: boolean): Promise<void>;
 }
 
 export const IInteractiveWindowProvider = Symbol('IInteractiveWindowProvider');

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -180,6 +180,19 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                         </ImageButton>
                         <ImageButton
                             baseTheme={this.props.baseTheme}
+                            onClick={this.props.exportAs}
+                            disabled={this.props.busy || !this.props.isNotebookTrusted}
+                            className="native-button"
+                            tooltip={getLocString('DataScience.notebookExportAs', 'Export as')}
+                        >
+                            <Image
+                                baseTheme={this.props.baseTheme}
+                                class="image-button-image"
+                                image={ImageName.ExportToPython}
+                            />
+                        </ImageButton>
+                        <ImageButton
+                            baseTheme={this.props.baseTheme}
                             onClick={this.props.expandAll}
                             disabled={this.props.cellVMs.length === 0}
                             tooltip={getLocString('DataScience.expandAll', 'Expand all cell inputs')}

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -36,8 +36,13 @@ export namespace Transfer {
     }
 
     export function showExportAsMenu(arg: CommonReducerArg): IMainState {
-        postActionToExtension(arg, InteractiveWindowMessages.ExportNotebookAs, arg.payload.data); // want to send filename
-        return arg.prevState;
+        const cellContents = arg.prevState.cellVMs.map((v) => v.cell);
+        postActionToExtension(arg, InteractiveWindowMessages.ExportNotebookAs, cellContents);
+
+        return {
+            ...arg.prevState,
+            busy: true
+        };
     }
 
     export function save(arg: CommonReducerArg): IMainState {

--- a/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/transfer.ts
@@ -40,8 +40,7 @@ export namespace Transfer {
         postActionToExtension(arg, InteractiveWindowMessages.ExportNotebookAs, cellContents);
 
         return {
-            ...arg.prevState,
-            busy: true
+            ...arg.prevState
         };
     }
 

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -209,13 +209,7 @@ import { ExportToHTML } from '../../client/datascience/export/exportToHTML';
 import { ExportToPDF } from '../../client/datascience/export/exportToPDF';
 import { ExportToPython } from '../../client/datascience/export/exportToPython';
 import { ExportUtil } from '../../client/datascience/export/exportUtil';
-import {
-    ExportFormat,
-    IExport,
-    IExportManager,
-    IExportManagerFilePicker,
-    IExportUtil
-} from '../../client/datascience/export/types';
+import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker } from '../../client/datascience/export/types';
 import { GatherProvider } from '../../client/datascience/gather/gather';
 import { GatherListener } from '../../client/datascience/gather/gatherListener';
 import { GatherLogger } from '../../client/datascience/gather/gatherLogger';
@@ -624,7 +618,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             ExportManagerDependencyChecker,
             ExportManagerDependencyChecker
         );
-        this.serviceManager.addSingleton<IExportUtil>(IExportUtil, ExportUtil);
+        this.serviceManager.addSingleton<ExportUtil>(ExportUtil, ExportUtil);
         this.serviceManager.addSingleton<INotebookModelFactory>(INotebookModelFactory, NotebookModelFactory);
         this.serviceManager.addSingleton<IExportManager>(IExportManager, ExportManagerFileOpener);
         this.serviceManager.addSingleton<IExport>(IExport, ExportToPDF, ExportFormat.pdf);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -208,7 +208,14 @@ import { ExportManagerFilePicker } from '../../client/datascience/export/exportM
 import { ExportToHTML } from '../../client/datascience/export/exportToHTML';
 import { ExportToPDF } from '../../client/datascience/export/exportToPDF';
 import { ExportToPython } from '../../client/datascience/export/exportToPython';
-import { ExportFormat, IExport, IExportManager, IExportManagerFilePicker } from '../../client/datascience/export/types';
+import { ExportUtil } from '../../client/datascience/export/exportUtil';
+import {
+    ExportFormat,
+    IExport,
+    IExportManager,
+    IExportManagerFilePicker,
+    IExportUtil
+} from '../../client/datascience/export/types';
 import { GatherProvider } from '../../client/datascience/gather/gather';
 import { GatherListener } from '../../client/datascience/gather/gatherListener';
 import { GatherLogger } from '../../client/datascience/gather/gatherLogger';
@@ -617,6 +624,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             ExportManagerDependencyChecker,
             ExportManagerDependencyChecker
         );
+        this.serviceManager.addSingleton<IExportUtil>(IExportUtil, ExportUtil);
         this.serviceManager.addSingleton<INotebookModelFactory>(INotebookModelFactory, NotebookModelFactory);
         this.serviceManager.addSingleton<IExportManager>(IExportManager, ExportManagerFileOpener);
         this.serviceManager.addSingleton<IExport>(IExport, ExportToPDF, ExportFormat.pdf);


### PR DESCRIPTION
Added exporting to PDF, HTML and Python to the interactive window. This feature works the same as exporting notebooks from the notebook editor. 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
