### PR TITLE
Skip indicating dirty when trust changes in native notebook

### DIFF
--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -249,7 +249,10 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
                     this.didNotebookChangeDueToTrustUpdate.set(e.document.uri, false);
                     return;
                 }
-                this.numberOfCellUpdatesPerTrustedNotebook.set(e.document.uri, (numberOfCellUpdates ? numberOfCellUpdates : 0) + e.cells.length);
+                this.numberOfCellUpdatesPerTrustedNotebook.set(
+                    e.document.uri,
+                    (numberOfCellUpdates ? numberOfCellUpdates : 0) + e.cells.length
+                );
             } else {
                 this.contentProvider.notifyChangesToDocument(e.document);
             }


### PR DESCRIPTION
For #12943

When we set `cell.outputs` in `updateVSCNotebookAfterTrustingNotebook`, this triggers per-cell `changeCellOutputs` events downstream. However, `changeCellOutputs` can also be fired as a result of the user clearing all outputs, and we need to distinguish between the two and only indicate dirty when the user actually clears all outputs. Solution is to not call `contentProvider.notifyChangesToDocument` while changes to cell outputs are still coming in as a result of trust changing.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
