### PR TITLE
Skip flaky file stat test

### DIFF
--- a/src/test/common/platform/filesystem.test.ts
+++ b/src/test/common/platform/filesystem.test.ts
@@ -37,7 +37,10 @@ suite('FileSystem - raw', () => {
     });
 
     suite('stat', () => {
-        test('gets the info for an existing file', async () => {
+        test('gets the info for an existing file', async function () {
+            // https://github.com/microsoft/vscode-python/issues/10294
+            // tslint:disable-next-line: no-invalid-this
+            return this.skip();
             const filename = await fix.createFile('x/y/z/spam.py', '...');
             const old = await fsextra.stat(filename);
             const expected = convertStat(old, FileType.File);


### PR DESCRIPTION
For #10294

Skip flaky test that compares ctime:
```
1) FileSystem - raw
       stat
         gets the info for an existing file:

      AssertionError: expected { Object (ctime, mtime, ...) } to deeply equal { Object (type, size, ...) }
      + expected - actual

       {
      -  "ctime": 1597306039735
      +  "ctime": 1597306039736
         "mtime": 1597306039736
         "size": 3
         "type": 1
       }
      
      at Context.<anonymous> (out/test/common/platform/filesystem.test.js:32:41)
      at processTicksAndRejections (internal/process/task_queues.js:85:5)
```