### PR TITLE
Add binding for cell selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,6 +289,16 @@
                 "command": "python.datascience.gotoPrevCellInFile",
                 "key": "ctrl+alt+[",
                 "when": "editorTextFocus && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
+            },
+            {
+                "command": "python.datascience.selectCellContents",
+                "key": "ctrl+alt+\\",
+                "when": "editorTextFocus && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
+            },
+            {
+                "command": "python.datascience.selectCell",
+                "key": "ctrl+alt+shift+\\",
+                "when": "editorTextFocus && python.datascience.hascodecells && python.datascience.featureenabled && !notebookEditorFocused"
             }
         ],
         "commands": [


### PR DESCRIPTION
Originally I thought that just having the keybinding for extending cell selection would be sufficient for ... well... cell selection, so I didn't bind the other two new commands from @earthastronaut: selectCell and selectCellContents. However, in dogfooding and swapping between a true notebook and a related python script I found that it would be highly useful to be able to select a script cell's contents (not the # %%) for enabling the swapping code between the notebook and script. So I'm adding bindings to those two commands as well.

selectCellContents => Ctrl-Alt-\
selectCell => Ctrl-Shift-Alt-\

