### PR TITLE
Add a legacy DI adapter for the Python envs component.

### DIFF
--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -31,6 +31,23 @@ export interface IVirtualEnvironmentsSearchPathProvider {
     getSearchPaths(resource?: Uri): Promise<string[]>;
 }
 
+export const IComponentAdapter = Symbol('IComponentAdapter');
+export interface IComponentAdapter {
+    // IInterpreterLocatorService
+    hasInterpreters: Promise<boolean>;
+    getInterpreters(resource?: Uri, options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[]>;
+    // IInterpreterService
+    getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;
+    // IInterpreterHelper
+    getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>>;
+    isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined>;
+    // ICondaService
+    isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined>;
+    getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
+    // IWindowsStoreInterpreter
+    isWindowsStoreInterpreter(pythonPath: string): Promise<boolean | undefined>;
+}
+
 export const IInterpreterLocatorService = Symbol('IInterpreterLocatorService');
 
 export interface IInterpreterLocatorService extends Disposable {

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -34,7 +34,7 @@ export interface IVirtualEnvironmentsSearchPathProvider {
 export const IComponentAdapter = Symbol('IComponentAdapter');
 export interface IComponentAdapter {
     // IInterpreterLocatorService
-    hasInterpreters: Promise<boolean> | undefined;
+    hasInterpreters: Promise<boolean | undefined>;
     getInterpreters(resource?: Uri): Promise<PythonEnvironment[] | undefined>;
     // IInterpreterService
     getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -35,7 +35,7 @@ export const IComponentAdapter = Symbol('IComponentAdapter');
 export interface IComponentAdapter {
     // IInterpreterLocatorService
     hasInterpreters: Promise<boolean> | undefined;
-    getInterpreters(resource?: Uri, options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[] | undefined>;
+    getInterpreters(resource?: Uri): Promise<PythonEnvironment[] | undefined>;
     // IInterpreterService
     getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;
     // IInterpreterHelper

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -34,8 +34,8 @@ export interface IVirtualEnvironmentsSearchPathProvider {
 export const IComponentAdapter = Symbol('IComponentAdapter');
 export interface IComponentAdapter {
     // IInterpreterLocatorService
-    hasInterpreters: Promise<boolean>;
-    getInterpreters(resource?: Uri, options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[]>;
+    hasInterpreters: Promise<boolean> | undefined;
+    getInterpreters(resource?: Uri, options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[] | undefined>;
     // IInterpreterService
     getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;
     // IInterpreterHelper

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -145,9 +145,12 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IInterpreterHelper
 
-    public async getInterpreterInformation(_pythonPath: string): Promise<undefined | Partial<PythonEnvironment>> {
-        return undefined;
-        // ...
+    public async getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>> {
+        const env = await this.api.resolveEnv(pythonPath);
+        if (env === undefined) {
+            return undefined;
+        }
+        return convertEnvInfo(env);
     }
 
     public async isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined> {

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -9,6 +9,7 @@ import {
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
     GLOBAL_VIRTUAL_ENV_SERVICE,
+    IComponentAdapter,
     ICondaService,
     IInterpreterLocatorHelper,
     IInterpreterLocatorProgressService,
@@ -109,24 +110,6 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     // or info.defaultDisplayName.
 
     return env;
-}
-
-export const IComponentAdapter = Symbol('IComponentAdapter');
-export interface IComponentAdapter {
-    // IInterpreterService
-    hasInterpreters: Promise<boolean>;
-    //getInterpreters(_resource?: vscode.Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;
-    getInterpreterDetails(pythonPath: string, _resource?: vscode.Uri): Promise<undefined | PythonEnvironment>;
-    // IInterpreterLocatorService
-    getInterpreters(resource?: vscode.Uri, options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[]>;
-    // IInterpreterHelper
-    getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>>;
-    isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined>;
-    // ICondaService
-    isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined>;
-    getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
-    // IWindowsStoreInterpreter
-    isWindowsStoreInterpreter(pythonPath: string): Promise<boolean | undefined>;
 }
 
 @injectable()

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -190,9 +190,19 @@ class ComponentAdapter implements IComponentAdapter {
         return env.kind === PythonEnvKind.Conda;
     }
 
-    public async getCondaEnvironment(_interpreterPath: string): Promise<CondaEnvironmentInfo | undefined> {
-        return undefined;
-        // ...
+    public async getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined> {
+        const env = await this.api.resolveEnv(interpreterPath);
+        if (env === undefined) {
+            return undefined;
+        }
+        if (env.kind !== PythonEnvKind.Conda) {
+            return undefined;
+        }
+        if (env.name !== '') {
+            return { name: env.name, path: '' };
+        } else {
+            return { name: '', path: env.location };
+        }
     }
 
     // IWindowsStoreInterpreter

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -172,9 +172,12 @@ class ComponentAdapter implements IComponentAdapter {
 
     //public async getInterpreters(_resource?: Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;
 
-    public async getInterpreterDetails(_pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment> {
-        return undefined;
-        // ...
+    public async getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment> {
+        const env = await this.api.resolveEnv(pythonPath);
+        if (env === undefined) {
+            return undefined;
+        }
+        return convertEnvInfo(env);
     }
 
     // ICondaService

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -24,7 +24,6 @@ import {
     WORKSPACE_VIRTUAL_ENV_SERVICE,
 } from '../interpreter/contracts';
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../interpreter/locators/types';
-//import { GetInterpreterOptions } from '../interpreter/interpreterService';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { PythonEnvInfo, PythonEnvKind, PythonReleaseLevel } from './base/info';
 import { PythonLocatorQuery } from './base/locator';

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -25,6 +25,7 @@ import {
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../interpreter/locators/types';
 //import { GetInterpreterOptions } from '../interpreter/interpreterService';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
+import { PythonEnvKind } from './base/info';
 import { initializeExternalDependencies } from './common/externalDependencies';
 import { PythonInterpreterLocatorService } from './discovery/locators';
 import { InterpreterLocatorHelper } from './discovery/locators/helpers';
@@ -96,9 +97,12 @@ class ComponentAdapter implements IComponentAdapter {
         // ...
     }
 
-    public async isMacDefaultPythonPath(_pythonPath: string): Promise<boolean> {
-        return false;
-        // ...
+    public async isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined> {
+        const env = await this.api.resolveEnv(pythonPath);
+        if (env === undefined) {
+            return undefined;
+        }
+        return env.kind === PythonEnvKind.MacDefault;
     }
 
     // IInterpreterService

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -133,9 +133,12 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IWindowsStoreInterpreter
 
-    public isWindowsStoreInterpreter(_pythonPath: string): boolean {
-        return false;
-        // ...
+    public async isWindowsStoreInterpreter(pythonPath: string): Promise<boolean | undefined> {
+        const env = await this.api.resolveEnv(pythonPath);
+        if (env === undefined) {
+            return undefined;
+        }
+        return env.kind === PythonEnvKind.WindowsStore;
     }
 
     // IInterpreterLocatorService

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -108,8 +108,10 @@ class ComponentAdapter implements IComponentAdapter {
     // IInterpreterService
 
     public get hasInterpreters(): Promise<boolean> {
-        return Promise.resolve(false);
-        // ...
+        const iterator = this.api.iterEnvs();
+        return iterator.next().then((res) => {
+            return !res.done;
+        });
     }
 
     //public async getInterpreters(_resource?: Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -121,9 +121,12 @@ class ComponentAdapter implements IComponentAdapter {
 
     // ICondaService
 
-    public async isCondaEnvironment(_interpreterPath: string): Promise<boolean> {
-        return false;
-        // ...
+    public async isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined> {
+        const env = await this.api.resolveEnv(interpreterPath);
+        if (env === undefined) {
+            return undefined;
+        }
+        return env.kind === PythonEnvKind.Conda;
     }
 
     public async getCondaEnvironment(_interpreterPath: string): Promise<CondaEnvironmentInfo | undefined> {

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { injectable } from 'inversify';
+import { Uri } from 'vscode';
 import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
@@ -22,11 +23,13 @@ import {
     WORKSPACE_VIRTUAL_ENV_SERVICE,
 } from '../interpreter/contracts';
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../interpreter/locators/types';
+//import { GetInterpreterOptions } from '../interpreter/interpreterService';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { initializeExternalDependencies } from './common/externalDependencies';
 import { PythonInterpreterLocatorService } from './discovery/locators';
 import { InterpreterLocatorHelper } from './discovery/locators/helpers';
 import { InterpreterLocatorProgressService } from './discovery/locators/progressService';
+import { CondaEnvironmentInfo } from './discovery/locators/services/conda';
 import { CondaEnvFileService } from './discovery/locators/services/condaEnvFileService';
 import { CondaEnvService } from './discovery/locators/services/condaEnvService';
 import { CondaService } from './discovery/locators/services/condaService';
@@ -48,13 +51,28 @@ import {
     WorkspaceVirtualEnvService,
 } from './discovery/locators/services/workspaceVirtualEnvService';
 import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services/workspaceVirtualEnvWatcherService';
+import { GetInterpreterLocatorOptions } from './discovery/locators/types';
+import { PythonEnvironment } from './info';
 import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environmentInfoService';
 
 import { PythonEnvironments } from '.';
 
 export const IComponentAdapter = Symbol('IComponentAdapter');
 export interface IComponentAdapter {
-    // We will fill in the API separately.
+    // IInterpreterService
+    hasInterpreters: Promise<boolean>;
+    //getInterpreters(_resource?: vscode.Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;
+    getInterpreterDetails(pythonPath: string, _resource?: vscode.Uri): Promise<undefined | PythonEnvironment>;
+    // IInterpreterLocatorService
+    getInterpreters(resource?: vscode.Uri, options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[]>;
+    // IInterpreterHelper
+    getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>>;
+    isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined>;
+    // ICondaService
+    isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined>;
+    getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
+    // IWindowsStoreInterpreter
+    isWindowsStoreInterpreter(pythonPath: string): Promise<boolean | undefined>;
 }
 
 @injectable()
@@ -69,6 +87,62 @@ class ComponentAdapter implements IComponentAdapter {
                 // do nothing
             });
         }
+    }
+
+    // IInterpreterHelper
+
+    public async getInterpreterInformation(_pythonPath: string): Promise<undefined | Partial<PythonEnvironment>> {
+        return undefined;
+        // ...
+    }
+
+    public async isMacDefaultPythonPath(_pythonPath: string): Promise<boolean> {
+        return false;
+        // ...
+    }
+
+    // IInterpreterService
+
+    public get hasInterpreters(): Promise<boolean> {
+        return Promise.resolve(false);
+        // ...
+    }
+
+    //public async getInterpreters(_resource?: Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;
+
+    public async getInterpreterDetails(_pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment> {
+        return undefined;
+        // ...
+    }
+
+    // ICondaService
+
+    public async isCondaEnvironment(_interpreterPath: string): Promise<boolean> {
+        return false;
+        // ...
+    }
+
+    public async getCondaEnvironment(_interpreterPath: string): Promise<CondaEnvironmentInfo | undefined> {
+        return undefined;
+        // ...
+    }
+
+    // IWindowsStoreInterpreter
+
+    public isWindowsStoreInterpreter(_pythonPath: string): boolean {
+        return false;
+        // ...
+    }
+
+    // IInterpreterLocatorService
+
+    public async getInterpreters(_resource?: Uri, _options?: GetInterpreterLocatorOptions): Promise<PythonEnvironment[]> {
+        //{
+        //    ignoreCache?: boolean
+        //    onSuggestion?: boolean;
+        //}
+        return [];
+        // ...
     }
 }
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -55,7 +55,6 @@ import {
     WorkspaceVirtualEnvService,
 } from './discovery/locators/services/workspaceVirtualEnvService';
 import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services/workspaceVirtualEnvWatcherService';
-import { GetInterpreterLocatorOptions } from './discovery/locators/types';
 import { EnvironmentType, PythonEnvironment } from './info';
 import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environmentInfoService';
 
@@ -269,16 +268,15 @@ class ComponentAdapter implements IComponentAdapter {
 
     public async getInterpreters(
         resource?: vscode.Uri,
-        _options?: GetInterpreterLocatorOptions, // eslint-disable-line @typescript-eslint/no-unused-vars
-    ): Promise<PythonEnvironment[] | undefined> {
-        if (!this.enabled) {
-            return undefined;
-        }
-        // We ignore the options:
+        // Currently we have no plans to support GetInterpreterLocatorOptions:
         // {
         //     ignoreCache?: boolean
         //     onSuggestion?: boolean;
         // }
+    ): Promise<PythonEnvironment[] | undefined> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const query: PythonLocatorQuery = {};
         if (resource !== undefined) {
             const wsFolder = vscode.workspace.getWorkspaceFolder(resource);

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -58,6 +58,18 @@ import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services
 import { EnvironmentType, PythonEnvironment } from './info';
 import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environmentInfoService';
 
+const convertedKinds = new Map(Object.entries({
+    [PythonEnvKind.System]: EnvironmentType.System,
+    [PythonEnvKind.MacDefault]: EnvironmentType.System,
+    [PythonEnvKind.WindowsStore]: EnvironmentType.WindowsStore,
+    [PythonEnvKind.Pyenv]: EnvironmentType.Pyenv,
+    [PythonEnvKind.Conda]: EnvironmentType.Conda,
+    [PythonEnvKind.CondaBase]: EnvironmentType.Conda,
+    [PythonEnvKind.VirtualEnv]: EnvironmentType.VirtualEnv,
+    [PythonEnvKind.Pipenv]: EnvironmentType.Pipenv,
+    [PythonEnvKind.Venv]: EnvironmentType.Venv,
+}));
+
 function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     const {
         name,
@@ -79,29 +91,17 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
         architecture: arch,
     };
 
-    if (kind === PythonEnvKind.System) {
-        env.envType = EnvironmentType.System;
-    } else if (kind === PythonEnvKind.MacDefault) {
-        env.envType = EnvironmentType.System;
-    } else if (kind === PythonEnvKind.WindowsStore) {
-        env.envType = EnvironmentType.WindowsStore;
-    } else if (kind === PythonEnvKind.Pyenv) {
-        env.envType = EnvironmentType.Pyenv;
-    } else if (kind === PythonEnvKind.Conda) {
-        env.envType = EnvironmentType.Conda;
-    } else if (kind === PythonEnvKind.CondaBase) {
-        env.envType = EnvironmentType.Conda;
-    } else if (kind === PythonEnvKind.VirtualEnv) {
-        env.envType = EnvironmentType.VirtualEnv;
-    } else if (kind === PythonEnvKind.Pipenv) {
-        env.envType = EnvironmentType.Pipenv;
-        if (searchLocation !== undefined) {
-            env.pipEnvWorkspaceFolder = searchLocation.fsPath;
-        }
-    } else if (kind === PythonEnvKind.Venv) {
-        env.envType = EnvironmentType.Venv;
+    const envType = convertedKinds.get(kind);
+    if (envType !== undefined) {
+        env.envType = envType;
     }
     // Otherwise it stays Unknown.
+
+    if (searchLocation !== undefined) {
+        if (kind === PythonEnvKind.Pipenv) {
+            env.pipEnvWorkspaceFolder = searchLocation.fsPath;
+        }
+    }
 
     if (version !== undefined) {
         const { release, sysVersion } = version;

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -59,52 +59,65 @@ import { EnvironmentType, PythonEnvironment } from './info';
 import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environmentInfoService';
 
 function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
+    const {
+        name,
+        location,
+        executable,
+        arch,
+        kind,
+        searchLocation,
+        version,
+        distro,
+    } = info;
+    const { filename, sysPrefix } = executable;
     const env: PythonEnvironment = {
+        sysPrefix,
         envType: EnvironmentType.Unknown,
-        envName: info.name,
-        envPath: info.location,
-        path: info.executable.filename,
-        architecture: info.arch,
-        sysPrefix: info.executable.sysPrefix,
+        envName: name,
+        envPath: location,
+        path: filename,
+        architecture: arch,
     };
 
-    if (info.kind === PythonEnvKind.System) {
+    if (kind === PythonEnvKind.System) {
         env.envType = EnvironmentType.System;
-    } else if (info.kind === PythonEnvKind.MacDefault) {
+    } else if (kind === PythonEnvKind.MacDefault) {
         env.envType = EnvironmentType.System;
-    } else if (info.kind === PythonEnvKind.WindowsStore) {
+    } else if (kind === PythonEnvKind.WindowsStore) {
         env.envType = EnvironmentType.WindowsStore;
-    } else if (info.kind === PythonEnvKind.Pyenv) {
+    } else if (kind === PythonEnvKind.Pyenv) {
         env.envType = EnvironmentType.Pyenv;
-    } else if (info.kind === PythonEnvKind.Conda) {
+    } else if (kind === PythonEnvKind.Conda) {
         env.envType = EnvironmentType.Conda;
-    } else if (info.kind === PythonEnvKind.CondaBase) {
+    } else if (kind === PythonEnvKind.CondaBase) {
         env.envType = EnvironmentType.Conda;
-    } else if (info.kind === PythonEnvKind.VirtualEnv) {
+    } else if (kind === PythonEnvKind.VirtualEnv) {
         env.envType = EnvironmentType.VirtualEnv;
-    } else if (info.kind === PythonEnvKind.Pipenv) {
+    } else if (kind === PythonEnvKind.Pipenv) {
         env.envType = EnvironmentType.Pipenv;
-        if (info.searchLocation !== undefined) {
-            env.pipEnvWorkspaceFolder = info.searchLocation.fsPath;
+        if (searchLocation !== undefined) {
+            env.pipEnvWorkspaceFolder = searchLocation.fsPath;
         }
-    } else if (info.kind === PythonEnvKind.Venv) {
+    } else if (kind === PythonEnvKind.Venv) {
         env.envType = EnvironmentType.Venv;
     }
     // Otherwise it stays Unknown.
 
-    if (info.version !== undefined) {
-        const releaseStr = info.version.release.level === PythonReleaseLevel.Final
+    if (version !== undefined) {
+        const { release, sysVersion } = version;
+        const { level, serial } = release;
+        const releaseStr = level === PythonReleaseLevel.Final
             ? 'final'
-            : `${info.version.release.level}${info.version.release.serial}`;
-        const versionStr = `${getVersionString(info.version)}-${releaseStr}`;
+            : `${level}${serial}`;
+        const versionStr = `${getVersionString(version)}-${releaseStr}`;
         env.version = parseVersion(versionStr);
-        env.sysVersion = info.version.sysVersion;
+        env.sysVersion = sysVersion;
     }
 
-    if (info.distro !== undefined && info.distro.org !== '') {
-        env.companyDisplayName = info.distro.org;
+    if (distro !== undefined && distro.org !== '') {
+        env.companyDisplayName = distro.org;
     }
-    // We do not worry about using info.distro.defaultDisplayName
+    // We do not worry about using distro.defaultDisplayName
     // or info.defaultDisplayName.
 
     return env;

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -3,6 +3,7 @@
 
 import { injectable } from 'inversify';
 import * as vscode from 'vscode';
+import { createDeferred } from '../common/utils/async';
 import { Architecture } from '../common/utils/platform';
 import { getVersionString, parseVersion } from '../common/utils/version';
 import {
@@ -293,14 +294,39 @@ class ComponentAdapter implements IComponentAdapter {
             }
         }
 
+        const deferred = createDeferred<PythonEnvironment[]>();
         const envs: PythonEnvironment[] = [];
+        const executableToLegacy: Record<string, PythonEnvironment> = {};
         const iterator = this.api.iterEnvs(query);
+
+        if (iterator.onUpdated !== undefined) {
+            iterator.onUpdated((event) => {
+                if (event === null) {
+                    deferred.resolve(envs);
+                } else {
+                    // Replace the old one.
+                    const old = executableToLegacy[event.old.executable.filename];
+                    if (old !== undefined) {
+                        const index = envs.indexOf(old);
+                        if (index !== -1) {
+                            envs[index] = convertEnvInfo(event.new);
+                        }
+                    }
+                }
+            });
+        } else {
+            deferred.resolve(envs);
+        }
+
         let res = await iterator.next();
         while (!res.done) {
-            envs.push(convertEnvInfo(res.value));
+            const env = convertEnvInfo(res.value);
+            envs.push(env);
+            executableToLegacy[env.path] = env;
             res = await iterator.next(); // eslint-disable-line no-await-in-loop
         }
-        return envs;
+
+        return deferred.promise;
     }
 }
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -27,7 +27,7 @@ import {
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../interpreter/locators/types';
 import { IServiceContainer, IServiceManager } from '../ioc/types';
 import { PythonEnvInfo, PythonEnvKind, PythonReleaseLevel } from './base/info';
-import { PythonLocatorQuery } from './base/locator';
+import { ILocator, PythonLocatorQuery } from './base/locator';
 import { initializeExternalDependencies } from './common/externalDependencies';
 import { PythonInterpreterLocatorService } from './discovery/locators';
 import { InterpreterLocatorHelper } from './discovery/locators/helpers';
@@ -57,8 +57,6 @@ import { WorkspaceVirtualEnvWatcherService } from './discovery/locators/services
 import { GetInterpreterLocatorOptions } from './discovery/locators/types';
 import { EnvironmentType, PythonEnvironment } from './info';
 import { EnvironmentInfoService, IEnvironmentInfoService } from './info/environmentInfoService';
-
-import { PythonEnvironments } from '.';
 
 function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     const env: PythonEnvironment = {
@@ -112,11 +110,13 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     return env;
 }
 
+interface IPythonEnvironments extends ILocator {}
+
 @injectable()
 class ComponentAdapter implements IComponentAdapter {
     constructor(
         // The adapter only wraps one thing: the component API.
-        private readonly api: PythonEnvironments,
+        private readonly api: IPythonEnvironments,
         // For now we effecitvely disable the component.
         private readonly enabled = false,
     ) {}
@@ -251,7 +251,7 @@ class ComponentAdapter implements IComponentAdapter {
 export function registerForIOC(
     serviceManager: IServiceManager,
     serviceContainer: IServiceContainer,
-    api: PythonEnvironments,
+    api: IPythonEnvironments,
 ): void {
     const adapter = new ComponentAdapter(api);
     serviceManager.addSingletonInstance<IComponentAdapter>(IComponentAdapter, adapter);

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -67,7 +67,7 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
         envPath: info.location,
         path: info.executable.filename,
         architecture: info.arch,
-        sysPrefix: info.executable.sysPrefix
+        sysPrefix: info.executable.sysPrefix,
     };
 
     if (info.kind === PythonEnvKind.System) {
@@ -118,7 +118,7 @@ class ComponentAdapter implements IComponentAdapter {
         // The adapter only wraps one thing: the component API.
         private readonly api: PythonEnvironments,
         // For now we effecitvely disable the component.
-        private readonly enabled = false
+        private readonly enabled = false,
     ) {}
 
     // IInterpreterHelper
@@ -152,14 +152,15 @@ class ComponentAdapter implements IComponentAdapter {
             return undefined;
         }
         const iterator = this.api.iterEnvs();
-        return iterator.next().then((res) => {
-            return !res.done;
-        });
+        return iterator.next().then((res) => !res.done);
     }
 
-    //public async getInterpreters(_resource?: vscode.Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;
+    // We use the same getInterpreters() here as for IInterpreterLocatorService.
 
-    public async getInterpreterDetails(pythonPath: string, _resource?: vscode.Uri): Promise<undefined | PythonEnvironment> {
+    public async getInterpreterDetails(
+        pythonPath: string,
+        _resource?: vscode.Uri, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ): Promise<undefined | PythonEnvironment> {
         if (!this.enabled) {
             return undefined;
         }
@@ -196,9 +197,9 @@ class ComponentAdapter implements IComponentAdapter {
         }
         if (env.name !== '') {
             return { name: env.name, path: '' };
-        } else {
-            return { name: '', path: env.location };
         }
+        // else
+        return { name: '', path: env.location };
     }
 
     // IWindowsStoreInterpreter
@@ -218,16 +219,16 @@ class ComponentAdapter implements IComponentAdapter {
 
     public async getInterpreters(
         resource?: vscode.Uri,
-        _options?: GetInterpreterLocatorOptions
+        _options?: GetInterpreterLocatorOptions, // eslint-disable-line @typescript-eslint/no-unused-vars
     ): Promise<PythonEnvironment[] | undefined> {
         if (!this.enabled) {
             return undefined;
         }
         // We ignore the options:
-        //{
-        //    ignoreCache?: boolean
-        //    onSuggestion?: boolean;
-        //}
+        // {
+        //     ignoreCache?: boolean
+        //     onSuggestion?: boolean;
+        // }
         const query: PythonLocatorQuery = {};
         if (resource !== undefined) {
             const wsFolder = vscode.workspace.getWorkspaceFolder(resource);
@@ -241,13 +242,17 @@ class ComponentAdapter implements IComponentAdapter {
         let res = await iterator.next();
         while (!res.done) {
             envs.push(convertEnvInfo(res.value));
-            res = await iterator.next();
+            res = await iterator.next(); // eslint-disable-line no-await-in-loop
         }
         return envs;
     }
 }
 
-export function registerForIOC(serviceManager: IServiceManager, serviceContainer: IServiceContainer, api: PythonEnvironments): void {
+export function registerForIOC(
+    serviceManager: IServiceManager,
+    serviceContainer: IServiceContainer,
+    api: PythonEnvironments,
+): void {
     const adapter = new ComponentAdapter(api);
     serviceManager.addSingletonInstance<IComponentAdapter>(IComponentAdapter, adapter);
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -116,12 +116,17 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
 class ComponentAdapter implements IComponentAdapter {
     constructor(
         // The adapter only wraps one thing: the component API.
-        private readonly api: PythonEnvironments
+        private readonly api: PythonEnvironments,
+        // For now we effecitvely disable the component.
+        private readonly enabled = false
     ) {}
 
     // IInterpreterHelper
 
     public async getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const env = await this.api.resolveEnv(pythonPath);
         if (env === undefined) {
             return undefined;
@@ -130,6 +135,9 @@ class ComponentAdapter implements IComponentAdapter {
     }
 
     public async isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const env = await this.api.resolveEnv(pythonPath);
         if (env === undefined) {
             return undefined;
@@ -139,7 +147,10 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IInterpreterService
 
-    public get hasInterpreters(): Promise<boolean> {
+    public get hasInterpreters(): Promise<boolean> | undefined {
+        if (!this.enabled) {
+            return undefined;
+        }
         const iterator = this.api.iterEnvs();
         return iterator.next().then((res) => {
             return !res.done;
@@ -149,6 +160,9 @@ class ComponentAdapter implements IComponentAdapter {
     //public async getInterpreters(_resource?: vscode.Uri, _options?: GetInterpreterOptions): Promise<PythonEnvironment[]>;
 
     public async getInterpreterDetails(pythonPath: string, _resource?: vscode.Uri): Promise<undefined | PythonEnvironment> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const env = await this.api.resolveEnv(pythonPath);
         if (env === undefined) {
             return undefined;
@@ -159,6 +173,9 @@ class ComponentAdapter implements IComponentAdapter {
     // ICondaService
 
     public async isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const env = await this.api.resolveEnv(interpreterPath);
         if (env === undefined) {
             return undefined;
@@ -167,6 +184,9 @@ class ComponentAdapter implements IComponentAdapter {
     }
 
     public async getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const env = await this.api.resolveEnv(interpreterPath);
         if (env === undefined) {
             return undefined;
@@ -184,6 +204,9 @@ class ComponentAdapter implements IComponentAdapter {
     // IWindowsStoreInterpreter
 
     public async isWindowsStoreInterpreter(pythonPath: string): Promise<boolean | undefined> {
+        if (!this.enabled) {
+            return undefined;
+        }
         const env = await this.api.resolveEnv(pythonPath);
         if (env === undefined) {
             return undefined;
@@ -196,7 +219,10 @@ class ComponentAdapter implements IComponentAdapter {
     public async getInterpreters(
         resource?: vscode.Uri,
         _options?: GetInterpreterLocatorOptions
-    ): Promise<PythonEnvironment[]> {
+    ): Promise<PythonEnvironment[] | undefined> {
+        if (!this.enabled) {
+            return undefined;
+        }
         // We ignore the options:
         //{
         //    ignoreCache?: boolean

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -158,7 +158,7 @@ class ComponentAdapter implements IComponentAdapter {
     constructor(
         // The adapter only wraps one thing: the component API.
         private readonly api: IPythonEnvironments,
-        // For now we effecitvely disable the component.
+        // For now we effectively disable the component.
         private readonly enabled = false,
     ) {}
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -117,14 +117,7 @@ class ComponentAdapter implements IComponentAdapter {
     constructor(
         // The adapter only wraps one thing: the component API.
         private readonly api: PythonEnvironments
-    ) {
-        // For the moment we use this placeholder to exercise the property.
-        if (this.api.onChanged) {
-            this.api.onChanged((_event) => {
-                // do nothing
-            });
-        }
-    }
+    ) {}
 
     // IInterpreterHelper
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -164,6 +164,7 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IInterpreterHelper
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>> {
         if (!this.enabled) {
             return undefined;
@@ -175,6 +176,7 @@ class ComponentAdapter implements IComponentAdapter {
         return convertEnvInfo(env);
     }
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async isMacDefaultPythonPath(pythonPath: string): Promise<boolean | undefined> {
         if (!this.enabled) {
             return undefined;
@@ -188,9 +190,10 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IInterpreterService
 
-    public get hasInterpreters(): Promise<boolean> | undefined {
+    // A result of `undefined` means "Fall back to the old code!"
+    public get hasInterpreters(): Promise<boolean | undefined> {
         if (!this.enabled) {
-            return undefined;
+            return Promise.resolve(undefined);
         }
         const iterator = this.api.iterEnvs();
         return iterator.next().then((res) => !res.done);
@@ -198,6 +201,7 @@ class ComponentAdapter implements IComponentAdapter {
 
     // We use the same getInterpreters() here as for IInterpreterLocatorService.
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async getInterpreterDetails(
         pythonPath: string,
         resource?: vscode.Uri,
@@ -222,6 +226,7 @@ class ComponentAdapter implements IComponentAdapter {
 
     // ICondaService
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined> {
         if (!this.enabled) {
             return undefined;
@@ -233,6 +238,7 @@ class ComponentAdapter implements IComponentAdapter {
         return env.kind === PythonEnvKind.Conda;
     }
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined> {
         if (!this.enabled) {
             return undefined;
@@ -253,6 +259,7 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IWindowsStoreInterpreter
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async isWindowsStoreInterpreter(pythonPath: string): Promise<boolean | undefined> {
         if (!this.enabled) {
             return undefined;
@@ -266,6 +273,7 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IInterpreterLocatorService
 
+    // A result of `undefined` means "Fall back to the old code!"
     public async getInterpreters(
         resource?: vscode.Uri,
         // Currently we have no plans to support GetInterpreterLocatorOptions:


### PR DESCRIPTION
This allows us to start using the new discovery code in the extension.

The key files are:
* src/client/pythonEnvironments/legacyIOC.ts
* src/client/pythonEnvironments/index.ts
* src/client/interpreter/contracts.ts

Everything else is touches to deal with slight API changes and things moving around.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
