### PR TITLE
change importSortProvider to use PythonToolExecutionService instead of ProcessServiceFactory

### DIFF
--- a/news/2 Fixes/13063.md
+++ b/news/2 Fixes/13063.md
@@ -1,0 +1,2 @@
+Fixes "write: EPIPE" error when calling "Python Refactor: Sort Imports" when
+"python.sortImports.path" is "isort"

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -291,6 +291,8 @@ export class PythonSettings implements IPythonSettings {
         } else {
             this.sortImports = sortImportSettings;
         }
+        this.sortImports.path = getAbsolutePath(systemVariables.resolveAny(this.sortImports.path), workspaceRoot);
+
         // Support for travis.
         this.sortImports = this.sortImports ? this.sortImports : { path: '', args: [] };
         // Support for travis.
@@ -396,6 +398,7 @@ export class PythonSettings implements IPythonSettings {
             systemVariables.resolveAny(this.formatting.blackPath),
             workspaceRoot
         );
+        console.log('configSettings', this.formatting);
 
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
         const autoCompleteSettings = systemVariables.resolveAny(

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -398,7 +398,6 @@ export class PythonSettings implements IPythonSettings {
             systemVariables.resolveAny(this.formatting.blackPath),
             workspaceRoot
         );
-        console.log('configSettings', this.formatting);
 
         // tslint:disable-next-line:no-backbone-get-set-outside-model no-non-null-assertion
         const autoCompleteSettings = systemVariables.resolveAny(

--- a/src/client/common/process/pythonToolService.ts
+++ b/src/client/common/process/pythonToolService.ts
@@ -25,7 +25,6 @@ export class PythonToolExecutionService implements IPythonToolExecutionService {
         if (options.env) {
             throw new Error('Environment variables are not supported');
         }
-        console.log('PythonToolExecutionService execObservable', executionInfo);
         if (executionInfo.moduleName && executionInfo.moduleName.length > 0) {
             const pythonExecutionService = await this.serviceContainer
                 .get<IPythonExecutionFactory>(IPythonExecutionFactory)
@@ -46,7 +45,6 @@ export class PythonToolExecutionService implements IPythonToolExecutionService {
         if (options.env) {
             throw new Error('Environment variables are not supported');
         }
-        console.log('PythonToolExecutionService exec', executionInfo);
         if (executionInfo.moduleName && executionInfo.moduleName.length > 0) {
             const pythonExecutionService = await this.serviceContainer
                 .get<IPythonExecutionFactory>(IPythonExecutionFactory)

--- a/src/client/common/process/pythonToolService.ts
+++ b/src/client/common/process/pythonToolService.ts
@@ -25,6 +25,7 @@ export class PythonToolExecutionService implements IPythonToolExecutionService {
         if (options.env) {
             throw new Error('Environment variables are not supported');
         }
+        console.log('PythonToolExecutionService execObservable', executionInfo);
         if (executionInfo.moduleName && executionInfo.moduleName.length > 0) {
             const pythonExecutionService = await this.serviceContainer
                 .get<IPythonExecutionFactory>(IPythonExecutionFactory)
@@ -45,6 +46,7 @@ export class PythonToolExecutionService implements IPythonToolExecutionService {
         if (options.env) {
             throw new Error('Environment variables are not supported');
         }
+        console.log('PythonToolExecutionService exec', executionInfo);
         if (executionInfo.moduleName && executionInfo.moduleName.length > 0) {
             const pythonExecutionService = await this.serviceContainer
                 .get<IPythonExecutionFactory>(IPythonExecutionFactory)

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -191,7 +191,7 @@ export interface IPythonSettings {
     readonly logging: ILoggingSettings;
 }
 export interface ISortImportSettings {
-    readonly path: string;
+    path: string;
     readonly args: string[];
 }
 

--- a/src/client/providers/importSortProvider.ts
+++ b/src/client/providers/importSortProvider.ts
@@ -154,25 +154,10 @@ export class SortImportsEditingProvider implements ISortImportsEditingProvider {
             cwd: path.dirname(uri.fsPath)
         };
 
-        // let moduleName: string | undefined;
-        // if (path.basename(_isort) === isort) {
-        //     moduleName = isort;
-        // }
-
-        // const executionInfo = {
-        //     execPath: isort,
-        //     moduleName,
-        //     args,
-        //     product: Product.isort
-        // };
-
         if (isort) {
-            const executionInfo = getExecutionInfo(isort, args);
-            // const procService = await this.processServiceFactory.create(document.uri);
             // Use isort directly instead of the internal script.
+            const executionInfo = getExecutionInfo(isort, args);
             return async (documentText: string) => {
-                // const args = getIsortArgs(filename, isortArgs);
-                // const result = procService.execObservable(isort, args, spawnOptions);
                 const result = await this.pythonToolExecutionService.execObservable(
                     executionInfo,
                     spawnOptions,


### PR DESCRIPTION
calling "Python Refactor: Sort Imports" from the command palette used to throw an `write: EPIPE` error when using a non-absolute path for isort. this PR fixes that by using a PythonToolExecutionService to execute `isort` instead of a `ProcessService`.

see #13063 

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
