### PR TITLE
Fix regression to allow notebooks to open settings links

### DIFF
--- a/news/2 Fixes/13156.md
+++ b/news/2 Fixes/13156.md
@@ -1,0 +1,1 @@
+Fix settings links to open correctly in the notebook editor.

--- a/src/datascience-ui/history-react/interactiveCell.tsx
+++ b/src/datascience-ui/history-react/interactiveCell.tsx
@@ -160,6 +160,7 @@ export class InteractiveCell extends React.Component<IInteractiveCellProps> {
                                         enableScroll={this.props.enableScroll}
                                         themeMatplotlibPlots={themeMatplotlibPlots}
                                         widgetFailed={this.props.widgetFailed}
+                                        openSettings={this.props.openSettings}
                                     />
                                 </div>
                             </div>

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -38,6 +38,7 @@ interface ICellOutputProps {
     themeMatplotlibPlots?: boolean;
     expandImage(imageHtml: string): void;
     widgetFailed(ex: Error): void;
+    openSettings(settings?: string): void;
 }
 
 interface ICellOutputData {
@@ -511,7 +512,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
                         buffer.push(
                             <div role="group" key={index} onDoubleClick={transformed.doubleClick} className={className}>
                                 {transformed.extraButton}
-                                <TrimmedOutputMessage></TrimmedOutputMessage>
+                                <TrimmedOutputMessage openSettings={this.props.openSettings} />
                                 <Transform data={transformed.output.data} />
                             </div>
                         );

--- a/src/datascience-ui/interactive-common/trimmedOutputLink.tsx
+++ b/src/datascience-ui/interactive-common/trimmedOutputLink.tsx
@@ -2,15 +2,13 @@
 // Licensed under the MIT License.
 
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { actionCreators } from '../history-react/redux/actions';
 import { getLocString } from '../react-common/locReactSide';
 
 interface ITrimmedOutputMessage {
-    openSettings(): void;
+    openSettings(setting?: string): void;
 }
 
-class TrimmedOutputMessageComponent extends React.PureComponent<ITrimmedOutputMessage> {
+export class TrimmedOutputMessage extends React.PureComponent<ITrimmedOutputMessage> {
     constructor(props: ITrimmedOutputMessage) {
         super(props);
     }
@@ -31,10 +29,6 @@ class TrimmedOutputMessageComponent extends React.PureComponent<ITrimmedOutputMe
         );
     }
     private changeTextOutputLimit = () => {
-        this.props.openSettings();
+        this.props.openSettings('python.dataScience.textOutputLimit');
     };
 }
-
-export const TrimmedOutputMessage = connect(undefined, {
-    openSettings: () => actionCreators.openSettings('python.dataScience.textOutputLimit')
-})(TrimmedOutputMessageComponent);

--- a/src/datascience-ui/native-editor/nativeCell.tsx
+++ b/src/datascience-ui/native-editor/nativeCell.tsx
@@ -822,6 +822,7 @@ export class NativeCell extends React.Component<INativeCellProps> {
                         enableScroll={this.props.enableScroll}
                         themeMatplotlibPlots={themeMatplotlibPlots}
                         widgetFailed={this.props.widgetFailed}
+                        openSettings={this.props.openSettings}
                     />
                 </div>
             );

--- a/src/datascience-ui/native-editor/redux/reducers/index.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/index.ts
@@ -67,6 +67,7 @@ export const reducerMap: Partial<INativeEditorActionMapping> = {
     [CommonActionType.CONTINUE]: Execution.continueExec,
     [CommonActionType.STEP]: Execution.step,
     [CommonActionType.RUN_BY_LINE]: Execution.runByLine,
+    [CommonActionType.OPEN_SETTINGS]: CommonEffects.openSettings,
 
     // Messages from the webview (some are ignored)
     [InteractiveWindowMessages.StartCell]: Creation.startCell,


### PR DESCRIPTION
For #13156 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
