### PR TITLE
Delete backing ipynbs as soon as remote session is created

### DIFF
--- a/news/2 Fixes/12510.md
+++ b/news/2 Fixes/12510.md
@@ -1,0 +1,2 @@
+Delete backing untitled ipynb notebook files as soon as the remote session has been created.
+

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -151,9 +151,6 @@ export class JupyterSession extends BaseJupyterSession {
             () =>
                 this.sessionManager!.startNew(options)
                     .then(async (session) => {
-                        if (this.connInfo && !this.connInfo.localLaunch) {
-                            this.contentsManager.delete(backingFile.path).ignoreErrors();
-                        }
                         this.logRemoteOutput(
                             localize.DataScience.createdNewKernel().format(this.connInfo.baseUrl, session.kernel.id)
                         );
@@ -173,7 +170,11 @@ export class JupyterSession extends BaseJupyterSession {
                         return session;
                     })
                     .catch((ex) => Promise.reject(new JupyterSessionStartError(ex)))
-                    .finally(() => this.contentsManager.delete(backingFile.path).ignoreErrors()),
+                    .finally(() => {
+                        if (this.connInfo && !this.connInfo.localLaunch) {
+                            this.contentsManager.delete(backingFile.path).ignoreErrors();
+                        }
+                    }),
             cancelToken
         );
     }

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -152,7 +152,7 @@ export class JupyterSession extends BaseJupyterSession {
                 this.sessionManager!.startNew(options)
                     .then(async (session) => {
                         if (this.connInfo && !this.connInfo.localLaunch) {
-                            await this.contentsManager.delete(backingFile.path);
+                            this.contentsManager.delete(backingFile.path).ignoreErrors();
                         }
                         this.logRemoteOutput(
                             localize.DataScience.createdNewKernel().format(this.connInfo.baseUrl, session.kernel.id)

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -1,21 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 'use strict';
-import type {
-    Contents,
-    ContentsManager,
-    Kernel,
-    ServerConnection,
-    Session,
-    SessionManager
-} from '@jupyterlab/services';
+import type { ContentsManager, Kernel, ServerConnection, Session, SessionManager } from '@jupyterlab/services';
 import * as uuid from 'uuid/v4';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { Cancellation } from '../../common/cancellation';
 import { traceError, traceInfo } from '../../common/logger';
 import { IOutputChannel } from '../../common/types';
 import * as localize from '../../common/utils/localize';
-import { noop } from '../../common/utils/misc';
 import { PythonInterpreter } from '../../pythonEnvironments/info';
 import { captureTelemetry } from '../../telemetry';
 import { BaseJupyterSession, JupyterSessionStartError } from '../baseJupyterSession';
@@ -28,7 +20,6 @@ import { JupyterWebSockets } from './jupyterWebSocket';
 import { LiveKernelModel } from './kernels/types';
 
 export class JupyterSession extends BaseJupyterSession {
-    private notebookFiles: Contents.IModel[] = [];
     constructor(
         private connInfo: IJupyterConnection,
         private serverSettings: ServerConnection.ISettings,
@@ -41,22 +32,6 @@ export class JupyterSession extends BaseJupyterSession {
     ) {
         super(restartSessionUsed);
         this.kernelSpec = kernelSpec;
-    }
-
-    public async shutdown(): Promise<void> {
-        // Destroy the notebook file if not local. Local is cleaned up when we destroy the kernel spec.
-        if (this.notebookFiles.length && this.contentsManager && this.connInfo && !this.connInfo.localLaunch) {
-            try {
-                // Make sure we have a session first and it returns something
-                await this.sessionManager.refreshRunning();
-                await Promise.all(this.notebookFiles.map((f) => this.contentsManager!.delete(f.path)));
-                this.notebookFiles = [];
-            } catch {
-                noop();
-            }
-        }
-
-        return super.shutdown();
     }
 
     @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
@@ -162,11 +137,11 @@ export class JupyterSession extends BaseJupyterSession {
         cancelToken?: CancellationToken
     ): Promise<ISessionWithSocket> {
         // Create a temporary notebook for this session.
-        this.notebookFiles.push(await contentsManager.newUntitled({ type: 'notebook' }));
+        const backingFile = await contentsManager.newUntitled({ type: 'notebook' });
 
         // Create our session options using this temporary notebook and our connection info
         const options: Session.IOptions = {
-            path: this.notebookFiles[this.notebookFiles.length - 1].path,
+            path: backingFile.path,
             kernelName: kernelSpec ? kernelSpec.name : '',
             name: uuid(), // This is crucial to distinguish this session from any other.
             serverSettings: serverSettings
@@ -176,6 +151,9 @@ export class JupyterSession extends BaseJupyterSession {
             () =>
                 this.sessionManager!.startNew(options)
                     .then(async (session) => {
+                        if (this.connInfo && !this.connInfo.localLaunch) {
+                            await this.contentsManager.delete(backingFile.path);
+                        }
                         this.logRemoteOutput(
                             localize.DataScience.createdNewKernel().format(this.connInfo.baseUrl, session.kernel.id)
                         );

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -172,7 +172,8 @@ export class JupyterSession extends BaseJupyterSession {
 
                         return session;
                     })
-                    .catch((ex) => Promise.reject(new JupyterSessionStartError(ex))),
+                    .catch((ex) => Promise.reject(new JupyterSessionStartError(ex)))
+                    .finally(() => this.contentsManager.delete(backingFile.path).ignoreErrors()),
             cancelToken
         );
     }

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -42,10 +42,11 @@ export async function createRemoteConnectionInfo(
     const id = url.searchParams.get(Identifiers.REMOTE_URI_ID_PARAM);
     const uriHandle = url.searchParams.get(Identifiers.REMOTE_URI_HANDLE_PARAM);
     const serverUri = id && uriHandle ? await providerRegistration.getJupyterServerUri(id, uriHandle) : undefined;
-    const baseUrl = serverUri ? serverUri.baseUrl : `${url.protocol}//${url.host}${url.pathname}`;
-    const token = serverUri ? serverUri.token : `${url.searchParams.get('token')}`;
-    const hostName = serverUri ? new URL(serverUri.baseUrl).hostname : url.hostname;
-    const displayName = serverUri ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
+    const baseUrl = serverUri && serverUri.baseUrl ? serverUri.baseUrl : `${url.protocol}//${url.host}${url.pathname}`;
+    const token = serverUri && serverUri.token ? serverUri.token : `${url.searchParams.get('token')}`;
+    const hostName = serverUri && serverUri.baseUrl ? new URL(serverUri.baseUrl).hostname : url.hostname;
+    const displayName =
+        serverUri && serverUri.displayName ? serverUri.displayName : getJupyterConnectionDisplayName(token, baseUrl);
 
     return {
         type: 'jupyter',

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -133,16 +133,6 @@ suite('DataScience - JupyterSession', () => {
             verify(kernel.interrupt()).once();
         });
         suite('Shutdown', () => {
-            test('Remote', async () => {
-                connection.setup((c) => c.localLaunch).returns(() => false);
-                when(sessionManager.refreshRunning()).thenResolve();
-                when(contentsManager.delete(anything())).thenResolve();
-
-                await jupyterSession.shutdown();
-
-                verify(sessionManager.refreshRunning()).once();
-                verify(contentsManager.delete(anything())).once();
-            });
             test('Remote sessions', async () => {
                 connection.setup((c) => c.localLaunch).returns(() => true);
                 when(sessionManager.refreshRunning()).thenResolve();

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -99,6 +99,7 @@ suite('DataScience - JupyterSession', () => {
         const nbFile = 'file path';
         // tslint:disable-next-line: no-any
         when(contentsManager.newUntitled(deepEqual({ type: 'notebook' }))).thenResolve({ path: nbFile } as any);
+        when(contentsManager.delete(anything())).thenResolve();
         when(sessionManager.startNew(anything())).thenResolve(instance(session));
         kernelSpec.setup((k) => k.name).returns(() => 'some name');
         kernelSpec.setup((k) => k.id).returns(() => undefined);
@@ -133,10 +134,9 @@ suite('DataScience - JupyterSession', () => {
             verify(kernel.interrupt()).once();
         });
         suite('Shutdown', () => {
-            test('Remote sessions', async () => {
-                connection.setup((c) => c.localLaunch).returns(() => true);
+            test('Remote session', async () => {
+                connection.setup((c) => c.localLaunch).returns(() => false);
                 when(sessionManager.refreshRunning()).thenResolve();
-                when(contentsManager.delete(anything())).thenResolve();
                 when(session.isRemoteSession).thenReturn(true);
                 when(session.shutdown()).thenResolve();
                 when(session.dispose()).thenReturn();
@@ -150,7 +150,7 @@ suite('DataScience - JupyterSession', () => {
                 // With remote sessions, we should not shut the session, but dispose it.
                 verify(session.dispose()).once();
             });
-            test('Local', async () => {
+            test('Local session', async () => {
                 connection.setup((c) => c.localLaunch).returns(() => true);
                 when(session.isRemoteSession).thenReturn(false);
                 when(session.isDisposed).thenReturn(false);


### PR DESCRIPTION
For #12510 

I tried @DonJayamanne's suggestion to just delete the backing files that we create for remote server connections right after the session has been created. Interestingly enough it doesn't appear to interfere with our ability to use the session. Might be the case that a session only needs to be created with a notebook, but doesn't need that notebook around for actually operating the session. I didn't find any Jupyter documentation to suggest that this might be a bad idea.

I've built and tested this locally with remote and local server connections, and everything looks fine.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
