### PR TITLE
Enable custom editor support again

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -165,12 +165,12 @@
         "name": "CustomEditorSupport - control",
         "salt": "CustomEditorSupport",
         "min": 0,
-        "max": 100
+        "max": 0
     },
     {
         "name": "CustomEditorSupport - experiment",
         "salt": "CustomEditorSupport",
-        "max": 0,
+        "max": 100,
         "min": 0
     },
     {

--- a/experiments.json
+++ b/experiments.json
@@ -165,12 +165,12 @@
         "name": "CustomEditorSupport - control",
         "salt": "CustomEditorSupport",
         "min": 0,
-        "max": 0
+        "max": 100
     },
     {
         "name": "CustomEditorSupport - experiment",
         "salt": "CustomEditorSupport",
-        "max": 100,
+        "max": 0,
         "min": 0
     },
     {

--- a/news/2 Fixes/12245.md
+++ b/news/2 Fixes/12245.md
@@ -1,0 +1,1 @@
+Fix opening new blank notebooks when using the VS code custom editor API.

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
         "onCommand:python.enableSourceMapSupport",
         "onNotebookEditor:jupyter-notebook",
         "workspaceContains:mspythonconfig.json",
-        "workspaceContains:pyproject.toml"
+        "workspaceContains:pyproject.toml",
+        "onCustomEditor:ms-python.python.notebook.ipynb"
     ],
     "main": "./out/client/extension",
     "contributes": {
@@ -3343,6 +3344,18 @@
                     }
                 ],
                 "priority": "option"
+            }
+        ],
+        "customEditors": [
+            {
+                "viewType": "ms-python.python.notebook.ipynb",
+                "displayName": "Jupyter Notebook",
+                "selector": [
+                    {
+                        "filenamePattern": "*.ipynb"
+                    }
+                ],
+                "priority": "default"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -102,8 +102,7 @@
         "onCommand:python.enableSourceMapSupport",
         "onNotebookEditor:jupyter-notebook",
         "workspaceContains:mspythonconfig.json",
-        "workspaceContains:pyproject.toml",
-        "onCustomEditor:ms-python.python.notebook.ipynb"
+        "workspaceContains:pyproject.toml"
     ],
     "main": "./out/client/extension",
     "contributes": {
@@ -3418,18 +3417,6 @@
                     }
                 ],
                 "priority": "option"
-            }
-        ],
-        "customEditors": [
-            {
-                "viewType": "ms-python.python.notebook.ipynb",
-                "displayName": "Jupyter Notebook",
-                "selector": [
-                    {
-                        "filenamePattern": "*.ipynb"
-                    }
-                ],
-                "priority": "default"
             }
         ]
     },

--- a/src/client/common/experiments/manager.ts
+++ b/src/client/common/experiments/manager.ts
@@ -163,6 +163,13 @@ export class ExperimentsManager implements IExperimentsManager {
                 ) {
                     continue;
                 }
+                // User cannot belong to CustomEditor Experiment if they are not using Insiders.
+                if (
+                    experiment.name === NotebookEditorSupport.customEditorExperiment &&
+                    this.appEnvironment.channel === 'stable'
+                ) {
+                    continue;
+                }
                 try {
                     if (
                         this._experimentsOptedOutFrom.includes('All') ||

--- a/src/client/datascience/codeCssGenerator.ts
+++ b/src/client/datascience/codeCssGenerator.ts
@@ -99,7 +99,7 @@ export class CodeCssGenerator implements ICodeCssGenerator {
         @inject(IThemeFinder) private themeFinder: IThemeFinder,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IDataScienceFileSystem) private fs: IDataScienceFileSystem
-    ) {}
+    ) { }
 
     public generateThemeCss(resource: Resource, isDark: boolean, theme: string): Promise<string> {
         return this.applyThemeData(resource, isDark, theme, '', this.generateCss.bind(this));
@@ -364,8 +364,8 @@ ${args.defaultStyle ? DefaultCssVars[args.defaultStyle] : ''}
             let tokenColors: JSONArray = [];
 
             if (typeof theme.tokenColors === 'string') {
-                const style = await this.fs.readLocalData(theme.tokenColors);
-                tokenColors = JSON.parse(style.toString());
+                const style = await this.fs.readLocalFile(theme.tokenColors);
+                tokenColors = JSON.parse(style);
             } else {
                 tokenColors = theme.tokenColors as JSONArray;
             }

--- a/src/client/datascience/codeCssGenerator.ts
+++ b/src/client/datascience/codeCssGenerator.ts
@@ -99,7 +99,7 @@ export class CodeCssGenerator implements ICodeCssGenerator {
         @inject(IThemeFinder) private themeFinder: IThemeFinder,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(IDataScienceFileSystem) private fs: IDataScienceFileSystem
-    ) { }
+    ) {}
 
     public generateThemeCss(resource: Resource, isDark: boolean, theme: string): Promise<string> {
         return this.applyThemeData(resource, isDark, theme, '', this.generateCss.bind(this));

--- a/src/client/datascience/common.ts
+++ b/src/client/datascience/common.ts
@@ -3,7 +3,6 @@
 'use strict';
 import type { nbformat } from '@jupyterlab/coreutils';
 import * as os from 'os';
-import * as path from 'path';
 import { Memento, Uri } from 'vscode';
 import { splitMultilineString } from '../../datascience-ui/common';
 import { traceError, traceInfo } from '../common/logger';
@@ -49,8 +48,8 @@ export function getSavedUriList(globalState: Memento): { uri: string; time: numb
     const uriList = globalState.get<{ uri: string; time: number }[]>(Settings.JupyterServerUriList);
     return uriList
         ? uriList.sort((a, b) => {
-              return b.time - a.time;
-          })
+            return b.time - a.time;
+        })
         : [];
 }
 export function addToUriList(globalState: Memento, uri: string, time: number) {
@@ -133,7 +132,7 @@ export function translateKernelLanguageToMonaco(kernelLanguage: string): string 
     return kernelLanguage.toLowerCase();
 }
 
-export function generateNewNotebookUri(counter: number, title?: string, forVSCodeNotebooks?: boolean): Uri {
+export function generateNewNotebookUri(counter: number, rootFolder: string | undefined, title?: string, forVSCodeNotebooks?: boolean): Uri {
     // However if there are files already on disk, we should be able to overwrite them because
     // they will only ever be used by 'open' editors. So just use the current counter for our untitled count.
     const fileName = title ? `${title}-${counter}.ipynb` : `${DataScience.untitledNotebookFileName()}-${counter}.ipynb`;
@@ -141,13 +140,8 @@ export function generateNewNotebookUri(counter: number, title?: string, forVSCod
     if (forVSCodeNotebooks) {
         return Uri.file(fileName).with({ scheme: 'untitled', path: fileName });
     } else {
-        // Because of this bug here:
-        // https://github.com/microsoft/vscode/issues/93441
-        // We can't create 'untitled' files anymore. The untitled scheme will just be ignored.
-        // Instead we need to create untitled files in the temp folder and force a saveas whenever they're
-        // saved.
-        const filePath = Uri.file(path.join(os.tmpdir(), fileName));
-        return filePath.with({ scheme: 'untitled', path: filePath.fsPath });
+        return Uri.joinPath(rootFolder ? Uri.file(rootFolder) : Uri.file(os.tmpdir()), fileName)
+            .with({ scheme: 'untitled' });
     }
 }
 

--- a/src/client/datascience/common.ts
+++ b/src/client/datascience/common.ts
@@ -48,8 +48,8 @@ export function getSavedUriList(globalState: Memento): { uri: string; time: numb
     const uriList = globalState.get<{ uri: string; time: number }[]>(Settings.JupyterServerUriList);
     return uriList
         ? uriList.sort((a, b) => {
-            return b.time - a.time;
-        })
+              return b.time - a.time;
+          })
         : [];
 }
 export function addToUriList(globalState: Memento, uri: string, time: number) {
@@ -132,7 +132,12 @@ export function translateKernelLanguageToMonaco(kernelLanguage: string): string 
     return kernelLanguage.toLowerCase();
 }
 
-export function generateNewNotebookUri(counter: number, rootFolder: string | undefined, title?: string, forVSCodeNotebooks?: boolean): Uri {
+export function generateNewNotebookUri(
+    counter: number,
+    rootFolder: string | undefined,
+    title?: string,
+    forVSCodeNotebooks?: boolean
+): Uri {
     // However if there are files already on disk, we should be able to overwrite them because
     // they will only ever be used by 'open' editors. So just use the current counter for our untitled count.
     const fileName = title ? `${title}-${counter}.ipynb` : `${DataScience.untitledNotebookFileName()}-${counter}.ipynb`;
@@ -140,8 +145,9 @@ export function generateNewNotebookUri(counter: number, rootFolder: string | und
     if (forVSCodeNotebooks) {
         return Uri.file(fileName).with({ scheme: 'untitled', path: fileName });
     } else {
-        return Uri.joinPath(rootFolder ? Uri.file(rootFolder) : Uri.file(os.tmpdir()), fileName)
-            .with({ scheme: 'untitled' });
+        return Uri.joinPath(rootFolder ? Uri.file(rootFolder) : Uri.file(os.tmpdir()), fileName).with({
+            scheme: 'untitled'
+        });
     }
 }
 

--- a/src/client/datascience/dataScienceFileSystem.ts
+++ b/src/client/datascience/dataScienceFileSystem.ts
@@ -21,6 +21,7 @@ export class DataScienceFileSystem implements IDataScienceFileSystem {
     protected vscfs: FileSystem;
     private globFiles: (pat: string, options?: { cwd: string; dot?: boolean }) => Promise<string[]>;
     private fsPathUtils: IFileSystemPathUtils;
+    // tslint:disable-next-line: no-any
     private pendingIO = new Map<string, Thenable<any>[]>();
 
     constructor() {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -564,12 +564,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
     }
 
     protected saveAll() {
-        // Ask user for a save as dialog if no title
-        if (this.isUntitled) {
-            this.commandManager.executeCommand('workbench.action.files.saveAs', this.file);
-        } else {
-            this.commandManager.executeCommand('workbench.action.files.save', this.file);
-        }
+        this.commandManager.executeCommand('workbench.action.files.save', this.file);
     }
 
     private async modelChanged(change: NotebookModelChange) {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -27,6 +27,7 @@ import {
     IMemento,
     WORKSPACE_MEMENTO
 } from '../../common/types';
+import { createDeferred } from '../../common/utils/async';
 import { isNotebookCell, noop } from '../../common/utils/misc';
 import { IServiceContainer } from '../../ioc/types';
 import { Commands, Identifiers } from '../constants';
@@ -57,7 +58,6 @@ import {
 import { NativeEditor } from './nativeEditor';
 import { NativeEditorOldWebView } from './nativeEditorOldWebView';
 import { NativeEditorSynchronizer } from './nativeEditorSynchronizer';
-import { createDeferred } from '../../common/utils/async';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 const debounce = require('lodash/debounce') as typeof import('lodash/debounce');

--- a/src/client/datascience/notebookStorage/nativeEditorProvider.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorProvider.ts
@@ -135,18 +135,15 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
     }
     public async saveCustomDocument(document: CustomDocument, cancellation: CancellationToken): Promise<void> {
         const model = await this.loadModel(document.uri);
-        // 1 second timeout on save so don't wait. Just write and forget
-        this.storage.save(model, cancellation).ignoreErrors();
+        return this.storage.save(model, cancellation);
     }
     public async saveCustomDocumentAs(document: CustomDocument, targetResource: Uri): Promise<void> {
         const model = await this.loadModel(document.uri);
-        // 1 second timeout on save so don't wait. Just write and forget
-        this.storage.saveAs(model, targetResource).ignoreErrors();
+        return this.storage.saveAs(model, targetResource);
     }
     public async revertCustomDocument(document: CustomDocument, cancellation: CancellationToken): Promise<void> {
         const model = await this.loadModel(document.uri);
-        // 1 second time limit on this so don't wait.
-        this.storage.revert(model, cancellation).ignoreErrors();
+        return this.storage.revert(model, cancellation);
     }
     public async backupCustomDocument(
         document: CustomDocument,

--- a/src/client/datascience/notebookStorage/nativeEditorProvider.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorProvider.ts
@@ -274,15 +274,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
             const model = await this.loadModel(resource);
 
             // Load it (should already be visible)
-            const result = this.createNotebookEditor(model, panel);
-
-            // Wait for monaco ready (it's not really useable until it has a language)
-            const readyPromise = createDeferred();
-            const disposable = result.ready(() => readyPromise.resolve());
-            await result.show();
-            await readyPromise.promise;
-            disposable.dispose();
-            return result;
+            return this.createNotebookEditor(model, panel);
         } catch (exc) {
             // Send telemetry indicating a failure
             sendTelemetryEvent(Telemetry.OpenNotebookFailure);
@@ -333,6 +325,6 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
     }
 
     private getNextNewNotebookUri(title?: string): Uri {
-        return generateNewNotebookUri(this.untitledCounter, title);
+        return generateNewNotebookUri(this.untitledCounter, this.workspace.rootPath, title);
     }
 }

--- a/src/client/datascience/notebookStorage/notebookStorageProvider.ts
+++ b/src/client/datascience/notebookStorage/notebookStorageProvider.ts
@@ -6,12 +6,12 @@
 import { inject, injectable } from 'inversify';
 import { EventEmitter, Uri } from 'vscode';
 import { CancellationToken } from 'vscode-jsonrpc';
+import { IWorkspaceService } from '../../common/application/types';
 import { IDisposable, IDisposableRegistry } from '../../common/types';
 import { generateNewNotebookUri } from '../common';
 import { INotebookModel, INotebookStorage } from '../types';
 import { getNextUntitledCounter } from './nativeEditorStorage';
 import { VSCodeNotebookModel } from './vscNotebookModel';
-import { IWorkspaceService } from '../../common/application/types';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 
@@ -109,7 +109,12 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
     }
 
     private getNextNewNotebookUri(forVSCodeNotebooks?: boolean): Uri {
-        return generateNewNotebookUri(NotebookStorageProvider.untitledCounter, this.workspace.rootPath, undefined, forVSCodeNotebooks);
+        return generateNewNotebookUri(
+            NotebookStorageProvider.untitledCounter,
+            this.workspace.rootPath,
+            undefined,
+            forVSCodeNotebooks
+        );
     }
 
     private trackModel(model: INotebookModel): INotebookModel {

--- a/src/client/datascience/notebookStorage/notebookStorageProvider.ts
+++ b/src/client/datascience/notebookStorage/notebookStorageProvider.ts
@@ -11,6 +11,7 @@ import { generateNewNotebookUri } from '../common';
 import { INotebookModel, INotebookStorage } from '../types';
 import { getNextUntitledCounter } from './nativeEditorStorage';
 import { VSCodeNotebookModel } from './vscNotebookModel';
+import { IWorkspaceService } from '../../common/application/types';
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 
@@ -30,7 +31,8 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
     private readonly disposables: IDisposable[] = [];
     constructor(
         @inject(INotebookStorage) private readonly storage: INotebookStorage,
-        @inject(IDisposableRegistry) disposables: IDisposableRegistry
+        @inject(IDisposableRegistry) disposables: IDisposableRegistry,
+        @inject(IWorkspaceService) private readonly workspace: IWorkspaceService
     ) {
         disposables.push(this);
     }
@@ -107,7 +109,7 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
     }
 
     private getNextNewNotebookUri(forVSCodeNotebooks?: boolean): Uri {
-        return generateNewNotebookUri(NotebookStorageProvider.untitledCounter, undefined, forVSCodeNotebooks);
+        return generateNewNotebookUri(NotebookStorageProvider.untitledCounter, this.workspace.rootPath, undefined, forVSCodeNotebooks);
     }
 
     private trackModel(model: INotebookModel): INotebookModel {

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -202,7 +202,9 @@ export function registerTypes(serviceManager: IServiceManager) {
     if (!useVSCodeNotebookAPI) {
         serviceManager.add<INotebookEditor>(INotebookEditor, usingCustomEditor ? NativeEditor : NativeEditorOldWebView);
         // These are never going to be required for new VSC NB.
-        serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, AutoSaveService);
+        if (!usingCustomEditor) {
+            serviceManager.add<IInteractiveWindowListener>(IInteractiveWindowListener, AutoSaveService);
+        }
         serviceManager.addSingleton<NativeEditorSynchronizer>(NativeEditorSynchronizer, NativeEditorSynchronizer);
     }
 

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -224,7 +224,10 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             // TODO: How to have this work for when the keyboard shortcuts are changed?
             case 's': {
                 if (!this.props.settings?.extraSettings.useCustomEditorApi) {
-                    if ((event.ctrlKey && getOSType() !== OSType.OSX) || (event.metaKey && getOSType() === OSType.OSX)) {
+                    if (
+                        (event.ctrlKey && getOSType() !== OSType.OSX) ||
+                        (event.metaKey && getOSType() === OSType.OSX)
+                    ) {
                         // This is save, save our cells
                         this.props.save();
                         this.props.sendCommand(NativeKeyboardCommandTelemetry.Save);

--- a/src/datascience-ui/native-editor/nativeEditor.tsx
+++ b/src/datascience-ui/native-editor/nativeEditor.tsx
@@ -223,10 +223,12 @@ ${buildSettingsCss(this.props.settings)}`}</style>
             // tslint:disable-next-line: no-suspicious-comment
             // TODO: How to have this work for when the keyboard shortcuts are changed?
             case 's': {
-                if ((event.ctrlKey && getOSType() !== OSType.OSX) || (event.metaKey && getOSType() === OSType.OSX)) {
-                    // This is save, save our cells
-                    this.props.save();
-                    this.props.sendCommand(NativeKeyboardCommandTelemetry.Save);
+                if (!this.props.settings?.extraSettings.useCustomEditorApi) {
+                    if ((event.ctrlKey && getOSType() !== OSType.OSX) || (event.metaKey && getOSType() === OSType.OSX)) {
+                        // This is save, save our cells
+                        this.props.save();
+                        this.props.sendCommand(NativeKeyboardCommandTelemetry.Save);
+                    }
                 }
                 break;
             }

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -355,7 +355,7 @@ suite('DataScience - Native Editor Storage', () => {
             new NotebookModelFactory(false)
         );
 
-        return new NotebookStorageProvider(notebookStorage, []);
+        return new NotebookStorageProvider(notebookStorage, [], instance(workspace));
     }
 
     teardown(() => {

--- a/src/test/datascience/mockFileSystem.ts
+++ b/src/test/datascience/mockFileSystem.ts
@@ -21,7 +21,11 @@ export class MockFileSystem extends DataScienceFileSystem {
         return super.readLocalFile(filePath);
     }
     public async readFile(filePath: Uri): Promise<string> {
-        return this.readLocalFile(filePath.fsPath);
+        const contents = this.contentOverloads.get(filePath.fsPath);
+        if (contents) {
+            return contents;
+        }
+        return super.readFile(filePath);
     }
     public addFileContents(filePath: string, contents: string): void {
         this.contentOverloads.set(filePath, contents);

--- a/src/test/mocks/vsc/uri.ts
+++ b/src/test/mocks/vsc/uri.ts
@@ -7,6 +7,7 @@
 /* tslint:disable */
 
 import { CharCode } from './charCode';
+import * as path from 'path';
 
 export namespace vscUri {
     const isWindows = /^win/.test(process.platform);
@@ -428,6 +429,20 @@ export namespace vscUri {
                 return result;
             }
         }
+
+        static joinPath(uri: URI, ...pathFragment: string[]): URI {
+            if (!uri.path) {
+                throw new Error(`[UriError]: cannot call joinPaths on URI without path`);
+            }
+            let newPath: string;
+            if (isWindows && uri.scheme === 'file') {
+                newPath = URI.file(path.join(uri.fsPath, ...pathFragment)).path;
+            } else {
+                newPath = path.join(uri.path, ...pathFragment);
+            }
+            return uri.with({ path: newPath });
+        }
+
     }
 
     export interface UriComponents {

--- a/src/test/mocks/vsc/uri.ts
+++ b/src/test/mocks/vsc/uri.ts
@@ -442,7 +442,6 @@ export namespace vscUri {
             }
             return uri.with({ path: newPath });
         }
-
     }
 
     export interface UriComponents {


### PR DESCRIPTION
For #7903, #12245

Turn on custom editor support (it works in VS code insiders)

Also want to say our functional tests caught a bug in this implementation. And for something unrelated (trusting notebooks). I love functional tests.

