### PR TITLE
Revert "Notebook undo command is same as standard undo cmd (#13293)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
                 "linux": "Z",
                 "key": "Z",
                 "when": "notebookEditorFocused && !inputFocus && notebookViewType == jupyter-notebook",
-                "command": "undo"
+                "command": "notebook.undo"
             },
             {
                 "mac": "C",


### PR DESCRIPTION
This reverts commit d7c934804d70e14604304c60e4d2ab25232b7724.

For #13316 
