### PR TITLE
More nightly failures

### DIFF
--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -711,7 +711,7 @@ for i in range(0, 100):
                 // Then open a second time and make sure it uses this new path
                 const secondPath = await interpreterService.getActiveInterpreter(secondUri);
                 assert.notEqual(secondPath?.path, activeInterpreter?.path, 'Second path was not set');
-                const newWindow = (await interactiveWindowProvider.getOrCreate(undefined)) as InteractiveWindow;
+                const newWindow = (await interactiveWindowProvider.getOrCreate(secondUri)) as InteractiveWindow;
                 await addCode(ioc, 'a=1\na', false, secondUri);
                 assert.notEqual(
                     newWindow.notebook!.getMatchingInterpreter()?.path,

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -514,10 +514,13 @@ suite('DataScience notebook tests', () => {
                             `--config=${configFile}`
                         ]);
 
+                        // To make sure we get an 'insecure' message, replace localhost with 127.0.0.1
+                        const replaced = uri.replace('localhost', '127.0.0.1');
+
                         // Try to create, we expect a failure here as we will deny the insecure connection
                         let madeItPast = false;
                         try {
-                            await createNotebook(uri, undefined);
+                            await createNotebook(replaced, undefined);
                             madeItPast = true;
                         } catch (exc) {
                             assert.ok(exc.toString().includes('insecure'), `Invalid exception thrown: ${exc}`);


### PR DESCRIPTION
- Insecure test wasn't throwing if local (linux seems to use localhost as the name)
- Multiple interpreters was not using the URI for the second file in the creation of the interactive window. 

Hopefully this will fix the last two failures left.