### PR TITLE
Fixes for trusted notebooks

### DIFF
--- a/src/datascience-ui/interactive-common/jupyterInfo.tsx
+++ b/src/datascience-ui/interactive-common/jupyterInfo.tsx
@@ -20,6 +20,7 @@ export interface IJupyterInfoProps {
 export class JupyterInfo extends React.Component<IJupyterInfoProps> {
     private get isKernelSelectionAllowed() {
         return (
+            this.props.isNotebookTrusted !== false &&
             this.props.kernel.jupyterServerStatus !== ServerStatus.Restarting &&
             this.props.kernel.jupyterServerStatus !== ServerStatus.Starting
         );

--- a/src/datascience-ui/interactive-common/jupyterInfo.tsx
+++ b/src/datascience-ui/interactive-common/jupyterInfo.tsx
@@ -127,9 +127,7 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
     }
 
     private selectKernel() {
-        if (this.props.isNotebookTrusted) {
-            this.props.selectKernel();
-        }
+        this.props.selectKernel();
     }
     private getIcon(): ImageName {
         return this.props.kernel.jupyterServerStatus === ServerStatus.NotStarted


### PR DESCRIPTION
+ Disable changing kernel if notebook is untrusted. Previously the kernel selection button was highlighted on mouse over but did nothing when clicked if the notebook was untrusted; this simply moves the trust check into the render logic so that the button is disabled too.
+ ~Treat all notebooks opened remotely as untrusted. This is a temporary workaround for the larger problem that in remote scenarios, all trust info gets stored on the remote machine, even though we really want it to be stored locally. More details: this happens because our extension all up is (rightly) treated as a workspace extension in remote scenarios, and because there's no way for an extension to access both the local and remote filesystems.~

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
