### PR TITLE
INotebookEditor need not inherit IInteractiveBase

### DIFF
--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -557,7 +557,7 @@ export interface INotebookEditorProvider {
 
 // For native editing, the INotebookEditor acts like a TextEditor and a TextDocument together
 export const INotebookEditor = Symbol('INotebookEditor');
-export interface INotebookEditor extends IInteractiveBase {
+export interface INotebookEditor extends Disposable {
     /**
      * Type of editor, whether it is the old, custom or native notebook editor.
      * Once VSC Notebook is stable, this property can be removed.
@@ -580,10 +580,19 @@ export interface INotebookEditor extends IInteractiveBase {
     readonly visible: boolean;
     readonly active: boolean;
     readonly model: INotebookModel;
+    onExecutedCode: Event<string>;
+    notebook?: INotebook;
     show(): Promise<void>;
     runAllCells(): void;
     runSelectedCell(): void;
     addCellBelow(): void;
+    // onExecutedCode: Event<string>;
+    // notebook?: INotebook;
+    undoCells(): void;
+    redoCells(): void;
+    removeAllCells(): void;
+    interruptKernel(): Promise<void>;
+    restartKernel(): Promise<void>;
 }
 
 export const IInteractiveWindowListener = Symbol('IInteractiveWindowListener');

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -586,8 +586,6 @@ export interface INotebookEditor extends Disposable {
     runAllCells(): void;
     runSelectedCell(): void;
     addCellBelow(): void;
-    // onExecutedCode: Event<string>;
-    // notebook?: INotebook;
     undoCells(): void;
     redoCells(): void;
     removeAllCells(): void;


### PR DESCRIPTION
For #12189
To be reviewed after https://github.com/microsoft/vscode-python/pull/13144