### PR TITLE
Fixes for persisting trust

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -348,18 +348,9 @@ export class NativeEditorStorage implements INotebookStorage {
         }
         const pythonNumber = json ? await this.extractPythonMainVersion(json) : 3;
 
-        /* As an optimization, we don't call trustNotebook for hot exit, since our hot exit backup code gets called by VS
-        Code whenever the notebook model changes. This means it's called very often, perhaps even as often as autosave.
-        Instead, when loading a file that is dirty, we check if the actual file contents on disk are trusted. If so, we treat
-        the dirty contents as trusted as well. */
-        const contentsToCheck = isInitiallyDirty && trueContents !== undefined ? trueContents : contents;
-        const isTrusted =
-            contents === undefined || isUntitledFile(file)
-                ? true // If no contents or untitled, this is a newly created file, so it should be trusted
-                : await this.trustService.isNotebookTrusted(file, contentsToCheck!);
-        return this.factory.createModel(
+        const model = this.factory.createModel(
             {
-                trusted: isTrusted,
+                trusted: true,
                 file,
                 cells: remapped,
                 notebookJson: json,
@@ -369,6 +360,24 @@ export class NativeEditorStorage implements INotebookStorage {
             },
             forVSCodeNotebook
         );
+
+        /* As an optimization, we don't call trustNotebook for hot exit, since our hot exit backup code gets called by VS
+        Code whenever the notebook model changes. This means it's called very often, perhaps even as often as autosave.
+        Instead, when loading a file that is dirty, we check if the actual file contents on disk are trusted. If so, we treat
+        the dirty contents as trusted as well. */
+        if (contents !== undefined && !isUntitledFile(file)) {
+            // If no contents or untitled, this is a newly created file, so it should be trusted
+            const contentsToCheck = isInitiallyDirty && trueContents !== undefined ? trueContents : model.getContent();
+            model.update({
+                source: 'user',
+                kind: 'updateTrust',
+                oldDirty: model.isDirty,
+                newDirty: model.isDirty,
+                isNotebookTrusted: await this.trustService.isNotebookTrusted(file, contentsToCheck)
+            });
+        }
+
+        return model;
     }
 
     private getStaticStorageKey(file: Uri): string {

--- a/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorStorage.ts
@@ -361,12 +361,12 @@ export class NativeEditorStorage implements INotebookStorage {
             forVSCodeNotebook
         );
 
-        /* As an optimization, we don't call trustNotebook for hot exit, since our hot exit backup code gets called by VS
-        Code whenever the notebook model changes. This means it's called very often, perhaps even as often as autosave.
-        Instead, when loading a file that is dirty, we check if the actual file contents on disk are trusted. If so, we treat
-        the dirty contents as trusted as well. */
+        // If no contents or untitled, this is a newly created file, so the model should remain trusted
         if (contents !== undefined && !isUntitledFile(file)) {
-            // If no contents or untitled, this is a newly created file, so it should be trusted
+            /* As an optimization, we don't call trustNotebook for hot exit, since our hot exit backup code gets called by VS
+            Code whenever the notebook model changes. This means it's called very often, perhaps even as often as autosave.
+            Instead, when loading a file that is dirty, we check if the actual file contents on disk are trusted. If so, we treat
+            the dirty contents as trusted as well. */
             const contentsToCheck = isInitiallyDirty && trueContents !== undefined ? trueContents : model.getContent();
             model.update({
                 source: 'user',

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -196,12 +196,8 @@ export abstract class BaseNotebookModel implements INotebookModel {
         this.ensureNotebookJson();
 
         // Reuse our original json except for the cells.
-        const json = {
-            cells: this.cells.map((c) => pruneCell(c.data)),
-            metadata: this.notebookJson.metadata,
-            nbformat: this.notebookJson.nbformat,
-            nbformat_minor: this.notebookJson.nbformat_minor
-        };
+        const json = { ...this.notebookJson };
+        json.cells = this.cells.map((c) => pruneCell(c.data));
         return JSON.stringify(json, null, this.indentAmount);
     }
 }


### PR DESCRIPTION
For #12933 

+ Don't unnecessarily reorder the notebook json in `model.getContent`, it interferes with hashing (and also adds unnecessary noise to diffs). This will address [this scenario](https://github.com/microsoft/vscode-python/issues/12933#issuecomment-657829220)
+ Use `model.getContent` for checking `isNotebookTrusted` to make sure we're loading and trusting the same thing always. This will address [this scenario](https://github.com/microsoft/vscode-python/issues/12933#issuecomment-657779540)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
