### PR TITLE
Create backing ipynbs in a separate directory

### DIFF
--- a/news/2 Fixes/12510.md
+++ b/news/2 Fixes/12510.md
@@ -1,0 +1,1 @@
+Store backing untitled ipynb notebook files in a directory called `vscode-temp` for remote Jupyter server connections to avoid cluttering the workspace root.

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -559,3 +559,4 @@ export namespace LiveShareCommands {
 export const VSCodeNotebookProvider = 'VSCodeNotebookProvider';
 export const OurNotebookProvider = 'OurNotebookProvider';
 export const DataScienceStartupTime = Symbol('DataScienceStartupTime');
+export const backingNotebookDir = 'vscode-temp';

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -174,7 +174,7 @@ export class JupyterSession extends BaseJupyterSession {
                     await contentsManager.newUntitled({ path: backingNotebookDir, type: 'notebook' })
                 );
             } else {
-                traceError(e);
+                traceError('Encountered error while initializing backing notebook for Jupyter session', e);
                 // We must have a backing notebook for each session, so fallback on creating an untitled notebook in the pwd like we currently do
                 this.notebookFiles.push(await contentsManager.newUntitled({ type: 'notebook' }));
             }

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -45,7 +45,7 @@ export async function createRemoteConnectionInfo(
     const baseUrl = serverUri ? serverUri.baseUrl : `${url.protocol}//${url.host}${url.pathname}`;
     const token = serverUri ? serverUri.token : `${url.searchParams.get('token')}`;
     const hostName = serverUri ? new URL(serverUri.baseUrl).hostname : url.hostname;
-    const displayName = serverUri ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
+    const displayName = serverUri && serverUri.displayName ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
 
     return {
         type: 'jupyter',

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -45,7 +45,8 @@ export async function createRemoteConnectionInfo(
     const baseUrl = serverUri ? serverUri.baseUrl : `${url.protocol}//${url.host}${url.pathname}`;
     const token = serverUri ? serverUri.token : `${url.searchParams.get('token')}`;
     const hostName = serverUri ? new URL(serverUri.baseUrl).hostname : url.hostname;
-    const displayName = serverUri && serverUri.displayName ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
+    const displayName =
+        serverUri && serverUri.displayName ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
 
     return {
         type: 'jupyter',


### PR DESCRIPTION
For #12510 (see issue description for additional context)

The root cause of this bug is that although we have code to clean up these backing notebooks on a connection dispose, that code doesn't execute in time if VSCode is killed too quickly, or if the server is killed remote-side. This also means that disposing the notebook on editor close, as was originally suggested in the bug issue, will suffer from the same problem.

The "solution" is to just move notebooks to a directory so that they aren't cluttering the workspace root. Unfortunately Jupyter's API doesn't expose a way to access the remote machine's temporary directory, so creating our own with a standard name is the best we can do. Jupyter's API also doesn't expose a way to create directories with a specific filename, and missing parent directories are not automatically created (unlike VSC's filesystem API). Hence I had to create a temp directory, rename it to the desired directory, and clean up afterwards if the rename failed due to the directory already existing.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
