### PR TITLE
Don't loop selection through all failed tests every time tests are run

### DIFF
--- a/news/2 Fixes/11743.md
+++ b/news/2 Fixes/11743.md
@@ -1,0 +1,1 @@
+Don't loop selection through all failed tests every time tests are run.

--- a/src/client/testing/explorer/treeView.ts
+++ b/src/client/testing/explorer/treeView.ts
@@ -40,6 +40,6 @@ export class TreeViewService implements IExtensionSingleActivationService, IDisp
         );
     }
     public async onRevealTestItem(testItem: TestDataItem): Promise<void> {
-        await this.treeView.reveal(testItem);
+        await this.treeView.reveal(testItem, { select: false });
     }
 }

--- a/src/test/testing/explorer/treeView.unit.test.ts
+++ b/src/test/testing/explorer/treeView.unit.test.ts
@@ -57,7 +57,7 @@ suite('Unit Tests Test Explorer Tree View', () => {
     test('Invoking the command handler will reveal the node in the tree', async () => {
         const data = {} as any;
         treeView
-            .setup((t) => t.reveal(typemoq.It.isAny()))
+            .setup((t) => t.reveal(typemoq.It.isAny(), { select: false }))
             .returns(() => Promise.resolve())
             .verifiable(typemoq.Times.once());
         when(appShell.createTreeView('python_tests', anything())).thenReturn(treeView.object);


### PR DESCRIPTION
For #11743

This was happening because we're revealing all the failed nodes upon every run. https://github.com/Microsoft/vscode-python/blob/61b179b2092050709e3c373a6738abad8ce581c4/src/client/testing/explorer/failedTestHandler.ts#L41

We should only execute the reveal command for the failed nodes in this run. The change event is being fired for even those nodes whose status is not affected.

This could also be solved if we aren't selecting the nodes we reveal. By default, all the nodes we reveal are selected. - **I went with this solution**

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
