### PR TITLE
Modify environment info worker to support new type and to work with resolver

### DIFF
--- a/pythonFiles/interpreterInfo.py
+++ b/pythonFiles/interpreterInfo.py
@@ -7,7 +7,7 @@ import sys
 obj = {}
 obj["versionInfo"] = tuple(sys.version_info)
 obj["sysPrefix"] = sys.prefix
-obj["version"] = sys.version
+obj["sysVersion"] = sys.version
 obj["is64Bit"] = sys.maxsize > 2 ** 32
 
 print(json.dumps(obj))

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -41,19 +41,19 @@ export * as vscode_datascience_helpers from './vscode_datascience_helpers';
 
 type ReleaseLevel = 'alpha' | 'beta' | 'candidate' | 'final';
 type PythonVersionInfo = [number, number, number, ReleaseLevel, number];
-export type PythonEnvInfo = {
+export type InterpreterInfoJson = {
     versionInfo: PythonVersionInfo;
     sysPrefix: string;
     sysVersion: string;
     is64Bit: boolean;
 };
 
-export function interpreterInfo(): [string[], (out: string) => PythonEnvInfo] {
+export function interpreterInfo(): [string[], (out: string) => InterpreterInfoJson] {
     const script = path.join(SCRIPTS_DIR, 'interpreterInfo.py');
     const args = [ISOLATED, script];
 
-    function parse(out: string): PythonEnvInfo {
-        let json: PythonEnvInfo;
+    function parse(out: string): InterpreterInfoJson {
+        let json: InterpreterInfoJson;
         try {
             json = JSON.parse(out);
         } catch (ex) {

--- a/src/client/common/process/pythonDaemon.ts
+++ b/src/client/common/process/pythonDaemon.ts
@@ -11,7 +11,7 @@ import { extractInterpreterInfo } from '../../pythonEnvironments/info/interprete
 import { traceWarning } from '../logger';
 import { IPlatformService } from '../platform/types';
 import { BasePythonDaemon } from './baseDaemon';
-import { PythonEnvInfo } from './internal/scripts';
+import { InterpreterInfoJson } from './internal/scripts';
 import {
     IPythonDaemonExecutionService,
     IPythonExecutionService,
@@ -45,7 +45,9 @@ export class PythonDaemonExecutionService extends BasePythonDaemon implements IP
     public async getInterpreterInformation(): Promise<InterpreterInformation | undefined> {
         try {
             this.throwIfRPCConnectionIsDead();
-            const request = new RequestType0<PythonEnvInfo & ErrorResponse, void, void>('get_interpreter_information');
+            const request = new RequestType0<InterpreterInfoJson & ErrorResponse, void, void>(
+                'get_interpreter_information'
+            );
             const response = await this.sendRequestWithoutArgs(request);
             if (response.error) {
                 throw Error(response.error);

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -26,7 +26,7 @@ export type InterpreterInformation = {
  * @param python - the path to the Python executable
  * @param raw - the information returned by the `interpreterInfo.py` script
  */
-export function extractPythonEnvInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
+function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
     const version = parseVersion(rawVersion);
     version.sysVersion = raw.sysVersion;
@@ -89,5 +89,5 @@ export async function getInterpreterInfo(
     if (logger) {
         logger.info(`Found interpreter for ${argv}`);
     }
-    return extractPythonEnvInfo(python.pythonExecutable, json);
+    return extractInterpreterInfo(python.pythonExecutable, json);
 }

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PythonVersion } from '.';
+import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../../common/process/internal/scripts';
+import { Architecture } from '../../../common/utils/platform';
+import { copyPythonExecInfo, PythonExecInfo } from '../../exec';
+import { parseVersion } from './pythonVersion';
+
+type PythonEnvInformation = {
+    arch: Architecture;
+    executable: {
+        filename: string;
+        sysPrefix: string;
+        mtime: number;
+        ctime: number;
+    };
+    version: PythonVersion;
+};
+
+/**
+ * Compose full interpreter information based on the given data.
+ *
+ * The data format corresponds to the output of the `interpreterInfo.py` script.
+ *
+ * @param python - the path to the Python executable
+ * @param raw - the information returned by the `interpreterInfo.py` script
+ */
+export function extractPythonEnvInfo(python: string, raw: PythonEnvInfo): PythonEnvInformation {
+    const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
+    const version = parseVersion(rawVersion);
+    version.sysVersion = raw.sysVersion;
+    return {
+        arch: raw.is64Bit ? Architecture.x64 : Architecture.x86,
+        executable: {
+            filename: python,
+            sysPrefix: raw.sysPrefix,
+            mtime: -1,
+            ctime: -1,
+        },
+        version: parseVersion(rawVersion),
+    };
+}
+
+type ShellExecResult = {
+    stdout: string;
+    stderr?: string;
+};
+type ShellExecFunc = (command: string, timeout: number) => Promise<ShellExecResult>;
+
+type Logger = {
+    info(msg: string): void;
+    error(msg: string): void;
+};
+
+/**
+ * Collect full interpreter information from the given Python executable.
+ *
+ * @param python - the information to use when running Python
+ * @param shellExec - the function to use to exec Python
+ * @param logger - if provided, used to log failures or other info
+ */
+export async function getInterpreterInfo(
+    python: PythonExecInfo,
+    shellExec: ShellExecFunc,
+    logger?: Logger,
+): Promise<PythonEnvInformation | undefined> {
+    const [args, parse] = getInterpreterInfoCommand();
+    const info = copyPythonExecInfo(python, args);
+    const argv = [info.command, ...info.args];
+
+    // Concat these together to make a set of quoted strings
+    const quoted = argv.reduce((p, c) => (p ? `${p} "${c}"` : `"${c.replace('\\', '\\\\')}"`), '');
+
+    // Try shell execing the command, followed by the arguments. This will make node kill the process if it
+    // takes too long.
+    // Sometimes the python path isn't valid, timeout if that's the case.
+    // See these two bugs:
+    // https://github.com/microsoft/vscode-python/issues/7569
+    // https://github.com/microsoft/vscode-python/issues/7760
+    const result = await shellExec(quoted, 15000);
+    if (result.stderr) {
+        if (logger) {
+            logger.error(`Failed to parse interpreter information for ${argv} stderr: ${result.stderr}`);
+        }
+        return undefined;
+    }
+    const json = parse(result.stdout);
+    if (logger) {
+        logger.info(`Found interpreter for ${argv}`);
+    }
+    return extractPythonEnvInfo(python.pythonExecutable, json);
+}

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { PythonExecutableInfo, PythonVersion } from '.';
-import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../../common/process/internal/scripts';
+import { interpreterInfo as getInterpreterInfoCommand, InterpreterInfoJson } from '../../../common/process/internal/scripts';
 import { Architecture } from '../../../common/utils/platform';
 import { copyPythonExecInfo, PythonExecInfo } from '../../exec';
 import { parseVersion } from './pythonVersion';
@@ -21,7 +21,7 @@ export type InterpreterInformation = {
  * @param python - the path to the Python executable
  * @param raw - the information returned by the `interpreterInfo.py` script
  */
-function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
+function extractInterpreterInfo(python: string, raw: InterpreterInfoJson): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
     return {
         arch: raw.is64Bit ? Architecture.x64 : Architecture.x86,
@@ -46,6 +46,7 @@ type ShellExecFunc = (command: string, timeout: number) => Promise<ShellExecResu
 
 type Logger = {
     info(msg: string): void;
+
     error(msg: string): void;
 };
 

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -7,7 +7,7 @@ import { Architecture } from '../../../common/utils/platform';
 import { copyPythonExecInfo, PythonExecInfo } from '../../exec';
 import { parseVersion } from './pythonVersion';
 
-type PythonEnvInformation = {
+export type InterpreterInformation = {
     arch: Architecture;
     executable: {
         filename: string;
@@ -26,7 +26,7 @@ type PythonEnvInformation = {
  * @param python - the path to the Python executable
  * @param raw - the information returned by the `interpreterInfo.py` script
  */
-export function extractPythonEnvInfo(python: string, raw: PythonEnvInfo): PythonEnvInformation {
+export function extractPythonEnvInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
     const version = parseVersion(rawVersion);
     version.sysVersion = raw.sysVersion;
@@ -64,7 +64,7 @@ export async function getInterpreterInfo(
     python: PythonExecInfo,
     shellExec: ShellExecFunc,
     logger?: Logger,
-): Promise<PythonEnvInformation | undefined> {
+): Promise<InterpreterInformation | undefined> {
     const [args, parse] = getInterpreterInfoCommand();
     const info = copyPythonExecInfo(python, args);
     const argv = [info.command, ...info.args];

--- a/src/client/pythonEnvironments/base/info/interpreter.ts
+++ b/src/client/pythonEnvironments/base/info/interpreter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { PythonVersion } from '.';
+import { PythonExecutableInfo, PythonVersion } from '.';
 import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../../common/process/internal/scripts';
 import { Architecture } from '../../../common/utils/platform';
 import { copyPythonExecInfo, PythonExecInfo } from '../../exec';
@@ -9,12 +9,7 @@ import { parseVersion } from './pythonVersion';
 
 export type InterpreterInformation = {
     arch: Architecture;
-    executable: {
-        filename: string;
-        sysPrefix: string;
-        mtime: number;
-        ctime: number;
-    };
+    executable: PythonExecutableInfo;
     version: PythonVersion;
 };
 
@@ -28,8 +23,6 @@ export type InterpreterInformation = {
  */
 function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
-    const version = parseVersion(rawVersion);
-    version.sysVersion = raw.sysVersion;
     return {
         arch: raw.is64Bit ? Architecture.x64 : Architecture.x86,
         executable: {
@@ -38,7 +31,10 @@ function extractInterpreterInfo(python: string, raw: PythonEnvInfo): Interpreter
             mtime: -1,
             ctime: -1,
         },
-        version: parseVersion(rawVersion),
+        version: {
+            ...parseVersion(rawVersion),
+            sysVersion: raw.sysVersion,
+        },
     };
 }
 

--- a/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PythonReleaseLevel, PythonVersion } from '.';
+import { EMPTY_VERSION, parseBasicVersionInfo } from '../../../common/utils/version';
+
+export function parseVersion(versionStr: string): PythonVersion {
+    const parsed = parseBasicVersionInfo<PythonVersion>(versionStr);
+    if (!parsed) {
+        if (versionStr === '') {
+            return EMPTY_VERSION as PythonVersion;
+        }
+        throw Error(`invalid version ${versionStr}`);
+    }
+    const { version, after } = parsed;
+    const match = after.match(/^(a|b|rc)(\d+)$/);
+    if (match) {
+        const [, levelStr, serialStr] = match;
+        let level: PythonReleaseLevel;
+        if (levelStr === 'a') {
+            level = PythonReleaseLevel.Alpha;
+        } else if (levelStr === 'b') {
+            level = PythonReleaseLevel.Beta;
+        } else if (levelStr === 'rc') {
+            level = PythonReleaseLevel.Candidate;
+        } else {
+            throw Error('unreachable!');
+        }
+        version.release = {
+            level,
+            serial: parseInt(serialStr, 10),
+        };
+    }
+    return version;
+}

--- a/src/client/pythonEnvironments/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/info/environmentInfoService.ts
@@ -29,11 +29,13 @@ async function buildEnvironmentInfo(environment: PythonEnvInfo): Promise<PythonE
     if (interpreterInfo === undefined || interpreterInfo.version === undefined) {
         return undefined;
     }
-    environment.version = interpreterInfo.version;
-    environment.executable.filename = interpreterInfo.executable.filename;
-    environment.executable.sysPrefix = interpreterInfo.executable.sysPrefix;
-    environment.arch = interpreterInfo.arch;
-    return environment;
+    // Deep copy into a new object
+    const resolvedEnv = JSON.parse(JSON.stringify(environment)) as PythonEnvInfo;
+    resolvedEnv.version = interpreterInfo.version;
+    resolvedEnv.executable.filename = interpreterInfo.executable.filename;
+    resolvedEnv.executable.sysPrefix = interpreterInfo.executable.sysPrefix;
+    resolvedEnv.arch = interpreterInfo.arch;
+    return resolvedEnv;
 }
 
 @injectable()

--- a/src/client/pythonEnvironments/info/environmentInfoService.ts
+++ b/src/client/pythonEnvironments/info/environmentInfoService.ts
@@ -22,7 +22,9 @@ export interface IEnvironmentInfoService {
 }
 
 async function buildEnvironmentInfo(interpreterPath: string): Promise<InterpreterInformation | undefined> {
-    const interpreterInfo = await getInterpreterInfo(buildPythonExecInfo(interpreterPath), shellExecute);
+    const interpreterInfo = await getInterpreterInfo(buildPythonExecInfo(interpreterPath), shellExecute).catch(
+        () => undefined,
+    );
     if (interpreterInfo === undefined || interpreterInfo.version === undefined) {
         return undefined;
     }

--- a/src/client/pythonEnvironments/info/interpreter.ts
+++ b/src/client/pythonEnvironments/info/interpreter.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { InterpreterInformation } from '.';
-import { interpreterInfo as getInterpreterInfoCommand, PythonEnvInfo } from '../../common/process/internal/scripts';
+import { interpreterInfo as getInterpreterInfoCommand, InterpreterInfoJson } from '../../common/process/internal/scripts';
 import { Architecture } from '../../common/utils/platform';
 import { copyPythonExecInfo, PythonExecInfo } from '../exec';
 import { parsePythonVersion } from './pythonVersion';
@@ -15,7 +15,7 @@ import { parsePythonVersion } from './pythonVersion';
  * @param python - the path to the Python executable
  * @param raw - the information returned by the `interpreterInfo.py` script
  */
-export function extractInterpreterInfo(python: string, raw: PythonEnvInfo): InterpreterInformation {
+export function extractInterpreterInfo(python: string, raw: InterpreterInfoJson): InterpreterInformation {
     const rawVersion = `${raw.versionInfo.slice(0, 3).join('.')}-${raw.versionInfo[3]}`;
     return {
         architecture: raw.is64Bit ? Architecture.x64 : Architecture.x86,

--- a/src/test/pythonEnvironments/base/common.ts
+++ b/src/test/pythonEnvironments/base/common.ts
@@ -3,13 +3,11 @@
 
 import { createDeferred, flattenIterator, iterable, mapToIterator } from '../../../client/common/utils/async';
 import { Architecture } from '../../../client/common/utils/platform';
-import { EMPTY_VERSION, parseBasicVersionInfo } from '../../../client/common/utils/version';
 import {
     PythonEnvInfo,
     PythonEnvKind,
-    PythonReleaseLevel,
-    PythonVersion
 } from '../../../client/pythonEnvironments/base/info';
+import { parseVersion } from '../../../client/pythonEnvironments/base/info/pythonVersion';
 import { IPythonEnvsIterator, Locator, PythonLocatorQuery } from '../../../client/pythonEnvironments/base/locator';
 import { PythonEnvsChangedEvent } from '../../../client/pythonEnvironments/base/watcher';
 
@@ -43,36 +41,6 @@ export function createEnv(
         },
         distro: { org: '' }
     };
-}
-
-function parseVersion(versionStr: string): PythonVersion {
-    const parsed = parseBasicVersionInfo<PythonVersion>(versionStr);
-    if (!parsed) {
-        if (versionStr === '') {
-            return EMPTY_VERSION as PythonVersion;
-        }
-        throw Error(`invalid version ${versionStr}`);
-    }
-    const { version, after } = parsed;
-    const match = after.match(/^(a|b|rc)(\d+)$/);
-    if (match) {
-        const [, levelStr, serialStr ] = match;
-        let level: PythonReleaseLevel;
-        if (levelStr === 'a') {
-            level = PythonReleaseLevel.Alpha;
-        } else if (levelStr === 'b') {
-            level = PythonReleaseLevel.Beta;
-        } else if (levelStr === 'rc') {
-            level = PythonReleaseLevel.Candidate;
-        } else {
-            throw Error('unreachable!');
-        }
-        version.release = {
-            level,
-            serial: parseInt(serialStr, 10)
-        };
-    }
-    return version;
 }
 
 export function createLocatedEnv(

--- a/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
@@ -21,7 +21,7 @@ suite('Environment Info Service', () => {
 
     function createExpectedEnvInfo(executable: string): InterpreterInformation {
         return {
-            version: parseVersion('3.8.3-final'),
+            version: { ...parseVersion('3.8.3-final'), sysVersion: '3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]' },
             arch: Architecture.x64,
             executable: {
                 filename: executable,
@@ -39,7 +39,7 @@ suite('Environment Info Service', () => {
             new Promise<ExecutionResult<string>>((resolve) => {
                 resolve({
                     stdout:
-                        '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "version": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
+                        '{"versionInfo": [3, 8, 3, "final", 0], "sysPrefix": "path", "sysVersion": "3.8.3 (tags/v3.8.3:6f8c832, May 13 2020, 22:37:02) [MSC v.1924 64 bit (AMD64)]", "is64Bit": true}',
                 });
             }),
         );

--- a/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
+++ b/src/test/pythonEnvironments/info/environmentInfoService.functional.test.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import { ImportMock } from 'ts-mock-imports';
 import { ExecutionResult } from '../../../client/common/process/types';
 import { Architecture } from '../../../client/common/utils/platform';
-import { PythonEnvInfo, PythonEnvKind } from '../../../client/pythonEnvironments/base/info';
+import { InterpreterInformation } from '../../../client/pythonEnvironments/base/info/interpreter';
 import { parseVersion } from '../../../client/pythonEnvironments/base/info/pythonVersion';
 import * as ExternalDep from '../../../client/pythonEnvironments/common/externalDependencies';
 import {
@@ -19,31 +19,9 @@ import {
 suite('Environment Info Service', () => {
     let stubShellExec: sinon.SinonStub;
 
-    function createEnvInfo(executable: string): PythonEnvInfo {
+    function createExpectedEnvInfo(executable: string): InterpreterInformation {
         return {
-            id: '',
-            kind: PythonEnvKind.Unknown,
-            version: parseVersion('0.0.0'),
-            name: '',
-            location: '',
-            arch: Architecture.x64,
-            executable: {
-                filename: executable,
-                sysPrefix: '',
-                mtime: -1,
-                ctime: -1,
-            },
-            distro: { org: '' },
-        };
-    }
-
-    function createExpectedEnvInfo(executable: string): PythonEnvInfo {
-        return {
-            id: '',
-            kind: PythonEnvKind.Unknown,
             version: parseVersion('3.8.3-final'),
-            name: '',
-            location: '',
             arch: Architecture.x64,
             executable: {
                 filename: executable,
@@ -51,7 +29,6 @@ suite('Environment Info Service', () => {
                 mtime: -1,
                 ctime: -1,
             },
-            distro: { org: '' },
         };
     }
 
@@ -72,16 +49,14 @@ suite('Environment Info Service', () => {
     });
     test('Add items to queue and get results', async () => {
         const envService = new EnvironmentInfoService();
-        const promises: Promise<PythonEnvInfo | undefined>[] = [];
-        const expected: PythonEnvInfo[] = [];
+        const promises: Promise<InterpreterInformation | undefined>[] = [];
+        const expected: InterpreterInformation[] = [];
         for (let i = 0; i < 10; i = i + 1) {
             const path = `any-path${i}`;
             if (i < 5) {
-                promises.push(envService.getEnvironmentInfo(createEnvInfo(path)));
+                promises.push(envService.getEnvironmentInfo(path));
             } else {
-                promises.push(
-                    envService.getEnvironmentInfo(createEnvInfo(path), EnvironmentInfoServiceQueuePriority.High),
-                );
+                promises.push(envService.getEnvironmentInfo(path, EnvironmentInfoServiceQueuePriority.High));
             }
             expected.push(createExpectedEnvInfo(path));
         }
@@ -97,17 +72,17 @@ suite('Environment Info Service', () => {
 
     test('Add same item to queue', async () => {
         const envService = new EnvironmentInfoService();
-        const promises: Promise<PythonEnvInfo | undefined>[] = [];
-        const expected: PythonEnvInfo[] = [];
+        const promises: Promise<InterpreterInformation | undefined>[] = [];
+        const expected: InterpreterInformation[] = [];
 
         const path = 'any-path';
         // Clear call counts
         stubShellExec.resetHistory();
         // Evaluate once so the result is cached.
-        await envService.getEnvironmentInfo(createEnvInfo(path));
+        await envService.getEnvironmentInfo(path);
 
         for (let i = 0; i < 10; i = i + 1) {
-            promises.push(envService.getEnvironmentInfo(createEnvInfo(path)));
+            promises.push(envService.getEnvironmentInfo(path));
             expected.push(createExpectedEnvInfo(path));
         }
 


### PR DESCRIPTION
Changing environment info worker to:
- ~Use the new environment type~
- ~Accept the whole "environment" as input instead of just the path. This is because it would overwrite certain existing fields like version which are returned by running interpreter info and are reliable, but others fields should remain intact. Right now it's returning empty fields like this which aren't useful.~
- Return new interpreter information type instead which is a subset of new environment type. Environment info service only informs about fields related to running `interpreterInfo.py`. It should have no business modifying other fields, that's the job of the consumer, in this case the resolver.
- Modified cache to carry deferred instead. If a previous call for the same environment path is already ongoing, we don't need add this environment to the worker pool but simply return the result from the previous call. This is a practical scenario the resolver runs into.