### PR TITLE
Turn off custom editor until we ship

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -164,14 +164,14 @@
     {
         "name": "CustomEditorSupport - control",
         "salt": "CustomEditorSupport",
-        "min": 20,
+        "min": 0,
         "max": 100
     },
     {
         "name": "CustomEditorSupport - experiment",
         "salt": "CustomEditorSupport",
         "min": 0,
-        "max": 20
+        "max": 0
     },
     {
         "name": "NativeNotebook - experiment",


### PR DESCRIPTION
Custom editor should wait until we actually ship a release to be enabled. Releases out in the wild actually read from the main branch.