### PR TITLE
Fix raw kernel disposed problem

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -825,6 +825,11 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     }
 
     protected async ensureConnectionAndNotebook(): Promise<void> {
+        // Start over if we somehow end up with a disposed notebook.
+        if (this._notebook && this._notebook.disposed) {
+            this._notebook = undefined;
+            this.connectionAndNotebookPromise = undefined;
+        }
         if (!this.connectionAndNotebookPromise) {
             this.connectionAndNotebookPromise = this.ensureConnectionAndNotebookImpl();
         }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -828,6 +828,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         // Start over if we somehow end up with a disposed notebook.
         if (this._notebook && this._notebook.disposed) {
             this._notebook = undefined;
+            this.notebookPromise = undefined;
             this.connectionAndNotebookPromise = undefined;
         }
         if (!this.connectionAndNotebookPromise) {


### PR DESCRIPTION
Finally got this to repro randomly (Direct Kernel disconnected). It seems this can occur if the editor or interactive window is holding onto a disposed notebook when multiple copies of the same file are opened and you close one.

Multiple copies of an editor opening is hard to repro though.