### PR TITLE
Use os.realpath instead of assuming location of jupyter kernels

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -22,6 +22,7 @@ import { IEnvironmentActivationService } from '../../../interpreter/activation/t
 import { IInterpreterService } from '../../../interpreter/contracts';
 import { PythonInterpreter } from '../../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../../telemetry';
+import { getRealPath } from '../../common';
 import { Telemetry } from '../../constants';
 import { reportAction } from '../../progress/decorator';
 import { ReportableAction } from '../../progress/types';
@@ -33,7 +34,7 @@ import {
     KernelInterpreterDependencyResponse
 } from '../../types';
 import { cleanEnvironment, detectDefaultKernelName } from './helpers';
-import { getKernelSpecFile, JupyterKernelSpec } from './jupyterKernelSpec';
+import { JupyterKernelSpec } from './jupyterKernelSpec';
 import { LiveKernelModel } from './types';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
@@ -542,7 +543,7 @@ export class KernelService {
             throw new Error('Unable to parse output to get the kernel info');
         }
 
-        const specFile = await getKernelSpecFile(
+        const specFile = await getRealPath(
             this.fileSystem,
             this.execFactory,
             pythonPath,

--- a/src/test/datascience/kernelFinder.unit.test.ts
+++ b/src/test/datascience/kernelFinder.unit.test.ts
@@ -11,6 +11,7 @@ import * as typemoq from 'typemoq';
 import { Uri } from 'vscode';
 import { IWorkspaceService } from '../../client/common/application/types';
 import { IFileSystem, IPlatformService } from '../../client/common/platform/types';
+import { PythonExecutionFactory } from '../../client/common/process/pythonExecutionFactory';
 import { IExtensionContext, IInstaller, IPathUtils, Resource } from '../../client/common/types';
 import { Architecture } from '../../client/common/utils/platform';
 import { defaultKernelSpecName } from '../../client/datascience/jupyter/kernels/helpers';
@@ -259,6 +260,8 @@ suite('Kernel Finder', () => {
                     }
                 });
 
+            const executionFactory = mock(PythonExecutionFactory);
+
             kernelFinder = new KernelFinder(
                 interpreterService.object,
                 interpreterLocator.object,
@@ -267,7 +270,8 @@ suite('Kernel Finder', () => {
                 pathUtils.object,
                 instance(installer),
                 context.object,
-                instance(workspaceService)
+                instance(workspaceService),
+                instance(executionFactory)
             );
         });
 
@@ -334,6 +338,7 @@ suite('Kernel Finder', () => {
             resource = Uri.file(context.object.globalStoragePath);
 
             workspaceService = mock<IWorkspaceService>();
+            const executionFactory = mock(PythonExecutionFactory);
 
             kernelFinder = new KernelFinder(
                 interpreterService.object,
@@ -343,7 +348,8 @@ suite('Kernel Finder', () => {
                 pathUtils.object,
                 instance(installer),
                 context.object,
-                instance(workspaceService)
+                instance(workspaceService),
+                instance(executionFactory)
             );
         });
 


### PR DESCRIPTION
For #11412

Was looking at raw kernel for another bug and realized raw kernel doesn't look in the correct locations with a store python as well.

Solution was to use the 'os.path.realpath' function instead of 'finding' the kernel location. Made this into a more generic function and called it from the raw kernel stuff too.
