### PR TITLE
Suppress stdout from cython layer

### DIFF
--- a/news/2 Fixes/11729.md
+++ b/news/2 Fixes/11729.md
@@ -1,0 +1,3 @@
+#11729
+Prevent test discovery from picking up stdout from low level file descriptors
+(thanks [Ryo Miyajima](https://github.com/sergeant-wizard))

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -173,7 +173,12 @@ def _replace_fd(file, target):
     Temporarily replace the file descriptor for `file`,
     for which sys.stdout or sys.stderr is passed.
     """
-    fd = file.fileno()
+    try:
+        fd = file.fileno()
+    except AttributeError:
+        # `file` does not have fileno() so it's been replaced from the
+        # default sys.stdout, etc. Return with noop.
+        return
     target_fd = target.fileno()
 
     # `os.dup2()` closes the original FD, so we make copies.
@@ -202,10 +207,10 @@ def _replace_stdx(attr, target):
 
 
 class _StringIO:
-    def set_value(self, value):
+    def setvalue(self, value):
         self._value = value
 
-    def get_value(self):
+    def getvalue(self):
         return self._value
 
 
@@ -219,7 +224,7 @@ def _temp_io():
             yield sio, f
     finally:
         with open(path, "r") as f:
-            sio.set_value(f.read())
+            sio.setvalue(f.read())
         try:
             os.remove(path)
         except OSError:

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -221,6 +221,12 @@ def _replace_stderr(target):
         sys.stderr = orig
 
 
+if sys.version_info < (3,):
+    _coerce_unicode = lambda s: unicode(s)
+else:
+    _coerce_unicode = lambda s: s
+
+
 @contextlib.contextmanager
 def _temp_io():
     sio = StringIO()
@@ -230,7 +236,7 @@ def _temp_io():
         finally:
             tmp.seek(0)
             buff = tmp.read()
-            sio.write(buff)
+            sio.write(_coerce_unicode(buff))
 
 
 @contextlib.contextmanager

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -220,7 +220,10 @@ def _temp_io():
     finally:
         with open(path, "r") as f:
             sio.set_value(f.read())
-        os.remove(path)
+        try:
+            os.remove(path)
+        except OSError:
+            pass
         os.rmdir(td)
 
 

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -2,6 +2,11 @@
 # Licensed under the MIT License.
 
 import contextlib
+
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO  # 2.7
 import os
 import os.path
 import sys
@@ -215,19 +220,11 @@ def _replace_stderr(target):
         sys.stderr = orig
 
 
-class _StringIO:
-    def setvalue(self, value):
-        self._value = value
-
-    def getvalue(self):
-        return self._value
-
-
 @contextlib.contextmanager
 def _temp_io():
     td = tempfile.mkdtemp()
     path = os.path.join(td, "temp")
-    sio = _StringIO()
+    sio = StringIO()
     try:
         with open(path, "w") as f:
             yield sio, f

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -223,12 +223,13 @@ def _replace_stderr(target):
 @contextlib.contextmanager
 def _temp_io():
     sio = StringIO()
-    with tempfile.TemporaryFile() as tmp:
+    with tempfile.TemporaryFile("r+") as tmp:
         try:
             yield sio, tmp
         finally:
             tmp.seek(0)
-            sio.setvalue(tmp.read())
+            buff = tmp.read()
+            sio.write(buff)
 
 
 @contextlib.contextmanager

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -222,20 +222,13 @@ def _replace_stderr(target):
 
 @contextlib.contextmanager
 def _temp_io():
-    td = tempfile.mkdtemp()
-    path = os.path.join(td, "temp")
     sio = StringIO()
-    try:
-        with open(path, "w") as f:
-            yield sio, f
-    finally:
-        with open(path, "r") as f:
-            sio.setvalue(f.read())
+    with tempfile.TemporaryFile() as tmp:
         try:
-            os.remove(path)
-        except OSError:
-            pass
-        os.rmdir(td)
+            yield sio, tmp
+        finally:
+            tmp.seek(0)
+            sio.setvalue(tmp.read())
 
 
 @contextlib.contextmanager

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -196,9 +196,9 @@ def hide_buffer(attr, ignored):
 def hide_stdio(_hide_buffer=hide_buffer):
     """Swallow stdout and stderr."""
     ignored = StdioStream()
-    with _hide_buffer("stdout", ignored):
+    with _hide_buffer("stdout", ignored) as stdout:
         with _hide_buffer("stderr", ignored):
-            yield
+            yield stdout
 
 
 if sys.version_info < (3,):

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -196,14 +196,23 @@ def _replace_fd(file, target):
 
 
 @contextlib.contextmanager
-def _replace_stdx(attr, target):
-    assert attr in ("stdout", "stderr")
-    orig = getattr(sys, attr)
-    setattr(sys, attr, target)
+def _replace_stdout(target):
+    orig = sys.stdout
+    sys.stdout = target
     try:
         yield orig
     finally:
-        setattr(sys, attr, orig)
+        sys.stdout = orig
+
+
+@contextlib.contextmanager
+def _replace_stderr(target):
+    orig = sys.stderr
+    sys.stderr = target
+    try:
+        yield orig
+    finally:
+        sys.stderr = orig
 
 
 class _StringIO:
@@ -237,9 +246,9 @@ def hide_stdio():
     """Swallow stdout and stderr."""
     with _temp_io() as (sio, fileobj):
         with _replace_fd(sys.stdout, fileobj):
-            with _replace_stdx("stdout", fileobj):
+            with _replace_stdout(fileobj):
                 with _replace_fd(sys.stderr, fileobj):
-                    with _replace_stdx("stderr", fileobj):
+                    with _replace_stderr(fileobj):
                         yield sio
 
 

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -183,10 +183,11 @@ def _replace_fd(file, target):
     except AttributeError:
         # `file` does not have fileno() so it's been replaced from the
         # default sys.stdout, etc. Return with noop.
+        yield
         return
     target_fd = target.fileno()
 
-    # `os.dup2()` closes the original FD, so we make copies.
+    # Keep the original FD to be restored in the finally clause.
     dup_fd = os.dup(fd)
     try:
         # Point the FD at the target.

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -171,7 +171,8 @@ def fix_fileid(
 
 
 @contextlib.contextmanager
-def hide_buffer(attr, ignored):
+def _hide_buffer(attr, ignored):
+    # an alternative approach is suggested: #6594
     assert attr in ("stdout", "stderr")
     stdout_fd = getattr(sys, attr).fileno()
     # Set / unset sys.stdout or sys.stderr values.
@@ -193,7 +194,7 @@ def hide_buffer(attr, ignored):
 
 
 @contextlib.contextmanager
-def hide_stdio(_hide_buffer=hide_buffer):
+def hide_stdio():
     """Swallow stdout and stderr."""
     ignored = StdioStream()
     with _hide_buffer("stdout", ignored) as stdout:

--- a/pythonFiles/testing_tools/adapter/util.py
+++ b/pythonFiles/testing_tools/adapter/util.py
@@ -2,11 +2,6 @@
 # Licensed under the MIT License.
 
 import contextlib
-
-try:
-    from io import StringIO
-except ImportError:
-    from StringIO import StringIO  # 2.7
 import os
 import os.path
 import sys
@@ -178,13 +173,7 @@ def _replace_fd(file, target):
     Temporarily replace the file descriptor for `file`,
     for which sys.stdout or sys.stderr is passed.
     """
-    # sys.stdout may have been altered to something (e.g., StringIO)
-    # which does not have fileno(), in which case we do nothing.
-    try:
-        get_fileno = file.fileno
-    except AttributeError:
-        return
-    fd = get_fileno()
+    fd = file.fileno()
     target_fd = target.fileno()
 
     # `os.dup2()` closes the original FD, so we make copies.
@@ -244,17 +233,6 @@ def hide_stdio():
                 with _replace_fd(sys.stderr, fileobj):
                     with _replace_stdx("stderr", fileobj):
                         yield sio
-
-
-if sys.version_info < (3,):
-
-    class StdioStream(StringIO):
-        def write(self, msg):
-            StringIO.write(self, msg.decode())
-
-
-else:
-    StdioStream = StringIO
 
 
 #############################

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -338,20 +338,21 @@ class DiscoverTests(unittest.TestCase):
             ("discovered.__len__", None, None),
             ("discovered.__getitem__", (0,), None),
         ]
+        pytest_stdout = "spamspamspamspamspamspamspammityspam"
 
         # In Python 3.8 __len__ is called twice.
         if PYTHON_38_OR_LATER:
             calls.insert(3, ("discovered.__len__", None, None))
 
-        # to simulate stdio behavior including methods like .fileno(),
+        # to simulate stdio behavior in methods like os.dup,
         # use actual files (rather than StringIO)
-        with tempfile.TemporaryFile() as mock:
+        with tempfile.TemporaryFile("r+") as mock:
             sys.stdout = mock
             try:
                 discover(
                     [],
                     hidestdio=True,
-                    _pytest_main=fake_pytest_main(stub, False),
+                    _pytest_main=fake_pytest_main(stub, False, pytest_stdout),
                     _plugin=plugin,
                 )
             finally:
@@ -369,7 +370,7 @@ class DiscoverTests(unittest.TestCase):
         discover(
             [],
             hidestdio=True,
-            _pytest_main=fake_pytest_main(stub, True),
+            _pytest_main=fake_pytest_main(stub, True, pytest_stdout),
             _plugin=plugin,
         )
         self.assertEqual(captured, "")
@@ -386,6 +387,7 @@ class DiscoverTests(unittest.TestCase):
             ("discovered.__len__", None, None),
             ("discovered.__getitem__", (0,), None),
         ]
+        pytest_stdout = "spamspamspamspamspamspamspammityspam"
 
         # In Python 3.8 __len__ is called twice.
         if PYTHON_38_OR_LATER:
@@ -393,7 +395,6 @@ class DiscoverTests(unittest.TestCase):
 
         buf = StringIO()
 
-        pytest_stdout = "spamspamspamspamspamspamspammityspam"
         sys.stdout = buf
         try:
             discover(
@@ -412,7 +413,6 @@ class DiscoverTests(unittest.TestCase):
         # simulate cases where stdout comes from the lower layer than sys.stdout
         # via file descriptors (e.g., from cython)
         stub.calls = []
-        pytest_stdout = "spamspamspamspamspamspamspammityspam"
         discover(
             [],
             hidestdio=False,

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -248,24 +248,24 @@ def generate_parse_item(pathsep):
 # tests
 
 
+def fake_pytest_main(stub, use_fd):
+    def ret(args, plugins):
+        stub.add_call("pytest.main", None, {"args": args, "plugins": plugins})
+        if use_fd:
+            write(sys.__stdout__.fileno(), DiscoverTests.pytest_stdout.encode())
+        else:
+            print(DiscoverTests.pytest_stdout, end="")
+        return 0
+
+    return ret
+
+
 class DiscoverTests(unittest.TestCase):
 
     DEFAULT_ARGS = [
         "--collect-only",
     ]
     pytest_stdout = "spamspamspamspamspamspamspammityspam"
-
-    @staticmethod
-    def fake_pytest_main(stub, use_fd):
-        def ret(args, plugins):
-            stub.add_call("pytest.main", None, {"args": args, "plugins": plugins})
-            if use_fd:
-                write(sys.__stdout__.fileno(), DiscoverTests.pytest_stdout.encode())
-            else:
-                print(DiscoverTests.pytest_stdout, end="")
-            return 0
-
-        return ret
 
     def test_basic(self):
         stub = Stub()
@@ -354,7 +354,7 @@ class DiscoverTests(unittest.TestCase):
                 discover(
                     [],
                     hidestdio=True,
-                    _pytest_main=self.fake_pytest_main(stub, False),
+                    _pytest_main=fake_pytest_main(stub, False),
                     _plugin=plugin,
                 )
             finally:
@@ -374,7 +374,7 @@ class DiscoverTests(unittest.TestCase):
         discover(
             [],
             hidestdio=True,
-            _pytest_main=self.fake_pytest_main(stub, True),
+            _pytest_main=fake_pytest_main(stub, True),
             _plugin=plugin,
         )
         self.assertEqual(captured, "")
@@ -403,7 +403,7 @@ class DiscoverTests(unittest.TestCase):
             discover(
                 [],
                 hidestdio=False,
-                _pytest_main=self.fake_pytest_main(stub, False),
+                _pytest_main=fake_pytest_main(stub, False),
                 _plugin=plugin,
             )
         finally:
@@ -419,7 +419,7 @@ class DiscoverTests(unittest.TestCase):
         discover(
             [],
             hidestdio=False,
-            _pytest_main=self.fake_pytest_main(stub, True),
+            _pytest_main=fake_pytest_main(stub, True),
             _plugin=plugin,
         )
         self.assertEqual(captured, DiscoverTests.pytest_stdout)

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -8,7 +8,7 @@ try:
 except ImportError:  # 2.7
     from StringIO import StringIO
 from os import name as OS_NAME
-from os import read, write
+from os import write
 import sys
 import tempfile
 import unittest

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -370,7 +370,7 @@ class DiscoverTests(unittest.TestCase):
 
         # simulate cases where stdout comes from the lower layer than sys.stdout
         # via file descriptors (e.g., from cython)
-        stub.calls.clear()
+        stub.calls = []
         discover(
             [],
             hidestdio=True,
@@ -415,7 +415,7 @@ class DiscoverTests(unittest.TestCase):
 
         # simulate cases where stdout comes from the lower layer than sys.stdout
         # via file descriptors (e.g., from cython)
-        stub.calls.clear()
+        stub.calls = []
         discover(
             [],
             hidestdio=False,

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -344,10 +344,15 @@ class DiscoverTests(unittest.TestCase):
             with open(stdio_mock, "w") as mock:
                 sys.stdout = mock
                 try:
-                    discover([], hidestdio=True, _pytest_main=fake_pytest_main, _plugin=plugin)
+                    discover(
+                        [],
+                        hidestdio=True,
+                        _pytest_main=fake_pytest_main,
+                        _plugin=plugin,
+                    )
                 finally:
                     sys.stdout = sys.__stdout__
-            
+
             with open(stdio_mock, "r") as mock:
                 captured = mock.read()
 

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -345,9 +345,7 @@ class DiscoverTests(unittest.TestCase):
 
         # to simulate stdio behavior including methods like .fileno(),
         # use actual files (rather than StringIO)
-        td = tempfile.mkdtemp()
-        stdio_mock = path.join(td, "stdio_mock")
-        with open(stdio_mock, "w") as mock:
+        with tempfile.TemporaryFile() as mock:
             sys.stdout = mock
             try:
                 discover(
@@ -359,10 +357,8 @@ class DiscoverTests(unittest.TestCase):
             finally:
                 sys.stdout = sys.__stdout__
 
-        with open(stdio_mock, "r") as mock:
+            mock.seek(0)
             captured = mock.read()
-        remove(stdio_mock)
-        rmdir(td)
 
         self.assertEqual(captured, "")
         self.assertEqual(stub.calls, calls)

--- a/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
+++ b/pythonFiles/tests/testing_tools/adapter/pytest/test_discovery.py
@@ -264,6 +264,7 @@ class DiscoverTests(unittest.TestCase):
             else:
                 print(DiscoverTests.pytest_stdout, end="")
             return 0
+
         return ret
 
     def test_basic(self):
@@ -371,7 +372,10 @@ class DiscoverTests(unittest.TestCase):
         # via file descriptors (e.g., from cython)
         stub.calls.clear()
         discover(
-            [], hidestdio=True, _pytest_main=self.fake_pytest_main(stub, True), _plugin=plugin,
+            [],
+            hidestdio=True,
+            _pytest_main=self.fake_pytest_main(stub, True),
+            _plugin=plugin,
         )
         self.assertEqual(captured, "")
         self.assertEqual(stub.calls, calls)
@@ -396,7 +400,12 @@ class DiscoverTests(unittest.TestCase):
 
         sys.stdout = buf
         try:
-            discover([], hidestdio=False, _pytest_main=self.fake_pytest_main(stub, False), _plugin=plugin)
+            discover(
+                [],
+                hidestdio=False,
+                _pytest_main=self.fake_pytest_main(stub, False),
+                _plugin=plugin,
+            )
         finally:
             sys.stdout = sys.__stdout__
         captured = buf.getvalue()
@@ -407,7 +416,12 @@ class DiscoverTests(unittest.TestCase):
         # simulate cases where stdout comes from the lower layer than sys.stdout
         # via file descriptors (e.g., from cython)
         stub.calls.clear()
-        discover([], hidestdio=False, _pytest_main=self.fake_pytest_main(stub, True), _plugin=plugin)
+        discover(
+            [],
+            hidestdio=False,
+            _pytest_main=self.fake_pytest_main(stub, True),
+            _plugin=plugin,
+        )
         self.assertEqual(captured, DiscoverTests.pytest_stdout)
         self.assertEqual(stub.calls, calls)
 


### PR DESCRIPTION
For #11729 


-   [X] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [X] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [X] Appropriate comments and documentation strings in the code.
-   [X] ~Has sufficient logging.~
-   [x] Has telemetry for enhancements.
-   [X] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~


I'm using pybullet for a project and it prints to stdout by simply running `import pybullet`.
What's more it can't be suppressed by the current `utils.hide_stdio` method because the message is coming from C code via Cython.
This patch will suppress messages from Cython layer by swapping the lower level file descriptors (I learned about the idea from [here](https://stackoverflow.com/questions/5081657/how-do-i-prevent-a-c-shared-library-to-print-on-stdout-in-python/17954769#17954769).
It's a dirty workaround but did work for my particular use case.
That said I think #6594 is probably the better approach.

I wasn't sure if I should send this PR as something to be considered merging, or if I should just inform users encountering #11729 to apply this patch as a temporary workaround.
I appreciate it if you could tell me what you think.