### PR TITLE
implement markdown cell highlight

### DIFF
--- a/news/1 Enhancements/13359.md
+++ b/news/1 Enhancements/13359.md
@@ -1,0 +1,1 @@
+Highlight markdown cell (thanks [Youwei Zhao](https://github.com/zhaouv/))

--- a/package.json
+++ b/package.json
@@ -3268,6 +3268,16 @@
                 "language": "pip-requirements",
                 "scopeName": "source.pip-requirements",
                 "path": "./syntaxes/pip-requirements.tmLanguage.json"
+            },
+            {
+                "injectTo": [
+                    "source.python"
+                ],
+                "scopeName": "comment.markdown-cell-inject.python",
+                "path": "./syntaxes/python.markdown.inject.json",
+                "embeddedLanguages": {
+                    "meta.embedded.block.md": "markdown"
+                }
             }
         ],
         "jsonValidation": [

--- a/syntaxes/python.markdown.inject.json
+++ b/syntaxes/python.markdown.inject.json
@@ -1,0 +1,36 @@
+{
+	"injectionSelector": "source.python",
+	"patterns": [
+		{
+			"include": "#comment-markdown-cell-inject-python"
+		}
+	],
+	"repository": {
+		"comment-markdown-cell-inject-python": {
+			"name": "text.html.markdown",
+			"begin": "(?<=(?:^|\\G)(?:#\\s*%%\\s*\\[markdown\\]|#\\s*<markdowncell>)\\s*)$",
+			"end": "(^|\\G)(?=[^#\\s]|#\\s*%%|\\s+\\S)",
+			"patterns": [
+				{
+					"include": "#sharp-quote"
+				}
+			]
+		},
+		"sharp-quote": {
+			"begin": "(^|\\G)(#) ?",
+			"captures": {
+				"2": {
+					"name": "comment.punctuation.definition.comment.python"
+				}
+			},
+			"contentName": "meta.embedded.block.md",
+			"patterns": [
+				{
+					"include": "text.html.markdown"
+				}
+			],
+			"while": "(^|\\G)(#) ?"
+		}
+	},
+    "scopeName": "comment.markdown-cell-inject.python"
+}

--- a/syntaxes/python.markdown.inject.json
+++ b/syntaxes/python.markdown.inject.json
@@ -7,20 +7,20 @@
 	],
 	"repository": {
 		"comment-markdown-cell-inject-python": {
-			"name": "text.html.markdown",
+			"name": "comment.quote_code.number-sign.python",
 			"begin": "(?<=(?:^|\\G)(?:#\\s*%%\\s*\\[markdown\\]|#\\s*<markdowncell>)\\s*)$",
-			"end": "(^|\\G)(?=[^#\\s]|#\\s*%%|\\s+\\S)",
+			"end": "(^|\\G)(?=\\s*[^#\\s]|\\s*#\\s*%%)",
 			"patterns": [
 				{
-					"include": "#sharp-quote"
+					"include": "#number-sign-quote"
 				}
 			]
 		},
-		"sharp-quote": {
-			"begin": "(^|\\G)(#) ?",
+		"number-sign-quote": {
+			"begin": "(^|\\G)\\s*(#) ?",
 			"captures": {
 				"2": {
-					"name": "comment.punctuation.definition.comment.python"
+					"name": "comment.punctuation.definition.quote_code.python"
 				}
 			},
 			"contentName": "meta.embedded.block.md",
@@ -29,7 +29,7 @@
 					"include": "text.html.markdown"
 				}
 			],
-			"while": "(^|\\G)(#) ?"
+			"while": "(^|\\G)\\s*(#) ?(?!\\s*%%)"
 		}
 	},
     "scopeName": "comment.markdown-cell-inject.python"


### PR DESCRIPTION
For #4356 

It would be better if the newline in markdown cell can be automatically added `"# "`, maybe the next pr.

![image](https://user-images.githubusercontent.com/26158289/89735521-b03d2180-da95-11ea-8a5d-0c4d95f40deb.png)

