### PR TITLE
Update experiments.json for raw kernel

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -105,12 +105,12 @@
         "name": "LocalZMQKernel - experiment",
         "salt": "LocalZMQKernel",
         "min": 0,
-        "max": 25
+        "max": 75
     },
     {
         "name": "LocalZMQKernel - control",
         "salt": "LocalZMQKernel",
-        "min": 25,
+        "min": 75,
         "max": 100
     },
     {


### PR DESCRIPTION
Significantly bump raw kernel. Latest data indicates that raw kernel success rate (ability to run a cell in a notebook or IW) is at least 10% greater than existing.
