### PR TITLE
Stop mv from complaining about renaming the VSIX to the same name

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -52,7 +52,7 @@ jobs:
         id: build-vsix
 
       - name: Rename VSIX
-        run: mv ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
+        run: mv --no-clobber ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -52,7 +52,8 @@ jobs:
         id: build-vsix
 
       - name: Rename VSIX
-        run: mv --no-clobber ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
+        if: steps.build-vsix.outputs.path != env.VSIX_NAME
+        run: mv ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         id: build-vsix
 
       - name: Rename VSIX
-        run: mv ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
+        run: mv --no-clobber ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
         id: build-vsix
 
       - name: Rename VSIX
-        run: mv --no-clobber ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
+        if: steps.build-vsix.outputs.path != env.VSIX_NAME
+        run: mv ${{ steps.build-vsix.outputs.path }} ${{ env.VSIX_NAME }}
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
See https://github.com/microsoft/vscode-python/runs/1033973237?check_suite_focus=true#step:8:16 for the failure.