### PR TITLE
Fix regressions in trusted notebooks

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -602,7 +602,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         if (this.previouslyNotTrusted && this.model?.isTrusted) {
             this.previouslyNotTrusted = false;
             // Tell UI to update main state
-            await this.postMessage(InteractiveWindowMessages.TrustNotebookComplete);
+            this.postMessage(InteractiveWindowMessages.TrustNotebookComplete).ignoreErrors();
         }
     }
     private renameVariableExplorerHeights(name: string, updatedName: string) {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -252,7 +252,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
 
         // Sign up for dirty events
         model.changed(this.modelChanged.bind(this));
-        this.previouslyNotTrusted = model.isTrusted;
+        this.previouslyNotTrusted = !model.isTrusted;
     }
 
     // tslint:disable-next-line: no-any
@@ -602,7 +602,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         if (this.previouslyNotTrusted && this.model?.isTrusted) {
             this.previouslyNotTrusted = false;
             // Tell UI to update main state
-            this.postMessage(InteractiveWindowMessages.TrustNotebookComplete).ignoreErrors();
+            await this.postMessage(InteractiveWindowMessages.TrustNotebookComplete);
         }
     }
     private renameVariableExplorerHeights(name: string, updatedName: string) {

--- a/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
+++ b/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
@@ -59,22 +59,25 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
             DataScience.doNotTrustNotebook(),
             DataScience.trustAllNotebooks()
         );
-        if (selection === DataScience.trustAllNotebooks()) {
-            commands.executeCommand('workbench.action.openSettings', 'python.dataScience.alwaysTrustNotebooks');
-            return;
+
+        switch (selection) {
+            case DataScience.trustAllNotebooks():
+                commands.executeCommand('workbench.action.openSettings', 'python.dataScience.alwaysTrustNotebooks');
+                break;
+            case DataScience.trustNotebook():
+                // Update model trust
+                model.update({
+                    source: 'user',
+                    kind: 'updateTrust',
+                    oldDirty: model.isDirty,
+                    newDirty: model.isDirty,
+                    isNotebookTrusted: true
+                });
+                const contents = model.getContent();
+                await this.trustService.trustNotebook(model.file, contents);
+                break;
+            default:
+                break;
         }
-        if (selection === DataScience.doNotTrustNotebook()) {
-            return;
-        }
-        // Update model trust
-        model.update({
-            source: 'user',
-            kind: 'updateTrust',
-            oldDirty: model.isDirty,
-            newDirty: model.isDirty,
-            isNotebookTrusted: true
-        });
-        const contents = model.getContent();
-        await this.trustService.trustNotebook(model.file, contents);
     }
 }

--- a/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
+++ b/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { inject, injectable } from 'inversify';
-import { Uri } from 'vscode';
+import { commands, Uri } from 'vscode';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { IApplicationShell, ICommandManager } from '../../common/application/types';
 import { ContextKey } from '../../common/contextKey';
@@ -59,7 +59,11 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
             DataScience.doNotTrustNotebook(),
             DataScience.trustAllNotebooks()
         );
-        if (selection !== DataScience.trustNotebook() || model.isTrusted) {
+        if (selection === DataScience.trustAllNotebooks()) {
+            commands.executeCommand('workbench.action.openSettings', 'python.dataScience.alwaysTrustNotebooks');
+            return;
+        }
+        if (selection === DataScience.doNotTrustNotebook()) {
             return;
         }
         // Update model trust


### PR DESCRIPTION
- Fixing a bug reported by @kimadeline where clicking "Trust" on the notebook trust prompt does nothing in the webview-based notebook
- Also fixing bug where trustAllNotebooks button stopped working

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
