### PR TITLE
Rename get to getOrCreateModel

### DIFF
--- a/src/client/datascience/export/exportUtil.ts
+++ b/src/client/datascience/export/exportUtil.ts
@@ -57,7 +57,7 @@ export class ExportUtil {
             await this.jupyterExporter.exportToFile(cells, tempFile.filePath, false);
             const newPath = path.join(tempDir.path, '.ipynb');
             await this.fs.copyLocal(tempFile.filePath, newPath);
-            model = await this.notebookStorage.get(Uri.file(newPath));
+            model = await this.notebookStorage.getOrCreateModel(Uri.file(newPath));
         } finally {
             tempFile.dispose();
             tempDir.dispose();
@@ -67,7 +67,7 @@ export class ExportUtil {
     }
 
     public async removeSvgs(source: Uri) {
-        const model = await this.notebookStorage.get(source);
+        const model = await this.notebookStorage.getOrCreateModel(source);
 
         const newCells: ICell[] = [];
         for (const cell of model.cells) {

--- a/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
+++ b/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
@@ -47,7 +47,7 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
             return;
         }
 
-        const model = await this.storageProvider.get(uri);
+        const model = await this.storageProvider.getOrCreateModel(uri);
         if (model.isTrusted) {
             return;
         }

--- a/src/client/datascience/notebook/contentProvider.ts
+++ b/src/client/datascience/notebook/contentProvider.ts
@@ -72,8 +72,8 @@ export class NotebookContentProvider implements INotebookContentProvider {
         }
         // If there's no backup id, then skip loading dirty contents.
         const model = await (openContext.backupId
-            ? this.notebookStorage.get(uri, undefined, openContext.backupId, true)
-            : this.notebookStorage.get(uri, undefined, true, true));
+            ? this.notebookStorage.getOrCreateModel(uri, undefined, openContext.backupId, true)
+            : this.notebookStorage.getOrCreateModel(uri, undefined, true, true));
 
         setSharedProperty('ds_notebookeditor', 'native');
         sendTelemetryEvent(Telemetry.CellCount, undefined, { count: model.cells.length });
@@ -81,7 +81,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
     }
     @captureTelemetry(Telemetry.Save, undefined, true)
     public async saveNotebook(document: NotebookDocument, cancellation: CancellationToken) {
-        const model = await this.notebookStorage.get(document.uri, undefined, undefined, true);
+        const model = await this.notebookStorage.getOrCreateModel(document.uri, undefined, undefined, true);
         if (cancellation.isCancellationRequested) {
             return;
         }
@@ -97,7 +97,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
         document: NotebookDocument,
         cancellation: CancellationToken
     ): Promise<void> {
-        const model = await this.notebookStorage.get(document.uri, undefined, undefined, true);
+        const model = await this.notebookStorage.getOrCreateModel(document.uri, undefined, undefined, true);
         if (!cancellation.isCancellationRequested) {
             await this.notebookStorage.saveAs(model, targetResource);
         }
@@ -107,7 +107,7 @@ export class NotebookContentProvider implements INotebookContentProvider {
         _context: NotebookDocumentBackupContext,
         cancellation: CancellationToken
     ): Promise<NotebookDocumentBackup> {
-        const model = await this.notebookStorage.get(document.uri, undefined, undefined, true);
+        const model = await this.notebookStorage.getOrCreateModel(document.uri, undefined, undefined, true);
         const id = this.notebookStorage.generateBackupId(model);
         await this.notebookStorage.backup(model, cancellation, id);
         return {

--- a/src/client/datascience/notebook/executionService.ts
+++ b/src/client/datascience/notebook/executionService.ts
@@ -150,7 +150,7 @@ export class NotebookExecutionService implements INotebookExecutionService {
     private async getNotebookAndModel(
         document: NotebookDocument
     ): Promise<{ model: VSCodeNotebookModel; nb: INotebook }> {
-        const model = await this.notebookStorage.get(document.uri, undefined, undefined, true);
+        const model = await this.notebookStorage.getOrCreateModel(document.uri, undefined, undefined, true);
         const nb = await this.notebookProvider.getOrCreateNotebook({
             identity: document.uri,
             resource: document.uri,

--- a/src/client/datascience/notebookStorage/nativeEditorProvider.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorProvider.ts
@@ -221,7 +221,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
         this.untitledCounter = getNextUntitledCounter(file, this.untitledCounter);
 
         // Load our model from our storage object.
-        const model = await this.storage.get(file, contents, options);
+        const model = await this.storage.getOrCreateModel(file, contents, options);
 
         // Make sure to listen to events on the model
         this.trackModel(model);

--- a/src/client/datascience/notebookStorage/nativeEditorStorage.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorStorage.ts
@@ -81,20 +81,20 @@ export class NativeEditorStorage implements INotebookStorage {
         return `${path.basename(model.file.fsPath)}-${uuid()}`;
     }
 
-    public get(
+    public getOrCreateModel(
         file: Uri,
         possibleContents?: string,
         backupId?: string,
         forVSCodeNotebook?: boolean
     ): Promise<INotebookModel>;
-    public get(
+    public getOrCreateModel(
         file: Uri,
         possibleContents?: string,
         // tslint:disable-next-line: unified-signatures
         skipDirtyContents?: boolean,
         forVSCodeNotebook?: boolean
     ): Promise<INotebookModel>;
-    public get(
+    public getOrCreateModel(
         file: Uri,
         possibleContents?: string,
         // tslint:disable-next-line: no-any

--- a/src/client/datascience/notebookStorage/notebookStorageProvider.ts
+++ b/src/client/datascience/notebookStorage/notebookStorageProvider.ts
@@ -56,8 +56,13 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
     public deleteBackup(model: INotebookModel, backupId?: string) {
         return this.storage.deleteBackup(model, backupId);
     }
-    public get(file: Uri, contents?: string, backupId?: string, forVSCodeNotebook?: boolean): Promise<INotebookModel>;
-    public get(
+    public getOrCreateModel(
+        file: Uri,
+        contents?: string,
+        backupId?: string,
+        forVSCodeNotebook?: boolean
+    ): Promise<INotebookModel>;
+    public getOrCreateModel(
         file: Uri,
         contents?: string,
         // tslint:disable-next-line: unified-signatures
@@ -65,8 +70,13 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
         forVSCodeNotebook?: boolean
     ): Promise<INotebookModel>;
 
-    // tslint:disable-next-line: no-any
-    public get(file: Uri, contents?: string, options?: any, forVSCodeNotebook?: boolean): Promise<INotebookModel> {
+    public getOrCreateModel(
+        file: Uri,
+        contents?: string,
+        // tslint:disable-next-line: no-any
+        options?: any,
+        forVSCodeNotebook?: boolean
+    ): Promise<INotebookModel> {
         const key = file.toString();
         if (!this.storageAndModels.has(key)) {
             // Every time we load a new untitled file, up the counter past the max value for this counter
@@ -74,7 +84,7 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
                 file,
                 NotebookStorageProvider.untitledCounter
             );
-            const promise = this.storage.get(file, contents, options, forVSCodeNotebook);
+            const promise = this.storage.getOrCreateModel(file, contents, options, forVSCodeNotebook);
             this.storageAndModels.set(key, promise.then(this.trackModel.bind(this)));
         }
         return this.storageAndModels.get(key)!;
@@ -90,7 +100,7 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
         const uri = this.getNextNewNotebookUri(forVSCodeNotebooks);
 
         // Always skip loading from the hot exit file. When creating a new file we want a new file.
-        return this.get(uri, contents, true);
+        return this.getOrCreateModel(uri, contents, true);
     }
 
     private getNextNewNotebookUri(forVSCodeNotebooks?: boolean): Uri {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1084,8 +1084,13 @@ export interface INotebookStorage {
     save(model: INotebookModel, cancellation: CancellationToken): Promise<void>;
     saveAs(model: INotebookModel, targetResource: Uri): Promise<void>;
     backup(model: INotebookModel, cancellation: CancellationToken, backupId?: string): Promise<void>;
-    get(file: Uri, contents?: string, backupId?: string, forVSCodeNotebook?: boolean): Promise<INotebookModel>;
-    get(
+    getOrCreateModel(
+        file: Uri,
+        contents?: string,
+        backupId?: string,
+        forVSCodeNotebook?: boolean
+    ): Promise<INotebookModel>;
+    getOrCreateModel(
         file: Uri,
         contents?: string,
         // tslint:disable-next-line: unified-signatures

--- a/src/test/datascience/export/exportUtil.test.ts
+++ b/src/test/datascience/export/exportUtil.test.ts
@@ -37,7 +37,7 @@ suite('DataScience - Export Util', () => {
         );
 
         await exportUtil.removeSvgs(file);
-        const model = await notebookStorage.get(file);
+        const model = await notebookStorage.getOrCreateModel(file);
 
         // make sure no svg exists in model
         const SVG = 'image/svg+xml';

--- a/src/test/datascience/interactive-common/trustCommandHandler.unit.test.ts
+++ b/src/test/datascience/interactive-common/trustCommandHandler.unit.test.ts
@@ -51,7 +51,7 @@ suite('DataScience - Trust Command Handler', () => {
         when(crypto.createHash(anything(), 'string')).thenReturn(`${testIndex}`);
         model = createNotebookModel(false, Uri.file('a'), new MockMemento(), instance(crypto));
         createNotebookDocument(model as VSCodeNotebookModel);
-        when(storageProvider.get(anything())).thenResolve(model);
+        when(storageProvider.getOrCreateModel(anything())).thenResolve(model);
         disposables = [];
 
         experiments = mock<IExperimentService>();

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -423,7 +423,7 @@ suite('DataScience - Native Editor Storage', () => {
     }
 
     test('Create new editor and add some cells', async () => {
-        model = await storage.get(baseUri);
+        model = await storage.getOrCreateModel(baseUri);
         insertCell(0, '1');
         const cells = model.cells;
         expect(cells).to.be.lengthOf(4);
@@ -432,7 +432,7 @@ suite('DataScience - Native Editor Storage', () => {
     });
 
     test('Move cells around', async () => {
-        model = await storage.get(baseUri);
+        model = await storage.getOrCreateModel(baseUri);
         swapCells('NotebookImport#0', 'NotebookImport#1');
         const cells = model.cells;
         expect(cells).to.be.lengthOf(3);
@@ -441,7 +441,7 @@ suite('DataScience - Native Editor Storage', () => {
     });
 
     test('Edit/delete cells', async () => {
-        model = await storage.get(baseUri);
+        model = await storage.getOrCreateModel(baseUri);
         expect(model.isDirty).to.be.equal(false, 'Editor should not be dirty');
         editCell(
             [
@@ -481,7 +481,7 @@ suite('DataScience - Native Editor Storage', () => {
     test('Editing a file and closing will keep contents', async () => {
         await filesConfig?.update('autoSave', 'off');
 
-        model = await storage.get(baseUri);
+        model = await storage.getOrCreateModel(baseUri);
         expect(model.isDirty).to.be.equal(false, 'Editor should not be dirty');
         editCell(
             [
@@ -510,7 +510,7 @@ suite('DataScience - Native Editor Storage', () => {
 
         // Recreate
         storage = createStorage();
-        model = await storage.get(baseUri);
+        model = await storage.getOrCreateModel(baseUri);
 
         const cells = model.cells;
         expect(cells).to.be.lengthOf(3);
@@ -520,7 +520,7 @@ suite('DataScience - Native Editor Storage', () => {
     });
 
     test('Editing a new file and closing will keep contents', async () => {
-        model = await storage.get(untiledUri, undefined, true);
+        model = await storage.getOrCreateModel(untiledUri, undefined, true);
         expect(model.isDirty).to.be.equal(false, 'Editor should not be dirty');
         insertCell(0, 'a=1');
 
@@ -529,7 +529,7 @@ suite('DataScience - Native Editor Storage', () => {
 
         // Recreate
         storage = createStorage();
-        model = await storage.get(untiledUri);
+        model = await storage.getOrCreateModel(untiledUri);
 
         const cells = model.cells;
         expect(cells).to.be.lengthOf(2);
@@ -548,7 +548,7 @@ suite('DataScience - Native Editor Storage', () => {
 
         // Put the regular file into the local storage
         await localMemento.update(`notebook-storage-${file.toString()}`, differentFile);
-        model = await storage.get(file);
+        model = await storage.getOrCreateModel(file);
 
         // It should load with that value
         const cells = model.cells;
@@ -569,7 +569,7 @@ suite('DataScience - Native Editor Storage', () => {
             contents: differentFile,
             lastModifiedTimeMs: Date.now()
         });
-        model = await storage.get(file);
+        model = await storage.getOrCreateModel(file);
 
         // It should load with that value
         const cells = model.cells;
@@ -599,7 +599,7 @@ suite('DataScience - Native Editor Storage', () => {
             lastModifiedTimeMs: Date.now()
         });
 
-        model = await storage.get(file);
+        model = await storage.getOrCreateModel(file);
 
         // It should load with that value
         const cells = model.cells;

--- a/src/test/datascience/notebook/contentProvider.unit.test.ts
+++ b/src/test/datascience/notebook/contentProvider.unit.test.ts
@@ -67,7 +67,7 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
                     ],
                     isTrusted: isNotebookTrusted
                 };
-                when(storageProvider.get(anything(), anything(), anything(), anything())).thenResolve(
+                when(storageProvider.getOrCreateModel(anything(), anything(), anything(), anything())).thenResolve(
                     (model as unknown) as INotebookModel
                 );
 
@@ -150,7 +150,7 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
                     ],
                     isTrusted: isNotebookTrusted
                 };
-                when(storageProvider.get(anything(), anything(), anything(), anything())).thenResolve(
+                when(storageProvider.getOrCreateModel(anything(), anything(), anything(), anything())).thenResolve(
                     (model as unknown) as INotebookModel
                 );
 


### PR DESCRIPTION
For #12189
Rename `get` to `getOrCreateModel` to be specific about the fact that the method either returns an existing model or creates a new model.