### PR TITLE
Merge release back into master

### DIFF
--- a/news/1 Enhancements/13177.md
+++ b/news/1 Enhancements/13177.md
@@ -1,1 +1,0 @@
-The gather icon will change and get disabled while gather is executing.

--- a/news/2 Fixes/13543.md
+++ b/news/2 Fixes/13543.md
@@ -1,1 +1,0 @@
-Added tooltip to indicate status of server connection

--- a/src/test/linters/lint.multilinter.test.ts
+++ b/src/test/linters/lint.multilinter.test.ts
@@ -90,12 +90,7 @@ suite('Linting - Multiple Linters Enabled Test', () => {
         return `linting.${linterManager.getLinterInfo(product).enabledSettingName}` as PythonSettingKeys;
     }
 
-    test('Multiple linters', async function () {
-        // This test is failing in the CI. See this issue here:
-        // https://github.com/microsoft/vscode-python/issues/13345
-        // tslint:disable-next-line: no-invalid-this
-        this.skip();
-
+    test('Multiple linters', async () => {
         await closeActiveWindows();
         const document = await workspace.openTextDocument(path.join(pythoFilesPath, 'print.py'));
         await window.showTextDocument(document);


### PR DESCRIPTION
@IanMatthewHuff looks like file 13177.md was not deleted when the change log was generated for the 2020.8.0 release. Was that that intentional. The bug itself is not closed, so it can create duplicate entries, if we have more fixes going to that bug. Also, 11711.md from June release will run into a similar case. Since there is a new 11711.md for that issue in master, since it was not entirely fixed in the June release (see changelog entry for this). I think it is OK to have multiple fixes go in for the same issue, I am just checking since it looked odd.