### PR TITLE
User KernelConnectionMetadata instead of KernelSpec+Interpreter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -234,7 +234,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                "--grep", "xxx",
+                //"--grep", "<suite name>",
                 "--timeout=300000"
             ],
             "outFiles": [
@@ -285,7 +285,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                "--grep", "xxx",
+                //"--grep", "<suite name>",
                 "--timeout=300000",
                 "--exit"
             ],
@@ -293,11 +293,11 @@
                 // Remove `X` prefix to test with real browser to host DS ui (for DS functional tests).
                 "XVSC_PYTHON_DS_UI_BROWSER": "1",
                 // Remove `X` prefix to test with real python (for DS functional tests).
-                "VSCODE_PYTHON_ROLLING": "1",
+                "XVSCODE_PYTHON_ROLLING": "1",
                 // Remove 'X' to turn on all logging in the debug output
                 "XVSC_PYTHON_FORCE_LOGGING": "1",
                 // Remove `X` prefix and update path to test with real python interpreter (for DS functional tests).
-                "CI_PYTHON_PATH": "/Users/donjayamanne/Desktop/Development/crap/docBug/venvDS/bin/python",
+                "XCI_PYTHON_PATH": "<Python Path>",
                 // Remove 'X' prefix to dump output for debugger. Directory has to exist prior to launch
                 "XDEBUGPY_LOG_DIR": "${workspaceRoot}/tmp/Debug_Output"
             },
@@ -305,7 +305,7 @@
                 "${workspaceFolder}/out/**/*.js",
                 "!${workspaceFolder}/**/node_modules**/*"
             ],
-            // "preLaunchTask": "Compile",
+            "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
             ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -285,7 +285,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                //"--grep", "<suite name>",
+                //"--grep", "<suite>",
                 "--timeout=300000",
                 "--exit"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -234,7 +234,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                //"--grep", "<suite name>",
+                "--grep", "xxx",
                 "--timeout=300000"
             ],
             "outFiles": [
@@ -285,7 +285,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                // "--grep", "<suite>",
+                "--grep", "xxx",
                 "--timeout=300000",
                 "--exit"
             ],
@@ -293,11 +293,11 @@
                 // Remove `X` prefix to test with real browser to host DS ui (for DS functional tests).
                 "XVSC_PYTHON_DS_UI_BROWSER": "1",
                 // Remove `X` prefix to test with real python (for DS functional tests).
-                "XVSCODE_PYTHON_ROLLING": "1",
+                "VSCODE_PYTHON_ROLLING": "1",
                 // Remove 'X' to turn on all logging in the debug output
                 "XVSC_PYTHON_FORCE_LOGGING": "1",
                 // Remove `X` prefix and update path to test with real python interpreter (for DS functional tests).
-                "XCI_PYTHON_PATH": "<Python Path>",
+                "CI_PYTHON_PATH": "/Users/donjayamanne/Desktop/Development/crap/docBug/venvDS/bin/python",
                 // Remove 'X' prefix to dump output for debugger. Directory has to exist prior to launch
                 "XDEBUGPY_LOG_DIR": "${workspaceRoot}/tmp/Debug_Output"
             },
@@ -305,7 +305,7 @@
                 "${workspaceFolder}/out/**/*.js",
                 "!${workspaceFolder}/**/node_modules**/*"
             ],
-            "preLaunchTask": "Compile",
+            // "preLaunchTask": "Compile",
             "skipFiles": [
                 "<node_internals>/**"
             ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -285,7 +285,7 @@
                 "--ui=tdd",
                 "--recursive",
                 "--colors",
-                //"--grep", "<suite>",
+                // "--grep", "<suite>",
                 "--timeout=300000",
                 "--exit"
             ],

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -190,7 +190,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
             this.session.statusChanged.connect(this.statusHandler);
 
             // After switching, start another in case we restart again.
-            this.restartSessionPromise = this.createRestartSession(this.kernelConnectionMetadata!, oldSession);
+            this.restartSessionPromise = this.createRestartSession(this.kernelConnectionMetadata, oldSession);
             traceInfo('Started new restart session');
             if (oldStatusHandler) {
                 oldSession.statusChanged.disconnect(oldStatusHandler);
@@ -316,7 +316,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     // Sub classes need to implement their own restarting specific code
     protected abstract startRestartSession(): void;
     protected abstract async createRestartSession(
-        kernelConnection: KernelConnectionMetadata,
+        kernelConnection: KernelConnectionMetadata | undefined,
         session: ISessionWithSocket,
         cancelToken?: CancellationToken
     ): Promise<ISessionWithSocket>;

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -124,19 +124,16 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         let newSession: ISessionWithSocket | undefined;
 
         // If we are already using this kernel in an active session just return back
-        const currentKernelConnection =
+        const currentKernelSpec =
             this.kernelConnectionMetadata && kernelConnectionMetadataHasKernelSpec(this.kernelConnectionMetadata)
                 ? this.kernelConnectionMetadata.kernelSpec
                 : undefined;
-        const kernelConnectionToUse = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+        const kernelSpecToUse = kernelConnectionMetadataHasKernelSpec(kernelConnection)
             ? kernelConnection.kernelSpec
             : undefined;
-        if (this.session && currentKernelConnection && kernelConnectionToUse) {
+        if (this.session && currentKernelSpec && kernelSpecToUse) {
             // Name and id have to match (id is only for active sessions)
-            if (
-                currentKernelConnection.name === kernelConnectionToUse.name &&
-                currentKernelConnection.id === kernelConnectionToUse.id
-            ) {
+            if (currentKernelSpec.name === kernelSpecToUse.name && currentKernelSpec.id === kernelSpecToUse.id) {
                 return;
             }
         }
@@ -149,7 +146,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
             this.restartSessionPromise?.then((r) => this.shutdownSession(r, undefined)).ignoreErrors(); // NOSONAR
         }
 
-        // Update our kernel spec and interpreter
+        // Update our kernel connection metadata.
         this.kernelConnectionMetadata = kernelConnection;
 
         // Save the new session

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -13,15 +13,15 @@ import { traceError, traceInfo, traceWarning } from '../common/logger';
 import { sleep, waitForPromise } from '../common/utils/async';
 import * as localize from '../common/utils/localize';
 import { noop } from '../common/utils/misc';
-import { PythonEnvironment } from '../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../telemetry';
 import { Identifiers, Telemetry } from './constants';
 import { JupyterInvalidKernelError } from './jupyter/jupyterInvalidKernelError';
 import { JupyterWaitForIdleError } from './jupyter/jupyterWaitForIdleError';
+import { kernelConnectionMetadataHasKernelSpec } from './jupyter/kernels/helpers';
 import { JupyterKernelPromiseFailedError } from './jupyter/kernels/jupyterKernelPromiseFailedError';
-import { LiveKernelModel } from './jupyter/kernels/types';
+import { KernelConnectionMetadata } from './jupyter/kernels/types';
 import { suppressShutdownErrors } from './raw-kernel/rawKernel';
-import { IJupyterKernelSpec, IJupyterSession, ISessionWithSocket, KernelSocketInformation } from './types';
+import { IJupyterSession, ISessionWithSocket, KernelSocketInformation } from './types';
 
 /**
  * Exception raised when starting a Jupyter Session fails.
@@ -42,8 +42,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     protected get session(): ISessionWithSocket | undefined {
         return this._session;
     }
-    protected kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined;
-    protected interpreter: PythonEnvironment | undefined;
+    protected kernelSpec?: KernelConnectionMetadata;
     public get kernelSocket(): Observable<KernelSocketInformation | undefined> {
         return this._kernelSocket;
     }
@@ -121,22 +120,25 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         }
     }
 
-    public async changeKernel(
-        kernel: IJupyterKernelSpec | LiveKernelModel,
-        timeoutMS: number,
-        interpreter?: PythonEnvironment
-    ): Promise<void> {
+    public async changeKernel(kernelConnection: KernelConnectionMetadata, timeoutMS: number): Promise<void> {
         let newSession: ISessionWithSocket | undefined;
 
         // If we are already using this kernel in an active session just return back
-        if (this.session && this.kernelSpec) {
+        const currentKernelSpec =
+            this.kernelSpec && kernelConnectionMetadataHasKernelSpec(this.kernelSpec)
+                ? this.kernelSpec.kernelSpec
+                : undefined;
+        const kernelSpecToUse = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+            ? kernelConnection.kernelSpec
+            : undefined;
+        if (this.session && currentKernelSpec && kernelSpecToUse) {
             // Name and id have to match (id is only for active sessions)
-            if (this.kernelSpec.name === kernel.name && this.kernelSpec.id === kernel.id) {
+            if (currentKernelSpec.name === kernelSpecToUse.name && currentKernelSpec.id === kernelSpecToUse.id) {
                 return;
             }
         }
 
-        newSession = await this.createNewKernelSession(kernel, timeoutMS, interpreter);
+        newSession = await this.createNewKernelSession(kernelConnection, timeoutMS);
 
         // This is just like doing a restart, kill the old session (and the old restart session), and start new ones
         if (this.session) {
@@ -145,8 +147,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         }
 
         // Update our kernel spec and interpreter
-        this.kernelSpec = kernel;
-        this.interpreter = interpreter;
+        this.kernelSpec = kernelConnection;
 
         // Save the new session
         this.setSession(newSession);
@@ -155,7 +156,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         this.session?.statusChanged.connect(this.statusHandler); // NOSONAR
 
         // Start the restart session promise too.
-        this.restartSessionPromise = this.createRestartSession(kernel, newSession, interpreter);
+        this.restartSessionPromise = this.createRestartSession(kernelConnection, newSession);
     }
 
     public async restart(_timeout: number): Promise<void> {
@@ -189,7 +190,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
             this.session.statusChanged.connect(this.statusHandler);
 
             // After switching, start another in case we restart again.
-            this.restartSessionPromise = this.createRestartSession(this.kernelSpec, oldSession);
+            this.restartSessionPromise = this.createRestartSession(this.kernelSpec!, oldSession);
             traceInfo('Started new restart session');
             if (oldStatusHandler) {
                 oldSession.statusChanged.disconnect(oldStatusHandler);
@@ -315,17 +316,15 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     // Sub classes need to implement their own restarting specific code
     protected abstract startRestartSession(): void;
     protected abstract async createRestartSession(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
+        kernelConnection: KernelConnectionMetadata,
         session: ISessionWithSocket,
-        interpreter?: PythonEnvironment,
         cancelToken?: CancellationToken
     ): Promise<ISessionWithSocket>;
 
     // Sub classes need to implement their own kernel change specific code
     protected abstract createNewKernelSession(
-        kernel: IJupyterKernelSpec | LiveKernelModel,
-        timeoutMS: number,
-        interpreter?: PythonEnvironment
+        kernelConnection: KernelConnectionMetadata,
+        timeoutMS: number
     ): Promise<ISessionWithSocket>;
 
     protected async waitForIdleOnSession(session: ISessionWithSocket | undefined, timeout: number): Promise<void> {
@@ -339,12 +338,16 @@ export abstract class BaseJupyterSession implements IJupyterSession {
                     traceError('Kernel died while waiting for idle');
                     // If we throw an exception, make sure to shutdown the session as it's not usable anymore
                     this.shutdownSession(session, this.statusHandler).ignoreErrors();
+                    const kernelModel = {
+                        ...session.kernel,
+                        lastActivityTime: new Date(),
+                        numberOfConnections: 0,
+                        session: session.model
+                    };
                     reject(
                         new JupyterInvalidKernelError({
-                            ...session.kernel,
-                            lastActivityTime: new Date(),
-                            numberOfConnections: 0,
-                            session: session.model
+                            kernelModel,
+                            kind: 'connectToLiveKernel'
                         })
                     );
                 }
@@ -409,7 +412,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         // If we have a new session, then emit the new kernel connection information.
         if (session && oldSession !== session) {
             if (!session.kernelSocketInformation) {
-                traceError(`Unable to find WebSocket connection assocated with kernel ${session.kernel.id}`);
+                traceError(`Unable to find WebSocket connection associated with kernel ${session.kernel.id}`);
                 this._kernelSocket.next(undefined);
             } else {
                 this._kernelSocket.next({

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -42,7 +42,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     protected get session(): ISessionWithSocket | undefined {
         return this._session;
     }
-    protected kernelSpec?: KernelConnectionMetadata;
+    protected kernelConnectionMetadata?: KernelConnectionMetadata;
     public get kernelSocket(): Observable<KernelSocketInformation | undefined> {
         return this._kernelSocket;
     }
@@ -124,16 +124,19 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         let newSession: ISessionWithSocket | undefined;
 
         // If we are already using this kernel in an active session just return back
-        const currentKernelSpec =
-            this.kernelSpec && kernelConnectionMetadataHasKernelSpec(this.kernelSpec)
-                ? this.kernelSpec.kernelSpec
+        const currentKernelConnection =
+            this.kernelConnectionMetadata && kernelConnectionMetadataHasKernelSpec(this.kernelConnectionMetadata)
+                ? this.kernelConnectionMetadata.kernelSpec
                 : undefined;
-        const kernelSpecToUse = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+        const kernelConnectionToUse = kernelConnectionMetadataHasKernelSpec(kernelConnection)
             ? kernelConnection.kernelSpec
             : undefined;
-        if (this.session && currentKernelSpec && kernelSpecToUse) {
+        if (this.session && currentKernelConnection && kernelConnectionToUse) {
             // Name and id have to match (id is only for active sessions)
-            if (currentKernelSpec.name === kernelSpecToUse.name && currentKernelSpec.id === kernelSpecToUse.id) {
+            if (
+                currentKernelConnection.name === kernelConnectionToUse.name &&
+                currentKernelConnection.id === kernelConnectionToUse.id
+            ) {
                 return;
             }
         }
@@ -147,7 +150,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         }
 
         // Update our kernel spec and interpreter
-        this.kernelSpec = kernelConnection;
+        this.kernelConnectionMetadata = kernelConnection;
 
         // Save the new session
         this.setSession(newSession);
@@ -190,7 +193,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
             this.session.statusChanged.connect(this.statusHandler);
 
             // After switching, start another in case we restart again.
-            this.restartSessionPromise = this.createRestartSession(this.kernelSpec!, oldSession);
+            this.restartSessionPromise = this.createRestartSession(this.kernelConnectionMetadata!, oldSession);
             traceInfo('Started new restart session');
             if (oldStatusHandler) {
                 oldSession.statusChanged.disconnect(oldStatusHandler);

--- a/src/client/datascience/commands/notebookCommands.ts
+++ b/src/client/datascience/commands/notebookCommands.ts
@@ -53,7 +53,7 @@ export class NotebookCommands implements IDisposable {
                       identity: this.interactiveWindowProvider.activeWindow?.identity,
                       resource: this.interactiveWindowProvider.activeWindow?.owner,
                       currentKernelDisplayName: getDisplayNameOrNameOfKernelConnection(
-                          this.interactiveWindowProvider.activeWindow?.notebook?.getKernelSpec()
+                          this.interactiveWindowProvider.activeWindow?.notebook?.getKernelConnection()
                       )
                   };
         }

--- a/src/client/datascience/commands/notebookCommands.ts
+++ b/src/client/datascience/commands/notebookCommands.ts
@@ -8,7 +8,10 @@ import { Uri } from 'vscode';
 import { ICommandManager } from '../../common/application/types';
 import { IDisposable } from '../../common/types';
 import { Commands } from '../constants';
-import { kernelConnectionMetadataHasKernelModel } from '../jupyter/kernels/helpers';
+import {
+    getDisplayNameOrNameOfKernelConnection,
+    kernelConnectionMetadataHasKernelModel
+} from '../jupyter/kernels/helpers';
 import { KernelSelector } from '../jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../jupyter/kernels/kernelSwitcher';
 import { KernelConnectionMetadata } from '../jupyter/kernels/types';
@@ -49,9 +52,9 @@ export class NotebookCommands implements IDisposable {
                 : {
                       identity: this.interactiveWindowProvider.activeWindow?.identity,
                       resource: this.interactiveWindowProvider.activeWindow?.owner,
-                      currentKernelDisplayName:
-                          this.interactiveWindowProvider.activeWindow?.notebook?.getKernelSpec()?.display_name ||
-                          this.interactiveWindowProvider.activeWindow?.notebook?.getKernelSpec()?.name
+                      currentKernelDisplayName: getDisplayNameOrNameOfKernelConnection(
+                          this.interactiveWindowProvider.activeWindow?.notebook?.getKernelSpec()
+                      )
                   };
         }
         if (options.identity) {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -521,7 +521,7 @@ export namespace Identifiers {
     export const REMOTE_URI_HANDLE_PARAM = 'uriHandle';
 }
 
-export namespace CodeSnippits {
+export namespace CodeSnippets {
     export const ChangeDirectory = [
         '{0}',
         '{1}',

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -1238,7 +1238,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             this.postMessage(InteractiveWindowMessages.UpdateKernel, {
                 jupyterServerStatus: ServerStatus.NotStarted,
                 localizedUri: '',
-                displayName: specOrModel?.display_name || specOrModel?.name || '',
+                displayName: getDisplayNameOrNameOfKernelConnection(data.kernelConnection),
                 language: translateKernelLanguageToMonaco(
                     getKernelConnectionLanguage(data.kernelConnection) || PYTHON_LANGUAGE
                 )

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -47,7 +47,6 @@ import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { isUntitledFile, noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { generateCellRangesFromDocument } from '../cellFactory';
 import { CellMatcher } from '../cellMatcher';
@@ -71,12 +70,14 @@ import {
 } from '../interactive-common/interactiveWindowTypes';
 import { JupyterInvalidKernelError } from '../jupyter/jupyterInvalidKernelError';
 import {
+    getDisplayNameOrNameOfKernelConnection,
+    getKernelConnectionLanguage,
     kernelConnectionMetadataHasKernelModel,
     kernelConnectionMetadataHasKernelSpec
 } from '../jupyter/kernels/helpers';
 import { JupyterKernelPromiseFailedError } from '../jupyter/kernels/jupyterKernelPromiseFailedError';
 import { KernelSelector } from '../jupyter/kernels/kernelSelector';
-import { KernelConnectionMetadata, LiveKernelModel } from '../jupyter/kernels/types';
+import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { CssMessages, SharedMessages } from '../messages';
 import {
     CellState,
@@ -88,7 +89,6 @@ import {
     IInteractiveWindowInfo,
     IInteractiveWindowListener,
     IJupyterDebugger,
-    IJupyterKernelSpec,
     IJupyterVariableDataProviderFactory,
     IJupyterVariables,
     IJupyterVariablesRequest,
@@ -501,7 +501,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     protected onViewStateChanged(args: WebViewViewChangeEventArgs) {
         // Only activate if the active editor is empty. This means that
         // vscode thinks we are actually supposed to have focus. It would be
-        // nice if they would more accurrately tell us this, but this works for now.
+        // nice if they would more accurately tell us this, but this works for now.
         // Essentially the problem is the webPanel.active state doesn't track
         // if the focus is supposed to be in the webPanel or not. It only tracks if
         // it's been activated. However if there's no active text editor and we're active, we
@@ -518,7 +518,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     protected async activating() {
         // Only activate if the active editor is empty. This means that
         // vscode thinks we are actually supposed to have focus. It would be
-        // nice if they would more accurrately tell us this, but this works for now.
+        // nice if they would more accurately tell us this, but this works for now.
         // Essentially the problem is the webPanel.active state doesn't track
         // if the focus is supposed to be in the webPanel or not. It only tracks if
         // it's been activated. However if there's no active text editor and we're active, we
@@ -545,10 +545,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
 
     protected abstract closeBecauseOfFailure(exc: Error): Promise<void>;
 
-    protected abstract updateNotebookOptions(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel,
-        interpreter: PythonEnvironment | undefined
-    ): Promise<void>;
+    protected abstract updateNotebookOptions(kernelConnection: KernelConnectionMetadata): Promise<void>;
 
     protected async clearResult(id: string): Promise<void> {
         await this.ensureConnectionAndNotebook();
@@ -1118,8 +1115,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             currentKernelDisplayName:
                 this.notebookMetadata?.kernelspec?.display_name ||
                 this.notebookMetadata?.kernelspec?.name ||
-                this._notebook?.getKernelSpec()?.display_name ||
-                this._notebook?.getKernelSpec()?.name
+                getDisplayNameOrNameOfKernelConnection(this._notebook?.getKernelSpec())
         });
     }
 
@@ -1146,7 +1142,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
                     const newKernel = await this.selector.askForLocalKernel(
                         this.owningResource,
                         serverConnection.type,
-                        e.kernelSpec
+                        e.kernelConnectionMetadata
                     );
                     if (newKernel && kernelConnectionMetadataHasKernelSpec(newKernel) && newKernel.kernelSpec) {
                         this.commandManager.executeCommand(
@@ -1184,14 +1180,16 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
 
     private async listenToNotebookEvents(notebook: INotebook): Promise<void> {
         const statusChangeHandler = async (status: ServerStatus) => {
-            const kernelSpec = notebook.getKernelSpec();
-            const name = kernelSpec?.display_name || kernelSpec?.name || '';
+            const connectionMetadata = notebook.getKernelSpec();
+            const name = getDisplayNameOrNameOfKernelConnection(connectionMetadata);
 
             await this.postMessage(InteractiveWindowMessages.UpdateKernel, {
                 jupyterServerStatus: status,
                 localizedUri: this.getServerUri(notebook.connection),
                 displayName: name,
-                language: translateKernelLanguageToMonaco(kernelSpec?.language ?? PYTHON_LANGUAGE)
+                language: translateKernelLanguageToMonaco(
+                    getKernelConnectionLanguage(connectionMetadata) || PYTHON_LANGUAGE
+                )
             });
         };
         notebook.onSessionStatusChanged(statusChangeHandler);
@@ -1245,7 +1243,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             }).ignoreErrors();
 
             // Update our model
-            this.updateNotebookOptions(specOrModel, data.kernel.interpreter).ignoreErrors();
+            this.updateNotebookOptions(data.kernel).ignoreErrors();
         }
     }
 
@@ -1445,7 +1443,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             }
             // Storing an object that looks like
             //  { "fully qualified Path to 1.ipynb": 1234,
-            //    "fully qualifieid path to 2.ipynb": 1234 }
+            //    "fully qualified path to 2.ipynb": 1234 }
 
             // tslint:disable-next-line: no-any
             const value = this.workspaceStorage.get(VariableExplorerStateKeys.height, {} as any);
@@ -1460,7 +1458,7 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
         const uri = this.owningResource; // Get file name
 
         if (!uri || isUntitledFile(uri)) {
-            return; // don't resotre height of untitled notebooks
+            return; // don't restore height of untitled notebooks
         }
 
         // tslint:disable-next-line: no-any
@@ -1519,14 +1517,14 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
     private async selectServer() {
         await this.commandManager.executeCommand(Commands.SelectJupyterURI);
     }
-    private async kernelChangeHandler(kernel: IJupyterKernelSpec | LiveKernelModel) {
+    private async kernelChangeHandler(kernelConnection: KernelConnectionMetadata) {
         // Check if we are changing to LiveKernelModel
-        if (kernel.hasOwnProperty('numberOfConnections')) {
+        if (kernelConnection.kind === 'connectToLiveKernel') {
             await this.addSysInfo(SysInfoReason.Connect);
         } else {
             await this.addSysInfo(SysInfoReason.New);
         }
-        return this.updateNotebookOptions(kernel, this._notebook?.getMatchingInterpreter());
+        return this.updateNotebookOptions(kernelConnection);
     }
 
     private openSettings(setting: string | undefined) {

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -17,16 +17,14 @@ import {
     NotifyIPyWidgeWidgetVersionNotSupportedAction
 } from '../../../datascience-ui/interactive-common/redux/reducers/types';
 import { Resource } from '../../common/types';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { NativeKeyboardCommandTelemetry, NativeMouseCommandTelemetry } from '../constants';
 import { WidgetScriptSource } from '../ipywidgets/types';
-import { LiveKernelModel } from '../jupyter/kernels/types';
+import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { CssMessages, IGetCssRequest, IGetCssResponse, IGetMonacoThemeRequest, SharedMessages } from '../messages';
 import { IGetMonacoThemeResponse } from '../monacoMessages';
 import {
     ICell,
     IInteractiveWindowInfo,
-    IJupyterKernelSpec,
     IJupyterVariable,
     IJupyterVariablesRequest,
     IJupyterVariablesResponse,
@@ -505,8 +503,7 @@ export interface INotebookModelEditChange extends INotebookModelChange {
 
 export interface INotebookModelVersionChange extends INotebookModelChange {
     kind: 'version';
-    interpreter: PythonEnvironment | undefined;
-    kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined;
+    kernelConnection?: KernelConnectionMetadata;
 }
 
 export type NotebookModelChange =

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -28,7 +28,7 @@ export class NotebookProvider implements INotebookProvider {
     private _notebookCreated = new EventEmitter<{ identity: Uri; notebook: INotebook }>();
     private readonly _onSessionStatusChanged = new EventEmitter<{ status: ServerStatus; notebook: INotebook }>();
     private _connectionMade = new EventEmitter<void>();
-    private _potentialKernelChanged = new EventEmitter<{ identity: Uri; kernel: KernelConnectionMetadata }>();
+    private _potentialKernelChanged = new EventEmitter<{ identity: Uri; kernelConnection: KernelConnectionMetadata }>();
     private _type: 'jupyter' | 'raw' = 'jupyter';
     public get activeNotebooks() {
         return [...this.notebooks.values()];
@@ -155,7 +155,7 @@ export class NotebookProvider implements INotebookProvider {
     // This method is here so that the kernel selector can pick a kernel and not have
     // to know about any of the UI that's active.
     public firePotentialKernelChanged(identity: Uri, kernel: KernelConnectionMetadata) {
-        this._potentialKernelChanged.fire({ identity, kernel });
+        this._potentialKernelChanged.fire({ identity, kernelConnection: kernel });
     }
 
     private fireConnectionMade() {

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -499,7 +499,7 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // Tell storage about our notebook object
         const notebook = this.getNotebook();
         if (notebook && this.model) {
-            const kernelConnection = notebook.getKernelSpec();
+            const kernelConnection = notebook.getKernelConnection();
             this.model.update({
                 source: 'user',
                 kind: 'version',

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -37,7 +37,6 @@ import {
 } from '../../common/types';
 import { StopWatch } from '../../common/utils/stopWatch';
 import { EXTENSION_ROOT_DIR } from '../../constants';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { Commands, EditorContexts, Identifiers, Telemetry } from '../constants';
 import { InteractiveBase } from '../interactive-common/interactiveBase';
@@ -61,7 +60,6 @@ import {
     IInteractiveWindowInfo,
     IInteractiveWindowListener,
     IJupyterDebugger,
-    IJupyterKernelSpec,
     IJupyterVariableDataProviderFactory,
     IJupyterVariables,
     INotebookEditor,
@@ -88,7 +86,7 @@ import { translateKernelLanguageToMonaco } from '../common';
 import { IDataViewerFactory } from '../data-viewing/types';
 import { getCellHashProvider } from '../editor-integration/cellhashprovider';
 import { KernelSelector } from '../jupyter/kernels/kernelSelector';
-import { LiveKernelModel } from '../jupyter/kernels/types';
+import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 
 const nativeEditorDir = path.join(EXTENSION_ROOT_DIR, 'out', 'datascience-ui', 'notebook');
 export class NativeEditor extends InteractiveBase implements INotebookEditor {
@@ -321,15 +319,11 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         return this.model.metadata;
     }
 
-    public async updateNotebookOptions(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel,
-        interpreter: PythonEnvironment | undefined
-    ): Promise<void> {
+    public async updateNotebookOptions(kernelConnection: KernelConnectionMetadata): Promise<void> {
         if (this.model) {
             const change: NotebookModelChange = {
                 kind: 'version',
-                kernelSpec,
-                interpreter,
+                kernelConnection,
                 oldDirty: this.model.isDirty,
                 newDirty: true,
                 source: 'user'
@@ -505,15 +499,13 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // Tell storage about our notebook object
         const notebook = this.getNotebook();
         if (notebook && this.model) {
-            const interpreter = notebook.getMatchingInterpreter();
-            const kernelSpec = notebook.getKernelSpec();
+            const kernelConnection = notebook.getKernelSpec();
             this.model.update({
                 source: 'user',
                 kind: 'version',
                 oldDirty: this.model.isDirty,
                 newDirty: this.model.isDirty,
-                interpreter,
-                kernelSpec
+                kernelConnection
             });
         }
 

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -27,7 +27,6 @@ import {
 import { createDeferred, Deferred } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { EXTENSION_ROOT_DIR } from '../../constants';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { Commands, EditorContexts, Identifiers, Telemetry } from '../constants';
 import { IDataViewerFactory } from '../data-viewing/types';
@@ -41,6 +40,7 @@ import {
     SysInfoReason
 } from '../interactive-common/interactiveWindowTypes';
 import { KernelSelector } from '../jupyter/kernels/kernelSelector';
+import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import {
     ICell,
     ICodeCssGenerator,
@@ -52,7 +52,6 @@ import {
     IInteractiveWindowLoadable,
     IInteractiveWindowProvider,
     IJupyterDebugger,
-    IJupyterKernelSpec,
     IJupyterVariableDataProviderFactory,
     IJupyterVariables,
     INotebookExporter,
@@ -387,10 +386,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
         return undefined;
     }
 
-    protected async updateNotebookOptions(
-        _kernelSpec: IJupyterKernelSpec,
-        _interpreter: PythonEnvironment | undefined
-    ): Promise<void> {
+    protected async updateNotebookOptions(_kernelConnection: KernelConnectionMetadata): Promise<void> {
         // Do nothing as this data isn't stored in our options.
     }
 

--- a/src/client/datascience/ipywidgets/localWidgetScriptSourceProvider.ts
+++ b/src/client/datascience/ipywidgets/localWidgetScriptSourceProvider.ts
@@ -91,19 +91,19 @@ export class LocalWidgetScriptSourceProvider implements IWidgetScriptSourceProvi
         if (interpreter?.sysPrefix) {
             return interpreter?.sysPrefix;
         }
-        if (!interpreter?.path) {
-            return;
-        }
         if (!isPythonKernelConnection(kernelConnectionMetadata)) {
             return;
         }
-        const kernelPath = getKernelPathFromKernelConnection(kernelConnectionMetadata);
-        if (!kernelPath) {
+        const interpreterOrKernelPath =
+            interpreter?.path || getKernelPathFromKernelConnection(kernelConnectionMetadata);
+        if (!interpreterOrKernelPath) {
             return;
         }
         const interpreterInfo = await this.interpreterService
-            .getInterpreterDetails(kernelPath)
-            .catch(traceError.bind(`Failed to get interpreter details for Kernel/Interpreter ${interpreter.path}`));
+            .getInterpreterDetails(interpreterOrKernelPath)
+            .catch(
+                traceError.bind(`Failed to get interpreter details for Kernel/Interpreter ${interpreterOrKernelPath}`)
+            );
 
         if (interpreterInfo) {
             return interpreterInfo?.sysPrefix;

--- a/src/client/datascience/ipywidgets/localWidgetScriptSourceProvider.ts
+++ b/src/client/datascience/ipywidgets/localWidgetScriptSourceProvider.ts
@@ -100,7 +100,7 @@ export class LocalWidgetScriptSourceProvider implements IWidgetScriptSourceProvi
         }
     }
     private getInterpreter(): Partial<PythonEnvironment> | undefined {
-        const kernelConnection = this.notebook.getKernelSpec();
+        const kernelConnection = this.notebook.getKernelConnection();
         if (!kernelConnection) {
             return;
         }
@@ -112,7 +112,7 @@ export class LocalWidgetScriptSourceProvider implements IWidgetScriptSourceProvi
             ? kernelConnection.kernelSpec
             : undefined;
         const kernelPath = model?.path || kernelSpec?.path;
-        let interpreter = getInterpreterFromKernelConnectionMetadata(this.notebook.getKernelSpec());
+        let interpreter = getInterpreterFromKernelConnectionMetadata(this.notebook.getKernelConnection());
 
         // If we still do not have the interpreter, then check if we have the path to the kernel.
         if (!interpreter && kernelPath) {

--- a/src/client/datascience/jupyter/jupyterExecution.ts
+++ b/src/client/datascience/jupyter/jupyterExecution.ts
@@ -36,7 +36,7 @@ import {
 import { JupyterSelfCertsError } from './jupyterSelfCertsError';
 import { createRemoteConnectionInfo, expandWorkingDir } from './jupyterUtils';
 import { JupyterWaitForIdleError } from './jupyterWaitForIdleError';
-import { kernelConnectionMetadataHasKernelSpec } from './kernels/helpers';
+import { getDisplayNameOrNameOfKernelConnection, kernelConnectionMetadataHasKernelSpec } from './kernels/helpers';
 import { KernelSelector } from './kernels/kernelSelector';
 import { KernelConnectionMetadata } from './kernels/types';
 import { NotebookStarter } from './notebookStarter';
@@ -212,11 +212,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                     // Populate the launch info that we are starting our server with
                     const launchInfo: INotebookServerLaunchInfo = {
                         connectionInfo: connection!,
-                        interpreter: kernelConnectionMetadata?.interpreter,
-                        kernelSpec:
-                            kernelConnectionMetadata && kernelConnectionMetadataHasKernelSpec(kernelConnectionMetadata)
-                                ? kernelConnectionMetadata?.kernelSpec
-                                : kernelConnectionMetadata?.kernelModel,
+                        kernelConnectionMetadata,
                         workingDir: options ? options.workingDir : undefined,
                         uri: options ? options.uri : undefined,
                         purpose: options ? options.purpose : uuid()
@@ -240,7 +236,7 @@ export class JupyterExecutionBase implements IJupyterExecution {
                                 // Sometimes if a bad kernel is selected, starting a session can fail.
                                 // In such cases we need to let the user know about this and prompt them to select another kernel.
                                 const message = localize.DataScience.sessionStartFailedWithKernel().format(
-                                    launchInfo.kernelSpec?.display_name || launchInfo.kernelSpec?.name || '',
+                                    getDisplayNameOrNameOfKernelConnection(launchInfo.kernelConnectionMetadata),
                                     Commands.ViewJupyterOutput
                                 );
                                 const selectKernel = localize.DataScience.selectDifferentKernel();
@@ -257,11 +253,10 @@ export class JupyterExecutionBase implements IJupyterExecution {
                                         new StopWatch(),
                                         sessionManager,
                                         cancelToken,
-                                        launchInfo.kernelSpec?.display_name || launchInfo.kernelSpec?.name
+                                        getDisplayNameOrNameOfKernelConnection(launchInfo.kernelConnectionMetadata)
                                     );
                                     if (kernelInterpreter) {
-                                        launchInfo.interpreter = kernelInterpreter.interpreter;
-                                        launchInfo.kernelSpec = kernelInterpreter?.kernelSpec;
+                                        launchInfo.kernelConnectionMetadata = kernelInterpreter;
                                         continue;
                                     }
                                 }

--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -17,7 +17,7 @@ import { IConfigurationService } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { CellMatcher } from '../cellMatcher';
-import { CodeSnippits, Identifiers } from '../constants';
+import { CodeSnippets, Identifiers } from '../constants';
 import {
     CellState,
     ICell,
@@ -149,9 +149,9 @@ export class JupyterExporter implements INotebookExporter {
         const changeDirectory = await this.calculateDirectoryChange(file, cells);
 
         if (changeDirectory) {
-            const exportChangeDirectory = CodeSnippits.ChangeDirectory.join(os.EOL).format(
+            const exportChangeDirectory = CodeSnippets.ChangeDirectory.join(os.EOL).format(
                 localize.DataScience.exportChangeDirectoryComment(),
-                CodeSnippits.ChangeDirectoryCommentIdentifier,
+                CodeSnippets.ChangeDirectoryCommentIdentifier,
                 changeDirectory
             );
 
@@ -192,7 +192,7 @@ export class JupyterExporter implements INotebookExporter {
         // Make sure we don't already have a cell with a ChangeDirectory comment in it.
         let directoryChange: string | undefined;
         const haveChangeAlready = cells.find((c) =>
-            concatMultilineString(c.data.source).includes(CodeSnippits.ChangeDirectoryCommentIdentifier)
+            concatMultilineString(c.data.source).includes(CodeSnippets.ChangeDirectoryCommentIdentifier)
         );
         if (!haveChangeAlready) {
             const notebookFilePath = path.dirname(notebookFile);

--- a/src/client/datascience/jupyter/jupyterImporter.ts
+++ b/src/client/datascience/jupyter/jupyterImporter.ts
@@ -14,7 +14,7 @@ import { IPlatformService } from '../../common/platform/types';
 import { IConfigurationService, IDisposableRegistry } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
-import { CodeSnippits, Identifiers } from '../constants';
+import { CodeSnippets, Identifiers } from '../constants';
 import {
     IDataScienceFileSystem,
     IJupyterExecution,
@@ -98,13 +98,13 @@ export class JupyterImporter implements INotebookImporter {
     }
 
     private addIPythonImport = (pythonOutput: string): string => {
-        return CodeSnippits.ImportIPython.format(this.defaultCellMarker, pythonOutput);
+        return CodeSnippets.ImportIPython.format(this.defaultCellMarker, pythonOutput);
     };
 
     private addDirectoryChange = (pythonOutput: string, directoryChange: string): string => {
-        const newCode = CodeSnippits.ChangeDirectory.join(os.EOL).format(
+        const newCode = CodeSnippets.ChangeDirectory.join(os.EOL).format(
             localize.DataScience.importChangeDirectoryComment().format(this.defaultCellMarker),
-            CodeSnippits.ChangeDirectoryCommentIdentifier,
+            CodeSnippets.ChangeDirectoryCommentIdentifier,
             directoryChange
         );
         return newCode.concat(pythonOutput);
@@ -116,7 +116,7 @@ export class JupyterImporter implements INotebookImporter {
         try {
             // Make sure we don't already have an import/export comment in the file
             const contents = await this.fs.readFile(notebookFile);
-            const haveChangeAlready = contents.includes(CodeSnippits.ChangeDirectoryCommentIdentifier);
+            const haveChangeAlready = contents.includes(CodeSnippets.ChangeDirectoryCommentIdentifier);
 
             if (!haveChangeAlready) {
                 const notebookFilePath = path.dirname(notebookFile.fsPath);

--- a/src/client/datascience/jupyter/jupyterInvalidKernelError.ts
+++ b/src/client/datascience/jupyter/jupyterInvalidKernelError.ts
@@ -4,16 +4,16 @@
 import * as localize from '../../common/utils/localize';
 import { sendTelemetryEvent } from '../../telemetry';
 import { Telemetry } from '../constants';
-import { IJupyterKernelSpec } from '../types';
-import { LiveKernelModel } from './kernels/types';
+import { getDisplayNameOrNameOfKernelConnection } from './kernels/helpers';
+import { KernelConnectionMetadata } from './kernels/types';
 
 export class JupyterInvalidKernelError extends Error {
-    constructor(private _kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined) {
-        super(localize.DataScience.kernelInvalid().format(_kernelSpec?.display_name || _kernelSpec?.name || ''));
+    constructor(public readonly kernelConnectionMetadata: KernelConnectionMetadata | undefined) {
+        super(
+            localize.DataScience.kernelInvalid().format(
+                getDisplayNameOrNameOfKernelConnection(kernelConnectionMetadata)
+            )
+        );
         sendTelemetryEvent(Telemetry.KernelInvalid);
-    }
-
-    public get kernelSpec(): IJupyterKernelSpec | LiveKernelModel | undefined {
-        return this._kernelSpec;
     }
 }

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -621,14 +621,14 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     public getMatchingInterpreter(): PythonEnvironment | undefined {
-        return getInterpreterFromKernelConnectionMetadata(this.getKernelSpec()) as PythonEnvironment | undefined;
+        return getInterpreterFromKernelConnectionMetadata(this.getKernelConnection()) as PythonEnvironment | undefined;
     }
 
-    public getKernelSpec(): KernelConnectionMetadata | undefined {
+    public getKernelConnection(): KernelConnectionMetadata | undefined {
         return this._executionInfo.kernelConnectionMetadata;
     }
 
-    public async setKernelSpec(connectionMetadata: KernelConnectionMetadata, timeoutMS: number): Promise<void> {
+    public async setKernelConnection(connectionMetadata: KernelConnectionMetadata, timeoutMS: number): Promise<void> {
         // We need to start a new session with the new kernel spec
         if (this.session) {
             // Turn off setup

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -19,16 +19,14 @@ import { createDeferred, Deferred, waitForPromise } from '../../common/utils/asy
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
 import { StopWatch } from '../../common/utils/stopWatch';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { generateCells } from '../cellFactory';
 import { CellMatcher } from '../cellMatcher';
-import { CodeSnippits, Identifiers, Telemetry } from '../constants';
+import { CodeSnippets, Identifiers, Telemetry } from '../constants';
 import {
     CellState,
     ICell,
     IDataScienceFileSystem,
-    IJupyterKernelSpec,
     IJupyterSession,
     INotebook,
     INotebookCompletion,
@@ -38,13 +36,14 @@ import {
     KernelSocketInformation
 } from '../types';
 import { expandWorkingDir } from './jupyterUtils';
-import { LiveKernelModel } from './kernels/types';
+import { KernelConnectionMetadata } from './kernels/types';
 
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
 import { concatMultilineString, formatStreamText } from '../../../datascience-ui/common';
-import { PYTHON_LANGUAGE } from '../../common/constants';
 import { RefBool } from '../../common/refBool';
+import { PythonEnvironment } from '../../pythonEnvironments/info';
+import { getInterpreterFromKernelConnectionMetadata, isPythonKernelConnection } from './kernels/helpers';
 
 class CellSubscriber {
     public get startTime(): number {
@@ -157,13 +156,13 @@ export class JupyterNotebookBase implements INotebook {
     public get onDisposed(): Event<void> {
         return this.disposedEvent.event;
     }
-    public get onKernelChanged(): Event<IJupyterKernelSpec | LiveKernelModel> {
+    public get onKernelChanged(): Event<KernelConnectionMetadata> {
         return this.kernelChanged.event;
     }
     public get disposed() {
         return this._disposed;
     }
-    private kernelChanged = new EventEmitter<IJupyterKernelSpec | LiveKernelModel>();
+    private kernelChanged = new EventEmitter<KernelConnectionMetadata>();
     public get onKernelRestarted(): Event<void> {
         return this.kernelRestarted.event;
     }
@@ -285,7 +284,7 @@ export class JupyterNotebookBase implements INotebook {
             } else {
                 this.initializedMatplotlib = false;
                 const configInit =
-                    !settings || settings.enablePlotViewer ? CodeSnippits.ConfigSvg : CodeSnippits.ConfigPng;
+                    !settings || settings.enablePlotViewer ? CodeSnippets.ConfigSvg : CodeSnippets.ConfigPng;
                 traceInfo(`Initialize config for plots for ${this.identity.toString()}`);
                 await this.executeSilently(configInit, cancelToken);
             }
@@ -622,46 +621,34 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     public getMatchingInterpreter(): PythonEnvironment | undefined {
-        return (
-            this._executionInfo.interpreter ||
-            (this._executionInfo.kernelSpec?.metadata?.interpreter as PythonEnvironment)
-        );
+        return getInterpreterFromKernelConnectionMetadata(this.getKernelSpec()) as PythonEnvironment | undefined;
     }
 
-    public getKernelSpec(): IJupyterKernelSpec | LiveKernelModel | undefined {
-        return this._executionInfo.kernelSpec;
+    public getKernelSpec(): KernelConnectionMetadata | undefined {
+        return this._executionInfo.kernelConnectionMetadata;
     }
 
-    public async setKernelSpec(
-        spec: IJupyterKernelSpec | LiveKernelModel,
-        timeoutMS: number,
-        interpreter: PythonEnvironment | undefined
-    ): Promise<void> {
+    public async setKernelSpec(connectionMetadata: KernelConnectionMetadata, timeoutMS: number): Promise<void> {
         // We need to start a new session with the new kernel spec
         if (this.session) {
             // Turn off setup
             this.ranInitialSetup = false;
 
             // Change the kernel on the session
-            await this.session.changeKernel(spec, timeoutMS, interpreter);
+            await this.session.changeKernel(connectionMetadata, timeoutMS);
 
             // Change our own kernel spec
             // Only after session was successfully created.
-            this._executionInfo.kernelSpec = spec;
+            this._executionInfo.kernelConnectionMetadata = connectionMetadata;
 
             // Rerun our initial setup
             await this.initialize();
         } else {
             // Change our own kernel spec
-            this._executionInfo.kernelSpec = spec;
+            this._executionInfo.kernelConnectionMetadata = connectionMetadata;
         }
 
-        this.kernelChanged.fire(spec);
-
-        // If our new kernelspec has an interpreter, set that as our interpreter too
-        if (interpreter) {
-            this._executionInfo.interpreter = interpreter;
-        }
+        this.kernelChanged.fire(connectionMetadata);
     }
 
     public getLoggers(): INotebookExecutionLogger[] {
@@ -736,8 +723,8 @@ export class JupyterNotebookBase implements INotebook {
         if (settings && settings.themeMatplotlibPlots) {
             const matplobInit =
                 !settings || settings.enablePlotViewer
-                    ? CodeSnippits.MatplotLibInitSvg
-                    : CodeSnippits.MatplotLibInitPng;
+                    ? CodeSnippets.MatplotLibInitSvg
+                    : CodeSnippets.MatplotLibInitPng;
 
             traceInfo(`Initialize matplotlib for ${this.identity.toString()}`);
             // Force matplotlib to inline and save the default style. We'll use this later if we
@@ -951,10 +938,10 @@ export class JupyterNotebookBase implements INotebook {
         if (
             this._executionInfo &&
             this._executionInfo.connectionInfo.localLaunch &&
-            this._executionInfo.kernelSpec?.language === PYTHON_LANGUAGE &&
+            isPythonKernelConnection(this._executionInfo.kernelConnectionMetadata) &&
             (await this.fs.localDirectoryExists(directory))
         ) {
-            await this.executeSilently(CodeSnippits.UpdateCWDAndPath.format(directory));
+            await this.executeSilently(CodeSnippets.UpdateCWDAndPath.format(directory));
         }
     };
 

--- a/src/client/datascience/jupyter/jupyterServer.ts
+++ b/src/client/datascience/jupyter/jupyterServer.ts
@@ -30,6 +30,7 @@ import {
     INotebookServer,
     INotebookServerLaunchInfo
 } from '../types';
+import { getDisplayNameOrNameOfKernelConnection } from './kernels/helpers';
 
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services
@@ -59,7 +60,10 @@ export class JupyterServerBase implements INotebookServer {
 
     public async connect(launchInfo: INotebookServerLaunchInfo, cancelToken?: CancellationToken): Promise<void> {
         traceInfo(
-            `Connecting server ${this.id} kernelSpec ${launchInfo.kernelSpec ? launchInfo.kernelSpec.name : 'unknown'}`
+            `Connecting server ${this.id} kernelSpec ${getDisplayNameOrNameOfKernelConnection(
+                launchInfo.kernelConnectionMetadata,
+                'unknown'
+            )}`
         );
 
         // Save our launch info
@@ -91,7 +95,7 @@ export class JupyterServerBase implements INotebookServer {
         // is running and connectable.
         let session: IJupyterSession | undefined;
         session = await this.sessionManager.startNew(
-            launchInfo.kernelSpec,
+            launchInfo.kernelConnectionMetadata,
             launchInfo.connectionInfo.rootDirectory,
             cancelToken
         );
@@ -261,7 +265,7 @@ export class JupyterServerBase implements INotebookServer {
 
     private async destroyKernelSpec() {
         if (this.launchInfo) {
-            this.launchInfo.kernelSpec = undefined;
+            this.launchInfo.kernelConnectionMetadata = undefined;
         }
     }
 

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -39,7 +39,7 @@ export class JupyterSession extends BaseJupyterSession {
         readonly workingDirectory: string
     ) {
         super(restartSessionUsed, workingDirectory);
-        this.kernelSpec = kernelSpec;
+        this.kernelConnectionMetadata = kernelSpec;
     }
 
     @reportAction(ReportableAction.JupyterSessionWaitForIdleSession)
@@ -55,7 +55,7 @@ export class JupyterSession extends BaseJupyterSession {
         }
 
         // Start a new session
-        this.setSession(await this.createNewKernelSession(this.kernelSpec, timeoutMs, cancelToken));
+        this.setSession(await this.createNewKernelSession(this.kernelConnectionMetadata, timeoutMs, cancelToken));
 
         // Listen for session status changes
         this.session?.statusChanged.connect(this.statusHandler); // NOSONAR
@@ -141,7 +141,7 @@ export class JupyterSession extends BaseJupyterSession {
 
     protected startRestartSession() {
         if (!this.restartSessionPromise && this.session && this.contentsManager) {
-            this.restartSessionPromise = this.createRestartSession(this.kernelSpec, this.session);
+            this.restartSessionPromise = this.createRestartSession(this.kernelConnectionMetadata, this.session);
         }
     }
 

--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -24,6 +24,7 @@ import { ReportableAction } from '../progress/types';
 import { IJupyterConnection, ISessionWithSocket } from '../types';
 import { JupyterInvalidKernelError } from './jupyterInvalidKernelError';
 import { JupyterWebSockets } from './jupyterWebSocket';
+import { getNameOfKernelConnection } from './kernels/helpers';
 import { KernelConnectionMetadata } from './kernels/types';
 
 export class JupyterSession extends BaseJupyterSession {
@@ -171,16 +172,9 @@ export class JupyterSession extends BaseJupyterSession {
         );
 
         // Create our session options using this temporary notebook and our connection info
-        let nameToUse: string | undefined;
-        if (kernelConnection) {
-            nameToUse =
-                kernelConnection.kind === 'connectToLiveKernel'
-                    ? kernelConnection.kernelModel.name
-                    : kernelConnection.kernelSpec?.name;
-        }
         const options: Session.IOptions = {
             path: backingFile.path,
-            kernelName: nameToUse || '',
+            kernelName: getNameOfKernelConnection(kernelConnection) || '',
             name: uuid(), // This is crucial to distinguish this session from any other.
             serverSettings: serverSettings
         };

--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -26,7 +26,7 @@ import { JupyterSession } from './jupyterSession';
 import { createJupyterWebSocket } from './jupyterWebSocket';
 import { createDefaultKernelSpec } from './kernels/helpers';
 import { JupyterKernelSpec } from './kernels/jupyterKernelSpec';
-import { LiveKernelModel } from './kernels/types';
+import { KernelConnectionMetadata } from './kernels/types';
 
 // Key for our insecure connection global state
 const GlobalStateUserAllowsInsecureConnections = 'DataScienceAllowInsecureConnections';
@@ -165,7 +165,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
     }
 
     public async startNew(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
+        kernelConnection: KernelConnectionMetadata | undefined,
         workingDirectory: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession> {
@@ -176,7 +176,7 @@ export class JupyterSessionManager implements IJupyterSessionManager {
         const session = new JupyterSession(
             this.connInfo,
             this.serverSettings,
-            kernelSpec,
+            kernelConnection,
             this.sessionManager,
             this.contentsManager,
             this.outputChannel,

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -252,7 +252,7 @@ export class KernelVariables implements IJupyterVariables {
 
     private getParser(notebook: INotebook) {
         // Figure out kernel language
-        const language = getKernelConnectionLanguage(notebook?.getKernelSpec()) || PYTHON_LANGUAGE;
+        const language = getKernelConnectionLanguage(notebook?.getKernelConnection()) || PYTHON_LANGUAGE;
 
         // We may have cached this information
         let result = this.languageToQueryMap.get(language);
@@ -446,7 +446,7 @@ export class KernelVariables implements IJupyterVariables {
             result.type &&
             result.count &&
             !result.shape &&
-            isPythonKernelConnection(notebook.getKernelSpec()) &&
+            isPythonKernelConnection(notebook.getKernelConnection()) &&
             result.supportsDataExplorer &&
             result.type !== 'list' // List count is good enough
         ) {

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -21,6 +21,7 @@ import {
     INotebook
 } from '../types';
 import { JupyterDataRateLimitError } from './jupyterDataRateLimitError';
+import { getKernelConnectionLanguage, isPythonKernelConnection } from './kernels/helpers';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
 
@@ -251,11 +252,7 @@ export class KernelVariables implements IJupyterVariables {
 
     private getParser(notebook: INotebook) {
         // Figure out kernel language
-        let language = PYTHON_LANGUAGE;
-        if (notebook) {
-            const kernel = notebook.getKernelSpec();
-            language = kernel && kernel.language ? kernel.language : PYTHON_LANGUAGE;
-        }
+        const language = getKernelConnectionLanguage(notebook?.getKernelSpec()) || PYTHON_LANGUAGE;
 
         // We may have cached this information
         let result = this.languageToQueryMap.get(language);
@@ -449,7 +446,7 @@ export class KernelVariables implements IJupyterVariables {
             result.type &&
             result.count &&
             !result.shape &&
-            notebook.getKernelSpec()?.language === 'python' &&
+            isPythonKernelConnection(notebook.getKernelSpec()) &&
             result.supportsDataExplorer &&
             result.type !== 'list' // List count is good enough
         ) {

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -3,6 +3,7 @@
 'use strict';
 
 import type { Kernel } from '@jupyterlab/services';
+import * as fastDeepEqual from 'fast-deep-equal';
 import { IJupyterKernelSpec } from '../../types';
 import { JupyterKernelSpec } from './jupyterKernelSpec';
 // tslint:disable-next-line: no-var-requires no-require-imports
@@ -131,6 +132,37 @@ export function createDefaultKernelSpec(displayName?: string): IJupyterKernelSpe
     return new JupyterKernelSpec(defaultSpec);
 }
 
+export function areKernelConnectionsEqual(
+    connection1?: KernelConnectionMetadata,
+    connection2?: KernelConnectionMetadata
+) {
+    if (!connection1 && !connection2) {
+        return true;
+    }
+    if (!connection1 && connection2) {
+        return false;
+    }
+    if (connection1 && !connection2) {
+        return false;
+    }
+    if (connection1?.kind !== connection2?.kind) {
+        return false;
+    }
+    if (connection1?.interpreter?.path !== connection2?.interpreter?.path) {
+        return false;
+    }
+    if (connection1?.kind === 'connectToLiveKernel' && connection2?.kind === 'connectToLiveKernel') {
+        return fastDeepEqual(connection1.kernelModel, connection2.kernelModel);
+    } else if (
+        connection1 &&
+        connection1.kind !== 'connectToLiveKernel' &&
+        connection2 &&
+        connection2.kind !== 'connectToLiveKernel'
+    ) {
+        return fastDeepEqual(connection1?.kernelSpec || {}, connection2?.kernelSpec || {});
+    }
+    return false;
+}
 // Check if a name is a default python kernel name and pull the version
 export function detectDefaultKernelName(name: string) {
     const regEx = NamedRegexp('python\\s*(?<version>(\\d+))', 'g');

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -77,6 +77,16 @@ export function getNameOfKernelConnection(
         : kernelConnection.kernelSpec?.name;
 }
 
+export function getKernelPathFromKernelConnection(kernelConnection?: KernelConnectionMetadata): string | undefined {
+    if (!kernelConnection) {
+        return;
+    }
+    const model = kernelConnectionMetadataHasKernelModel(kernelConnection) ? kernelConnection.kernelModel : undefined;
+    const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+        ? kernelConnection.kernelSpec
+        : undefined;
+    return model?.path || kernelSpec?.path;
+}
 export function getInterpreterFromKernelConnectionMetadata(
     kernelConnection?: KernelConnectionMetadata
 ): Partial<PythonEnvironment> | undefined {

--- a/src/client/datascience/jupyter/kernels/helpers.ts
+++ b/src/client/datascience/jupyter/kernels/helpers.ts
@@ -10,6 +10,8 @@ const NamedRegexp = require('named-js-regexp') as typeof import('named-js-regexp
 
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
+import { PYTHON_LANGUAGE } from '../../../common/constants';
+import { PythonEnvironment } from '../../../pythonEnvironments/info';
 import {
     DefaultKernelConnectionMetadata,
     KernelConnectionMetadata,
@@ -43,6 +45,74 @@ export function kernelConnectionMetadataHasKernelModel(
     connectionMetadata: KernelConnectionMetadata
 ): connectionMetadata is LiveKernelConnectionMetadata {
     return connectionMetadata.kind === 'connectToLiveKernel';
+}
+export function getDisplayNameOrNameOfKernelConnection(
+    kernelConnection: KernelConnectionMetadata | undefined,
+    defaultValue: string = ''
+) {
+    if (!kernelConnection) {
+        return defaultValue;
+    }
+    const displayName =
+        kernelConnection.kind === 'connectToLiveKernel'
+            ? kernelConnection.kernelModel.display_name
+            : kernelConnection.kernelSpec?.display_name;
+    const name =
+        kernelConnection.kind === 'connectToLiveKernel'
+            ? kernelConnection.kernelModel.name
+            : kernelConnection.kernelSpec?.name;
+    return displayName || name || defaultValue;
+}
+
+export function getNameOfKernelConnection(
+    kernelConnection: KernelConnectionMetadata | undefined,
+    defaultValue: string = ''
+) {
+    if (!kernelConnection) {
+        return defaultValue;
+    }
+    return kernelConnection.kind === 'connectToLiveKernel'
+        ? kernelConnection.kernelModel.name
+        : kernelConnection.kernelSpec?.name;
+}
+
+export function getInterpreterFromKernelConnectionMetadata(
+    kernelConnection?: KernelConnectionMetadata
+): Partial<PythonEnvironment> | undefined {
+    if (!kernelConnection) {
+        return;
+    }
+    if (kernelConnection.interpreter) {
+        return kernelConnection.interpreter;
+    }
+    const model = kernelConnectionMetadataHasKernelModel(kernelConnection) ? kernelConnection.kernelModel : undefined;
+    if (model?.metadata?.interpreter) {
+        return model.metadata.interpreter;
+    }
+    const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+        ? kernelConnection.kernelSpec
+        : undefined;
+    return kernelSpec?.metadata?.interpreter;
+}
+export function isPythonKernelConnection(kernelConnection?: KernelConnectionMetadata): boolean {
+    if (!kernelConnection) {
+        return false;
+    }
+    const model = kernelConnectionMetadataHasKernelModel(kernelConnection) ? kernelConnection.kernelModel : undefined;
+    const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+        ? kernelConnection.kernelSpec
+        : undefined;
+    return model?.language === PYTHON_LANGUAGE || kernelSpec?.language === PYTHON_LANGUAGE;
+}
+export function getKernelConnectionLanguage(kernelConnection?: KernelConnectionMetadata): string | undefined {
+    if (!kernelConnection) {
+        return;
+    }
+    const model = kernelConnectionMetadataHasKernelModel(kernelConnection) ? kernelConnection.kernelModel : undefined;
+    const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernelConnection)
+        ? kernelConnection.kernelSpec
+        : undefined;
+    return model?.language || kernelSpec?.language;
 }
 // Create a default kernelspec with the given display name
 export function createDefaultKernelSpec(displayName?: string): IJupyterKernelSpec {

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -42,9 +42,6 @@ export class Kernel implements IKernel {
     get connection(): INotebookProviderConnection | undefined {
         return this.notebook?.connection;
     }
-    get kernelConnection(): KernelConnectionMetadata | undefined {
-        return this.notebook ? this.notebook.getKernelConnection() : this.metadata;
-    }
     get onStatusChanged(): Event<ServerStatus> {
         return this._onStatusChanged.event;
     }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -42,8 +42,8 @@ export class Kernel implements IKernel {
     get connection(): INotebookProviderConnection | undefined {
         return this.notebook?.connection;
     }
-    get kernelSpec(): KernelConnectionMetadata | undefined {
-        return this.notebook ? this.notebook.getKernelSpec() : this.metadata;
+    get kernelConnection(): KernelConnectionMetadata | undefined {
+        return this.notebook ? this.notebook.getKernelConnection() : this.metadata;
     }
     get onStatusChanged(): Event<ServerStatus> {
         return this._onStatusChanged.event;

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -28,7 +28,6 @@ import { getDefaultNotebookContent, updateNotebookMetadata } from '../../noteboo
 import {
     ICell,
     IDataScienceErrorHandler,
-    IJupyterKernelSpec,
     INotebook,
     INotebookEditorProvider,
     INotebookProvider,
@@ -36,27 +35,15 @@ import {
     InterruptResult,
     KernelSocketInformation
 } from '../../types';
-import { kernelConnectionMetadataHasKernelModel } from './helpers';
 import { KernelExecution } from './kernelExecution';
-import type {
-    IKernel,
-    IKernelProvider,
-    IKernelSelectionUsage,
-    KernelConnectionMetadata,
-    LiveKernelModel
-} from './types';
+import type { IKernel, IKernelProvider, IKernelSelectionUsage, KernelConnectionMetadata } from './types';
 
 export class Kernel implements IKernel {
     get connection(): INotebookProviderConnection | undefined {
         return this.notebook?.connection;
     }
-    get kernelSpec(): IJupyterKernelSpec | LiveKernelModel | undefined {
-        if (this.notebook) {
-            return this.notebook.getKernelSpec();
-        }
-        return kernelConnectionMetadataHasKernelModel(this.metadata)
-            ? this.metadata.kernelModel
-            : this.metadata.kernelSpec;
+    get kernelSpec(): KernelConnectionMetadata | undefined {
+        return this.notebook ? this.notebook.getKernelSpec() : this.metadata;
     }
     get onStatusChanged(): Event<ServerStatus> {
         return this._onStatusChanged.event;
@@ -154,11 +141,7 @@ export class Kernel implements IKernel {
             const metadata = ((getDefaultNotebookContent().metadata || {}) as unknown) as nbformat.INotebookMetadata;
             // tslint:disable-next-line: no-suspicious-comment
             // TODO: Just pass the `this.metadata` into the func.
-            updateNotebookMetadata(
-                metadata,
-                this.metadata.interpreter,
-                this.metadata.kind === 'connectToLiveKernel' ? this.metadata.kernelModel : this.metadata.kernelSpec
-            );
+            updateNotebookMetadata(metadata, this.metadata);
 
             this._notebookPromise = this.notebookProvider.getOrCreateNotebook({
                 identity: this.uri,

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -403,18 +403,18 @@ export class KernelSelector implements IKernelSelectionUsage {
         type: 'raw' | 'jupyter',
         currentKernelDisplayName: string | undefined
     ): Promise<KernelConnectionMetadata | undefined> {
-        let kernel: KernelConnectionMetadata | undefined;
+        let kernelConnection: KernelConnectionMetadata | undefined;
         const settings = this.configService.getSettings(resource);
         const isLocalConnection =
             connection?.localLaunch ??
             settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
 
         if (isLocalConnection) {
-            kernel = await this.selectLocalJupyterKernel(resource, connection?.type || type, currentKernelDisplayName);
+            kernelConnection = await this.selectLocalJupyterKernel(resource, connection?.type || type, currentKernelDisplayName);
         } else if (connection && connection.type === 'jupyter') {
-            kernel = await this.selectRemoteJupyterKernel(resource, connection, currentKernelDisplayName);
+            kernelConnection = await this.selectRemoteJupyterKernel(resource, connection, currentKernelDisplayName);
         }
-        return kernel;
+        return kernelConnection;
     }
 
     private async selectLocalJupyterKernel(

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -3,6 +3,8 @@
 import type { nbformat } from '@jupyterlab/coreutils';
 import type { Kernel } from '@jupyterlab/services';
 import { inject, injectable } from 'inversify';
+// tslint:disable-next-line: no-require-imports
+import cloneDeep = require('lodash/cloneDeep');
 import { CancellationToken } from 'vscode-jsonrpc';
 import { IApplicationShell } from '../../../common/application/types';
 import '../../../common/extensions';
@@ -39,8 +41,6 @@ import {
     LiveKernelConnectionMetadata,
     PythonKernelConnectionMetadata
 } from './types';
-// tslint:disable-next-line: no-require-imports
-import cloneDeep = require('lodash/cloneDeep');
 
 /**
  * All KernelConnections returned (as return values of methods) by the KernelSelector can be used in a number of ways.

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -410,7 +410,11 @@ export class KernelSelector implements IKernelSelectionUsage {
             settings.datascience.jupyterServerURI.toLowerCase() === Settings.JupyterServerLocalLaunch;
 
         if (isLocalConnection) {
-            kernelConnection = await this.selectLocalJupyterKernel(resource, connection?.type || type, currentKernelDisplayName);
+            kernelConnection = await this.selectLocalJupyterKernel(
+                resource,
+                connection?.type || type,
+                currentKernelDisplayName
+            );
         } else if (connection && connection.type === 'jupyter') {
             kernelConnection = await this.selectRemoteJupyterKernel(resource, connection, currentKernelDisplayName);
         }

--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -46,10 +46,10 @@ import {
 type PromiseFunctionReturningKernelConnection = (...any: any[]) => Promise<any | undefined>;
 
 /**
- * All KernelConnections returned by the KernelSelector can be used in a number of ways and can get updated.
- * We need to ensure changes downstream do not change the values we stored internally in this class.
- * E.g. when returning a kernel connection with a kernel spec, its possible some metadata or the interpreter will get updated later on.
- * Such changes should not result in changes to the data returned from this class.
+ * All KernelConnections returned (as return values of methods) by the KernelSelector can be used in a number of ways.
+ * E.g. some part of the code update the `interpreter` property in the `KernelConnectionMetadata` object.
+ * We need to ensure such changes (i.e. updates to the `KernelConnectionMetadata`) downstream do not change the original `KernelConnectionMetadata`.
+ * Hence always clone the `KernelConnectionMetadata` returned by the `kernelSelector`.
  */
 function cloneReturnedKernelConnection() {
     return function (

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -70,7 +70,9 @@ export class KernelSwitcher {
     }
     private async switchToKernel(notebook: INotebook, kernelConnection: KernelConnectionMetadata): Promise<void> {
         if (notebook.connection?.type === 'raw' && kernelConnection.interpreter) {
-            const response = await this.kernelDependencyService.installMissingDependencies(kernelConnection.interpreter);
+            const response = await this.kernelDependencyService.installMissingDependencies(
+                kernelConnection.interpreter
+            );
             if (response === KernelInterpreterDependencyResponse.cancel) {
                 return;
             }

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -68,24 +68,24 @@ export class KernelSwitcher {
             }
         }
     }
-    private async switchToKernel(notebook: INotebook, kernel: KernelConnectionMetadata): Promise<void> {
-        if (notebook.connection?.type === 'raw' && kernel.interpreter) {
-            const response = await this.kernelDependencyService.installMissingDependencies(kernel.interpreter);
+    private async switchToKernel(notebook: INotebook, kernelConnection: KernelConnectionMetadata): Promise<void> {
+        if (notebook.connection?.type === 'raw' && kernelConnection.interpreter) {
+            const response = await this.kernelDependencyService.installMissingDependencies(kernelConnection.interpreter);
             if (response === KernelInterpreterDependencyResponse.cancel) {
                 return;
             }
         }
 
-        const switchKernel = async (newKernel: KernelConnectionMetadata) => {
+        const switchKernel = async (newKernelConnection: KernelConnectionMetadata) => {
             // Change the kernel. A status update should fire that changes our display
-            await notebook.setKernelSpec(
-                newKernel,
+            await notebook.setKernelConnection(
+                newKernelConnection,
                 this.configService.getSettings(notebook.resource).datascience.jupyterLaunchTimeout
             );
         };
 
-        const kernelModel = kernelConnectionMetadataHasKernelModel(kernel) ? kernel : undefined;
-        const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernel) ? kernel : undefined;
+        const kernelModel = kernelConnectionMetadataHasKernelModel(kernelConnection) ? kernelConnection : undefined;
+        const kernelSpec = kernelConnectionMetadataHasKernelSpec(kernelConnection) ? kernelConnection : undefined;
         const kernelName = kernelSpec?.kernelSpec?.name || kernelModel?.kernelModel?.name;
         // One of them is bound to be non-empty.
         const displayName = kernelModel?.kernelModel?.display_name || kernelName || '';
@@ -94,6 +94,6 @@ export class KernelSwitcher {
             cancellable: false,
             title: DataScience.switchingKernelProgress().format(displayName)
         };
-        await this.appShell.withProgress(options, async (_, __) => switchKernel(kernel!));
+        await this.appShell.withProgress(options, async (_, __) => switchKernel(kernelConnection!));
     }
 }

--- a/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSwitcher.ts
@@ -57,7 +57,7 @@ export class KernelSwitcher {
                     const potential = await this.selector.askForLocalKernel(
                         notebook.resource,
                         notebook.connection?.type || 'noConnection',
-                        kernelConnectionMetadataHasKernelModel(kernel) ? kernel.kernelModel : kernel.kernelSpec
+                        kernel
                     );
                     if (potential && Object.keys(potential).length > 0) {
                         kernel = potential;
@@ -79,9 +79,8 @@ export class KernelSwitcher {
         const switchKernel = async (newKernel: KernelConnectionMetadata) => {
             // Change the kernel. A status update should fire that changes our display
             await notebook.setKernelSpec(
-                newKernel.kind === 'connectToLiveKernel' ? newKernel.kernelModel : newKernel.kernelSpec!,
-                this.configService.getSettings(notebook.resource).datascience.jupyterLaunchTimeout,
-                newKernel.interpreter
+                newKernel,
+                this.configService.getSettings(notebook.resource).datascience.jupyterLaunchTimeout
             );
         };
 

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -106,7 +106,6 @@ export interface IKernelSelectionUsage {
 
 export interface IKernel extends IAsyncDisposable {
     readonly uri: Uri;
-    readonly kernelConnection?: KernelConnectionMetadata;
     readonly metadata: Readonly<KernelConnectionMetadata>;
     readonly onStatusChanged: Event<ServerStatus>;
     readonly onDisposed: Event<void>;

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -106,7 +106,7 @@ export interface IKernelSelectionUsage {
 
 export interface IKernel extends IAsyncDisposable {
     readonly uri: Uri;
-    readonly kernelSpec?: KernelConnectionMetadata;
+    readonly kernelConnection?: KernelConnectionMetadata;
     readonly metadata: Readonly<KernelConnectionMetadata>;
     readonly onStatusChanged: Event<ServerStatus>;
     readonly onDisposed: Event<void>;

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -106,7 +106,7 @@ export interface IKernelSelectionUsage {
 
 export interface IKernel extends IAsyncDisposable {
     readonly uri: Uri;
-    readonly kernelSpec?: IJupyterKernelSpec | LiveKernelModel;
+    readonly kernelSpec?: KernelConnectionMetadata;
     readonly metadata: Readonly<KernelConnectionMetadata>;
     readonly onStatusChanged: Event<ServerStatus>;
     readonly onDisposed: Event<void>;

--- a/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
@@ -242,11 +242,11 @@ export class GuestJupyterNotebook
         return;
     }
 
-    public getKernelSpec(): KernelConnectionMetadata | undefined {
+    public getKernelConnection(): KernelConnectionMetadata | undefined {
         return;
     }
 
-    public setKernelSpec(_spec: KernelConnectionMetadata, _timeout: number): Promise<void> {
+    public setKernelConnection(_spec: KernelConnectionMetadata, _timeout: number): Promise<void> {
         return Promise.resolve();
     }
     public getLoggers(): INotebookExecutionLogger[] {

--- a/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
@@ -19,7 +19,6 @@ import { PythonEnvironment } from '../../../pythonEnvironments/info';
 import { LiveShare, LiveShareCommands } from '../../constants';
 import {
     ICell,
-    IJupyterKernelSpec,
     INotebook,
     INotebookCompletion,
     INotebookExecutionInfo,
@@ -28,7 +27,7 @@ import {
     InterruptResult,
     KernelSocketInformation
 } from '../../types';
-import { LiveKernelModel } from '../kernels/types';
+import { KernelConnectionMetadata } from '../kernels/types';
 import { LiveShareParticipantDefault, LiveShareParticipantGuest } from './liveShareParticipantMixin';
 import { ResponseQueue } from './responseQueue';
 import { IExecuteObservableResponse, ILiveShareParticipant, IServerResponse } from './types';
@@ -68,9 +67,7 @@ export class GuestJupyterNotebook
         return ServerStatus.Idle;
     }
 
-    public onKernelChanged: Event<IJupyterKernelSpec | LiveKernelModel> = new EventEmitter<
-        IJupyterKernelSpec | LiveKernelModel
-    >().event;
+    public onKernelChanged = new EventEmitter<KernelConnectionMetadata>().event;
     public onKernelRestarted = new EventEmitter<void>().event;
     public onKernelInterrupted = new EventEmitter<void>().event;
     public onDisposed = new EventEmitter<void>().event;
@@ -245,11 +242,11 @@ export class GuestJupyterNotebook
         return;
     }
 
-    public getKernelSpec(): IJupyterKernelSpec | LiveKernelModel | undefined {
+    public getKernelSpec(): KernelConnectionMetadata | undefined {
         return;
     }
 
-    public setKernelSpec(_spec: IJupyterKernelSpec | LiveKernelModel, _timeout: number): Promise<void> {
+    public setKernelSpec(_spec: KernelConnectionMetadata, _timeout: number): Promise<void> {
         return Promise.resolve();
     }
     public getLoggers(): INotebookExecutionLogger[] {

--- a/src/client/datascience/jupyter/liveshare/guestJupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterSessionManager.ts
@@ -13,7 +13,7 @@ import {
     IJupyterSession,
     IJupyterSessionManager
 } from '../../types';
-import { LiveKernelModel } from '../kernels/types';
+import { KernelConnectionMetadata } from '../kernels/types';
 
 export class GuestJupyterSessionManager implements IJupyterSessionManager {
     private connInfo: IJupyterConnection | undefined;
@@ -33,11 +33,11 @@ export class GuestJupyterSessionManager implements IJupyterSessionManager {
         return this.restartSessionUsedEvent.event;
     }
     public startNew(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
+        kernelConnection: KernelConnectionMetadata | undefined,
         workingDirectory: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession> {
-        return this.realSessionManager.startNew(kernelSpec, workingDirectory, cancelToken);
+        return this.realSessionManager.startNew(kernelConnection, workingDirectory, cancelToken);
     }
 
     public async getKernelSpecs(): Promise<IJupyterKernelSpec[]> {

--- a/src/client/datascience/jupyter/oldJupyterVariables.ts
+++ b/src/client/datascience/jupyter/oldJupyterVariables.ts
@@ -238,7 +238,7 @@ export class OldJupyterVariables implements IJupyterVariables {
 
     private getParser(notebook: INotebook) {
         // Figure out kernel language
-        const language = getKernelConnectionLanguage(notebook?.getKernelSpec()) || PYTHON_LANGUAGE;
+        const language = getKernelConnectionLanguage(notebook?.getKernelConnection()) || PYTHON_LANGUAGE;
 
         // We may have cached this information
         let result = this.languageToQueryMap.get(language);
@@ -431,7 +431,7 @@ export class OldJupyterVariables implements IJupyterVariables {
             result.type &&
             result.count &&
             !result.shape &&
-            isPythonKernelConnection(notebook.getKernelSpec()) &&
+            isPythonKernelConnection(notebook.getKernelConnection()) &&
             result.supportsDataExplorer &&
             result.type !== 'list' // List count is good enough
         ) {

--- a/src/client/datascience/jupyter/oldJupyterVariables.ts
+++ b/src/client/datascience/jupyter/oldJupyterVariables.ts
@@ -25,6 +25,7 @@ import {
     INotebook
 } from '../types';
 import { JupyterDataRateLimitError } from './jupyterDataRateLimitError';
+import { getKernelConnectionLanguage, isPythonKernelConnection } from './kernels/helpers';
 
 // tslint:disable-next-line: no-var-requires no-require-imports
 
@@ -237,11 +238,7 @@ export class OldJupyterVariables implements IJupyterVariables {
 
     private getParser(notebook: INotebook) {
         // Figure out kernel language
-        let language = PYTHON_LANGUAGE;
-        if (notebook) {
-            const kernel = notebook.getKernelSpec();
-            language = kernel && kernel.language ? kernel.language : PYTHON_LANGUAGE;
-        }
+        const language = getKernelConnectionLanguage(notebook?.getKernelSpec()) || PYTHON_LANGUAGE;
 
         // We may have cached this information
         let result = this.languageToQueryMap.get(language);
@@ -434,7 +431,7 @@ export class OldJupyterVariables implements IJupyterVariables {
             result.type &&
             result.count &&
             !result.shape &&
-            notebook.getKernelSpec()?.language === 'python' &&
+            isPythonKernelConnection(notebook.getKernelSpec()) &&
             result.supportsDataExplorer &&
             result.type !== 'list' // List count is good enough
         ) {

--- a/src/client/datascience/kernel-launcher/kernelLauncher.ts
+++ b/src/client/datascience/kernel-launcher/kernelLauncher.ts
@@ -6,13 +6,12 @@ import { inject, injectable } from 'inversify';
 import * as portfinder from 'portfinder';
 import { promisify } from 'util';
 import * as uuid from 'uuid/v4';
-
 import { IProcessServiceFactory } from '../../common/process/types';
 import { Resource } from '../../common/types';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry } from '../../telemetry';
 import { Telemetry } from '../constants';
-import { IDataScienceFileSystem, IJupyterKernelSpec } from '../types';
+import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
+import { IDataScienceFileSystem } from '../types';
 import { KernelDaemonPool } from './kernelDaemonPool';
 import { KernelProcess } from './kernelProcess';
 import { IKernelConnection, IKernelLauncher, IKernelProcess } from './types';
@@ -33,20 +32,18 @@ export class KernelLauncher implements IKernelLauncher {
 
     @captureTelemetry(Telemetry.KernelLauncherPerf)
     public async launch(
-        kernelSpec: IJupyterKernelSpec,
+        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         resource: Resource,
-        workingDirectory: string,
-        interpreter?: PythonEnvironment
+        workingDirectory: string
     ): Promise<IKernelProcess> {
         const connection = await this.getKernelConnection();
         const kernelProcess = new KernelProcess(
             this.processExecutionFactory,
             this.daemonPool,
             connection,
-            kernelSpec,
+            kernelConnectionMetadata,
             this.fs,
-            resource,
-            interpreter
+            resource
         );
         await kernelProcess.launch(workingDirectory);
         return kernelProcess;

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -6,20 +6,23 @@ import { ChildProcess } from 'child_process';
 import * as tcpPortUsed from 'tcp-port-used';
 import * as tmp from 'tmp';
 import { Event, EventEmitter } from 'vscode';
-import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError, traceInfo, traceWarning } from '../../common/logger';
 import { IProcessServiceFactory, ObservableExecutionResult } from '../../common/process/types';
 import { Resource } from '../../common/types';
 import { noop, swallowExceptions } from '../../common/utils/misc';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry } from '../../telemetry';
 import { Telemetry } from '../constants';
-import { cleanEnvironment, findIndexOfConnectionFile } from '../jupyter/kernels/helpers';
-import { IDataScienceFileSystem, IJupyterKernelSpec } from '../types';
+import {
+    cleanEnvironment,
+    findIndexOfConnectionFile,
+    isPythonKernelConnection,
+    kernelConnectionMetadataHasKernelSpec
+} from '../jupyter/kernels/helpers';
+import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
+import { IDataScienceFileSystem } from '../types';
+import { KernelDaemonPool } from './kernelDaemonPool';
 import { PythonKernelLauncherDaemon } from './kernelLauncherDaemon';
 import { IKernelConnection, IKernelProcess, IPythonKernelDaemon, PythonKernelDiedError } from './types';
-
-import { KernelDaemonPool } from './kernelDaemonPool';
 
 // Launches and disposes a kernel process given a kernelspec and a resource or python interpreter.
 // Exposes connection information and the process itself.
@@ -27,14 +30,14 @@ export class KernelProcess implements IKernelProcess {
     public get exited(): Event<{ exitCode?: number; reason?: string }> {
         return this.exitEvent.event;
     }
-    public get kernelSpec(): Readonly<IJupyterKernelSpec> {
+    public get kernelSpec(): Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata> {
         return this.originalKernelSpec;
     }
     public get connection(): Readonly<IKernelConnection> {
         return this._connection;
     }
     private get isPythonKernel(): boolean {
-        return this.kernelSpec.language.toLowerCase() === PYTHON_LANGUAGE.toLowerCase();
+        return isPythonKernelConnection(this.kernelSpec);
     }
     private _process?: ChildProcess;
     private exitEvent = new EventEmitter<{ exitCode?: number; reason?: string }>();
@@ -42,20 +45,19 @@ export class KernelProcess implements IKernelProcess {
     private launchedOnce?: boolean;
     private disposed?: boolean;
     private kernelDaemon?: IPythonKernelDaemon;
-    private readonly _kernelSpec: IJupyterKernelSpec;
-    private readonly originalKernelSpec: IJupyterKernelSpec;
+    private readonly _kernelSpec: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata;
+    private readonly originalKernelSpec: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata;
     private connectionFile?: string;
     constructor(
         private readonly processExecutionFactory: IProcessServiceFactory,
         private readonly daemonPool: KernelDaemonPool,
         private readonly _connection: IKernelConnection,
-        kernelSpec: IJupyterKernelSpec,
+        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         private readonly fs: IDataScienceFileSystem,
-        private readonly resource: Resource,
-        private readonly interpreter?: PythonEnvironment
+        private readonly resource: Resource
     ) {
-        this.originalKernelSpec = kernelSpec;
-        this._kernelSpec = cleanEnvironment(kernelSpec);
+        this.originalKernelSpec = kernelConnectionMetadata;
+        this._kernelSpec = cleanEnvironment(kernelConnectionMetadata);
     }
     public async interrupt(): Promise<void> {
         if (this.kernelDaemon) {
@@ -142,31 +144,36 @@ export class KernelProcess implements IKernelProcess {
             throw new Error('Timed out waiting to get a heartbeat from kernel process.');
         }
     }
-
+    private get kernelSpecArgv(): string[] {
+        return this._kernelSpec.kernelSpec?.argv || ([] as string[]);
+    }
     // Instead of having to use a connection file update our local copy of the kernelspec to launch
     // directly with command line arguments
     private async updateConnectionArgs() {
         // First check to see if we have a kernelspec that expects a connection file,
         // Error if we don't have one. We expect '-f', '{connectionfile}' in our launch args
-        const indexOfConnectionFile = findIndexOfConnectionFile(this._kernelSpec);
+        const kernelSpec = kernelConnectionMetadataHasKernelSpec(this._kernelSpec)
+            ? this._kernelSpec.kernelSpec
+            : undefined;
+        const indexOfConnectionFile = kernelSpec ? findIndexOfConnectionFile(kernelSpec) : -1;
         if (indexOfConnectionFile === -1) {
-            throw new Error(`Connection file not found in kernelspec json args, ${this._kernelSpec.argv.join(' ')}`);
+            throw new Error(`Connection file not found in kernelspec json args, ${this.kernelSpecArgv.join(' ')}`);
         }
         if (
             this.isPythonKernel &&
             indexOfConnectionFile === 0 &&
-            this._kernelSpec.argv[indexOfConnectionFile - 1] !== '-f'
+            this.kernelSpecArgv[indexOfConnectionFile - 1] !== '-f'
         ) {
-            throw new Error(`Connection file not found in kernelspec json args, ${this._kernelSpec.argv.join(' ')}`);
+            throw new Error(`Connection file not found in kernelspec json args, ${this.kernelSpecArgv.join(' ')}`);
         }
 
         // Python kernels are special. Handle the extra arguments.
         if (this.isPythonKernel) {
             // Slice out -f and the connection file from the args
-            this._kernelSpec.argv.splice(indexOfConnectionFile - 1, 2);
+            this.kernelSpecArgv.splice(indexOfConnectionFile - 1, 2);
 
             // Add in our connection command line args
-            this._kernelSpec.argv.push(...this.addPythonConnectionArgs());
+            this.kernelSpecArgv.push(...this.addPythonConnectionArgs());
         } else {
             // For other kernels, just write to the connection file.
             // Note: We have to dispose the temp file and recreate it because otherwise the file
@@ -178,7 +185,7 @@ export class KernelProcess implements IKernelProcess {
             await this.fs.writeLocalFile(this.connectionFile, JSON.stringify(this._connection));
 
             // Then replace the connection file argument with this file
-            this._kernelSpec.argv[indexOfConnectionFile] = this.connectionFile;
+            this.kernelSpecArgv[indexOfConnectionFile] = this.connectionFile;
         }
     }
 
@@ -217,8 +224,8 @@ export class KernelProcess implements IKernelProcess {
             const kernelDaemonLaunch = await this.pythonKernelLauncher.launch(
                 this.resource,
                 workingDirectory,
-                this._kernelSpec,
-                this.interpreter
+                this._kernelSpec.kernelSpec!,
+                this._kernelSpec.interpreter
             );
 
             this.kernelDaemon = kernelDaemonLaunch.daemon;
@@ -228,10 +235,10 @@ export class KernelProcess implements IKernelProcess {
         // If we are not python just use the ProcessExecutionFactory
         if (!exeObs) {
             // First part of argument is always the executable.
-            const executable = this._kernelSpec.argv[0];
+            const executable = this.kernelSpecArgv[0];
             const executionService = await this.processExecutionFactory.create(this.resource);
-            exeObs = executionService.execObservable(executable, this._kernelSpec.argv.slice(1), {
-                env: this._kernelSpec.env,
+            exeObs = executionService.execObservable(executable, this.kernelSpecArgv.slice(1), {
+                env: this._kernelSpec.kernelSpec?.env,
                 cwd: workingDirectory
             });
         }

--- a/src/client/datascience/kernel-launcher/kernelProcess.ts
+++ b/src/client/datascience/kernel-launcher/kernelProcess.ts
@@ -145,7 +145,17 @@ export class KernelProcess implements IKernelProcess {
         }
     }
     private get kernelSpecArgv(): string[] {
-        return this._kernelSpec.kernelSpec?.argv || ([] as string[]);
+        // We always expect a kernel spec, even when launching a Python process, cuz we generate a dummy `kernelSpec`.
+        const kernelSpec = this._kernelSpec.kernelSpec;
+        if (!kernelSpec) {
+            throw new Error('KernelSpec cannot be empty in KernelProcess.ts');
+        }
+        if (!Array.isArray(kernelSpec.argv)) {
+            traceError('KernelSpec.argv in KernelPrcess is undefined');
+            // tslint:disable-next-line: no-any
+            (kernelSpec as any).argv = [];
+        }
+        return kernelSpec.argv;
     }
     // Instead of having to use a connection file update our local copy of the kernelspec to launch
     // directly with command line arguments

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -8,16 +8,15 @@ import { CancellationToken, Event } from 'vscode';
 import { InterpreterUri } from '../../common/installer/types';
 import { ObservableExecutionResult } from '../../common/process/types';
 import { IAsyncDisposable, IDisposable, Resource } from '../../common/types';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
+import { KernelSpecConnectionMetadata, PythonKernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IJupyterKernelSpec } from '../types';
 
 export const IKernelLauncher = Symbol('IKernelLauncher');
 export interface IKernelLauncher {
     launch(
-        kernelSpec: IJupyterKernelSpec,
+        kernelConnectionMetadata: KernelSpecConnectionMetadata | PythonKernelConnectionMetadata,
         resource: Resource,
-        workingDirectory: string,
-        interpreter?: PythonEnvironment
+        workingDirectory: string
     ): Promise<IKernelProcess>;
 }
 
@@ -36,7 +35,7 @@ export interface IKernelConnection {
 
 export interface IKernelProcess extends IAsyncDisposable {
     readonly connection: Readonly<IKernelConnection>;
-    readonly kernelSpec: Readonly<IJupyterKernelSpec>;
+    readonly kernelSpec: Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
     /**
      * This event is triggered if the process is exited
      */

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -35,7 +35,7 @@ export interface IKernelConnection {
 
 export interface IKernelProcess extends IAsyncDisposable {
     readonly connection: Readonly<IKernelConnection>;
-    readonly kernelSpec: Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
+    readonly kernelConnectionMetadata: Readonly<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata>;
     /**
      * This event is triggered if the process is exited
      */

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -21,14 +21,13 @@ import { MARKDOWN_LANGUAGE, PYTHON_LANGUAGE } from '../../../common/constants';
 import { traceError, traceWarning } from '../../../common/logger';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
-import { CellState, ICell, IJupyterKernelSpec, INotebookModel } from '../../types';
+import { CellState, ICell, INotebookModel } from '../../types';
 import { JupyterNotebookView } from '../constants';
 // tslint:disable-next-line: no-var-requires no-require-imports
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
-import { PythonEnvironment } from '../../../pythonEnvironments/info';
-import { LiveKernelModel } from '../../jupyter/kernels/types';
+import { KernelConnectionMetadata } from '../../jupyter/kernels/types';
 import { updateNotebookMetadata } from '../../notebookStorage/baseModel';
 import { VSCodeNotebookModel } from '../../notebookStorage/vscNotebookModel';
 import { INotebookContentProvider } from '../types';
@@ -61,8 +60,7 @@ export function getNotebookMetadata(document: NotebookDocument): nbformat.INoteb
 }
 export function updateKernelInNotebookMetadata(
     document: NotebookDocument,
-    kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
-    interpreter: PythonEnvironment | undefined,
+    kernelConnection: KernelConnectionMetadata | undefined,
     notebookContentProvider: INotebookContentProvider
 ) {
     // tslint:disable-next-line: no-any
@@ -71,7 +69,7 @@ export function updateKernelInNotebookMetadata(
         traceError('VSCode Notebook does not have custom metadata', notebookContent);
         throw new Error('VSCode Notebook does not have custom metadata');
     }
-    const info = updateNotebookMetadata(notebookContent.metadata, interpreter, kernelSpec);
+    const info = updateNotebookMetadata(notebookContent.metadata, kernelConnection);
 
     if (info.changed) {
         notebookContentProvider.notifyChangesToDocument(document);

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -177,12 +177,7 @@ export class VSCodeKernelPickerProvider implements NotebookKernelProvider {
                         if (notebook.disposed) {
                             return;
                         }
-                        updateKernelInNotebookMetadata(
-                            document,
-                            e,
-                            notebook.getMatchingInterpreter(),
-                            this.notebookContentProvider
-                        );
+                        updateKernelInNotebookMetadata(document, e, this.notebookContentProvider);
                     },
                     this,
                     this.disposables
@@ -190,12 +185,7 @@ export class VSCodeKernelPickerProvider implements NotebookKernelProvider {
             }
             this.kernelSwitcher.switchKernelWithRetry(notebook, selection).catch(noop);
         } else {
-            updateKernelInNotebookMetadata(
-                document,
-                selection.kind === 'connectToLiveKernel' ? selection.kernelModel : selection.kernelSpec,
-                selection.interpreter,
-                this.notebookContentProvider
-            );
+            updateKernelInNotebookMetadata(document, selection, this.notebookContentProvider);
         }
     }
 }

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -24,7 +24,6 @@ import { noop } from '../../../common/utils/misc';
 import { IServiceContainer } from '../../../ioc/types';
 import { Identifiers, LiveShare, LiveShareCommands, Settings } from '../../constants';
 import { computeWorkingDirectory } from '../../jupyter/jupyterUtils';
-import { kernelConnectionMetadataHasKernelSpec } from '../../jupyter/kernels/helpers';
 import { KernelSelector } from '../../jupyter/kernels/kernelSelector';
 import { KernelConnectionMetadata } from '../../jupyter/kernels/types';
 import { HostJupyterNotebook } from '../../jupyter/liveshare/hostJupyterNotebook';
@@ -171,12 +170,7 @@ export class HostRawNotebookProvider
             if (!kernelConnectionMetadata?.kernelSpec) {
                 notebookPromise.reject('Failed to find a kernelspec to use for ipykernel launch');
             } else {
-                await rawSession.connect(
-                    kernelConnectionMetadata.kernelSpec,
-                    launchTimeout,
-                    kernelConnectionMetadata.interpreter,
-                    cancelToken
-                );
+                await rawSession.connect(kernelConnectionMetadata, launchTimeout, cancelToken);
 
                 // Get the execution info for our notebook
                 const info = await this.getExecutionInfo(kernelConnectionMetadata);
@@ -230,10 +224,7 @@ export class HostRawNotebookProvider
         return {
             connectionInfo: this.getConnection(),
             uri: Settings.JupyterServerLocalLaunch,
-            interpreter: kernelConnectionMetadata.interpreter,
-            kernelSpec: kernelConnectionMetadataHasKernelSpec(kernelConnectionMetadata)
-                ? kernelConnectionMetadata.kernelSpec
-                : kernelConnectionMetadata.kernelModel,
+            kernelConnectionMetadata,
             workingDir: await calculateWorkingDirectory(this.configService, this.workspaceService, this.fs),
             purpose: Identifiers.RawPurpose
         };

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -117,10 +117,10 @@ export class RawJupyterSession extends BaseJupyterSession {
                 this.session?.statusChanged.connect(this.statusHandler); // NOSONAR
 
                 // Update kernelspec and interpreter
-                this.kernelSpec = newSession.kernelProcess?.kernelSpec;
+                this.kernelConnectionMetadata = newSession.kernelProcess?.kernelSpec;
 
                 this.outputChannel.appendLine(
-                    localize.DataScience.kernelStarted().format(getDisplayNameOrNameOfKernelConnection(this.kernelSpec))
+                    localize.DataScience.kernelStarted().format(getDisplayNameOrNameOfKernelConnection(this.kernelConnectionMetadata))
                 );
             }
         } catch (error) {
@@ -191,7 +191,7 @@ export class RawJupyterSession extends BaseJupyterSession {
 
     protected startRestartSession() {
         if (!this.restartSessionPromise && this.session) {
-            this.restartSessionPromise = this.createRestartSession(this.kernelSpec, this.session);
+            this.restartSessionPromise = this.createRestartSession(this.kernelConnectionMetadata, this.session);
         }
     }
     protected async createRestartSession(

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -117,7 +117,7 @@ export class RawJupyterSession extends BaseJupyterSession {
                 this.session?.statusChanged.connect(this.statusHandler); // NOSONAR
 
                 // Update kernelspec and interpreter
-                this.kernelConnectionMetadata = newSession.kernelProcess?.kernelSpec;
+                this.kernelConnectionMetadata = newSession.kernelProcess?.kernelConnectionMetadata;
 
                 this.outputChannel.appendLine(
                     localize.DataScience.kernelStarted().format(
@@ -134,7 +134,7 @@ export class RawJupyterSession extends BaseJupyterSession {
         }
 
         this.connected = true;
-        return (newSession as RawSession).kernelProcess.kernelSpec;
+        return (newSession as RawSession).kernelProcess.kernelConnectionMetadata;
     }
 
     public async createNewKernelSession(

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -10,21 +10,25 @@ import { IDisposable, IOutputChannel, Resource } from '../../common/types';
 import { waitForPromise } from '../../common/utils/async';
 import * as localize from '../../common/utils/localize';
 import { noop } from '../../common/utils/misc';
-import { PythonEnvironment } from '../../pythonEnvironments/info';
 import { captureTelemetry, sendTelemetryEvent } from '../../telemetry';
 import { BaseJupyterSession } from '../baseJupyterSession';
 import { Identifiers, Telemetry } from '../constants';
-import { LiveKernelModel } from '../jupyter/kernels/types';
+import { getDisplayNameOrNameOfKernelConnection } from '../jupyter/kernels/helpers';
+import { KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { IKernelLauncher } from '../kernel-launcher/types';
 import { reportAction } from '../progress/decorator';
 import { ReportableAction } from '../progress/types';
 import { RawSession } from '../raw-kernel/rawSession';
-import { IJupyterKernelSpec, ISessionWithSocket } from '../types';
+import { ISessionWithSocket } from '../types';
 
 // Error thrown when we are unable to start a raw kernel session
 export class RawKernelSessionStartError extends Error {
-    constructor(kernelTitle: string) {
-        super(localize.DataScience.rawKernelSessionFailed().format(kernelTitle));
+    constructor(kernelConnection: KernelConnectionMetadata) {
+        super(
+            localize.DataScience.rawKernelSessionFailed().format(
+                getDisplayNameOrNameOfKernelConnection(kernelConnection)
+            )
+        );
     }
 }
 
@@ -74,11 +78,10 @@ export class RawJupyterSession extends BaseJupyterSession {
     @captureTelemetry(Telemetry.RawKernelSessionConnect, undefined, true)
     @reportAction(ReportableAction.RawKernelConnecting)
     public async connect(
-        kernelSpec: IJupyterKernelSpec,
+        kernelConnection: KernelConnectionMetadata,
         timeout: number,
-        interpreter?: PythonEnvironment,
         cancelToken?: CancellationToken
-    ): Promise<IJupyterKernelSpec | undefined> {
+    ): Promise<KernelConnectionMetadata | undefined> {
         // Save the resource that we connect with
         let newSession: RawSession | null | CancellationError = null;
         try {
@@ -86,7 +89,7 @@ export class RawJupyterSession extends BaseJupyterSession {
             // Notebook Provider level will handle the thrown error
             newSession = await waitForPromise(
                 Promise.race([
-                    this.startRawSession(kernelSpec, interpreter, cancelToken),
+                    this.startRawSession(kernelConnection, cancelToken),
                     createPromiseFromCancellation({
                         cancelAction: 'reject',
                         defaultValue: new CancellationError(),
@@ -104,7 +107,7 @@ export class RawJupyterSession extends BaseJupyterSession {
             } else if (newSession === null) {
                 sendTelemetryEvent(Telemetry.RawKernelSessionStartTimeout);
                 traceError('Raw session failed to start in given timeout');
-                throw new RawKernelSessionStartError(kernelSpec.display_name || kernelSpec.name);
+                throw new RawKernelSessionStartError(kernelConnection);
             } else {
                 sendTelemetryEvent(Telemetry.RawKernelSessionStartSuccess);
                 traceInfo('Raw session started and connected');
@@ -115,10 +118,9 @@ export class RawJupyterSession extends BaseJupyterSession {
 
                 // Update kernelspec and interpreter
                 this.kernelSpec = newSession.kernelProcess?.kernelSpec;
-                this.interpreter = interpreter;
 
                 this.outputChannel.appendLine(
-                    localize.DataScience.kernelStarted().format(this.kernelSpec.display_name || this.kernelSpec.name)
+                    localize.DataScience.kernelStarted().format(getDisplayNameOrNameOfKernelConnection(this.kernelSpec))
                 );
             }
         } catch (error) {
@@ -134,22 +136,22 @@ export class RawJupyterSession extends BaseJupyterSession {
     }
 
     public async createNewKernelSession(
-        kernel: IJupyterKernelSpec | LiveKernelModel,
+        kernelConnection: KernelConnectionMetadata,
         timeoutMS: number,
-        interpreter?: PythonEnvironment,
         _cancelToken?: CancellationToken
     ): Promise<ISessionWithSocket> {
-        if (!kernel || 'session' in kernel) {
+        if (!kernelConnection || 'session' in kernelConnection) {
             // Don't allow for connecting to a LiveKernelModel
             throw new Error(localize.DataScience.sessionDisposed());
         }
 
-        this.outputChannel.appendLine(localize.DataScience.kernelStarted().format(kernel.display_name || kernel.name));
+        const displayName = getDisplayNameOrNameOfKernelConnection(kernelConnection);
+        this.outputChannel.appendLine(localize.DataScience.kernelStarted().format(displayName));
 
-        const newSession = await waitForPromise(this.startRawSession(kernel, interpreter), timeoutMS);
+        const newSession = await waitForPromise(this.startRawSession(kernelConnection), timeoutMS);
 
         if (!newSession) {
-            throw new RawKernelSessionStartError(kernel.display_name || kernel.name);
+            throw new RawKernelSessionStartError(kernelConnection);
         }
 
         return newSession;
@@ -189,20 +191,19 @@ export class RawJupyterSession extends BaseJupyterSession {
 
     protected startRestartSession() {
         if (!this.restartSessionPromise && this.session) {
-            this.restartSessionPromise = this.createRestartSession(this.kernelSpec, this.session, this.interpreter);
+            this.restartSessionPromise = this.createRestartSession(this.kernelSpec, this.session);
         }
     }
     protected async createRestartSession(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
+        kernelConnection: KernelConnectionMetadata | undefined,
         _session: ISessionWithSocket,
-        interpreter?: PythonEnvironment,
         cancelToken?: CancellationToken
     ): Promise<ISessionWithSocket> {
-        if (!kernelSpec || 'session' in kernelSpec) {
+        if (!kernelConnection || kernelConnection.kind === 'connectToLiveKernel') {
             // Need to have connected before restarting and can't use a LiveKernelModel
             throw new Error(localize.DataScience.sessionDisposed());
         }
-        const startPromise = this.startRawSession(kernelSpec, interpreter, cancelToken);
+        const startPromise = this.startRawSession(kernelConnection, cancelToken);
         return startPromise.then((session) => {
             this.restartSessionCreated(session.kernel);
             return session;
@@ -211,10 +212,15 @@ export class RawJupyterSession extends BaseJupyterSession {
 
     @captureTelemetry(Telemetry.RawKernelStartRawSession, undefined, true)
     private async startRawSession(
-        kernelSpec: IJupyterKernelSpec,
-        interpreter?: PythonEnvironment,
+        kernelConnection: KernelConnectionMetadata,
         cancelToken?: CancellationToken
     ): Promise<RawSession> {
+        if (
+            kernelConnection.kind !== 'startUsingKernelSpec' &&
+            kernelConnection.kind !== 'startUsingPythonInterpreter'
+        ) {
+            throw new Error(`Unable to start Raw Kernels for Kernel Connection of type ${kernelConnection.kind}`);
+        }
         const cancellationPromise = createPromiseFromCancellation({
             cancelAction: 'reject',
             defaultValue: undefined,
@@ -223,7 +229,7 @@ export class RawJupyterSession extends BaseJupyterSession {
         cancellationPromise.catch(noop);
 
         const process = await Promise.race([
-            this.kernelLauncher.launch(kernelSpec, this.resource, this.workingDirectory, interpreter),
+            this.kernelLauncher.launch(kernelConnection, this.resource, this.workingDirectory),
             cancellationPromise
         ]);
 

--- a/src/client/datascience/raw-kernel/rawJupyterSession.ts
+++ b/src/client/datascience/raw-kernel/rawJupyterSession.ts
@@ -120,7 +120,9 @@ export class RawJupyterSession extends BaseJupyterSession {
                 this.kernelConnectionMetadata = newSession.kernelProcess?.kernelSpec;
 
                 this.outputChannel.appendLine(
-                    localize.DataScience.kernelStarted().format(getDisplayNameOrNameOfKernelConnection(this.kernelConnectionMetadata))
+                    localize.DataScience.kernelStarted().format(
+                        getDisplayNameOrNameOfKernelConnection(this.kernelConnectionMetadata)
+                    )
                 );
             }
         } catch (error) {

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -262,7 +262,7 @@ export function createRawKernel(kernelProcess: IKernelProcess, clientId: string)
     }
     const realKernel = new nonSerializingKernel.DefaultKernel(
         {
-            name: getNameOfKernelConnection(kernelProcess.kernelSpec),
+            name: getNameOfKernelConnection(kernelProcess.kernelConnectionMetadata),
             serverSettings: settings,
             clientId,
             handleComms: true

--- a/src/client/datascience/raw-kernel/rawKernel.ts
+++ b/src/client/datascience/raw-kernel/rawKernel.ts
@@ -5,6 +5,7 @@ import * as uuid from 'uuid/v4';
 import { isTestExecution } from '../../common/constants';
 import { IDisposable } from '../../common/types';
 import { swallowExceptions } from '../../common/utils/misc';
+import { getNameOfKernelConnection } from '../jupyter/kernels/helpers';
 import { IKernelProcess } from '../kernel-launcher/types';
 import { IWebSocketLike } from '../kernelSocketWrapper';
 import { IKernelSocket } from '../types';
@@ -261,7 +262,7 @@ export function createRawKernel(kernelProcess: IKernelProcess, clientId: string)
     }
     const realKernel = new nonSerializingKernel.DefaultKernel(
         {
-            name: kernelProcess.kernelSpec.name,
+            name: getNameOfKernelConnection(kernelProcess.kernelSpec),
             serverSettings: settings,
             clientId,
             handleComms: true

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -37,7 +37,7 @@ import { NotebookModelChange } from './interactive-common/interactiveWindowTypes
 import { JupyterServerInfo } from './jupyter/jupyterConnection';
 import { JupyterInstallError } from './jupyter/jupyterInstallError';
 import { JupyterKernelSpec } from './jupyter/kernels/jupyterKernelSpec';
-import { KernelConnectionMetadata, LiveKernelModel } from './jupyter/kernels/types';
+import { KernelConnectionMetadata } from './jupyter/kernels/types';
 
 // tslint:disable-next-line:no-any
 export type PromiseFunction = (...any: any[]) => Promise<any>;
@@ -91,12 +91,8 @@ export interface INotebookExecutionInfo {
     // Connection to what has provided our notebook, such as a jupyter
     // server or a raw ZMQ kernel
     connectionInfo: INotebookProviderConnection;
-    /**
-     * The python interpreter associated with the kernel.
-     */
-    interpreter: PythonEnvironment | undefined;
     uri: string | undefined; // Different from the connectionInfo as this is the setting used, not the result
-    kernelSpec: IJupyterKernelSpec | undefined | LiveKernelModel;
+    kernelConnectionMetadata?: KernelConnectionMetadata;
     workingDir: string | undefined;
     purpose: string | undefined; // Purpose this server is for
 }
@@ -106,15 +102,8 @@ export interface INotebookExecutionInfo {
 // Information used to launch a notebook server
 export interface INotebookServerLaunchInfo {
     connectionInfo: IJupyterConnection;
-    /**
-     * The python interpreter associated with the kernel.
-     *
-     * @type {(PythonEnvironment | undefined)}
-     * @memberof INotebookServerLaunchInfo
-     */
-    interpreter: PythonEnvironment | undefined;
     uri: string | undefined; // Different from the connectionInfo as this is the setting used, not the result
-    kernelSpec: IJupyterKernelSpec | undefined | LiveKernelModel;
+    kernelConnectionMetadata?: KernelConnectionMetadata;
     workingDir: string | undefined;
     purpose: string | undefined; // Purpose this server is for
 }
@@ -186,7 +175,7 @@ export interface INotebook extends IAsyncDisposable {
     readonly disposed: boolean;
     onSessionStatusChanged: Event<ServerStatus>;
     onDisposed: Event<void>;
-    onKernelChanged: Event<IJupyterKernelSpec | LiveKernelModel>;
+    onKernelChanged: Event<KernelConnectionMetadata>;
     onKernelRestarted: Event<void>;
     onKernelInterrupted: Event<void>;
     clear(id: string): void;
@@ -212,12 +201,8 @@ export interface INotebook extends IAsyncDisposable {
     getSysInfo(): Promise<ICell | undefined>;
     setMatplotLibStyle(useDark: boolean): Promise<void>;
     getMatchingInterpreter(): PythonEnvironment | undefined;
-    getKernelSpec(): IJupyterKernelSpec | LiveKernelModel | undefined;
-    setKernelSpec(
-        spec: IJupyterKernelSpec | LiveKernelModel,
-        timeoutMS: number,
-        interpreter: PythonEnvironment | undefined
-    ): Promise<void>;
+    getKernelSpec(): KernelConnectionMetadata | undefined;
+    setKernelSpec(connectionMetadata: KernelConnectionMetadata, timeoutMS: number): Promise<void>;
     getLoggers(): INotebookExecutionLogger[];
     registerIOPubListener(listener: (msg: KernelMessage.IIOPubMessage, requestId: string) => void): void;
     registerCommTarget(
@@ -342,11 +327,7 @@ export interface IJupyterSession extends IAsyncDisposable {
         content: KernelMessage.IInspectRequestMsg['content']
     ): Promise<KernelMessage.IInspectReplyMsg | undefined>;
     sendInputReply(content: string): void;
-    changeKernel(
-        kernel: IJupyterKernelSpec | LiveKernelModel,
-        timeoutMS: number,
-        interpreter?: PythonEnvironment
-    ): Promise<void>;
+    changeKernel(kernelConnection: KernelConnectionMetadata, timeoutMS: number): Promise<void>;
     registerCommTarget(
         targetName: string,
         callback: (comm: Kernel.IComm, msg: KernelMessage.ICommOpenMsg) => void | PromiseLike<void>
@@ -388,7 +369,7 @@ export interface IJupyterSessionManager extends IAsyncDisposable {
     readonly onRestartSessionCreated: Event<Kernel.IKernelConnection>;
     readonly onRestartSessionUsed: Event<Kernel.IKernelConnection>;
     startNew(
-        kernelSpec: IJupyterKernelSpec | LiveKernelModel | undefined,
+        kernelConnection: KernelConnectionMetadata | undefined,
         workingDirectory: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession>;

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -201,8 +201,8 @@ export interface INotebook extends IAsyncDisposable {
     getSysInfo(): Promise<ICell | undefined>;
     setMatplotLibStyle(useDark: boolean): Promise<void>;
     getMatchingInterpreter(): PythonEnvironment | undefined;
-    getKernelSpec(): KernelConnectionMetadata | undefined;
-    setKernelSpec(connectionMetadata: KernelConnectionMetadata, timeoutMS: number): Promise<void>;
+    getKernelConnection(): KernelConnectionMetadata | undefined;
+    setKernelConnection(connectionMetadata: KernelConnectionMetadata, timeoutMS: number): Promise<void>;
     getLoggers(): INotebookExecutionLogger[];
     registerIOPubListener(listener: (msg: KernelMessage.IIOPubMessage, requestId: string) => void): void;
     registerCommTarget(
@@ -1153,7 +1153,7 @@ export interface INotebookProvider {
     /**
      * Fired when a kernel would have been changed if a notebook had existed.
      */
-    onPotentialKernelChanged: Event<{ identity: Uri; kernel: KernelConnectionMetadata }>;
+    onPotentialKernelChanged: Event<{ identity: Uri; kernelConnection: KernelConnectionMetadata }>;
 
     /**
      * List of all notebooks (active and ones that are being constructed).

--- a/src/test/datascience/commands/notebookCommands.functional.test.ts
+++ b/src/test/datascience/commands/notebookCommands.functional.test.ts
@@ -174,9 +174,9 @@ suite('DataScience - Notebook Commands', () => {
                 return obj;
             }
             function verifyCallToSetKernelSpec(notebook: JupyterNotebookBase) {
-                verify(notebook.setKernelSpec(anything(), anything())).once();
+                verify(notebook.setKernelConnection(anything(), anything())).once();
 
-                const kernelConnection = capture(notebook.setKernelSpec).first()[0];
+                const kernelConnection = capture(notebook.setKernelConnection).first()[0];
                 if (isLocalConnection) {
                     assert.equal(kernelConnection.kind, 'startUsingKernelSpec');
                     const kernelSpec =

--- a/src/test/datascience/commands/notebookCommands.functional.test.ts
+++ b/src/test/datascience/commands/notebookCommands.functional.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import type { Kernel } from '@jupyterlab/services/lib/kernel/kernel';
+import { assert } from 'chai';
 import { anything, capture, instance, mock, verify, when } from 'ts-mockito';
-import { Matcher } from 'ts-mockito/lib/matcher/type/Matcher';
 import { EventEmitter, Uri } from 'vscode';
 import { ApplicationShell } from '../../../client/common/application/applicationShell';
 import { CommandManager } from '../../../client/common/application/commandManager';
@@ -168,29 +168,28 @@ suite('DataScience - Notebook Commands', () => {
                 );
             });
 
-            class FunctionMatcher extends Matcher {
-                private func: (obj: any) => boolean;
-                constructor(func: (obj: any) => boolean) {
-                    super();
-                    this.func = func;
-                }
-                public match(value: Object): boolean {
-                    return this.func(value);
-                }
-                public toString(): string {
-                    return 'FunctionMatcher';
-                }
-            }
-
-            function argThat(func: (obj: any) => boolean): any {
-                return new FunctionMatcher(func);
-            }
-
             function createNotebookMock() {
                 const obj = mock(JupyterNotebookBase);
                 when((obj as any).then).thenReturn(undefined);
                 return obj;
             }
+            function verifyCallToSetKernelSpec(notebook: JupyterNotebookBase) {
+                verify(notebook.setKernelSpec(anything(), anything())).once();
+
+                const kernelConnection = capture(notebook.setKernelSpec).first()[0];
+                if (isLocalConnection) {
+                    assert.equal(kernelConnection.kind, 'startUsingKernelSpec');
+                    const kernelSpec =
+                        kernelConnection.kind !== 'connectToLiveKernel' ? kernelConnection.kernelSpec : undefined;
+                    assert.equal(kernelSpec?.name, localKernel.name);
+                } else {
+                    assert.equal(kernelConnection.kind, 'connectToLiveKernel');
+                    const kernelModel =
+                        kernelConnection.kind === 'connectToLiveKernel' ? kernelConnection.kernelModel : undefined;
+                    assert.equal(kernelModel?.name, remoteKernel.name);
+                }
+            }
+
             test('Register Command', () => {
                 notebookCommands.register();
 
@@ -218,7 +217,7 @@ suite('DataScience - Notebook Commands', () => {
                         )
                     ).never();
                 });
-                test('Should switch kernel using the provided notebook', async () => {
+                test('Should switch kernel using the provided notebookxxx', async () => {
                     const notebook = createNotebookMock();
                     when((notebook as any).then).thenReturn(undefined);
                     const uri = Uri.file('test.ipynb');
@@ -227,17 +226,8 @@ suite('DataScience - Notebook Commands', () => {
                     });
 
                     await commandHandler.bind(notebookCommands)({ identity: uri });
-                    verify(
-                        notebook.setKernelSpec(
-                            argThat((o) => {
-                                return isLocalConnection
-                                    ? o.name === localKernel.name
-                                    : o.name === remoteKernel.name && o.lastActivityTime;
-                            }),
-                            anything(),
-                            anything()
-                        )
-                    ).once();
+
+                    verifyCallToSetKernelSpec(notebook);
                 });
                 test('Should switch kernel using the active Native Editor', async () => {
                     const nativeEditor = createNotebookMock();
@@ -251,17 +241,7 @@ suite('DataScience - Notebook Commands', () => {
 
                     await commandHandler.bind(notebookCommands)();
 
-                    verify(
-                        nativeEditor.setKernelSpec(
-                            argThat((o) => {
-                                return isLocalConnection
-                                    ? o.name === localKernel.name
-                                    : o.name === remoteKernel.name && o.lastActivityTime;
-                            }),
-                            anything(),
-                            anything()
-                        )
-                    ).once();
+                    verifyCallToSetKernelSpec(nativeEditor);
                 });
                 test('Should switch kernel using the active Interactive Window', async () => {
                     const interactiveWindow = createNotebookMock();
@@ -274,17 +254,7 @@ suite('DataScience - Notebook Commands', () => {
 
                     await commandHandler.bind(notebookCommands)();
 
-                    verify(
-                        interactiveWindow.setKernelSpec(
-                            argThat((o) => {
-                                return isLocalConnection
-                                    ? o.name === localKernel.name
-                                    : o.name === remoteKernel.name && o.lastActivityTime;
-                            }),
-                            anything(),
-                            anything()
-                        )
-                    ).once();
+                    verifyCallToSetKernelSpec(interactiveWindow);
                 });
                 test('Should switch kernel using the active Native editor even if an Interactive Window is available', async () => {
                     const uri1 = Uri.parse('history://foobar');
@@ -305,17 +275,7 @@ suite('DataScience - Notebook Commands', () => {
 
                     await commandHandler.bind(notebookCommands)();
 
-                    verify(
-                        nativeEditor.setKernelSpec(
-                            argThat((o) => {
-                                return isLocalConnection
-                                    ? o.name === localKernel.name
-                                    : o.name === remoteKernel.name && o.lastActivityTime;
-                            }),
-                            anything(),
-                            anything()
-                        )
-                    ).once();
+                    verifyCallToSetKernelSpec(nativeEditor);
                 });
                 test('With no notebook, should still fire change', async () => {
                     when(notebookProvider.getOrCreateNotebook(anything())).thenResolve(undefined);

--- a/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
@@ -37,14 +37,14 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         );
     });
     test('No script source when there is no kernel associated with notebook', async () => {
-        when(notebook.getKernelSpec()).thenReturn();
+        when(notebook.getKernelConnection()).thenReturn();
 
         const value = await scriptSourceProvider.getWidgetScriptSource('ModuleName', '1');
 
         assert.deepEqual(value, { moduleName: 'ModuleName' });
     });
     test('No script source when there are no widgets', async () => {
-        when(notebook.getKernelSpec()).thenReturn({
+        when(notebook.getKernelConnection()).thenReturn({
             kernelSpec: { metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
@@ -60,7 +60,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
 
-        when(notebook.getKernelSpec()).thenReturn({
+        when(notebook.getKernelConnection()).thenReturn({
             kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
@@ -78,7 +78,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         when(interpreterService.getInterpreterDetails(kernelPath)).thenResolve({ sysPrefix } as any);
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
 
-        when(notebook.getKernelSpec()).thenReturn({ kernelSpec: { path: kernelPath } } as any);
+        when(notebook.getKernelConnection()).thenReturn({ kernelSpec: { path: kernelPath } } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
         const value = await scriptSourceProvider.getWidgetScriptSource('ModuleName', '1');
@@ -89,7 +89,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         verify(fs.searchLocal(filesToLookSerachFor, searchDirectory)).once();
     });
     test('Ensure we cache the list of widgets source (when nothing is found)', async () => {
-        when(notebook.getKernelSpec()).thenReturn({
+        when(notebook.getKernelConnection()).thenReturn({
             kernelSpec: { metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
@@ -107,7 +107,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
     test('Ensure we search directory only once (cache results)', async () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
-        when(notebook.getKernelSpec()).thenReturn({
+        when(notebook.getKernelConnection()).thenReturn({
             kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([
@@ -134,7 +134,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
     test('Get source for a specific widget & search in the right place', async () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
-        when(notebook.getKernelSpec()).thenReturn({
+        when(notebook.getKernelConnection()).thenReturn({
             kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([
@@ -159,7 +159,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
     test('Return empty source for widgets that cannot be found', async () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
-        when(notebook.getKernelSpec()).thenReturn({
+        when(notebook.getKernelConnection()).thenReturn({
             kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([

--- a/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
@@ -4,6 +4,7 @@ import { assert } from 'chai';
 import * as path from 'path';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
 import { Uri } from 'vscode';
+import { PYTHON_LANGUAGE } from '../../../client/common/constants';
 import { DataScienceFileSystem } from '../../../client/datascience/dataScienceFileSystem';
 import { LocalWidgetScriptSourceProvider } from '../../../client/datascience/ipywidgets/localWidgetScriptSourceProvider';
 import { IWidgetScriptSourceProvider } from '../../../client/datascience/ipywidgets/types';
@@ -19,7 +20,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
     let resourceConverter: ILocalResourceUriConverter;
     let fs: IDataScienceFileSystem;
     let interpreterService: IInterpreterService;
-    const filesToLookSerachFor = `*${path.sep}index.js`;
+    const filesToLookSearchFor = `*${path.sep}index.js`;
     function asVSCodeUri(uri: Uri) {
         return `vscodeUri://${uri.fsPath}`;
     }
@@ -70,7 +71,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         assert.deepEqual(value, { moduleName: 'ModuleName' });
 
         // Ensure we look for the right things in the right place.
-        verify(fs.searchLocal(filesToLookSerachFor, searchDirectory)).once();
+        verify(fs.searchLocal(filesToLookSearchFor, searchDirectory)).once();
     });
     test('Look for widgets in sysPath of kernel', async () => {
         const sysPrefix = 'sysPrefix Of Kernel';
@@ -78,7 +79,9 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         when(interpreterService.getInterpreterDetails(kernelPath)).thenResolve({ sysPrefix } as any);
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
 
-        when(notebook.getKernelConnection()).thenReturn({ kernelSpec: { path: kernelPath } } as any);
+        when(notebook.getKernelConnection()).thenReturn({
+            kernelSpec: { path: kernelPath, language: PYTHON_LANGUAGE }
+        } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
         const value = await scriptSourceProvider.getWidgetScriptSource('ModuleName', '1');
@@ -86,7 +89,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         assert.deepEqual(value, { moduleName: 'ModuleName' });
 
         // Ensure we look for the right things in the right place.
-        verify(fs.searchLocal(filesToLookSerachFor, searchDirectory)).once();
+        verify(fs.searchLocal(filesToLookSearchFor, searchDirectory)).once();
     });
     test('Ensure we cache the list of widgets source (when nothing is found)', async () => {
         when(notebook.getKernelConnection()).thenReturn({
@@ -129,7 +132,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         assert.deepEqual(value2, value);
 
         // Ensure we look for the right things in the right place.
-        verify(fs.searchLocal(filesToLookSerachFor, searchDirectory)).once();
+        verify(fs.searchLocal(filesToLookSearchFor, searchDirectory)).once();
     });
     test('Get source for a specific widget & search in the right place', async () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
@@ -154,7 +157,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         });
 
         // Ensure we look for the right things in the right place.
-        verify(fs.searchLocal(filesToLookSerachFor, searchDirectory)).once();
+        verify(fs.searchLocal(filesToLookSearchFor, searchDirectory)).once();
     });
     test('Return empty source for widgets that cannot be found', async () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
@@ -183,6 +186,6 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
 
         // Ensure we look for the right things in the right place.
         // Also ensure we call once (& cache for subsequent searches).
-        verify(fs.searchLocal(filesToLookSerachFor, searchDirectory)).once();
+        verify(fs.searchLocal(filesToLookSearchFor, searchDirectory)).once();
     });
 });

--- a/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
+++ b/src/test/datascience/ipywidgets/localWidgetScriptSourceProvider.unit.test.ts
@@ -45,7 +45,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
     });
     test('No script source when there are no widgets', async () => {
         when(notebook.getKernelSpec()).thenReturn({
-            metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } }
+            kernelSpec: { metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -61,7 +61,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
 
         when(notebook.getKernelSpec()).thenReturn({
-            metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
+            kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -78,7 +78,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         when(interpreterService.getInterpreterDetails(kernelPath)).thenResolve({ sysPrefix } as any);
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
 
-        when(notebook.getKernelSpec()).thenReturn({ path: kernelPath } as any);
+        when(notebook.getKernelSpec()).thenReturn({ kernelSpec: { path: kernelPath } } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
         const value = await scriptSourceProvider.getWidgetScriptSource('ModuleName', '1');
@@ -90,7 +90,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
     });
     test('Ensure we cache the list of widgets source (when nothing is found)', async () => {
         when(notebook.getKernelSpec()).thenReturn({
-            metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } }
+            kernelSpec: { metadata: { interpreter: { sysPrefix: 'sysPrefix', path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([]);
 
@@ -108,7 +108,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
         when(notebook.getKernelSpec()).thenReturn({
-            metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
+            kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([
             // In order to match the real behavior, don't use join here
@@ -135,7 +135,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
         when(notebook.getKernelSpec()).thenReturn({
-            metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
+            kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([
             // In order to match the real behavior, don't use join here
@@ -160,7 +160,7 @@ suite('DataScience - ipywidget - Local Widget Script Source', () => {
         const sysPrefix = 'sysPrefix Of Python in Metadata';
         const searchDirectory = path.join(sysPrefix, 'share', 'jupyter', 'nbextensions');
         when(notebook.getKernelSpec()).thenReturn({
-            metadata: { interpreter: { sysPrefix, path: 'pythonPath' } }
+            kernelSpec: { metadata: { interpreter: { sysPrefix, path: 'pythonPath' } } }
         } as any);
         when(fs.searchLocal(anything(), anything())).thenResolve([
             // In order to match the real behavior, don't use join here

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -167,8 +167,8 @@ suite('DataScience - KernelSelector', () => {
                 instance(sessionManager)
             );
 
-            assert.isOk((kernel as any)?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             verify(
                 kernelSelectionProvider.getKernelSelectionsForRemoteSession(
                     anything(),
@@ -285,8 +285,8 @@ suite('DataScience - KernelSelector', () => {
                 instance(sessionManager)
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
                     anything(),
@@ -325,7 +325,7 @@ suite('DataScience - KernelSelector', () => {
                 instance(sessionManager)
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
             verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(kernelService.findMatchingKernelSpec(interpreter, instance(sessionManager), anything())).once();
             verify(
@@ -371,8 +371,8 @@ suite('DataScience - KernelSelector', () => {
                 instance(sessionManager)
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(kernelService.findMatchingKernelSpec(interpreter, instance(sessionManager), anything())).once();
             verify(
@@ -416,7 +416,7 @@ suite('DataScience - KernelSelector', () => {
                 instance(sessionManager)
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
             verify(dependencyService.areDependenciesInstalled(interpreter, anything())).once();
             verify(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(
@@ -448,9 +448,11 @@ suite('DataScience - KernelSelector', () => {
 
             const kernel = await kernelSelector.selectLocalKernel(undefined, 'raw', new StopWatch());
 
-            assert.isOk(kernel?.interpreter === interpreter);
-            expect(kernel?.kernelSpec, 'Should have kernelspec').to.not.be.undefined;
-            expect(kernel!.kernelSpec!.name, 'Spec should have default name').to.include(defaultKernelSpecName);
+            assert.deepEqual(kernel?.interpreter, interpreter);
+            expect((kernel as any)?.kernelSpec, 'Should have kernelspec').to.not.be.undefined;
+            expect((kernel as any)?.kernelSpec!.name, 'Spec should have default name').to.include(
+                defaultKernelSpecName
+            );
         });
         test('For a raw connection, if a kernel spec is selected return it with the interpreter', async () => {
             when(dependencyService.areDependenciesInstalled(interpreter, anything())).thenResolve(true);
@@ -462,8 +464,8 @@ suite('DataScience - KernelSelector', () => {
                 selection: { interpreter: undefined, kernelSpec }
             } as any);
             const kernel = await kernelSelector.selectLocalKernel(undefined, 'raw', new StopWatch());
-            expect(kernel?.kernelSpec).to.equal(kernelSpec);
-            expect(kernel!.interpreter).to.equal(interpreter);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
         });
     });
     // tslint:disable-next-line: max-func-body-length
@@ -509,8 +511,8 @@ suite('DataScience - KernelSelector', () => {
 
             const kernel = await kernelSelector.getKernelForLocalConnection(anything(), 'raw', undefined, nbMetadata);
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual((kernel as any).kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
         });
         test('If metadata contains kernel information, then return a matching kernel and a matching interpreter', async () => {
             when(
@@ -533,8 +535,8 @@ suite('DataScience - KernelSelector', () => {
                 nbMetadata
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual((kernel as any).kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
@@ -564,7 +566,7 @@ suite('DataScience - KernelSelector', () => {
                 nbMetadata
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
+            assert.deepEqual((kernel as any).kernelSpec, kernelSpec);
             assert.isUndefined(kernel?.interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(
@@ -607,8 +609,8 @@ suite('DataScience - KernelSelector', () => {
                 nbMetadata
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual((kernel as any)?.kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(
                 kernelService.findMatchingKernelSpec(nbMetadataKernelSpec, instance(sessionManager), anything())
@@ -653,8 +655,8 @@ suite('DataScience - KernelSelector', () => {
                 undefined
             );
 
-            assert.isOk(kernel?.kernelSpec === kernelSpec);
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual(kernel?.kernelSpec, kernelSpec);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
             verify(kernelService.searchAndRegisterKernel(interpreter, anything(), anything())).once();
@@ -700,8 +702,9 @@ suite('DataScience - KernelSelector', () => {
                 undefined
             );
 
+            assert.ok((kernel as any)?.kernelSpec, 'No kernel spec found for remote');
             assert.equal((kernel as any)?.kernelSpec?.display_name, 'foo', 'Did not find the python kernel spec');
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
             verify(kernelService.searchAndRegisterKernel(interpreter, anything(), anything())).never();
@@ -760,7 +763,7 @@ suite('DataScience - KernelSelector', () => {
                 'foo',
                 'Did not find the preferred python kernel spec'
             );
-            assert.isOk(kernel?.interpreter === interpreter);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
             verify(kernelService.searchAndRegisterKernel(interpreter, anything())).never();
@@ -819,7 +822,7 @@ suite('DataScience - KernelSelector', () => {
                 'foo',
                 'Did not find the preferred python kernel spec'
             );
-            assert.isOk((kernel as any)?.interpreter === interpreter);
+            assert.deepEqual(kernel?.interpreter, interpreter);
             assert.isOk(selectLocalKernelStub.notCalled);
             verify(appShell.showInformationMessage(anything(), anything(), anything())).never();
             verify(kernelService.searchAndRegisterKernel(interpreter, anything())).never();

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -114,16 +114,19 @@ suite('DataScience - Kernel Switcher', () => {
             ].forEach((currentKernelInfo) => {
                 suite(currentKernelInfo.title, () => {
                     setup(() => {
-                        when(notebook.getKernelSpec()).thenReturn(currentKernelInfo.currentKernel);
+                        when(notebook.getKernelSpec()).thenReturn({
+                            kernelSpec: currentKernelInfo.currentKernel as any,
+                            kind: 'startUsingKernelSpec'
+                        });
                     });
 
                     test('Switch to new kernel', async () => {
                         await kernelSwitcher.switchKernelWithRetry(instance(notebook), newKernelSpec);
-                        verify(notebook.setKernelSpec(anything(), anything(), anything())).once();
+                        verify(notebook.setKernelSpec(anything(), anything())).once();
                     });
                     test('Switch to new kernel with error', async () => {
                         const ex = new JupyterSessionStartError(new Error('Kaboom'));
-                        when(notebook.setKernelSpec(anything(), anything(), anything())).thenReject(ex);
+                        when(notebook.setKernelSpec(anything(), anything())).thenReject(ex);
                         when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve(
                             // tslint:disable-next-line: no-any
                             Common.cancel() as any

--- a/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSwitcher.unit.test.ts
@@ -36,7 +36,7 @@ suite('DataScience - Kernel Switcher', () => {
     let currentKernel: IJupyterKernelSpec | LiveKernelModel;
     let selectedInterpreter: PythonEnvironment;
     let settings: IPythonSettings;
-    let newKernelSpec: KernelConnectionMetadata;
+    let newKernelConnection: KernelConnectionMetadata;
     setup(() => {
         connection = mock<IJupyterConnection>();
         settings = mock(PythonSettings);
@@ -54,7 +54,7 @@ suite('DataScience - Kernel Switcher', () => {
             sysPrefix: '',
             sysVersion: ''
         };
-        newKernelSpec = {
+        newKernelConnection = {
             kernelModel: currentKernel,
             interpreter: selectedInterpreter,
             kind: 'connectToLiveKernel'
@@ -114,19 +114,19 @@ suite('DataScience - Kernel Switcher', () => {
             ].forEach((currentKernelInfo) => {
                 suite(currentKernelInfo.title, () => {
                     setup(() => {
-                        when(notebook.getKernelSpec()).thenReturn({
+                        when(notebook.getKernelConnection()).thenReturn({
                             kernelSpec: currentKernelInfo.currentKernel as any,
                             kind: 'startUsingKernelSpec'
                         });
                     });
 
                     test('Switch to new kernel', async () => {
-                        await kernelSwitcher.switchKernelWithRetry(instance(notebook), newKernelSpec);
-                        verify(notebook.setKernelSpec(anything(), anything())).once();
+                        await kernelSwitcher.switchKernelWithRetry(instance(notebook), newKernelConnection);
+                        verify(notebook.setKernelConnection(anything(), anything())).once();
                     });
                     test('Switch to new kernel with error', async () => {
                         const ex = new JupyterSessionStartError(new Error('Kaboom'));
-                        when(notebook.setKernelSpec(anything(), anything())).thenReject(ex);
+                        when(notebook.setKernelConnection(anything(), anything())).thenReject(ex);
                         when(appShell.showErrorMessage(anything(), anything(), anything())).thenResolve(
                             // tslint:disable-next-line: no-any
                             Common.cancel() as any
@@ -135,7 +135,7 @@ suite('DataScience - Kernel Switcher', () => {
                         // This wouldn't normally fail for remote because sessions should always start if
                         // the remote server is up but both should throw
                         try {
-                            await kernelSwitcher.switchKernelWithRetry(instance(notebook), newKernelSpec);
+                            await kernelSwitcher.switchKernelWithRetry(instance(notebook), newKernelConnection);
                             assert.fail('Should throw exception');
                         } catch {
                             // This is expected

--- a/src/test/datascience/kernelLauncher.functional.test.ts
+++ b/src/test/datascience/kernelLauncher.functional.test.ts
@@ -67,7 +67,11 @@ suite('DataScience - Kernel Launcher', () => {
         } else {
             let exitExpected = false;
             const deferred = createDeferred<boolean>();
-            const kernel = await kernelLauncher.launch(kernelSpec, undefined, process.cwd());
+            const kernel = await kernelLauncher.launch(
+                { kernelSpec, kind: 'startUsingKernelSpec' },
+                undefined,
+                process.cwd()
+            );
             kernel.exited(() => {
                 if (exitExpected) {
                     deferred.resolve(true);
@@ -109,7 +113,11 @@ suite('DataScience - Kernel Launcher', () => {
             };
             kernelFinder.addKernelSpec(pythonInterpreter.path, spec);
 
-            const kernel = await kernelLauncher.launch(spec, undefined, process.cwd());
+            const kernel = await kernelLauncher.launch(
+                { kernelSpec: spec, kind: 'startUsingKernelSpec' },
+                undefined,
+                process.cwd()
+            );
             const exited = new Promise<boolean>((resolve) => kernel.exited(() => resolve(true)));
 
             assert.isOk<IKernelConnection | undefined>(kernel.connection, 'Connection not found');
@@ -139,7 +147,11 @@ suite('DataScience - Kernel Launcher', () => {
             // tslint:disable-next-line: no-invalid-this
             this.skip();
         } else {
-            const kernel = await kernelLauncher.launch(kernelSpec, undefined, process.cwd());
+            const kernel = await kernelLauncher.launch(
+                { kernelSpec, kind: 'startUsingKernelSpec' },
+                undefined,
+                process.cwd()
+            );
 
             try {
                 const zmq = await import('zeromq');

--- a/src/test/datascience/mockJupyterManager.ts
+++ b/src/test/datascience/mockJupyterManager.ts
@@ -28,7 +28,8 @@ import { IConfigurationService, IInstaller, Product } from '../../client/common/
 import { EXTENSION_ROOT_DIR } from '../../client/constants';
 import { generateCells } from '../../client/datascience/cellFactory';
 import { CellMatcher } from '../../client/datascience/cellMatcher';
-import { CodeSnippits, Identifiers } from '../../client/datascience/constants';
+import { CodeSnippets, Identifiers } from '../../client/datascience/constants';
+import { KernelConnectionMetadata } from '../../client/datascience/jupyter/kernels/types';
 import {
     ICell,
     IJupyterConnection,
@@ -147,18 +148,18 @@ export class MockJupyterManager implements IJupyterSessionManager {
         });
 
         // Setup our default cells that happen for everything
-        this.addCell(CodeSnippits.MatplotLibInitSvg);
-        this.addCell(CodeSnippits.MatplotLibInitPng);
-        this.addCell(CodeSnippits.ConfigSvg);
-        this.addCell(CodeSnippits.ConfigPng);
-        this.addCell(CodeSnippits.UpdateCWDAndPath.format(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience')));
+        this.addCell(CodeSnippets.MatplotLibInitSvg);
+        this.addCell(CodeSnippets.MatplotLibInitPng);
+        this.addCell(CodeSnippets.ConfigSvg);
+        this.addCell(CodeSnippets.ConfigPng);
+        this.addCell(CodeSnippets.UpdateCWDAndPath.format(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience')));
         this.addCell(
-            CodeSnippits.UpdateCWDAndPath.format(
+            CodeSnippets.UpdateCWDAndPath.format(
                 Uri.file(path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'datascience')).fsPath
             )
         );
         tmp.file((_e, p, _fd, cleanup) => {
-            this.addCell(CodeSnippits.UpdateCWDAndPath.format(path.dirname(p)));
+            this.addCell(CodeSnippets.UpdateCWDAndPath.format(path.dirname(p)));
             this.cleanTemp = cleanup;
         });
         this.addCell(`import sys\r\nsys.path.append('undefined')\r\nsys.path`);
@@ -425,7 +426,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
     }
 
     public startNew(
-        _kernelSpec: IJupyterKernelSpec,
+        _kernelConnection: KernelConnectionMetadata | undefined,
         _workingDirectory: string,
         cancelToken?: CancellationToken
     ): Promise<IJupyterSession> {
@@ -445,7 +446,7 @@ export class MockJupyterManager implements IJupyterSessionManager {
     }
 
     public changeWorkingDirectory(workingDir: string) {
-        this.addCell(CodeSnippits.UpdateCWDAndPath.format(workingDir));
+        this.addCell(CodeSnippets.UpdateCWDAndPath.format(workingDir));
         this.addCell('import os\nos.getcwd()', path.join(workingDir));
         this.addCell('import sys\nsys.path[0]', path.join(workingDir));
     }

--- a/src/test/datascience/mockJupyterNotebook.ts
+++ b/src/test/datascience/mockJupyterNotebook.ts
@@ -7,11 +7,10 @@ import { Observable } from 'rxjs/Observable';
 import { CancellationToken, Event, EventEmitter, Uri } from 'vscode';
 import { Resource } from '../../client/common/types';
 import { getDefaultInteractiveIdentity } from '../../client/datascience/interactive-window/identity';
-import { LiveKernelModel } from '../../client/datascience/jupyter/kernels/types';
+import { KernelConnectionMetadata } from '../../client/datascience/jupyter/kernels/types';
 import {
     ICell,
     ICellHashProvider,
-    IJupyterKernelSpec,
     INotebook,
     INotebookCompletion,
     INotebookExecutionLogger,
@@ -48,9 +47,7 @@ export class MockJupyterNotebook implements INotebook {
         return this.kernelInterrupted.event;
     }
     public kernelSocket = new Observable<KernelSocketInformation | undefined>();
-    public onKernelChanged: Event<IJupyterKernelSpec | LiveKernelModel> = new EventEmitter<
-        IJupyterKernelSpec | LiveKernelModel
-    >().event;
+    public onKernelChanged = new EventEmitter<KernelConnectionMetadata>().event;
     public onDisposed = new EventEmitter<void>().event;
     public onKernelRestarted = new EventEmitter<void>().event;
     public readonly disposed: boolean = false;
@@ -132,11 +129,11 @@ export class MockJupyterNotebook implements INotebook {
         noop();
     }
 
-    public getKernelSpec(): IJupyterKernelSpec | undefined {
+    public getKernelSpec(): KernelConnectionMetadata | undefined {
         return;
     }
 
-    public setKernelSpec(_spec: IJupyterKernelSpec | LiveKernelModel, _timeout: number): Promise<void> {
+    public setKernelSpec(_spec: KernelConnectionMetadata, _timeout: number): Promise<void> {
         return Promise.resolve();
     }
 

--- a/src/test/datascience/mockJupyterNotebook.ts
+++ b/src/test/datascience/mockJupyterNotebook.ts
@@ -129,11 +129,11 @@ export class MockJupyterNotebook implements INotebook {
         noop();
     }
 
-    public getKernelSpec(): KernelConnectionMetadata | undefined {
+    public getKernelConnection(): KernelConnectionMetadata | undefined {
         return;
     }
 
-    public setKernelSpec(_spec: KernelConnectionMetadata, _timeout: number): Promise<void> {
+    public setKernelConnection(_spec: KernelConnectionMetadata, _timeout: number): Promise<void> {
         return Promise.resolve();
     }
 

--- a/src/test/datascience/mockJupyterServer.ts
+++ b/src/test/datascience/mockJupyterServer.ts
@@ -4,6 +4,7 @@ import * as uuid from 'uuid/v4';
 import { Uri } from 'vscode';
 import { TemporaryFile } from '../../client/common/platform/types';
 import { noop } from '../../client/common/utils/misc';
+import { getNameOfKernelConnection } from '../../client/datascience/jupyter/kernels/helpers';
 import {
     IJupyterConnection,
     INotebook,
@@ -21,15 +22,12 @@ export class MockJupyterServer implements INotebookServer {
         return this._id;
     }
     public connect(launchInfo: INotebookServerLaunchInfo): Promise<void> {
-        if (launchInfo && launchInfo.connectionInfo && launchInfo.kernelSpec) {
+        if (launchInfo && launchInfo.connectionInfo && launchInfo.kernelConnectionMetadata) {
             this.launchInfo = launchInfo;
 
             // Validate connection info and kernel spec
-            if (
-                launchInfo.connectionInfo.baseUrl &&
-                launchInfo.kernelSpec.name &&
-                /[a-z,A-Z,0-9,-,.,_]+/.test(launchInfo.kernelSpec.name)
-            ) {
+            const name = getNameOfKernelConnection(launchInfo.kernelConnectionMetadata);
+            if (launchInfo.connectionInfo.baseUrl && name && /[a-z,A-Z,0-9,-,.,_]+/.test(name)) {
                 return Promise.resolve();
             }
         }

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -10,8 +10,8 @@ import { noop } from '../../client/common/utils/misc';
 import { JupyterInvalidKernelError } from '../../client/datascience/jupyter/jupyterInvalidKernelError';
 import { JupyterWaitForIdleError } from '../../client/datascience/jupyter/jupyterWaitForIdleError';
 import { JupyterKernelPromiseFailedError } from '../../client/datascience/jupyter/kernels/jupyterKernelPromiseFailedError';
-import { LiveKernelModel } from '../../client/datascience/jupyter/kernels/types';
-import { ICell, IJupyterKernelSpec, IJupyterSession, KernelSocketInformation } from '../../client/datascience/types';
+import { KernelConnectionMetadata } from '../../client/datascience/jupyter/kernels/types';
+import { ICell, IJupyterSession, KernelSocketInformation } from '../../client/datascience/types';
 import { ServerStatus } from '../../datascience-ui/interactive-common/mainState';
 import { sleep } from '../core';
 import { MockJupyterRequest } from './mockJupyterRequest';
@@ -192,10 +192,10 @@ export class MockJupyterSession implements IJupyterSession {
         this.completionTimeout = timeout;
     }
 
-    public changeKernel(kernel: IJupyterKernelSpec | LiveKernelModel, _timeoutMS: number): Promise<void> {
+    public changeKernel(kernelConnection: KernelConnectionMetadata, _timeoutMS: number): Promise<void> {
         if (this.pendingKernelChangeFailure) {
             this.pendingKernelChangeFailure = false;
-            return Promise.reject(new JupyterInvalidKernelError(kernel));
+            return Promise.reject(new JupyterInvalidKernelError(kernelConnection));
         }
         return Promise.resolve();
     }

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -271,7 +271,7 @@ suite('DataScience Native Editor', () => {
 
                         // Force an update to the editor so that it has a new kernel
                         const editor = (ne.editor as any) as NativeEditorWebView;
-                        await editor.updateNotebookOptions(invalidKernel, undefined);
+                        await editor.updateNotebookOptions({ kernelSpec: invalidKernel, kind: 'startUsingKernelSpec' });
 
                         // Run the first cell. Should fail but then ask for another
                         await addCell(ne.mount, 'a=1\na');

--- a/src/test/datascience/notebook/notebookStorage.unit.test.ts
+++ b/src/test/datascience/notebook/notebookStorage.unit.test.ts
@@ -33,17 +33,21 @@ suite('DataScience - Notebook Storage', () => {
     }
 
     function updateModelKernel(model: BaseNotebookModel, id: string) {
+        const kernelModel = {
+            name: 'foo',
+            // tslint:disable-next-line: no-any
+            session: {} as any,
+            lastActivityTime: new Date(),
+            numberOfConnections: 1,
+            id
+        };
         const change: NotebookModelChange = {
             kind: 'version',
-            kernelSpec: {
-                name: 'foo',
-                // tslint:disable-next-line: no-any
-                session: {} as any,
-                lastActivityTime: new Date(),
-                numberOfConnections: 1,
-                id
+            kernelConnection: {
+                kernelModel,
+                interpreter: undefined,
+                kind: 'connectToLiveKernel'
             },
-            interpreter: undefined,
             oldDirty: false,
             newDirty: true,
             source: 'user'

--- a/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
+++ b/src/test/datascience/raw-kernel/rawKernel.functional.test.ts
@@ -80,10 +80,9 @@ suite('DataScience raw kernel tests', () => {
             ioc.get<IProcessServiceFactory>(IProcessServiceFactory),
             ioc.get<KernelDaemonPool>(KernelDaemonPool),
             connectionInfo as any,
-            kernelSpec,
+            { kernelSpec, interpreter, kind: 'startUsingKernelSpec' },
             ioc.get<IDataScienceFileSystem>(IDataScienceFileSystem),
-            undefined,
-            interpreter
+            undefined
         );
         await kernelProcess.launch(process.cwd());
         return createRawKernel(kernelProcess, uuid());


### PR DESCRIPTION
For #13406 
**Summary of changes**
* Use KernelConnectionMetadata where ever we had `KernelSpec & PythonInterpreter` as two separate properties
	* Single change, but we had this used in a number of places
	* 99% of the code had both as two separate entities (now merged into one)
* Renamed props,vars, args from `kernelSpec` to `KernelConnectionMetadata` (as a result of the change in data `type`).

Oh yes, I'm going to ignore `SonarCloud Code Analysis` for now. Its related to existing code, and I'd like to minimize changes in this PR (even though i got a little carried away with fixing some typos 😄 ).

## Large PR
* Unfortunately its a single change, but its a core change, hence the large number of affected files (we had two types, now one)

# Question
* Should the variables be named `kernelMetadata` or `kernelConnection` or `kernelConnectionMetadata`
Personally I think `kernelConnection` or `kernelConnectionMetadata` are ok, interchangeably.
`kernelMetadata` seems to be too close to `kernelSpec` & `kernelModel`.
* [x] Run CI (ran once, and seemed ok)
* [x] Run Nightly tests (ran once, and seemed ok)
	* Windows is failing due to memory issues