### PR TITLE
Fix when clauses for new interactive cell shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1080,73 +1080,73 @@
                     "command": "python.datascience.insertCellBelowPosition",
                     "title": "%python.command.python.datascience.insertCellBelowPosition.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.insertCellBelow",
                     "title": "%python.command.python.datascience.insertCellBelow.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.insertCellAbove",
                     "title": "%python.command.python.datascience.insertCellAbove.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.deleteCells",
                     "title": "%python.command.python.datascience.deleteCells.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.selectCell",
                     "title": "%python.command.python.datascience.selectCell.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.selectCellContents",
                     "title": "%python.command.python.datascience.selectCellContents.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.extendSelectionByCellAbove",
                     "title": "%python.command.python.datascience.extendSelectionByCellAbove.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.extendSelectionByCellBelow",
                     "title": "%python.command.python.datascience.extendSelectionByCellBelow.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.moveCellsUp",
                     "title": "%python.command.python.datascience.moveCellsUp.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.moveCellsDown",
                     "title": "%python.command.python.datascience.moveCellsDown.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.changeCellToMarkdown",
                     "title": "%python.command.python.datascience.changeCellToMarkdown.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.changeCellToCode",
                     "title": "%python.command.python.datascience.changeCellToCode.title%",
                     "category": "Python",
-                    "when": "python.datascience.hascodecells && editorFocus && editorLangId == python && python.datascience.featureenabled"
+                    "when": "python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
                 },
                 {
                     "command": "python.datascience.runcurrentcell",

--- a/package.nls.json
+++ b/package.nls.json
@@ -446,7 +446,7 @@
     "downloading.file.progress": "{0}{1} of {2} KB ({3}%)",
     "DataScience.jupyterDataRateExceeded": "Cannot view variable because data rate exceeded. Please restart your server with a higher data rate limit. For example, --NotebookApp.iopub_data_rate_limit=10000000000.0",
     "DataScience.addCellBelowCommandTitle": "Add cell",
-    "DataScience.debugCellCommandTitle": "Debug cell",
+    "DataScience.debugCellCommandTitle": "Debug Cell",
     "DataScience.debugStepOverCommandTitle": "Step over",
     "DataScience.debugContinueCommandTitle": "Continue",
     "DataScience.debugStopCommandTitle": "Stop",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -787,7 +787,7 @@ export namespace DataScience {
         'Cannot view variable because data rate exceeded. Please restart your server with a higher data rate limit. For example, --NotebookApp.iopub_data_rate_limit=10000000000.0'
     );
     export const addCellBelowCommandTitle = localize('DataScience.addCellBelowCommandTitle', 'Add cell');
-    export const debugCellCommandTitle = localize('DataScience.debugCellCommandTitle', 'Debug cell');
+    export const debugCellCommandTitle = localize('DataScience.debugCellCommandTitle', 'Debug Cell');
     export const debugStepOverCommandTitle = localize('DataScience.debugStepOverCommandTitle', 'Step over');
     export const debugContinueCommandTitle = localize('DataScience.debugContinueCommandTitle', 'Continue');
     export const debugStopCommandTitle = localize('DataScience.debugStopCommandTitle', 'Stop');


### PR DESCRIPTION
For #13271

+ Actually show interactive cell shortcuts only when there is a python file with code cells (and ensure they're hidden when the notebook editor has focus)
+ Also fix capitalization on 'Debug cell' codelens


![cells](https://user-images.githubusercontent.com/30305945/89348994-5639f780-d662-11ea-9dd3-5cde3a40cfc7.gif)


Kinda weird that the `editorFocus` context key seems to break things. VSCode docs suggest that they're responsible for setting that key. `editorLangId == python` is harmless. Still, I'm dropping them for now as what I have here should be sufficient to ensure correct behavior.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
