### PR TITLE
Add uploading to the insiders build GitHub Action

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Install dependencies (npm ci)
         run: npm ci --prefer-offline
 
-      - name: Clean directory
-        run: npm run clean
-
       # Use the GITHUB_RUN_ID environment variable to update the build number.
       # GITHUB_RUN_ID is a unique number for each run within a repository.
       # This number does not change if you re-run the workflow run.


### PR DESCRIPTION
This includes some re-orientation as the insiders build mechanism. The action was also simplified with the expectation that it will be (mostly) copied over for doing release builds.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] The wiki is updated with any design decisions/details.
