### PR TITLE
Do not quote isolated in exec module

### DIFF
--- a/src/client/common/process/internal/python.ts
+++ b/src/client/common/process/internal/python.ts
@@ -28,7 +28,7 @@ export function execCode(code: string, isolated = true): string[] {
 export function execModule(name: string, moduleArgs: string[], isolated = true): string[] {
     const args = ['-m', name, ...moduleArgs];
     if (isolated) {
-        args[0] = ISOLATED.fileToCommandArgument();
+        args[0] = ISOLATED; // replace
     }
     // "code" isn't specific enough to know how to parse it,
     // so we only return the args.

--- a/src/client/common/process/internal/python.ts
+++ b/src/client/common/process/internal/python.ts
@@ -28,7 +28,7 @@ export function execCode(code: string, isolated = true): string[] {
 export function execModule(name: string, moduleArgs: string[], isolated = true): string[] {
     const args = ['-m', name, ...moduleArgs];
     if (isolated) {
-        args[0] = ISOLATED;
+        args[0] = ISOLATED.fileToCommandArgument();
     }
     // "code" isn't specific enough to know how to parse it,
     // so we only return the args.

--- a/src/client/common/process/internal/python.ts
+++ b/src/client/common/process/internal/python.ts
@@ -28,7 +28,7 @@ export function execCode(code: string, isolated = true): string[] {
 export function execModule(name: string, moduleArgs: string[], isolated = true): string[] {
     const args = ['-m', name, ...moduleArgs];
     if (isolated) {
-        args[0] = ISOLATED.fileToCommandArgument();
+        args[0] = ISOLATED;
     }
     // "code" isn't specific enough to know how to parse it,
     // so we only return the args.

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -306,7 +306,7 @@ export function shell_exec(command: string, lockfile: string, shellArgs: string[
     // We don't bother with a "parse" function since the output
     // could be anything.
     return [
-        ISOLATED.fileToCommandArgument(),
+        ISOLATED,
         script,
         command.fileToCommandArgument(),
         // The shell args must come after the command

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -140,7 +140,7 @@ import { closeActiveWindows, initializeTest } from './../initialize';
 
 chai_use(chaiAsPromised);
 
-const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py').replace(/\\/g, '/');
+const isolated = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'pythonFiles', 'pyvsc-run-isolated.py');
 
 const info: PythonEnvironment = {
     architecture: Architecture.Unknown,


### PR DESCRIPTION
Adding @IanMatthewHuff @rchiodo Since you had to address some related issue with this recently.

In this change I am reverting part of a fix that addressed a DS issue  https://github.com/microsoft/vscode-python/commit/23725abd4249811f24475e215c2d78ed5e508e79

This caused an error when running tests. This breaks running tests from the test explorer (on some systems).
```
C:\all_pys\Python39\python.exe: can't open file 'c:\GIT\s p\jedi_lsp\"c:\GIT\s p\vscode-python\pythonFiles\pyvsc-run-isolated.py"': [Errno 22] Invalid argument
```
The change seems to cause quoting twice, As seen from Process Execution Block. 
```
    CurrentDirectory:  'c:\GIT\s p\jedi_lsp\'
    WindowTitle:  'c:\GIT\s p\jedi_lsp\.venv\Scripts\python.exe'
    ImageFile:    'c:\GIT\s p\jedi_lsp\.venv\Scripts\python.exe'
    CommandLine:  '"c:\GIT\s p\jedi_lsp\.venv\Scripts\python.exe" "\"c:/GIT/s p/vscode-python/pythonFiles/pyvsc-run-isolated.py\"" pytest --override-ini junit_family=xunit1 --rootdir "c:\GIT\s p\jedi_lsp" --junit-xml=C:\Users\KARTHI~1\AppData\Local\Temp\tmp-34344X8H7zvi1LHCH.xml tests'
    DllPath:      '< Name not readable >'

 

    CurrentDirectory:  'c:\GIT\s p\jedi_lsp\'
    WindowTitle:  'C:\all_pys\Python39\python.exe'
    ImageFile:    'C:\all_pys\Python39\python.exe'
    CommandLine:  'C:\all_pys\Python39\python.exe "\"c:/GIT/s p/vscode-python/pythonFiles/pyvsc-run-isolated.py\"" pytest --override-ini junit_family=xunit1 --rootdir "c:\GIT\s p\jedi_lsp" --junit-xml=C:\Users\KARTHI~1\AppData\Local\Temp\tmp-34344X8H7zvi1LHCH.xml tests'
    DllPath:      '< Name not readable >'
```

I am wondering if I can revert just part of the commit. Please let me know if that works for you.