### PR TITLE
Remove work arounds for SaveAs of Native Notebooks

### DIFF
--- a/news/2 Fixes/13235.md
+++ b/news/2 Fixes/13235.md
@@ -1,0 +1,1 @@
+Handle `Save As` of preview Notebooks.

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -11,7 +11,6 @@ import { IDisposableRegistry, Resource } from '../../common/types';
 import { noop } from '../../common/utils/misc';
 import { Identifiers } from '../constants';
 import { KernelSpecInterpreter } from '../jupyter/kernels/kernelSelector';
-import { INotebookStorageProvider } from '../notebookStorage/notebookStorageProvider';
 import {
     ConnectNotebookProviderOptions,
     GetNotebookOptions,
@@ -43,10 +42,8 @@ export class NotebookProvider implements INotebookProvider {
         @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
         @inject(IRawNotebookProvider) private readonly rawNotebookProvider: IRawNotebookProvider,
         @inject(IJupyterNotebookProvider) private readonly jupyterNotebookProvider: IJupyterNotebookProvider,
-        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
-        @inject(INotebookStorageProvider) storageProvider: INotebookStorageProvider
+        @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService
     ) {
-        disposables.push(storageProvider.onSavedAs(this.onSavedAs, this));
         this.rawNotebookProvider
             .supported()
             .then((b) => (this._type = b ? 'raw' : 'jupyter'))
@@ -182,14 +179,5 @@ export class NotebookProvider implements INotebookProvider {
 
         // If promise fails, then remove the promise from cache.
         promise.catch(removeFromCache);
-    }
-
-    private async onSavedAs(e: { new: Uri; old: Uri }) {
-        // Swap the Uris when a notebook is saved as a different file.
-        const notebookPromise = this.notebooks.get(e.old.toString());
-        if (notebookPromise) {
-            this.notebooks.set(e.new.toString(), notebookPromise);
-            this.notebooks.delete(e.old.toString());
-        }
     }
 }

--- a/src/client/datascience/notebook/contentProvider.ts
+++ b/src/client/datascience/notebook/contentProvider.ts
@@ -14,7 +14,6 @@ import type {
     NotebookDocumentContentChangeEvent,
     NotebookDocumentOpenContext
 } from 'vscode-proposed';
-import { ICommandManager } from '../../common/application/types';
 import { MARKDOWN_LANGUAGE } from '../../common/constants';
 import { DataScience } from '../../common/utils/localize';
 import { captureTelemetry, sendTelemetryEvent, setSharedProperty } from '../../telemetry';
@@ -42,7 +41,6 @@ export class NotebookContentProvider implements INotebookContentProvider {
     }
     constructor(
         @inject(INotebookStorageProvider) private readonly notebookStorage: INotebookStorageProvider,
-        @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(NotebookEditorCompatibilitySupport)
         private readonly compatibilitySupport: NotebookEditorCompatibilitySupport
     ) {}
@@ -85,11 +83,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
         if (cancellation.isCancellationRequested) {
             return;
         }
-        if (model.isUntitled) {
-            await this.commandManager.executeCommand('workbench.action.files.saveAs', document.uri);
-        } else {
-            await this.notebookStorage.save(model, cancellation);
-        }
+        await this.notebookStorage.save(model, cancellation);
     }
 
     public async saveNotebookAs(

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -7,7 +7,6 @@ import { inject, injectable } from 'inversify';
 import { Event, EventEmitter, Uri } from 'vscode';
 import type { NotebookDocument, NotebookEditor as VSCodeNotebookEditor } from 'vscode-proposed';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../common/application/types';
-import { UseVSCodeNotebookEditorApi } from '../../common/constants';
 import '../../common/extensions';
 
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
@@ -69,7 +68,6 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
         @inject(IApplicationShell) private readonly appShell: IApplicationShell,
         @inject(IStatusProvider) private readonly statusProvider: IStatusProvider,
         @inject(IServiceContainer) private readonly serviceContainer: IServiceContainer,
-        @inject(UseVSCodeNotebookEditorApi) useVSCodeNotebookEditorApi: boolean,
         @inject(IDataScienceFileSystem) private readonly fs: IDataScienceFileSystem
     ) {
         this.disposables.push(this.vscodeNotebook.onDidOpenNotebookDocument(this.onDidOpenNotebookDocument, this));
@@ -82,21 +80,6 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
                     setSharedProperty('ds_notebookeditor', 'native');
                     captureTelemetry(Telemetry.OpenNotebook, { scope: 'command' }, false);
                     this.open(uri).ignoreErrors();
-                }
-            })
-        );
-
-        // Swap the uris.
-        this.disposables.push(
-            this.storage.onSavedAs((e) => {
-                // We are interested in this ONLY if we have a VS Code NotebookEditor opened or if we belong to the nb experiment.
-                if (!useVSCodeNotebookEditorApi && !this.vscodeNotebook.notebookDocuments.length) {
-                    return;
-                }
-                const savedEditor = this.notebookEditorsByUri.get(e.old.toString());
-                if (savedEditor) {
-                    this.notebookEditorsByUri.delete(e.old.toString());
-                    this.notebookEditorsByUri.set(e.new.toString(), savedEditor);
                 }
             })
         );

--- a/src/client/datascience/notebookStorage/notebookStorageProvider.ts
+++ b/src/client/datascience/notebookStorage/notebookStorageProvider.ts
@@ -10,6 +10,7 @@ import { IDisposable, IDisposableRegistry } from '../../common/types';
 import { generateNewNotebookUri } from '../common';
 import { INotebookModel, INotebookStorage } from '../types';
 import { getNextUntitledCounter } from './nativeEditorStorage';
+import { VSCodeNotebookModel } from './vscNotebookModel';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 
@@ -32,7 +33,6 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
         @inject(IDisposableRegistry) disposables: IDisposableRegistry
     ) {
         disposables.push(this);
-        disposables.push(storage.onSavedAs((e) => this._savedAs.fire(e)));
     }
     public async save(model: INotebookModel, cancellation: CancellationToken) {
         await this.storage.save(model, cancellation);
@@ -40,6 +40,9 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
     public async saveAs(model: INotebookModel, targetResource: Uri) {
         const oldUri = model.file;
         await this.storage.saveAs(model, targetResource);
+        if (model instanceof VSCodeNotebookModel) {
+            return;
+        }
         this.trackModel(model);
         this.storageAndModels.delete(oldUri.toString());
         this.storageAndModels.set(targetResource.toString(), Promise.resolve(model));

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1079,7 +1079,6 @@ export interface INotebookModel {
 export const INotebookStorage = Symbol('INotebookStorage');
 
 export interface INotebookStorage {
-    readonly onSavedAs: Event<{ new: Uri; old: Uri }>;
     generateBackupId(model: INotebookModel): string;
     save(model: INotebookModel, cancellation: CancellationToken): Promise<void>;
     saveAs(model: INotebookModel, targetResource: Uri): Promise<void>;

--- a/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
+++ b/src/test/datascience/interactive-common/notebookProvider.unit.test.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import { IWorkspaceService } from '../../../client/common/application/types';
 import { IDataScienceSettings, IDisposableRegistry, IPythonSettings } from '../../../client/common/types';
 import { NotebookProvider } from '../../../client/datascience/interactive-common/notebookProvider';
-import { INotebookStorageProvider } from '../../../client/datascience/notebookStorage/notebookStorageProvider';
 import { IJupyterNotebookProvider, INotebook, IRawNotebookProvider } from '../../../client/datascience/types';
 
 function Uri(filename: string): vscode.Uri {
@@ -42,7 +41,6 @@ suite('DataScience - NotebookProvider', () => {
         // Set up our settings
         pythonSettings = mock<IPythonSettings>();
         dataScienceSettings = mock<IDataScienceSettings>();
-        const storageProvider = mock<INotebookStorageProvider>();
         when(pythonSettings.datascience).thenReturn(instance(dataScienceSettings));
         when(workspaceService.hasWorkspaceFolders).thenReturn(false);
         when(dataScienceSettings.jupyterServerURI).thenReturn('local');
@@ -53,8 +51,7 @@ suite('DataScience - NotebookProvider', () => {
             instance(disposableRegistry),
             instance(rawNotebookProvider),
             instance(jupyterNotebookProvider),
-            instance(workspaceService),
-            instance(storageProvider)
+            instance(workspaceService)
         );
     });
 

--- a/src/test/datascience/notebook/contentProvider.unit.test.ts
+++ b/src/test/datascience/notebook/contentProvider.unit.test.ts
@@ -10,7 +10,6 @@ import { Uri } from 'vscode';
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 import type { NotebookContentProvider as VSCodeNotebookContentProvider } from 'vscode-proposed';
 import { NotebookCellData } from '../../../../typings/vscode-proposed';
-import { ICommandManager } from '../../../client/common/application/types';
 import { MARKDOWN_LANGUAGE, PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { NotebookContentProvider } from '../../../client/datascience/notebook/contentProvider';
 import { NotebookEditorCompatibilitySupport } from '../../../client/datascience/notebook/notebookEditorCompatibilitySupport';
@@ -23,15 +22,10 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
     const fileUri = Uri.file('a.ipynb');
     setup(async () => {
         storageProvider = mock<INotebookStorageProvider>();
-        const commandManager = mock<ICommandManager>();
         const compatSupport = mock(NotebookEditorCompatibilitySupport);
         when(compatSupport.canOpenWithOurNotebookEditor(anything())).thenReturn(true);
         when(compatSupport.canOpenWithVSCodeNotebookEditor(anything())).thenReturn(true);
-        contentProvider = new NotebookContentProvider(
-            instance(storageProvider),
-            instance(commandManager),
-            instance(compatSupport)
-        );
+        contentProvider = new NotebookContentProvider(instance(storageProvider), instance(compatSupport));
     });
     [true, false].forEach((isNotebookTrusted) => {
         suite(isNotebookTrusted ? 'Trusted Notebook' : 'Un-trusted notebook', () => {


### PR DESCRIPTION
For #13235
When a document is `saved as`, then VSC re-opens the document using the new file name