### PR TITLE
Disable trust message button if notebook is trusted

### DIFF
--- a/src/datascience-ui/interactive-common/common.css
+++ b/src/datascience-ui/interactive-common/common.css
@@ -469,7 +469,20 @@ body, html {
     width: 100%;
 }
 
-
+.jupyter-info-section {
+    padding: 0px 5px;
+    align-self: center;
+    margin-top: 1px;
+    margin-bottom: 2px;
+    background-color: transparent;
+    border: none;
+    outline: none;
+    font-size: var(--vscode-font-size);
+    font-family: var(--vscode-font-family);
+}
+.jupyter-info-section-hoverable:hover {
+    background-color: var(--override-badge-background, var(--vscode-badge-background));
+}
 
 
 .kernel-status {

--- a/src/datascience-ui/interactive-common/jupyterInfo.tsx
+++ b/src/datascience-ui/interactive-common/jupyterInfo.tsx
@@ -108,7 +108,7 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
                 <div className="kernel-status" style={maxWidth}>
                     <button
                         type="button"
-                        disabled={this.props.isNotebookTrusted} // Disable showing prompt for already-trusted notebooks
+                        disabled={this.props.isNotebookTrusted}
                         aria-disabled={this.props.isNotebookTrusted}
                         className={`jupyter-info-section${
                             this.props.isNotebookTrusted ? '' : ' jupyter-info-section-hoverable'

--- a/src/datascience-ui/interactive-common/jupyterInfo.tsx
+++ b/src/datascience-ui/interactive-common/jupyterInfo.tsx
@@ -95,26 +95,29 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
                 ? getLocString('DataScience.notebookIsTrusted', 'Trusted')
                 : getLocString('DataScience.notebookIsNotTrusted', 'Not Trusted');
             const textSize = text.length;
-            const dynamicFont: React.CSSProperties = {
-                fontSize: 'var(--vscode-font-size)', // Use the same font and size as the menu
-                fontFamily: 'var(--vscode-font-family)',
-                maxWidth: this.getMaxWidth(textSize + 5), // plus 5 for the line and margins,
-                color: this.props.isNotebookTrusted ? undefined : 'var(--vscode-editorError-foreground)'
+            const maxWidth: React.CSSProperties = {
+                maxWidth: this.getMaxWidth(textSize + 5) // plus 5 for the line and margins,
             };
-            const trustTextWidth: React.CSSProperties = {
-                maxWidth: this.getMaxWidth(textSize)
+            const dynamicStyle: React.CSSProperties = {
+                maxWidth: this.getMaxWidth(textSize),
+                color: this.props.isNotebookTrusted ? undefined : 'var(--vscode-editorError-foreground)',
+                cursor: this.props.isNotebookTrusted ? undefined : 'pointer'
             };
 
             return (
-                <div className="kernel-status" style={dynamicFont}>
-                    <div
-                        className="kernel-status-section kernel-status-section-hoverable kernel-status-status"
-                        style={trustTextWidth}
+                <div className="kernel-status" style={maxWidth}>
+                    <button
+                        type="button"
+                        disabled={this.props.isNotebookTrusted} // Disable showing prompt for already-trusted notebooks
+                        aria-disabled={this.props.isNotebookTrusted}
+                        className={`jupyter-info-section${
+                            this.props.isNotebookTrusted ? '' : ' jupyter-info-section-hoverable'
+                        }`} // Disable animation on hover for already-trusted notebooks
+                        style={dynamicStyle}
                         onClick={this.props.launchNotebookTrustPrompt}
-                        role="button"
                     >
                         <div className="kernel-status-text">{text}</div>
-                    </div>
+                    </button>
                     <div className="kernel-status-divider" />
                 </div>
             );


### PR DESCRIPTION
Changes:
+ Make trust message a `button` instead of `div` and set `disabled` and `aria-disabled` flags for accessibility
+ Display pointer and background highlight on hover only if the notebook is untrusted

![hover](https://user-images.githubusercontent.com/30305945/86526822-92a0ea80-be4d-11ea-8e65-f7fe1ffee2da.gif)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
