### PR TITLE
Disable sorting tests for Python 2.7 as isort5 is not compatible with Python 2.7

### DIFF
--- a/news/3 Code Health/13542.md
+++ b/news/3 Code Health/13542.md
@@ -1,0 +1,1 @@
+Disable sorting tests for Python 2.7 as isort5 is not compatible with Python 2.7.

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 # IntelliSense
 jedi==0.17.2
 # Sort Imports
-isort==5.3.2
+isort==5.3.2; python_version >= '3.6'
 # DS Python daemon
 python-jsonrpc-server==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 future==0.18.2 \
     --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d \
     # via python-jsonrpc-server
-isort==5.3.2 \
+isort==5.3.2 ; python_version >= "3.6" \
     --hash=sha256:5196bd2f5b23dc91215734b1c96c6d28390061d69860a948094c12635d6d64e6 \
     --hash=sha256:ba83762132a8661d3525f87a86549712fb7d8da79eeb452e01f327ada9e87920 \
     # via -r requirements.in

--- a/src/test/format/extension.sort.test.ts
+++ b/src/test/format/extension.sort.test.ts
@@ -28,7 +28,18 @@ suite('Sorting', () => {
     let ioc: UnitTestIocContainer;
     let sorter: ISortImportsEditingProvider;
     const configTarget = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
-    suiteSetup(initialize);
+    suiteSetup(async function () {
+        const pythonVersion = process.env.CI_PYTHON_VERSION // GHA uses this
+            ? parseFloat(process.env.CI_PYTHON_VERSION)
+            : process.env.PythonVersion // Azdo uses this
+            ? parseFloat(process.env.PythonVersion)
+            : undefined;
+        if (pythonVersion && pythonVersion < 3) {
+            // tslint:disable-next-line:no-invalid-this
+            return this.skip();
+        }
+        await initialize();
+    });
     suiteTeardown(async () => {
         fs.writeFileSync(fileToFormatWithConfig, fs.readFileSync(originalFileToFormatWithConfig));
         fs.writeFileSync(fileToFormatWithConfig1, fs.readFileSync(originalFileToFormatWithConfig1));


### PR DESCRIPTION
For #13542

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
