### PR TITLE
Dispose notebook on close of VSC Notebooks

### DIFF
--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { inject } from 'inversify';
+import { NotebookDocument } from '../../../../typings/vscode-proposed';
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { IApplicationEnvironment, IVSCodeNotebook } from '../../common/application/types';
+import { IDisposableRegistry } from '../../common/types';
+import { INotebookProvider } from '../types';
+
+export class NotebookDisposeService implements IExtensionSingleActivationService {
+    constructor(
+        @inject(IApplicationEnvironment) private readonly env: IApplicationEnvironment,
+        @inject(IVSCodeNotebook) private readonly vscNotebook: IVSCodeNotebook,
+        @inject(IDisposableRegistry) private readonly disposables: IDisposableRegistry,
+        @inject(INotebookProvider) private readonly notebookProvider: INotebookProvider
+    ) {}
+    public async activate(): Promise<void> {
+        if (this.env.channel !== 'insiders') {
+            return;
+        }
+
+        this.vscNotebook.onDidCloseNotebookDocument(this.onDidCloseNotebookDocument, this, this.disposables);
+    }
+    private onDidCloseNotebookDocument(document: NotebookDocument) {
+        this.notebookProvider.disposeAssociatedNotebook({ identity: document.uri });
+    }
+}

--- a/src/client/datascience/notebook/notebookDisposeService.ts
+++ b/src/client/datascience/notebook/notebookDisposeService.ts
@@ -3,13 +3,14 @@
 
 'use strict';
 
-import { inject } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { NotebookDocument } from '../../../../typings/vscode-proposed';
 import { IExtensionSingleActivationService } from '../../activation/types';
 import { IApplicationEnvironment, IVSCodeNotebook } from '../../common/application/types';
 import { IDisposableRegistry } from '../../common/types';
 import { INotebookProvider } from '../types';
 
+@injectable()
 export class NotebookDisposeService implements IExtensionSingleActivationService {
     constructor(
         @inject(IApplicationEnvironment) private readonly env: IApplicationEnvironment,

--- a/src/client/datascience/notebook/serviceRegistry.ts
+++ b/src/client/datascience/notebook/serviceRegistry.ts
@@ -8,6 +8,7 @@ import { IServiceManager } from '../../ioc/types';
 import { NotebookContentProvider } from './contentProvider';
 import { NotebookExecutionService } from './executionService';
 import { NotebookIntegration } from './integration';
+import { NotebookDisposeService } from './notebookDisposeService';
 import { NotebookKernel } from './notebookKernel';
 import { NotebookOutputRenderer } from './renderer';
 import { NotebookSurveyBanner, NotebookSurveyDataLogger } from './survey';
@@ -19,6 +20,10 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         NotebookIntegration
+    );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        NotebookDisposeService
     );
     serviceManager.addSingleton<NotebookIntegration>(NotebookIntegration, NotebookIntegration);
     serviceManager.addSingleton<NotebookKernel>(NotebookKernel, NotebookKernel);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1173,6 +1173,11 @@ export interface INotebookProvider {
      */
     activeNotebooks: Promise<INotebook>[];
     /**
+     * Disposes notebook associated with the given identity.
+     * Using `getOrCreateNotebook` would be incorrect as thats async, and its possible a document has been opened in the interim (meaning we could end up disposing something that is required).
+     */
+    disposeAssociatedNotebook(options: { identity: Uri }): void;
+    /**
      * Gets or creates a notebook, and manages the lifetime of notebooks.
      */
     getOrCreateNotebook(options: GetNotebookOptions): Promise<INotebook | undefined>;


### PR DESCRIPTION
For #12189
Dispose INotebook when the corresponding VSC notebook (i.e. all editors associated with this NotebookDocument) is closed.