### PR TITLE
Add back font awesome

### DIFF
--- a/build/webpack/webpack.datascience-ui.config.builder.js
+++ b/build/webpack/webpack.datascience-ui.config.builder.js
@@ -137,6 +137,10 @@ function buildConfiguration(bundle) {
                 {
                     from: path.join(constants.ExtensionRootDir, 'out/ipywidgets/dist/ipywidgets.js'),
                     to: path.join(constants.ExtensionRootDir, 'out', 'datascience-ui', bundleFolder)
+                },
+                {
+                    from: path.join(constants.ExtensionRootDir, 'node_modules/font-awesome/**/*'),
+                    to: path.join(constants.ExtensionRootDir, 'out', 'datascience-ui', bundleFolder, 'node_modules')
                 }
             ]
         );

--- a/news/2 Fixes/12202.md
+++ b/news/2 Fixes/12202.md
@@ -1,0 +1,1 @@
+Fix missing css for some ipywidget output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10617,8 +10617,7 @@
         "font-awesome": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-            "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
-            "dev": true
+            "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
         },
         "fontkit": {
             "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -3228,6 +3228,7 @@
         "detect-indent": "^6.0.0",
         "diff-match-patch": "^1.0.0",
         "fast-deep-equal": "^2.0.1",
+        "font-awesome": "^4.7.0",
         "fs-extra": "^4.0.3",
         "fuzzy": "^0.1.3",
         "get-port": "^3.2.0",

--- a/src/client/common/application/webPanels/webPanel.ts
+++ b/src/client/common/application/webPanels/webPanel.ts
@@ -3,6 +3,7 @@
 'use strict';
 import '../../extensions';
 
+import * as path from 'path';
 import { Uri, Webview, WebviewOptions, WebviewPanel, window } from 'vscode';
 import { Identifiers } from '../../../datascience/constants';
 import { IFileSystem } from '../../platform/types';
@@ -140,6 +141,13 @@ export class WebPanel implements IWebPanel {
             .forEach((f) => webView.asWebviewUri(Uri.file(f)));
 
         const rootPath = webView.asWebviewUri(Uri.file(this.options.rootPath)).toString();
+        const fontAwesomePath = webView
+            .asWebviewUri(
+                Uri.file(
+                    path.join(this.options.rootPath, 'node_modules', 'font-awesome', 'css', 'font-awesome.min.css')
+                )
+            )
+            .toString();
         return `<!doctype html>
         <html lang="en">
             <head>
@@ -152,6 +160,7 @@ export class WebPanel implements IWebPanel {
                 <meta name="theme" content="${Identifiers.GeneratedThemeName}"/>
                 <title>VS Code Python React UI</title>
                 <base href="${uriBase}${uriBase.endsWith('/') ? '' : '/'}"/>
+                <link rel="stylesheet" href="${fontAwesomePath}">
                 </head>
             <body>
                 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/ipywidgets/src/libembed.ts
+++ b/src/ipywidgets/src/libembed.ts
@@ -6,8 +6,10 @@ declare let __webpack_public_path__: string;
 // eslint-disable-next-line prefer-const
 __webpack_public_path__ = (window as any).__jupyter_widgets_assets_path__ || __webpack_public_path__;
 
-import '@jupyter-widgets/controls/css/widgets.css';
 import '@phosphor/widgets/style/index.css';
+import 'font-awesome/css/font-awesome.css';
+
+import '@jupyter-widgets/controls/css/widgets.css';
 
 // Load json schema validator
 const Ajv = require('ajv');


### PR DESCRIPTION
For #12202

We removed font awesome as part of legal review (turns out it was included anyway with one of our dependencies). Since legal gave preliminary approval, putting it back.

Note, had to change location. Was getting 401 error on the old location. Might be that VS code is requiring all files loading into a webview from disk be relative to the root for the webview.

