### PR TITLE
Fix HTML escaping to match what Jupyter does

### DIFF
--- a/news/2 Fixes/5678.md
+++ b/news/2 Fixes/5678.md
@@ -1,0 +1,1 @@
+Fix escaping of output to encode HTML chars correctly.

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -40,6 +40,10 @@ import { KernelConnectionMetadata } from './kernels/types';
 
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
+// tslint:disable-next-line: no-require-imports
+import escape = require('lodash/escape');
+// tslint:disable-next-line: no-require-imports
+import unescape = require('lodash/unescape');
 import { concatMultilineString, formatStreamText } from '../../../datascience-ui/common';
 import { RefBool } from '../../common/refBool';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
@@ -783,12 +787,12 @@ export class JupyterNotebookBase implements INotebook {
                 outputs.forEach((o) => {
                     if (o.output_type === 'stream') {
                         const stream = o as nbformat.IStream;
-                        result = result.concat(formatStreamText(concatMultilineString(stream.text, true)));
+                        result = result.concat(formatStreamText(unescape(concatMultilineString(stream.text, true))));
                     } else {
                         const data = o.data;
                         if (data && data.hasOwnProperty('text/plain')) {
                             // tslint:disable-next-line:no-any
-                            result = result.concat((data as any)['text/plain']);
+                            result = result.concat(unescape((data as any)['text/plain']));
                         }
                     }
                 });
@@ -1233,7 +1237,7 @@ export class JupyterNotebookBase implements INotebook {
     ) {
         // Check our length on text output
         if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
-            msg.content.data['text/plain'] = trimFunc(msg.content.data['text/plain'] as string);
+            msg.content.data['text/plain'] = escape(trimFunc(msg.content.data['text/plain'] as string));
         }
 
         this.addToCellData(
@@ -1262,7 +1266,7 @@ export class JupyterNotebookBase implements INotebook {
                 if (o.data && o.data.hasOwnProperty('text/plain')) {
                     // tslint:disable-next-line: no-any
                     const str = (o.data as any)['text/plain'].toString();
-                    const data = trimFunc(str) as string;
+                    const data = escape(trimFunc(str)) as string;
                     this.addToCellData(
                         cell,
                         {
@@ -1310,13 +1314,13 @@ export class JupyterNotebookBase implements INotebook {
                 : undefined;
         if (existing) {
             // tslint:disable-next-line:restrict-plus-operands
-            existing.text = existing.text + msg.content.text;
+            existing.text = existing.text + escape(msg.content.text);
             const originalText = formatStreamText(concatMultilineString(existing.text));
             originalTextLength = originalText.length;
             existing.text = trimFunc(originalText);
             trimmedTextLength = existing.text.length;
         } else {
-            const originalText = formatStreamText(concatMultilineString(msg.content.text));
+            const originalText = formatStreamText(concatMultilineString(escape(msg.content.text)));
             originalTextLength = originalText.length;
             // Create a new stream entry
             const output: nbformat.IStream = {
@@ -1346,6 +1350,11 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     private handleDisplayData(msg: KernelMessage.IDisplayDataMsg, clearState: RefBool, cell: ICell) {
+        // Escape text output
+        if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
+            msg.content.data['text/plain'] = escape(msg.content.data['text/plain'] as string);
+        }
+
         const output: nbformat.IDisplayData = {
             output_type: 'display_data',
             data: msg.content.data,
@@ -1393,9 +1402,9 @@ export class JupyterNotebookBase implements INotebook {
     private handleError(msg: KernelMessage.IErrorMsg, clearState: RefBool, cell: ICell) {
         const output: nbformat.IError = {
             output_type: 'error',
-            ename: msg.content.ename,
-            evalue: msg.content.evalue,
-            traceback: msg.content.traceback
+            ename: escape(msg.content.ename),
+            evalue: escape(msg.content.evalue),
+            traceback: msg.content.traceback.map(escape)
         };
         this.addToCellData(cell, output, clearState);
         cell.state = CellState.error;

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -6,6 +6,8 @@ import { inject, injectable } from 'inversify';
 import stripAnsi from 'strip-ansi';
 import * as uuid from 'uuid/v4';
 
+// tslint:disable-next-line: no-require-imports
+import unescape = require('lodash/unescape');
 import { CancellationToken, Event, EventEmitter, Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError } from '../../common/logger';
@@ -246,7 +248,7 @@ export class KernelVariables implements IJupyterVariables {
 
     // Pull our text result out of the Jupyter cell
     private deserializeJupyterResult<T>(cells: ICell[]): T {
-        const text = this.extractJupyterResultText(cells);
+        const text = unescape(this.extractJupyterResultText(cells));
         return JSON.parse(text) as T;
     }
 
@@ -371,7 +373,7 @@ export class KernelVariables implements IJupyterVariables {
         // Now execute the query
         if (notebook && query) {
             const cells = await notebook.execute(query.query, Identifiers.EmptyFileName, 0, uuid(), token, true);
-            const text = this.extractJupyterResultText(cells);
+            const text = unescape(this.extractJupyterResultText(cells));
 
             // Apply the expression to it
             const matches = this.getAllMatches(query.parser, text);

--- a/src/client/datascience/jupyter/oldJupyterVariables.ts
+++ b/src/client/datascience/jupyter/oldJupyterVariables.ts
@@ -11,6 +11,8 @@ import { Event, EventEmitter, Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError } from '../../common/logger';
 
+// tslint:disable-next-line: no-require-imports
+import unescape = require('lodash/unescape');
 import { IConfigurationService } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { EXTENSION_ROOT_DIR } from '../../constants';
@@ -232,7 +234,7 @@ export class OldJupyterVariables implements IJupyterVariables {
 
     // Pull our text result out of the Jupyter cell
     private deserializeJupyterResult<T>(cells: ICell[]): T {
-        const text = this.extractJupyterResultText(cells);
+        const text = unescape(this.extractJupyterResultText(cells));
         return JSON.parse(text) as T;
     }
 
@@ -357,7 +359,7 @@ export class OldJupyterVariables implements IJupyterVariables {
         // Now execute the query
         if (notebook && query) {
             const cells = await notebook.execute(query.query, Identifiers.EmptyFileName, 0, uuid(), undefined, true);
-            const text = this.extractJupyterResultText(cells);
+            const text = unescape(this.extractJupyterResultText(cells));
 
             // Apply the expression to it
             const matches = this.getAllMatches(query.parser, text);

--- a/src/test/datascience/Untitled-1.ipynb
+++ b/src/test/datascience/Untitled-1.ipynb
@@ -1,0 +1,47 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6-final"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "1"
+     },
+     "metadata": {},
+     "execution_count": 1
+    }
+   ],
+   "source": [
+    "a=1\n",
+    "a"
+   ]
+  }
+ ]
+}

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -128,7 +128,7 @@ suite('DataScience Interactive Window output tests', () => {
         async () => {
             await addCode(ioc, 'a=1\na');
 
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
         },
         () => {
             return ioc;
@@ -171,7 +171,7 @@ for i in range(10):
             addMockData(ioc, 'a=1', undefined, 'text/plain');
             await addCode(ioc, 'a=1');
 
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.First);
+            verifyHtmlOnInteractiveCell('1', CellPosition.First);
             verifyHtmlOnInteractiveCell(undefined, CellPosition.Last);
         },
         () => {
@@ -236,7 +236,7 @@ for i in range(10):
                 }
             }
 
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
         },
         () => {
             return ioc;
@@ -300,7 +300,7 @@ for i in range(10):
                 }
             }
 
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
         },
         () => {
             return ioc;
@@ -698,7 +698,7 @@ for i in range(0, 100):
                 const window = (await interactiveWindowProvider.getOrCreate(undefined)) as InteractiveWindow;
                 await addCode(ioc, 'a=1\na');
                 const activeInterpreter = await interpreterService.getActiveInterpreter(window.owningResource);
-                verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+                verifyHtmlOnInteractiveCell('1', CellPosition.Last);
                 assert.equal(
                     window.notebook!.getMatchingInterpreter()?.path,
                     activeInterpreter?.path,
@@ -724,7 +724,7 @@ for i in range(0, 100):
                     activeInterpreter?.path,
                     'Active intrepreter used to launch second notebook when it should not have'
                 );
-                verifyHtmlOnCell(ioc.getWrapper('interactive'), 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+                verifyHtmlOnCell(ioc.getWrapper('interactive'), 'InteractiveCell', '1', CellPosition.Last);
             } else {
                 context.skip();
             }
@@ -867,7 +867,7 @@ for i in range(0, 100):
 
             // Then enter some code.
             await enterInput(mount, 'a=1\na', 'InteractiveCell');
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
         },
         () => {
             return ioc;
@@ -888,7 +888,7 @@ for i in range(0, 100):
 
             // Then enter some code.
             await enterInput(mount, 'a=1\na', 'InteractiveCell');
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
             const ImageButtons = getLastOutputCell(mount.wrapper, 'InteractiveCell').find(ImageButton);
             assert.equal(ImageButtons.length, 4, 'Cell buttons not found');
             const copyToSource = ImageButtons.at(2);
@@ -911,7 +911,7 @@ for i in range(0, 100):
 
             // Then enter some code.
             await enterInput(mount, 'a=1\na', 'InteractiveCell');
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
 
             // Then delete the node
             const lastCell = getLastOutputCell(mount.wrapper, 'InteractiveCell');
@@ -928,7 +928,7 @@ for i in range(0, 100):
 
             // Should be able to enter again
             await enterInput(mount, 'a=1\na', 'InteractiveCell');
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
 
             // Try a 3rd time with some new input
             addMockData(ioc, 'print("hello")', 'hello');
@@ -952,7 +952,7 @@ for i in range(0, 100):
         async () => {
             // Prime the pump
             await addCode(ioc, 'a=1\na');
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
 
             // Then something that could possibly timeout
             addContinuousMockData(ioc, 'import time\r\ntime.sleep(1000)', (_c) => {
@@ -979,7 +979,7 @@ for i in range(0, 100):
 
             // Now see if our wrapper still works. Interactive window should have forced a restart
             await window.addCode('a=1\na', Uri.file('foo'), 0);
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
         },
         () => {
             return ioc;
@@ -1071,7 +1071,7 @@ for i in range(0, 100):
 
             // Then enter some code.
             await enterInput(mount, 'a=1\na', 'InteractiveCell');
-            verifyHtmlOnInteractiveCell('<span>1</span>', CellPosition.Last);
+            verifyHtmlOnInteractiveCell('1', CellPosition.Last);
             const ImageButtons = getLastOutputCell(mount.wrapper, 'InteractiveCell').find(ImageButton);
             assert.equal(ImageButtons.length, 4, 'Cell buttons not found');
             const gatherCode = ImageButtons.at(0);
@@ -1198,21 +1198,21 @@ for i in range(0, 100):
         await addCell(ne.mount, 'a=1\na', true);
 
         // Make sure both are correct
-        verifyHtmlOnCell(iw.mount.wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
-        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(iw.mount.wrapper, 'InteractiveCell', '1', CellPosition.Last);
+        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '1', CellPosition.Last);
 
         // Close the interactive editor.
         await closeInteractiveWindow(ioc, iw.window);
 
         // Run another cell and make sure it works in the notebook
         await addCell(ne.mount, 'b=2\nb', true);
-        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '<span>2</span>', CellPosition.Last);
+        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '2', CellPosition.Last);
 
         // Rerun the interactive window
         iw = await getOrCreateInteractiveWindow(ioc);
         await addCode(ioc, 'a=1\na');
 
-        verifyHtmlOnCell(iw.mount.wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(iw.mount.wrapper, 'InteractiveCell', '1', CellPosition.Last);
     });
     test('Multiple interactive windows', async () => {
         ioc.forceDataScienceSettingsChanged({ interactiveWindowMode: 'multiple' });

--- a/src/test/datascience/liveshare.functional.test.tsx
+++ b/src/test/datascience/liveshare.functional.test.tsx
@@ -217,7 +217,7 @@ suite('DataScience LiveShare tests', () => {
 
         // Just run some code in the host
         const wrapper = await addCodeToRole(vsls.Role.Host, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
     });
 
     test('Host & Guest Simple', async function () {
@@ -234,14 +234,14 @@ suite('DataScience LiveShare tests', () => {
 
         // Send code through the host
         const wrapper = await addCodeToRole(vsls.Role.Host, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
 
         // Verify it ended up on the guest too
         assert.ok(guestContainer.getInteractiveWebPanel(undefined), 'Guest wrapper not created');
         verifyHtmlOnCell(
             guestContainer.getInteractiveWebPanel(undefined).wrapper,
             'InteractiveCell',
-            '<span>1</span>',
+            '1',
             CellPosition.Last
         );
     });
@@ -253,7 +253,7 @@ suite('DataScience LiveShare tests', () => {
         addMockData(hostContainer!, 'b=2\nb', 2);
         await getOrCreateInteractiveWindow(vsls.Role.Host);
         let wrapper = await addCodeToRole(vsls.Role.Host, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
 
         await startSession(vsls.Role.Host);
         await getOrCreateInteractiveWindow(vsls.Role.Guest);
@@ -265,7 +265,7 @@ suite('DataScience LiveShare tests', () => {
         verifyHtmlOnCell(
             guestContainer.getInteractiveWebPanel(undefined).wrapper,
             'InteractiveCell',
-            '<span>2</span>',
+            '2',
             CellPosition.Last
         );
     });
@@ -280,14 +280,14 @@ suite('DataScience LiveShare tests', () => {
 
         // Send code through the host
         let wrapper = await addCodeToRole(vsls.Role.Host, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
 
         // Stop the session
         await stopSession(vsls.Role.Host);
 
         // Send code again. It should still work.
         wrapper = await addCodeToRole(vsls.Role.Host, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
     });
 
     test('Host startup and guest restart', async function () {
@@ -302,7 +302,7 @@ suite('DataScience LiveShare tests', () => {
 
         // Send code through the host
         let wrapper = await addCodeToRole(vsls.Role.Host, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
 
         // Shutdown the host
         host.window.dispose();
@@ -310,13 +310,13 @@ suite('DataScience LiveShare tests', () => {
         // Startup a guest and run some code.
         await startSession(vsls.Role.Guest);
         wrapper = await addCodeToRole(vsls.Role.Guest, 'a=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
 
         assert.ok(hostContainer.getInteractiveWebPanel(undefined), 'Host wrapper not created');
         verifyHtmlOnCell(
             hostContainer.getInteractiveWebPanel(undefined).wrapper,
             'InteractiveCell',
-            '<span>1</span>',
+            '1',
             CellPosition.Last
         );
     });
@@ -349,12 +349,12 @@ suite('DataScience LiveShare tests', () => {
             assert.ok(both, 'Expected both guest and host to be used');
             await codeWatcher.runAllCells();
         });
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
         assert.ok(hostContainer.getInteractiveWebPanel(undefined), 'Host wrapper not created for some reason');
         verifyHtmlOnCell(
             hostContainer.getInteractiveWebPanel(undefined).wrapper,
             'InteractiveCell',
-            '<span>1</span>',
+            '1',
             CellPosition.Last
         );
     });
@@ -425,7 +425,7 @@ suite('DataScience LiveShare tests', () => {
         // Start just the host and verify it works
         await startSession(vsls.Role.Host);
         let wrapper = await addCodeToRole(vsls.Role.Host, '#%%\na=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
 
         // Disable guest checking on the guest (same as if the guest doesn't have the python extension)
         await startSession(vsls.Role.Guest);
@@ -434,7 +434,7 @@ suite('DataScience LiveShare tests', () => {
         // Host should now be in a state that if any code runs, the session should end. However
         // the code should still run
         wrapper = await addCodeToRole(vsls.Role.Host, '#%%\na=1\na');
-        verifyHtmlOnCell(wrapper, 'InteractiveCell', '<span>1</span>', CellPosition.Last);
+        verifyHtmlOnCell(wrapper, 'InteractiveCell', '1', CellPosition.Last);
         assert.equal(isSessionStarted(vsls.Role.Host), false, 'Host should have exited session');
         assert.equal(isSessionStarted(vsls.Role.Guest), false, 'Guest should have exited session');
         assert.ok(lastErrorMessage, 'Error was not set during session shutdown');

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -223,7 +223,7 @@ suite('DataScience Native Editor', () => {
                     // Add a cell into the UI and wait for it to render
                     await addCell(mount, 'a=1\na');
 
-                    verifyHtmlOnCell(mount.wrapper, 'NativeCell', '<span>1</span>', 1);
+                    verifyHtmlOnCell(mount.wrapper, 'NativeCell', '1', 1);
                 });
 
                 runMountedTest('Invalid session still runs', async (context) => {
@@ -238,7 +238,7 @@ suite('DataScience Native Editor', () => {
                         // Run the first cell. Should fail but then ask for another
                         await addCell(mount, 'a=1\na');
 
-                        verifyHtmlOnCell(mount.wrapper, 'NativeCell', '<span>1</span>', 1);
+                        verifyHtmlOnCell(mount.wrapper, 'NativeCell', '1', 1);
                     } else {
                         context.skip();
                     }
@@ -414,7 +414,7 @@ suite('DataScience Native Editor', () => {
                         // Run the first cell. Should fail but then ask for another
                         await addCell(ne.mount, 'a=1\na');
 
-                        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '<span>1</span>', 1);
+                        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '1', 1);
                     } else {
                         context.skip();
                     }
@@ -448,7 +448,7 @@ suite('DataScience Native Editor', () => {
                         // Verify we picked the valid kernel.
                         await addCell(ne.mount, 'a=1\na');
 
-                        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '<span>1</span>', 2);
+                        verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', '1', 2);
                     } else {
                         context.skip();
                     }
@@ -1694,7 +1694,7 @@ df.head()`;
                         wrapper.update();
 
                         // Ensure cell was executed.
-                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '2', 1);
 
                         // The third cell should be selected.
                         assert.ok(isCellSelected(wrapper, 'NativeCell', 2));
@@ -1732,7 +1732,7 @@ df.head()`;
                         await update;
 
                         // Ensure cell was executed.
-                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '2', 1);
 
                         // The first cell should be selected.
                         assert.ok(isCellSelected(wrapper, 'NativeCell', 1));
@@ -1962,7 +1962,7 @@ df.head()`;
                         await update;
 
                         // Ensure cell was executed.
-                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '3', 2);
 
                         // Hide the output
                         update = waitForMessage(ioc, InteractiveWindowMessages.OutputToggled);
@@ -1970,7 +1970,7 @@ df.head()`;
                         await update;
 
                         // Ensure cell output is hidden (looking for cell results will throw an exception).
-                        assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2));
+                        assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '3', 2));
 
                         // Display the output
                         update = waitForMessage(ioc, InteractiveWindowMessages.OutputToggled);
@@ -1978,7 +1978,7 @@ df.head()`;
                         await update;
 
                         // Ensure cell output is visible again.
-                        verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2);
+                        verifyHtmlOnCell(wrapper, 'NativeCell', '3', 2);
                     });
 
                     test("Toggle line numbers using the 'l' key", async () => {

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -6,6 +6,8 @@ import { assert } from 'chai';
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs-extra';
 import { injectable } from 'inversify';
+// tslint:disable-next-line: no-require-imports
+import escape = require('lodash/escape');
 import * as os from 'os';
 import * as path from 'path';
 import { SemVer } from 'semver';
@@ -1024,6 +1026,15 @@ a`,
                 },
                 {
                     markdownRegEx: undefined,
+                    code: `a="<a href=f>"
+a`,
+                    mimeType: 'text/plain',
+                    cellType: 'code',
+                    result: `<a href=f>`,
+                    verifyValue: (d) => assert.equal(d, escape(`<a href=f>`), 'XML not escaped')
+                },
+                {
+                    markdownRegEx: undefined,
                     code: `import pandas as pd
 df = pd.read("${escapePath(path.join(srcDirectory(), 'DefaultSalesReport.csv'))}")
 df.head()`,
@@ -1032,7 +1043,7 @@ df.head()`,
                     cellType: 'error',
                     // tslint:disable-next-line:quotemark
                     verifyValue: (d) =>
-                        assert.ok((d as string).includes("has no attribute 'read'"), 'Unexpected error result')
+                        assert.ok((d as string).includes(escape("has no attribute 'read'")), 'Unexpected error result')
                 },
                 {
                     markdownRegEx: undefined,

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -161,7 +161,7 @@ suite('DataScience notebook tests', () => {
                 const data = extractDataOutput(cells[0]);
                 if (pathVerify) {
                     // For a path comparison normalize output
-                    const normalizedOutput = path.normalize(data).toUpperCase().replace(/'/g, '');
+                    const normalizedOutput = path.normalize(data).toUpperCase().replace(/&#39;/g, '');
                     const normalizedTarget = path.normalize(expectedValue).toUpperCase().replace(/'/g, '');
                     assert.equal(normalizedOutput, normalizedTarget, 'Cell path values does not match');
                 } else {

--- a/src/test/datascience/trustedNotebooks.functional.test.tsx
+++ b/src/test/datascience/trustedNotebooks.functional.test.tsx
@@ -273,9 +273,9 @@ suite('Notebook trust', () => {
     suite('Open an untrusted notebook', async () => {
         test('Outputs are not rendered', () => {
             // No outputs should have rendered
-            assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>1</span>', 0));
-            assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', 1));
-            assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>3</span>', 2));
+            assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '1', 0));
+            assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '2', 1));
+            assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '3', 2));
         });
         test('Cannot edit cell contents', async () => {
             await focusCell(0);
@@ -332,7 +332,7 @@ suite('Notebook trust', () => {
                 // Waiting for an execution rendered message should timeout
                 await expect(promise).to.eventually.be.rejected;
                 // No output should have been rendered
-                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', cellIndex));
+                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '2', cellIndex));
             });
             test('Shift+enter does not execute cell or advance to next cell', async () => {
                 const cellIndex = 1;
@@ -344,7 +344,7 @@ suite('Notebook trust', () => {
                 // Waiting for an execution rendered message should timeout
                 await expect(promise).to.eventually.be.rejected;
                 // No output should have been rendered
-                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', cellIndex));
+                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '2', cellIndex));
                 // 3rd cell should be neither selected nor focused
                 assert.isFalse(isCellSelected(wrapper, 'NativeCell', cellIndex + 1));
                 assert.isFalse(isCellFocused(wrapper, 'NativeCell', cellIndex + 1));
@@ -360,7 +360,7 @@ suite('Notebook trust', () => {
                 // Waiting for an execution rendered message should timeout
                 await expect(promise).to.eventually.be.rejected;
                 // No output should have been rendered
-                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '<span>2</span>', cellIndex));
+                assert.throws(() => verifyHtmlOnCell(wrapper, 'NativeCell', '2', cellIndex));
                 // No cell should have been added
                 assert.equal(wrapper.find('NativeCell').length, 3, 'Cell added');
             });

--- a/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
+++ b/src/test/datascience/uiTests/ipywidget.ui.functional.test.ts
@@ -155,7 +155,7 @@ use(chaiAsPromised);
             await retryIfFail(async () => {
                 await assert.eventually.isTrue(notebookUI.cellHasOutput(0));
                 const outputHtml = await notebookUI.getCellOutputHTML(0);
-                assert.include(outputHtml, '<span>1</span>');
+                assert.include(outputHtml, '1');
             });
         });
 


### PR DESCRIPTION
For #5678 

Any time we change our output to be HTML, we were not escaping the output at all. This makes this sort of thing not work:

```python
raise Exception("<I have xml/>")
````

