### PR TITLE
Implement merge environments

### DIFF
--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -10,7 +10,7 @@ import { isMacDefaultPythonPath } from '../pythonEnvironments/discovery';
 import { InterpeterHashProviderFactory } from '../pythonEnvironments/discovery/locators/services/hashProviderFactory';
 import {
     EnvironmentType,
-    getInterpreterTypeName,
+    getEnvironmentTypeName,
     InterpreterInformation,
     PythonEnvironment,
     sortInterpreters
@@ -119,7 +119,7 @@ export class InterpreterHelper implements IInterpreterHelper {
         return isMacDefaultPythonPath(pythonPath);
     }
     public getInterpreterTypeDisplayName(interpreterType: EnvironmentType) {
-        return getInterpreterTypeName(interpreterType);
+        return getEnvironmentTypeName(interpreterType);
     }
     public getBestInterpreter(interpreters?: PythonEnvironment[]): PythonEnvironment | undefined {
         if (!Array.isArray(interpreters) || interpreters.length === 0) {

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -129,6 +129,9 @@ export function areSameEnvironment(
     if (!environment1 || !environment2) {
         return false;
     }
+    if (fs.arePathsSame(environment1.path, environment2.path)) {
+        return true;
+    }
     if (!areSameVersion(environment1.version, environment2.version)) {
         return false;
     }
@@ -149,7 +152,7 @@ export function areSameEnvironment(
 export function updateEnvironment(environment: PythonEnvironment, other: PythonEnvironment): void {
     // Preserve type information.
     // Possible we identified environment as unknown, but a later provider has identified env type.
-    if (environment.envType === EnvironmentType.Unknown && other.envType !== EnvironmentType.Unknown) {
+    if (environment.envType === EnvironmentType.Unknown && other.envType && other.envType !== EnvironmentType.Unknown) {
         environment.envType = other.envType;
     }
     const props: (keyof PythonEnvironment)[] = [

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -85,7 +85,7 @@ export type PartialPythonEnvironment = Partial<Omit<PythonEnvironment, 'path'>> 
  *
  * @param environment = the env info to normalize
  */
-export function normalizeEnvironment(environment: PythonEnvironment): void {
+export function normalizeEnvironment(environment: PartialPythonEnvironment): void {
     environment.path = path.normalize(environment.path);
 }
 
@@ -122,8 +122,8 @@ export function getEnvironmentTypeName(environmentType: EnvironmentType) {
  * @param environment2 - one of the two envs to compare
  */
 export function areSameEnvironment(
-    environment1: PythonEnvironment | undefined,
-    environment2: PythonEnvironment | undefined,
+    environment1: PartialPythonEnvironment | undefined,
+    environment2: PartialPythonEnvironment | undefined,
     fs: IFileSystem
 ): boolean {
     if (!environment1 || !environment2) {
@@ -149,7 +149,7 @@ export function areSameEnvironment(
  * @param environment - the info to update
  * @param other - the info to copy in
  */
-export function updateEnvironment(environment: PythonEnvironment, other: PythonEnvironment): void {
+export function updateEnvironment(environment: PartialPythonEnvironment, other: PartialPythonEnvironment): void {
     // Preserve type information.
     // Possible we identified environment as unknown, but a later provider has identified env type.
     if (environment.envType === EnvironmentType.Unknown && other.envType && other.envType !== EnvironmentType.Unknown) {
@@ -180,11 +180,14 @@ export function updateEnvironment(environment: PythonEnvironment, other: PythonE
  *
  * @param environments - the env infos to merge
  */
-export function mergeEnvironments(environments: PythonEnvironment[], fs: IFileSystem): PythonEnvironment[] {
-    return environments.reduce<PythonEnvironment[]>((accumulator, current) => {
+export function mergeEnvironments(
+    environments: PartialPythonEnvironment[],
+    fs: IFileSystem
+): PartialPythonEnvironment[] {
+    return environments.reduce<PartialPythonEnvironment[]>((accumulator, current) => {
         const existingItem = accumulator.find((item) => areSameEnvironment(current, item, fs));
         if (!existingItem) {
-            const copied: PythonEnvironment = { ...current };
+            const copied: PartialPythonEnvironment = { ...current };
             normalizeEnvironment(copied);
             accumulator.push(copied);
         } else {

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -83,18 +83,16 @@ export type PartialPythonEnvironment = Partial<Omit<PythonEnvironment, 'path'>> 
 /**
  * Standardize the given env info.
  *
- * @param interp = the env info to normalize
- * @param deps - functional dependencies
- * @prop deps.normalizePath - (like `path.normalize`)
+ * @param environment = the env info to normalize
  */
-export function normalizeEnvironment(interp: PythonEnvironment): void {
-    interp.path = path.normalize(interp.path);
+export function normalizeEnvironment(environment: PythonEnvironment): void {
+    environment.path = path.normalize(environment.path);
 }
 
 /**
  * Convert the Python environment type to a user-facing name.
  */
-export function getInterpreterTypeName(environmentType: EnvironmentType) {
+export function getEnvironmentTypeName(environmentType: EnvironmentType) {
     switch (environmentType) {
         case EnvironmentType.Conda: {
             return 'conda';
@@ -120,26 +118,23 @@ export function getInterpreterTypeName(environmentType: EnvironmentType) {
 /**
  * Determine if the given infos correspond to the same env.
  *
- * @param interp1 - one of the two envs to compare
- * @param interp2 - one of the two envs to compare
- * @param deps - functional dependencies
- * @prop deps.areSameVersion - determine if two versions are the same
- * @prop deps.inSameDirectory - determine if two files are in the same directory
+ * @param environment1 - one of the two envs to compare
+ * @param environment2 - one of the two envs to compare
  */
 export function areSameEnvironment(
-    interp1: PythonEnvironment | undefined,
-    interp2: PythonEnvironment | undefined,
+    environment1: PythonEnvironment | undefined,
+    environment2: PythonEnvironment | undefined,
     fs: IFileSystem
 ): boolean {
-    if (!interp1 || !interp2) {
+    if (!environment1 || !environment2) {
         return false;
     }
-    if (!areSameVersion(interp1.version, interp2.version)) {
+    if (!areSameVersion(environment1.version, environment2.version)) {
         return false;
     }
     // Could be Python 3.6 with path = python.exe, and Python 3.6
     // and path = python3.exe, so we check the parent directory.
-    if (!inSameDirectory(interp1.path, interp2.path, fs)) {
+    if (!inSameDirectory(environment1.path, environment2.path, fs)) {
         return false;
     }
     return true;
@@ -148,14 +143,14 @@ export function areSameEnvironment(
 /**
  * Update one env info with another.
  *
- * @param interp - the info to update
+ * @param environment - the info to update
  * @param other - the info to copy in
  */
-export function updateEnvironment(interp: PythonEnvironment, other: PythonEnvironment): void {
+export function updateEnvironment(environment: PythonEnvironment, other: PythonEnvironment): void {
     // Preserve type information.
     // Possible we identified environment as unknown, but a later provider has identified env type.
-    if (interp.envType === EnvironmentType.Unknown && other.envType !== EnvironmentType.Unknown) {
-        interp.envType = other.envType;
+    if (environment.envType === EnvironmentType.Unknown && other.envType !== EnvironmentType.Unknown) {
+        environment.envType = other.envType;
     }
     const props: (keyof PythonEnvironment)[] = [
         'envName',
@@ -168,9 +163,9 @@ export function updateEnvironment(interp: PythonEnvironment, other: PythonEnviro
         'pipEnvWorkspaceFolder'
     ];
     for (const prop of props) {
-        if (!interp[prop] && other[prop]) {
+        if (!environment[prop] && other[prop]) {
             // tslint:disable-next-line: no-any
-            (interp as any)[prop] = other[prop];
+            (environment as any)[prop] = other[prop];
         }
     }
 }
@@ -201,9 +196,6 @@ export function mergeEnvironments(environments: PythonEnvironment[], fs: IFileSy
  *
  * @param path1 - one of the two paths to compare
  * @param path2 - one of the two paths to compare
- * @param deps - functional dependencies
- * @prop deps.arePathsSame - determine if two filenames point to the same file
- * @prop deps.getPathDirname - (like `path.dirname`)
  */
 export function inSameDirectory(path1: string | undefined, path2: string | undefined, fs: IFileSystem): boolean {
     if (!path1 || !path2) {

--- a/src/client/pythonEnvironments/info/index.ts
+++ b/src/client/pythonEnvironments/info/index.ts
@@ -165,12 +165,12 @@ export function updateEnvironment(environment: PartialPythonEnvironment, other: 
         'version',
         'pipEnvWorkspaceFolder'
     ];
-    for (const prop of props) {
+    props.forEach((prop) => {
         if (!environment[prop] && other[prop]) {
             // tslint:disable-next-line: no-any
             (environment as any)[prop] = other[prop];
         }
-    }
+    });
 }
 
 /**

--- a/src/client/pythonEnvironments/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/info/pythonVersion.ts
@@ -74,6 +74,19 @@ export function parsePythonVersion(raw: string): PythonVersion | undefined {
     return new SemVer(rawVersion);
 }
 
+/**
+ * Determine if the given versions are the same.
+ *
+ * @param version1 - one of the two versions to compare
+ * @param version2 - one of the two versions to compare
+ */
+export function areSameVersion(version1?: PythonVersion, version2?: PythonVersion): boolean {
+    if (!version1 || !version2) {
+        return false;
+    }
+    return version1.raw === version2.raw;
+}
+
 type ExecResult = {
     stdout: string;
 };

--- a/src/test/pythonEnvironments/info/index.unit.test.ts
+++ b/src/test/pythonEnvironments/info/index.unit.test.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+// Move all the tests from `helper.unit.test.ts` here once `helper.ts` which contains
+// the old merge environments implementation is removed.


### PR DESCRIPTION
This is almost the same as `IInterpreterLocatorHelper.mergeInterpreters`, but does not use `getPipEnvInfo`. This will directly be consumed in environment collection. Help taken from https://github.com/microsoft/vscode-python/pull/12850/