### PR TITLE
Update reducer to use new implementation of merge environments

### DIFF
--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -37,6 +37,8 @@ export function buildEnvInfo(init?: {
         },
         name: '',
         location: '',
+        searchLocation: undefined,
+        defaultDisplayName: undefined,
         version: {
             major: -1,
             minor: -1,
@@ -65,7 +67,7 @@ export function buildEnvInfo(init?: {
 export function copyEnvInfo(
     env: PythonEnvInfo,
     updates?: {
-        kind?: PythonEnvKind,
+        kind?: PythonEnvKind;
     },
 ): PythonEnvInfo {
     // We don't care whether or not extra/hidden properties
@@ -77,12 +79,15 @@ export function copyEnvInfo(
     return copied;
 }
 
-function updateEnv(env: PythonEnvInfo, updates: {
-    kind?: PythonEnvKind;
-    executable?: string;
-    location?: string;
-    version?: PythonVersion;
-}): void {
+function updateEnv(
+    env: PythonEnvInfo,
+    updates: {
+        kind?: PythonEnvKind;
+        executable?: string;
+        location?: string;
+        version?: PythonVersion;
+    },
+): void {
     if (updates.kind !== undefined) {
         env.kind = updates.kind;
     }
@@ -109,7 +114,9 @@ export function getMinimalPartialInfo(env: string | Partial<PythonEnvInfo>): Par
             return undefined;
         }
         return {
-            executable: { filename: env, sysPrefix: '', ctime: -1, mtime: -1 },
+            executable: {
+                filename: env, sysPrefix: '', ctime: -1, mtime: -1,
+            },
         };
     }
     if (env.executable === undefined) {
@@ -136,7 +143,7 @@ export function getMinimalPartialInfo(env: string | Partial<PythonEnvInfo>): Par
 export function areSameEnv(
     left: string | Partial<PythonEnvInfo>,
     right: string | Partial<PythonEnvInfo>,
-    allowPartialMatch?: boolean,
+    allowPartialMatch = true,
 ): boolean | undefined {
     const leftInfo = getMinimalPartialInfo(left);
     const rightInfo = getMinimalPartialInfo(right);
@@ -173,7 +180,7 @@ export function areSameEnv(
  * weighted by most important to least important fields.
  * Wn > Wn-1 + Wn-2 + ... W0
  */
-function getPythonVersionInfoHeuristic(version:PythonVersion): number {
+function getPythonVersionInfoHeuristic(version: PythonVersion): number {
     let infoLevel = 0;
     if (version.major > 0) {
         infoLevel += 20; // W4
@@ -205,7 +212,7 @@ function getPythonVersionInfoHeuristic(version:PythonVersion): number {
  * weighted by most important to least important fields.
  * Wn > Wn-1 + Wn-2 + ... W0
  */
-function getFileInfoHeuristic(file:FileInfo): number {
+function getFileInfoHeuristic(file: FileInfo): number {
     let infoLevel = 0;
     if (file.filename.length > 0) {
         infoLevel += 5; // W2
@@ -229,7 +236,7 @@ function getFileInfoHeuristic(file:FileInfo): number {
  * weighted by most important to least important fields.
  * Wn > Wn-1 + Wn-2 + ... W0
  */
-function getDistroInfoHeuristic(distro:PythonDistroInfo):number {
+function getDistroInfoHeuristic(distro: PythonDistroInfo): number {
     let infoLevel = 0;
     if (distro.org.length > 0) {
         infoLevel += 20; // W3
@@ -251,62 +258,6 @@ function getDistroInfoHeuristic(distro:PythonDistroInfo):number {
 }
 
 /**
- * Gets a prioritized list of environment types for identification.
- * @returns {PythonEnvKind[]} : List of environments ordered by identification priority
- *
- * Remarks: This is the order of detection based on how the various distributions and tools
- * configure the environment, and the fall back for identification.
- * Top level we have the following environment types, since they leave a unique signature
- * in the environment or * use a unique path for the environments they create.
- *  1. Conda
- *  2. Windows Store
- *  3. PipEnv
- *  4. Pyenv
- *  5. Poetry
- *
- * Next level we have the following virtual environment tools. The are here because they
- * are consumed by the tools above, and can also be used independently.
- *  1. venv
- *  2. virtualenvwrapper
- *  3. virtualenv
- *
- * Last category is globally installed python, or system python.
- */
-export function getPrioritizedEnvironmentKind(): PythonEnvKind[] {
-    return [
-        PythonEnvKind.CondaBase,
-        PythonEnvKind.Conda,
-        PythonEnvKind.WindowsStore,
-        PythonEnvKind.Pipenv,
-        PythonEnvKind.Pyenv,
-        PythonEnvKind.Poetry,
-        PythonEnvKind.Venv,
-        PythonEnvKind.VirtualEnvWrapper,
-        PythonEnvKind.VirtualEnv,
-        PythonEnvKind.OtherVirtual,
-        PythonEnvKind.OtherGlobal,
-        PythonEnvKind.MacDefault,
-        PythonEnvKind.System,
-        PythonEnvKind.Custom,
-        PythonEnvKind.Unknown,
-    ];
-}
-
-/**
- * Selects an environment based on the environment selection priority. This should
- * match the priority in the environment identifier.
- */
-export function sortEnvInfoByPriority(...envs: PythonEnvInfo[]): PythonEnvInfo[] {
-    // tslint:disable-next-line: no-suspicious-comment
-    // TODO: When we consolidate the PythonEnvKind and EnvironmentType we should have
-    // one location where we define priority and
-    const envKindByPriority:PythonEnvKind[] = getPrioritizedEnvironmentKind();
-    return envs.sort(
-        (a:PythonEnvInfo, b:PythonEnvInfo) => envKindByPriority.indexOf(a.kind) - envKindByPriority.indexOf(b.kind),
-    );
-}
-
-/**
  * Merges properties of the `target` environment and `other` environment and returns the merged environment.
  * if the value in the `target` environment is not defined or has less information. This does not mutate
  * the `target` instead it returns a new object that contains the merged results.
@@ -318,18 +269,19 @@ export function mergeEnvironments(target: PythonEnvInfo, other: PythonEnvInfo): 
 
     const version = cloneDeep(
         getPythonVersionInfoHeuristic(target.version) > getPythonVersionInfoHeuristic(other.version)
-            ? target.version : other.version,
+            ? target.version
+            : other.version,
     );
 
     const executable = cloneDeep(
         getFileInfoHeuristic(target.executable) > getFileInfoHeuristic(other.executable)
-            ? target.executable : other.executable,
+            ? target.executable
+            : other.executable,
     );
     executable.sysPrefix = target.executable.sysPrefix ?? other.executable.sysPrefix;
 
     const distro = cloneDeep(
-        getDistroInfoHeuristic(target.distro) > getDistroInfoHeuristic(other.distro)
-            ? target.distro : other.distro,
+        getDistroInfoHeuristic(target.distro) > getDistroInfoHeuristic(other.distro) ? target.distro : other.distro,
     );
 
     merged.arch = merged.arch === Architecture.Unknown ? other.arch : target.arch;
@@ -341,8 +293,8 @@ export function mergeEnvironments(target: PythonEnvInfo, other: PythonEnvInfo): 
     // preferred env based on kind.
     merged.kind = target.kind;
 
-    merged.location = merged.location ?? other.location;
-    merged.name = merged.name ?? other.name;
+    merged.location = merged.location.length ? merged.location : other.location;
+    merged.name = merged.name.length ? merged.name : other.name;
     merged.searchLocation = merged.searchLocation ?? other.searchLocation;
     merged.version = version;
 

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -67,7 +67,7 @@ export function buildEnvInfo(init?: {
 export function copyEnvInfo(
     env: PythonEnvInfo,
     updates?: {
-        kind?: PythonEnvKind;
+        kind?: PythonEnvKind,
     },
 ): PythonEnvInfo {
     // We don't care whether or not extra/hidden properties
@@ -79,15 +79,12 @@ export function copyEnvInfo(
     return copied;
 }
 
-function updateEnv(
-    env: PythonEnvInfo,
-    updates: {
-        kind?: PythonEnvKind;
-        executable?: string;
-        location?: string;
-        version?: PythonVersion;
-    },
-): void {
+function updateEnv(env: PythonEnvInfo, updates: {
+    kind?: PythonEnvKind;
+    executable?: string;
+    location?: string;
+    version?: PythonVersion;
+}): void {
     if (updates.kind !== undefined) {
         env.kind = updates.kind;
     }

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { cloneDeep, isEqual } from 'lodash';
+import { isEqual } from 'lodash';
 import { Event, EventEmitter } from 'vscode';
 import { traceVerbose } from '../../../../common/logger';
-import { createDeferred } from '../../../../common/utils/async';
 import { PythonEnvInfo, PythonEnvKind } from '../../info';
-import { areSameEnv } from '../../info/env';
+import { areSameEnv, mergeEnvironments } from '../../info/env';
 import {
     ILocator, IPythonEnvsIterator, PythonEnvUpdatedEvent, PythonLocatorQuery,
 } from '../../locator';
+import { getEnvs } from '../../locatorUtils';
 import { PythonEnvsChangedEvent } from '../../watcher';
 
 /**
@@ -23,27 +23,11 @@ export class PythonEnvsReducer implements ILocator {
     constructor(private readonly parentLocator: ILocator) {}
 
     public async resolveEnv(env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
-        let environment: PythonEnvInfo | undefined;
-        const waitForUpdatesDeferred = createDeferred<void>();
-        const iterator = this.iterEnvs();
-        iterator.onUpdated!((event) => {
-            if (event === null) {
-                waitForUpdatesDeferred.resolve();
-            } else if (environment && areSameEnv(environment, event.update)) {
-                environment = event.update;
-            }
-        });
-        let result = await iterator.next();
-        while (!result.done) {
-            if (areSameEnv(result.value, env)) {
-                environment = result.value;
-            }
-            result = await iterator.next();
-        }
+        const environments = await getEnvs(this.iterEnvs());
+        const environment = environments.find((e) => areSameEnv(e, env));
         if (!environment) {
             return undefined;
         }
-        await waitForUpdatesDeferred.promise;
         return this.parentLocator.resolveEnv(environment);
     }
 
@@ -73,8 +57,7 @@ async function* iterEnvsIterator(
                 checkIfFinishedAndNotify(state, didUpdate);
             } else if (seen[event.index] !== undefined) {
                 state.pending += 1;
-                resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen)
-                    .ignoreErrors();
+                resolveDifferencesInBackground(event.index, event.update, state, didUpdate, seen).ignoreErrors();
             } else {
                 // This implies a problem in a downstream locator
                 traceVerbose(`Expected already iterated env, got ${event.old} (#${event.index})`);
@@ -110,7 +93,7 @@ async function resolveDifferencesInBackground(
     seen: PythonEnvInfo[],
 ) {
     const oldEnv = seen[oldIndex];
-    const merged = mergeEnvironments(oldEnv, newEnv);
+    const merged = resolveEnvCollision(oldEnv, newEnv);
     if (!isEqual(oldEnv, merged)) {
         seen[oldIndex] = merged;
         didUpdate.fire({ index: oldIndex, old: oldEnv, update: merged });
@@ -134,29 +117,63 @@ function checkIfFinishedAndNotify(
     }
 }
 
-export function mergeEnvironments(environment: PythonEnvInfo, other: PythonEnvInfo): PythonEnvInfo {
-    const result = cloneDeep(environment);
-    // Preserve type information.
-    // Possible we identified environment as unknown, but a later provider has identified env type.
-    if (environment.kind === PythonEnvKind.Unknown && other.kind && other.kind !== PythonEnvKind.Unknown) {
-        result.kind = other.kind;
-    }
-    const props: (keyof PythonEnvInfo)[] = [
-        'version',
-        'kind',
-        'executable',
-        'name',
-        'arch',
-        'distro',
-        'defaultDisplayName',
-        'searchLocation',
+function resolveEnvCollision(oldEnv: PythonEnvInfo, newEnv: PythonEnvInfo): PythonEnvInfo {
+    const [env, other] = sortEnvInfoByPriority(oldEnv, newEnv);
+    return mergeEnvironments(env, other);
+}
+
+/**
+ * Selects an environment based on the environment selection priority. This should
+ * match the priority in the environment identifier.
+ */
+function sortEnvInfoByPriority(...envs: PythonEnvInfo[]): PythonEnvInfo[] {
+    // tslint:disable-next-line: no-suspicious-comment
+    // TODO: When we consolidate the PythonEnvKind and EnvironmentType we should have
+    // one location where we define priority and
+    const envKindByPriority: PythonEnvKind[] = getPrioritizedEnvironmentKind();
+    return envs.sort(
+        (a: PythonEnvInfo, b: PythonEnvInfo) => envKindByPriority.indexOf(a.kind) - envKindByPriority.indexOf(b.kind),
+    );
+}
+
+/**
+ * Gets a prioritized list of environment types for identification.
+ * @returns {PythonEnvKind[]} : List of environments ordered by identification priority
+ *
+ * Remarks: This is the order of detection based on how the various distributions and tools
+ * configure the environment, and the fall back for identification.
+ * Top level we have the following environment types, since they leave a unique signature
+ * in the environment or * use a unique path for the environments they create.
+ *  1. Conda
+ *  2. Windows Store
+ *  3. PipEnv
+ *  4. Pyenv
+ *  5. Poetry
+ *
+ * Next level we have the following virtual environment tools. The are here because they
+ * are consumed by the tools above, and can also be used independently.
+ *  1. venv
+ *  2. virtualenvwrapper
+ *  3. virtualenv
+ *
+ * Last category is globally installed python, or system python.
+ */
+function getPrioritizedEnvironmentKind(): PythonEnvKind[] {
+    return [
+        PythonEnvKind.CondaBase,
+        PythonEnvKind.Conda,
+        PythonEnvKind.WindowsStore,
+        PythonEnvKind.Pipenv,
+        PythonEnvKind.Pyenv,
+        PythonEnvKind.Poetry,
+        PythonEnvKind.Venv,
+        PythonEnvKind.VirtualEnvWrapper,
+        PythonEnvKind.VirtualEnv,
+        PythonEnvKind.OtherVirtual,
+        PythonEnvKind.OtherGlobal,
+        PythonEnvKind.MacDefault,
+        PythonEnvKind.System,
+        PythonEnvKind.Custom,
+        PythonEnvKind.Unknown,
     ];
-    props.forEach((prop) => {
-        if (!result[prop] && other[prop]) {
-            // tslint:disable: no-any
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (result as any)[prop] = other[prop];
-        }
-    });
-    return result;
 }

--- a/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/environmentsReducer.ts
@@ -129,7 +129,7 @@ function resolveEnvCollision(oldEnv: PythonEnvInfo, newEnv: PythonEnvInfo): Pyth
 function sortEnvInfoByPriority(...envs: PythonEnvInfo[]): PythonEnvInfo[] {
     // tslint:disable-next-line: no-suspicious-comment
     // TODO: When we consolidate the PythonEnvKind and EnvironmentType we should have
-    // one location where we define priority and
+    // one location where we define priority.
     const envKindByPriority: PythonEnvKind[] = getPrioritizedEnvironmentKind();
     return envs.sort(
         (a: PythonEnvInfo, b: PythonEnvInfo) => envKindByPriority.indexOf(a.kind) - envKindByPriority.indexOf(b.kind),

--- a/src/test/pythonEnvironments/base/common.ts
+++ b/src/test/pythonEnvironments/base/common.ts
@@ -64,7 +64,6 @@ export function createNamedEnv(
 
 export class SimpleLocator extends Locator {
     private deferred = createDeferred<void>();
-
     constructor(
         private envs: PythonEnvInfo[],
         public callbacks: {
@@ -75,24 +74,21 @@ export class SimpleLocator extends Locator {
             beforeEach?(e: PythonEnvInfo): Promise<void>;
             afterEach?(e: PythonEnvInfo): Promise<void>;
             onQuery?(query: PythonLocatorQuery | undefined, envs: PythonEnvInfo[]): Promise<PythonEnvInfo[]>;
-        },
+        }
     ) {
         super();
     }
-
     public get done(): Promise<void> {
         return this.deferred.promise;
     }
-
     public fire(event: PythonEnvsChangedEvent) {
         this.emitter.fire(event);
     }
-
     public iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator {
-        const { deferred } = this;
-        const { callbacks } = this;
-        let { envs } = this;
-        const iterator: IPythonEnvsIterator = (async function* () {
+        const deferred = this.deferred;
+        const callbacks = this.callbacks;
+        let envs = this.envs;
+        const iterator: IPythonEnvsIterator = async function*() {
             if (callbacks?.onQuery !== undefined) {
                 envs = await callbacks.onQuery(query, envs);
             }
@@ -119,23 +115,23 @@ export class SimpleLocator extends Locator {
                     }
                 }
             }
-            if (callbacks?.after !== undefined) {
+            if (callbacks?.after!== undefined) {
                 await callbacks.after;
             }
             deferred.resolve();
-        }());
+        }();
         iterator.onUpdated = this.callbacks?.onUpdated;
         return iterator;
     }
-
     public async resolveEnv(env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
         const envInfo: PythonEnvInfo = typeof env === 'string' ? createLocatedEnv('', '', undefined, env) : env;
         if (this.callbacks.resolve === undefined) {
             return envInfo;
-        } if (this.callbacks?.resolve === null) {
+        } else if (this.callbacks?.resolve === null) {
             return undefined;
+        } else {
+            return this.callbacks.resolve(envInfo);
         }
-        return this.callbacks.resolve(envInfo);
     }
 }
 

--- a/src/test/pythonEnvironments/base/common.ts
+++ b/src/test/pythonEnvironments/base/common.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// tslint:disable: no-this-assignment
+
 import * as path from 'path';
 import { Event } from 'vscode';
 import {
@@ -84,7 +86,7 @@ export class SimpleLocator extends Locator {
         return this.deferred.promise;
     }
 
-    public fire(event: PythonEnvsChangedEvent) {
+    public fire(event: PythonEnvsChangedEvent): void {
         this.emitter.fire(event);
     }
 

--- a/src/test/pythonEnvironments/base/common.ts
+++ b/src/test/pythonEnvironments/base/common.ts
@@ -8,13 +8,18 @@ import {
 } from '../../../client/common/utils/async';
 import { Architecture } from '../../../client/common/utils/platform';
 import {
+    PythonDistroInfo,
     PythonEnvInfo,
     PythonEnvKind,
+    PythonExecutableInfo,
 } from '../../../client/pythonEnvironments/base/info';
 import { buildEnvInfo } from '../../../client/pythonEnvironments/base/info/env';
 import { parseVersion } from '../../../client/pythonEnvironments/base/info/pythonVersion';
 import {
-    IPythonEnvsIterator, Locator, PythonEnvUpdatedEvent, PythonLocatorQuery,
+    IPythonEnvsIterator,
+    Locator,
+    PythonEnvUpdatedEvent,
+    PythonLocatorQuery,
 } from '../../../client/pythonEnvironments/base/locator';
 import { PythonEnvsChangedEvent } from '../../../client/pythonEnvironments/base/watcher';
 
@@ -22,16 +27,26 @@ export function createLocatedEnv(
     locationStr: string,
     versionStr: string,
     kind = PythonEnvKind.Unknown,
-    execStr = 'python',
+    exec: string | PythonExecutableInfo = 'python',
+    distro: PythonDistroInfo = { org: '' },
 ): PythonEnvInfo {
     const location = locationStr === '' ? '' : path.normalize(locationStr);
-    const normalizedExecutable = path.normalize(execStr);
-    const executable = location === '' || path.isAbsolute(normalizedExecutable)
-        ? normalizedExecutable
-        : path.join(location, 'bin', normalizedExecutable);
+    let executable: string | undefined;
+    if (typeof exec === 'string') {
+        const normalizedExecutable = path.normalize(exec);
+        executable = location === '' || path.isAbsolute(normalizedExecutable)
+            ? normalizedExecutable
+            : path.join(location, 'bin', normalizedExecutable);
+    }
     const version = parseVersion(versionStr);
-    const env = buildEnvInfo({ kind, executable, location, version });
+    const env = buildEnvInfo({
+        kind, executable, location, version,
+    });
     env.arch = Architecture.x86;
+    env.distro = distro;
+    if (typeof exec !== 'string') {
+        env.executable = exec;
+    }
     return env;
 }
 
@@ -39,15 +54,17 @@ export function createNamedEnv(
     name: string,
     versionStr: string,
     kind?: PythonEnvKind,
-    execStr = 'python',
+    exec: string | PythonExecutableInfo = 'python',
+    distro?: PythonDistroInfo,
 ): PythonEnvInfo {
-    const env = createLocatedEnv('', versionStr, kind, execStr);
+    const env = createLocatedEnv('', versionStr, kind, exec, distro);
     env.name = name;
     return env;
 }
 
 export class SimpleLocator extends Locator {
     private deferred = createDeferred<void>();
+
     constructor(
         private envs: PythonEnvInfo[],
         public callbacks: {
@@ -58,22 +75,25 @@ export class SimpleLocator extends Locator {
             beforeEach?(e: PythonEnvInfo): Promise<void>;
             afterEach?(e: PythonEnvInfo): Promise<void>;
             onQuery?(query: PythonLocatorQuery | undefined, envs: PythonEnvInfo[]): Promise<PythonEnvInfo[]>;
-        } = {},
+        },
     ) {
         super();
     }
+
     public get done(): Promise<void> {
         return this.deferred.promise;
     }
+
     public fire(event: PythonEnvsChangedEvent) {
         this.emitter.fire(event);
     }
+
     public iterEnvs(query?: PythonLocatorQuery): IPythonEnvsIterator {
-        const deferred = this.deferred;
-        const callbacks = this.callbacks;
-        let envs = this.envs;
-        const iterator: IPythonEnvsIterator = async function*() {
-            if (callbacks.onQuery !== undefined) {
+        const { deferred } = this;
+        const { callbacks } = this;
+        let { envs } = this;
+        const iterator: IPythonEnvsIterator = (async function* () {
+            if (callbacks?.onQuery !== undefined) {
                 envs = await callbacks.onQuery(query, envs);
             }
             if (callbacks.before !== undefined) {
@@ -99,23 +119,23 @@ export class SimpleLocator extends Locator {
                     }
                 }
             }
-            if (callbacks.after!== undefined) {
+            if (callbacks?.after !== undefined) {
                 await callbacks.after;
             }
             deferred.resolve();
-        }();
-        iterator.onUpdated = this.callbacks.onUpdated;
+        }());
+        iterator.onUpdated = this.callbacks?.onUpdated;
         return iterator;
     }
+
     public async resolveEnv(env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
         const envInfo: PythonEnvInfo = typeof env === 'string' ? createLocatedEnv('', '', undefined, env) : env;
         if (this.callbacks.resolve === undefined) {
             return envInfo;
-        } else if (this.callbacks.resolve === null) {
+        } if (this.callbacks?.resolve === null) {
             return undefined;
-        } else {
-            return this.callbacks.resolve(envInfo);
         }
+        return this.callbacks.resolve(envInfo);
     }
 }
 


### PR DESCRIPTION
Didn't move `mergeEnvironments()` as it's not specific to the reducer, can be used in resolver as well.