### PR TITLE
Refactor KernelSelection type to include a `kind`

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelExecution.ts
+++ b/src/client/datascience/jupyter/kernels/kernelExecution.ts
@@ -152,7 +152,12 @@ export class KernelExecution implements IDisposable {
         if (!kernel) {
             const activeInterpreter = await this.interpreterService.getActiveInterpreter(document.uri);
             kernel = this.kernelProvider.getOrCreate(document.uri, {
-                metadata: { interpreter: activeInterpreter!, kernelModel: undefined, kernelSpec: undefined },
+                metadata: {
+                    interpreter: activeInterpreter!,
+                    kernelModel: undefined,
+                    kernelSpec: undefined,
+                    kind: 'pythonInterpreter'
+                },
                 launchingFile: document.uri.fsPath
             });
         }

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -158,13 +158,12 @@ export class KernelSelector implements IKernelSelectionUsage {
         cancelToken?: CancellationToken,
         currentKernelDisplayName?: string
     ): Promise<KernelSpecInterpreter> {
-        let suggestions = await this.selectionProvider.getKernelSelectionsForLocalSession(
+        const suggestions = await this.selectionProvider.getKernelSelectionsForLocalSession(
             resource,
             type,
             session,
             cancelToken
         );
-        suggestions = suggestions.filter((item) => !this.kernelIdsToHide.has(item.selection.kernelModel?.id || ''));
         return this.selectKernel(
             resource,
             type,

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -22,22 +22,71 @@ import type { KernelSpecInterpreter } from './kernelSelector';
 export type LiveKernelModel = IJupyterKernel & Partial<IJupyterKernelSpec> & { session: Session.IModel };
 
 /**
- * Whether a selected kernel is:
- * - Kernel spec (IJupyterKernelSpec)
- * - Active kernel (IJupyterKernel) or
- * - An Interpreter
+ * Connection metadata for Live Kernels.
+ * With this we are able connect to an existing kernel (instead of starting a new session).
  */
+export type LiveKernelConnectionMetadata = {
+    kernelModel: LiveKernelModel;
+    kernelSpec: undefined;
+    interpreter: undefined;
+    kind: 'live';
+};
+/**
+ * Connection metadata for Kernels started using kernelspec (JSON).
+ * This could be a raw kernel (spec might have path to executable for .NET or the like).
+ */
+export type KernelSpecConnectionMetadata = {
+    kernelModel: undefined;
+    kernelSpec: IJupyterKernelSpec;
+    interpreter: undefined;
+    kind: 'kernelSpec';
+};
+/**
+ * Connection metadata for Kernels started using Python interpreter.
+ * These are not necessarily raw (it could be plain old Jupyter Kernels, where we register Python interpreter as a kernel)
+ */
+export type PythonKernelConnectionMetadata = {
+    kernelModel: undefined;
+    kernelSpec: undefined;
+    interpreter: PythonInterpreter;
+    kind: 'pythonInterpreter';
+};
+// /**
+//  * Connection metadata for Kernels started using Python interpreter with Kernel spec (JSON).
+//  * Sometimes, we're unable to determine the exact interpreter associated with a kernelspec, in such cases this is a closes match.
+//  */
+
+// export type PythonKernelSpecConnectionMetadata = {
+//     kernelModel: undefined;
+//     kernelSpec: IJupyterKernelSpec;
+//     interpreter: PythonInterpreter;
+//     kind: 'pythonInterpreterKernelSpec';
+// };
+// /**
+//  * Connection metadata for Kernels started using kernelspec (JSON).
+//  * Note, we could be connecting/staring a kernel on a remote jupyter server.
+//  * Sometimes, we're unable to determine the exact interpreter associated with a kernelspec, in such cases this is a closes match.
+//  * E.g. when selecting a remote kernel, we do not have the remote interpreter information, we can only try to find a close match.}
+//  */
+
+// export type PythonLiveKernelConnectionMetadata = {
+//     kernelModel: undefined;
+//     kernelSpec: IJupyterKernelSpec;
+//     interpreter: PythonInterpreter;
+//     kind: 'pythonInterpreterLive';
+// };
 export type KernelSelection =
-    | { kernelModel: LiveKernelModel; kernelSpec: undefined; interpreter: undefined }
-    | { kernelModel: undefined; kernelSpec: IJupyterKernelSpec; interpreter: undefined }
-    | { kernelModel: undefined; kernelSpec: undefined; interpreter: PythonInterpreter };
+    | LiveKernelConnectionMetadata
+    | KernelSpecConnectionMetadata
+    | PythonKernelConnectionMetadata;
+// | PythonKernelSpecConnectionMetadata
+// | PythonLiveKernelConnectionMetadata;
 
-export interface IKernelSpecQuickPickItem extends QuickPickItem {
-    selection: KernelSelection;
+export interface IKernelSpecQuickPickItem<T extends KernelSelection = KernelSelection> extends QuickPickItem {
+    selection: T;
 }
-
-export interface IKernelSelectionListProvider {
-    getKernelSelections(resource: Resource, cancelToken?: CancellationToken): Promise<IKernelSpecQuickPickItem[]>;
+export interface IKernelSelectionListProvider<T extends KernelSelection = KernelSelection> {
+    getKernelSelections(resource: Resource, cancelToken?: CancellationToken): Promise<IKernelSpecQuickPickItem<T>[]>;
 }
 
 export interface IKernelSelectionUsage {

--- a/src/test/datascience/commands/notebookCommands.functional.test.ts
+++ b/src/test/datascience/commands/notebookCommands.functional.test.ts
@@ -20,7 +20,12 @@ import { KernelSelectionProvider } from '../../../client/datascience/jupyter/ker
 import { KernelSelector } from '../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelService } from '../../../client/datascience/jupyter/kernels/kernelService';
 import { KernelSwitcher } from '../../../client/datascience/jupyter/kernels/kernelSwitcher';
-import { IKernelSpecQuickPickItem } from '../../../client/datascience/jupyter/kernels/types';
+import {
+    IKernelSpecQuickPickItem,
+    KernelSpecConnectionMetadata,
+    LiveKernelConnectionMetadata,
+    PythonKernelConnectionMetadata
+} from '../../../client/datascience/jupyter/kernels/types';
 import { IKernelFinder } from '../../../client/datascience/kernel-launcher/types';
 import { NativeEditorProvider } from '../../../client/datascience/notebookStorage/nativeEditorProvider';
 import { IInteractiveWindowProvider, INotebookEditorProvider } from '../../../client/datascience/types';
@@ -58,23 +63,25 @@ suite('DataScience - Notebook Commands', () => {
         sysPrefix: '',
         sysVersion: ''
     };
-    const remoteSelections: IKernelSpecQuickPickItem[] = [
+    const remoteSelections: IKernelSpecQuickPickItem<LiveKernelConnectionMetadata>[] = [
         {
             label: 'foobar',
             selection: {
                 kernelSpec: undefined,
                 kernelModel: remoteKernel,
-                interpreter: undefined
+                interpreter: undefined,
+                kind: 'live'
             }
         }
     ];
-    const localSelections: IKernelSpecQuickPickItem[] = [
+    const localSelections: IKernelSpecQuickPickItem<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata>[] = [
         {
             label: 'foobar',
             selection: {
                 kernelSpec: localKernel,
                 kernelModel: undefined,
-                interpreter: undefined
+                interpreter: undefined,
+                kind: 'kernelSpec'
             }
         },
         {
@@ -82,7 +89,8 @@ suite('DataScience - Notebook Commands', () => {
             selection: {
                 kernelSpec: undefined,
                 kernelModel: undefined,
-                interpreter: selectedInterpreter
+                interpreter: selectedInterpreter,
+                kind: 'pythonInterpreter'
             }
         }
     ];

--- a/src/test/datascience/jupyter/kernels/kernelSelections.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelections.unit.test.ts
@@ -205,7 +205,8 @@ suite('DataScience - KernelSelections', () => {
                             // tslint:disable-next-line: no-any
                         } as any
                     },
-                    kernelSpec: undefined
+                    kernelSpec: undefined,
+                    kind: 'live'
                 },
                 detail: '<user friendly path>',
                 description: localize.DataScience.jupyterSelectURIRunningDetailFormat().format(
@@ -232,7 +233,8 @@ suite('DataScience - KernelSelections', () => {
                             // tslint:disable-next-line: no-any
                         } as any
                     },
-                    kernelSpec: undefined
+                    kernelSpec: undefined,
+                    kind: 'live'
                 },
                 detail: '<user friendly path>',
                 description: localize.DataScience.jupyterSelectURIRunningDetailFormat().format(
@@ -264,7 +266,7 @@ suite('DataScience - KernelSelections', () => {
             return {
                 label: item.display_name,
                 detail: '<user friendly path>',
-                selection: { interpreter: undefined, kernelModel: undefined, kernelSpec: item }
+                selection: { interpreter: undefined, kernelModel: undefined, kernelSpec: item, kind: 'kernelSpec' }
             };
         });
         const expectedInterpreterItems: IKernelSpecQuickPickItem[] = allInterpreters.map((item) => {
@@ -273,7 +275,12 @@ suite('DataScience - KernelSelections', () => {
                 label: item.label,
                 detail: '<user friendly path>',
                 description: '',
-                selection: { kernelModel: undefined, interpreter: item.interpreter, kernelSpec: undefined }
+                selection: {
+                    kernelModel: undefined,
+                    interpreter: item.interpreter,
+                    kernelSpec: undefined,
+                    kind: 'pythonInterpreter'
+                }
             };
         });
         const expectedList = [...expectedKernelItems, ...expectedInterpreterItems];
@@ -300,7 +307,7 @@ suite('DataScience - KernelSelections', () => {
             return {
                 label: item.display_name,
                 detail: '<user friendly path>',
-                selection: { interpreter: undefined, kernelModel: undefined, kernelSpec: item }
+                selection: { interpreter: undefined, kernelModel: undefined, kernelSpec: item, kind: 'kernelSpec' }
             };
         });
         const expectedInterpreterItems: IKernelSpecQuickPickItem[] = allInterpreters.map((item) => {
@@ -309,7 +316,12 @@ suite('DataScience - KernelSelections', () => {
                 label: item.label,
                 detail: '<user friendly path>',
                 description: '',
-                selection: { kernelModel: undefined, interpreter: item.interpreter, kernelSpec: undefined }
+                selection: {
+                    kernelModel: undefined,
+                    interpreter: item.interpreter,
+                    kernelSpec: undefined,
+                    kind: 'pythonInterpreter'
+                }
             };
         });
         const expectedList = [...expectedKernelItems, ...expectedInterpreterItems];

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -24,7 +24,12 @@ import { KernelDependencyService } from '../../../../client/datascience/jupyter/
 import { KernelSelectionProvider } from '../../../../client/datascience/jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../../../../client/datascience/jupyter/kernels/kernelSelector';
 import { KernelService } from '../../../../client/datascience/jupyter/kernels/kernelService';
-import { IKernelSpecQuickPickItem, LiveKernelModel } from '../../../../client/datascience/jupyter/kernels/types';
+import {
+    IKernelSpecQuickPickItem,
+    KernelSpecConnectionMetadata,
+    LiveKernelConnectionMetadata,
+    LiveKernelModel
+} from '../../../../client/datascience/jupyter/kernels/types';
 import { IKernelFinder } from '../../../../client/datascience/kernel-launcher/types';
 import { IJupyterSessionManager } from '../../../../client/datascience/types';
 import { IInterpreterService } from '../../../../client/interpreter/contracts';
@@ -216,10 +221,12 @@ suite('DataScience - KernelSelector', () => {
                     session: {} as any
                 }
             ];
-            const quickPickItems: IKernelSpecQuickPickItem[] = kernelModels.map((kernelModel) => {
+            const quickPickItems: IKernelSpecQuickPickItem<
+                LiveKernelConnectionMetadata | KernelSpecConnectionMetadata
+            >[] = kernelModels.map((kernelModel) => {
                 return {
                     label: '',
-                    selection: { kernelModel, kernelSpec: undefined, interpreter: undefined }
+                    selection: { kernelModel, kernelSpec: undefined, interpreter: undefined, kind: 'live' }
                 };
             });
 
@@ -246,89 +253,6 @@ suite('DataScience - KernelSelector', () => {
             verify(
                 kernelSelectionProvider.getKernelSelectionsForRemoteSession(
                     anything(),
-                    instance(sessionManager),
-                    anything()
-                )
-            ).once();
-            verify(appShell.showQuickPick(anything(), anything(), anything())).once();
-            const suggestions = capture(appShell.showQuickPick).first()[0] as IKernelSpecQuickPickItem[];
-            assert.deepEqual(
-                suggestions,
-                quickPickItems.filter((item) => !['id2', 'id4'].includes(item.selection?.kernelModel?.id || ''))
-            );
-        });
-        test('Should hide kernel from local sessions', async () => {
-            const kernelModels: LiveKernelModel[] = [
-                {
-                    lastActivityTime: new Date(),
-                    name: '1one',
-                    numberOfConnections: 1,
-                    id: 'id1',
-                    display_name: '1',
-                    // tslint:disable-next-line: no-any
-                    session: {} as any
-                },
-                {
-                    lastActivityTime: new Date(),
-                    name: '2two',
-                    numberOfConnections: 1,
-                    id: 'id2',
-                    display_name: '2',
-                    // tslint:disable-next-line: no-any
-                    session: {} as any
-                },
-                {
-                    lastActivityTime: new Date(),
-                    name: '3three',
-                    numberOfConnections: 1,
-                    id: 'id3',
-                    display_name: '3',
-                    // tslint:disable-next-line: no-any
-                    session: {} as any
-                },
-                {
-                    lastActivityTime: new Date(),
-                    name: '4four',
-                    numberOfConnections: 1,
-                    id: 'id4',
-                    display_name: '4',
-                    // tslint:disable-next-line: no-any
-                    session: {} as any
-                }
-            ];
-            const quickPickItems: IKernelSpecQuickPickItem[] = kernelModels.map((kernelModel) => {
-                return {
-                    label: '',
-                    selection: { kernelModel, kernelSpec: undefined, interpreter: undefined }
-                };
-            });
-
-            when(
-                kernelSelectionProvider.getKernelSelectionsForLocalSession(
-                    anything(),
-                    'jupyter',
-                    instance(sessionManager),
-                    anything()
-                )
-            ).thenResolve(quickPickItems);
-            when(appShell.showQuickPick(anything(), anything(), anything())).thenResolve(undefined);
-
-            // tslint:disable-next-line: no-any
-            kernelSelector.addKernelToIgnoreList({ id: 'id2' } as any);
-            // tslint:disable-next-line: no-any
-            kernelSelector.addKernelToIgnoreList({ clientId: 'id4' } as any);
-            const kernel = await kernelSelector.selectLocalKernel(
-                undefined,
-                'jupyter',
-                new StopWatch(),
-                instance(sessionManager)
-            );
-
-            assert.isEmpty(kernel);
-            verify(
-                kernelSelectionProvider.getKernelSelectionsForLocalSession(
-                    anything(),
-                    'jupyter',
                     instance(sessionManager),
                     anything()
                 )


### PR DESCRIPTION
For #13406 

First refactor existing code to ensure we do not need the `interpreter` property along with `kernelspecs`
