### PR TITLE
Fix an input for codecov-action step for passing in the codecov token

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -473,7 +473,7 @@ jobs:
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v1
         with:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/cobertura-coverage.xml
 
   upload:


### PR DESCRIPTION
Currently it [triggers a warning](https://github.com/microsoft/vscode-python/runs/1027829702?check_suite_focus=true#step:8:1).