### PR TITLE
Minimize dependencies for InterpreterLocatorHelper.

### DIFF
--- a/src/client/pythonEnvironments/discovery/locators/helpers.ts
+++ b/src/client/pythonEnvironments/discovery/locators/helpers.ts
@@ -8,6 +8,9 @@ import { InterpreterType, PythonInterpreter } from '../../info';
 
 const CheckPythonInterpreterRegEx = IS_WINDOWS ? /^python(\d+(.\d+)?)?\.exe$/ : /^python(\d+(.\d+)?)?$/;
 
+// tslint:disable-next-line:no-suspicious-comment
+// TODO: Switch back to using IFileSystem.
+// https://github.com/microsoft/vscode-python/issues/11338
 export async function lookForInterpretersInDirectory(pathToCheck: string, _: IFileSystem): Promise<string[]> {
     // Technically, we should be able to use fs.getFiles().  However,
     // that breaks some tests.  So we stick with the broader behavior.

--- a/src/client/pythonEnvironments/discovery/locators/helpers.ts
+++ b/src/client/pythonEnvironments/discovery/locators/helpers.ts
@@ -1,19 +1,10 @@
 import * as fsapi from 'fs-extra';
-import { inject } from 'inversify';
 import * as path from 'path';
 import { Uri } from 'vscode';
 import { traceError } from '../../../common/logger';
 import { IS_WINDOWS } from '../../../common/platform/constants';
 import { IFileSystem } from '../../../common/platform/types';
-import { IPipEnvServiceHelper } from '../../../interpreter/locators/types';
-import {
-    areSameInterpreter,
-    InterpreterType,
-    normalizeInterpreter,
-    PythonInterpreter,
-    updateInterpreter
-} from '../../info';
-import { areSameVersion } from '../../info/pythonVersion';
+import { InterpreterType, PythonInterpreter } from '../../info';
 
 const CheckPythonInterpreterRegEx = IS_WINDOWS ? /^python(\d+(.\d+)?)?\.exe$/ : /^python(\d+(.\d+)?)?$/;
 
@@ -33,36 +24,6 @@ export async function lookForInterpretersInDirectory(pathToCheck: string, _: IFi
     }
 }
 
-export class InterpreterLocatorHelper {
-    constructor(
-        @inject(IFileSystem) private readonly fs: IFileSystem,
-        @inject(IPipEnvServiceHelper) private readonly pipEnvServiceHelper: IPipEnvServiceHelper
-    ) {}
-
-    public async mergeInterpreters(interpreters: PythonInterpreter[]): Promise<PythonInterpreter[]> {
-        const deps = {
-            updateInterpreter,
-            areSameInterpreter: (i1: PythonInterpreter, i2: PythonInterpreter) =>
-                areSameInterpreter(i1, i2, {
-                    areSameVersion,
-                    inSameDirectory: (p1?: string, p2?: string) =>
-                        inSameDirectory(p1, p2, {
-                            arePathsSame: this.fs.arePathsSame,
-                            getPathDirname: path.dirname
-                        })
-                }),
-            normalizeInterpreter: (i: PythonInterpreter) => normalizeInterpreter(i, { normalizePath: path.normalize }),
-            getPipEnvInfo: this.pipEnvServiceHelper.getPipEnvInfo.bind(this.pipEnvServiceHelper)
-        };
-        const merged = mergeInterpreters(interpreters, deps);
-        await Promise.all(
-            // At this point they are independent so we can update them separately.
-            merged.map(async (interp) => updateEnvInfo(interp, deps))
-        );
-        return merged;
-    }
-}
-
 /**
  * Combine env info for matching environments.
  *
@@ -73,7 +34,7 @@ export class InterpreterLocatorHelper {
  * @prop deps.areSameInterpreter - determine if 2 infos match the same env
  * @prop deps.normalizeInterpreter - standardize the given env info
  */
-function mergeInterpreters(
+export function mergeInterpreters(
     interpreters: PythonInterpreter[],
     deps: {
         areSameInterpreter(i1: PythonInterpreter, i2: PythonInterpreter): boolean;
@@ -103,7 +64,7 @@ function mergeInterpreters(
  * @prop deps.arePathsSame - determine if two filenames point to the same file
  * @prop deps.getPathDirname - (like `path.dirname`)
  */
-function inSameDirectory(
+export function inSameDirectory(
     path1: string | undefined,
     path2: string | undefined,
     deps: {
@@ -126,7 +87,7 @@ function inSameDirectory(
  * @param deps - functional dependencies
  * @prop deps.getPipEnvInfo - provides extra pip-specific env info, if applicable
  */
-async function updateEnvInfo(
+export async function updateEnvInfo(
     interp: PythonInterpreter,
     deps: {
         getPipEnvInfo(p: string): Promise<{ workspaceFolder: Uri; envName: string } | undefined>;

--- a/src/client/pythonEnvironments/discovery/locators/helpers.ts
+++ b/src/client/pythonEnvironments/discovery/locators/helpers.ts
@@ -28,62 +28,6 @@ export async function lookForInterpretersInDirectory(pathToCheck: string, _: IFi
 }
 
 /**
- * Combine env info for matching environments.
- *
- * Environments are matched by path and version.
- *
- * @param interpreters - the env infos to merge
- * @param deps - functional dependencies
- * @prop deps.areSameInterpreter - determine if 2 infos match the same env
- * @prop deps.normalizeInterpreter - standardize the given env info
- */
-export function mergeInterpreters(
-    interpreters: PythonInterpreter[],
-    deps: {
-        areSameInterpreter(i1: PythonInterpreter, i2: PythonInterpreter): boolean;
-        normalizeInterpreter(i: PythonInterpreter): void;
-        updateInterpreter(i: PythonInterpreter, o: PythonInterpreter): void;
-    }
-): PythonInterpreter[] {
-    return interpreters.reduce<PythonInterpreter[]>((accumulator, current) => {
-        const existingItem = accumulator.find((item) => deps.areSameInterpreter(current, item));
-        if (!existingItem) {
-            const copied: PythonInterpreter = { ...current };
-            deps.normalizeInterpreter(copied);
-            accumulator.push(copied);
-        } else {
-            deps.updateInterpreter(existingItem, current);
-        }
-        return accumulator;
-    }, []);
-}
-
-/**
- * Determine if the given paths are in the same directory.
- *
- * @param path1 - one of the two paths to compare
- * @param path2 - one of the two paths to compare
- * @param deps - functional dependencies
- * @prop deps.arePathsSame - determine if two filenames point to the same file
- * @prop deps.getPathDirname - (like `path.dirname`)
- */
-export function inSameDirectory(
-    path1: string | undefined,
-    path2: string | undefined,
-    deps: {
-        arePathsSame(p1: string, p2: string): boolean;
-        getPathDirname(p: string): string;
-    }
-): boolean {
-    if (!path1 || !path2) {
-        return false;
-    }
-    const dir1 = deps.getPathDirname(path1);
-    const dir2 = deps.getPathDirname(path2);
-    return deps.arePathsSame(dir1, dir2);
-}
-
-/**
  * Update the given env info with extra information.
  *
  * @param interp - the env info to update

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -172,6 +172,62 @@ export function updateInterpreter(interp: PythonInterpreter, other: PythonInterp
 }
 
 /**
+ * Combine env info for matching environments.
+ *
+ * Environments are matched by path and version.
+ *
+ * @param interpreters - the env infos to merge
+ * @param deps - functional dependencies
+ * @prop deps.areSameInterpreter - determine if 2 infos match the same env
+ * @prop deps.normalizeInterpreter - standardize the given env info
+ */
+export function mergeInterpreters(
+    interpreters: PythonInterpreter[],
+    deps: {
+        areSameInterpreter(i1: PythonInterpreter, i2: PythonInterpreter): boolean;
+        normalizeInterpreter(i: PythonInterpreter): void;
+        updateInterpreter(i: PythonInterpreter, o: PythonInterpreter): void;
+    }
+): PythonInterpreter[] {
+    return interpreters.reduce<PythonInterpreter[]>((accumulator, current) => {
+        const existingItem = accumulator.find((item) => deps.areSameInterpreter(current, item));
+        if (!existingItem) {
+            const copied: PythonInterpreter = { ...current };
+            deps.normalizeInterpreter(copied);
+            accumulator.push(copied);
+        } else {
+            deps.updateInterpreter(existingItem, current);
+        }
+        return accumulator;
+    }, []);
+}
+
+/**
+ * Determine if the given paths are in the same directory.
+ *
+ * @param path1 - one of the two paths to compare
+ * @param path2 - one of the two paths to compare
+ * @param deps - functional dependencies
+ * @prop deps.arePathsSame - determine if two filenames point to the same file
+ * @prop deps.getPathDirname - (like `path.dirname`)
+ */
+export function inSameDirectory(
+    path1: string | undefined,
+    path2: string | undefined,
+    deps: {
+        arePathsSame(p1: string, p2: string): boolean;
+        getPathDirname(p: string): string;
+    }
+): boolean {
+    if (!path1 || !path2) {
+        return false;
+    }
+    const dir1 = deps.getPathDirname(path1);
+    const dir2 = deps.getPathDirname(path2);
+    return deps.arePathsSame(dir1, dir2);
+}
+
+/**
  * Build a version-sorted list from the given one, with lowest first.
  */
 export function sortInterpreters(interpreters: PythonInterpreter[]): PythonInterpreter[] {

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -74,6 +74,19 @@ export function parsePythonVersion(raw: string): PythonVersion | undefined {
     return new SemVer(rawVersion);
 }
 
+/**
+ * Determine if the given versions are the same.
+ *
+ * @param version1 - one of the two versions to compare
+ * @param version2 - one of the two versions to compare
+ */
+export function areSameVersion(version1?: PythonVersion, version2?: PythonVersion): boolean {
+    if (!version1 || !version2) {
+        return false;
+    }
+    return version1.raw === version2.raw;
+}
+
 type ExecResult = {
     stdout: string;
 };

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -181,7 +181,7 @@ class InterpreterLocatorHelperProxy implements IInterpreterLocatorHelper {
                     areSameVersion,
                     inSameDirectory: (p1?: string, p2?: string) =>
                         inSameDirectory(p1, p2, {
-                            arePathsSame: this.fs.arePathsSame,
+                            arePathsSame: (p1b: string, p2b: string) => this.fs.arePathsSame(p1b, p2b),
                             getPathDirname: path.dirname
                         })
                 }),

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -43,7 +43,7 @@ import {
 } from '../interpreter/locators/types';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { PythonInterpreterLocatorService } from './discovery/locators';
-import { inSameDirectory, mergeInterpreters, updateEnvInfo } from './discovery/locators/helpers';
+import { updateEnvInfo } from './discovery/locators/helpers';
 import { InterpreterLocatorProgressService } from './discovery/locators/progressService';
 import { CondaEnvironmentInfo, CondaInfo } from './discovery/locators/services/conda';
 import { CondaEnvFileService } from './discovery/locators/services/condaEnvFileService';
@@ -68,7 +68,14 @@ import {
 } from './discovery/locators/services/workspaceVirtualEnvService';
 import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services/workspaceVirtualEnvWatcherService';
 import { GetInterpreterLocatorOptions } from './discovery/locators/types';
-import { areSameInterpreter, normalizeInterpreter, PythonInterpreter, updateInterpreter } from './info';
+import {
+    areSameInterpreter,
+    inSameDirectory,
+    mergeInterpreters,
+    normalizeInterpreter,
+    PythonInterpreter,
+    updateInterpreter
+} from './info';
 import { areSameVersion } from './info/pythonVersion';
 
 export function registerForIOC(serviceManager: IServiceManager) {

--- a/src/test/pythonEnvironments/discovery/locators/helpers.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/helpers.unit.test.ts
@@ -16,15 +16,13 @@ import { Architecture } from '../../../../client/common/utils/platform';
 import { IInterpreterHelper } from '../../../../client/interpreter/contracts';
 import { IPipEnvServiceHelper } from '../../../../client/interpreter/locators/types';
 import { IServiceContainer } from '../../../../client/ioc/types';
-import {
-    inSameDirectory,
-    mergeInterpreters,
-    updateEnvInfo
-} from '../../../../client/pythonEnvironments/discovery/locators/helpers';
+import { updateEnvInfo } from '../../../../client/pythonEnvironments/discovery/locators/helpers';
 import { PipEnvServiceHelper } from '../../../../client/pythonEnvironments/discovery/locators/services/pipEnvServiceHelper';
 import {
     areSameInterpreter,
+    inSameDirectory,
     InterpreterType,
+    mergeInterpreters,
     normalizeInterpreter,
     PythonInterpreter,
     updateInterpreter


### PR DESCRIPTION
This is the work to eliminate `@inject` from InterpreterLocatorHelper .  The change does the following:

* replaces the functionality of InterpreterLocatorHelper with helper functions
* updates InterpreterLocatorHelperProxy to compose the helpers and their dependencies

Compare with #12849 (the minimal PR).