### PR TITLE
Provide an id for native notebook kernels returned to VSCode

### DIFF
--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -82,6 +82,24 @@ export type KernelConnectionMetadata =
     | PythonKernelConnectionMetadata
     | DefaultKernelConnectionMetadata;
 
+/**
+ * Returns a string that can be used to uniquely identify a Kernel Connection.
+ */
+export function getKernelConnectionId(kernelConnection: KernelConnectionMetadata) {
+    switch (kernelConnection.kind) {
+        case 'connectToLiveKernel':
+            return `${kernelConnection.kind}#${kernelConnection.kernelModel.name}.${kernelConnection.kernelModel.session.id}.${kernelConnection.kernelModel.session.name}`;
+        case 'startUsingDefaultKernel':
+            return `${kernelConnection.kind}#${kernelConnection}`;
+        case 'startUsingKernelSpec':
+            return `${kernelConnection.kind}#${kernelConnection.kernelSpec.name}.${kernelConnection.kernelSpec.display_name}`;
+        case 'startUsingPythonInterpreter':
+            return `${kernelConnection.kind}#${kernelConnection.interpreter.path}`;
+        default:
+            throw new Error(`Unsupported Kernel Connection ${kernelConnection}`);
+    }
+}
+
 export interface IKernelSpecQuickPickItem<T extends KernelConnectionMetadata = KernelConnectionMetadata>
     extends QuickPickItem {
     selection: T;

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -19,7 +19,7 @@ import { areKernelConnectionsEqual } from '../jupyter/kernels/helpers';
 import { KernelSelectionProvider } from '../jupyter/kernels/kernelSelections';
 import { KernelSelector } from '../jupyter/kernels/kernelSelector';
 import { KernelSwitcher } from '../jupyter/kernels/kernelSwitcher';
-import { IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
+import { getKernelConnectionId, IKernelProvider, KernelConnectionMetadata } from '../jupyter/kernels/types';
 import { INotebookStorageProvider } from '../notebookStorage/notebookStorageProvider';
 import { INotebook, INotebookProvider } from '../types';
 import { getNotebookMetadata, isJupyterNotebook, updateKernelInNotebookMetadata } from './helpers/helpers';
@@ -28,6 +28,9 @@ import { INotebookContentProvider } from './types';
 class VSCodeNotebookKernelMetadata implements VSCNotebookKernel {
     get preloads(): Uri[] {
         return [];
+    }
+    get id() {
+        return getKernelConnectionId(this.selection);
     }
     constructor(
         public readonly label: string,


### PR DESCRIPTION
For #13661
Provide an Id so VSC can use this to uniquely identify kernels.
Useful for when user selects the same kernel when switching kernels.