### PR TITLE
Cleanup interpreter filter

### DIFF
--- a/src/client/interpreter/locators/types.ts
+++ b/src/client/interpreter/locators/types.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import { Uri } from 'vscode';
-import { PythonInterpreter } from '../../pythonEnvironments/info';
 
 export const IPythonInPathCommandProvider = Symbol('IPythonInPathCommandProvider');
 export interface IPythonInPathCommandProvider {
@@ -62,8 +61,4 @@ export interface IWindowsStoreInterpreter {
      * @memberof IInterpreterHelper
      */
     isHiddenInterpreter(pythonPath: string): boolean;
-}
-
-export interface IInterpreterFilter {
-    isHiddenInterpreter(interpreter: PythonInterpreter): boolean;
 }

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -21,7 +21,6 @@ import {
 } from '../pythonEnvironments/discovery/locators/services/globalVirtualEnvService';
 import { InterpreterHashProvider } from '../pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { InterpreterWatcherBuilder } from '../pythonEnvironments/discovery/locators/services/interpreterWatcherBuilder';
 import {
     KnownPathsService,
@@ -285,7 +284,6 @@ export function registerInterpreterTypes(serviceManager: IServiceManager) {
         InterpeterHashProviderFactory,
         InterpeterHashProviderFactory
     );
-    serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         PreWarmActivatedEnvironmentVariables

--- a/src/client/pythonEnvironments/discovery/locators/index.ts
+++ b/src/client/pythonEnvironments/discovery/locators/index.ts
@@ -17,10 +17,9 @@ import {
     WINDOWS_REGISTRY_SERVICE,
     WORKSPACE_VIRTUAL_ENV_SERVICE
 } from '../../../interpreter/contracts';
-import { IInterpreterFilter } from '../../../interpreter/locators/types';
 import { IServiceContainer } from '../../../ioc/types';
 import { PythonInterpreter } from '../../info';
-import { InterpreterFilter } from './services/interpreterFilter';
+import { isHiddenInterpreter } from './services/interpreterFilter';
 import { GetInterpreterLocatorOptions } from './types';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
@@ -38,10 +37,7 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
     private readonly interpreterLocatorHelper: IInterpreterLocatorHelper;
     private readonly _hasInterpreters: Deferred<boolean>;
 
-    constructor(
-        @inject(IServiceContainer) private serviceContainer: IServiceContainer,
-        @inject(InterpreterFilter) private readonly interpreterFilter: IInterpreterFilter
-    ) {
+    constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {
         this._hasInterpreters = createDeferred<boolean>();
         serviceContainer.get<Disposable[]>(IDisposableRegistry).push(this);
         this.platform = serviceContainer.get<IPlatformService>(IPlatformService);
@@ -96,7 +92,7 @@ export class PythonInterpreterLocatorService implements IInterpreterLocatorServi
         const items = flatten(listOfInterpreters)
             .filter((item) => !!item)
             .map((item) => item!)
-            .filter((item) => !this.interpreterFilter.isHiddenInterpreter(item));
+            .filter((item) => !isHiddenInterpreter(item));
         this._hasInterpreters.resolve(items.length > 0);
         return this.interpreterLocatorHelper.mergeInterpreters(items);
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/interpreterFilter.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/interpreterFilter.ts
@@ -3,15 +3,9 @@
 
 'use strict';
 
-import { inject, injectable } from 'inversify';
-import { IInterpreterFilter, IWindowsStoreInterpreter } from '../../../../interpreter/locators/types';
 import { PythonInterpreter } from '../../../info';
-import { WindowsStoreInterpreter } from './windowsStoreInterpreter';
+import { isRestrictedWindowsStoreInterpreterPath } from './windowsStoreInterpreter';
 
-@injectable()
-export class InterpreterFilter implements IInterpreterFilter {
-    constructor(@inject(WindowsStoreInterpreter) private readonly windowsStoreInterpreter: IWindowsStoreInterpreter) {}
-    public isHiddenInterpreter(interpreter: PythonInterpreter): boolean {
-        return this.windowsStoreInterpreter.isHiddenInterpreter(interpreter.path);
-    }
+export function isHiddenInterpreter(interpreter: PythonInterpreter): boolean {
+    return isRestrictedWindowsStoreInterpreterPath(interpreter.path);
 }

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter.ts
@@ -13,19 +13,38 @@ import { IInterpreterHashProvider, IWindowsStoreInterpreter } from '../../../../
 import { IServiceContainer } from '../../../../ioc/types';
 
 /**
+ * When using Windows Store interpreter the path that should be used is under
+ * %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\python*.exe. The python.exe path
+ * under ProgramFiles\WindowsApps should not be used at all. Execute permissions on
+ * that instance of the store interpreter are restricted to system. Paths under
+ * %USERPROFILE%\AppData\Local\Microsoft\WindowsApps\PythonSoftwareFoundation* are also ok
+ * to use. But currently this results in duplicate entries.
+ *
+ * @param {string} pythonPath
+ * @returns {boolean}
+ */
+export function isRestrictedWindowsStoreInterpreterPath(pythonPath: string): boolean {
+    const pythonPathToCompare = pythonPath.toUpperCase().replace(/\//g, '\\');
+    return (
+        pythonPathToCompare.includes('\\Program Files\\WindowsApps\\'.toUpperCase()) ||
+        pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\PythonSoftwareFoundation'.toUpperCase())
+    );
+}
+
+/**
  * The default location of Windows apps are `%ProgramFiles%\WindowsApps`.
  * (https://www.samlogic.net/articles/windows-8-windowsapps-folder.htm)
  * When users access Python interpreter it is installed in `<users local folder>\Microsoft\WindowsApps`
  * Based on our testing this is where Python interpreters installed from Windows Store is always installed.
- * (unforutnately couldn't find any documentation on this).
+ * (unfortunately couldn't find any documentation on this).
  * What we've identified is the fact that:
  * - The Python interpreter in Microsoft\WIndowsApps\python.exe is a symbolic link to files located in:
  *  - Program Files\WindowsApps\ & Microsoft\WindowsApps\PythonSoftwareFoundation
  * - I.e. they all point to the same place.
- * However when the user lauches the executabale, its located in `Microsoft\WindowsAapps\python.exe`
+ * However when the user launches the executable, its located in `Microsoft\WindowsApps\python.exe`
  * Hence for all intensive purposes that's the main executable, that's what the user uses.
  * As a result:
- * - We'll only display what the user has access to, that being `Microsoft\WindowsAapps\python.exe`
+ * - We'll only display what the user has access to, that being `Microsoft\WindowsApps\python.exe`
  * - Others are hidden.
  *
  * Details can be found here (original issue https://github.com/microsoft/vscode-python/issues/5926).
@@ -66,11 +85,7 @@ export class WindowsStoreInterpreter implements IWindowsStoreInterpreter, IInter
      * @memberof IInterpreterHelper
      */
     public isHiddenInterpreter(pythonPath: string): boolean {
-        const pythonPathToCompare = pythonPath.toUpperCase().replace(/\//g, '\\');
-        return (
-            pythonPathToCompare.includes('\\Program Files\\WindowsApps\\'.toUpperCase()) ||
-            pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\PythonSoftwareFoundation'.toUpperCase())
-        );
+        return isRestrictedWindowsStoreInterpreterPath(pythonPath);
     }
     /**
      * Gets the hash of the Python interpreter (installed from the windows store).

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -129,7 +129,6 @@ import { ICondaService } from '../../client/interpreter/contracts';
 import { CondaService } from '../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { ImportTracker } from '../../client/telemetry/importTracker';
 import { IImportTracker } from '../../client/telemetry/types';
@@ -231,7 +230,6 @@ suite('Installer', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
 
         ioc.serviceManager.addSingleton<IActiveResourceService>(IActiveResourceService, ActiveResourceService);
         ioc.serviceManager.addSingleton<IInterpreterPathService>(IInterpreterPathService, InterpreterPathService);

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -130,7 +130,6 @@ import {
 import { IServiceContainer } from '../../client/ioc/types';
 import { InterpreterHashProvider } from '../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { InterpreterType, PythonInterpreter } from '../../client/pythonEnvironments/info';
 import { ImportTracker } from '../../client/telemetry/importTracker';
@@ -239,7 +238,6 @@ suite('Module Installer', () => {
                 InterpeterHashProviderFactory,
                 InterpeterHashProviderFactory
             );
-            ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
 
             ioc.serviceManager.addSingleton<IActiveResourceService>(IActiveResourceService, ActiveResourceService);
             ioc.serviceManager.addSingleton<IInterpreterPathService>(IInterpreterPathService, InterpreterPathService);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -397,7 +397,6 @@ import {
 } from '../../client/pythonEnvironments/discovery/locators/services/globalVirtualEnvService';
 import { InterpreterHashProvider } from '../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { InterpreterWatcherBuilder } from '../../client/pythonEnvironments/discovery/locators/services/interpreterWatcherBuilder';
 import {
     KnownPathsService,
@@ -1079,7 +1078,6 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             this.serviceManager.addSingleton<IInterpreterEvaluation>(IInterpreterEvaluation, InterpreterEvaluation);
             this.serviceManager.addSingleton<WindowsStoreInterpreter>(WindowsStoreInterpreter, WindowsStoreInterpreter);
             this.serviceManager.addSingleton<InterpreterHashProvider>(InterpreterHashProvider, InterpreterHashProvider);
-            this.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
             this.serviceManager.add<IInterpreterWatcher>(
                 IInterpreterWatcher,
                 WorkspaceVirtualEnvWatcherService,

--- a/src/test/format/extension.format.test.ts
+++ b/src/test/format/extension.format.test.ts
@@ -13,7 +13,6 @@ import { ICondaService } from '../../client/interpreter/contracts';
 import { CondaService } from '../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { isPythonVersionInProcess } from '../common';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
@@ -94,7 +93,6 @@ suite('Formatting - General', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
         ioc.serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
 
         // Mocks.

--- a/src/test/pythonEnvironments/discovery/locators/index.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/index.unit.test.ts
@@ -25,7 +25,6 @@ import {
     WINDOWS_REGISTRY_SERVICE,
     WORKSPACE_VIRTUAL_ENV_SERVICE
 } from '../../../../client/interpreter/contracts';
-import { IInterpreterFilter } from '../../../../client/interpreter/locators/types';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import { PythonInterpreterLocatorService } from '../../../../client/pythonEnvironments/discovery/locators';
 import { InterpreterType, PythonInterpreter } from '../../../../client/pythonEnvironments/info';
@@ -35,19 +34,17 @@ suite('Interpreters - Locators Index', () => {
     let platformSvc: TypeMoq.IMock<IPlatformService>;
     let helper: TypeMoq.IMock<IInterpreterLocatorHelper>;
     let locator: IInterpreterLocatorService;
-    let filter: TypeMoq.IMock<IInterpreterFilter>;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         platformSvc = TypeMoq.Mock.ofType<IPlatformService>();
         helper = TypeMoq.Mock.ofType<IInterpreterLocatorHelper>();
-        filter = TypeMoq.Mock.ofType<IInterpreterFilter>();
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => []);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platformSvc.object);
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterLocatorHelper)))
             .returns(() => helper.object);
 
-        locator = new PythonInterpreterLocatorService(serviceContainer.object, filter.object);
+        locator = new PythonInterpreterLocatorService(serviceContainer.object);
     });
     [undefined, Uri.file('Something')].forEach((resource) => {
         getNamesAndValues<OSType>(OSType).forEach((osType) => {

--- a/src/test/pythonEnvironments/discovery/locators/interpreterFilter.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/interpreterFilter.unit.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import { isHiddenInterpreter } from '../../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
+import { InterpreterType, PythonInterpreter } from '../../../../client/pythonEnvironments/info';
+
+// tslint:disable:no-unused-expression
+
+suite('Interpreters - Filter', () => {
+    const doNotHideThesePaths = [
+        'python',
+        'python.exe',
+        'python2',
+        'python2.exe',
+        'python38',
+        'python3.8.exe',
+        'C:\\Users\\SomeUser\\AppData\\Local\\Microsoft\\WindowsApps\\python.exe',
+        '%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps\\python.exe',
+        '%LOCALAPPDATA%\\Microsoft\\WindowsApps\\python.exe'
+    ];
+    const hideThesePaths = [
+        '%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\\python.exe',
+        'C:\\Users\\SomeUser\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\\python.exe',
+        '%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python.exe',
+        'C:\\Users\\SomeUser\\AppData\\Local\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python.exe',
+        '%LOCALAPPDATA%\\Microsoft\\WindowsApps\\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\\python.exe',
+        '%LOCALAPPDATA%\\Microsoft\\WindowsApps\\PythonSoftwareFoundation\\python.exe',
+        'C:\\Program Files\\WindowsApps\\python.exe',
+        'C:\\Program Files\\WindowsApps\\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\\python.exe',
+        'C:\\Program Files\\WindowsApps\\PythonSoftwareFoundation\\python.exe'
+    ];
+
+    function getInterpreterFromPath(interpreterPath: string): PythonInterpreter {
+        return {
+            path: interpreterPath,
+            sysVersion: '',
+            sysPrefix: '',
+            architecture: 1,
+            companyDisplayName: '',
+            displayName: 'python',
+            type: InterpreterType.WindowsStore,
+            envName: '',
+            envPath: '',
+            cachedEntry: false
+        };
+    }
+
+    doNotHideThesePaths.forEach((interpreterPath) => {
+        test(`Interpreter path should NOT be hidden - ${interpreterPath}`, () => {
+            const interpreter: PythonInterpreter = getInterpreterFromPath(interpreterPath);
+            expect(isHiddenInterpreter(interpreter), `${interpreterPath} should NOT be treated as hidden.`).to.be.false;
+        });
+    });
+    hideThesePaths.forEach((interpreterPath) => {
+        test(`Interpreter path should be hidden - ${interpreterPath}`, () => {
+            const interpreter: PythonInterpreter = getInterpreterFromPath(interpreterPath);
+            expect(isHiddenInterpreter(interpreter), `${interpreterPath} should be treated as hidden.`).to.be.true;
+        });
+    });
+});

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -75,7 +75,6 @@ import { CurrentPathService } from '../client/pythonEnvironments/discovery/locat
 import { GlobalVirtualEnvService } from '../client/pythonEnvironments/discovery/locators/services/globalVirtualEnvService';
 import { InterpreterHashProvider } from '../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { KnownPathsService } from '../client/pythonEnvironments/discovery/locators/services/KnownPathsService';
 import { PipEnvService } from '../client/pythonEnvironments/discovery/locators/services/pipEnvService';
 import { PipEnvServiceHelper } from '../client/pythonEnvironments/discovery/locators/services/pipEnvServiceHelper';
@@ -279,7 +278,6 @@ export class IocContainer {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        this.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
     public registerVariableTypes() {
         variableRegisterTypes(this.serviceManager);

--- a/src/test/testing/nosetest/nosetest.disovery.test.ts
+++ b/src/test/testing/nosetest/nosetest.disovery.test.ts
@@ -13,7 +13,6 @@ import { InterpreterService } from '../../../client/interpreter/interpreterServi
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { CommandSource } from '../../../client/testing/common/constants';
 import { ITestManagerFactory } from '../../../client/testing/common/types';
@@ -91,7 +90,6 @@ suite('Unit Tests - nose - discovery with mocked process output', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
 
     async function injectTestDiscoveryOutput(outputFileName: string) {

--- a/src/test/testing/nosetest/nosetest.run.test.ts
+++ b/src/test/testing/nosetest/nosetest.run.test.ts
@@ -11,7 +11,6 @@ import { ICondaService } from '../../../client/interpreter/contracts';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { CommandSource } from '../../../client/testing/common/constants';
 import { ITestManagerFactory, TestsToRun } from '../../../client/testing/common/types';
@@ -84,7 +83,6 @@ suite('Unit Tests - nose - run against actual python process', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
 
     async function injectTestDiscoveryOutput(outputFileName: string) {

--- a/src/test/testing/pytest/pytest.discovery.test.ts
+++ b/src/test/testing/pytest/pytest.discovery.test.ts
@@ -26,7 +26,6 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { CommandSource } from '../../../client/testing/common/constants';
 import { ITestManagerFactory } from '../../../client/testing/common/types';
@@ -147,7 +146,6 @@ suite('Unit Tests - pytest - discovery with mocked process output', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
 
     async function injectTestDiscoveryOutput(output: string) {

--- a/src/test/testing/pytest/pytest.run.test.ts
+++ b/src/test/testing/pytest/pytest.run.test.ts
@@ -27,7 +27,6 @@ import { IServiceContainer } from '../../../client/ioc/types';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { CommandSource } from '../../../client/testing/common/constants';
 import { UnitTestDiagnosticService } from '../../../client/testing/common/services/unitTestDiagnosticService';
@@ -467,7 +466,6 @@ suite('Unit Tests - pytest - run with mocked process output', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
 
     async function injectTestDiscoveryOutput(outputFileName: string) {

--- a/src/test/testing/unittest/unittest.discovery.test.ts
+++ b/src/test/testing/unittest/unittest.discovery.test.ts
@@ -14,7 +14,6 @@ import { InterpreterService } from '../../../client/interpreter/interpreterServi
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { CommandSource } from '../../../client/testing/common/constants';
 import { ITestManagerFactory } from '../../../client/testing/common/types';
@@ -73,7 +72,6 @@ suite('Unit Tests - unittest - discovery with mocked process output', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
 
     async function injectTestDiscoveryOutput(output: string) {

--- a/src/test/testing/unittest/unittest.run.test.ts
+++ b/src/test/testing/unittest/unittest.run.test.ts
@@ -14,7 +14,6 @@ import { InterpreterService } from '../../../client/interpreter/interpreterServi
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { InterpreterHashProvider } from '../../../client/pythonEnvironments/discovery/locators/services/hashProvider';
 import { InterpeterHashProviderFactory } from '../../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
-import { InterpreterFilter } from '../../../client/pythonEnvironments/discovery/locators/services/interpreterFilter';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { ArgumentsHelper } from '../../../client/testing/common/argumentsHelper';
 import { CommandSource, UNITTEST_PROVIDER } from '../../../client/testing/common/constants';
@@ -125,7 +124,6 @@ suite('Unit Tests - unittest - run with mocked process output', () => {
             InterpeterHashProviderFactory,
             InterpeterHashProviderFactory
         );
-        ioc.serviceManager.addSingleton<InterpreterFilter>(InterpreterFilter, InterpreterFilter);
     }
 
     async function ignoreTestLauncher() {


### PR DESCRIPTION
This PR aims to simply the use of Interpreter Filter which is currently limited to hiding windows store paths that are either duplicates or restricted by system.

While looking at the implementation I found a bunch of issues. This is due to the number of copies of python.exe that the store install adds to path. If users have more than one version of python interpreter say 3.7, and 3.8. Then the python.exe at the root of windows apps depends on which ever one was last installed. Currently we rely on multiple sources to find these python paths and we end up asking for interpreter info for each of these multiple times via different methods. 

When we do intend to solve this we should take advantage of the `PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0` path, and only consider that path for the store python. This uniquely identifies store python path, and we only ned to look for `python.exe`, and we can avoid trying to find `python3.exe`, `python3.7.exe` etc versions of the store app.