### PR TITLE
Use the Python environments component DI adapter in the extension.

### DIFF
--- a/src/client/application/diagnostics/checks/macPythonInterpreter.ts
+++ b/src/client/application/diagnostics/checks/macPythonInterpreter.ts
@@ -95,7 +95,7 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
             return [];
         }
 
-        if (!this.helper.isMacDefaultPythonPath(settings.pythonPath)) {
+        if (!(await this.helper.isMacDefaultPythonPath(settings.pythonPath))) {
             return [];
         }
         if (!currentInterpreter || currentInterpreter.envType !== EnvironmentType.Unknown) {
@@ -103,18 +103,19 @@ export class InvalidMacPythonInterpreterService extends BaseDiagnosticsService {
         }
 
         const interpreters = await this.interpreterService.getInterpreters(resource);
-        if (interpreters.filter((i) => !this.helper.isMacDefaultPythonPath(i.path)).length === 0) {
-            return [
-                new InvalidMacPythonInterpreterDiagnostic(
-                    DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic,
-                    resource
-                )
-            ];
+        for (const info of interpreters) {
+            if (!(await this.helper.isMacDefaultPythonPath(info.path))) {
+                return [
+                    new InvalidMacPythonInterpreterDiagnostic(
+                        DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic,
+                        resource
+                    )
+                ];
+            }
         }
-
         return [
             new InvalidMacPythonInterpreterDiagnostic(
-                DiagnosticCodes.MacInterpreterSelectedAndHaveOtherInterpretersDiagnostic,
+                DiagnosticCodes.MacInterpreterSelectedAndNoOtherInterpretersDiagnostic,
                 resource
             )
         ];

--- a/src/client/common/process/pythonExecutionFactory.ts
+++ b/src/client/common/process/pythonExecutionFactory.ts
@@ -71,7 +71,7 @@ export class PythonExecutionFactory implements IPythonExecutionFactory {
             processService,
             this.fileSystem,
             undefined,
-            this.windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)
+            await this.windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)
         );
     }
 

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -100,7 +100,7 @@ export const IInterpreterHelper = Symbol('IInterpreterHelper');
 export interface IInterpreterHelper {
     getActiveWorkspaceUri(resource: Resource): WorkspacePythonPath | undefined;
     getInterpreterInformation(pythonPath: string): Promise<undefined | Partial<PythonEnvironment>>;
-    isMacDefaultPythonPath(pythonPath: string): Boolean;
+    isMacDefaultPythonPath(pythonPath: string): Promise<boolean>;
     getInterpreterTypeDisplayName(interpreterType: EnvironmentType): string | undefined;
     getBestInterpreter(interpreters?: PythonEnvironment[]): PythonEnvironment | undefined;
 }

--- a/src/client/interpreter/locators/types.ts
+++ b/src/client/interpreter/locators/types.ts
@@ -53,7 +53,7 @@ export interface IWindowsStoreInterpreter {
      * @returns {boolean}
      * @memberof WindowsStoreInterpreter
      */
-    isWindowsStoreInterpreter(pythonPath: string): boolean;
+    isWindowsStoreInterpreter(pythonPath: string): Promise<boolean>;
     /**
      * Whether this is a python executable in a windows app store folder that is internal and can be hidden from users.
      *

--- a/src/client/pythonEnvironments/discovery/locators/services/hashProviderFactory.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/hashProviderFactory.ts
@@ -28,7 +28,7 @@ export class InterpeterHashProviderFactory implements IInterpreterHashProviderFa
             ? options.pythonPath
             : this.configService.getSettings(options.resource).pythonPath;
 
-        return this.windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)
+        return (await this.windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath))
             ? this.windowsStoreHashProvider
             : this.hashProvider;
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryService.ts
@@ -186,7 +186,7 @@ export class WindowsRegistryService extends CacheableLocatorService {
                     // Give preference to what we have retrieved from getInterpreterInformation.
                     version: details.version || parsePythonVersion(version),
                     companyDisplayName: interpreterInfo.companyDisplayName,
-                    envType: this.windowsStoreInterpreter.isWindowsStoreInterpreter(executablePath)
+                    envType: (await this.windowsStoreInterpreter.isWindowsStoreInterpreter(executablePath))
                         ? EnvironmentType.WindowsStore
                         : EnvironmentType.Unknown,
                 } as PythonEnvironment;

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -191,15 +191,6 @@ class ComponentAdapter implements IComponentAdapter {
 
     // IInterpreterService
 
-    // A result of `undefined` means "Fall back to the old code!"
-    public get hasInterpreters(): Promise<boolean | undefined> {
-        if (!this.enabled) {
-            return Promise.resolve(undefined);
-        }
-        const iterator = this.api.iterEnvs();
-        return iterator.next().then((res) => !res.done);
-    }
-
     // We use the same getInterpreters() here as for IInterpreterLocatorService.
 
     // A result of `undefined` means "Fall back to the old code!"
@@ -273,6 +264,15 @@ class ComponentAdapter implements IComponentAdapter {
     }
 
     // IInterpreterLocatorService
+
+    // A result of `undefined` means "Fall back to the old code!"
+    public get hasInterpreters(): Promise<boolean | undefined> {
+        if (!this.enabled) {
+            return Promise.resolve(undefined);
+        }
+        const iterator = this.api.iterEnvs();
+        return iterator.next().then((res) => !res.done);
+    }
 
     // A result of `undefined` means "Fall back to the old code!"
     public async getInterpreters(

--- a/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
+++ b/src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
@@ -220,7 +220,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .verifiable(typemoq.Times.once());
             helper
                 .setup((i) => i.isMacDefaultPythonPath(typemoq.It.isAny()))
-                .returns(() => false)
+                .returns(() => Promise.resolve(false))
                 .verifiable(typemoq.Times.once());
 
             const diagnostics = await diagnosticService.diagnose(undefined);
@@ -251,7 +251,7 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .verifiable(typemoq.Times.once());
             helper
                 .setup((i) => i.isMacDefaultPythonPath(typemoq.It.isValue(pythonPath)))
-                .returns(() => true)
+                .returns(() => Promise.resolve(true))
                 .verifiable(typemoq.Times.atLeastOnce());
 
             const diagnostics = await diagnosticService.diagnose(undefined);
@@ -291,11 +291,11 @@ suite('Application Diagnostics - Checks Mac Python Interpreter', () => {
                 .verifiable(typemoq.Times.once());
             helper
                 .setup((i) => i.isMacDefaultPythonPath(typemoq.It.isValue(pythonPath)))
-                .returns(() => true)
+                .returns(() => Promise.resolve(true))
                 .verifiable(typemoq.Times.atLeastOnce());
             helper
                 .setup((i) => i.isMacDefaultPythonPath(typemoq.It.isValue(nonMacStandardInterpreter)))
-                .returns(() => false)
+                .returns(() => Promise.resolve(false))
                 .verifiable(typemoq.Times.atLeastOnce());
             interpreterService
                 .setup((i) => i.getActiveInterpreter(typemoq.It.isAny()))

--- a/src/test/common/process/pythonExecutionFactory.unit.test.ts
+++ b/src/test/common/process/pythonExecutionFactory.unit.test.ts
@@ -217,7 +217,7 @@ suite('Process - PythonExecutionFactory', () => {
                 when(processFactory.create(resource)).thenResolve(processService.object);
                 when(pythonSettings.pythonPath).thenReturn(pythonPath);
                 when(configService.getSettings(resource)).thenReturn(instance(pythonSettings));
-                when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(true);
+                when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(Promise.resolve(true));
 
                 const service = await factory.create({ resource });
 

--- a/src/test/interpreters/helpers.unit.test.ts
+++ b/src/test/interpreters/helpers.unit.test.ts
@@ -8,6 +8,7 @@ import { SemVer } from 'semver';
 import * as TypeMoq from 'typemoq';
 import { ConfigurationTarget, TextDocument, TextEditor, Uri } from 'vscode';
 import { IDocumentManager, IWorkspaceService } from '../../client/common/application/types';
+import { IComponentAdapter } from '../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../client/interpreter/helpers';
 import { IInterpreterHashProviderFactory } from '../../client/interpreter/locators/types';
 import { IServiceContainer } from '../../client/ioc/types';
@@ -19,11 +20,13 @@ suite('Interpreters Display Helper', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let helper: InterpreterHelper;
     let hashProviderFactory: TypeMoq.IMock<IInterpreterHashProviderFactory>;
+    let pyenvs: TypeMoq.IMock<IComponentAdapter>;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         documentManager = TypeMoq.Mock.ofType<IDocumentManager>();
         hashProviderFactory = TypeMoq.Mock.ofType<IInterpreterHashProviderFactory>();
+        pyenvs = TypeMoq.Mock.ofType<IComponentAdapter>();
 
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IWorkspaceService)))
@@ -32,7 +35,7 @@ suite('Interpreters Display Helper', () => {
             .setup((c) => c.get(TypeMoq.It.isValue(IDocumentManager)))
             .returns(() => documentManager.object);
 
-        helper = new InterpreterHelper(serviceContainer.object, hashProviderFactory.object);
+        helper = new InterpreterHelper(serviceContainer.object, hashProviderFactory.object, pyenvs.object);
     });
     test('getActiveWorkspaceUri should return undefined if there are no workspaces', () => {
         workspaceService.setup((w) => w.workspaceFolders).returns(() => []);

--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -14,7 +14,7 @@ import { IProcessService, IProcessServiceFactory } from '../../../../client/comm
 import { ITerminalActivationCommandProvider } from '../../../../client/common/terminal/types';
 import { IConfigurationService, IPersistentStateFactory, IPythonSettings } from '../../../../client/common/types';
 import { Architecture } from '../../../../client/common/utils/platform';
-import { IInterpreterLocatorService, IInterpreterService } from '../../../../client/interpreter/contracts';
+import { IComponentAdapter, IInterpreterLocatorService, IInterpreterService } from '../../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import { CondaService } from '../../../../client/pythonEnvironments/discovery/locators/services/condaService';
 import { EnvironmentType, PythonEnvironment } from '../../../../client/pythonEnvironments/info';
@@ -39,6 +39,7 @@ suite('Interpreters Conda Service', () => {
     let processService: TypeMoq.IMock<IProcessService>;
     let platformService: TypeMoq.IMock<IPlatformService>;
     let condaService: CondaService;
+    let pyenvs: TypeMoq.IMock<IComponentAdapter>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     let config: TypeMoq.IMock<IConfigurationService>;
     let settings: TypeMoq.IMock<IPythonSettings>;
@@ -59,6 +60,7 @@ suite('Interpreters Conda Service', () => {
         persistentStateFactory = TypeMoq.Mock.ofType<IPersistentStateFactory>();
         interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
         registryInterpreterLocatorService = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
+        pyenvs = TypeMoq.Mock.ofType<IComponentAdapter>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         config = TypeMoq.Mock.ofType<IConfigurationService>();
@@ -123,6 +125,7 @@ suite('Interpreters Conda Service', () => {
             config.object,
             disposableRegistry,
             workspaceService.object,
+            pyenvs.object,
             registryInterpreterLocatorService.object,
         );
     });
@@ -606,6 +609,7 @@ suite('Interpreters Conda Service', () => {
             config.object,
             disposableRegistry,
             workspaceService.object,
+            pyenvs.object,
         );
 
         const result = await condaSrv.getCondaFile();

--- a/src/test/pythonEnvironments/discovery/locators/hasProviderFactory.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/hasProviderFactory.unit.test.ts
@@ -40,7 +40,7 @@ suite('Interpretersx - Interpreter Hash Provider Factory', () => {
     });
     test('When provided python path is not a window store interpreter return standard hash provider', async () => {
         const pythonPath = 'NonWindowsInterpreterPath';
-        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(false);
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(Promise.resolve(false));
 
         const provider = await factory.create({ pythonPath });
 
@@ -49,7 +49,7 @@ suite('Interpretersx - Interpreter Hash Provider Factory', () => {
     });
     test('When provided python path is a windows store interpreter return windows store hash provider', async () => {
         const pythonPath = 'NonWindowsInterpreterPath';
-        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(true);
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(Promise.resolve(true));
 
         const provider = await factory.create({ pythonPath });
 
@@ -60,7 +60,7 @@ suite('Interpretersx - Interpreter Hash Provider Factory', () => {
         const pythonPath = 'NonWindowsInterpreterPath';
         const resource = Uri.file('1');
         when(configService.getSettings(resource)).thenReturn({ pythonPath } as any);
-        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(false);
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(Promise.resolve(false));
 
         const provider = await factory.create({ resource });
 
@@ -71,7 +71,7 @@ suite('Interpretersx - Interpreter Hash Provider Factory', () => {
         const pythonPath = 'NonWindowsInterpreterPath';
         const resource = Uri.file('1');
         when(configService.getSettings(resource)).thenReturn({ pythonPath } as any);
-        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(true);
+        when(windowsStoreInterpreter.isWindowsStoreInterpreter(pythonPath)).thenReturn(Promise.resolve(true));
 
         const provider = await factory.create({ resource });
 

--- a/src/test/pythonEnvironments/discovery/locators/helpers.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/helpers.unit.test.ts
@@ -76,7 +76,7 @@ suite('Interpreters - Locators Helper', () => {
             // Treat 'mac' as as mac interpreter.
             interpreterServiceHelper
                 .setup((i) => i.isMacDefaultPythonPath(TypeMoq.It.isValue(interpreter.path)))
-                .returns(() => name === 'mac')
+                .returns(() => Promise.resolve(name === 'mac'))
                 .verifiable(TypeMoq.Times.never());
         });
 
@@ -93,7 +93,9 @@ suite('Interpreters - Locators Helper', () => {
     });
     getNamesAndValues<OS>(OS).forEach((os) => {
         test(`Ensure duplicates are removed (same version and same interpreter directory on ${os.name})`, async () => {
-            interpreterServiceHelper.setup((i) => i.isMacDefaultPythonPath(TypeMoq.It.isAny())).returns(() => false);
+            interpreterServiceHelper
+                .setup((i) => i.isMacDefaultPythonPath(TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(false));
             platform.setup((p) => p.isWindows).returns(() => os.value === OS.Windows);
             platform.setup((p) => p.isLinux).returns(() => os.value === OS.Linux);
             platform.setup((p) => p.isMac).returns(() => os.value === OS.Mac);
@@ -158,7 +160,9 @@ suite('Interpreters - Locators Helper', () => {
     });
     getNamesAndValues<OS>(OS).forEach((os) => {
         test(`Ensure interpreter types are identified from other locators (${os.name})`, async () => {
-            interpreterServiceHelper.setup((i) => i.isMacDefaultPythonPath(TypeMoq.It.isAny())).returns(() => false);
+            interpreterServiceHelper
+                .setup((i) => i.isMacDefaultPythonPath(TypeMoq.It.isAny()))
+                .returns(() => Promise.resolve(false));
             platform.setup((p) => p.isWindows).returns(() => os.value === OS.Windows);
             platform.setup((p) => p.isLinux).returns(() => os.value === OS.Linux);
             platform.setup((p) => p.isMac).returns(() => os.value === OS.Mac);

--- a/src/test/pythonEnvironments/discovery/locators/index.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/index.unit.test.ts
@@ -19,6 +19,7 @@ import {
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
     GLOBAL_VIRTUAL_ENV_SERVICE,
+    IComponentAdapter,
     IInterpreterLocatorHelper,
     IInterpreterLocatorService,
     KNOWN_PATH_SERVICE,
@@ -839,18 +840,21 @@ suite('Interpreters - Locators Index', () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let platformSvc: TypeMoq.IMock<IPlatformService>;
     let helper: TypeMoq.IMock<IInterpreterLocatorHelper>;
+    let pyenvs: TypeMoq.IMock<IComponentAdapter>;
     let locator: IInterpreterLocatorService;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         platformSvc = TypeMoq.Mock.ofType<IPlatformService>();
         helper = TypeMoq.Mock.ofType<IInterpreterLocatorHelper>();
+        pyenvs = TypeMoq.Mock.ofType<IComponentAdapter>();
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => []);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IPlatformService))).returns(() => platformSvc.object);
+        serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IComponentAdapter))).returns(() => pyenvs.object);
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterLocatorHelper)))
             .returns(() => helper.object);
 
-        locator = new PythonInterpreterLocatorService(serviceContainer.object);
+        locator = new PythonInterpreterLocatorService(serviceContainer.object, pyenvs.object);
     });
     [undefined, Uri.file('Something')].forEach((resource) => {
         getNamesAndValues<OSType>(OSType).forEach((osType) => {

--- a/src/test/pythonEnvironments/discovery/locators/windowsRegistryService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsRegistryService.unit.test.ts
@@ -32,7 +32,9 @@ suite('Interpreters from Windows Registry (unit)', () => {
         fs = TypeMoq.Mock.ofType<IFileSystem>();
         windowsStoreInterpreter = TypeMoq.Mock.ofType<IWindowsStoreInterpreter>();
         windowsStoreInterpreter.setup((w) => w.isHiddenInterpreter(TypeMoq.It.isAny())).returns(() => false);
-        windowsStoreInterpreter.setup((w) => w.isWindowsStoreInterpreter(TypeMoq.It.isAny())).returns(() => false);
+        windowsStoreInterpreter
+            .setup((w) => w.isWindowsStoreInterpreter(TypeMoq.It.isAny()))
+            .returns(() => Promise.resolve(false));
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IPersistentStateFactory)))
             .returns(() => stateFactory.object);
@@ -331,7 +333,7 @@ suite('Interpreters from Windows Registry (unit)', () => {
             .verifiable(TypeMoq.Times.atLeastOnce());
         windowsStoreInterpreter
             .setup((w) => w.isWindowsStoreInterpreter(TypeMoq.It.isValue(expectedPythonPath)))
-            .returns(() => true)
+            .returns(() => Promise.resolve(true))
             .verifiable(TypeMoq.Times.atLeastOnce());
 
         const interpreters = await winRegistry.getInterpreters();

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreInterpreter.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreInterpreter.unit.test.ts
@@ -19,13 +19,22 @@ import { ServiceContainer } from '../../../../client/ioc/container';
 import { IServiceContainer } from '../../../../client/ioc/types';
 import { WindowsStoreInterpreter } from '../../../../client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 
+// We use this for mocking.
+class ComponentAdapter {
+    public async isWindowsStoreInterpreter(_pythonPath: string): Promise<boolean | undefined> {
+        return undefined;
+    }
+}
+
 suite('Interpreters - Windows Store Interpreter', () => {
     let windowsStoreInterpreter: WindowsStoreInterpreter;
+    let pyenvs: ComponentAdapter;
     let fs: IFileSystem;
     let persistanceStateFactory: IPersistentStateFactory;
     let executionFactory: IPythonExecutionFactory;
     let serviceContainer: IServiceContainer;
     setup(() => {
+        pyenvs = mock(ComponentAdapter);
         fs = mock(FileSystem);
         persistanceStateFactory = mock(PersistentStateFactory);
         executionFactory = mock(PythonExecutionFactory);
@@ -33,10 +42,12 @@ suite('Interpreters - Windows Store Interpreter', () => {
         when(serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory)).thenReturn(
             instance(executionFactory),
         );
+        when(pyenvs.isWindowsStoreInterpreter(anything())).thenReturn(Promise.resolve(undefined));
         windowsStoreInterpreter = new WindowsStoreInterpreter(
             instance(serviceContainer),
             instance(persistanceStateFactory),
             instance(fs),
+            instance(pyenvs)
         );
     });
     const windowsStoreInterpreters = [
@@ -51,23 +62,23 @@ suite('Interpreters - Windows Store Interpreter', () => {
         'C:\\microsoft\\WindowsApps\\PythonSoftwareFoundation\\Something\\Python.exe',
     ];
     for (const interpreter of windowsStoreInterpreters) {
-        test(`${interpreter} must be identified as a windows store interpter`, () => {
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter)).to.equal(true, 'Must be true');
+        test(`${interpreter} must be identified as a windows store interpter`, async () => {
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter)).to.equal(true, 'Must be true');
         });
-        test(`${interpreter.toLowerCase()} must be identified as a windows store interpter (ignoring case)`, () => {
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toLowerCase())).to.equal(
+        test(`${interpreter.toLowerCase()} must be identified as a windows store interpter (ignoring case)`, async () => {
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toLowerCase())).to.equal(
                 true,
                 'Must be true',
             );
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toUpperCase())).to.equal(
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toUpperCase())).to.equal(
                 true,
                 'Must be true',
             );
         });
         test(`D${interpreter.substring(
             1,
-        )} must be identified as a windows store interpter (ignoring driver letter)`, () => {
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(`D${interpreter.substring(1)}`)).to.equal(
+        )} must be identified as a windows store interpter (ignoring driver letter)`, async () => {
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(`D${interpreter.substring(1)}`)).to.equal(
                 true,
                 'Must be true',
             );
@@ -75,8 +86,8 @@ suite('Interpreters - Windows Store Interpreter', () => {
         test(`${interpreter.replace(
             /\\/g,
             '/',
-        )} must be identified as a windows store interpter (ignoring path separator)`, () => {
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(
+        )} must be identified as a windows store interpter (ignoring path separator)`, async () => {
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(
                 true,
                 'Must be true',
             );
@@ -97,14 +108,14 @@ suite('Interpreters - Windows Store Interpreter', () => {
         'C:\\Apps\\Python.exe',
     ];
     for (const interpreter of nonWindowsStoreInterpreters) {
-        test(`${interpreter} must not be identified as a windows store interpter`, () => {
+        test(`${interpreter} must not be identified as a windows store interpter`, async () => {
             expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter)).to.equal(false, 'Must be false');
             expect(windowsStoreInterpreter.isHiddenInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(
                 false,
                 'Must be false',
             );
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter)).to.equal(false, 'Must be false');
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter)).to.equal(false, 'Must be false');
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.replace(/\\/g, '/'))).to.equal(
                 false,
                 'Must be false',
             );
@@ -112,11 +123,11 @@ suite('Interpreters - Windows Store Interpreter', () => {
                 false,
                 'Must be false',
             );
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toUpperCase())).to.equal(
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(interpreter.toUpperCase())).to.equal(
                 false,
                 'Must be false',
             );
-            expect(windowsStoreInterpreter.isWindowsStoreInterpreter(`D${interpreter.substring(1)}`)).to.equal(
+            expect(await windowsStoreInterpreter.isWindowsStoreInterpreter(`D${interpreter.substring(1)}`)).to.equal(
                 false,
                 'Must be false',
             );


### PR DESCRIPTION
This allows us to start using the new discovery code in the extension. The key thing is to be careful not to regress in the available functionality. So it may make sense to only enable the adapter once we have all our new low-level locators in place.

This PR involves small fixes to a large number of files due to API changes. The adapter is actually used (injected) in the following files:

- src/client/interpreter/interpreterService.ts
- src/client/interpreter/helpers.ts
- src/client/pythonEnvironments/discovery/locators/index.ts
- src/client/pythonEnvironments/discovery/locators/services/condaService.ts
- src/client/pythonEnvironments/discovery/locators/services/windowsStoreInterpreter.ts

(Note that at the moment this PR is based on top of #13858.)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~