### PR TITLE
Identify conda and windows store environments from given interpreter path

### DIFF
--- a/src/client/common/utils/platform.ts
+++ b/src/client/common/utils/platform.ts
@@ -3,6 +3,8 @@
 
 'use strict';
 
+import { EnvironmentVariables } from '../variables/types';
+
 export enum Architecture {
     Unknown = 1,
     x86 = 2,
@@ -26,4 +28,20 @@ export function getOSType(platform: string = process.platform): OSType {
     } else {
         return OSType.Unknown;
     }
+}
+
+export function getEnv(n: string): string | undefined {
+    // tslint:disable-next-line: no-any
+    return ((process as any) as EnvironmentVariables)[n];
+}
+
+export function getPathEnv(): string | undefined {
+    return getEnv('Path') || getEnv('PATH');
+}
+
+export function getUserHomeDir(): string | undefined {
+    if (getOSType() === OSType.Windows) {
+        return getEnv('USERPROFILE');
+    }
+    return getEnv('HOME');
 }

--- a/src/client/common/utils/platform.ts
+++ b/src/client/common/utils/platform.ts
@@ -30,18 +30,18 @@ export function getOSType(platform: string = process.platform): OSType {
     }
 }
 
-export function getEnv(n: string): string | undefined {
+export function getEnvironmentVariable(key: string): string | undefined {
     // tslint:disable-next-line: no-any
-    return ((process as any) as EnvironmentVariables)[n];
+    return ((process.env as any) as EnvironmentVariables)[key];
 }
 
-export function getPathEnv(): string | undefined {
-    return getEnv('Path') || getEnv('PATH');
+export function getPathEnvironmentVariable(): string | undefined {
+    return getEnvironmentVariable('Path') || getEnvironmentVariable('PATH');
 }
 
 export function getUserHomeDir(): string | undefined {
     if (getOSType() === OSType.Windows) {
-        return getEnv('USERPROFILE');
+        return getEnvironmentVariable('USERPROFILE');
     }
-    return getEnv('HOME');
+    return getEnvironmentVariable('HOME');
 }

--- a/src/client/common/utils/platform.ts
+++ b/src/client/common/utils/platform.ts
@@ -43,5 +43,5 @@ export function getUserHomeDir(): string | undefined {
     if (getOSType() === OSType.Windows) {
         return getEnvironmentVariable('USERPROFILE');
     }
-    return getEnvironmentVariable('HOME');
+    return getEnvironmentVariable('HOME') || getEnvironmentVariable('HOMEPATH');
 }

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as fsapi from 'fs-extra';
+import * as path from 'path';
+import { createDeferred } from '../../common/utils/async';
+import { getEnv, getPathEnv, getUserHomeDir } from '../../common/utils/platform';
+import { EnvironmentVariables } from '../../common/variables/types';
+import { EnvironmentType } from '../info';
+
+function pathExists(absPath: string): Promise<boolean> {
+    const deferred = createDeferred<boolean>();
+    fsapi.exists(absPath, (result) => {
+        deferred.resolve(result);
+    });
+    return deferred.promise;
+}
+
+function or(...arr: boolean[]): boolean {
+    return arr.filter((x) => x).length > 0;
+}
+
+/**
+ * Checks if the given interpreter path belongs to a conda environment. Using
+ * known folder layout, and presence of 'conda-meta' directory.
+ * @param {string} interpreterPath: Path to any python interpreter.
+ *
+ * Remarks: This is what we will use to begin with. Another approach we can take
+ * here is to parse ~/.conda/environments.txt. This file will have list of conda
+ * environments. We can compare the interpreter path against the paths in that file.
+ * We don't want to rely on this file because it is an implementation detail of
+ * conda. If it turns out that the layout based identification is not sufficient
+ * that is the next alternative that is cheap.
+ */
+async function isCondaEnvironment(interpreterPath: string): Promise<boolean> {
+    const conda_dir = 'conda-meta';
+
+    // Check if the conda-meta directory is in the same directory as the interpreter.
+    // This layout is common in Windows.
+    // env
+    // |__ conda-meta  <--- check if this directory exists
+    // |__ python.exe  <--- interpreterPath
+    const conda_env_dir_1 = path.join(path.dirname(interpreterPath), conda_dir);
+
+    // Check if the conda-meta directory is in the same directory as the interpreter.
+    // This layout is common on linux/MAc.
+    // env
+    // |__ conda-meta  <--- check if this directory exists
+    // |__ bin
+    //     |__ python  <--- interpreterPath
+    const conda_env_dir_2 = path.join(path.dirname(path.dirname(interpreterPath)), conda_dir);
+
+    return or(await pathExists(conda_env_dir_1), await pathExists(conda_env_dir_2));
+}
+
+async function isPyenvEnvironment(interpreterPath: string): Promise<boolean> {
+    let pyenvRoot = getEnv('PYENV_ROOT');
+    if (pyenvRoot === undefined) {
+        pyenvRoot = getPathEnv()
+            ?.split(path.delimiter)
+            .filter((p) => p.includes('.pyenv'))
+            .shift();
+    }
+
+    if (pyenvRoot === undefined) {
+        const userHome = getUserHomeDir();
+        if (userHome !== undefined) {
+            const pathToCheck: string = path.join(userHome, '.pyenv');
+            if (await pathExists(pathToCheck)) {
+                pyenvRoot = pathToCheck;
+            }
+        }
+    }
+}
+
+async function isWindowsStoreEnvironment(interpreterPath: string): Promise<boolean> {
+    const pythonPathToCompare = interpreterPath.toUpperCase().replace(/\//g, '\\');
+    return (
+        pythonPathToCompare.includes('\\Microsoft\\WindowsApps\\'.toUpperCase()) ||
+        pythonPathToCompare.includes('\\Program Files\\WindowsApps\\'.toUpperCase())
+    );
+}
+
+export async function identifyEnvironment(interpreterPath: string): Promise<EnvironmentType> {
+    if (await isCondaEnvironment(interpreterPath)) {
+        return EnvironmentType.Conda;
+    }
+
+    if (await isWindowsStoreEnvironment(interpreterPath)) {
+        return EnvironmentType.WindowsStore;
+    }
+
+    return EnvironmentType.Unknown;
+}

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -16,10 +16,6 @@ function pathExists(absPath: string): Promise<boolean> {
     return deferred.promise;
 }
 
-function or(...arr: boolean[]): boolean {
-    return arr.includes(true);
-}
-
 /**
  * Checks if the given interpreter path belongs to a conda environment. Using
  * known folder layout, and presence of 'conda-meta' directory.
@@ -68,7 +64,7 @@ async function isCondaEnvironment(interpreterPath: string): Promise<boolean> {
     //     |__ python  <--- interpreterPath
     const conda_env_dir_2 = path.join(path.dirname(path.dirname(interpreterPath)), condaMetaDir);
 
-    return or(await pathExists(conda_env_dir_1), await pathExists(conda_env_dir_2));
+    return [await pathExists(conda_env_dir_1), await pathExists(conda_env_dir_2)].includes(true);
 }
 
 /**

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -82,7 +82,8 @@ async function isWindowsStoreEnvironment(interpreterPath: string): Promise<boole
     const pythonPathToCompare = interpreterPath.toUpperCase().replace(/\//g, '\\');
     const localAppDataStorePath = path
         .join(getEnvironmentVariable('LOCALAPPDATA') || '', 'Microsoft', 'WindowsApps')
-        .toUpperCase();
+        .toUpperCase()
+        .replace(/\//g, '\\');
     if (pythonPathToCompare.includes(localAppDataStorePath)) {
         return true;
     }
@@ -91,7 +92,8 @@ async function isWindowsStoreEnvironment(interpreterPath: string): Promise<boole
     // We should never have to look at this path or even execute python from this path.
     const programFilesStorePath = path
         .join(getEnvironmentVariable('ProgramFiles') || 'Program Files', 'WindowsApps')
-        .toUpperCase();
+        .toUpperCase()
+        .replace(/\//g, '\\');
     if (pythonPathToCompare.includes(programFilesStorePath)) {
         traceWarning('isWindowsStoreEnvironment called with Program Files store path.');
         return true;

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -51,14 +51,14 @@ function or(...arr: boolean[]): boolean {
  * }
  */
 async function isCondaEnvironment(interpreterPath: string): Promise<boolean> {
-    const conda_dir = 'conda-meta';
+    const conda_meta_dir = 'conda-meta';
 
     // Check if the conda-meta directory is in the same directory as the interpreter.
     // This layout is common in Windows.
     // env
     // |__ conda-meta  <--- check if this directory exists
     // |__ python.exe  <--- interpreterPath
-    const conda_env_dir_1 = path.join(path.dirname(interpreterPath), conda_dir);
+    const conda_env_dir_1 = path.join(path.dirname(interpreterPath), conda_meta_dir);
 
     // Check if the conda-meta directory is in the same directory as the interpreter.
     // This layout is common on linux/Mac.
@@ -66,7 +66,7 @@ async function isCondaEnvironment(interpreterPath: string): Promise<boolean> {
     // |__ conda-meta  <--- check if this directory exists
     // |__ bin
     //     |__ python  <--- interpreterPath
-    const conda_env_dir_2 = path.join(path.dirname(path.dirname(interpreterPath)), conda_dir);
+    const conda_env_dir_2 = path.join(path.dirname(path.dirname(interpreterPath)), conda_meta_dir);
 
     return or(await pathExists(conda_env_dir_1), await pathExists(conda_env_dir_2));
 }

--- a/src/client/pythonEnvironments/common/environmentIdentifier.ts
+++ b/src/client/pythonEnvironments/common/environmentIdentifier.ts
@@ -54,7 +54,7 @@ async function isCondaEnvironment(interpreterPath: string): Promise<boolean> {
     // env
     // |__ conda-meta  <--- check if this directory exists
     // |__ python.exe  <--- interpreterPath
-    const conda_env_dir_1 = path.join(path.dirname(interpreterPath), condaMetaDir);
+    const condaEnvDir1 = path.join(path.dirname(interpreterPath), condaMetaDir);
 
     // Check if the conda-meta directory is in the parent directory relative to the interpreter.
     // This layout is common on linux/Mac.
@@ -62,9 +62,9 @@ async function isCondaEnvironment(interpreterPath: string): Promise<boolean> {
     // |__ conda-meta  <--- check if this directory exists
     // |__ bin
     //     |__ python  <--- interpreterPath
-    const conda_env_dir_2 = path.join(path.dirname(path.dirname(interpreterPath)), condaMetaDir);
+    const condaEnvDir2 = path.join(path.dirname(path.dirname(interpreterPath)), condaMetaDir);
 
-    return [await pathExists(conda_env_dir_1), await pathExists(conda_env_dir_2)].includes(true);
+    return [await pathExists(condaEnvDir1), await pathExists(condaEnvDir2)].includes(true);
 }
 
 /**

--- a/src/client/pythonEnvironments/discovery/locators/helpers.ts
+++ b/src/client/pythonEnvironments/discovery/locators/helpers.ts
@@ -21,7 +21,7 @@ export async function lookForInterpretersInDirectory(pathToCheck: string, _: IFi
             .map((filename) => path.join(pathToCheck, filename))
             .filter((fileName) => CheckPythonInterpreterRegEx.test(path.basename(fileName)));
     } catch (err) {
-        traceError('Python Extension (lookForInterpretersInDirectory.fs.listdir):', err);
+        traceError('Python Extension (lookForInterpretersInDirectory.fs.readdir):', err);
         return [] as string[];
     }
 }

--- a/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { identifyEnvironment } from '../../../client/pythonEnvironments/common/environmentIdentifier';
+import { EnvironmentType } from '../../../client/pythonEnvironments/info';
+
+suite('Environment Identifier', () => {
+    const testLayoutsRoot = path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        '..',
+        'src',
+        'test',
+        'pythonEnvironments',
+        'common',
+        'envlayouts'
+    );
+    test('Conda layout with conda-meta and python binary in the same directory', async () => {
+        const interpreterPath: string = path.join(testLayoutsRoot, 'conda1', 'python.exe');
+        const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+        assert.deepEqual(envType, EnvironmentType.Conda);
+    });
+    test('Conda layout with conda-meta and python binary in a sub directory', async () => {
+        const interpreterPath: string = path.join(testLayoutsRoot, 'conda2', 'bin', 'python');
+        const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+        assert.deepEqual(envType, EnvironmentType.Conda);
+    });
+});

--- a/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
@@ -74,13 +74,13 @@ suite('Environment Identifier', () => {
                 const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
                 assert.deepEqual(envType, EnvironmentType.WindowsStore);
             });
-            test('Local app data not set', async () => {
+            test(`Local app data not set (${exe})`, async () => {
                 getEnvVar.withArgs('LOCALAPPDATA').returns(undefined);
                 const interpreterPath = path.join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe);
                 const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
                 assert.deepEqual(envType, EnvironmentType.WindowsStore);
             });
-            test('Program files app data not set', async () => {
+            test(`Program files app data not set (${exe})`, async () => {
                 getEnvVar.withArgs('ProgramFiles').returns(undefined);
                 const interpreterPath = path.join(
                     fakeProgramFilesPath,
@@ -89,6 +89,20 @@ suite('Environment Identifier', () => {
                     exe
                 );
                 const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+            test(`Path using forward slashes (${exe})`, async () => {
+                const interpreterPath = path
+                    .join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe)
+                    .replace('\\', '/');
+                const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+            test(`Path using long path style slashes (${exe})`, async () => {
+                const interpreterPath = path
+                    .join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe)
+                    .replace('\\', '/');
+                const envType: EnvironmentType = await identifyEnvironment(`\\\\?\\${interpreterPath}`);
                 assert.deepEqual(envType, EnvironmentType.WindowsStore);
             });
         });

--- a/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
+++ b/src/test/pythonEnvironments/common/environmentIdentifier.unit.test.ts
@@ -3,6 +3,8 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
+import * as sinon from 'sinon';
+import * as platformApis from '../../../client/common/utils/platform';
 import { identifyEnvironment } from '../../../client/pythonEnvironments/common/environmentIdentifier';
 import { EnvironmentType } from '../../../client/pythonEnvironments/info';
 
@@ -19,14 +21,76 @@ suite('Environment Identifier', () => {
         'common',
         'envlayouts'
     );
-    test('Conda layout with conda-meta and python binary in the same directory', async () => {
-        const interpreterPath: string = path.join(testLayoutsRoot, 'conda1', 'python.exe');
-        const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
-        assert.deepEqual(envType, EnvironmentType.Conda);
+    suite('Conda', () => {
+        test('Conda layout with conda-meta and python binary in the same directory', async () => {
+            const interpreterPath: string = path.join(testLayoutsRoot, 'conda1', 'python.exe');
+            const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+            assert.deepEqual(envType, EnvironmentType.Conda);
+        });
+        test('Conda layout with conda-meta and python binary in a sub directory', async () => {
+            const interpreterPath: string = path.join(testLayoutsRoot, 'conda2', 'bin', 'python');
+            const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+            assert.deepEqual(envType, EnvironmentType.Conda);
+        });
     });
-    test('Conda layout with conda-meta and python binary in a sub directory', async () => {
-        const interpreterPath: string = path.join(testLayoutsRoot, 'conda2', 'bin', 'python');
-        const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
-        assert.deepEqual(envType, EnvironmentType.Conda);
+
+    suite('Windows Store', () => {
+        let getEnvVar: sinon.SinonStub;
+        const fakeLocalAppDataPath = 'X:\\users\\user\\AppData\\Local';
+        const fakeProgramFilesPath = 'X:\\Program Files';
+        const executable = ['python.exe', 'python3.exe', 'python3.8.exe'];
+        suiteSetup(() => {
+            getEnvVar = sinon.stub(platformApis, 'getEnvironmentVariable');
+            getEnvVar.withArgs('LOCALAPPDATA').returns(fakeLocalAppDataPath);
+            getEnvVar.withArgs('ProgramFiles').returns(fakeProgramFilesPath);
+        });
+        suiteTeardown(() => {
+            getEnvVar.restore();
+        });
+        executable.forEach((exe) => {
+            test(`Path to local app data windows store interpreter (${exe})`, async () => {
+                const interpreterPath = path.join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe);
+                const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+            test(`Path to local app data windows store interpreter app sub-directory (${exe})`, async () => {
+                const interpreterPath = path.join(
+                    fakeLocalAppDataPath,
+                    'Microsoft',
+                    'WindowsApps',
+                    'PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0',
+                    exe
+                );
+                const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+            test(`Path to program files windows store interpreter app sub-directory (${exe})`, async () => {
+                const interpreterPath = path.join(
+                    fakeProgramFilesPath,
+                    'WindowsApps',
+                    'PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0',
+                    exe
+                );
+                const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+            test('Local app data not set', async () => {
+                getEnvVar.withArgs('LOCALAPPDATA').returns(undefined);
+                const interpreterPath = path.join(fakeLocalAppDataPath, 'Microsoft', 'WindowsApps', exe);
+                const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+            test('Program files app data not set', async () => {
+                getEnvVar.withArgs('ProgramFiles').returns(undefined);
+                const interpreterPath = path.join(
+                    fakeProgramFilesPath,
+                    'WindowsApps',
+                    'PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0',
+                    exe
+                );
+                const envType: EnvironmentType = await identifyEnvironment(interpreterPath);
+                assert.deepEqual(envType, EnvironmentType.WindowsStore);
+            });
+        });
     });
 });

--- a/src/test/pythonEnvironments/common/envlayouts/conda1/conda-meta/history
+++ b/src/test/pythonEnvironments/common/envlayouts/conda1/conda-meta/history
@@ -1,0 +1,1 @@
+Usually contains command that was used to create or update the conda environment with time stamps.

--- a/src/test/pythonEnvironments/common/envlayouts/conda1/python.exe
+++ b/src/test/pythonEnvironments/common/envlayouts/conda1/python.exe
@@ -1,0 +1,1 @@
+Not real python exe

--- a/src/test/pythonEnvironments/common/envlayouts/conda2/bin/python
+++ b/src/test/pythonEnvironments/common/envlayouts/conda2/bin/python
@@ -1,0 +1,1 @@
+Not a real python binary

--- a/src/test/pythonEnvironments/common/envlayouts/conda2/conda-meta/history
+++ b/src/test/pythonEnvironments/common/envlayouts/conda2/conda-meta/history
@@ -1,0 +1,1 @@
+Usually contains command that was used to create or update the conda environment with time stamps.


### PR DESCRIPTION
This API is not consumed any where. This is adding all the low-level APIs we need for environment identification. In this PR, there is code to identify conda and windows store environments.