### PR TITLE
Ignore dependency check when finding a kernel spec

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelSelector.ts
+++ b/src/client/datascience/jupyter/kernels/kernelSelector.ts
@@ -166,7 +166,8 @@ export class KernelSelector implements IKernelSelectionUsage {
         sessionManager?: IJupyterSessionManager,
         notebookMetadata?: nbformat.INotebookMetadata,
         disableUI?: boolean,
-        cancelToken?: CancellationToken
+        cancelToken?: CancellationToken,
+        ignoreDependencyCheck?: boolean
     ): Promise<
         KernelSpecConnectionMetadata | PythonKernelConnectionMetadata | DefaultKernelConnectionMetadata | undefined
     > {
@@ -199,7 +200,12 @@ export class KernelSelector implements IKernelSelectionUsage {
                 cancelToken
             );
         } else if (type === 'raw') {
-            selection = await this.getKernelForLocalRawConnection(resource, notebookMetadata, cancelToken);
+            selection = await this.getKernelForLocalRawConnection(
+                resource,
+                notebookMetadata,
+                cancelToken,
+                ignoreDependencyCheck
+            );
         }
 
         // If still not found, log an error (this seems possible for some people, so use the default)
@@ -484,10 +490,16 @@ export class KernelSelector implements IKernelSelectionUsage {
     private async getKernelForLocalRawConnection(
         resource: Resource,
         notebookMetadata?: nbformat.INotebookMetadata,
-        cancelToken?: CancellationToken
+        cancelToken?: CancellationToken,
+        ignoreDependencyCheck?: boolean
     ): Promise<KernelSpecConnectionMetadata | PythonKernelConnectionMetadata | undefined> {
         // First use our kernel finder to locate a kernelspec on disk
-        const kernelSpec = await this.kernelFinder.findKernelSpec(resource, notebookMetadata?.kernelspec, cancelToken);
+        const kernelSpec = await this.kernelFinder.findKernelSpec(
+            resource,
+            notebookMetadata?.kernelspec,
+            cancelToken,
+            ignoreDependencyCheck
+        );
         if (!kernelSpec) {
             return;
         }

--- a/src/client/datascience/kernel-launcher/types.ts
+++ b/src/client/datascience/kernel-launcher/types.ts
@@ -48,7 +48,8 @@ export interface IKernelFinder {
     findKernelSpec(
         interpreterUri: InterpreterUri,
         kernelSpecMetadata?: nbformat.IKernelspecMetadata,
-        cancelToken?: CancellationToken
+        cancelToken?: CancellationToken,
+        ignoreDependencyCheck?: boolean
     ): Promise<IJupyterKernelSpec>;
     listKernelSpecs(resource: Resource): Promise<IJupyterKernelSpec[]>;
 }

--- a/src/client/datascience/notebook/kernelProvider.ts
+++ b/src/client/datascience/notebook/kernelProvider.ts
@@ -147,7 +147,8 @@ export class VSCodeKernelPickerProvider implements NotebookKernelProvider {
             undefined,
             getNotebookMetadata(document),
             true,
-            token
+            token,
+            true
         );
     }
     private async onDidChangeActiveNotebookKernel({

--- a/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
+++ b/src/test/datascience/jupyter/kernels/kernelSelector.unit.test.ts
@@ -498,7 +498,7 @@ suite('DataScience - KernelSelector', () => {
         });
         teardown(() => sinon.restore());
         test('Raw kernel connection finds a valid kernel spec and interpreter', async () => {
-            when(kernelFinder.findKernelSpec(anything(), anything(), anything())).thenResolve(kernelSpec);
+            when(kernelFinder.findKernelSpec(anything(), anything(), anything(), anything())).thenResolve(kernelSpec);
             when(kernelService.findMatchingInterpreter(kernelSpec, anything())).thenResolve(interpreter);
             when(
                 kernelSelectionProvider.getKernelSelectionsForLocalSession(


### PR DESCRIPTION
For #13754
Speed up kernel provider for native notebooks.
Ignoring the dependency checker makes a significant difference.