### PR TITLE
Disable flakey CI test 

### DIFF
--- a/src/test/linters/lint.multilinter.test.ts
+++ b/src/test/linters/lint.multilinter.test.ts
@@ -88,7 +88,12 @@ suite('Linting - Multiple Linters Enabled Test', () => {
         return `linting.${linterManager.getLinterInfo(product).enabledSettingName}` as PythonSettingKeys;
     }
 
-    test('Multiple linters', async () => {
+    test('Multiple linters', async function () {
+        // This test is failing in the CI. See this issue here:
+        // https://github.com/microsoft/vscode-python/issues/13345
+        // tslint:disable-next-line: no-invalid-this
+        this.skip();
+
         await closeActiveWindows();
         const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
         await window.showTextDocument(document);


### PR DESCRIPTION
This change is to disable this test so that CI passes and we can generate an insiders build.

I added this bug here: https://github.com/microsoft/vscode-python/issues/13345 to fix the test later.
