### PR TITLE
Set cwd for native notebooks before executing code

### DIFF
--- a/src/client/datascience/notebook/executionService.ts
+++ b/src/client/datascience/notebook/executionService.ts
@@ -241,6 +241,7 @@ export class NotebookExecutionService implements INotebookExecutionService {
         try {
             nb.clear(cell.uri.toString()); // NOSONAR
             editor.notifyExecution(cell.document.getText());
+            await nb.setLaunchingFile(model.file.path);
             const observable = nb.executeObservable(
                 cell.document.getText(),
                 document.fileName,


### PR DESCRIPTION
Closes #12992

Needed to fix this before @claudiaregio can announce native notebooks in insiders.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
