### PR TITLE
Fix 2.7 unit test requirements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@
 # IntelliSense. This is a specific commit id of our fork of the pappasam jedi-language-server
 # If you make fixes to the fork, update the commit id here. 
 # Note: This pulls in Jedi too but the pypi version. 
-git+git://github.com/vscode-python/jedi-language-server@42823a2598d4b6369e9273c5ad237a48c5d67553
+git+git://github.com/vscode-python/jedi-language-server@42823a2598d4b6369e9273c5ad237a48c5d67553; python_version >= '3.6'
 # Sort Imports
 isort==5.5.2; python_version >= '3.6'
 # DS Python daemon

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 click==7.1.2              # via jedi-language-server
 future==0.18.2            # via python-jsonrpc-server
 isort==5.5.2 ; python_version >= "3.6"  # via -r requirements.in
-git+git://github.com/vscode-python/jedi-language-server@42823a2598d4b6369e9273c5ad237a48c5d67553  # via -r requirements.in
+git+git://github.com/vscode-python/jedi-language-server@42823a2598d4b6369e9273c5ad237a48c5d67553 ; python_version >= "3.6"  # via -r requirements.in
 jedi==0.17.2              # via jedi-language-server
 parso==0.7.0              # via jedi
 pygls==0.9.0              # via jedi-language-server

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -26,7 +26,7 @@ function start() {
     runTests({
         extensionDevelopmentPath: extensionDevelopmentPath,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
-        launchArgs: ['--disable-gpu', '--disable-extensions', workspacePath]
+        launchArgs: ['--disable-extensions', workspacePath]
             .concat(channel === 'insiders' ? ['--enable-proposed-api'] : [])
             .concat(['--timeout', '5000']),
         version: channel,

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -26,7 +26,7 @@ function start() {
     runTests({
         extensionDevelopmentPath: extensionDevelopmentPath,
         extensionTestsPath: path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'out', 'test', 'index'),
-        launchArgs: ['--disable-extensions', workspacePath]
+        launchArgs: ['--disable-gpu', '--disable-extensions', workspacePath]
             .concat(channel === 'insiders' ? ['--enable-proposed-api'] : [])
             .concat(['--timeout', '5000']),
         version: channel,


### PR DESCRIPTION
CI is failing for 2.7 because of jedi-language-server requirement

