### PR TITLE
Fix ts failure

### DIFF
--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -62,7 +62,9 @@ export function getNotebookMetadata(document: NotebookDocument): nbformat.INoteb
         const content = notebookContent || {};
         const metadata = content.metadata || { orig_nbformat: 3, language_info: {} };
         const language_info = { ...metadata.language_info, name: document.languages[0] };
-        notebookContent = { ...content, metadata: { ...metadata, language_info } };
+        // Fix nyc compiler not working.
+        // tslint:disable-next-line: no-any
+        notebookContent = { ...content, metadata: { ...metadata, language_info } } as any;
     }
     return notebookContent?.metadata;
 }


### PR DESCRIPTION
This error is happening here:
```
TSError: ⨯ Unable to compile TypeScript:
##[error]src/client/datascience/notebook/helpers/helpers.ts(65,66): error TS2322: Type '{ name: string; } | { name: string; codemirror_mode?: string | JSONObject | undefined; file_extension?: string | undefined; mimetype?: string | undefined; pygments_lexer?: string | undefined; } | { ...; }' is not assignable to type 'ILanguageInfoMetadata | undefined'.
  Type '{ name: string; codemirror_mode?: string | JSONObject | undefined; file_extension?: string | undefined; mimetype?: string | undefined; pygments_lexer?: string | undefined; }' is not assignable to type 'ILanguageInfoMetadata'.
    Property 'codemirror_mode' is incompatible with index signature.
      Type 'string | JSONObject | undefined' is not assignable to type 'JSONValue'.
        Type 'undefined' is not assignable to type 'JSONValue'.
```

Caused by my submission this morning.