### PR TITLE
Fix git diff detection code

### DIFF
--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -378,7 +378,7 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
             (editorUri) =>
                 editorUri.document &&
                 editorUri.document.uri.scheme === 'git' &&
-                this.fs.arePathsSame(editorUri.document.uri, editor.document.uri)
+                editorUri.document.uri.fsPath === editor.document.uri.fsPath
         );
 
         if (!gitSchemeEditor) {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/13569

I regressed this as part of the filesystem refactor. In the following snippet, `editor.document.uri` has scheme `file`, but the git diff editor has scheme `git`, so doing a full URI object comparison via `arePathsSame` always returned false. I believe this is an exceptional case where we should be using `fsPath` instead of the URI object when comparing URIs.

```typescript
        const gitSchemeEditor = this.documentManager.visibleTextEditors.find(
            (editorUri) =>
                editorUri.document &&
                editorUri.document.uri.scheme === 'git' &&
                this.fs.arePathsSame(editorUri.document.uri, editor.document.uri)
        );
```

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
