### PR TITLE
Don't run workflow jobs in forks

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -23,6 +23,7 @@ jobs:
   build-vsix:
     name: Build VSIX
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -63,6 +64,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -119,6 +121,7 @@ jobs:
     name: Tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'microsoft/vscode-python'
     strategy:
       fail-fast: false
       matrix:
@@ -347,6 +350,7 @@ jobs:
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'microsoft/vscode-python'
     needs: [build-vsix]
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   build-vsix:
     name: Build VSIX
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -66,6 +67,7 @@ jobs:
     # will be caught when we merge back into 'main'.
     name: Lint
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/vscode-python'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -99,6 +101,7 @@ jobs:
     name: Tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'microsoft/vscode-python'
     strategy:
       fail-fast: false
       matrix:
@@ -319,6 +322,7 @@ jobs:
     name: Smoke tests
     # The value of runs-on is the OS of the current job (specified in the strategy matrix below) instead of being hardcoded.
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'microsoft/vscode-python'
     needs: [build-vsix]
     strategy:
       fail-fast: false


### PR DESCRIPTION
These jobs run on any push to master/main, including on forks, leading extra runs and notifications for simple things like pulling upstreams. The workflows also only run on master/main, which means they don't provide any early feedback for people submitting PRs (unless you're submitting your PR from the default branch, which is a no-no anyway).

There's no way to mark an entire workflow to only run on a specific repo (boo), so add the if statement to each of the jobs that don't already have it.

If someone does actually want these checks temporarily, they can modify their config and remove it before PRing, but I personally don't expect anyone to do that.