### PR TITLE
Update the README to drop Python 3.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python extension for Visual Studio Code
 
-A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/VSCode) with rich support for the [Python language](https://www.python.org/) (for all [actively supported versions](https://devguide.python.org/#status-of-python-branches) of the language: 2.7, >=3.5), including features such as IntelliSense, linting, debugging, code navigation, code formatting, Jupyter notebook support, refactoring, variable explorer, test explorer, snippets, and more!
+A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marketplace.visualstudio.com/VSCode) with rich support for the [Python language](https://www.python.org/) (for all [actively supported versions](https://devguide.python.org/#status-of-python-branches) of the language: 2.7, >=3.6), including features such as IntelliSense, linting, debugging, code navigation, code formatting, Jupyter notebook support, refactoring, variable explorer, test explorer, snippets, and more!
 
 ## Quick start
 

--- a/news/3 Code Health/13459.md
+++ b/news/3 Code Health/13459.md
@@ -1,0 +1,1 @@
+Drop support for Python 3.5 (it reaches end-of-life on September 13, 2020 and isort 5 does not support it)

--- a/news/3 Code Health/13459.md
+++ b/news/3 Code Health/13459.md
@@ -1,1 +1,1 @@
-Drop support for Python 3.5 (it reaches end-of-life on September 13, 2020 and isort 5 does not support it)
+Drop support for Python 3.5 (it reaches end-of-life on September 13, 2020 and isort 5 does not support it).


### PR DESCRIPTION
isort 5 dropped Python 3.5 and it also reaches EOL on September 13, 2020 which is less than a month away.

Closes #13459.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [x] The wiki is updated with any design decisions/details.
