### PR TITLE
Add generic utils: DeepReadonly<T> and VersionInfo.

### DIFF
--- a/src/client/common/utils/misc.ts
+++ b/src/client/common/utils/misc.ts
@@ -41,6 +41,20 @@ export async function usingAsync<T extends IAsyncDisposable, R>(
     }
 }
 
+/**
+ * Like `Readonly<>`, but recursive.
+ *
+ * See https://github.com/Microsoft/TypeScript/pull/21316.
+ */
+// tslint:disable-next-line:no-any
+export type DeepReadonly<T> = T extends any[] ? IDeepReadonlyArray<T[number]> : DeepReadonlyNonArray<T>;
+type DeepReadonlyNonArray<T> = T extends object ? DeepReadonlyObject<T> : T;
+interface IDeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
+type DeepReadonlyObject<T> = {
+    readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
+};
+type NonFunctionPropertyNames<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T];
+
 // Information about a traced function/method call.
 export type TraceInfo = {
     elapsed: number; // milliseconds

--- a/src/client/common/utils/regexp.ts
+++ b/src/client/common/utils/regexp.ts
@@ -15,8 +15,13 @@
  * indicated by "\s".  Also, unlike with regular expression literals,
  * backslashes must be escaped.  Conversely, forward slashes do not
  * need to be escaped.
+ *
+ * Line comments are also removed.  A comment is two spaces followed
+ * by `#` followed by a space and then the rest of the text to the
+ * end of the line.
  */
-export function verboseRegExp(pattern: string): RegExp {
+export function verboseRegExp(pattern: string, flags?: string): RegExp {
+    pattern = pattern.replace(/(^| {2})# .*$/gm, '');
     pattern = pattern.replace(/\s+?/g, '');
-    return RegExp(pattern);
+    return RegExp(pattern, flags);
 }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -63,6 +63,9 @@ type RawBasicVersionInfo = BasicVersionInfo & {
 
 /**
  * Make a copy and set all the properties properly.
+ *
+ * Only the "basic" version info will be normalized.  The caller
+ * is responsible for any other properties beyond that.
  */
 export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): T {
     if (!info) {
@@ -112,6 +115,9 @@ function validateVersionPart(prop: string, part: unknown, unnormalized?: unknown
  * Fail if any properties are not set properly.
  *
  * The info is expected to be normalized already.
+ *
+ * Only the "basic" version info will be validated.  The caller
+ * is responsible for any other properties beyond that.
  */
 export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
     if (!info) {

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -10,58 +10,133 @@ import * as semver from 'semver';
 
 /**
  * basic version information
+ *
+ * A normalized object will only have non-negative numbers, or `-1`,
+ * in its properties.  A `-1` value is an indicator that the property
+ * is not set.  Lower properties will not be set if a higher property
+ * is not.
+ *
+ * Note that any object can be forced to look like a VersionInfo and
+ * any of the properties may be forced to hold a non-number value.
+ * To resolve this situation, pass the object through
+ * `normalizeVersionInfo()` and then `validateVersionInfo()`.
  */
-export type VersionInfo = {
+export type BasicVersionInfo = {
     major: number;
     minor: number;
     micro: number;
+    // There is also a hidden `unnormalized` property.
+};
+
+function normalizeVersionPart(part: number): number {
+    // Any -1 values where the original is not a number are handled in validation.
+    if (typeof part === 'number') {
+        if (isNaN(part) || part < 0) {
+            // We leave this as a marker.
+            return -1;
+        }
+        return part;
+    }
+    if (typeof part === 'string') {
+        const parsed = parseInt((part as unknown) as string, 10);
+        if (isNaN(parsed) || parsed < 0) {
+            return -1;
+        }
+        return parsed;
+    }
+    if (part === undefined || part === null) {
+        return -1;
+    }
+    return -1;
+}
+
+type RawBasicVersionInfo = BasicVersionInfo & {
+    unnormalized?: {
+        // tslint:disable:no-any
+        major?: any;
+        minor?: any;
+        micro?: any;
+        // tslint:enable:no-any
+    };
 };
 
 /**
  * Make a copy and set all the properties properly.
  */
-export function normalizeVersionInfo(info: VersionInfo): VersionInfo {
-    const norm = { ...info };
-    if (!norm.major || norm.major < 0) {
-        norm.major = 0;
-    }
-    if (!norm.minor || norm.minor < 0) {
-        norm.minor = 0;
-    }
-    if (!norm.micro || norm.micro < 0) {
-        norm.micro = 0;
+export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): T {
+    const norm: T = { ...info };
+    const raw = (norm as unknown) as RawBasicVersionInfo;
+    if (raw.unnormalized === undefined) {
+        raw.unnormalized = { ...norm };
+        norm.major = normalizeVersionPart(norm.major);
+        norm.minor = normalizeVersionPart(norm.minor);
+        norm.micro = normalizeVersionPart(norm.micro);
     }
     return norm;
+}
+
+function validateVersionPart(prop: string, part: number, unnormalized?: unknown) {
+    if (typeof part !== 'number' || isNaN(part)) {
+        throw Error(`invalid ${prop} version (not normalized)`);
+    }
+    if (part === 0 || part > 0) {
+        return;
+    }
+    if (typeof unnormalized === 'number') {
+        return;
+    }
+    if (unnormalized === undefined || unnormalized === null) {
+        return;
+    }
+    if (typeof unnormalized === 'string' && !isNaN(parseInt(unnormalized, 10))) {
+        return;
+    }
+    throw Error(`invalid ${prop} version (failed to normalize)`);
 }
 
 /**
  * Fail if any properties are not set properly.
  *
- * Optional properties that are not set are ignored.
- *
- * This assumes that the info has already been normalized.
+ * The info is expected to be normalized already.
  */
-export function validateVersionInfo(_info: VersionInfo) {
-    // For now we don't do any checks.
+export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
+    const raw = (info as unknown) as RawBasicVersionInfo;
+    validateVersionPart('major', info.major, raw.unnormalized?.major);
+    validateVersionPart('minor', info.minor, raw.unnormalized?.minor);
+    validateVersionPart('micro', info.micro, raw.unnormalized?.micro);
+    if (info.major < 0) {
+        throw Error('missing major version');
+    }
+    if (info.minor < 0) {
+        if (info.micro === 0 || info.micro > 0) {
+            throw Error('missing minor version');
+        }
+    }
 }
 
 /**
  * Convert the info to a simple string.
+ *
+ * Any negative parts are ignored.
+ *
+ * The object is expected to be normalized.
  */
-export function getVersionString(ver: VersionInfo): string {
-    if (ver.major === undefined) {
+export function getVersionString<T extends BasicVersionInfo>(info: T): string {
+    if (typeof info.major !== 'number' || typeof info.minor !== 'number' || typeof info.micro !== 'number') {
         return '';
-    } else if (ver.minor === undefined) {
-        return `${ver.major}`;
     }
-    if (ver.micro === undefined) {
-        return `${ver.major}.${ver.minor}`;
+    if (info.major < 0) {
+        return '';
+    } else if (info.minor < 0) {
+        return `${info.major}`;
+    } else if (info.micro < 0) {
+        return `${info.major}.${info.minor}`;
     }
-    return `${ver.major}.${ver.minor}.${ver.micro}`;
+    return `${info.major}.${info.minor}.${info.micro}`;
 }
 
-export type ParseResult = {
-    version: VersionInfo;
+export type ParseResult<T extends BasicVersionInfo = BasicVersionInfo> = {
+    version: T;
     before: string;
     after: string;
 };
@@ -72,7 +147,7 @@ export type ParseResult = {
  * If the version is surrounded by other text then that is provided
  * as well.
  */
-export function parseVersionInfo(verStr: string): ParseResult | undefined {
+export function parseBasicVersionInfo<T extends BasicVersionInfo>(verStr: string): ParseResult<T> | undefined {
     // ^
     // (.*?)
     // (\d+)
@@ -108,14 +183,11 @@ export function parseVersionInfo(verStr: string): ParseResult | undefined {
         }
     }
     const major = parseInt(majorStr, 10);
-    const minor = minorStr ? parseInt(minorStr, 10) : undefined;
-    const micro = microStr ? parseInt(microStr, 10) : undefined;
+    const minor = minorStr ? parseInt(minorStr, 10) : -1;
+    const micro = microStr ? parseInt(microStr, 10) : -1;
     return {
-        version: {
-            major,
-            minor: (minor as unknown) as number,
-            micro: (micro as unknown) as number
-        },
+        // This is effectively normalized.
+        version: ({ major, minor, micro } as unknown) as T,
         before: before || '',
         after: after || ''
     };
@@ -123,28 +195,33 @@ export function parseVersionInfo(verStr: string): ParseResult | undefined {
 
 /**
  * Returns true if the given version appears to be not set.
+ *
+ * The object is expected to already be normalized.
  */
-export function isVersionEmpty(ver: VersionInfo): boolean {
-    return ver.major === 0 && ver.minor === 0 && ver.micro === 0;
+export function isVersionInfoEmpty<T extends BasicVersionInfo>(info: T): boolean {
+    if (typeof info.major !== 'number' || typeof info.minor !== 'number' || typeof info.micro !== 'number') {
+        return false;
+    }
+    return info.major < 0 && info.minor < 0 && info.micro < 0;
 }
 
 //===========================
-// basic version
+// base version info
 
 /**
  * basic version information
  *
  * @prop raw - the unparsed version string, if any
  */
-export type Version = VersionInfo & {
+export type VersionInfo = BasicVersionInfo & {
     raw?: string;
 };
 
 /**
  * Make a copy and set all the properties properly.
  */
-export function normalizeVersion(info: Version): Version {
-    const norm = { ...info, ...normalizeVersionInfo(info) };
+export function normalizeVersionInfo<T extends VersionInfo>(info: T): T {
+    const norm = { ...info, ...normalizeBasicVersionInfo(info) };
     if (!norm.raw) {
         norm.raw = '';
     }
@@ -158,9 +235,24 @@ export function normalizeVersion(info: Version): Version {
  *
  * This assumes that the info has already been normalized.
  */
-export function validateVersion(info: Version) {
-    validateVersionInfo(info);
+export function validateVersionInfo<T extends VersionInfo>(info: T) {
+    validateBasicVersionInfo(info);
     // `info.raw` can be anything.
+}
+
+/**
+ * Extract a version from the given text.
+ *
+ * If the version is surrounded by other text then that is provided
+ * as well.
+ */
+export function parseVersionInfo<T extends VersionInfo>(verStr: string): ParseResult<T> | undefined {
+    const result = parseBasicVersionInfo<T>(verStr);
+    if (result === undefined) {
+        return undefined;
+    }
+    result.version.raw = verStr;
+    return result;
 }
 
 //===========================

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -3,7 +3,10 @@
 
 'use strict';
 
+// tslint:disable:no-multiline-string
+
 import * as semver from 'semver';
+import { verboseRegExp } from './regexp';
 
 //===========================
 // basic version info
@@ -141,6 +144,23 @@ export type ParseResult<T extends BasicVersionInfo = BasicVersionInfo> = {
     after: string;
 };
 
+const basicVersionPattern = `
+    ^
+    (.*?)  # <before>
+    (\\d+)  # <major>
+    (?:
+        [.]
+        (\\d+)  # <minor>
+        (?:
+            [.]
+            (\\d+)  # <micro>
+        )?
+    )?
+    ([^\\d].*)?  # <after>
+    $
+`;
+const basicVersionRegexp = verboseRegExp(basicVersionPattern, 's');
+
 /**
  * Extract a version from the given text.
  *
@@ -148,20 +168,7 @@ export type ParseResult<T extends BasicVersionInfo = BasicVersionInfo> = {
  * as well.
  */
 export function parseBasicVersionInfo<T extends BasicVersionInfo>(verStr: string): ParseResult<T> | undefined {
-    // ^
-    // (.*?)
-    // (\d+)
-    // (?:
-    //   \.
-    //   (\d+)
-    //   (?:
-    //     \.
-    //     (\d+)
-    //   )?
-    // )?
-    // ([^\d].*)?
-    // $
-    const match = verStr.match(/^(.*?)(\d+)(?:\.(\d+)(?:\.(\d+))?)?([^\d].*)?$/s);
+    const match = verStr.match(basicVersionRegexp);
     if (!match) {
         return undefined;
     }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -69,25 +69,26 @@ type RawBasicVersionInfo = BasicVersionInfo & {
     };
 };
 
+export const EMPTY_VERSION: RawBasicVersionInfo = {
+    major: -1,
+    minor: -1,
+    micro: -1,
+    unnormalized: {
+        major: undefined,
+        minor: undefined,
+        micro: undefined
+    }
+};
+
 /**
  * Make a copy and set all the properties properly.
  *
  * Only the "basic" version info will be normalized.  The caller
  * is responsible for any other properties beyond that.
  */
-export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): T {
+export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T | undefined): T {
     if (!info) {
-        const empty: unknown = {
-            major: -1,
-            minor: -1,
-            micro: -1,
-            unnormalized: {
-                major: undefined,
-                minor: undefined,
-                micro: undefined
-            }
-        };
-        return empty as T;
+        return EMPTY_VERSION as T;
     }
     const norm: T = { ...info };
     const raw = (norm as unknown) as RawBasicVersionInfo;
@@ -101,10 +102,9 @@ export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): 
     return norm;
 }
 
-function validateVersionPart(prop: string, part: unknown, unnormalized?: ErrorMsg) {
-    if (typeof part !== 'number' || isNaN(part)) {
-        throw Error(`invalid ${prop} version (not normalized)`);
-    }
+function validateVersionPart(prop: string, part: number, unnormalized?: ErrorMsg) {
+    // We expect a normalized version part here, so there's no need
+    // to check for NaN or non-numbers here.
     if (part === 0 || part > 0) {
         return;
     }
@@ -123,9 +123,6 @@ function validateVersionPart(prop: string, part: unknown, unnormalized?: ErrorMs
  * is responsible for any other properties beyond that.
  */
 export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
-    if (!info) {
-        throw Error('invalid version (not normalized)');
-    }
     const raw = (info as unknown) as RawBasicVersionInfo;
     validateVersionPart('major', info.major, raw.unnormalized?.major);
     validateVersionPart('minor', info.minor, raw.unnormalized?.minor);

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -67,6 +67,15 @@ type RawBasicVersionInfo = BasicVersionInfo & {
  * Make a copy and set all the properties properly.
  */
 export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): T {
+    if (!info) {
+        const empty = { major: -1, minor: -1, micro: -1 };
+        ((empty as unknown) as RawBasicVersionInfo).unnormalized = {
+            major: undefined,
+            minor: undefined,
+            micro: undefined
+        };
+        return empty as T;
+    }
     const norm: T = { ...info };
     const raw = (norm as unknown) as RawBasicVersionInfo;
     if (raw.unnormalized === undefined) {
@@ -103,6 +112,9 @@ function validateVersionPart(prop: string, part: number, unnormalized?: unknown)
  * The info is expected to be normalized already.
  */
 export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
+    if (!info) {
+        throw Error('invalid version (not normalized)');
+    }
     const raw = (info as unknown) as RawBasicVersionInfo;
     validateVersionPart('major', info.major, raw.unnormalized?.major);
     validateVersionPart('minor', info.minor, raw.unnormalized?.minor);
@@ -125,6 +137,9 @@ export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
  * The object is expected to be normalized.
  */
 export function getVersionString<T extends BasicVersionInfo>(info: T): string {
+    if (!info) {
+        return '';
+    }
     if (typeof info.major !== 'number' || typeof info.minor !== 'number' || typeof info.micro !== 'number') {
         return '';
     }
@@ -206,6 +221,9 @@ export function parseBasicVersionInfo<T extends BasicVersionInfo>(verStr: string
  * The object is expected to already be normalized.
  */
 export function isVersionInfoEmpty<T extends BasicVersionInfo>(info: T): boolean {
+    if (!info) {
+        return false;
+    }
     if (typeof info.major !== 'number' || typeof info.minor !== 'number' || typeof info.micro !== 'number') {
         return false;
     }
@@ -228,7 +246,12 @@ export type VersionInfo = BasicVersionInfo & {
  * Make a copy and set all the properties properly.
  */
 export function normalizeVersionInfo<T extends VersionInfo>(info: T): T {
-    const norm = { ...info, ...normalizeBasicVersionInfo(info) };
+    const basic = normalizeBasicVersionInfo(info);
+    if (!info) {
+        basic.raw = '';
+        return basic;
+    }
+    const norm = { ...info, ...basic };
     if (!norm.raw) {
         norm.raw = '';
     }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -5,6 +5,9 @@
 
 import * as semver from 'semver';
 
+//===========================
+// basic version info
+
 /**
  * basic version information
  */
@@ -15,6 +18,120 @@ export type VersionInfo = {
 };
 
 /**
+ * Make a copy and set all the properties properly.
+ */
+export function normalizeVersionInfo(info: VersionInfo): VersionInfo {
+    const norm = { ...info };
+    if (!norm.major || norm.major < 0) {
+        norm.major = 0;
+    }
+    if (!norm.minor || norm.minor < 0) {
+        norm.minor = 0;
+    }
+    if (!norm.micro || norm.micro < 0) {
+        norm.micro = 0;
+    }
+    return norm;
+}
+
+/**
+ * Fail if any properties are not set properly.
+ *
+ * Optional properties that are not set are ignored.
+ *
+ * This assumes that the info has already been normalized.
+ */
+export function validateVersionInfo(_info: VersionInfo) {
+    // For now we don't do any checks.
+}
+
+/**
+ * Convert the info to a simple string.
+ */
+export function getVersionString(ver: VersionInfo): string {
+    if (ver.major === undefined) {
+        return '';
+    } else if (ver.minor === undefined) {
+        return `${ver.major}`;
+    }
+    if (ver.micro === undefined) {
+        return `${ver.major}.${ver.minor}`;
+    }
+    return `${ver.major}.${ver.minor}.${ver.micro}`;
+}
+
+export type ParseResult = {
+    version: VersionInfo;
+    before: string;
+    after: string;
+};
+
+/**
+ * Extract a version from the given text.
+ *
+ * If the version is surrounded by other text then that is provided
+ * as well.
+ */
+export function parseVersionInfo(verStr: string): ParseResult | undefined {
+    // ^
+    // (.*?)
+    // (\d+)
+    // (?:
+    //   \.
+    //   (\d+)
+    //   (?:
+    //     \.
+    //     (\d+)
+    //   )?
+    // )?
+    // ([^\d].*)?
+    // $
+    const match = verStr.match(/^(.*?)(\d+)(?:\.(\d+)(?:\.(\d+))?)?([^\d].*)?$/s);
+    if (!match) {
+        return undefined;
+    }
+    // Ignore the first element (the full match).
+    const [, before, majorStr, minorStr, microStr, after] = match;
+    if (before && before.endsWith('.')) {
+        return undefined;
+    }
+
+    if (after && after !== '') {
+        if (after === '.') {
+            return undefined;
+        }
+        // Disallow a plain version with trailing text if it isn't complete
+        if (!before || before === '') {
+            if (!microStr || microStr === '') {
+                return undefined;
+            }
+        }
+    }
+    const major = parseInt(majorStr, 10);
+    const minor = minorStr ? parseInt(minorStr, 10) : undefined;
+    const micro = microStr ? parseInt(microStr, 10) : undefined;
+    return {
+        version: {
+            major,
+            minor: (minor as unknown) as number,
+            micro: (micro as unknown) as number
+        },
+        before: before || '',
+        after: after || ''
+    };
+}
+
+/**
+ * Returns true if the given version appears to be not set.
+ */
+export function isVersionEmpty(ver: VersionInfo): boolean {
+    return ver.major === 0 && ver.minor === 0 && ver.micro === 0;
+}
+
+//===========================
+// basic version
+
+/**
  * basic version information
  *
  * @prop raw - the unparsed version string, if any
@@ -22,6 +139,32 @@ export type VersionInfo = {
 export type Version = VersionInfo & {
     raw?: string;
 };
+
+/**
+ * Make a copy and set all the properties properly.
+ */
+export function normalizeVersion(info: Version): Version {
+    const norm = { ...info, ...normalizeVersionInfo(info) };
+    if (!norm.raw) {
+        norm.raw = '';
+    }
+    return norm;
+}
+
+/**
+ * Fail if any properties are not set properly.
+ *
+ * Optional properties that are not set are ignored.
+ *
+ * This assumes that the info has already been normalized.
+ */
+export function validateVersion(info: Version) {
+    validateVersionInfo(info);
+    // `info.raw` can be anything.
+}
+
+//===========================
+// semver
 
 export function parseVersion(raw: string): semver.SemVer {
     raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -5,6 +5,24 @@
 
 import * as semver from 'semver';
 
+/**
+ * basic version information
+ */
+export type VersionInfo = {
+    major: number;
+    minor: number;
+    micro: number;
+};
+
+/**
+ * basic version information
+ *
+ * @prop raw - the unparsed version string, if any
+ */
+export type Version = VersionInfo & {
+    raw?: string;
+};
+
 export function parseVersion(raw: string): semver.SemVer {
     raw = raw.replace(/\.00*(?=[1-9]|0\.)/, '.');
     const ver = semver.coerce(raw);

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -36,7 +36,10 @@ type ErrorMsg = string;
 function normalizeVersionPart(part: unknown): [number, ErrorMsg] {
     // Any -1 values where the original is not a number are handled in validation.
     if (typeof part === 'number') {
-        if (isNaN(part) || part < 0) {
+        if (isNaN(part)) {
+            return [-1, 'missing'];
+        }
+        if (part < 0) {
             // We leave this as a marker.
             return [-1, ''];
         }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -43,7 +43,7 @@ function normalizeVersionPart(part: unknown): [number, ErrorMsg] {
         return [part, ''];
     }
     if (typeof part === 'string') {
-        const parsed = parseInt(part as string, 10);
+        const parsed = parseInt(part, 10);
         if (isNaN(parsed)) {
             return [-1, 'string not numeric'];
         }

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -145,12 +145,6 @@ export function validateBasicVersionInfo<T extends BasicVersionInfo>(info: T) {
  * The object is expected to be normalized.
  */
 export function getVersionString<T extends BasicVersionInfo>(info: T): string {
-    if (!info) {
-        return '';
-    }
-    if (typeof info.major !== 'number' || typeof info.minor !== 'number' || typeof info.micro !== 'number') {
-        return '';
-    }
     if (info.major < 0) {
         return '';
     } else if (info.minor < 0) {

--- a/src/client/common/utils/version.ts
+++ b/src/client/common/utils/version.ts
@@ -31,7 +31,7 @@ export type BasicVersionInfo = {
     // There is also a hidden `unnormalized` property.
 };
 
-function normalizeVersionPart(part: number): number {
+function normalizeVersionPart(part: unknown): number {
     // Any -1 values where the original is not a number are handled in validation.
     if (typeof part === 'number') {
         if (isNaN(part) || part < 0) {
@@ -41,7 +41,7 @@ function normalizeVersionPart(part: number): number {
         return part;
     }
     if (typeof part === 'string') {
-        const parsed = parseInt((part as unknown) as string, 10);
+        const parsed = parseInt(part as string, 10);
         if (isNaN(parsed) || parsed < 0) {
             return -1;
         }
@@ -55,11 +55,9 @@ function normalizeVersionPart(part: number): number {
 
 type RawBasicVersionInfo = BasicVersionInfo & {
     unnormalized?: {
-        // tslint:disable:no-any
-        major?: any;
-        minor?: any;
-        micro?: any;
-        // tslint:enable:no-any
+        major?: unknown;
+        minor?: unknown;
+        micro?: unknown;
     };
 };
 
@@ -68,11 +66,15 @@ type RawBasicVersionInfo = BasicVersionInfo & {
  */
 export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): T {
     if (!info) {
-        const empty = { major: -1, minor: -1, micro: -1 };
-        ((empty as unknown) as RawBasicVersionInfo).unnormalized = {
-            major: undefined,
-            minor: undefined,
-            micro: undefined
+        const empty: unknown = {
+            major: -1,
+            minor: -1,
+            micro: -1,
+            unnormalized: {
+                major: undefined,
+                minor: undefined,
+                micro: undefined
+            }
         };
         return empty as T;
     }
@@ -87,7 +89,7 @@ export function normalizeBasicVersionInfo<T extends BasicVersionInfo>(info: T): 
     return norm;
 }
 
-function validateVersionPart(prop: string, part: number, unnormalized?: unknown) {
+function validateVersionPart(prop: string, part: unknown, unnormalized?: unknown) {
     if (typeof part !== 'number' || isNaN(part)) {
         throw Error(`invalid ${prop} version (not normalized)`);
     }

--- a/src/test/common/utils/version.unit.test.ts
+++ b/src/test/common/utils/version.unit.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+
+import { ParseResult, parseVersionInfo } from '../../../client/common/utils/version';
+
+function res(
+    major: number,
+    minor: number | undefined,
+    micro: number | undefined,
+    before: string,
+    after: string
+): ParseResult {
+    return {
+        before,
+        after,
+        version: {
+            major,
+            minor: (minor as unknown) as number,
+            micro: (micro as unknown) as number
+        }
+    };
+}
+
+const VERSIONS: [string, ParseResult][] = [
+    // plain
+    ['2.7.0', res(2, 7, 0, '', '')],
+    ['2.7', res(2, 7, undefined, '', '')],
+    ['02.7', res(2, 7, undefined, '', '')],
+    ['2.07', res(2, 7, undefined, '', '')],
+    ['2.7.01', res(2, 7, 1, '', '')],
+    ['2.7.11', res(2, 7, 11, '', '')],
+    ['3.11.1', res(3, 11, 1, '', '')],
+    ['0.0.0', res(0, 0, 0, '', '')],
+    // with before/after
+    [' 2.7.9 ', res(2, 7, 9, ' ', ' ')],
+    ['2.7.9-3.2.7', res(2, 7, 9, '', '-3.2.7')],
+    ['python2.7.exe', res(2, 7, undefined, 'python', '.exe')],
+    ['1.2.3.4.5-x2.2', res(1, 2, 3, '', '.4.5-x2.2')],
+    ['3.8.1a2', res(3, 8, 1, '', 'a2')],
+    ['3.8.1-alpha2', res(3, 8, 1, '', '-alpha2')],
+    [
+        '3.7.5 (default, Nov  7 2019, 10:50:52) \\n[GCC 8.3.0]',
+        res(3, 7, 5, '', ' (default, Nov  7 2019, 10:50:52) \\n[GCC 8.3.0]')
+    ],
+    ['2', res(2, undefined, undefined, '', '')],
+    ['python2', res(2, undefined, undefined, 'python', '')],
+    // without the "before" the following won't match.
+    ['python2.a', res(2, undefined, undefined, 'python', '.a')],
+    ['python2.b7', res(2, undefined, undefined, 'python', '.b7')]
+];
+
+suite('common utils - parseVersionInfo', () => {
+    suite('invalid versions', () => {
+        const INVALID = [
+            // Note that some of these are *almost* valid.
+            '2.',
+            '.2',
+            '.2.7',
+            'a',
+            '2.a',
+            '2.b7',
+            '2-b.7',
+            '2.7rc1',
+            ''
+        ];
+        for (const verStr of INVALID) {
+            test(`invalid - '${verStr}'`, () => {
+                const result = parseVersionInfo(verStr);
+
+                assert.equal(result, undefined);
+            });
+        }
+    });
+
+    for (const info of VERSIONS) {
+        const [verStr, expected] = info;
+        test(`valid - '${verStr}'`, () => {
+            const result = parseVersionInfo(verStr);
+
+            assert.deepEqual(result, expected);
+        });
+    }
+});

--- a/src/test/common/utils/version.unit.test.ts
+++ b/src/test/common/utils/version.unit.test.ts
@@ -76,24 +76,12 @@ const INVALID: VersionInfo[] = [
 ];
 
 suite('common utils - getVersionString', () => {
-    suite('valid', () => {
-        VERSIONS.forEach((data) => {
-            const [info, expected] = data;
-            test(`${expected}`, () => {
-                const result = getVersionString(info);
+    VERSIONS.forEach((data) => {
+        const [info, expected] = data;
+        test(`${expected}`, () => {
+            const result = getVersionString(info);
 
-                assert.equal(result, expected);
-            });
-        });
-    });
-
-    suite('invalid', () => {
-        INVALID.forEach((info) => {
-            test(`[${info.major}, ${info.minor}, ${info.micro}]`, () => {
-                const result = getVersionString(info);
-
-                assert.equal(result, '');
-            });
+            assert.equal(result, expected);
         });
     });
 });

--- a/src/test/common/utils/version.unit.test.ts
+++ b/src/test/common/utils/version.unit.test.ts
@@ -3,57 +3,307 @@
 
 import * as assert from 'assert';
 
-import { ParseResult, parseVersionInfo } from '../../../client/common/utils/version';
+import {
+    getVersionString,
+    isVersionInfoEmpty,
+    normalizeVersionInfo,
+    ParseResult,
+    parseVersionInfo,
+    validateVersionInfo,
+    VersionInfo
+} from '../../../client/common/utils/version';
+
+const NOT_USED = {};
+
+function ver(
+    // tslint:disable:no-any
+    major: any,
+    minor: any = NOT_USED,
+    micro: any = NOT_USED,
+    // tslint:enable:no-any
+    unnormalized?: VersionInfo
+): VersionInfo {
+    if (minor === NOT_USED) {
+        minor = -1;
+    }
+    if (micro === NOT_USED) {
+        micro = -1;
+    }
+    const info = {
+        major: (major as unknown) as number,
+        minor: (minor as unknown) as number,
+        micro: (micro as unknown) as number,
+        raw: undefined
+    };
+    if (unnormalized !== undefined) {
+        // tslint:disable-next-line:no-any
+        ((info as unknown) as any).unnormalized = unnormalized;
+    }
+    return info;
+}
 
 function res(
+    // These go into the VersionInfo:
     major: number,
-    minor: number | undefined,
-    micro: number | undefined,
+    minor: number,
+    micro: number,
+    // These are the remainder of the ParseResult:
     before: string,
     after: string
-): ParseResult {
+): ParseResult<VersionInfo> {
     return {
         before,
         after,
-        version: {
-            major,
-            minor: (minor as unknown) as number,
-            micro: (micro as unknown) as number
-        }
+        version: ver(major, minor, micro)
     };
 }
 
-const VERSIONS: [string, ParseResult][] = [
-    // plain
-    ['2.7.0', res(2, 7, 0, '', '')],
-    ['2.7', res(2, 7, undefined, '', '')],
-    ['02.7', res(2, 7, undefined, '', '')],
-    ['2.07', res(2, 7, undefined, '', '')],
-    ['2.7.01', res(2, 7, 1, '', '')],
-    ['2.7.11', res(2, 7, 11, '', '')],
-    ['3.11.1', res(3, 11, 1, '', '')],
-    ['0.0.0', res(0, 0, 0, '', '')],
-    // with before/after
-    [' 2.7.9 ', res(2, 7, 9, ' ', ' ')],
-    ['2.7.9-3.2.7', res(2, 7, 9, '', '-3.2.7')],
-    ['python2.7.exe', res(2, 7, undefined, 'python', '.exe')],
-    ['1.2.3.4.5-x2.2', res(1, 2, 3, '', '.4.5-x2.2')],
-    ['3.8.1a2', res(3, 8, 1, '', 'a2')],
-    ['3.8.1-alpha2', res(3, 8, 1, '', '-alpha2')],
-    [
-        '3.7.5 (default, Nov  7 2019, 10:50:52) \\n[GCC 8.3.0]',
-        res(3, 7, 5, '', ' (default, Nov  7 2019, 10:50:52) \\n[GCC 8.3.0]')
-    ],
-    ['2', res(2, undefined, undefined, '', '')],
-    ['python2', res(2, undefined, undefined, 'python', '')],
-    // without the "before" the following won't match.
-    ['python2.a', res(2, undefined, undefined, 'python', '.a')],
-    ['python2.b7', res(2, undefined, undefined, 'python', '.b7')]
+const VERSIONS: [VersionInfo, string][] = [
+    [ver(2, 7, 0), '2.7.0'],
+    [ver(2, 7, -1), '2.7'],
+    [ver(2, -1, -1), '2'],
+    [ver(-1, -1, -1), ''],
+    [ver(2, 7, 11), '2.7.11'],
+    [ver(3, 11, 1), '3.11.1'],
+    [ver(0, 0, 0), '0.0.0']
 ];
+const INVALID: VersionInfo[] = [
+    ver(undefined, undefined, undefined),
+    ver(null, null, null),
+    ver({}, {}, {}),
+    //ver('-1', '-1', '-1'),
+    ver('x', 'y', 'z')
+];
+
+suite('common utils - getVersionString', () => {
+    suite('valid', () => {
+        VERSIONS.forEach((data) => {
+            const [info, expected] = data;
+            test(`${expected}`, () => {
+                const result = getVersionString(info);
+
+                assert.equal(result, expected);
+            });
+        });
+    });
+
+    suite('invalid', () => {
+        INVALID.forEach((info) => {
+            test(`[${info.major}, ${info.minor}, ${info.micro}]`, () => {
+                const result = getVersionString(info);
+
+                assert.equal(result, '');
+            });
+        });
+    });
+});
+
+suite('common utils - isVersionEmpty', () => {
+    [
+        ver(-1, -1, -1),
+        // normalization failed:
+        ver(-1, -1, -1, ver(null, null, null)),
+        // not normalized by still empty
+        ver(-10, -10, -10)
+    ].forEach((data: VersionInfo) => {
+        const info = data;
+        test(`empty: ${info}`, () => {
+            const result = isVersionInfoEmpty(info);
+
+            assert.ok(result);
+        });
+    });
+
+    [
+        // clearly not empty:
+        ver(3, 4, 5),
+        ver(3, 4, -1),
+        ver(3, -1, -1),
+        // 0 is not empty:
+        ver(0, 0, 0),
+        ver(0, 0, -1),
+        ver(0, -1, -1)
+    ].forEach((data: VersionInfo) => {
+        const info = data;
+        test(`not empty: ${info.major}.${info.minor}.${info.micro}`, () => {
+            const result = isVersionInfoEmpty(info);
+
+            assert.equal(result, false);
+        });
+    });
+
+    INVALID.forEach((data: VersionInfo) => {
+        const info = data;
+        test(`bogus: ${info.major}`, () => {
+            const result = isVersionInfoEmpty(info);
+
+            assert.equal(result, false);
+        });
+    });
+});
+
+suite('common utils - normalizeVersionInfo', () => {
+    test(`noop`, () => {
+        const info = ver(1, 2, 3);
+        info.raw = '1.2.3';
+        // tslint:disable-next-line:no-any
+        ((info as unknown) as any).unnormalized = { ...info };
+        const expected = info;
+
+        const normalized = normalizeVersionInfo(info);
+
+        assert.deepEqual(normalized, expected);
+    });
+
+    test(`same`, () => {
+        const info = ver(1, 2, 3);
+        info.raw = '1.2.3';
+        // tslint:disable-next-line:no-any
+        const expected: any = { ...info };
+        expected.unnormalized = { ...info };
+
+        const normalized = normalizeVersionInfo(info);
+
+        assert.deepEqual(normalized, expected);
+    });
+
+    test(`NaN`, () => {
+        const info = ver(NaN, 2, 3);
+        info.raw = '';
+        // tslint:disable-next-line:no-any
+        const expected: any = { ...info };
+        expected.major = -1;
+        expected.unnormalized = { ...info };
+
+        const normalized = normalizeVersionInfo(info);
+
+        // tslint:disable-next-line:no-any
+        const raw = (normalized as unknown) as any;
+        assert.ok(isNaN(raw.unnormalized?.major));
+        raw.unnormalized.major = 1;
+        expected.unnormalized.major = 1;
+        assert.deepEqual(normalized, expected);
+    });
+
+    test('valid', () => {
+        const info = ver(3, -1, -10);
+        // tslint:disable-next-line:no-any
+        const expected: any = ver(3, -1, -1);
+        expected.raw = '';
+        expected.unnormalized = { ...info };
+
+        const normalized = normalizeVersionInfo(info);
+
+        assert.deepEqual(normalized, expected);
+    });
+
+    test('empty', () => {
+        const info = ver(-1, -5, -10);
+        // tslint:disable-next-line:no-any
+        const expected: any = ver(-1, -1, -1);
+        expected.raw = '';
+        expected.unnormalized = { ...info };
+
+        const normalized = normalizeVersionInfo(info);
+
+        assert.deepEqual(normalized, expected);
+    });
+
+    [
+        [ver(3, null, undefined), ver(3, -1, -1)],
+        [ver('', 4, '5'), ver(-1, 4, 5)],
+        [ver({}, [], 5), ver(-1, -1, 5)]
+    ].forEach((data) => {
+        const [info, expected] = data;
+        // tslint:disable-next-line:no-any
+        ((expected as unknown) as any).unnormalized = info;
+        expected.raw = '';
+        test(`partially invalid: [${info.major}, ${info.minor}, ${info.micro}]`, () => {
+            const normalized = normalizeVersionInfo(info);
+
+            assert.deepEqual(normalized, expected);
+        });
+    });
+});
+
+suite('common utils - validateVersionInfo', () => {
+    suite('valid', () => {
+        [
+            ver(3, 4, 5),
+            ver(3, 4, -1),
+            ver(3, -1, -1),
+            // unnormalized but still valid:
+            ver(3, -7, -11)
+        ].forEach((info) => {
+            test(`as-is: [${info.major}, ${info.minor}, ${info.micro}]`, () => {
+                validateVersionInfo(info);
+            });
+        });
+
+        [
+            // Each of these normalizes to -1:
+            NaN,
+            '-1',
+            '-10',
+            -11,
+            undefined,
+            null
+        ].forEach((value) => {
+            const raw = ver(3, 4, value);
+            const info = ver(3, 4, -1, raw);
+            test(`normalization worked: [${raw.major}, ${raw.minor}, ${raw.micro}]`, () => {
+                validateVersionInfo(info);
+            });
+        });
+    });
+
+    suite('invalid', () => {
+        [
+            // missing major:
+            ver(-1, -1, -1),
+            ver(-1, -1, 5),
+            ver(-1, 4, -1),
+            ver(-1, 4, 5),
+            // missing minor:
+            ver(3, -1, 5)
+        ].forEach((info) => {
+            test(`missing parts: [${info.major}.${info.minor}.${info.micro}]`, () => {
+                assert.throws(() => validateVersionInfo(info));
+            });
+        });
+
+        [
+            // parseInt() -> NaN:
+            '',
+            ' ',
+            '\n',
+            'foo',
+            // no equivalent number and no special-case:
+            {},
+            []
+        ].forEach((value) => {
+            const raw = ver(3, 4, value);
+            const info = ver(3, 4, -1, raw);
+            test(`normalization failed: [${raw.major}, ${raw.minor}, ${raw.micro}]`, () => {
+                assert.throws(() => validateVersionInfo(info));
+            });
+        });
+
+        [
+            ...INVALID,
+            // extra cases:
+            ver(NaN, 4, 5)
+        ].forEach((info) => {
+            test(`bogus: [${info.major}, ${info.minor}, ${info.micro}]`, () => {
+                assert.throws(() => validateVersionInfo(info));
+            });
+        });
+    });
+});
 
 suite('common utils - parseVersionInfo', () => {
     suite('invalid versions', () => {
-        const INVALID = [
+        const BOGUS = [
             // Note that some of these are *almost* valid.
             '2.',
             '.2',
@@ -65,7 +315,7 @@ suite('common utils - parseVersionInfo', () => {
             '2.7rc1',
             ''
         ];
-        for (const verStr of INVALID) {
+        for (const verStr of BOGUS) {
             test(`invalid - '${verStr}'`, () => {
                 const result = parseVersionInfo(verStr);
 
@@ -74,12 +324,40 @@ suite('common utils - parseVersionInfo', () => {
         }
     });
 
-    for (const info of VERSIONS) {
-        const [verStr, expected] = info;
-        test(`valid - '${verStr}'`, () => {
-            const result = parseVersionInfo(verStr);
+    suite('valid versions', () => {
+        ([
+            // plain
+            ...VERSIONS.map(([v, s]) => [s, { version: v, before: '', after: '' }]),
+            ['02.7', res(2, 7, -1, '', '')],
+            ['2.07', res(2, 7, -1, '', '')],
+            ['2.7.01', res(2, 7, 1, '', '')],
+            // with before/after
+            [' 2.7.9 ', res(2, 7, 9, ' ', ' ')],
+            ['2.7.9-3.2.7', res(2, 7, 9, '', '-3.2.7')],
+            ['python2.7.exe', res(2, 7, -1, 'python', '.exe')],
+            ['1.2.3.4.5-x2.2', res(1, 2, 3, '', '.4.5-x2.2')],
+            ['3.8.1a2', res(3, 8, 1, '', 'a2')],
+            ['3.8.1-alpha2', res(3, 8, 1, '', '-alpha2')],
+            [
+                '3.7.5 (default, Nov  7 2019, 10:50:52) \\n[GCC 8.3.0]',
+                res(3, 7, 5, '', ' (default, Nov  7 2019, 10:50:52) \\n[GCC 8.3.0]')
+            ],
+            ['python2', res(2, -1, -1, 'python', '')],
+            // without the "before" the following won't match.
+            ['python2.a', res(2, -1, -1, 'python', '.a')],
+            ['python2.b7', res(2, -1, -1, 'python', '.b7')]
+        ] as [string, ParseResult<VersionInfo>][]).forEach((data) => {
+            const [verStr, result] = data;
+            if (verStr === '') {
+                return;
+            }
+            const expected = { ...result, version: { ...result.version } };
+            expected.version.raw = verStr;
+            test(`valid - '${verStr}'`, () => {
+                const parsed = parseVersionInfo(verStr);
 
-            assert.deepEqual(result, expected);
+                assert.deepEqual(parsed, expected);
+            });
         });
-    }
+    });
 });

--- a/src/test/common/utils/version.unit.test.ts
+++ b/src/test/common/utils/version.unit.test.ts
@@ -283,15 +283,8 @@ suite('common utils - validateVersionInfo', () => {
             });
         });
 
-        [
-            ...INVALID,
-            // extra cases:
-            ver(NaN, 4, 5)
-        ].forEach((info) => {
-            test(`bogus: [${info.major}, ${info.minor}, ${info.micro}]`, () => {
-                assert.throws(() => validateVersionInfo(info));
-            });
-        });
+        // We expect only numbers, so NaN nor any of the items
+        // in INVALID need to be tested.
     });
 });
 


### PR DESCRIPTION
This will be used in upcoming locator-related changes.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
