### PR TITLE
Fix conda's bin path not recognized in Fedora

### DIFF
--- a/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts
@@ -76,7 +76,13 @@ export class CondaActivationCommandProvider implements ITerminalActivationComman
             }
             if (versionInfo.minor >= CondaRequiredMinor) {
                 // New version.
-                const interpreterPath = await this.condaService.getCondaFileFromInterpreter(pythonPath, envInfo.name);
+                const envNamePos = envInfo.name ? pythonPath.indexOf(envInfo.name) : -1;
+                const scriptsDir = this.platform.isWindows ? 'Scripts' : 'bin';
+                const interpreterPath =
+                    (await this.condaService.getCondaFileFromInterpreter(pythonPath, envInfo.name)) ||
+                    // On Fedora or related distros, binaries lay in each env directory
+                    path.join(pythonPath.slice(0, envNamePos + envInfo.name.length), scriptsDir);
+
                 if (interpreterPath) {
                     const activatePath = path.join(path.dirname(interpreterPath), 'activate').fileToCommandArgument();
                     const firstActivate = this.platform.isWindows ? activatePath : `source ${activatePath}`;


### PR DESCRIPTION
By far extension assumes
- there is an `activate` binary: https://github.com/microsoft/vscode-python/blob/329292c120490bdef69eaa6bc0997b4fd00beba8/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts#L79-L81
- `conda` and `activate` are in the same dir, such as `~/.conda/bin`: https://github.com/microsoft/vscode-python/blob/6b94c8bc5b2b6575aba8c664a50d5963e2d50c17/src/client/pythonEnvironments/discovery/locators/services/condaService.ts#L315-L326

However, on Fedora (if you use conda in the system repo), there is no `activate` at all. Also. we still needs to https://github.com/microsoft/vscode-python/blob/329292c120490bdef69eaa6bc0997b4fd00beba8/src/client/common/terminal/environmentActivationProviders/condaActivationProvider.ts#L83. Moreover, the binaries are under dirs such as `~/.conda/env/envName/bin`.