### PR TITLE
Use jupyter inspect to get signature of dynamic functions in notebook editor when language server doesn't provide enough hint.

### DIFF
--- a/news/1 Enhancements/13259.md
+++ b/news/1 Enhancements/13259.md
@@ -1,0 +1,1 @@
+Use jupyter inspect to get signature of dynamic functions in notebook editor when language server doesn't provide enough hint.

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -354,7 +354,7 @@ export class JupyterNotebookBase implements INotebook {
         return deferred.promise;
     }
 
-    public inspect(code: string, cancelToken?: CancellationToken): Promise<JSONObject> {
+    public inspect(code: string, offsetInCode = 0, cancelToken?: CancellationToken): Promise<JSONObject> {
         // Create a deferred that will fire when the request completes
         const deferred = createDeferred<JSONObject>();
 
@@ -366,7 +366,7 @@ export class JupyterNotebookBase implements INotebook {
         } else {
             // Ask session for inspect result
             this.session
-                .requestInspect({ code, cursor_pos: 0, detail_level: 0 })
+                .requestInspect({ code, cursor_pos: offsetInCode, detail_level: 0 })
                 .then((r) => {
                     if (r && r.content.status === 'ok') {
                         deferred.resolve(r.content.data);

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -395,7 +395,7 @@ export class KernelVariables implements IJupyterVariables {
     ): Promise<IJupyterVariable> {
         let result = { ...targetVariable };
         if (notebook) {
-            const output = await notebook.inspect(targetVariable.name, token);
+            const output = await notebook.inspect(targetVariable.name, 0, token);
 
             // Should be a text/plain inside of it (at least IPython does this)
             if (output && output.hasOwnProperty('text/plain')) {

--- a/src/client/datascience/jupyter/liveshare/hostJupyterNotebook.ts
+++ b/src/client/datascience/jupyter/liveshare/hostJupyterNotebook.ts
@@ -96,7 +96,7 @@ export class HostJupyterNotebook
                     this.onGetSysInfoRequest(cancellation)
                 );
                 service.onRequest(LiveShareCommands.inspect, (args: any[], cancellation: CancellationToken) =>
-                    this.inspect(args[0], cancellation)
+                    this.inspect(args[0], 0, cancellation)
                 );
                 service.onRequest(LiveShareCommands.restart, (args: any[], cancellation: CancellationToken) =>
                     this.onRestartRequest(

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -198,7 +198,7 @@ export interface INotebook extends IAsyncDisposable {
         cancelToken?: CancellationToken,
         silent?: boolean
     ): Promise<ICell[]>;
-    inspect(code: string, cancelToken?: CancellationToken): Promise<JSONObject>;
+    inspect(code: string, offsetInCode?: number, cancelToken?: CancellationToken): Promise<JSONObject>;
     getCompletion(
         cellCode: string,
         offsetInCode: number,

--- a/src/test/datascience/mockJupyterNotebook.ts
+++ b/src/test/datascience/mockJupyterNotebook.ts
@@ -73,7 +73,7 @@ export class MockJupyterNotebook implements INotebook {
         throw new Error('Method not implemented');
     }
 
-    public inspect(_code: string, _cancelToken?: CancellationToken): Promise<JSONObject> {
+    public inspect(_code: string, _offsetInCode = 0, _cancelToken?: CancellationToken): Promise<JSONObject> {
         return Promise.resolve({});
     }
 


### PR DESCRIPTION
For #13067, we try to get the signature help from Jupyter kernel for a function which is dynamically created in Jupyter notebook,  by calling `activeNotebook.inspect` like what `provideJupyterCompletionItems` does.

In the code, when handling the hover request/signature help request, if the following conditions are satisfied, we will show the inspect result from Jupyter Kernel:
1. The Jupyter kernel provide a callable signature;
2. The language server doesn't return a callable signature, or the signature of callable is (*args, **kwargs);

Result:
In most cases, the hover and the signature help work as before.
For the case the the function is dynamically created like the following:
```
def create_function_with_parameters(f, sig, name, doc):
    f = types.FunctionType(
        code=f.__code__,
        globals=f.__globals__,
        name=name,
        argdefs=f.__defaults__,
        closure=f.__closure__,
    )
    f.__signature__ = sig
    f.__doc__ = doc
    return f
signature = Signature([Parameter(name='str_param', kind=Parameter.KEYWORD_ONLY, default='a', annotation=str)], return_annotation=int)
g = create_function_with_parameters(f, sig=signature, name='g', doc="Some doc")
```

**Before**:
Signature help:
![image](https://user-images.githubusercontent.com/3871260/89270103-71f6cb00-d66d-11ea-9b21-606472e3450b.png)
Hover:
![image](https://user-images.githubusercontent.com/3871260/89270142-820eaa80-d66d-11ea-972c-5bbe39b37726.png)

**After**:
Signature help:
![image](https://user-images.githubusercontent.com/3871260/89269681-cd748900-d66c-11ea-8788-111a37d44a34.png)
Hover:
![image](https://user-images.githubusercontent.com/3871260/89269718-df562c00-d66c-11ea-93bf-b0425e6e7ba0.png)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] ~Has sufficient logging.~
-   [ ] ~Has telemetry for enhancements.~
-   [ ] ~Unit tests & system/integration tests are added/updated.~
-   [ ] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [ ] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [ ] ~The wiki is updated with any design decisions/details.~
