### PR TITLE
Implement the high-level component API.

### DIFF
--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -3,18 +3,63 @@
 
 import * as vscode from 'vscode';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
-import { ILocator } from './base/locator';
+import { PythonEnvInfo } from './base/info';
+import { ILocator, PythonEnvsIterator, PythonLocatorQuery } from './base/locator';
+import { PythonEnvsChangedEvent } from './base/watcher';
 import { ExtensionLocators, WorkspaceLocators } from './discovery/locators';
 import { registerForIOC } from './legacyIOC';
 
+/**
+ * Activate the Python environments component (during extension activation).'
+ */
 export function activate(serviceManager: IServiceManager, serviceContainer: IServiceContainer) {
-    registerForIOC(serviceManager, serviceContainer);
-
-    const [locators, activateLocators] = initLocators();
-    activateLocators();
-    // We will pass the locators into the component API.
+    const [api, activateAPI] = createAPI();
+    activateAPI();
     // tslint:disable-next-line:no-unused-expression
-    locators;
+    api;
+
+    registerForIOC(serviceManager, serviceContainer);
+}
+
+/**
+ * The public API for the Python environments component.
+ *
+ * Note that this is composed of sub-components.
+ */
+export class PythonEnvironments implements ILocator {
+    constructor(
+        // These are the sub-components the full component is composed of:
+        private readonly locators: ILocator
+    ) {}
+
+    public get onChanged(): vscode.Event<PythonEnvsChangedEvent> {
+        return this.locators.onChanged;
+    }
+
+    public iterEnvs(query?: PythonLocatorQuery): PythonEnvsIterator {
+        return this.locators.iterEnvs(query);
+    }
+
+    public async resolveEnv(env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
+        return this.locators.resolveEnv(env);
+    }
+}
+
+/**
+ * Initialize everything needed for the API and provide the API object.
+ *
+ * An activation function is also returned, which should be called soon.
+ */
+export function createAPI(): [PythonEnvironments, () => void] {
+    const [locators, activateLocators] = initLocators();
+
+    return [
+        new PythonEnvironments(locators),
+        () => {
+            activateLocators();
+            // Any other activation needed for the API will go here later.
+        }
+    ];
 }
 
 function initLocators(): [ExtensionLocators, () => void] {

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -14,11 +14,8 @@ import { registerForIOC } from './legacyIOC';
  */
 export function activate(serviceManager: IServiceManager, serviceContainer: IServiceContainer) {
     const [api, activateAPI] = createAPI();
+    registerForIOC(serviceManager, serviceContainer, api);
     activateAPI();
-    // tslint:disable-next-line:no-unused-expression
-    api;
-
-    registerForIOC(serviceManager, serviceContainer);
 }
 
 /**

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -49,7 +49,12 @@ import {
 import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services/workspaceVirtualEnvWatcherService';
 import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environmentInfoService';
 
-export function registerForIOC(serviceManager: IServiceManager, serviceContainer: IServiceContainer): void {
+import { PythonEnvironments } from '.';
+
+export function registerForIOC(serviceManager: IServiceManager, serviceContainer: IServiceContainer, api: PythonEnvironments): void {
+    // tslint:disable-next-line:no-unused-expression
+    api;
+
     serviceManager.addSingleton<IInterpreterLocatorHelper>(IInterpreterLocatorHelper, InterpreterLocatorHelper);
     serviceManager.addSingleton<IInterpreterLocatorService>(
         IInterpreterLocatorService,

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { injectable } from 'inversify';
 import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
@@ -51,9 +52,29 @@ import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environm
 
 import { PythonEnvironments } from '.';
 
+export const IComponentAdapter = Symbol('IComponentAdapter');
+export interface IComponentAdapter {
+    // We will fill in the API separately.
+}
+
+@injectable()
+class ComponentAdapter implements IComponentAdapter {
+    constructor(
+        // The adapter only wraps one thing: the component API.
+        private readonly api: PythonEnvironments
+    ) {
+        // For the moment we use this placeholder to exercise the property.
+        if (this.api.onChanged) {
+            this.api.onChanged((_event) => {
+                // do nothing
+            });
+        }
+    }
+}
+
 export function registerForIOC(serviceManager: IServiceManager, serviceContainer: IServiceContainer, api: PythonEnvironments): void {
-    // tslint:disable-next-line:no-unused-expression
-    api;
+    const adapter = new ComponentAdapter(api);
+    serviceManager.addSingletonInstance<IComponentAdapter>(IComponentAdapter, adapter);
 
     serviceManager.addSingleton<IInterpreterLocatorHelper>(IInterpreterLocatorHelper, InterpreterLocatorHelper);
     serviceManager.addSingleton<IInterpreterLocatorService>(

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -373,6 +373,7 @@ import { registerInterpreterTypes } from '../../client/interpreter/serviceRegist
 import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
 import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
 import { ProposePylanceBanner } from '../../client/languageServices/proposeLanguageServerBanner';
+import { PythonEnvironments } from '../../client/pythonEnvironments';
 import { CacheableLocatorPromiseCache } from '../../client/pythonEnvironments/discovery/locators/services/cacheableLocatorService';
 import { InterpeterHashProviderFactory } from '../../client/pythonEnvironments/discovery/locators/services/hashProviderFactory';
 import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironments/info';
@@ -434,6 +435,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
     // tslint:disable-next-line:no-any
     public datascience!: TypeMoq.IMock<IDataScience>;
     public shouldMockJupyter: boolean;
+    public readonly pythonEnvs: PythonEnvironments;
     private commandManager: MockCommandManager = new MockCommandManager();
     private setContexts: Record<string, boolean> = {};
     private contextSetEvent: EventEmitter<{ name: string; value: boolean }> = new EventEmitter<{
@@ -479,6 +481,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     constructor(private readonly uiTest: boolean = false) {
         super();
+        this.pythonEnvs = mock(PythonEnvironments);
         this.useVSCodeAPI = false;
         const isRollingBuild = process.env ? process.env.VSCODE_PYTHON_ROLLING !== undefined : false;
         this.shouldMockJupyter = !isRollingBuild;
@@ -1064,7 +1067,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
             when(this.kernelServiceMock.getKernelSpecs(anything(), anything())).thenResolve([]);
             this.serviceManager.addSingletonInstance<KernelService>(KernelService, instance(this.kernelServiceMock));
 
-            registerForIOC(this.serviceManager, this.serviceContainer);
+            registerForIOC(this.serviceManager, this.serviceContainer, instance(this.pythonEnvs));
 
             this.serviceManager.addSingleton<IInterpreterSecurityService>(
                 IInterpreterSecurityService,
@@ -1122,7 +1125,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
             // Make sure full interpreter services are available.
             registerInterpreterTypes(this.serviceManager);
-            registerForIOC(this.serviceManager, this.serviceContainer);
+            registerForIOC(this.serviceManager, this.serviceContainer, instance(this.pythonEnvs));
 
             // Rebind the interpreter display as we don't want to use the real one
             this.serviceManager.rebindInstance<IInterpreterDisplay>(IInterpreterDisplay, interpreterDisplay.object);

--- a/src/test/format/extension.format.test.ts
+++ b/src/test/format/extension.format.test.ts
@@ -4,11 +4,13 @@
 
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { instance, mock } from 'ts-mockito';
 import { CancellationTokenSource, Position, Uri, window, workspace } from 'vscode';
 import { IProcessServiceFactory } from '../../client/common/process/types';
 import { AutoPep8Formatter } from '../../client/formatters/autoPep8Formatter';
 import { BlackFormatter } from '../../client/formatters/blackFormatter';
 import { YapfFormatter } from '../../client/formatters/yapfFormatter';
+import { PythonEnvironments } from '../../client/pythonEnvironments';
 import { registerForIOC } from '../../client/pythonEnvironments/legacyIOC';
 import { isPythonVersionInProcess } from '../common';
 import { closeActiveWindows, initialize, initializeTest } from '../initialize';
@@ -35,6 +37,7 @@ let formattedAutoPep8 = '';
 // tslint:disable-next-line:max-func-body-length
 suite('Formatting - General', () => {
     let ioc: UnitTestIocContainer;
+    let pythonEnvs: PythonEnvironments;
 
     suiteSetup(async function () {
         // https://github.com/microsoft/vscode-python/issues/12564
@@ -60,6 +63,7 @@ suite('Formatting - General', () => {
 
     setup(async () => {
         await initializeTest();
+        pythonEnvs = mock(PythonEnvironments);
         initializeDI();
     });
     suiteTeardown(async () => {
@@ -87,7 +91,7 @@ suite('Formatting - General', () => {
         ioc.registerMockProcessTypes();
         ioc.registerMockInterpreterTypes();
 
-        registerForIOC(ioc.serviceManager, ioc.serviceContainer);
+        registerForIOC(ioc.serviceManager, ioc.serviceContainer, instance(pythonEnvs));
     }
 
     async function injectFormatOutput(outputFileName: string) {

--- a/src/test/pythonEnvironments/legacyIOC.unit.test.ts
+++ b/src/test/pythonEnvironments/legacyIOC.unit.test.ts
@@ -30,6 +30,7 @@ import {
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../../client/interpreter/locators/types';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
+import { PythonEnvironments } from '../../client/pythonEnvironments';
 import { PythonInterpreterLocatorService } from '../../client/pythonEnvironments/discovery/locators';
 import { InterpreterLocatorHelper } from '../../client/pythonEnvironments/discovery/locators/helpers';
 import { InterpreterLocatorProgressService } from '../../client/pythonEnvironments/discovery/locators/progressService';
@@ -67,7 +68,8 @@ suite('Interpreters - Service Registry', () => {
     test('Registrations', () => {
         const serviceManager = mock(ServiceManager);
         const serviceContainer = mock(ServiceContainer);
-        registerForIOC(instance(serviceManager), instance(serviceContainer));
+        const api = mock(PythonEnvironments);
+        registerForIOC(instance(serviceManager), instance(serviceContainer), instance(api));
         verify(serviceManager.addSingleton(IKnownSearchPathsForInterpreters, KnownSearchPathsForInterpreters)).once();
         verify(serviceManager.addSingleton(IVirtualEnvironmentsSearchPathProvider, GlobalVirtualEnvironmentsSearchPathProvider, 'global')).once();
         verify(serviceManager.addSingleton(IVirtualEnvironmentsSearchPathProvider, WorkspaceVirtualEnvironmentsSearchPathProvider, 'workspace')).once();

--- a/src/test/serviceRegistry.ts
+++ b/src/test/serviceRegistry.ts
@@ -53,6 +53,7 @@ import { ServiceContainer } from '../client/ioc/container';
 import { ServiceManager } from '../client/ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from '../client/ioc/types';
 import { registerTypes as lintersRegisterTypes } from '../client/linters/serviceRegistry';
+import { PythonEnvironments } from '../client/pythonEnvironments';
 import { registerForIOC } from '../client/pythonEnvironments/legacyIOC';
 import { TEST_OUTPUT_CHANNEL } from '../client/testing/common/constants';
 import { registerTypes as unittestsRegisterTypes } from '../client/testing/serviceRegistry';
@@ -171,6 +172,7 @@ export class IocContainer {
 
     public readonly serviceManager: IServiceManager;
     public readonly serviceContainer: IServiceContainer;
+    public readonly pythonEnvs: PythonEnvironments;
 
     private disposables: Disposable[] = [];
 
@@ -178,6 +180,7 @@ export class IocContainer {
         const cont = new Container();
         this.serviceManager = new ServiceManager(cont);
         this.serviceContainer = new ServiceContainer(cont);
+        this.pythonEnvs = mock(PythonEnvironments);
 
         this.serviceManager.addSingletonInstance<IServiceContainer>(IServiceContainer, this.serviceContainer);
         this.serviceManager.addSingletonInstance<Disposable[]>(IDisposableRegistry, this.disposables);
@@ -299,7 +302,7 @@ export class IocContainer {
     public registerMockInterpreterTypes() {
         this.serviceManager.addSingleton<IInterpreterService>(IInterpreterService, InterpreterService);
         this.serviceManager.addSingleton<IRegistry>(IRegistry, RegistryImplementation);
-        registerForIOC(this.serviceManager, this.serviceContainer);
+        registerForIOC(this.serviceManager, this.serviceContainer, instance(this.pythonEnvs));
     }
 
     public registerMockProcess() {

--- a/src/test/testing/nosetest/nosetest.disovery.test.ts
+++ b/src/test/testing/nosetest/nosetest.disovery.test.ts
@@ -10,6 +10,7 @@ import { EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { IProcessServiceFactory } from '../../../client/common/process/types';
 import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
+import { PythonEnvironments } from '../../../client/pythonEnvironments';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { registerForIOC } from '../../../client/pythonEnvironments/legacyIOC';
 import { CommandSource } from '../../../client/testing/common/constants';
@@ -38,6 +39,7 @@ const filesToDelete = [
 // tslint:disable-next-line:max-func-body-length
 suite('Unit Tests - nose - discovery with mocked process output', () => {
     let ioc: UnitTestIocContainer;
+    let pythonEnvs: PythonEnvironments;
     const configTarget = IS_MULTI_ROOT_TEST
         ? vscode.ConfigurationTarget.WorkspaceFolder
         : vscode.ConfigurationTarget.Workspace;
@@ -61,6 +63,7 @@ suite('Unit Tests - nose - discovery with mocked process output', () => {
     });
     setup(async () => {
         await initializeTest();
+        pythonEnvs = mock(PythonEnvironments);
         initializeDI();
     });
     teardown(async () => {
@@ -82,7 +85,7 @@ suite('Unit Tests - nose - discovery with mocked process output', () => {
             instance(mock(InterpreterService))
         );
 
-        registerForIOC(ioc.serviceManager, ioc.serviceContainer);
+        registerForIOC(ioc.serviceManager, ioc.serviceContainer, instance(pythonEnvs));
         ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, instance(mock(CondaService)));
     }
 

--- a/src/test/testing/pytest/pytest.discovery.test.ts
+++ b/src/test/testing/pytest/pytest.discovery.test.ts
@@ -23,6 +23,7 @@ import { IEnvironmentActivationService } from '../../../client/interpreter/activ
 import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { IServiceContainer } from '../../../client/ioc/types';
+import { PythonEnvironments } from '../../../client/pythonEnvironments';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { registerForIOC } from '../../../client/pythonEnvironments/legacyIOC';
@@ -60,6 +61,7 @@ Run the command `python <ExtensionDir>/pythonFiles/testing_tools/run_adapter.py 
 // tslint:disable:max-func-body-length
 suite('Unit Tests - pytest - discovery with mocked process output', () => {
     let ioc: UnitTestIocContainer;
+    let pythonEnvs: PythonEnvironments;
     const configTarget = IS_MULTI_ROOT_TEST
         ? vscode.ConfigurationTarget.WorkspaceFolder
         : vscode.ConfigurationTarget.Workspace;
@@ -116,6 +118,7 @@ suite('Unit Tests - pytest - discovery with mocked process output', () => {
     });
     setup(async () => {
         await initializeTest();
+        pythonEnvs = mock(PythonEnvironments);
         initializeDI();
     });
     teardown(async () => {
@@ -137,7 +140,7 @@ suite('Unit Tests - pytest - discovery with mocked process output', () => {
             instance(mock(InterpreterService))
         );
         ioc.serviceManager.rebind<IPythonExecutionFactory>(IPythonExecutionFactory, ExecutionFactory);
-        registerForIOC(ioc.serviceManager, ioc.serviceContainer);
+        registerForIOC(ioc.serviceManager, ioc.serviceContainer, instance(pythonEnvs));
         ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, instance(mock(CondaService)));
     }
 

--- a/src/test/testing/pytest/pytest.run.test.ts
+++ b/src/test/testing/pytest/pytest.run.test.ts
@@ -24,6 +24,7 @@ import { IEnvironmentActivationService } from '../../../client/interpreter/activ
 import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
 import { IServiceContainer } from '../../../client/ioc/types';
+import { PythonEnvironments } from '../../../client/pythonEnvironments';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { WindowsStoreInterpreter } from '../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { registerForIOC } from '../../../client/pythonEnvironments/legacyIOC';
@@ -383,6 +384,7 @@ async function testDiagnosticRelatedInformation(
 
 suite('Unit Tests - pytest - run with mocked process output', () => {
     let ioc: UnitTestIocContainer;
+    let pythonEnvs: PythonEnvironments;
     const configTarget = IS_MULTI_ROOT_TEST
         ? vscode.ConfigurationTarget.WorkspaceFolder
         : vscode.ConfigurationTarget.Workspace;
@@ -460,7 +462,7 @@ suite('Unit Tests - pytest - run with mocked process output', () => {
         );
         ioc.serviceManager.rebind<IPythonExecutionFactory>(IPythonExecutionFactory, ExecutionFactory);
 
-        registerForIOC(ioc.serviceManager, ioc.serviceContainer);
+        registerForIOC(ioc.serviceManager, ioc.serviceContainer, instance(pythonEnvs));
         ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, instance(mock(CondaService)));
     }
 
@@ -518,6 +520,7 @@ suite('Unit Tests - pytest - run with mocked process output', () => {
                 // tslint:disable-next-line: no-invalid-this
                 this.timeout(TEST_TIMEOUT * 2);
                 await initializeTest();
+                pythonEnvs = mock(PythonEnvironments);
                 initializeDI();
                 await injectTestDiscoveryOutput(scenario.discoveryOutput);
                 await injectTestRunOutput(scenario.runOutput);

--- a/src/test/testing/unittest/unittest.discovery.test.ts
+++ b/src/test/testing/unittest/unittest.discovery.test.ts
@@ -11,6 +11,7 @@ import { EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { IProcessServiceFactory } from '../../../client/common/process/types';
 import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
+import { PythonEnvironments } from '../../../client/pythonEnvironments';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { registerForIOC } from '../../../client/pythonEnvironments/legacyIOC';
 import { CommandSource } from '../../../client/testing/common/constants';
@@ -29,6 +30,7 @@ const defaultUnitTestArgs = ['-v', '-s', '.', '-p', '*test*.py'];
 // tslint:disable-next-line:max-func-body-length
 suite('Unit Tests - unittest - discovery with mocked process output', () => {
     let ioc: UnitTestIocContainer;
+    let pythonEnvs: PythonEnvironments;
     const rootDirectory = UNITTEST_TEST_FILES_PATH;
     const configTarget = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
 
@@ -42,6 +44,7 @@ suite('Unit Tests - unittest - discovery with mocked process output', () => {
             await fs.remove(cachePath);
         }
         await initializeTest();
+        pythonEnvs = mock(PythonEnvironments);
         initializeDI();
     });
     teardown(async () => {
@@ -62,7 +65,7 @@ suite('Unit Tests - unittest - discovery with mocked process output', () => {
             IInterpreterService,
             instance(mock(InterpreterService))
         );
-        registerForIOC(ioc.serviceManager, ioc.serviceContainer);
+        registerForIOC(ioc.serviceManager, ioc.serviceContainer, instance(pythonEnvs));
         ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, instance(mock(CondaService)));
     }
 

--- a/src/test/testing/unittest/unittest.run.test.ts
+++ b/src/test/testing/unittest/unittest.run.test.ts
@@ -11,6 +11,7 @@ import { EXTENSION_ROOT_DIR } from '../../../client/common/constants';
 import { IProcessServiceFactory } from '../../../client/common/process/types';
 import { ICondaService, IInterpreterService } from '../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../client/interpreter/interpreterService';
+import { PythonEnvironments } from '../../../client/pythonEnvironments';
 import { CondaService } from '../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { registerForIOC } from '../../../client/pythonEnvironments/legacyIOC';
 import { ArgumentsHelper } from '../../../client/testing/common/argumentsHelper';
@@ -46,6 +47,7 @@ const defaultUnitTestArgs = ['-v', '-s', '.', '-p', '*test*.py'];
 
 suite('Unit Tests - unittest - run with mocked process output', () => {
     let ioc: UnitTestIocContainer;
+    let pythonEnvs: PythonEnvironments;
     const rootDirectory = UNITTEST_TEST_FILES_PATH;
     const configTarget = IS_MULTI_ROOT_TEST ? ConfigurationTarget.WorkspaceFolder : ConfigurationTarget.Workspace;
 
@@ -59,6 +61,7 @@ suite('Unit Tests - unittest - run with mocked process output', () => {
             await fs.remove(cachePath);
         }
         await initializeTest();
+        pythonEnvs = mock(PythonEnvironments);
         initializeDI();
         await ignoreTestLauncher();
     });
@@ -115,7 +118,7 @@ suite('Unit Tests - unittest - run with mocked process output', () => {
             IInterpreterService,
             instance(mock(InterpreterService))
         );
-        registerForIOC(ioc.serviceManager, ioc.serviceContainer);
+        registerForIOC(ioc.serviceManager, ioc.serviceContainer, instance(pythonEnvs));
         ioc.serviceManager.rebindInstance<ICondaService>(ICondaService, instance(mock(CondaService)));
     }
 


### PR DESCRIPTION
This is where we define the top-level interface for the component.  We also stub out our use of the component in the legacy IOC code.

This is a prerequisite for using the injected component adapter in the extension.  That will be done in a follow-on PR.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] Unit tests & system/integration tests are added/updated.~
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
