### PR TITLE
Port Flakey CI test disable

### DIFF
--- a/src/test/linters/lint.multilinter.test.ts
+++ b/src/test/linters/lint.multilinter.test.ts
@@ -88,7 +88,12 @@ suite('Linting - Multiple Linters Enabled Test', () => {
         return `linting.${linterManager.getLinterInfo(product).enabledSettingName}` as PythonSettingKeys;
     }
 
-    test('Multiple linters', async () => {
+    test('Multiple linters', async function () {
+        // This test is failing in the CI. See this issue here:
+        // https://github.com/microsoft/vscode-python/issues/13345
+        // tslint:disable-next-line: no-invalid-this
+        this.skip();
+
         await closeActiveWindows();
         const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
         await window.showTextDocument(document);


### PR DESCRIPTION
Porting Rich's disabling of this test to release so we can get a clean CI build:
https://github.com/microsoft/vscode-python/pull/13346

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
