### PR TITLE
Change name of event used to activate extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
         "onCommand:python.datascience.selectJupyterInterpreter",
         "onCommand:python.datascience.selectjupytercommandline",
         "onCommand:python.enableSourceMapSupport",
-        "onNotebookEditor:jupyter-notebook",
+        "onNotebook:jupyter-notebook",
         "workspaceContains:mspythonconfig.json",
         "workspaceContains:pyproject.toml",
         "onCustomEditor:ms-python.python.notebook.ipynb"


### PR DESCRIPTION
Notebook doesn't open as the VSC API has changed.