### PR TITLE
PORT showStartPage setting fix (#13706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 1. Fixed connection to a Compute Instance from the quickpicks history options.
    ([#13387](https://github.com/Microsoft/vscode-python/issues/13387))
+1. Fixed the behavior of the 'python.showStartPage' setting.
+   ([#13347](https://github.com/microsoft/vscode-python/issues/13347))
 
 ### Thanks
 

--- a/news/2 Fixes/13706.md
+++ b/news/2 Fixes/13706.md
@@ -1,0 +1,1 @@
+Fix the behavior of the 'python.showStartPage' setting.

--- a/news/2 Fixes/13706.md
+++ b/news/2 Fixes/13706.md
@@ -1,1 +1,0 @@
-Fix the behavior of the 'python.showStartPage' setting.

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -544,6 +544,11 @@ export class PythonSettings implements IPythonSettings {
             this.datascience = dataScienceSettings;
         }
 
+        const showStartPage = pythonSettings.get<boolean>('showStartPage');
+        if (showStartPage !== undefined) {
+            this.showStartPage = showStartPage;
+        }
+
         this.insidersChannel = pythonSettings.get<ExtensionChannels>('insidersChannel')!;
     }
 

--- a/src/test/common/configSettings/configSettings.unit.test.ts
+++ b/src/test/common/configSettings/configSettings.unit.test.ts
@@ -47,7 +47,7 @@ suite('Python Settings', async () => {
     let settings: CustomPythonSettings;
     setup(() => {
         sinon.stub(EnvFileTelemetry, 'sendSettingTelemetry').returns();
-        config = TypeMoq.Mock.ofType<WorkspaceConfiguration>(undefined, TypeMoq.MockBehavior.Strict);
+        config = TypeMoq.Mock.ofType<WorkspaceConfiguration>(undefined, TypeMoq.MockBehavior.Loose);
         expected = new CustomPythonSettings(undefined, new MockAutoSelectionService());
         settings = new CustomPythonSettings(undefined, new MockAutoSelectionService());
         expected.defaultInterpreterPath = 'python';


### PR DESCRIPTION
* fix showStartPage setting on configSettings.ts

* add news file

* Fix unit tests

* oops

For #13347

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/master/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
