### PR TITLE
Set up a configuration for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
 
   - package-ecosystem: 'pip'
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
 
   - package-ecosystem: 'pip'
     directory: /news
@@ -18,4 +18,4 @@ updates:
   # - package-ecosystem: 'npm'
   #   directory: /
   #   schedule:
-  #     interval: weekly
+  #     interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: 'pip'
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: 'pip'
+    directory: /news
+    schedule:
+      interval: monthly
+  # Activate when we feel ready to keep up with frequency.
+  # - package-ecosystem: 'npm'
+  #   directory: /
+  #   schedule:
+  #     interval: weekly


### PR DESCRIPTION
Starting out with `news` being updated monthly as we don't run it that often, GitHub Actions and the main Python dependencies as daily as we use/push things out that frequently. I am starting out with npm turned off until we are comfortable to handle the initial onslaught of updates that will trigger and we are comfortable with our testing being able to catch potential errors.