### PR TITLE
Select, not focus, notebook cells created via 'a' and 'b' shortcuts

### DIFF
--- a/news/2 Fixes/13165.md
+++ b/news/2 Fixes/13165.md
@@ -1,0 +1,1 @@
+"a" and "b" Jupyter shortcuts should not automatically enter edit mode.

--- a/src/datascience-ui/native-editor/redux/reducers/creation.ts
+++ b/src/datascience-ui/native-editor/redux/reducers/creation.ts
@@ -61,7 +61,7 @@ export namespace Creation {
             cellId: arg.payload.data.cellId,
             newCellId: arg.payload.data.newCellId
         });
-        queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, {
+        queueIncomingActionWithPayload(arg, CommonActionType.SELECT_CELL, {
             cellId: arg.payload.data.newCellId,
             cursorPos: CursorPos.Current
         });
@@ -73,7 +73,7 @@ export namespace Creation {
             cellId: arg.payload.data.cellId,
             newCellId: arg.payload.data.newCellId
         });
-        queueIncomingActionWithPayload(arg, CommonActionType.FOCUS_CELL, {
+        queueIncomingActionWithPayload(arg, CommonActionType.SELECT_CELL, {
             cellId: arg.payload.data.newCellId,
             cursorPos: CursorPos.Current
         });

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -1922,7 +1922,7 @@ df.head()`;
                         // Add, then undo, keep doing at least 3 times and confirm it works as expected.
                         for (let i = 0; i < 3; i += 1) {
                             // Add a new cell
-                            let update = waitForMessage(ioc, InteractiveWindowMessages.FocusedCellEditor);
+                            let update = waitForMessage(ioc, InteractiveWindowMessages.SelectedCell);
                             simulateKeyPressOnCell(0, { code: 'a' });
                             await update;
 
@@ -1930,18 +1930,12 @@ df.head()`;
                             // fixed when we switch to redux)
                             await sleep(100);
 
-                            // There should be 4 cells and first cell is focused.
-                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), false);
+                            // There should be 4 cells and first cell is selected.
+                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
                             assert.equal(isCellSelected(wrapper, 'NativeCell', 1), false);
-                            assert.equal(isCellFocused(wrapper, 'NativeCell', 0), true);
+                            assert.equal(isCellFocused(wrapper, 'NativeCell', 0), false);
                             assert.equal(isCellFocused(wrapper, 'NativeCell', 1), false);
                             assert.equal(wrapper.find('NativeCell').length, 4);
-
-                            // Unfocus the cell
-                            update = waitForMessage(ioc, InteractiveWindowMessages.UnfocusedCellEditor);
-                            simulateKeyPressOnCell(0, { code: 'Escape' });
-                            await update;
-                            assert.equal(isCellSelected(wrapper, 'NativeCell', 0), true);
 
                             // Press 'ctrl+z'. This should do nothing
                             simulateKeyPressOnCell(0, { code: 'z', ctrlKey: true });


### PR DESCRIPTION
For #13165 

User pointed out in a tweet that our 'a' and 'b' shortcuts deviate from Jupyter's in behavior. I was able to verify that classic Jupyter in the browser will keep the cell selected but not focused, so that you can add multiple cells at a time. We focus the cell after adding it instead of selecting the cell. This behavioral inconsistency seems like it would annoy users enough to be worth fixing, especially since these are officially supported shortcuts (i.e. not contributed through a third-party plugin).

We haven't triaged this bug, but this was a super easy fix, so went ahead and implemented the fix

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
