### PR TITLE
Remove "no-reload" from debug configurations by default

### DIFF
--- a/news/1 Enhancements/13061.md
+++ b/news/1 Enhancements/13061.md
@@ -1,0 +1,2 @@
+Remove default "--no-reload" from debug configurations.
+(thanks [ian910297](https://github.com/ian910297))

--- a/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
@@ -27,7 +27,7 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
         @inject(IFileSystem) private fs: IFileSystem,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(IPathUtils) private pathUtils: IPathUtils
-    ) { }
+    ) {}
     public async buildConfiguration(input: MultiStepInput<DebugConfigurationState>, state: DebugConfigurationState) {
         const program = await this.getManagePyPath(state.folder);
         let manuallyEnteredAValue: boolean | undefined;

--- a/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/djangoLaunch.ts
@@ -27,7 +27,7 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
         @inject(IFileSystem) private fs: IFileSystem,
         @inject(IWorkspaceService) private readonly workspace: IWorkspaceService,
         @inject(IPathUtils) private pathUtils: IPathUtils
-    ) {}
+    ) { }
     public async buildConfiguration(input: MultiStepInput<DebugConfigurationState>, state: DebugConfigurationState) {
         const program = await this.getManagePyPath(state.folder);
         let manuallyEnteredAValue: boolean | undefined;
@@ -37,7 +37,7 @@ export class DjangoLaunchDebugConfigurationProvider implements IDebugConfigurati
             type: DebuggerTypeName,
             request: 'launch',
             program: program || defaultProgram,
-            args: ['runserver', '--noreload'],
+            args: ['runserver'],
             django: true
         };
         if (!program) {

--- a/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
@@ -17,7 +17,7 @@ import { DebugConfigurationState, DebugConfigurationType, IDebugConfigurationPro
 
 @injectable()
 export class FlaskLaunchDebugConfigurationProvider implements IDebugConfigurationProvider {
-    constructor(@inject(IFileSystem) private fs: IFileSystem) { }
+    constructor(@inject(IFileSystem) private fs: IFileSystem) {}
     public isSupported(debugConfigurationType: DebugConfigurationType): boolean {
         return debugConfigurationType === DebugConfigurationType.launchFlask;
     }

--- a/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
+++ b/src/client/debugger/extension/configuration/providers/flaskLaunch.ts
@@ -17,7 +17,7 @@ import { DebugConfigurationState, DebugConfigurationType, IDebugConfigurationPro
 
 @injectable()
 export class FlaskLaunchDebugConfigurationProvider implements IDebugConfigurationProvider {
-    constructor(@inject(IFileSystem) private fs: IFileSystem) {}
+    constructor(@inject(IFileSystem) private fs: IFileSystem) { }
     public isSupported(debugConfigurationType: DebugConfigurationType): boolean {
         return debugConfigurationType === DebugConfigurationType.launchFlask;
     }
@@ -34,7 +34,7 @@ export class FlaskLaunchDebugConfigurationProvider implements IDebugConfiguratio
                 FLASK_ENV: 'development',
                 FLASK_DEBUG: '0'
             },
-            args: ['run', '--no-debugger', '--no-reload'],
+            args: ['run', '--no-debugger'],
             jinja: true
         };
 

--- a/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
@@ -139,7 +139,7 @@ suite('Debugging - Configuration Provider Django', () => {
             type: DebuggerTypeName,
             request: 'launch',
             program: 'xyz.py',
-            args: ['runserver', '--noreload'],
+            args: ['runserver'],
             django: true
         };
 
@@ -159,7 +159,7 @@ suite('Debugging - Configuration Provider Django', () => {
             type: DebuggerTypeName,
             request: 'launch',
             program: 'hello',
-            args: ['runserver', '--noreload'],
+            args: ['runserver'],
             django: true
         };
 
@@ -182,7 +182,7 @@ suite('Debugging - Configuration Provider Django', () => {
             type: DebuggerTypeName,
             request: 'launch',
             program: defaultProgram,
-            args: ['runserver', '--noreload'],
+            args: ['runserver'],
             django: true
         };
 

--- a/src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
@@ -69,7 +69,7 @@ suite('Debugging - Configuration Provider Flask', () => {
                 FLASK_ENV: 'development',
                 FLASK_DEBUG: '0'
             },
-            args: ['run', '--no-debugger', '--no-reload'],
+            args: ['run', '--no-debugger'],
             jinja: true
         };
 
@@ -94,7 +94,7 @@ suite('Debugging - Configuration Provider Flask', () => {
                 FLASK_ENV: 'development',
                 FLASK_DEBUG: '0'
             },
-            args: ['run', '--no-debugger', '--no-reload'],
+            args: ['run', '--no-debugger'],
             jinja: true
         };
 
@@ -119,7 +119,7 @@ suite('Debugging - Configuration Provider Flask', () => {
                 FLASK_ENV: 'development',
                 FLASK_DEBUG: '0'
             },
-            args: ['run', '--no-debugger', '--no-reload'],
+            args: ['run', '--no-debugger'],
             jinja: true
         };
 


### PR DESCRIPTION
For #13061 
* Flask:  remove "--no-reload" flag
* Django: remove "--noreload" flag

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
