### PR TITLE
Fix nightly failures for remote and new registration test.

### DIFF
--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import type { ContentsManager, Kernel, ServerConnection, Session, SessionManager } from '@jupyterlab/services';
+import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { CancellationToken } from 'vscode-jsonrpc';
 import { Cancellation } from '../../common/cancellation';
@@ -136,8 +137,12 @@ export class JupyterSession extends BaseJupyterSession {
         contentsManager: ContentsManager,
         cancelToken?: CancellationToken
     ): Promise<ISessionWithSocket> {
-        // Create a temporary notebook for this session.
-        const backingFile = await contentsManager.newUntitled({ type: 'notebook' });
+        // Create a temporary notebook for this session. Each needs a unique name (otherwise we get the same session every time)
+        let backingFile = await contentsManager.newUntitled({ type: 'notebook' });
+        backingFile = await contentsManager.rename(
+            backingFile.path,
+            `${path.dirname(backingFile.path)}/t-${uuid()}.ipynb` // Note, the docs say the path uses UNIX delimiters.
+        );
 
         // Create our session options using this temporary notebook and our connection info
         const options: Session.IOptions = {

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -99,6 +99,7 @@ suite('DataScience - JupyterSession', () => {
         const nbFile = 'file path';
         // tslint:disable-next-line: no-any
         when(contentsManager.newUntitled(deepEqual({ type: 'notebook' }))).thenResolve({ path: nbFile } as any);
+        // tslint:disable-next-line: no-any
         when(contentsManager.rename(anything(), anything())).thenResolve({ path: nbFile } as any);
         when(contentsManager.delete(anything())).thenResolve();
         when(sessionManager.startNew(anything())).thenResolve(instance(session));

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -99,6 +99,7 @@ suite('DataScience - JupyterSession', () => {
         const nbFile = 'file path';
         // tslint:disable-next-line: no-any
         when(contentsManager.newUntitled(deepEqual({ type: 'notebook' }))).thenResolve({ path: nbFile } as any);
+        when(contentsManager.rename(anything(), anything())).thenResolve({ path: nbFile } as any);
         when(contentsManager.delete(anything())).thenResolve();
         when(sessionManager.startNew(anything())).thenResolve(instance(session));
         kernelSpec.setup((k) => k.name).returns(() => 'some name');

--- a/src/test/datascience/jupyterUriProviderRegistration.functional.test.ts
+++ b/src/test/datascience/jupyterUriProviderRegistration.functional.test.ts
@@ -88,6 +88,8 @@ suite(`DataScience JupyterServerUriProvider tests`, () => {
 
     setup(async () => {
         ioc = new DataScienceIocContainer();
+        // Force to always be a mock run. Real will try to connect to the dummy URI
+        ioc.shouldMockJupyter = true;
         ioc.registerDataScienceTypes(false);
         ioc.serviceManager.rebindInstance<IExtensions>(IExtensions, new UriMockExtensions(ioc));
         return ioc.activate();


### PR DESCRIPTION
Two failures (well 3 actually but I'm ignoring the ipywidget one as that's just flakey).

1) The new test I added for URI provider expiration only works with mock. Switched it to only run mock.
2) The new test I added to verify remote servers can be reselected was broken by the change to delete the remote untitled files. Yay! a functional test caught a bug.

