### PR TITLE
If we fail to start a raw kernel daemon, fall back on process execution

### DIFF
--- a/news/2 Fixes/12355.md
+++ b/news/2 Fixes/12355.md
@@ -1,0 +1,1 @@
+If we fail to start a raw kernel daemon then fall back to using process execution.

--- a/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncherDaemon.ts
@@ -27,8 +27,15 @@ export class PythonKernelLauncherDaemon implements IDisposable {
         resource: Resource,
         kernelSpec: IJupyterKernelSpec,
         interpreter?: PythonInterpreter
-    ): Promise<{ observableOutput: ObservableExecutionResult<string>; daemon: IPythonKernelDaemon }> {
+    ): Promise<{ observableOutput: ObservableExecutionResult<string>; daemon: IPythonKernelDaemon } | undefined> {
         const daemon = await this.daemonPool.get(resource, kernelSpec, interpreter);
+
+        // The daemon pool can return back a non-IPythonKernelDaemon if daemon service is not supported or for Python 2.
+        // Use a check for the daemon.start function here before we call it.
+        if (!daemon.start) {
+            return undefined;
+        }
+
         const args = kernelSpec.argv.slice();
         const modulePrefixIndex = args.findIndex((item) => item === '-m');
         if (modulePrefixIndex === -1) {

--- a/src/test/datascience/kernel-launcher/kernelLauncherDaemon.unit.test.ts
+++ b/src/test/datascience/kernel-launcher/kernelLauncherDaemon.unit.test.ts
@@ -52,9 +52,19 @@ suite('Data Science - Kernel Launcher Daemon', () => {
         await assert.isRejected(promise, /^Unsupported KernelSpec file. args must be/g);
     });
     test('Creates and returns a daemon', async () => {
-        const { observableOutput, daemon } = await launcher.launch(undefined, kernelSpec, interpreter);
+        const daemonCreationOutput = await launcher.launch(undefined, kernelSpec, interpreter);
 
-        assert.equal(observableOutput, instance(observableOutputForDaemon));
-        assert.equal(daemon, instance(kernelDaemon));
+        assert.isDefined(daemonCreationOutput);
+
+        if (daemonCreationOutput) {
+            assert.equal(daemonCreationOutput.observableOutput, instance(observableOutputForDaemon));
+            assert.equal(daemonCreationOutput.daemon, instance(kernelDaemon));
+        }
+    });
+    test('If our daemon pool return does not support start, return undefined', async () => {
+        when(daemonPool.get(anything(), anything(), anything())).thenResolve({} as any);
+        const daemonCreationOutput = await launcher.launch(undefined, kernelSpec, interpreter);
+
+        assert.isUndefined(daemonCreationOutput);
     });
 });


### PR DESCRIPTION
For #12355 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
