### PR TITLE
Fix pygls for 2.7 too

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@
 # If you make fixes to the fork, update the commit id here. 
 # Note: This pulls in Jedi too but the pypi version. 
 git+git://github.com/vscode-python/jedi-language-server@42823a2598d4b6369e9273c5ad237a48c5d67553; python_version >= '3.6'
+pygls==0.9.0; python_version >= '3.6'
 # Sort Imports
 isort==5.5.2; python_version >= '3.6'
 # DS Python daemon

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ isort==5.5.2 ; python_version >= "3.6"  # via -r requirements.in
 git+git://github.com/vscode-python/jedi-language-server@42823a2598d4b6369e9273c5ad237a48c5d67553 ; python_version >= "3.6"  # via -r requirements.in
 jedi==0.17.2              # via jedi-language-server
 parso==0.7.0              # via jedi
-pygls==0.9.0              # via jedi-language-server
+pygls==0.9.0 ; python_version >= "3.6"  # via -r requirements.in, jedi-language-server
 python-jsonrpc-server==0.2.0  # via -r requirements.in


### PR DESCRIPTION
Seems pygls doesn't work on 2.7 either. Force this dependency to be 3.6 or newer.