### PR TITLE
Ensure terminal is not shown or activated if hideFromUser is set to true

### DIFF
--- a/news/2 Fixes/13117.md
+++ b/news/2 Fixes/13117.md
@@ -1,0 +1,1 @@
+Ensure terminal is not shown or activated if hideFromUser is set to true.

--- a/src/client/common/terminal/activator/index.ts
+++ b/src/client/common/terminal/activator/index.ts
@@ -25,7 +25,7 @@ export class TerminalActivator implements ITerminalActivator {
     ): Promise<boolean> {
         const settings = this.configurationService.getSettings(options?.resource);
         const activateEnvironment = settings.terminal.activateEnvironment;
-        if (!activateEnvironment) {
+        if (!activateEnvironment || options?.hideFromUser) {
             return false;
         }
 

--- a/src/client/common/terminal/service.ts
+++ b/src/client/common/terminal/service.ts
@@ -62,7 +62,9 @@ export class TerminalService implements ITerminalService, Disposable {
     }
     public async show(preserveFocus: boolean = true): Promise<void> {
         await this.ensureTerminal(preserveFocus);
-        this.terminal!.show(preserveFocus);
+        if (!this.options?.hideFromUser) {
+            this.terminal!.show(preserveFocus);
+        }
     }
     private async ensureTerminal(preserveFocus: boolean = true): Promise<void> {
         if (this.terminal) {

--- a/src/test/common/terminals/activator/index.unit.test.ts
+++ b/src/test/common/terminals/activator/index.unit.test.ts
@@ -40,10 +40,14 @@ suite('Terminal Activator', () => {
             }
         })(TypeMoq.Mock.ofType<ITerminalHelper>().object, [handler1.object, handler2.object], configService.object);
     });
-    async function testActivationAndHandlers(activationSuccessful: boolean) {
+    async function testActivationAndHandlers(
+        activationSuccessful: boolean,
+        activateEnvironmentSetting: boolean,
+        hidden: boolean = false
+    ) {
         terminalSettings
             .setup((b) => b.activateEnvironment)
-            .returns(() => activationSuccessful)
+            .returns(() => activateEnvironmentSetting)
             .verifiable(TypeMoq.Times.once());
         baseActivator
             .setup((b) => b.activateEnvironmentInTerminal(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
@@ -74,7 +78,8 @@ suite('Terminal Activator', () => {
 
         const terminal = TypeMoq.Mock.ofType<Terminal>();
         const activated = await activator.activateEnvironmentInTerminal(terminal.object, {
-            preserveFocus: activationSuccessful
+            preserveFocus: activationSuccessful,
+            hideFromUser: hidden
         });
 
         assert.equal(activated, activationSuccessful);
@@ -82,6 +87,8 @@ suite('Terminal Activator', () => {
         handler1.verifyAll();
         handler2.verifyAll();
     }
-    test('Terminal is activated and handlers are invoked', () => testActivationAndHandlers(true));
-    test('Terminal is not activated and handlers are invoked', () => testActivationAndHandlers(false));
+    test('Terminal is activated and handlers are invoked', () => testActivationAndHandlers(true, true));
+    test('Terminal is not activated if auto-activate setting is set to true but terminal is hidden', () =>
+        testActivationAndHandlers(false, true, true));
+    test('Terminal is not activated and handlers are invoked', () => testActivationAndHandlers(false, false));
 });

--- a/src/test/common/terminals/service.unit.test.ts
+++ b/src/test/common/terminals/service.unit.test.ts
@@ -116,7 +116,20 @@ suite('Terminal Service', () => {
         terminal.verify((t) => t.sendText(TypeMoq.It.isValue(textToSend)), TypeMoq.Times.exactly(1));
     });
 
-    test('Ensure terminal shown', async () => {
+    test('Ensure terminal is not shown if `hideFromUser` option is set to `true`', async () => {
+        terminalHelper
+            .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(undefined));
+        service = new TerminalService(mockServiceContainer.object, { hideFromUser: true });
+        terminalHelper.setup((h) => h.identifyTerminalShell(TypeMoq.It.isAny())).returns(() => TerminalShellType.bash);
+        terminalManager.setup((t) => t.createTerminal(TypeMoq.It.isAny())).returns(() => terminal.object);
+
+        await service.show();
+
+        terminal.verify((t) => t.show(TypeMoq.It.isValue(true)), TypeMoq.Times.never());
+    });
+
+    test('Ensure terminal shown otherwise', async () => {
         terminalHelper
             .setup((helper) => helper.getEnvironmentActivationCommands(TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(undefined));


### PR DESCRIPTION
For #11122 

### This fix is for the hidden terminals created by the extension

We should be checking `this.options?.hideFromUser` before calling `Terminal.show`.

Also, added a check for `options.hideFromUser` inside the [implementation](https://github.com/Microsoft/vscode-python/blob/4bed5606e1b7fb29f246837147105c0a80bfcab9/src/client/common/terminal/activator/index.ts#L28) alongside where we check the value of setting `python.terminal.activateEnvironment` just to be sure.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
