### PR TITLE
Add restart language server command

### DIFF
--- a/news/1 Enhancements/3073.md
+++ b/news/1 Enhancements/3073.md
@@ -1,0 +1,1 @@
+Add "Restart Language Server" command

--- a/package.json
+++ b/package.json
@@ -835,6 +835,11 @@
                 "command": "python.datascience.latestExtension",
                 "title": "DataScience.latestExtension",
                 "category": "Python"
+            },
+            {
+                "command": "python.analysis.restartLanguageServer",
+                "title": "%python.command.python.analysis.restartLanguageServer.title%",
+                "category": "Python"
             }
         ],
         "menus": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -114,6 +114,7 @@
     "python.command.python.datascience.selectJupyterInterpreter.title": "Select Interpreter to start Jupyter server",
     "Datascience.currentlySelectedJupyterInterpreterForPlaceholder": "current: {0}",
     "python.command.python.analysis.clearCache.title": "Clear Module Analysis Cache",
+    "python.command.python.analysis.restartLanguageServer.title": "Restart Language Server",
     "python.snippet.launch.standard.label": "Python: Current File",
     "python.snippet.launch.module.label": "Python: Module",
     "python.snippet.launch.module.default": "enter-your-module-name",

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -32,8 +32,8 @@ import { IServiceContainer } from '../ioc/types';
 import { PythonInterpreter } from '../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../telemetry';
 import { EventName } from '../telemetry/constants';
+import { Commands } from './commands';
 import { LanguageServerChangeHandler } from './common/languageServerChangeHandler';
-import { Commands } from './languageServer/constants';
 import { RefCountedLanguageServer } from './refCountedLanguageServer';
 import {
     IExtensionActivationService,

--- a/src/client/activation/commands.ts
+++ b/src/client/activation/commands.ts
@@ -4,4 +4,5 @@
 
 export namespace Commands {
     export const ClearAnalyisCache = 'python.analysis.clearCache';
+    export const RestartLS = 'python.analysis.restartLanguageServer';
 }

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -4,6 +4,7 @@ import '../../common/extensions';
 
 import { inject, injectable, named } from 'inversify';
 
+import { ICommandManager } from '../../common/application/types';
 import { traceDecorators } from '../../common/logger';
 import { IConfigurationService, IDisposable, IExperimentsManager, Resource } from '../../common/types';
 import { debounceSync } from '../../common/utils/decorators';
@@ -11,6 +12,7 @@ import { IServiceContainer } from '../../ioc/types';
 import { PythonInterpreter } from '../../pythonEnvironments/info';
 import { captureTelemetry } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
+import { Commands } from '../commands';
 import { LanguageClientMiddleware } from '../languageClientMiddleware';
 import {
     ILanguageServerAnalysisOptions,
@@ -20,8 +22,6 @@ import {
     ILanguageServerProxy,
     LanguageServerType
 } from '../types';
-import { ICommandManager } from '../../common/application/types';
-import { Commands } from '../commands';
 
 @injectable()
 export class DotNetLanguageServerManager implements ILanguageServerManager {

--- a/src/client/activation/languageServer/manager.ts
+++ b/src/client/activation/languageServer/manager.ts
@@ -20,6 +20,8 @@ import {
     ILanguageServerProxy,
     LanguageServerType
 } from '../types';
+import { ICommandManager } from '../../common/application/types';
+import { Commands } from '../commands';
 
 @injectable()
 export class DotNetLanguageServerManager implements ILanguageServerManager {
@@ -39,8 +41,15 @@ export class DotNetLanguageServerManager implements ILanguageServerManager {
         @inject(ILanguageServerExtension) private readonly lsExtension: ILanguageServerExtension,
         @inject(ILanguageServerFolderService) private readonly folderService: ILanguageServerFolderService,
         @inject(IExperimentsManager) private readonly experimentsManager: IExperimentsManager,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService
-    ) {}
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(ICommandManager) commandManager: ICommandManager
+    ) {
+        this.disposables.push(
+            commandManager.registerCommand(Commands.RestartLS, () => {
+                this.restartLanguageServer().ignoreErrors();
+            })
+        );
+    }
 
     private static versionTelemetryProps(instance: DotNetLanguageServerManager) {
         return {

--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -19,6 +19,8 @@ import {
     ILanguageServerProxy,
     LanguageServerType
 } from '../types';
+import { ICommandManager } from '../../common/application/types';
+import { Commands } from '../commands';
 
 @injectable()
 export class NodeLanguageServerManager implements ILanguageServerManager {
@@ -38,8 +40,15 @@ export class NodeLanguageServerManager implements ILanguageServerManager {
         @inject(ILanguageServerFolderService)
         private readonly folderService: ILanguageServerFolderService,
         @inject(IExperimentsManager) private readonly experimentsManager: IExperimentsManager,
-        @inject(IConfigurationService) private readonly configService: IConfigurationService
-    ) {}
+        @inject(IConfigurationService) private readonly configService: IConfigurationService,
+        @inject(ICommandManager) commandManager: ICommandManager
+    ) {
+        this.disposables.push(
+            commandManager.registerCommand(Commands.RestartLS, () => {
+                this.restartLanguageServer().ignoreErrors();
+            })
+        );
+    }
 
     private static versionTelemetryProps(instance: NodeLanguageServerManager) {
         return {

--- a/src/client/activation/node/manager.ts
+++ b/src/client/activation/node/manager.ts
@@ -4,6 +4,7 @@ import '../../common/extensions';
 
 import { inject, injectable, named } from 'inversify';
 
+import { ICommandManager } from '../../common/application/types';
 import { traceDecorators } from '../../common/logger';
 import { IConfigurationService, IDisposable, IExperimentsManager, Resource } from '../../common/types';
 import { debounceSync } from '../../common/utils/decorators';
@@ -11,6 +12,7 @@ import { IServiceContainer } from '../../ioc/types';
 import { PythonInterpreter } from '../../pythonEnvironments/info';
 import { captureTelemetry } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
+import { Commands } from '../commands';
 import { LanguageClientMiddleware } from '../languageClientMiddleware';
 import {
     ILanguageServerAnalysisOptions,
@@ -19,8 +21,6 @@ import {
     ILanguageServerProxy,
     LanguageServerType
 } from '../types';
-import { ICommandManager } from '../../common/application/types';
-import { Commands } from '../commands';
 
 @injectable()
 export class NodeLanguageServerManager implements ILanguageServerManager {

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { CancellationToken, Position, TextDocument, Uri } from 'vscode';
-import { Commands as LSCommands } from '../../activation/languageServer/constants';
+import { Commands as LSCommands } from '../../activation/commands';
 import { Commands as DSCommands } from '../../datascience/constants';
 import { KernelSpecInterpreter } from '../../datascience/jupyter/kernels/kernelSelector';
 import { INotebookModel, ISwitchKernelOptions } from '../../datascience/types';
@@ -77,6 +77,7 @@ interface ICommandNameWithoutArgumentTypeMapping {
     [DSCommands.CreateNewNotebook]: [];
     [Commands.OpenStartPage]: [];
     [LSCommands.ClearAnalyisCache]: [];
+    [LSCommands.RestartLS]: [];
 }
 
 /**

--- a/src/test/activation/languageServer/manager.unit.test.ts
+++ b/src/test/activation/languageServer/manager.unit.test.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { Disposable } from 'vscode';
-import { instance, mock, verify, when, anything } from 'ts-mockito';
-import { Uri } from 'vscode';
+import { anything, instance, mock, verify, when } from 'ts-mockito';
+import { Disposable, Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient/node';
+import { Commands } from '../../../client/activation/commands';
 import { DotNetLanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
 import { LanguageServerExtension } from '../../../client/activation/languageServer/languageServerExtension';
 import { DotNetLanguageServerFolderService } from '../../../client/activation/languageServer/languageServerFolderService';
@@ -17,15 +17,14 @@ import {
     ILanguageServerFolderService,
     ILanguageServerProxy
 } from '../../../client/activation/types';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { ICommandManager } from '../../../client/common/application/types';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { ExperimentsManager } from '../../../client/common/experiments/manager';
 import { IConfigurationService, IExperimentsManager } from '../../../client/common/types';
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { sleep } from '../../core';
-import { ICommandManager } from '../../../client/common/application/types';
-import { CommandManager } from '../../../client/common/application/commandManager';
-import { Commands } from '../../../client/activation/commands';
 
 use(chaiAsPromised);
 

--- a/src/test/activation/languageServer/manager.unit.test.ts
+++ b/src/test/activation/languageServer/manager.unit.test.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 import { expect, use } from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
-import { instance, mock, verify, when } from 'ts-mockito';
+import { Disposable } from 'vscode';
+import { instance, mock, verify, when, anything } from 'ts-mockito';
 import { Uri } from 'vscode';
 import { LanguageClientOptions } from 'vscode-languageclient/node';
 import { DotNetLanguageServerAnalysisOptions } from '../../../client/activation/languageServer/analysisOptions';
@@ -22,6 +23,9 @@ import { IConfigurationService, IExperimentsManager } from '../../../client/comm
 import { ServiceContainer } from '../../../client/ioc/container';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { sleep } from '../../core';
+import { ICommandManager } from '../../../client/common/application/types';
+import { CommandManager } from '../../../client/common/application/commandManager';
+import { Commands } from '../../../client/activation/commands';
 
 use(chaiAsPromised);
 
@@ -37,6 +41,7 @@ suite('Language Server - Manager', () => {
     let folderService: ILanguageServerFolderService;
     let experimentsManager: IExperimentsManager;
     let configService: IConfigurationService;
+    let commandManager: ICommandManager;
     const languageClientOptions = ({ x: 1 } as any) as LanguageClientOptions;
     setup(() => {
         serviceContainer = mock(ServiceContainer);
@@ -46,13 +51,19 @@ suite('Language Server - Manager', () => {
         folderService = mock(DotNetLanguageServerFolderService);
         experimentsManager = mock(ExperimentsManager);
         configService = mock(ConfigurationService);
+
+        commandManager = mock(CommandManager);
+        const disposable = mock(Disposable);
+        when(commandManager.registerCommand(Commands.RestartLS, anything())).thenReturn(instance(disposable));
+
         manager = new DotNetLanguageServerManager(
             instance(serviceContainer),
             instance(analysisOptions),
             instance(lsExtension),
             instance(folderService),
             instance(experimentsManager),
-            instance(configService)
+            instance(configService),
+            instance(commandManager)
         );
     });
 


### PR DESCRIPTION
For #3073

Uses the existing language server restarting mechanism, which is already used for things like interpreter changes and such.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
