### PR TITLE
Drop `workspaceService.hasWorkspaceFolders`

### DIFF
--- a/news/3 Code Health/6237.md
+++ b/news/3 Code Health/6237.md
@@ -1,0 +1,1 @@
+Drop `workspaceService.hasWorkspaceFolders` to get rid of ignoring ts compiler warning

--- a/src/client/activation/activationManager.ts
+++ b/src/client/activation/activationManager.ts
@@ -92,7 +92,7 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         }
         const key = this.getWorkspaceKey(doc.uri);
         // If we have opened a doc that does not belong to workspace, then do nothing.
-        if (key === '' && this.workspaceService.hasWorkspaceFolders) {
+        if (key === '' && (this.workspaceService.workspaceFolders || []).length > 0) {
             return;
         }
         if (this.activatedWorkspaces.has(key)) {
@@ -161,7 +161,10 @@ export class ExtensionActivationManager implements IExtensionActivationManager {
         this.addRemoveDocOpenedHandlers();
     }
     protected hasMultipleWorkspaces() {
-        return this.workspaceService.hasWorkspaceFolders && this.workspaceService.workspaceFolders!.length > 1;
+        return (
+            (this.workspaceService.workspaceFolders || []).length > 0 &&
+            this.workspaceService.workspaceFolders!.length > 1
+        );
     }
     protected getWorkspaceKey(resource: Resource) {
         return this.workspaceService.getWorkspaceFolderIdentifier(resource, '');

--- a/src/client/activation/activationService.ts
+++ b/src/client/activation/activationService.ts
@@ -279,9 +279,10 @@ export class LanguageServerExtensionActivationService
     }
 
     private async onDidChangeConfiguration(event: ConfigurationChangeEvent): Promise<void> {
-        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders
-            ? this.workspaceService.workspaceFolders!.map((workspace) => workspace.uri)
-            : [undefined];
+        const workspacesUris: (Uri | undefined)[] =
+            (this.workspaceService.workspaceFolders || []).length > 0
+                ? this.workspaceService.workspaceFolders!.map((workspace) => workspace.uri)
+                : [undefined];
         if (
             workspacesUris.findIndex((uri) => event.affectsConfiguration(`python.${languageServerSetting}`, uri)) === -1
         ) {

--- a/src/client/application/diagnostics/checks/invalidLaunchJsonDebugger.ts
+++ b/src/client/application/diagnostics/checks/invalidLaunchJsonDebugger.ts
@@ -72,7 +72,7 @@ export class InvalidLaunchJsonDebuggerService extends BaseDiagnosticsService {
         );
     }
     public async diagnose(resource: Resource): Promise<IDiagnostic[]> {
-        if (!this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0) {
             return [];
         }
         const workspaceFolder = resource
@@ -84,7 +84,7 @@ export class InvalidLaunchJsonDebuggerService extends BaseDiagnosticsService {
         diagnostics.forEach((diagnostic) => this.handleDiagnostic(diagnostic));
     }
     protected async fixLaunchJson(code: DiagnosticCodes) {
-        if (!this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0) {
             return;
         }
 

--- a/src/client/datascience/interactive-common/notebookProvider.ts
+++ b/src/client/datascience/interactive-common/notebookProvider.ts
@@ -133,9 +133,10 @@ export class NotebookProvider implements INotebookProvider {
             // This is required, else using `undefined` as a resource when we have worksapce folders is a different meaning.
             // This means interactive window doesn't properly support mult-root workspaces as we pick first workspace.
             // Ideally we need to pick the resource of the corresponding Python file.
-            resource = this.workspaceService.hasWorkspaceFolders
-                ? this.workspaceService.workspaceFolders![0]!.uri
-                : undefined;
+            resource =
+                (this.workspaceService.workspaceFolders || []).length > 0
+                    ? this.workspaceService.workspaceFolders![0]!.uri
+                    : undefined;
         }
         const promise = rawKernel
             ? this.rawNotebookProvider.createNotebook(

--- a/src/client/datascience/jupyter/jupyterExporter.ts
+++ b/src/client/datascience/jupyter/jupyterExporter.ts
@@ -197,7 +197,7 @@ export class JupyterExporter implements INotebookExporter {
         if (!haveChangeAlready) {
             const notebookFilePath = path.dirname(notebookFile);
             // First see if we have a workspace open, this only works if we have a workspace root to be relative to
-            if (this.workspaceService.hasWorkspaceFolders) {
+            if ((this.workspaceService.workspaceFolders || []).length > 0) {
                 const workspacePath = await this.firstWorkspaceFolder(cells);
 
                 // Make sure that we have everything that we need here

--- a/src/client/datascience/jupyter/jupyterImporter.ts
+++ b/src/client/datascience/jupyter/jupyterImporter.ts
@@ -121,7 +121,7 @@ export class JupyterImporter implements INotebookImporter {
             if (!haveChangeAlready) {
                 const notebookFilePath = path.dirname(notebookFile.fsPath);
                 // First see if we have a workspace open, this only works if we have a workspace root to be relative to
-                if (this.workspaceService.hasWorkspaceFolders) {
+                if ((this.workspaceService.workspaceFolders || []).length > 0) {
                     const workspacePath = this.workspaceService.workspaceFolders![0].uri.fsPath;
 
                     // Make sure that we have everything that we need here

--- a/src/client/datascience/kernel-launcher/kernelDaemonPool.ts
+++ b/src/client/datascience/kernel-launcher/kernelDaemonPool.ts
@@ -52,7 +52,7 @@ export class KernelDaemonPool implements IDisposable {
         this.envVars.onDidEnvironmentVariablesChange(this.onDidEnvironmentVariablesChange.bind(this));
         this.interrpeterService.onDidChangeInterpreter(this.onDidChangeInterpreter.bind(this));
         const promises: Promise<void>[] = [];
-        if (this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length > 0) {
             promises.push(
                 ...(this.workspaceService.workspaceFolders || []).map((item) => this.preWarmKernelDaemon(item.uri))
             );

--- a/src/client/debugger/extension/hooks/childProcessAttachService.ts
+++ b/src/client/debugger/extension/hooks/childProcessAttachService.ts
@@ -42,7 +42,7 @@ export class ChildProcessAttachService implements IChildProcessAttachService {
         config: AttachRequestArguments & DebugConfiguration
     ): WorkspaceFolder | undefined {
         const workspaceFolder = config.workspaceFolder;
-        if (!this.workspaceService.hasWorkspaceFolders || !workspaceFolder) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0 || !workspaceFolder) {
             return;
         }
         return this.workspaceService.workspaceFolders!.find((ws) => ws.uri.fsPath === workspaceFolder);

--- a/src/client/interpreter/virtualEnvs/index.ts
+++ b/src/client/interpreter/virtualEnvs/index.ts
@@ -137,9 +137,10 @@ export class VirtualEnvironmentManager implements IVirtualEnvironmentManager {
     }
 
     private async getWorkspaceRoot(resource?: Uri): Promise<string | undefined> {
-        const defaultWorkspaceUri = this.workspaceService.hasWorkspaceFolders
-            ? this.workspaceService.workspaceFolders![0].uri
-            : undefined;
+        const defaultWorkspaceUri =
+            (this.workspaceService.workspaceFolders || []).length > 0
+                ? this.workspaceService.workspaceFolders![0].uri
+                : undefined;
         const workspaceFolder = resource ? this.workspaceService.getWorkspaceFolder(resource) : undefined;
         const uri = workspaceFolder ? workspaceFolder.uri : defaultWorkspaceUri;
         return uri ? uri.fsPath : undefined;

--- a/src/client/linters/linterAvailability.ts
+++ b/src/client/linters/linterAvailability.ts
@@ -100,7 +100,7 @@ export class AvailableLinterActivator implements IAvailableLinterActivator {
      * @param resource Context information for workspace.
      */
     public async isLinterAvailable(linterInfo: ILinterInfo, resource: Resource): Promise<boolean | undefined> {
-        if (!this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0) {
             return false;
         }
         const workspaceFolder =

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -368,7 +368,7 @@ export class CondaService implements ICondaService {
     }
 
     private async onDidChangeConfiguration(event: ConfigurationChangeEvent) {
-        const workspacesUris: (Uri | undefined)[] = this.workspaceService.hasWorkspaceFolders
+        const workspacesUris: (Uri | undefined)[] = ((this.workspaceService.workspaceFolders || []).length > 0)
             ? this.workspaceService.workspaceFolders!.map((workspace) => workspace.uri)
             : [undefined];
         if (workspacesUris.findIndex((uri) => event.affectsConfiguration('python.condaPath', uri)) === -1) {

--- a/src/client/testing/common/debugLauncher.ts
+++ b/src/client/testing/common/debugLauncher.ts
@@ -68,7 +68,7 @@ export class DebugLauncher implements ITestDebugLauncher {
         }
     }
     private resolveWorkspaceFolder(cwd: string): WorkspaceFolder {
-        if (!this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0) {
             throw new Error('Please open a workspace');
         }
 

--- a/src/client/testing/common/services/configSettingService.ts
+++ b/src/client/testing/common/services/configSettingService.ts
@@ -54,7 +54,7 @@ export class TestConfigSettingsService implements ITestConfigSettingsService {
     private async updateSetting(testDirectory: string | Uri, setting: string, value: any) {
         let pythonConfig: WorkspaceConfiguration;
         const resource = typeof testDirectory === 'string' ? Uri.file(testDirectory) : testDirectory;
-        if (!this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0) {
             pythonConfig = this.workspaceService.getConfiguration('python');
         } else if (this.workspaceService.workspaceFolders!.length === 1) {
             pythonConfig = this.workspaceService.getConfiguration(

--- a/src/client/testing/main.ts
+++ b/src/client/testing/main.ts
@@ -151,7 +151,10 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
     public async configurationChangeHandler(eventArgs: ConfigurationChangeEvent) {
         // If there's one workspace, then stop the tests and restart,
         // else let the user do this manually.
-        if (!this.workspaceService.hasWorkspaceFolders || this.workspaceService.workspaceFolders!.length > 1) {
+        if (
+            (this.workspaceService.workspaceFolders || []).length === 0 ||
+            this.workspaceService.workspaceFolders!.length > 1
+        ) {
             return;
         }
         if (!Array.isArray(this.workspaceService.workspaceFolders)) {
@@ -212,7 +215,7 @@ export class UnitTestManagementService implements ITestManagementService, Dispos
         );
     }
     public async autoDiscoverTests(resource: Resource) {
-        if (!this.workspaceService.hasWorkspaceFolders) {
+        if ((this.workspaceService.workspaceFolders || []).length === 0) {
             return;
         }
         // Default to discovering tests in first folder if none specified.


### PR DESCRIPTION
To stop ignoring warnings from the usage below:
    `workspaceService.hasWorkspaceFolders`

We replaced all of these usage with:
   `(this.workspaceService.workspaceFolders || []).length > 0`

For #6237 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
