### PR TITLE
Remove release notes from the start page

### DIFF
--- a/StartPageReleaseNotes.md
+++ b/StartPageReleaseNotes.md
@@ -1,3 +1,0 @@
-Added a start page for the extension. Launched in experimental mode such that it opens to new users or when there is a new release. It can be disabled with the setting 'Python: Show Start Page' and it can be opened at any time with the command 'Python: Open Start Page'.
-Removed `python.jediEnabled` setting in favor of `python.languageServer`. Instead of `"python.jediEnabled": true` please use `"python.languageServer": "Jedi"`.
-Made the variable explorer in the Notebook editor resizable.

--- a/package.nls.json
+++ b/package.nls.json
@@ -528,7 +528,7 @@
     "StartPage.pythonFileDescription": "- Create a <div class=\"link\" role=\"button\" onclick={0}>new file</div> with a .py extension",
     "StartPage.openInteractiveWindow": "Use the Interactive Window to develop Python Scripts",
     "StartPage.interactiveWindowDesc": "- You can create cells on a Python file by typing \"#%%\" <br /> - Use \"<div class=\"italics\">Shift + Enter</div> \" to run a cell, the output will be shown in the interactive window",
-    "StartPage.releaseNotes": "Take a look at our <a class=\"link\" href={0}>Release Notes</a> to learn more about the latest features",
+    "StartPage.releaseNotes": "Take a look at our <a class=\"link\" href={0}>Release Notes</a> to learn more about the latest features.",
     "StartPage.tutorialAndDoc": "Explore more features in our <a class=\"link\" href={0}>Tutorials</a> or check <a class=\"link\" href={1}>Documentation</a> for tips and troubleshooting.",
     "StartPage.dontShowAgain": "Don't show this page again",
     "StartPage.helloWorld": "Hello world",

--- a/src/client/common/startPage/startPage.ts
+++ b/src/client/common/startPage/startPage.ts
@@ -120,11 +120,9 @@ export class StartPage extends WebViewHost<IStartPageMapping> implements IStartP
             case StartPageMessages.Started:
                 this.webviewDidLoad = true;
                 break;
-            case StartPageMessages.RequestReleaseNotesAndShowAgainSetting:
+            case StartPageMessages.RequestShowAgainSetting:
                 const settings = this.configuration.getSettings();
-                const filteredNotes = await this.handleReleaseNotesRequest();
-                await this.postMessage(StartPageMessages.SendReleaseNotes, {
-                    notes: filteredNotes,
+                await this.postMessage(StartPageMessages.SendSetting, {
                     showAgainSetting: settings.showStartPage
                 });
                 break;
@@ -243,12 +241,6 @@ export class StartPage extends WebViewHost<IStartPageMapping> implements IStartP
         // if savedVersion != version, there was an update
         await this.context.globalState.update('extensionVersion', version);
         return shouldShowStartPage;
-    }
-
-    // This gets the release notes from StartPageReleaseNotes.md
-    private async handleReleaseNotesRequest(): Promise<string[]> {
-        const releaseNotes = await this.file.readFile(path.join(EXTENSION_ROOT_DIR, 'StartPageReleaseNotes.md'));
-        return releaseNotes.splitLines();
     }
 
     private async activateBackground(): Promise<void> {

--- a/src/client/common/startPage/types.ts
+++ b/src/client/common/startPage/types.ts
@@ -8,16 +8,15 @@ export interface IStartPage {
     extensionVersionChanged(): Promise<boolean>;
 }
 
-export interface IReleaseNotesPackage {
-    notes: string[];
+export interface ISettingPackage {
     showAgainSetting: boolean;
 }
 
 export namespace StartPageMessages {
     export const Started = SharedMessages.Started;
     export const UpdateSettings = SharedMessages.UpdateSettings;
-    export const RequestReleaseNotesAndShowAgainSetting = 'RequestReleaseNotesAndShowAgainSetting';
-    export const SendReleaseNotes = 'SendReleaseNotes';
+    export const RequestShowAgainSetting = 'RequestShowAgainSetting';
+    export const SendSetting = 'SendSetting';
     export const OpenBlankNotebook = 'OpenBlankNotebook';
     export const OpenBlankPythonFile = 'OpenBlankPythonFile';
     export const OpenInteractiveWindow = 'OpenInteractiveWindow';
@@ -30,8 +29,8 @@ export namespace StartPageMessages {
 }
 
 export class IStartPageMapping {
-    public [StartPageMessages.RequestReleaseNotesAndShowAgainSetting]: IReleaseNotesPackage;
-    public [StartPageMessages.SendReleaseNotes]: IReleaseNotesPackage;
+    public [StartPageMessages.RequestShowAgainSetting]: ISettingPackage;
+    public [StartPageMessages.SendSetting]: ISettingPackage;
     public [StartPageMessages.Started]: never | undefined;
     public [StartPageMessages.UpdateSettings]: boolean;
     public [StartPageMessages.OpenBlankNotebook]: never | undefined;

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -1062,7 +1062,7 @@ export namespace StartPage {
 
     export const releaseNotes = localize(
         'StartPage.releaseNotes',
-        'Take a look at our <a class="link" href={0}>Release Notes</a> to learn more about the latest features'
+        'Take a look at our <a class="link" href={0}>Release Notes</a> to learn more about the latest features.'
     );
     export const tutorialAndDoc = localize(
         'StartPage.tutorialAndDoc',

--- a/src/datascience-ui/startPage/startPage.css
+++ b/src/datascience-ui/startPage/startPage.css
@@ -53,6 +53,12 @@
     white-space: nowrap;
 }
 
+.releaseNotesRow {
+    display: block;
+    min-height: 50px;
+    white-space: nowrap;
+}
+
 .link {
     display: inline;
     color: var(--vscode-debugIcon-continueForeground);

--- a/src/datascience-ui/startPage/startPage.tsx
+++ b/src/datascience-ui/startPage/startPage.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react';
 import '../../client/common/extensions';
-import { IReleaseNotesPackage, IStartPageMapping, StartPageMessages } from '../../client/common/startPage/types';
+import { ISettingPackage, IStartPageMapping, StartPageMessages } from '../../client/common/startPage/types';
 import { Image, ImageName } from '../react-common/image';
 import { getLocString } from '../react-common/locReactSide';
 import { IMessageHandler, PostOffice } from '../react-common/postOffice';
@@ -19,8 +19,7 @@ export interface IStartPageProps {
 // Front end of the Python extension start page.
 // In general it consists of its render method and methods that send and receive messages.
 export class StartPage extends React.Component<IStartPageProps> implements IMessageHandler {
-    private releaseNotes: IReleaseNotesPackage = {
-        notes: [],
+    private releaseNotes: ISettingPackage = {
         showAgainSetting: false
     };
     private postOffice: PostOffice = new PostOffice();
@@ -30,7 +29,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
     }
 
     public componentDidMount() {
-        this.postOffice.sendMessage<IStartPageMapping>(StartPageMessages.RequestReleaseNotesAndShowAgainSetting);
+        this.postOffice.sendMessage<IStartPageMapping>(StartPageMessages.RequestShowAgainSetting);
     }
 
     // tslint:disable: no-any
@@ -129,9 +128,8 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
                         {this.renderInteractiveWindowDescription()}
                     </div>
                 </div>
-                <div className="row">
+                <div className="releaseNotesRow">
                     {this.renderReleaseNotesLink()}
-                    {this.renderReleaseNotes()}
                     {this.renderTutorialAndDoc()}
                 </div>
                 <div className="block">
@@ -151,8 +149,7 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
 
     // tslint:disable-next-line: no-any
     public handleMessage = (msg: string, payload?: any) => {
-        if (msg === StartPageMessages.SendReleaseNotes) {
-            this.releaseNotes.notes = payload.notes;
+        if (msg === StartPageMessages.SendSetting) {
             this.releaseNotes.showAgainSetting = payload.showAgainSetting;
             this.setState({});
         }
@@ -240,19 +237,11 @@ export class StartPage extends React.Component<IStartPageProps> implements IMess
                 dangerouslySetInnerHTML={{
                     __html: getLocString(
                         'StartPage.releaseNotes',
-                        'Take a look at our <a class="link" href={0}>Release Notes</a> to learn more about the latest features'
+                        'Take a look at our <a class="link" href={0}>Release Notes</a> to learn more about the latest features.'
                     ).format('https://aka.ms/AA8dxtb')
                 }}
             />
         );
-    }
-
-    private renderReleaseNotes(): JSX.Element {
-        const notes: JSX.Element[] = [];
-        this.releaseNotes.notes.forEach((rel, index) => {
-            notes.push(<li key={index}>{rel}</li>);
-        });
-        return <ul className="list">{notes}</ul>;
     }
 
     private renderTutorialAndDoc(): JSX.Element {


### PR DESCRIPTION
This was suggested by Brett and then reviewed by Jeffrey, Luciana and I.

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
