### PR TITLE
Remove unused node memwatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3118,24 +3118,6 @@
                 }
             }
         },
-        "@raghb1/node-memwatch": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@raghb1/node-memwatch/-/node-memwatch-3.0.1.tgz",
-            "integrity": "sha512-35KIUjB0llg8N13yf4zQ4RCLBPB7BrqLQ9w1oXde70MjoAu9plnMTH4iJBUihZtumLc9OMhViEX0deaI+XRo+w==",
-            "dev": true,
-            "requires": {
-                "bindings": "^1.5.0",
-                "nan": "^2.14.1"
-            },
-            "dependencies": {
-                "nan": {
-                    "version": "2.14.1",
-                    "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-                    "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-                    "dev": true
-                }
-            }
-        },
         "@sheerun/mutationobserver-shim": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
@@ -5807,6 +5789,7 @@
             "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
             "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
@@ -10360,7 +10343,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "filemanager-webpack-plugin-fixed": {
             "version": "2.0.9",

--- a/package.json
+++ b/package.json
@@ -3299,7 +3299,6 @@
         "@nteract/transform-vega": "^6.0.3",
         "@nteract/transforms": "^4.4.7",
         "@phosphor/widgets": "^1.9.3",
-        "@raghb1/node-memwatch": "^3.0.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@testing-library/react": "^9.4.0",
         "@types/ansi-regex": "^4.0.0",


### PR DESCRIPTION
This package isn't being used at the moment and it breaks npm ci on machines without a VS installed (well windows machines)