### PR TITLE
All languages in native notebooks, default Python

### DIFF
--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -27,6 +27,7 @@ import { JupyterNotebookView } from '../constants';
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
+import { isUntitledFile } from '../../../common/utils/misc';
 import { KernelConnectionMetadata } from '../../jupyter/kernels/types';
 import { updateNotebookMetadata } from '../../notebookStorage/baseModel';
 import { VSCodeNotebookModel } from '../../notebookStorage/vscNotebookModel';
@@ -95,9 +96,18 @@ export function notebookModelToVSCNotebookData(model: VSCodeNotebookModel): Note
         .map((item) => item!);
 
     const defaultLanguage = getDefaultCodeLanguage(model);
+    if (cells.length === 0 && isUntitledFile(model.file)) {
+        cells.push({
+            cellKind: vscodeNotebookEnums.CellKind.Code,
+            language: defaultLanguage,
+            metadata: {},
+            outputs: [],
+            source: ''
+        });
+    }
     return {
         cells,
-        languages: [defaultLanguage],
+        languages: ['*'],
         metadata: {
             custom: model.notebookContentWithoutCells,
             cellEditable: model.isTrusted,

--- a/src/test/datascience/notebook/contentProvider.unit.test.ts
+++ b/src/test/datascience/notebook/contentProvider.unit.test.ts
@@ -62,7 +62,7 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
                 const notebook = await contentProvider.openNotebook(fileUri, {});
 
                 assert.isOk(notebook);
-                assert.deepEqual(notebook.languages, [PYTHON_LANGUAGE]);
+                assert.deepEqual(notebook.languages, ['*']);
                 // ignore metadata we add.
                 const cellsWithoutCustomMetadata = notebook.cells.map((cell) => {
                     const cellToCompareWith = cloneDeep(cell);
@@ -142,7 +142,7 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
                 const notebook = await contentProvider.openNotebook(fileUri, {});
 
                 assert.isOk(notebook);
-                assert.deepEqual(notebook.languages, ['csharp']);
+                assert.deepEqual(notebook.languages, ['*']);
 
                 assert.equal(notebook.metadata.cellEditable, isNotebookTrusted);
                 assert.equal(notebook.metadata.cellRunnable, isNotebookTrusted);

--- a/src/test/datascience/notebook/helpers.unit.test.ts
+++ b/src/test/datascience/notebook/helpers.unit.test.ts
@@ -49,7 +49,7 @@ suite('DataScience - NativeNotebook helpers', () => {
         const notebook = notebookModelToVSCNotebookData(model as any);
 
         assert.isOk(notebook);
-        assert.deepEqual(notebook.languages, [PYTHON_LANGUAGE]);
+        assert.deepEqual(notebook.languages, ['*']);
         // ignore metadata we add.
         const cellsWithoutCustomMetadata = notebook.cells.map((cell) => {
             const cellToCompareWith = cloneDeep(cell);


### PR DESCRIPTION
For #13484
Temporarily defaults to Python, later we'll support defaulting to other languages based on notebooks used by user https://github.com/microsoft/vscode-python/issues/13522