### PR TITLE
Don't indicate dirty when trust changes

### DIFF
--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -102,11 +102,16 @@ export abstract class BaseNotebookModel implements INotebookModel {
         }
 
         // Forward onto our listeners if necessary
-        if (changed || this.isDirty !== oldDirty) {
+        if ((changed || this.isDirty !== oldDirty) && change.kind !== 'updateTrust') {
             this._changedEmitter.fire({ ...change, newDirty: this.isDirty, oldDirty, model: this });
         }
         // Slightly different for the event we send to VS code. Skip version and file changes. Only send user events.
-        if ((changed || this.isDirty !== oldDirty) && change.kind !== 'version' && change.source === 'user') {
+        if (
+            (changed || this.isDirty !== oldDirty) &&
+            change.kind !== 'version' &&
+            change.source === 'user' &&
+            change.kind !== 'updateTrust'
+        ) {
             this._editEventEmitter.fire(change);
         }
     }


### PR DESCRIPTION
Skip indicating dirty in UI for model trust state changes. Previously, we showed the dirty indicator (* next to filename) in the tab when trust changed.

![indicate-dirty](https://user-images.githubusercontent.com/30305945/86541373-311a6380-bec1-11ea-97f5-612928004c92.gif)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
