### PR TITLE
Allow a custom display string as part of the remote jupyter server provider

### DIFF
--- a/news/1 Enhancements/12988.md
+++ b/news/1 Enhancements/12988.md
@@ -1,0 +1,1 @@
+Allow a custom display string for remote servers as part of the remote Jupyter server provider extensibility point.

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -45,6 +45,7 @@ export async function createRemoteConnectionInfo(
     const baseUrl = serverUri ? serverUri.baseUrl : `${url.protocol}//${url.host}${url.pathname}`;
     const token = serverUri ? serverUri.token : `${url.searchParams.get('token')}`;
     const hostName = serverUri ? new URL(serverUri.baseUrl).hostname : url.hostname;
+    const displayName = serverUri ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
 
     return {
         type: 'jupyter',
@@ -54,7 +55,7 @@ export async function createRemoteConnectionInfo(
         localLaunch: false,
         localProcExitCode: undefined,
         valid: true,
-        displayName: getJupyterConnectionDisplayName(token, baseUrl),
+        displayName,
         disconnected: (_l) => {
             return { dispose: noop };
         },

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1284,6 +1284,7 @@ export interface IJupyterServerUri {
     token: string;
     // tslint:disable-next-line: no-any
     authorizationHeader: any; // JSON object for authorization header.
+    displayName: string;
 }
 
 export type JupyterServerUriHandle = string;

--- a/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
+++ b/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
@@ -34,7 +34,8 @@ class MockProvider implements IJupyterUriProvider {
                 // tslint:disable-next-line: no-http-string
                 baseUrl: 'http://foobar:3000',
                 token: '',
-                authorizationHeader: { Bearer: '1' }
+                authorizationHeader: { Bearer: '1' },
+                displayName: 'dummy'
             };
         }
 

--- a/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
+++ b/src/test/datascience/jupyterUriProviderRegistration.unit.test.ts
@@ -83,6 +83,7 @@ suite('DataScience URI Picker', () => {
         const uri = await registration.getJupyterServerUri('1', handle!);
         // tslint:disable-next-line: no-http-string
         assert.equal(uri.baseUrl, 'http://foobar:3000', 'Base URL not found');
+        assert.equal(uri.displayName, 'dummy', 'Display name not found');
     });
     test('Back', async () => {
         const registration = createRegistration(['1']);


### PR DESCRIPTION
For #12988

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
