### PR TITLE
Closing a notebook marked as trusted shouldn't trigger the save modal

### DIFF
--- a/src/client/datascience/notebookStorage/notebookModel.ts
+++ b/src/client/datascience/notebookStorage/notebookModel.ts
@@ -90,7 +90,7 @@ export class NativeEditorNotebookModel extends BaseNotebookModel {
 
         // Dirty state comes from undo. At least VS code will track it that way. However
         // skip file changes as we don't forward those to VS code
-        if (change.kind !== 'save' && change.kind !== 'saveAs') {
+        if (change.kind !== 'save' && change.kind !== 'saveAs' && change.kind !== 'updateTrust') {
             this.changeCount += 1;
         }
 


### PR DESCRIPTION
For #12867

Don't increase model change count when trust updates

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
