### PR TITLE
Add Pylance to languageServer setting enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1786,6 +1786,7 @@
                             "CollectNodeLSRequestTiming - experiment",
                             "DeprecatePythonPath - experiment",
                             "RunByLine - experiment",
+                            "EnableTrustedNotebooks",
                             "All"
                         ]
                     },
@@ -2259,6 +2260,7 @@
                     "enum": [
                         "Jedi",
                         "Microsoft",
+                        "Pylance",
                         "None"
                     ],
                     "default": "Jedi",

--- a/package.json
+++ b/package.json
@@ -1786,7 +1786,6 @@
                             "CollectNodeLSRequestTiming - experiment",
                             "DeprecatePythonPath - experiment",
                             "RunByLine - experiment",
-                            "EnableTrustedNotebooks",
                             "All"
                         ]
                     },


### PR DESCRIPTION
After a user installs Pylance, Pylance updates the `python.languageServer` setting to 'Pylance', which appears to not be a recognized option for that setting. The user sees this:
![image](https://user-images.githubusercontent.com/30305945/86813266-c68a3480-c034-11ea-9f58-9e8d61375698.png)

Just had a customer report this here: https://github.com/microsoft/vscode-python/issues/12751#issuecomment-654875902

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
