### PR TITLE
Specify that blob storage is authorized via az login

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -497,8 +497,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Upload to Blob Storage
-        uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az storage blob upload --file ${{ env.VSIX_NAME }} --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }}
-            az storage blob url --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }}
+        run: az storage blob upload --file ${{ env.VSIX_NAME }} --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }} --auth-mode login
+
+      - name: Get URL to uploaded VSIX
+        run: az storage blob url --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }} --auth-mode login


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-cli#authorize-access-to-blob-storage this should fix things.

Also simplify things by dropping the Azure/CLI action since we don't need CLI versioning and az is installed in the [base image](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#ubuntu-20041-lts).

See the failure at https://github.com/microsoft/vscode-python/runs/1024462127?check_suite_focus=true#step:4:24.