### PR TITLE
Auto open the variable explorer when doing run by line

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,6 +55,5 @@
         // Match what black does.
         "--max-line-length=88"
     ],
-    "typescript.preferences.importModuleSpecifier": "relative",
-    "debug.javascript.usePreview": false
+    "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/news/2 Fixes/12773.md
+++ b/news/2 Fixes/12773.md
@@ -1,0 +1,1 @@
+Open variable explorer when opening variable explorer during debugging.

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1364,7 +1364,10 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             const openValue = payload as boolean;
 
             // Log the state in our Telemetry
-            sendTelemetryEvent(Telemetry.VariableExplorerToggled, undefined, { open: openValue });
+            sendTelemetryEvent(Telemetry.VariableExplorerToggled, undefined, {
+                open: openValue,
+                runByLine: this.jupyterDebugger.isRunningByLine
+            });
         }
     };
 

--- a/src/client/datascience/jupyter/jupyterDebugger.ts
+++ b/src/client/datascience/jupyter/jupyterDebugger.ts
@@ -44,6 +44,7 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
     private readonly waitForDebugClientCode: string;
     private readonly tracingEnableCode: string;
     private readonly tracingDisableCode: string;
+    private runningByLine: boolean = false;
     constructor(
         @inject(IApplicationShell) private appShell: IApplicationShell,
         @inject(IConfigurationService) private configService: IConfigurationService,
@@ -59,7 +60,12 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
         this.tracingDisableCode = `from debugpy import trace_this_thread;trace_this_thread(False)`;
     }
 
+    public get isRunningByLine(): boolean {
+        return this.debugService.activeDebugSession !== undefined && this.runningByLine;
+    }
+
     public startRunByLine(notebook: INotebook, cellHashFileName: string): Promise<void> {
+        this.runningByLine = true;
         traceInfo(`Running by line for ${cellHashFileName}`);
         const config: Partial<DebugConfiguration> = {
             justMyCode: false,
@@ -90,6 +96,7 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
     }
 
     public async stopDebugging(notebook: INotebook): Promise<void> {
+        this.runningByLine = false;
         const config = this.configs.get(notebook.identity.toString());
         if (config) {
             traceInfo('stop debugging');

--- a/src/client/datascience/jupyter/jupyterVariables.ts
+++ b/src/client/datascience/jupyter/jupyterVariables.ts
@@ -17,6 +17,7 @@ import {
     IJupyterVariablesResponse,
     INotebook
 } from '../types';
+import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 
 /**
  * This class provides variable data for showing in the interactive window or a notebook.
@@ -50,15 +51,15 @@ export class JupyterVariables implements IJupyterVariables {
         notebook: INotebook,
         request: IJupyterVariablesRequest
     ): Promise<IJupyterVariablesResponse> {
-        return this.realVariables.getVariables(notebook, request);
+        return this.getVariableHandler(notebook).getVariables(notebook, request);
     }
 
     public getMatchingVariable(notebook: INotebook, name: string): Promise<IJupyterVariable | undefined> {
-        return this.realVariables.getMatchingVariable(notebook, name);
+        return this.getVariableHandler(notebook).getMatchingVariable(notebook, name);
     }
 
     public async getDataFrameInfo(targetVariable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariable> {
-        return this.realVariables.getDataFrameInfo(targetVariable, notebook);
+        return this.getVariableHandler(notebook).getDataFrameInfo(targetVariable, notebook);
     }
 
     public async getDataFrameRows(
@@ -67,14 +68,14 @@ export class JupyterVariables implements IJupyterVariables {
         start: number,
         end: number
     ): Promise<JSONObject> {
-        return this.realVariables.getDataFrameRows(targetVariable, notebook, start, end);
+        return this.getVariableHandler(notebook).getDataFrameRows(targetVariable, notebook, start, end);
     }
 
-    private get realVariables(): IJupyterVariables {
+    private getVariableHandler(notebook: INotebook): IJupyterVariables {
         if (!this.experimentsManager.inExperiment(RunByLine.experiment)) {
             return this.oldVariables;
         }
-        if (this.debuggerVariables.active) {
+        if (this.debuggerVariables.active && notebook.status === ServerStatus.Busy) {
             return this.debuggerVariables;
         }
 

--- a/src/client/datascience/jupyter/jupyterVariables.ts
+++ b/src/client/datascience/jupyter/jupyterVariables.ts
@@ -5,6 +5,7 @@ import type { JSONObject } from '@phosphor/coreutils';
 import { inject, injectable, named } from 'inversify';
 
 import { Event, EventEmitter } from 'vscode';
+import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 import { RunByLine } from '../../common/experiments/groups';
 import { IDisposableRegistry, IExperimentsManager } from '../../common/types';
 import { captureTelemetry } from '../../telemetry';
@@ -17,7 +18,6 @@ import {
     IJupyterVariablesResponse,
     INotebook
 } from '../types';
-import { ServerStatus } from '../../../datascience-ui/interactive-common/mainState';
 
 /**
  * This class provides variable data for showing in the interactive window or a notebook.

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -301,6 +301,7 @@ export interface IJupyterExecution extends IAsyncDisposable {
 
 export const IJupyterDebugger = Symbol('IJupyterDebugger');
 export interface IJupyterDebugger {
+    readonly isRunningByLine: boolean;
     startRunByLine(notebook: INotebook, cellHashFileName: string): Promise<void>;
     startDebugging(notebook: INotebook): Promise<void>;
     stopDebugging(notebook: INotebook): Promise<void>;

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -1775,7 +1775,7 @@ export interface IEventNamePropertyMapping {
     [Telemetry.SubmitCellThroughInput]: never | undefined;
     [Telemetry.Undo]: never | undefined;
     [Telemetry.VariableExplorerFetchTime]: never | undefined;
-    [Telemetry.VariableExplorerToggled]: { open: boolean };
+    [Telemetry.VariableExplorerToggled]: { open: boolean; runByLine: boolean };
     [Telemetry.VariableExplorerVariableCount]: { variableCount: number };
     [Telemetry.WaitForIdleJupyter]: never | undefined;
     [Telemetry.WebviewMonacoStyleUpdate]: never | undefined;

--- a/src/datascience-ui/history-react/redux/store.ts
+++ b/src/datascience-ui/history-react/redux/store.ts
@@ -8,5 +8,5 @@ import { reducerMap } from './reducers';
 
 // This special version uses the reducer map from the IInteractiveWindowMapping
 export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean, postOffice: PostOffice) {
-    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, false, reducerMap, postOffice);
+    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, false, false, reducerMap, postOffice);
 }

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../client/datascience/types';
 import { combineReducers, QueuableAction, ReducerArg, ReducerFunc } from '../../../react-common/reduxUtils';
 import { postActionToExtension } from '../helpers';
-import { CommonActionType, CommonActionTypeMapping, IVariableExplorerHeight } from './types';
+import { CommonActionType, CommonActionTypeMapping, ICellAction, IVariableExplorerHeight } from './types';
 
 export type IVariableState = {
     currentExecutionCount: number;
@@ -27,6 +27,7 @@ export type IVariableState = {
     containerHeight: number;
     gridHeight: number;
     refreshCount: number;
+    showVariablesOnDebug: boolean;
 };
 
 type VariableReducerFunc<T = never | undefined> = ReducerFunc<
@@ -254,6 +255,18 @@ function handleRefresh(arg: VariableReducerArg): IVariableState {
     };
 }
 
+function handleDebugStart(arg: VariableReducerArg<ICellAction>): IVariableState {
+    // If we haven't already turned on variables, do so now
+    if (arg.prevState.showVariablesOnDebug) {
+        return {
+            ...arg.prevState,
+            showVariablesOnDebug: false,
+            visible: true
+        };
+    }
+    return arg.prevState;
+}
+
 type VariableReducerFunctions<T> = {
     [P in keyof T]: T[P] extends never | undefined ? VariableReducerFunc : VariableReducerFunc<T[P]>;
 };
@@ -270,10 +283,13 @@ const reducerMap: Partial<VariableActionMapping> = {
     [CommonActionType.SET_VARIABLE_EXPLORER_HEIGHT]: setVariableExplorerHeight,
     [InteractiveWindowMessages.VariableExplorerHeightResponse]: handleVariableExplorerHeightResponse,
     [CommonActionType.GET_VARIABLE_DATA]: handleRequest,
-    [InteractiveWindowMessages.GetVariablesResponse]: handleResponse
+    [InteractiveWindowMessages.GetVariablesResponse]: handleResponse,
+    [CommonActionType.RUN_BY_LINE]: handleDebugStart
 };
 
-export function generateVariableReducer(): Reducer<IVariableState, QueuableAction<Partial<VariableActionMapping>>> {
+export function generateVariableReducer(
+    showVariablesOnDebug: boolean
+): Reducer<IVariableState, QueuableAction<Partial<VariableActionMapping>>> {
     // First create our default state.
     const defaultState: IVariableState = {
         currentExecutionCount: 0,
@@ -284,7 +300,8 @@ export function generateVariableReducer(): Reducer<IVariableState, QueuableActio
         pageSize: 5,
         containerHeight: 0,
         gridHeight: 200,
-        refreshCount: 0
+        refreshCount: 0,
+        showVariablesOnDebug
     };
 
     // Then combine that with our map of state change message to reducer

--- a/src/datascience-ui/interactive-common/redux/reducers/variables.ts
+++ b/src/datascience-ui/interactive-common/redux/reducers/variables.ts
@@ -63,7 +63,8 @@ function handleRequest(arg: VariableReducerArg<IJupyterVariablesRequest>): IVari
 function toggleVariableExplorer(arg: VariableReducerArg): IVariableState {
     const newState: IVariableState = {
         ...arg.prevState,
-        visible: !arg.prevState.visible
+        visible: !arg.prevState.visible,
+        showVariablesOnDebug: false // If user does any toggling don't auto open this.
     };
 
     postActionToExtension(arg, InteractiveWindowMessages.VariableExplorerToggle, newState.visible);

--- a/src/datascience-ui/interactive-common/redux/store.ts
+++ b/src/datascience-ui/interactive-common/redux/store.ts
@@ -196,7 +196,8 @@ function createTestMiddleware(): Redux.Middleware<{}, IStore> {
         // Indicate variables complete
         if (
             (!fastDeepEqual(prevState.variables.variables, afterState.variables.variables) ||
-                prevState.variables.currentExecutionCount !== afterState.variables.currentExecutionCount) &&
+                prevState.variables.currentExecutionCount !== afterState.variables.currentExecutionCount ||
+                prevState.variables.refreshCount !== afterState.variables.refreshCount) &&
             action.type === InteractiveWindowMessages.GetVariablesResponse
         ) {
             sendMessage(InteractiveWindowMessages.VariablesComplete);
@@ -387,6 +388,7 @@ export function createStore<M>(
     baseTheme: string,
     testMode: boolean,
     editable: boolean,
+    showVariablesOnDebug: boolean,
     reducerMap: M,
     postOffice: PostOffice
 ) {
@@ -400,7 +402,7 @@ export function createStore<M>(
     const monacoReducer = generateMonacoReducer(testMode, postOffice);
 
     // Create another reducer for handling variable state
-    const variableReducer = generateVariableReducer();
+    const variableReducer = generateVariableReducer(showVariablesOnDebug);
 
     // Combine these together
     const rootReducer = Redux.combineReducers<IStore>({

--- a/src/datascience-ui/native-editor/redux/store.ts
+++ b/src/datascience-ui/native-editor/redux/store.ts
@@ -8,5 +8,5 @@ import { reducerMap } from './reducers';
 
 // This special version uses the reducer map from the INativeEditorMapping
 export function createStore(skipDefault: boolean, baseTheme: string, testMode: boolean, postOffice: PostOffice) {
-    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, true, reducerMap, postOffice);
+    return ReduxCommon.createStore(skipDefault, baseTheme, testMode, true, true, reducerMap, postOffice);
 }

--- a/src/test/datascience/debugger.functional.test.tsx
+++ b/src/test/datascience/debugger.functional.test.tsx
@@ -203,8 +203,11 @@ suite('DataScience Debugger tests', () => {
 
                 // Step if allowed
                 if (stepAndVerify && ioc.getDefaultWrapper() && !ioc.mockJupyter) {
-                    // Verify variables work
-                    openVariableExplorer(ioc.getDefaultWrapper());
+                    // Verify variables work. Native editor should already open the variable explorer
+                    // automatically
+                    if (type === 'default') {
+                        openVariableExplorer(ioc.getDefaultWrapper());
+                    }
                     breakPromise = createDeferred<void>();
                     await jupyterDebuggerService?.step();
                     await breakPromise.promise;

--- a/src/test/datascience/interactivePanel.functional.test.tsx
+++ b/src/test/datascience/interactivePanel.functional.test.tsx
@@ -109,7 +109,8 @@ suite('DataScience Interactive Panel', () => {
                 visible: true,
                 containerHeight: 0,
                 gridHeight: 200,
-                refreshCount: 0
+                refreshCount: 0,
+                showVariablesOnDebug: false
             },
             setVariableExplorerHeight: noopAny,
             editorOptions: {},

--- a/src/test/datascience/variableexplorer.functional.test.tsx
+++ b/src/test/datascience/variableexplorer.functional.test.tsx
@@ -553,7 +553,7 @@ Name: 0, dtype: float64`,
                             verifyVariables(wrapper, nonValued);
                             return Promise.resolve();
                         },
-                        2 // 2 refreshes because the variable explorer is scrolled to the bottom.
+                        3 // 3 refreshes because the variable explorer is scrolled to the bottom.
                     );
                 }
             },


### PR DESCRIPTION
For #12773 

Since all QP attendees said they wouldn't use run by line without the variable explorer, we're going to turn it on every time they start run by line (and only for run by line) unless they forcefully close the variable explorer.

