### PR TITLE
Ensure languageServer value is valid, send event during activate

### DIFF
--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -188,7 +188,6 @@ export class LanguageServerExtensionActivationService
         // Configuration is non-default, so `languageServer` should be present.
         const configurationService = this.serviceContainer.get<IConfigurationService>(IConfigurationService);
         const lstType = configurationService.getSettings(this.resource).languageServer;
-        this.sendTelemetryForChosenLanguageServer(lstType).ignoreErrors();
         return lstType === LanguageServerType.Jedi;
     }
 
@@ -252,6 +251,8 @@ export class LanguageServerExtensionActivationService
                 serverType = LanguageServerType.Jedi;
                 break;
         }
+
+        this.sendTelemetryForChosenLanguageServer(serverType).ignoreErrors();
 
         await this.logStartup(serverType);
         let server = this.serviceContainer.get<ILanguageServerActivator>(ILanguageServerActivator, serverType);

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -233,7 +233,7 @@ export class PythonSettings implements IPythonSettings {
 
         let ls = pythonSettings.get<LanguageServerType>('languageServer') ?? LanguageServerType.Jedi;
         ls = systemVariables.resolveAny(ls);
-        if (!(ls in LanguageServerType)) {
+        if (!Object.values(LanguageServerType).includes(ls)) {
             ls = LanguageServerType.Jedi;
         }
         this.languageServer = ls;

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -231,11 +231,11 @@ export class PythonSettings implements IPythonSettings {
             pythonSettings.get<boolean>('autoUpdateLanguageServer', true)
         )!;
 
-        let ls = pythonSettings.get<LanguageServerType>('languageServer');
-        if (!ls) {
-            ls = LanguageServerType.Jedi;
+        const ls = pythonSettings.get<LanguageServerType>('languageServer') ?? LanguageServerType.Jedi;
+        this.languageServer = systemVariables.resolveAny(ls);
+        if (!(this.languageServer in LanguageServerType)) {
+            this.languageServer = LanguageServerType.Jedi;
         }
-        this.languageServer = systemVariables.resolveAny(ls)!;
 
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
         this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!;

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -231,11 +231,12 @@ export class PythonSettings implements IPythonSettings {
             pythonSettings.get<boolean>('autoUpdateLanguageServer', true)
         )!;
 
-        const ls = pythonSettings.get<LanguageServerType>('languageServer') ?? LanguageServerType.Jedi;
-        this.languageServer = systemVariables.resolveAny(ls);
-        if (!(this.languageServer in LanguageServerType)) {
-            this.languageServer = LanguageServerType.Jedi;
+        let ls = pythonSettings.get<LanguageServerType>('languageServer') ?? LanguageServerType.Jedi;
+        ls = systemVariables.resolveAny(ls);
+        if (!(ls in LanguageServerType)) {
+            ls = LanguageServerType.Jedi;
         }
+        this.languageServer = ls;
 
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
         this.jediPath = systemVariables.resolveAny(pythonSettings.get<string>('jediPath'))!;

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -193,18 +193,29 @@ suite('Python Settings', async () => {
         config.verifyAll();
     });
 
-    test('Invalid languageServer type is fixed', () => {
-        expected.languageServer = 'invalid' as any;
-        initializeConfig(expected);
-        config
-            .setup((c) => c.get<LanguageServerType>('languageServer'))
-            .returns(() => expected.languageServer)
-            .verifiable(TypeMoq.Times.once());
+    function testLanguageServer(languageServer: LanguageServerType, expectedValue: LanguageServerType) {
+        test(`languageServer=${languageServer}`, () => {
+            expected.pythonPath = 'python3';
+            expected.languageServer = languageServer;
+            initializeConfig(expected);
+            config
+                .setup((c) => c.get<LanguageServerType>('languageServer'))
+                .returns(() => expected.languageServer)
+                .verifiable(TypeMoq.Times.once());
 
-        settings.update(config.object);
+            settings.update(config.object);
 
-        expect(settings.languageServer).to.be.equal(LanguageServerType.Jedi);
-        config.verifyAll();
+            expect(settings.languageServer).to.be.equal(expectedValue);
+            config.verifyAll();
+        });
+    }
+
+    suite('languageServer settings', async () => {
+        Object.values(LanguageServerType).forEach(async (languageServer) => {
+            testLanguageServer(languageServer, languageServer);
+        });
+
+        testLanguageServer('invalid' as LanguageServerType, LanguageServerType.Jedi);
     });
 
     function testExperiments(enabled: boolean) {

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -194,7 +194,7 @@ suite('Python Settings', async () => {
     });
 
     function testLanguageServer(languageServer: LanguageServerType, expectedValue: LanguageServerType) {
-        test(`languageServer=${languageServer}`, () => {
+        test(languageServer, () => {
             expected.pythonPath = 'python3';
             expected.languageServer = languageServer;
             initializeConfig(expected);

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -193,6 +193,20 @@ suite('Python Settings', async () => {
         config.verifyAll();
     });
 
+    test('Invalid languageServer type is fixed', () => {
+        expected.languageServer = 'invalid' as any;
+        initializeConfig(expected);
+        config
+            .setup((c) => c.get<LanguageServerType>('languageServer'))
+            .returns(() => expected.languageServer)
+            .verifiable(TypeMoq.Times.once());
+
+        settings.update(config.object);
+
+        expect(settings.languageServer).to.be.equal(LanguageServerType.Jedi);
+        config.verifyAll();
+    });
+
     function testExperiments(enabled: boolean) {
         expected.pythonPath = 'python3';
         // tslint:disable-next-line:no-any


### PR DESCRIPTION
This value is read directly from the settings without validation; since the type is an enum, it's assumed that it's one of the valid values. Check if the resolved value is actually one of the enum's options, and switch it to the default if not.

During activation, send the current setting event during activation after the actual LS type is chosen, not arbitrarily during `isJedi()`.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
