### PR TITLE
Replace 'master' with 'main' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@ A [Visual Studio Code](https://code.visualstudio.com/) [extension](https://marke
 
 -   Select your Python interpreter by clicking on the status bar
 
-     <img src=https://raw.githubusercontent.com/microsoft/vscode-python/master/images/InterpreterSelectionZoom.gif width=280 height=100>
+     <img src=https://raw.githubusercontent.com/microsoft/vscode-python/main/images/InterpreterSelectionZoom.gif width=280 height=100>
 
 -   Configure the debugger through the Debug Activity Bar
 
-      <img src=https://raw.githubusercontent.com/microsoft/vscode-python/master/images/ConfigureDebugger.gif width=734 height=413>
+      <img src=https://raw.githubusercontent.com/microsoft/vscode-python/main/images/ConfigureDebugger.gif width=734 height=413>
 
 -   Configure tests by running the `Configure Tests` command
 
-      <img src=https://raw.githubusercontent.com/microsoft/vscode-python/master/images/ConfigureTests.gif width=734 height=413>
+      <img src=https://raw.githubusercontent.com/microsoft/vscode-python/main/images/ConfigureTests.gif width=734 height=413>
 
 ## Jupyter Notebook quick start
 
 -   Open or create a Jupyter Notebook file (.ipynb) and start coding in our Notebook Editor!
 
-      <img src=https://raw.githubusercontent.com/microsoft/vscode-python/master/images/OpenOrCreateNotebook.gif width=1029 height=602>
+      <img src=https://raw.githubusercontent.com/microsoft/vscode-python/main/images/OpenOrCreateNotebook.gif width=1029 height=602>
 
 For more information you can:
 
@@ -77,11 +77,11 @@ The extension is available in multiple languages: `de`, `en`, `es`, `fa`, `fr`, 
 
 -   If you have a question about how to accomplish something with the extension, please [ask on Stack Overflow](https://stackoverflow.com/questions/tagged/visual-studio-code+python)
 -   If you come across a problem with the extension, please [file an issue](https://github.com/microsoft/vscode-python)
--   Contributions are always welcome! Please see our [contributing guide](https://github.com/Microsoft/vscode-python/blob/master/CONTRIBUTING.md) for more details
+-   Contributions are always welcome! Please see our [contributing guide](https://github.com/Microsoft/vscode-python/blob/main/CONTRIBUTING.md) for more details
 -   Any and all feedback is appreciated and welcome!
     -   If someone has already [filed an issue](https://github.com/Microsoft/vscode-python) that encompasses your feedback, please leave a 👍/👎 reaction on the issue
     -   Otherwise please file a new issue
--   If you're interested in the development of the extension, you can read about our [development process](https://github.com/Microsoft/vscode-python/blob/master/CONTRIBUTING.md#development-process)
+-   If you're interested in the development of the extension, you can read about our [development process](https://github.com/Microsoft/vscode-python/blob/main/CONTRIBUTING.md#development-process)
 
 ## Data and telemetry
 


### PR DESCRIPTION
Since I will be doing a point release, might as well take this change to fix the market place.