### PR TITLE
Fix forGetting an error on selecting an existing CI which has a display name from the historical CI's in the quick picks

### DIFF
--- a/news/2 Fixes/13387.md
+++ b/news/2 Fixes/13387.md
@@ -1,0 +1,1 @@
+Fixed connection to a Compute Instance from the quickpicks history options

--- a/src/client/datascience/common.ts
+++ b/src/client/datascience/common.ts
@@ -44,21 +44,23 @@ const AllowedKeys = {
     ['execute_result']: new Set(Object.keys(dummyExecuteResultObj))
 };
 
-export function getSavedUriList(globalState: Memento): { uri: string; time: number }[] {
-    const uriList = globalState.get<{ uri: string; time: number }[]>(Settings.JupyterServerUriList);
+export function getSavedUriList(globalState: Memento): { uri: string; time: number; displayName?: string }[] {
+    const uriList = globalState.get<{ uri: string; time: number; displayName?: string }[]>(
+        Settings.JupyterServerUriList
+    );
     return uriList
         ? uriList.sort((a, b) => {
               return b.time - a.time;
           })
         : [];
 }
-export function addToUriList(globalState: Memento, uri: string, time: number) {
+export function addToUriList(globalState: Memento, uri: string, time: number, displayName: string) {
     const uriList = getSavedUriList(globalState);
 
     const editList = uriList.filter((f, i) => {
         return f.uri !== uri && i < Settings.JupyterServerUriListMax - 1;
     });
-    editList.splice(0, 0, { uri, time });
+    editList.splice(0, 0, { uri, time, displayName });
 
     globalState.update(Settings.JupyterServerUriList, editList).then(noop, noop);
 }

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -37,6 +37,7 @@ import { EXTENSION_ROOT_DIR, isTestExecution, PYTHON_LANGUAGE } from '../../comm
 import { RemoveKernelToolbarInInteractiveWindow, RunByLine } from '../../common/experiments/groups';
 import { traceError, traceInfo, traceWarning } from '../../common/logger';
 
+import { isNil } from 'lodash';
 import {
     IConfigurationService,
     IDisposableRegistry,
@@ -1168,10 +1169,13 @@ export abstract class InteractiveBase extends WebViewHost<IInteractiveWindowMapp
             if (serverConnection.localLaunch) {
                 localizedUri = localize.DataScience.localJupyterServer();
             } else {
-                localizedUri = serverConnection.displayName;
-
                 // Log this remote URI into our MRU list
-                addToUriList(this.globalStorage, localizedUri, Date.now());
+                addToUriList(
+                    this.globalStorage,
+                    !isNil(serverConnection.url) ? serverConnection.url : serverConnection.displayName,
+                    Date.now(),
+                    serverConnection.displayName
+                );
             }
         }
 

--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -76,7 +76,8 @@ export function createRemoteConnectionInfo(
         },
         dispose: noop,
         rootDirectory: '',
-        getAuthHeader: serverUri ? () => getJupyterServerUri(uri)?.authorizationHeader : undefined
+        getAuthHeader: serverUri ? () => getJupyterServerUri(uri)?.authorizationHeader : undefined,
+        url: uri
     };
 }
 

--- a/src/client/datascience/jupyter/serverSelector.ts
+++ b/src/client/datascience/jupyter/serverSelector.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { inject, injectable, named } from 'inversify';
+import { isNil } from 'lodash';
 import { ConfigurationTarget, Memento, QuickPickItem, Uri } from 'vscode';
 import { IClipboard, ICommandManager } from '../../common/application/types';
 import { GLOBAL_MEMENTO, IConfigurationService, IMemento } from '../../common/types';
@@ -26,6 +27,7 @@ const defaultUri = 'https://hostname:8080/?token=849d61a414abafab97bc4aab1f35477
 interface ISelectUriQuickPickItem extends QuickPickItem {
     newChoice: boolean;
     provider?: IJupyterUriProvider;
+    url?: string;
 }
 
 @injectable()
@@ -66,7 +68,7 @@ export class JupyterServerSelector {
         if (item.label === this.localLabel) {
             await this.setJupyterURIToLocal();
         } else if (!item.newChoice && !item.provider) {
-            await this.setJupyterURIToRemote(item.label);
+            await this.setJupyterURIToRemote(!isNil(item.url) ? item.url : item.label);
         } else if (!item.provider) {
             return this.selectRemoteURI.bind(this);
         } else {
@@ -208,9 +210,10 @@ export class JupyterServerSelector {
             if (uriItem.uri) {
                 const uriDate = new Date(uriItem.time);
                 items.push({
-                    label: uriItem.uri,
+                    label: !isNil(uriItem.displayName) ? uriItem.displayName : uriItem.uri,
                     detail: DataScience.jupyterSelectURIMRUDetail().format(uriDate.toLocaleString()),
-                    newChoice: false
+                    newChoice: false,
+                    url: uriItem.uri
                 });
             }
         });

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -74,6 +74,7 @@ export interface IJupyterConnection extends Disposable {
     readonly hostName: string;
     localProcExitCode: number | undefined;
     readonly rootDirectory: string; // Directory where the notebook server was started.
+    readonly url?: string;
     // tslint:disable-next-line: no-any
     getAuthHeader?(): any; // Snould be a json object
 }

--- a/src/test/datascience/jupyter/serverSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/serverSelector.unit.test.ts
@@ -103,7 +103,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         // Add in a new server
         const serverA1 = { uri: 'ServerA', time: 1, date: new Date(1) };
-        addToUriList(mockStorage, serverA1.uri, serverA1.time);
+        addToUriList(mockStorage, serverA1.uri, serverA1.time, serverA1.uri);
 
         await ds.selectJupyterURI(true);
         assert.equal(quickPick?.items.length, 3, 'Wrong number of items in the quick pick');
@@ -111,7 +111,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         // Add in a second server, the newer server should be higher in the list due to newer time
         const serverB1 = { uri: 'ServerB', time: 2, date: new Date(2) };
-        addToUriList(mockStorage, serverB1.uri, serverB1.time);
+        addToUriList(mockStorage, serverB1.uri, serverB1.time, serverB1.uri);
         await ds.selectJupyterURI(true);
         assert.equal(quickPick?.items.length, 4, 'Wrong number of items in the quick pick');
         quickPickCheck(quickPick?.items[2], serverB1);
@@ -119,7 +119,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         // Reconnect to server A with a new time, it should now be higher in the list
         const serverA3 = { uri: 'ServerA', time: 3, date: new Date(3) };
-        addToUriList(mockStorage, serverA3.uri, serverA3.time);
+        addToUriList(mockStorage, serverA3.uri, serverA3.time, serverA3.uri);
         await ds.selectJupyterURI(true);
         assert.equal(quickPick?.items.length, 4, 'Wrong number of items in the quick pick');
         quickPickCheck(quickPick?.items[3], serverB1);
@@ -127,7 +127,7 @@ suite('DataScience - Jupyter Server URI Selector', () => {
 
         // Verify that we stick to our settings limit
         for (let i = 0; i < Settings.JupyterServerUriListMax + 10; i = i + 1) {
-            addToUriList(mockStorage, i.toString(), i);
+            addToUriList(mockStorage, i.toString(), i, i.toString());
         }
 
         await ds.selectJupyterURI(true);


### PR DESCRIPTION

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [x] The wiki is updated with any design decisions/details.

When a display name is provided for a remote jupyter server (right now contributed by Azure ML extension), the historical server quickpicks does not store the uri but only the display name of the server and thus throws an error when connecting to that remote server. This PR fixes the issue and now stores both the display name as well as the uri. Backward compatibility has been ensured by checking for non-null display names when needed

 
![image](https://user-images.githubusercontent.com/44413557/91475846-cd595900-e8b9-11ea-92e1-aff967db28d7.png)
