### PR TITLE
Specify the storage account name when interacting with Azure Blob Storage

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -497,7 +497,7 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Upload to Blob Storage
-        run: az storage blob upload --file ${{ env.VSIX_NAME }} --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }} --auth-mode login
+        run: az storage blob upload --file ${{ env.VSIX_NAME }} --account-name pvsc --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }} --auth-mode login
 
       - name: Get URL to uploaded VSIX
-        run: az storage blob url --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }} --auth-mode login
+        run: az storage blob url --account-name pvsc --container-name ${{ env.BLOB_CONTAINER_NAME }} --name ${{ env.BLOB_NAME }} --auth-mode login


### PR DESCRIPTION
Failure at https://github.com/microsoft/vscode-python/runs/1028651418?check_suite_focus=true#step:4:20 suggests that the lack of specific storage account to access is cause of the failure (for now).