### PR TITLE
Show a hover over "Disconnected/Connected" label for the connection icon in the toolbar

### DIFF
--- a/news/2 Fixes/13543.md
+++ b/news/2 Fixes/13543.md
@@ -1,0 +1,1 @@
+Added tooltip to indicate status of server connection

--- a/package.nls.json
+++ b/package.nls.json
@@ -179,6 +179,8 @@
     "DataScience.connectingToJupyter": "Connecting to Jupyter server",
     "DataScience.connectingToIPyKernel": "Connecting to IPython kernel",
     "DataScience.connectedToIPyKernel": "Connected.",
+    "DataScience.connected": "Connected",
+    "DataScience.disconnected": "Disconnected",
     "Experiments.inGroup": "User belongs to experiment group '{0}'",
     "Interpreters.RefreshingInterpreters": "Refreshing Python Interpreters",
     "Interpreters.entireWorkspace": "Entire workspace",

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -1106,6 +1106,8 @@ export namespace DataScience {
         'DataScience.previewNotebookOnlySupportedInVSCInsiders',
         'The Preview Notebook Editor is supported only in the Insiders version of Visual Studio Code.'
     );
+    export const connected = localize('DataScience.connected', 'Connected');
+    export const disconnected = localize('DataScience.disconnected', 'Disconnected');
 }
 
 export namespace StartPage {

--- a/src/datascience-ui/interactive-common/jupyterInfo.tsx
+++ b/src/datascience-ui/interactive-common/jupyterInfo.tsx
@@ -61,6 +61,7 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
                         baseTheme={this.props.baseTheme}
                         class="image-button-image kernel-status-icon"
                         image={this.getIcon()}
+                        title={this.getStatus()}
                     />
                 </div>
                 <div className="kernel-status-divider" />
@@ -112,5 +113,11 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
         return this.props.kernel.jupyterServerStatus === ServerStatus.NotStarted
             ? ImageName.JupyterServerDisconnected
             : ImageName.JupyterServerConnected;
+    }
+
+    private getStatus() {
+        return this.props.kernel.jupyterServerStatus === ServerStatus.NotStarted
+            ? getLocString('DataScience.disconnected', 'Disconnected')
+            : getLocString('DataScience.connected', 'Connected');
     }
 }

--- a/src/datascience-ui/react-common/image.tsx
+++ b/src/datascience-ui/react-common/image.tsx
@@ -238,6 +238,7 @@ interface IImageProps {
     baseTheme: string;
     image: ImageName;
     class: string;
+    title?: string;
 }
 
 export class Image extends React.Component<IImageProps> {
@@ -249,6 +250,6 @@ export class Image extends React.Component<IImageProps> {
         const key = ImageName[this.props.image].toString();
         const image = images.hasOwnProperty(key) ? images[key] : images.Cancel; // Default is cancel.
         const source = this.props.baseTheme.includes('dark') ? image.dark : image.light;
-        return <InlineSVG className={this.props.class} src={source} />;
+        return <InlineSVG className={this.props.class} src={source} title={this.props.title} />;
     }
 }


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [x] The wiki is updated with any design decisions/details.

The connection icon in the Notebook toolbar (on the top right corner), it displays red icon for Disconnected and green for Connected but does not show not show anything when you hover over it. This PR shows "Connected/Disconnected tooltip" on hovering over that icon


![image](https://user-images.githubusercontent.com/44413557/90810003-ee60fd80-e33f-11ea-81e3-a4cc04ab0ce4.png)

