### PR TITLE
Show a prompt asking user to upgrade Code runner to new version to keep using it when in Deprecate PythonPath experiment

### DIFF
--- a/news/1 Enhancements/12764.md
+++ b/news/1 Enhancements/12764.md
@@ -1,0 +1,1 @@
+Show a prompt asking user to upgrade Code runner to new version to keep using it when in Deprecate PythonPath experiment.

--- a/src/client/application/diagnostics/checks/upgradeCodeRunner.ts
+++ b/src/client/application/diagnostics/checks/upgradeCodeRunner.ts
@@ -58,7 +58,8 @@ export class UpgradeCodeRunnerDiagnosticService extends BaseDiagnosticsService {
         if (!extension) {
             return [];
         }
-        const flagValue: boolean | undefined = extension.packageJSON?.featureFlags?.usingNewPythonInterpreterPathApi;
+        // Available feature flags: https://github.com/formulahendry/vscode-code-runner/blob/master/package.json#L6
+        const flagValue: boolean | undefined = extension.packageJSON?.featureFlags?.usingNewPythonInterpreterPathApiV2;
         if (flagValue) {
             // Using new version of Code runner already, no need to upgrade
             return [];

--- a/src/test/application/diagnostics/checks/upgradeCodeRunner.unit.test.ts
+++ b/src/test/application/diagnostics/checks/upgradeCodeRunner.unit.test.ts
@@ -261,7 +261,7 @@ suite('Application Diagnostics - Upgrade Code Runner', () => {
                 .setup((e) => e.packageJSON)
                 .returns(() => ({
                     featureFlags: {
-                        usingNewPythonInterpreterPathApi: true
+                        usingNewPythonInterpreterPathApiV2: true
                     }
                 }));
             workspaceService


### PR DESCRIPTION
For #12764

The latest extension is not compatible with old versions of Code runner - when in DeprecatePythonPath experiment, ask users to upgrade it.
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
