### PR TITLE
Notebook undo command is same as standard undo cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
                 "linux": "Z",
                 "key": "Z",
                 "when": "notebookEditorFocused && !inputFocus && notebookViewType == jupyter-notebook",
-                "command": "notebook.undo"
+                "command": "undo"
             },
             {
                 "mac": "C",


### PR DESCRIPTION
For #12189
Account for changes in upstream VSCode.