### PR TITLE
Move (external) dependency composition for InterpreterLocatorHelper to the proxy.

### DIFF
--- a/src/client/pythonEnvironments/discovery/locators/helpers.ts
+++ b/src/client/pythonEnvironments/discovery/locators/helpers.ts
@@ -8,6 +8,9 @@ import { InterpreterType, PythonInterpreter } from '../../info';
 
 const CheckPythonInterpreterRegEx = IS_WINDOWS ? /^python(\d+(.\d+)?)?\.exe$/ : /^python(\d+(.\d+)?)?$/;
 
+// tslint:disable-next-line:no-suspicious-comment
+// TODO: Switch back to using IFileSystem.
+// https://github.com/microsoft/vscode-python/issues/11338
 export async function lookForInterpretersInDirectory(pathToCheck: string, _: IFileSystem): Promise<string[]> {
     // Technically, we should be able to use fs.getFiles().  However,
     // that breaks some tests.  So we stick with the broader behavior.

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -169,7 +169,7 @@ class InterpreterLocatorHelperProxy implements IInterpreterLocatorHelper {
         this.impl = new InterpreterLocatorHelper({
             normalizePath: path.normalize,
             getPathDirname: path.dirname,
-            arePathsSame: fs.arePathsSame,
+            arePathsSame: (p1: string, p2: string) => fs.arePathsSame(p1, p2),
             getPipEnvInfo: (p: string) => pipEnvServiceHelper.getPipEnvInfo(p)
         });
     }

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -4,6 +4,7 @@
 // tslint:disable:no-use-before-declare max-classes-per-file
 
 import { inject, injectable, named, optional } from 'inversify';
+import * as path from 'path';
 import { SemVer } from 'semver';
 import { Disposable, Event, Uri } from 'vscode';
 import { IWorkspaceService } from '../common/application/types';
@@ -165,7 +166,12 @@ class InterpreterLocatorHelperProxy implements IInterpreterLocatorHelper {
         @inject(IFileSystem) fs: IFileSystem,
         @inject(IPipEnvServiceHelper) pipEnvServiceHelper: IPipEnvServiceHelper
     ) {
-        this.impl = new InterpreterLocatorHelper(fs, pipEnvServiceHelper);
+        this.impl = new InterpreterLocatorHelper({
+            normalizePath: path.normalize,
+            getPathDirname: path.dirname,
+            arePathsSame: fs.arePathsSame,
+            getPipEnvInfo: (p: string) => pipEnvServiceHelper.getPipEnvInfo(p)
+        });
     }
     public async mergeInterpreters(interpreters: PythonInterpreter[]): Promise<PythonInterpreter[]> {
         return this.impl.mergeInterpreters(interpreters);

--- a/src/test/pythonEnvironments/discovery/locators/helpers.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/helpers.unit.test.ts
@@ -45,7 +45,12 @@ suite('Interpreters - Locators Helper', () => {
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterHelper)))
             .returns(() => interpreterServiceHelper.object);
 
-        helper = new InterpreterLocatorHelper(fs.object, instance(pipEnvHelper));
+        helper = new InterpreterLocatorHelper({
+            normalizePath: path.normalize,
+            getPathDirname: path.dirname,
+            arePathsSame: (p1: string, p2: string) => fs.object.arePathsSame(p1, p2),
+            getPipEnvInfo: (p: string) => instance(pipEnvHelper).getPipEnvInfo(p)
+        });
     });
     test('Ensure default Mac interpreter is not excluded from the list of interpreters', async () => {
         platform.setup((p) => p.isWindows).returns(() => false);


### PR DESCRIPTION
This is the work to eliminate `@inject` from InterpreterLocatorHelper .

Compare with #12850 (which includes refactoring to make the implementation less complex and to get better DI).