### PR TITLE
Add compiler support for ES2020 wherever we support ES2019

### DIFF
--- a/src/test/datascience/extensionapi/exampleextension/ms-ai-tools-test/tsconfig.json
+++ b/src/test/datascience/extensionapi/exampleextension/ms-ai-tools-test/tsconfig.json
@@ -7,7 +7,13 @@
         "module": "commonjs",
         "target": "es2018",
         "outDir": "dist",
-        "lib": ["es6", "es2018", "dom", "ES2019"],
+        "lib": [
+            "es6",
+            "es2018",
+            "dom",
+            "ES2019",
+            "ES2020"
+        ],
         "jsx": "react",
         "sourceMap": true,
         "rootDir": "src",

--- a/tsconfig.extension.json
+++ b/tsconfig.extension.json
@@ -7,7 +7,8 @@
         "lib": [
             "es6",
             "es2018",
-            "ES2019"
+            "ES2019",
+            "ES2020",
         ],
         "jsx": "react",
         "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,13 @@
         "module": "commonjs",
         "target": "es2018",
         "outDir": "out",
-        "lib": ["es6", "es2018", "dom", "ES2019"],
+        "lib": [
+            "es6",
+            "es2018",
+            "dom",
+            "ES2019",
+            "ES2020"
+        ],
         "jsx": "react",
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
So we can use stuff like https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
