### PR TITLE
Hide the gather button while a cell is executing

### DIFF
--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -189,6 +189,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
                     onClick={gatherCode}
                     hidden={
                         this.props.cellVM.cell.state === CellState.error ||
+                        this.props.cellVM.cell.state === CellState.executing ||
                         this.props.cellVM.cell.data.cell_type === 'markdown' ||
                         !this.props.settings.gatherIsInstalled
                     }

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -595,6 +595,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
             this.props.cellVM.cell.data.execution_count === null ||
             this.props.cellVM.hasBeenRun === null ||
             this.props.cellVM.hasBeenRun === false ||
+            this.props.cellVM.cell.state === CellState.executing ||
             this.isError() ||
             this.isMarkdownCell() ||
             !this.props.gatherIsInstalled;


### PR DESCRIPTION
As Joyce just pointed out, the gather button appears while executing. And if you have an error in your cell and manage to push the button before the cell is done executing, the cell with the error is gathered incorreclty.

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
