### PR TITLE
Bump plotly.js-dist at v1.55.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19664,9 +19664,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.55.1",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.55.1.tgz",
-            "integrity": "sha512-XQSE+r/HKysvFlFovXCZJXQZ2a9nwUkGDcdkcEtcN61irgfFAxTjtalx9iXvVBAIbhILt3fJGUjOEOAzsjyLwA==",
+            "version": "1.55.2",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.55.2.tgz",
+            "integrity": "sha512-1QBBIPnh/G+8w9h/6pr7DQGm3t/XZptskUxJQsqTJJ1uth4xsDj2ltkmzujI5cG4lZadurJnfrJbFof+LHiyHg==",
             "dev": true
         },
         "plugin-error": {

--- a/package.json
+++ b/package.json
@@ -3700,7 +3700,7 @@
         "node-html-parser": "^1.1.13",
         "nyc": "^15.0.0",
         "playwright-chromium": "^0.13.0",
-        "plotly.js-dist": "^1.55.1",
+        "plotly.js-dist": "^1.55.2",
         "postcss": "^7.0.27",
         "postcss-cssnext": "^3.1.0",
         "postcss-import": "^12.0.1",


### PR DESCRIPTION
Bumping `plotly.js-dist` module now that `plotly.js` `v1.55.2` is out https://github.com/plotly/plotly.js/releases/tag/v1.55.2

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Similar to PR #13774
Also FYI a PR is submitted to https://github.com/nteract/outputs/pull/18.

@rchiodo
cc: @nicolaskruchten 
