### PR TITLE
Show the server display string that the user is going to connect to after selecting a compute instance and reloading the window.a…

### DIFF
--- a/news/2 Fixes/13551.md
+++ b/news/2 Fixes/13551.md
@@ -1,0 +1,1 @@
+Show the server display string that the user is going to connect to after selecting a compute instance and reloading the window.

--- a/src/datascience-ui/history-react/interactivePanel.tsx
+++ b/src/datascience-ui/history-react/interactivePanel.tsx
@@ -237,6 +237,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                         selectServer={this.props.selectServer}
                         selectKernel={this.props.selectKernel}
                         shouldShowTrustMessage={false}
+                        settings={this.props.settings}
                     />
                 );
             } else if (this.props.kernel.localizedUri === getLocString('DataScience.localJupyterServer', 'local')) {
@@ -252,6 +253,7 @@ ${buildSettingsCss(this.props.settings)}`}</style>
                 selectServer={this.props.selectServer}
                 selectKernel={this.props.selectKernel}
                 shouldShowTrustMessage={false}
+                settings={this.props.settings}
             />
         );
     }

--- a/src/datascience-ui/native-editor/toolbar.tsx
+++ b/src/datascience-ui/native-editor/toolbar.tsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { NativeMouseCommandTelemetry } from '../../client/datascience/constants';
+import { IDataScienceExtraSettings } from '../../client/datascience/types';
 import { JupyterInfo } from '../interactive-common/jupyterInfo';
 import {
     getSelectedAndFocusedInfo,
@@ -28,6 +29,7 @@ type INativeEditorDataProps = {
     kernel: IServerState;
     selectionFocusedInfo: SelectionAndFocusedInfo;
     variablesVisible: boolean;
+    settings?: IDataScienceExtraSettings;
 };
 export type INativeEditorToolbarProps = INativeEditorDataProps & {
     sendCommand: typeof actionCreators.sendCommand;
@@ -266,6 +268,7 @@ export class Toolbar extends React.PureComponent<INativeEditorToolbarProps> {
                         shouldShowTrustMessage={true}
                         isNotebookTrusted={this.props.isNotebookTrusted}
                         launchNotebookTrustPrompt={launchNotebookTrustPrompt}
+                        settings={this.props.settings}
                     />
                 </div>
                 <div className="toolbar-divider" />


### PR DESCRIPTION
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [x] The wiki is updated with any design decisions/details.

When the user selects a compute instance as a remote jupyter connection and then reloads the window, the user will see the name of the compute instance in the jupyter info toolbar along with the disconnected icon. 

![image](https://user-images.githubusercontent.com/44413557/91161829-e65ee000-e6e8-11ea-8320-1eb9c8080064.png)
