### PR TITLE
Bump plotly.js-dist at v1.55.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19664,9 +19664,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.54.5",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.54.5.tgz",
-            "integrity": "sha512-gIvJw5pG5ZeqhzJHcSS7Cl6Zfwl1etnMiVI951bJVyvh9q5Bjwiyo1pgqfcYcI14jCAlGXLi2G2s7At3YtPkKA==",
+            "version": "1.55.1",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.55.1.tgz",
+            "integrity": "sha512-XQSE+r/HKysvFlFovXCZJXQZ2a9nwUkGDcdkcEtcN61irgfFAxTjtalx9iXvVBAIbhILt3fJGUjOEOAzsjyLwA==",
             "dev": true
         },
         "plugin-error": {

--- a/package.json
+++ b/package.json
@@ -3700,7 +3700,7 @@
         "node-html-parser": "^1.1.13",
         "nyc": "^15.0.0",
         "playwright-chromium": "^0.13.0",
-        "plotly.js-dist": "^1.54.5",
+        "plotly.js-dist": "^1.55.1",
         "postcss": "^7.0.27",
         "postcss-cssnext": "^3.1.0",
         "postcss-import": "^12.0.1",


### PR DESCRIPTION
Bumping `plotly.js-dist` module now that `plotly.js` `v1.55.1` is out :tada:

-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Looks like PR https://github.com/microsoft/vscode-python/pull/12609.
Also FYI a PR is submitted to https://github.com/nteract/outputs/pull/17.

@rchiodo
cc: @nicolaskruchten 
