### PR TITLE
Workaround test issue

### DIFF
--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -11,4 +11,4 @@ variables:
   npm_config_cache: $(Pipeline.Workspace)/.npm
   vmImageMacOS: 'macOS-10.15'
   TS_NODE_FILES: true # Temporarily enabled to allow using types from vscode.proposed.d.ts from ts-node (for tests).
-  VSC_PYTHON_CI_TEST_VSC_CHANNEL: '1.48' # Enforce this until https://github.com/microsoft/vscode-test/issues/73 is fixed
+  VSC_PYTHON_CI_TEST_VSC_CHANNEL: '1.48.0' # Enforce this until https://github.com/microsoft/vscode-test/issues/73 is fixed

--- a/build/ci/templates/globals.yml
+++ b/build/ci/templates/globals.yml
@@ -11,3 +11,4 @@ variables:
   npm_config_cache: $(Pipeline.Workspace)/.npm
   vmImageMacOS: 'macOS-10.15'
   TS_NODE_FILES: true # Temporarily enabled to allow using types from vscode.proposed.d.ts from ts-node (for tests).
+  VSC_PYTHON_CI_TEST_VSC_CHANNEL: '1.48' # Enforce this until https://github.com/microsoft/vscode-test/issues/73 is fixed

--- a/src/test/standardTest.ts
+++ b/src/test/standardTest.ts
@@ -16,9 +16,7 @@ const extensionDevelopmentPath = process.env.CODE_EXTENSIONS_PATH
     ? process.env.CODE_EXTENSIONS_PATH
     : EXTENSION_ROOT_DIR_FOR_TESTS;
 
-const channel = (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL || '').toLowerCase().includes('insiders')
-    ? 'insiders'
-    : 'stable';
+const channel = process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL || 'stable';
 
 function start() {
     console.log('*'.repeat(100));


### PR DESCRIPTION
VS Code test issue https://github.com/microsoft/vscode-test/issues/73 causes our tests to fail. Force to 1.48.0 to work around it.