### PR TITLE
Make Jupyter Server name clickable to select Jupyter server

### DIFF
--- a/news/1 Enhancements/13656.md
+++ b/news/1 Enhancements/13656.md
@@ -1,0 +1,1 @@
+Make Jupyter Server name clickable to select Jupyter server

--- a/src/datascience-ui/interactive-common/jupyterInfo.tsx
+++ b/src/datascience-ui/interactive-common/jupyterInfo.tsx
@@ -33,6 +33,7 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
     constructor(prop: IJupyterInfoProps) {
         super(prop);
         this.selectKernel = this.selectKernel.bind(this);
+        this.selectServer = this.selectServer.bind(this);
     }
 
     public render() {
@@ -59,11 +60,18 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
             maxWidth: getMaxWidth(displayNameTextSize)
         };
 
+        const ariaDisabled = this.props.isNotebookTrusted === undefined ? false : this.props.isNotebookTrusted;
         return (
             <div className="kernel-status" style={dynamicFont}>
                 {this.renderTrustMessage()}
-                <div className="kernel-status-section kernel-status-server" style={serverTextWidth} role="button">
-                    <div className="kernel-status-text" title={jupyterServerDisplayName}>
+                <div className="kernel-status-section kernel-status-server" style={serverTextWidth}>
+                    <div
+                        className="kernel-status-text kernel-status-section-hoverable"
+                        style={serverTextWidth}
+                        onClick={this.selectServer}
+                        role="button"
+                        aria-disabled={ariaDisabled}
+                    >
                         {getLocString('DataScience.jupyterServer', 'Jupyter Server')}: {jupyterServerDisplayName}
                     </div>
                     <Image
@@ -152,5 +160,9 @@ export class JupyterInfo extends React.Component<IJupyterInfoProps> {
         }
 
         return res[1];
+    }
+
+    private selectServer(): void {
+        this.props.selectServer();
     }
 }


### PR DESCRIPTION
For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [x] The wiki is updated with any design decisions/details.

The Jupyter server name on the top right corner of a notebook/Interactive window is now clickable and it basically executes the command "Python: Specify local or remote Jupyter server for connection" and lets you change the way you want to connect to a Jupyter server directly from the UI

![image](https://user-images.githubusercontent.com/44413557/91540045-e274cd00-e937-11ea-9e0c-ad9854a54a5d.png)

