### PR TITLE
ESLint fixes for unrelated files in pythonEnvironments/discovery 

### DIFF
--- a/src/client/pythonEnvironments/discovery/index.ts
+++ b/src/client/pythonEnvironments/discovery/index.ts
@@ -4,6 +4,6 @@
 /**
  * Decide if the given Python executable looks like the MacOS default Python.
  */
-export function isMacDefaultPythonPath(pythonPath: string) {
+export function isMacDefaultPythonPath(pythonPath: string): boolean {
     return pythonPath === 'python' || pythonPath === '/usr/bin/python';
 }

--- a/src/client/pythonEnvironments/discovery/locators/types.ts
+++ b/src/client/pythonEnvironments/discovery/locators/types.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { GetInterpreterOptions } from '../../../interpreter/interpreterService';
+import type { GetInterpreterOptions } from '../../../interpreter/interpreterService';
 
 export type GetInterpreterLocatorOptions = GetInterpreterOptions & { ignoreCache?: boolean };

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -12,8 +12,6 @@ type ExecFunc = (cmd: string, args: string[]) => Promise<{ stdout: string }>;
 type NameFinderFunc = (python: string) => Promise<string | undefined>;
 type TypeFinderFunc = (python: string) => Promise<EnvironmentType | undefined>;
 type ExecutableFinderFunc = (python: string) => Promise<string | undefined>;
-type VirtualEnvFinderFunc = (python: string) => Promise<EnvironmentType.VirtualEnv | undefined>;
-type PipenvFinderFunc = (python: string) => Promise<EnvironmentType.Pipenv | undefined>;
 
 /**
  * Determine the environment name for the given Python executable.
@@ -194,7 +192,7 @@ export function getVirtualenvTypeFinder(
     pathJoin: (...parts: string[]) => string,
     // </path>
     fileExists: (n: string) => Promise<boolean>,
-): VirtualEnvFinderFunc {
+): TypeFinderFunc {
     const find = getVenvExecutableFinder(scripts, pathDirname, pathJoin, fileExists);
     return async (python: string) => {
         const found = await find(python);
@@ -213,7 +211,7 @@ export function getVirtualenvTypeFinder(
 export function getPipenvTypeFinder(
     getCurDir: () => Promise<string | undefined>,
     isPipenvRoot: (dir: string, python: string) => Promise<boolean>,
-): PipenvFinderFunc {
+): TypeFinderFunc {
     return async (python: string) => {
         const curDir = await getCurDir();
         if (curDir && (await isPipenvRoot(curDir, python))) {

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -19,13 +19,9 @@ type PipenvFinderFunc = (python: string) => Promise<EnvironmentType.Pipenv | und
  * @param finders - the functions specific to different Python environment types
  */
 export async function getName(python: string, finders: NameFinderFunc[]): Promise<string | undefined> {
-    try {
-        const envNames = await Promise.all(finders.map((find) => find(python)));
+    const envNames = await Promise.all(finders.map((find) => find(python)));
 
-        return envNames.find((name) => name && name !== '');
-    } catch {
-        return undefined;
-    }
+    return envNames.find((name) => name && name !== '');
 }
 
 /**
@@ -35,13 +31,9 @@ export async function getName(python: string, finders: NameFinderFunc[]): Promis
  * @param finders - the functions specific to different Python environment types
  */
 export async function getType(python: string, finders: TypeFinderFunc[]): Promise<EnvironmentType | undefined> {
-    try {
-        const envTypes = await Promise.all(finders.map((find) => find(python)));
+    const envTypes = await Promise.all(finders.map((find) => find(python)));
 
-        return envTypes.find((type) => type && type !== EnvironmentType.Unknown);
-    } catch {
-        return undefined;
-    }
+    return envTypes.find((type) => type && type !== EnvironmentType.Unknown);
 }
 
 // ======= default sets ========

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -126,14 +126,10 @@ export function getVenvTypeFinder(
         const dir = pathDirname(python);
         const VENVFILES = ['pyvenv.cfg', pathJoin('..', 'pyvenv.cfg')];
         const cfgFiles = VENVFILES.map((file) => pathJoin(dir, file));
-        try {
-            const files = await Promise.all(cfgFiles.map(fileExists));
+        const files = await Promise.all(cfgFiles.map(fileExists));
 
-            if (files.find((file) => file)) {
-                return EnvironmentType.Venv;
-            }
-        } catch {
-            return undefined;
+        if (files.find((file) => file)) {
+            return EnvironmentType.Venv;
         }
 
         return undefined;

--- a/src/client/pythonEnvironments/discovery/subenv.ts
+++ b/src/client/pythonEnvironments/discovery/subenv.ts
@@ -173,6 +173,7 @@ export function getVenvExecutableFinder(
             }
         }
         // No matches so return undefined.
+        return undefined;
     };
 }
 

--- a/src/test/pythonEnvironments/discovery/subenv.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/subenv.unit.test.ts
@@ -20,14 +20,6 @@ suite('getType()', () => {
     let finders: TypeMoq.IMock<IFinders>;
     setup(() => {
         finders = TypeMoq.Mock.ofType<IFinders>(undefined, TypeMoq.MockBehavior.Strict);
-
-        // not found
-        finders
-            .setup((f) => f.pipenv(TypeMoq.It.isAnyString()))
-            .returns(() => Promise.resolve(undefined));
-        finders
-            .setup((f) => f.virtualenv(TypeMoq.It.isAnyString()))
-            .returns(() => Promise.resolve(undefined));
     });
     function verifyAll() {
         finders.verifyAll();
@@ -39,10 +31,6 @@ suite('getType()', () => {
             .setup((f) => f.venv(python))
             // found
             .returns(() => Promise.resolve(EnvironmentType.Venv));
-        finders
-            .setup((f) => f.pyenv(python))
-            // not found
-            .returns(() => Promise.resolve(undefined));
 
         const result = await sut.getType(python, [
             (p: string) => finders.object.venv(p),

--- a/src/test/pythonEnvironments/discovery/subenv.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/subenv.unit.test.ts
@@ -20,6 +20,14 @@ suite('getType()', () => {
     let finders: TypeMoq.IMock<IFinders>;
     setup(() => {
         finders = TypeMoq.Mock.ofType<IFinders>(undefined, TypeMoq.MockBehavior.Strict);
+
+        // not found
+        finders
+            .setup((f) => f.pipenv(TypeMoq.It.isAnyString()))
+            .returns(() => Promise.resolve(undefined));
+        finders
+            .setup((f) => f.virtualenv(TypeMoq.It.isAnyString()))
+            .returns(() => Promise.resolve(undefined));
     });
     function verifyAll() {
         finders.verifyAll();
@@ -31,6 +39,10 @@ suite('getType()', () => {
             .setup((f) => f.venv(python))
             // found
             .returns(() => Promise.resolve(EnvironmentType.Venv));
+        finders
+            .setup((f) => f.pyenv(python))
+            // not found
+            .returns(() => Promise.resolve(undefined));
 
         const result = await sut.getType(python, [
             (p: string) => finders.object.venv(p),


### PR DESCRIPTION
For #13142


Added directives to disable ESLint checks for `for ... of` + `await` in loop, these will be revisited once we add async `array.find` and `array.filter` utility functions.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
