### PR TITLE
Ensure CI runs against PRs

### DIFF
--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -10,6 +10,7 @@ pr:
     include:
       - 'main'
       - 'release*'
+      - 'WIP/NoDS'
       - 'ds*'
       - 'logging-changes-and-drop-old-debugger'
   paths:


### PR DESCRIPTION
Currenly these arent running and the extension (VSIX) can no longer be built