### PR TITLE
Up idle timeout to match launch timeout (nightly flake failure)

### DIFF
--- a/src/client/datascience/jupyter/jupyterSession.ts
+++ b/src/client/datascience/jupyter/jupyterSession.ts
@@ -37,7 +37,8 @@ export class JupyterSession extends BaseJupyterSession {
         private readonly outputChannel: IOutputChannel,
         private readonly restartSessionCreated: (id: Kernel.IKernelConnection) => void,
         restartSessionUsed: (id: Kernel.IKernelConnection) => void,
-        readonly workingDirectory: string
+        readonly workingDirectory: string,
+        private readonly idleTimeout: number
     ) {
         super(restartSessionUsed, workingDirectory);
         this.kernelConnectionMetadata = kernelSpec;
@@ -106,7 +107,6 @@ export class JupyterSession extends BaseJupyterSession {
         if (!session || !this.contentsManager || !this.sessionManager) {
             throw new Error(localize.DataScience.sessionDisposed());
         }
-
         let result: ISessionWithSocket | undefined;
         let tryCount = 0;
         // tslint:disable-next-line: no-any
@@ -114,7 +114,7 @@ export class JupyterSession extends BaseJupyterSession {
         while (tryCount < 3) {
             try {
                 result = await this.createSession(session.serverSettings, kernelConnection, cancelToken);
-                await this.waitForIdleOnSession(result, 30000);
+                await this.waitForIdleOnSession(result, this.idleTimeout);
                 this.restartSessionCreated(result.kernel);
                 return result;
             } catch (exc) {

--- a/src/client/datascience/jupyter/jupyterSessionManager.ts
+++ b/src/client/datascience/jupyter/jupyterSessionManager.ts
@@ -182,7 +182,8 @@ export class JupyterSessionManager implements IJupyterSessionManager {
             this.outputChannel,
             this.restartSessionCreatedEvent.fire.bind(this.restartSessionCreatedEvent),
             this.restartSessionUsedEvent.fire.bind(this.restartSessionUsedEvent),
-            workingDirectory
+            workingDirectory,
+            this.configService.getSettings().datascience.jupyterLaunchTimeout
         );
         try {
             await session.connect(this.configService.getSettings().datascience.jupyterLaunchTimeout, cancelToken);

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -1419,7 +1419,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
         pythonSettings.datascience = {
             allowImportFromNotebook: true,
             alwaysTrustNotebooks: true,
-            jupyterLaunchTimeout: 60000,
+            jupyterLaunchTimeout: 120000,
             jupyterLaunchRetries: 3,
             enabled: true,
             jupyterServerURI: 'local',

--- a/src/test/datascience/jupyter/jupyterSession.unit.test.ts
+++ b/src/test/datascience/jupyter/jupyterSession.unit.test.ts
@@ -95,7 +95,8 @@ suite('DataScience - JupyterSession', () => {
             () => {
                 restartSessionUsedEvent.resolve();
             },
-            ''
+            '',
+            60_000
         );
     });
 


### PR DESCRIPTION
Flake test for one of the remote situations failed last night on Windows only. Looking at logs it seems like it ran out of time during creation of the restart session:

```
2020-09-02T09:38:35.8992367Z Info 2020-09-02 09:38:35: Finished waiting for idle on (kernel): 98172ac0-c39e-4f2f-b18d-80d2bdcacc54 -> idle
2020-09-02T09:39:05.7787233Z Info 2020-09-02 09:39:05: Finished waiting for idle on (kernel): 09f4fb51-8143-451d-8fd4-a307e42fde90 -> connected
2020-09-02T09:39:05.7794718Z Info 2020-09-02 09:39:05: shutdownSession 09f4fb51-8143-451d-8fd4-a307e42fde90 - start
2020-09-02T09:39:05.7854336Z Error 2020-09-02 09:39:05: Failed to change kernel JupyterWaitForIdleError: The Jupyter notebook server failed to launch in time
```
