### PR TITLE
In the isolation script use a dummy dir instead of deleting the path entry.

### DIFF
--- a/news/2 Fixes/11875.md
+++ b/news/2 Fixes/11875.md
@@ -1,0 +1,4 @@
+Some tools (like pytest) rely on the existence of `sys.path[0]`, so
+deleting it in the isolation script can sometimes cause problems.  The
+solution is to point `sys.path[0]` to a bogus directory that we know
+does not exist (assuming noone modifies the extension install dir).

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -10,7 +10,7 @@ import sys
 # We "isolate" the script/module (sys.argv[1]) by
 # replacing sys.path[0] with a dummy path and then sending the target
 # on to runpy.
-sys.path[0] = os.path.join(os.path.dirname(__file__), '.does-not-exist')
+sys.path[0] = os.path.join(os.path.dirname(__file__), ".does-not-exist")
 del sys.argv[0]
 module = sys.argv[0]
 if module == "-c":

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -8,9 +8,9 @@ import runpy
 import sys
 
 # We "isolate" the script/module (sys.argv[1]) by
-# deleting sys.path[0] and then sending the target
+# replacing sys.path[0] with a dummy path and then sending the target
 # on to runpy.
-del sys.path[0]
+sys.path[0] = os.path.join(os.path.dirname(__file__), '.does-not-exist')
 del sys.argv[0]
 module = sys.argv[0]
 if module == "-c":

--- a/pythonFiles/pyvsc-run-isolated.py
+++ b/pythonFiles/pyvsc-run-isolated.py
@@ -4,6 +4,7 @@
 if __name__ != "__main__":
     raise Exception("{} cannot be imported".format(__name__))
 
+import os.path
 import runpy
 import sys
 


### PR DESCRIPTION
(for #11875)

We found that some tools (like pytest) rely on `sys.path[0]` and deleting it in the isolation script sometimes causes problems.  The solution provided here is to replace `sys.path[0]` with a directory we know does not exist, rather than deleting it.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] Unit tests & system/integration tests are added/updated.~
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
