### PR TITLE
Fix backup storage by looking at the options correctly

### DIFF
--- a/news/2 Fixes/13981.md
+++ b/news/2 Fixes/13981.md
@@ -1,0 +1,1 @@
+Backup on custom editors is being ignored.

--- a/src/client/datascience/export/exportUtil.ts
+++ b/src/client/datascience/export/exportUtil.ts
@@ -57,7 +57,7 @@ export class ExportUtil {
             await this.jupyterExporter.exportToFile(cells, tempFile.filePath, false);
             const newPath = path.join(tempDir.path, '.ipynb');
             await this.fs.copyLocal(tempFile.filePath, newPath);
-            model = await this.notebookStorage.getOrCreateModel(Uri.file(newPath));
+            model = await this.notebookStorage.getOrCreateModel({ file: Uri.file(newPath) });
         } finally {
             tempFile.dispose();
             tempDir.dispose();
@@ -67,7 +67,7 @@ export class ExportUtil {
     }
 
     public async removeSvgs(source: Uri) {
-        const model = await this.notebookStorage.getOrCreateModel(source);
+        const model = await this.notebookStorage.getOrCreateModel({ file: source });
 
         const newCells: ICell[] = [];
         for (const cell of model.cells) {

--- a/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorProviderOld.ts
@@ -299,7 +299,7 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
         this.activeEditors.set(e.file.fsPath, e);
 
         // Remove backup storage
-        this.loadModel(Uri.file(oldPath))
+        this.loadModel({ file: Uri.file(oldPath) })
             .then((m) => this.storage.deleteBackup(m))
             .ignoreErrors();
     }
@@ -347,7 +347,7 @@ export class NativeEditorProviderOld extends NativeEditorProvider {
      * I.e. document is already opened in a VSC Notebook.
      */
     private async isDocumentOpenedInVSCodeNotebook(document: TextDocument): Promise<boolean> {
-        const model = await this.loadModel(document.uri);
+        const model = await this.loadModel({ file: document.uri });
         // This is temporary code.
         return model instanceof VSCodeNotebookModel;
     }

--- a/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
+++ b/src/client/datascience/interactive-ipynb/trustCommandHandler.ts
@@ -42,7 +42,7 @@ export class TrustCommandHandler implements IExtensionSingleActivationService {
             return;
         }
 
-        const model = await this.storageProvider.getOrCreateModel(uri);
+        const model = await this.storageProvider.getOrCreateModel({ file: uri });
         if (model.isTrusted) {
             return;
         }

--- a/src/client/datascience/interactive-window/interactiveWindow.ts
+++ b/src/client/datascience/interactive-window/interactiveWindow.ts
@@ -256,7 +256,7 @@ export class InteractiveWindow extends InteractiveBase implements IInteractiveWi
                 break;
 
             case InteractiveWindowMessages.ExportNotebookAs:
-                this.handleMessage(message, payload, this.exportAs);
+                this.handleMessage(message, payload, this.exportAs.bind);
                 break;
 
             case InteractiveWindowMessages.HasCellResponse:

--- a/src/client/datascience/notebook/notebookEditorProvider.ts
+++ b/src/client/datascience/notebook/notebookEditorProvider.ts
@@ -145,7 +145,7 @@ export class NotebookEditorProvider implements INotebookEditorProvider {
             return;
         }
         const uri = doc.uri;
-        const model = await this.storage.getOrCreateModel(uri, undefined, undefined, true);
+        const model = await this.storage.getOrCreateModel({ file: uri, isNative: true });
         if (model instanceof VSCodeNotebookModel) {
             model.associateNotebookDocument(doc);
         }

--- a/src/client/datascience/notebookStorage/nativeEditorProvider.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorProvider.ts
@@ -51,6 +51,7 @@ import {
     IJupyterDebugger,
     IJupyterVariableDataProviderFactory,
     IJupyterVariables,
+    IModelLoadOptions,
     INotebookEditor,
     INotebookEditorProvider,
     INotebookExporter,
@@ -128,22 +129,26 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
         context: CustomDocumentOpenContext, // This has info about backups. right now we use our own data.
         _cancellation: CancellationToken
     ): Promise<CustomDocument> {
-        const model = await this.loadModel(uri, undefined, context.backupId);
+        const model = await this.loadModel({
+            file: uri,
+            backupId: context.backupId,
+            skipLoadingDirtyContents: context.backupId === undefined
+        });
         return {
             uri,
             dispose: () => model.dispose()
         };
     }
     public async saveCustomDocument(document: CustomDocument, cancellation: CancellationToken): Promise<void> {
-        const model = await this.loadModel(document.uri);
+        const model = await this.loadModel({ file: document.uri });
         return this.storage.save(model, cancellation);
     }
     public async saveCustomDocumentAs(document: CustomDocument, targetResource: Uri): Promise<void> {
-        const model = await this.loadModel(document.uri);
+        const model = await this.loadModel({ file: document.uri });
         return this.storage.saveAs(model, targetResource);
     }
     public async revertCustomDocument(document: CustomDocument, cancellation: CancellationToken): Promise<void> {
-        const model = await this.loadModel(document.uri);
+        const model = await this.loadModel({ file: document.uri });
         return this.storage.revert(model, cancellation);
     }
     public async backupCustomDocument(
@@ -151,7 +156,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
         _context: CustomDocumentBackupContext,
         cancellation: CancellationToken
     ): Promise<CustomDocumentBackup> {
-        const model = await this.loadModel(document.uri);
+        const model = await this.loadModel({ file: document.uri });
         const id = this.storage.generateBackupId(model);
         await this.storage.backup(model, cancellation, id);
         return {
@@ -167,7 +172,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
 
     public async resolveCustomDocument(document: CustomDocument): Promise<void> {
         this.customDocuments.set(document.uri.fsPath, document);
-        await this.loadModel(document.uri);
+        await this.loadModel({ file: document.uri });
     }
 
     public async open(file: Uri): Promise<INotebookEditor> {
@@ -199,30 +204,26 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
     }
 
     @captureTelemetry(Telemetry.CreateNewNotebook, undefined, false)
-    public async createNew(contents?: string, title?: string): Promise<INotebookEditor> {
+    public async createNew(possibleContents?: string, title?: string): Promise<INotebookEditor> {
         // Create a new URI for the dummy file using our root workspace path
         const uri = this.getNextNewNotebookUri(title);
 
         // Set these contents into the storage before the file opens. Make sure not
         // load from the memento storage though as this is an entirely brand new file.
-        await this.loadModel(uri, contents, true);
+        await this.loadModel({ file: uri, possibleContents, skipLoadingDirtyContents: true });
 
         return this.open(uri);
     }
 
-    public async loadModel(file: Uri, contents?: string, skipDirtyContents?: boolean): Promise<INotebookModel>;
-    // tslint:disable-next-line: unified-signatures
-    public async loadModel(file: Uri, contents?: string, backupId?: string): Promise<INotebookModel>;
-    // tslint:disable-next-line: no-any
-    public async loadModel(file: Uri, contents?: string, options?: any): Promise<INotebookModel> {
+    public async loadModel(options: IModelLoadOptions): Promise<INotebookModel> {
         // Get the model that may match this file
-        let model = [...this.models.values()].find((m) => this.fs.arePathsSame(m.file, file));
+        let model = [...this.models.values()].find((m) => this.fs.arePathsSame(m.file, options.file));
         if (!model) {
             // Every time we load a new untitled file, up the counter past the max value for this counter
-            this.untitledCounter = getNextUntitledCounter(file, this.untitledCounter);
+            this.untitledCounter = getNextUntitledCounter(options.file, this.untitledCounter);
 
             // Load our model from our storage object.
-            model = await this.storage.getOrCreateModel(file, contents, options);
+            model = await this.storage.getOrCreateModel(options);
 
             // Make sure to listen to events on the model
             this.trackModel(model);
@@ -273,7 +274,7 @@ export class NativeEditorProvider implements INotebookEditorProvider, CustomEdit
     protected async loadNotebookEditor(resource: Uri, panel?: WebviewPanel) {
         try {
             // Get the model
-            const model = await this.loadModel(resource);
+            const model = await this.loadModel({ file: resource });
 
             // Load it (should already be visible)
             return this.createNotebookEditor(model, panel);

--- a/src/client/datascience/notebookStorage/nativeEditorStorage.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorStorage.ts
@@ -251,7 +251,9 @@ export class NativeEditorStorage implements INotebookStorage {
             }
 
             // See if this file was stored in storage prior to shutdown
-            const dirtyContents = await this.getStoredContents(options.file, backupId);
+            const dirtyContents = options.skipLoadingDirtyContents
+                ? undefined
+                : await this.getStoredContents(options.file, backupId);
             if (dirtyContents) {
                 // This means we're dirty. Indicate dirty and load from this content
                 return this.loadContents(options.file, dirtyContents, true, options.isNative);

--- a/src/client/datascience/notebookStorage/nativeEditorStorage.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorStorage.ts
@@ -276,7 +276,7 @@ export class NativeEditorStorage implements INotebookStorage {
             // Attempt to read the contents if a viable file
             const contents = NativeEditorStorage.isUntitledFile(file) ? possibleContents : await this.fs.readFile(file);
 
-            const skipDirtyContents = typeof options === 'boolean' ? options : !!options;
+            const skipDirtyContents = typeof options === 'boolean' ? options : !options || options.length === 0;
             // Use backupId provided, else use static storage key.
             const backupId =
                 typeof options === 'string' ? options : skipDirtyContents ? undefined : this.getStaticStorageKey(file);

--- a/src/client/datascience/notebookStorage/nativeEditorStorage.ts
+++ b/src/client/datascience/notebookStorage/nativeEditorStorage.ts
@@ -17,6 +17,7 @@ import {
     CellState,
     IDataScienceFileSystem,
     IJupyterExecution,
+    IModelLoadOptions,
     INotebookModel,
     INotebookStorage,
     ITrustService
@@ -75,27 +76,8 @@ export class NativeEditorStorage implements INotebookStorage {
     public get(_file: Uri): INotebookModel | undefined {
         return undefined;
     }
-    public getOrCreateModel(
-        file: Uri,
-        possibleContents?: string,
-        backupId?: string,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel>;
-    public getOrCreateModel(
-        file: Uri,
-        possibleContents?: string,
-        // tslint:disable-next-line: unified-signatures
-        skipDirtyContents?: boolean,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel>;
-    public getOrCreateModel(
-        file: Uri,
-        possibleContents?: string,
-        // tslint:disable-next-line: no-any
-        options?: any,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel> {
-        return this.loadFromFile(file, possibleContents, options, forVSCodeNotebook);
+    public getOrCreateModel(options: IModelLoadOptions): Promise<INotebookModel> {
+        return this.loadFromFile(options);
     }
     public async save(model: INotebookModel, _cancellation: CancellationToken): Promise<void> {
         const contents = model.getContent();
@@ -154,8 +136,8 @@ export class NativeEditorStorage implements INotebookStorage {
     }
 
     public async revert(model: INotebookModel, _cancellation: CancellationToken): Promise<void> {
-        // Revert to what is in the hot exit file
-        await this.loadFromFile(model.file);
+        // Revert to what is in the real file. This is only used for the custom editor
+        await this.loadFromFile({ file: model.file, skipLoadingDirtyContents: true });
     }
 
     public async deleteBackup(model: INotebookModel, backupId: string): Promise<void> {
@@ -253,54 +235,42 @@ export class NativeEditorStorage implements INotebookStorage {
             noop();
         }
     }
-    private loadFromFile(
-        file: Uri,
-        possibleContents?: string,
-        backupId?: string,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel>;
-    private loadFromFile(
-        file: Uri,
-        possibleContents?: string,
-        // tslint:disable-next-line: unified-signatures
-        skipDirtyContents?: boolean,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel>;
-    private async loadFromFile(
-        file: Uri,
-        possibleContents?: string,
-        options?: boolean | string,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel> {
+    private async loadFromFile(options: IModelLoadOptions): Promise<INotebookModel> {
         try {
             // Attempt to read the contents if a viable file
-            const contents = NativeEditorStorage.isUntitledFile(file) ? possibleContents : await this.fs.readFile(file);
+            const contents = NativeEditorStorage.isUntitledFile(options.file)
+                ? options.possibleContents
+                : await this.fs.readFile(options.file);
 
-            const skipDirtyContents = typeof options === 'boolean' ? options : !options || options.length === 0;
-            // Use backupId provided, else use static storage key.
-            const backupId =
-                typeof options === 'string' ? options : skipDirtyContents ? undefined : this.getStaticStorageKey(file);
+            // Get backup id from the options if available.
+            const backupId = options.backupId ? options.backupId : this.getStaticStorageKey(options.file);
 
             // If skipping dirty contents, delete the dirty hot exit file now
-            if (skipDirtyContents) {
-                await this.clearHotExit(file, backupId);
+            if (options.skipLoadingDirtyContents) {
+                await this.clearHotExit(options.file, backupId);
             }
 
             // See if this file was stored in storage prior to shutdown
-            const dirtyContents = skipDirtyContents ? undefined : await this.getStoredContents(file, backupId);
+            const dirtyContents = await this.getStoredContents(options.file, backupId);
             if (dirtyContents) {
                 // This means we're dirty. Indicate dirty and load from this content
-                return this.loadContents(file, dirtyContents, true, forVSCodeNotebook);
+                return this.loadContents(options.file, dirtyContents, true, options.isNative);
             } else {
                 // Load without setting dirty
-                return this.loadContents(file, contents, undefined, forVSCodeNotebook);
+                return this.loadContents(options.file, contents, undefined, options.isNative);
             }
         } catch (ex) {
             // May not exist at this time. Should always have a single cell though
-            traceError(`Failed to load notebook file ${file.toString()}`, ex);
+            traceError(`Failed to load notebook file ${options.file.toString()}`, ex);
             return this.factory.createModel(
-                { trusted: true, file, cells: [], crypto: this.crypto, globalMemento: this.globalStorage },
-                forVSCodeNotebook
+                {
+                    trusted: true,
+                    file: options.file,
+                    cells: [],
+                    crypto: this.crypto,
+                    globalMemento: this.globalStorage
+                },
+                options.isNative
             );
         }
     }

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1106,6 +1106,14 @@ export interface INotebookModel {
     trust(): void;
 }
 
+export interface IModelLoadOptions {
+    isNative?: boolean;
+    file: Uri;
+    possibleContents?: string;
+    backupId?: string;
+    skipLoadingDirtyContents?: boolean;
+}
+
 export const INotebookStorage = Symbol('INotebookStorage');
 
 export interface INotebookStorage {
@@ -1114,19 +1122,7 @@ export interface INotebookStorage {
     saveAs(model: INotebookModel, targetResource: Uri): Promise<void>;
     backup(model: INotebookModel, cancellation: CancellationToken, backupId?: string): Promise<void>;
     get(file: Uri): INotebookModel | undefined;
-    getOrCreateModel(
-        file: Uri,
-        contents?: string,
-        backupId?: string,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel>;
-    getOrCreateModel(
-        file: Uri,
-        contents?: string,
-        // tslint:disable-next-line: unified-signatures
-        skipDirtyContents?: boolean,
-        forVSCodeNotebook?: boolean
-    ): Promise<INotebookModel>;
+    getOrCreateModel(options: IModelLoadOptions): Promise<INotebookModel>;
     revert(model: INotebookModel, cancellation: CancellationToken): Promise<void>;
     deleteBackup(model: INotebookModel, backupId?: string): Promise<void>;
 }

--- a/src/test/datascience/export/exportUtil.test.ts
+++ b/src/test/datascience/export/exportUtil.test.ts
@@ -37,7 +37,7 @@ suite('DataScience - Export Util', () => {
         );
 
         await exportUtil.removeSvgs(file);
-        const model = await notebookStorage.getOrCreateModel(file);
+        const model = await notebookStorage.getOrCreateModel({ file });
 
         // make sure no svg exists in model
         const SVG = 'image/svg+xml';

--- a/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
+++ b/src/test/datascience/interactive-ipynb/nativeEditorStorage.unit.test.ts
@@ -425,7 +425,7 @@ suite('DataScience - Native Editor Storage', () => {
     }
 
     test('Create new editor and add some cells', async () => {
-        model = await storage.getOrCreateModel(baseUri);
+        model = await storage.getOrCreateModel({ file: baseUri });
         insertCell(0, '1');
         const cells = model.cells;
         expect(cells).to.be.lengthOf(4);
@@ -434,7 +434,7 @@ suite('DataScience - Native Editor Storage', () => {
     });
 
     test('Move cells around', async () => {
-        model = await storage.getOrCreateModel(baseUri);
+        model = await storage.getOrCreateModel({ file: baseUri });
         swapCells('NotebookImport#0', 'NotebookImport#1');
         const cells = model.cells;
         expect(cells).to.be.lengthOf(3);
@@ -443,7 +443,7 @@ suite('DataScience - Native Editor Storage', () => {
     });
 
     test('Edit/delete cells', async () => {
-        model = await storage.getOrCreateModel(baseUri);
+        model = await storage.getOrCreateModel({ file: baseUri });
         expect(model.isDirty).to.be.equal(false, 'Editor should not be dirty');
         editCell(
             [
@@ -483,7 +483,7 @@ suite('DataScience - Native Editor Storage', () => {
     test('Editing a file and closing will keep contents', async () => {
         await filesConfig?.update('autoSave', 'off');
 
-        model = await storage.getOrCreateModel(baseUri);
+        model = await storage.getOrCreateModel({ file: baseUri });
         expect(model.isDirty).to.be.equal(false, 'Editor should not be dirty');
         editCell(
             [
@@ -512,7 +512,7 @@ suite('DataScience - Native Editor Storage', () => {
 
         // Recreate
         storage = createStorage();
-        model = await storage.getOrCreateModel(baseUri);
+        model = await storage.getOrCreateModel({ file: baseUri });
 
         const cells = model.cells;
         expect(cells).to.be.lengthOf(3);
@@ -522,7 +522,7 @@ suite('DataScience - Native Editor Storage', () => {
     });
 
     test('Editing a new file and closing will keep contents', async () => {
-        model = await storage.getOrCreateModel(untiledUri, undefined, true);
+        model = await storage.getOrCreateModel({ file: untiledUri, skipLoadingDirtyContents: true });
         expect(model.isDirty).to.be.equal(false, 'Editor should not be dirty');
         insertCell(0, 'a=1');
 
@@ -531,7 +531,7 @@ suite('DataScience - Native Editor Storage', () => {
 
         // Recreate
         storage = createStorage();
-        model = await storage.getOrCreateModel(untiledUri);
+        model = await storage.getOrCreateModel({ file: untiledUri });
 
         const cells = model.cells;
         expect(cells).to.be.lengthOf(2);
@@ -550,7 +550,7 @@ suite('DataScience - Native Editor Storage', () => {
 
         // Put the regular file into the local storage
         await localMemento.update(`notebook-storage-${file.toString()}`, differentFile);
-        model = await storage.getOrCreateModel(file);
+        model = await storage.getOrCreateModel({ file });
 
         // It should load with that value
         const cells = model.cells;
@@ -571,7 +571,7 @@ suite('DataScience - Native Editor Storage', () => {
             contents: differentFile,
             lastModifiedTimeMs: Date.now()
         });
-        model = await storage.getOrCreateModel(file);
+        model = await storage.getOrCreateModel({ file });
 
         // It should load with that value
         const cells = model.cells;
@@ -601,7 +601,7 @@ suite('DataScience - Native Editor Storage', () => {
             lastModifiedTimeMs: Date.now()
         });
 
-        model = await storage.getOrCreateModel(file);
+        model = await storage.getOrCreateModel({ file });
 
         // It should load with that value
         const cells = model.cells;

--- a/src/test/datascience/mockCustomEditorService.ts
+++ b/src/test/datascience/mockCustomEditorService.ts
@@ -138,7 +138,7 @@ export class MockCustomEditorService implements ICustomEditorService {
     private async getModel(file: Uri): Promise<NativeEditorNotebookModel | undefined> {
         const nativeProvider = this.provider as NativeEditorProvider;
         if (nativeProvider) {
-            return (nativeProvider.loadModel(file) as unknown) as Promise<NativeEditorNotebookModel | undefined>;
+            return (nativeProvider.loadModel({ file }) as unknown) as Promise<NativeEditorNotebookModel | undefined>;
         }
         return undefined;
     }

--- a/src/test/datascience/notebook/contentProvider.ds.test.ts
+++ b/src/test/datascience/notebook/contentProvider.ds.test.ts
@@ -60,7 +60,7 @@ suite('DataScience - VSCode Notebook - (Open)', function () {
             'notebook',
             'testJsonContents.ipynb'
         );
-        const model = await storageProvider.getOrCreateModel(Uri.file(file));
+        const model = await storageProvider.getOrCreateModel({ file: Uri.file(file) });
         disposables.push(model);
         model.trust();
         const jsonStr = fs.readFileSync(file, { encoding: 'utf8' });

--- a/src/test/datascience/notebook/contentProvider.unit.test.ts
+++ b/src/test/datascience/notebook/contentProvider.unit.test.ts
@@ -55,9 +55,7 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
                         ]
                     }
                 );
-                when(storageProvider.getOrCreateModel(anything(), anything(), anything(), anything())).thenResolve(
-                    model
-                );
+                when(storageProvider.getOrCreateModel(anything())).thenResolve(model);
 
                 const notebook = await contentProvider.openNotebook(fileUri, {});
 
@@ -135,9 +133,7 @@ suite('DataScience - NativeNotebook ContentProvider', () => {
                         ]
                     }
                 );
-                when(storageProvider.getOrCreateModel(anything(), anything(), anything(), anything())).thenResolve(
-                    model
-                );
+                when(storageProvider.getOrCreateModel(anything())).thenResolve(model);
 
                 const notebook = await contentProvider.openNotebook(fileUri, {});
 


### PR DESCRIPTION
For #13981

Root cause is backup id was not being checked correctly.

This should not affect the old editor in any way as it doesn't pass in the 'options' the same way. It uses a boolean.