### PR TITLE
Fix nyc unit test failures

### DIFF
--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -116,7 +116,8 @@ export class JupyterExporter implements INotebookExporter {
                 version: pythonNumber
             },
             orig_nbformat: 2,
-            kernelspec: kernelSpec
+            // tslint:disable-next-line: no-any
+            kernelspec: kernelSpec as any
         };
 
         // Create an object for matching cell definitions

--- a/src/client/datascience/notebookStorage/baseModel.ts
+++ b/src/client/datascience/notebookStorage/baseModel.ts
@@ -128,7 +128,9 @@ export abstract class BaseNotebookModel implements INotebookModel {
                   ...this.notebookJson.metadata,
                   id: this.kernelId
               }
-            : this.notebookJson.metadata;
+            : // Fix nyc compiler problem
+              // tslint:disable-next-line: no-any
+              (this.notebookJson.metadata as any);
     }
     public get isTrusted() {
         return this._isTrusted;


### PR DESCRIPTION
CI is consistently failing on this:

```
> python@2020.9.0-dev test:unittests:cover /home/runner/work/vscode-python/vscode-python
> nyc --no-clean --nycrc-path build/.nycrc mocha --config ./build/.mocha.unittests.ts.json


TSError: ⨯ Unable to compile TypeScript:
##[error]src/client/datascience/notebookStorage/baseModel.ts(126,9): error TS2322: Type 'INotebookMetadata | { id: string; kernelspec?: IKernelspecMetadata | undefined; language_info?: ILanguageInfoMetadata | undefined; orig_nbformat: number; } | undefined' is not assignable to type 'INotebookMetadataLive | undefined'.
```