### PR TITLE
Remove unused LS settings from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2593,12 +2593,6 @@
                     "description": "Defines type of the language server.",
                     "scope": "window"
                 },
-                "python.analysis.openFilesOnly": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Only show errors and warnings for open files rather than for the entire workspace.",
-                    "scope": "resource"
-                },
                 "python.analysis.diagnosticPublishDelay": {
                     "type": "integer",
                     "default": 1000,
@@ -2661,12 +2655,6 @@
                     "description": "Allows code analysis to keep parser trees in memory. Increases memory consumption but may improve performance with large library analysis.",
                     "scope": "resource"
                 },
-                "python.analysis.memory.keepLibraryLocalVariables": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Allows code analysis to keep library function local variables. Allows code navigation in Python libraries function bodies. Increases memory consumption.",
-                    "scope": "resource"
-                },
                 "python.analysis.logLevel": {
                     "type": "string",
                     "enum": [
@@ -2683,18 +2671,6 @@
                     "type": "integer",
                     "default": 10,
                     "description": "Limits depth of the symbol tree in the document outline.",
-                    "scope": "resource"
-                },
-                "python.analysis.cachingLevel": {
-                    "type": "string",
-                    "enum": [
-                        "Default",
-                        "None",
-                        "System",
-                        "Library"
-                    ],
-                    "default": "Default",
-                    "description": "Defines which types of modules get their analysis cached.",
                     "scope": "resource"
                 },
                 "python.linting.enabled": {

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -325,7 +325,6 @@ export enum AnalysisSettingsLogLevel {
 export type LanguageServerDownloadChannels = 'stable' | 'beta' | 'daily';
 export interface IAnalysisSettings {
     readonly downloadChannel?: LanguageServerDownloadChannels;
-    readonly openFilesOnly: boolean;
     readonly typeshedPaths: string[];
     readonly cacheFolderPath: string | null;
     readonly errors: string[];


### PR DESCRIPTION
These options are old and haven't been used by any language server in months. Remove them to reduce settings UI/completion clutter.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~