### PR TITLE
A different way of fixing escaping

### DIFF
--- a/src/client/datascience/editor-integration/cellhashprovider.ts
+++ b/src/client/datascience/editor-integration/cellhashprovider.ts
@@ -29,7 +29,9 @@ import {
 
 // tslint:disable-next-line:no-require-imports no-var-requires
 const _escapeRegExp = require('lodash/escapeRegExp') as typeof import('lodash/escapeRegExp'); // NOSONAR
-const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)/g;
+// tslint:disable-next-line: no-require-imports no-var-requires
+const _escape = require('lodash/escape') as typeof import('lodash/escape'); // NOSONAR
+const LineNumberMatchRegex = /(;32m[ ->]*?)(\d+)(.*)/g;
 
 interface IRangedCellHash extends ICellHash {
     code: string;
@@ -133,7 +135,7 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
                 ...msg,
                 content: {
                     ...msg.content,
-                    traceback: this.modifyTraceback(msg as KernelMessage.IErrorMsg) // NOSONAR
+                    transient: this.modifyTraceback(msg as KernelMessage.IErrorMsg) // NOSONAR
                 }
             };
         }
@@ -423,14 +425,16 @@ export class CellHashProvider implements ICellHashProvider, INotebookExecutionLo
             // Now attempt to find a cell that matches these source lines
             const offset = this.findCellOffset(this.hashes.get(match[0]), sourceLines);
             if (offset !== undefined) {
-                return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num) => {
+                return traceFrame.replace(LineNumberMatchRegex, (_s, prefix, num, suffix) => {
                     const n = parseInt(num, 10);
                     const newLine = offset + n - 1;
-                    return `${prefix}<a href='file://${match[0]}?line=${newLine}'>${newLine + 1}</a>`;
+                    return `${_escape(prefix)}<a href='file://${match[0]}?line=${newLine}'>${newLine + 1}</a>${_escape(
+                        suffix
+                    )}`;
                 });
             }
         }
-        return traceFrame;
+        return _escape(traceFrame);
     }
 }
 

--- a/src/client/datascience/jupyter/jupyterDebugger.ts
+++ b/src/client/datascience/jupyter/jupyterDebugger.ts
@@ -3,8 +3,6 @@
 'use strict';
 import type { nbformat } from '@jupyterlab/coreutils';
 import { inject, injectable, named } from 'inversify';
-// tslint:disable-next-line: no-require-imports
-import unescape = require('lodash/unescape');
 import * as path from 'path';
 import * as uuid from 'uuid/v4';
 import { DebugConfiguration, Disposable } from 'vscode';
@@ -475,10 +473,8 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
             if (outputs.length > 0) {
                 const data = outputs[0].data;
                 if (data && data.hasOwnProperty('text/plain')) {
-                    // Plain text should be escaped by our execution engine. Unescape it so
-                    // we can parse it.
                     // tslint:disable-next-line:no-any
-                    return unescape((data as any)['text/plain']);
+                    return (data as any)['text/plain'];
                 }
                 if (outputs[0].output_type === 'stream') {
                     const stream = outputs[0] as nbformat.IStream;

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -40,10 +40,6 @@ import { KernelConnectionMetadata } from './kernels/types';
 
 // tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
-// tslint:disable-next-line: no-require-imports
-import escape = require('lodash/escape');
-// tslint:disable-next-line: no-require-imports
-import unescape = require('lodash/unescape');
 import { concatMultilineString, formatStreamText } from '../../../datascience-ui/common';
 import { RefBool } from '../../common/refBool';
 import { PythonEnvironment } from '../../pythonEnvironments/info';
@@ -787,12 +783,12 @@ export class JupyterNotebookBase implements INotebook {
                 outputs.forEach((o) => {
                     if (o.output_type === 'stream') {
                         const stream = o as nbformat.IStream;
-                        result = result.concat(formatStreamText(unescape(concatMultilineString(stream.text, true))));
+                        result = result.concat(formatStreamText(concatMultilineString(stream.text, true)));
                     } else {
                         const data = o.data;
                         if (data && data.hasOwnProperty('text/plain')) {
                             // tslint:disable-next-line:no-any
-                            result = result.concat(unescape((data as any)['text/plain']));
+                            result = result.concat((data as any)['text/plain']);
                         }
                     }
                 });
@@ -1237,7 +1233,7 @@ export class JupyterNotebookBase implements INotebook {
     ) {
         // Check our length on text output
         if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
-            msg.content.data['text/plain'] = escape(trimFunc(msg.content.data['text/plain'] as string));
+            msg.content.data['text/plain'] = trimFunc(msg.content.data['text/plain'] as string);
         }
 
         this.addToCellData(
@@ -1266,7 +1262,7 @@ export class JupyterNotebookBase implements INotebook {
                 if (o.data && o.data.hasOwnProperty('text/plain')) {
                     // tslint:disable-next-line: no-any
                     const str = (o.data as any)['text/plain'].toString();
-                    const data = escape(trimFunc(str)) as string;
+                    const data = trimFunc(str) as string;
                     this.addToCellData(
                         cell,
                         {
@@ -1314,13 +1310,13 @@ export class JupyterNotebookBase implements INotebook {
                 : undefined;
         if (existing) {
             // tslint:disable-next-line:restrict-plus-operands
-            existing.text = existing.text + escape(msg.content.text);
+            existing.text = existing.text + msg.content.text;
             const originalText = formatStreamText(concatMultilineString(existing.text));
             originalTextLength = originalText.length;
             existing.text = trimFunc(originalText);
             trimmedTextLength = existing.text.length;
         } else {
-            const originalText = formatStreamText(concatMultilineString(escape(msg.content.text)));
+            const originalText = formatStreamText(concatMultilineString(msg.content.text));
             originalTextLength = originalText.length;
             // Create a new stream entry
             const output: nbformat.IStream = {
@@ -1350,11 +1346,6 @@ export class JupyterNotebookBase implements INotebook {
     }
 
     private handleDisplayData(msg: KernelMessage.IDisplayDataMsg, clearState: RefBool, cell: ICell) {
-        // Escape text output
-        if (msg.content.data && msg.content.data.hasOwnProperty('text/plain')) {
-            msg.content.data['text/plain'] = escape(msg.content.data['text/plain'] as string);
-        }
-
         const output: nbformat.IDisplayData = {
             output_type: 'display_data',
             data: msg.content.data,
@@ -1402,10 +1393,14 @@ export class JupyterNotebookBase implements INotebook {
     private handleError(msg: KernelMessage.IErrorMsg, clearState: RefBool, cell: ICell) {
         const output: nbformat.IError = {
             output_type: 'error',
-            ename: escape(msg.content.ename),
-            evalue: escape(msg.content.evalue),
-            traceback: msg.content.traceback.map(escape)
+            ename: msg.content.ename,
+            evalue: msg.content.evalue,
+            traceback: msg.content.traceback
         };
+        if (msg.content.hasOwnProperty('transient')) {
+            // tslint:disable-next-line: no-any
+            output.transient = (msg.content as any).transient;
+        }
         this.addToCellData(cell, output, clearState);
         cell.state = CellState.error;
 

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -6,8 +6,6 @@ import { inject, injectable } from 'inversify';
 import stripAnsi from 'strip-ansi';
 import * as uuid from 'uuid/v4';
 
-// tslint:disable-next-line: no-require-imports
-import unescape = require('lodash/unescape');
 import { CancellationToken, Event, EventEmitter, Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError } from '../../common/logger';
@@ -248,7 +246,7 @@ export class KernelVariables implements IJupyterVariables {
 
     // Pull our text result out of the Jupyter cell
     private deserializeJupyterResult<T>(cells: ICell[]): T {
-        const text = unescape(this.extractJupyterResultText(cells));
+        const text = this.extractJupyterResultText(cells);
         return JSON.parse(text) as T;
     }
 
@@ -373,7 +371,7 @@ export class KernelVariables implements IJupyterVariables {
         // Now execute the query
         if (notebook && query) {
             const cells = await notebook.execute(query.query, Identifiers.EmptyFileName, 0, uuid(), token, true);
-            const text = unescape(this.extractJupyterResultText(cells));
+            const text = this.extractJupyterResultText(cells);
 
             // Apply the expression to it
             const matches = this.getAllMatches(query.parser, text);

--- a/src/client/datascience/jupyter/oldJupyterVariables.ts
+++ b/src/client/datascience/jupyter/oldJupyterVariables.ts
@@ -11,8 +11,6 @@ import { Event, EventEmitter, Uri } from 'vscode';
 import { PYTHON_LANGUAGE } from '../../common/constants';
 import { traceError } from '../../common/logger';
 
-// tslint:disable-next-line: no-require-imports
-import unescape = require('lodash/unescape');
 import { IConfigurationService } from '../../common/types';
 import * as localize from '../../common/utils/localize';
 import { EXTENSION_ROOT_DIR } from '../../constants';
@@ -234,7 +232,7 @@ export class OldJupyterVariables implements IJupyterVariables {
 
     // Pull our text result out of the Jupyter cell
     private deserializeJupyterResult<T>(cells: ICell[]): T {
-        const text = unescape(this.extractJupyterResultText(cells));
+        const text = this.extractJupyterResultText(cells);
         return JSON.parse(text) as T;
     }
 
@@ -359,7 +357,7 @@ export class OldJupyterVariables implements IJupyterVariables {
         // Now execute the query
         if (notebook && query) {
             const cells = await notebook.execute(query.query, Identifiers.EmptyFileName, 0, uuid(), undefined, true);
-            const text = unescape(this.extractJupyterResultText(cells));
+            const text = this.extractJupyterResultText(cells);
 
             // Apply the expression to it
             const matches = this.getAllMatches(query.parser, text);

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -20,6 +20,8 @@ import { getRichestMimetype, getTransform, isIPyWidgetOutput, isMimeTypeSupporte
 
 // tslint:disable-next-line: no-var-requires no-require-imports
 const ansiToHtml = require('ansi-to-html');
+// tslint:disable-next-line: no-var-requires no-require-imports
+const lodashEscape = require('lodash/escape');
 
 // tslint:disable-next-line: no-require-imports no-var-requires
 const cloneDeep = require('lodash/cloneDeep');
@@ -328,7 +330,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             // tslint:disable-next-line: no-any
             const text = (input as any)['text/plain'];
             input = {
-                'text/html': text // XML tags should have already been escaped.
+                'text/html': lodashEscape(text)
             };
         } else if (output.output_type === 'stream') {
             mimeType = 'text/html';
@@ -337,7 +339,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             renderWithScrollbars = true;
             // Sonar is wrong, TS won't compile without this AS
             const stream = output as nbformat.IStream; // NOSONAR
-            const concatted = concatMultilineString(stream.text);
+            const concatted = lodashEscape(concatMultilineString(stream.text));
             input = {
                 'text/html': concatted // XML tags should have already been escaped.
             };
@@ -363,14 +365,18 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             const error = output as nbformat.IError; // NOSONAR
             try {
                 const converter = new CellOutput.ansiToHtmlClass(CellOutput.getAnsiToHtmlOptions());
-                const trace = error.traceback.length ? converter.toHtml(error.traceback.join('\n')) : error.evalue;
+                // Modified traceback may exist. If so use that instead. It's only at run time though
+                const traceback: string[] = error.transient
+                    ? (error.transient as string[])
+                    : error.traceback.map(lodashEscape);
+                const trace = traceback ? converter.toHtml(traceback.join('\n')) : error.evalue;
                 input = {
                     'text/html': trace
                 };
             } catch {
                 // This can fail during unit tests, just use the raw data
                 input = {
-                    'text/html': error.evalue
+                    'text/html': lodashEscape(error.evalue)
                 };
             }
         } else if (input) {
@@ -393,6 +399,12 @@ export class CellOutput extends React.Component<ICellOutputProps> {
         // Fixup latex to make sure it has the requisite $$ around it
         if (mimeType === 'text/latex') {
             data = fixMarkdown(concatMultilineString(data as nbformat.MultilineString, true), true);
+        }
+
+        // Make sure text output is escaped (nteract texttransform won't)
+        if (mimeType === 'text/plain') {
+            data = lodashEscape(data.toString());
+            mimeType = 'text/html';
         }
 
         return {

--- a/src/test/datascience/interactiveWindow.functional.test.tsx
+++ b/src/test/datascience/interactiveWindow.functional.test.tsx
@@ -63,6 +63,8 @@ import {
     verifyLastCellInputState
 } from './testHelpers';
 import { ITestInteractiveWindowProvider } from './testInteractiveWindowProvider';
+// tslint:disable-next-line: no-require-imports no-var-requires
+const _escape = require('lodash/escape') as typeof import('lodash/escape'); // NOSONAR
 
 // tslint:disable:max-func-body-length trailing-comma no-any no-multiline-string
 suite('DataScience Interactive Window output tests', () => {
@@ -385,6 +387,9 @@ for _ in range(50):
     time.sleep(0.1)
     sys.stdout.write('\\r')`;
 
+            const exception = 'raise Exception("<html check>")';
+            addMockData(ioc, exception, `"<html check>"`, 'text/html', 'error');
+
             addMockData(ioc, badPanda, `pandas has no attribute 'read'`, 'text/html', 'error');
             addMockData(ioc, goodPanda, `<td>A table</td>`, 'text/html');
             addMockData(ioc, matPlotLib, matPlotLibResults, 'text/html');
@@ -400,6 +405,9 @@ for _ in range(50):
                 }
                 return Promise.resolve({ result: result, haveMore: loops > 0 });
             });
+
+            await addCode(ioc, exception, true);
+            verifyHtmlOnInteractiveCell(_escape(`<html check>`), CellPosition.Last);
 
             await addCode(ioc, badPanda, true);
             verifyHtmlOnInteractiveCell(`has no attribute 'read'`, CellPosition.Last);

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -34,6 +34,7 @@ import { KeyPrefix } from '../../client/datascience/notebookStorage/nativeEditor
 import {
     ICell,
     IDataScienceErrorHandler,
+    IDataScienceFileSystem,
     IJupyterExecution,
     INotebookEditor,
     INotebookEditorProvider,
@@ -878,6 +879,133 @@ df.head()`;
                     verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', `1`, 0);
                     verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', `2`, 1);
                     verifyHtmlOnCell(ne.mount.wrapper, 'NativeCell', `3`, 2);
+                });
+
+                runMountedTest('Roundtrip with jupyter', async () => {
+                    // Write out a temporary file
+                    const baseFile = `
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a='<1>'\\n",
+    "a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "b=2\\n",
+    "b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c=3\\n",
+    "c"
+   ]
+  }
+ ],
+ "metadata": {
+  "file_extension": ".py",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  },
+  "mimetype": "text/x-python",
+  "name": "python",
+  "npconvert_exporter": "python",
+  "pygments_lexer": "ipython3",
+  "version": 3
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}`;
+                    addMockData(ioc, `a='<1>'\na`, `'<1>'`);
+                    const dsfs = ioc.get<IDataScienceFileSystem>(IDataScienceFileSystem);
+                    const tf = await dsfs.createTemporaryLocalFile('.ipynb');
+                    try {
+                        await dsfs.writeLocalFile(tf.filePath, baseFile);
+
+                        // File should exist. Open and run all cells
+                        const n = await openEditor(ioc, '', tf.filePath);
+                        const threeCellsUpdated = n.mount.waitForMessage(InteractiveWindowMessages.ExecutionRendered, {
+                            numberOfTimes: 3
+                        });
+                        n.editor.runAllCells();
+                        await threeCellsUpdated;
+
+                        // Save the file
+                        const saveButton = findButton(n.mount.wrapper, NativeEditor, 8);
+                        const saved = waitForMessage(ioc, InteractiveWindowMessages.NotebookClean);
+                        saveButton!.simulate('click');
+                        await saved;
+
+                        // Read in the file contents. Should match the original
+                        const savedContents = await dsfs.readLocalFile(tf.filePath);
+                        assert.equal(savedContents, baseFile, 'File contents were changed by execution');
+                    } finally {
+                        tf.dispose();
+                    }
                 });
 
                 runMountedTest('Startup and shutdown', async () => {

--- a/src/test/datascience/nativeEditor.functional.test.tsx
+++ b/src/test/datascience/nativeEditor.functional.test.tsx
@@ -896,7 +896,7 @@ df.head()`;
     {
      "data": {
       "text/plain": [
-       "1"
+       "'<1>'"
       ]
      },
      "execution_count": 1,
@@ -981,6 +981,8 @@ df.head()`;
  "nbformat_minor": 2
 }`;
                     addMockData(ioc, `a='<1>'\na`, `'<1>'`);
+                    addMockData(ioc, 'b=2\nb', 2);
+                    addMockData(ioc, 'c=3\nc', 3);
                     const dsfs = ioc.get<IDataScienceFileSystem>(IDataScienceFileSystem);
                     const tf = await dsfs.createTemporaryLocalFile('.ipynb');
                     try {
@@ -1002,7 +1004,18 @@ df.head()`;
 
                         // Read in the file contents. Should match the original
                         const savedContents = await dsfs.readLocalFile(tf.filePath);
-                        assert.equal(savedContents, baseFile, 'File contents were changed by execution');
+                        const savedJSON = JSON.parse(savedContents);
+                        const baseJSON = JSON.parse(baseFile);
+
+                        // Don't compare kernelspec names
+                        delete savedJSON.metadata.kernelspec.display_name;
+                        delete baseJSON.metadata.kernelspec.display_name;
+
+                        // Don't compare python versions
+                        delete savedJSON.metadata.language_info.version;
+                        delete baseJSON.metadata.language_info.version;
+
+                        assert.deepEqual(savedJSON, baseJSON, 'File contents were changed by execution');
                     } finally {
                         tf.dispose();
                     }

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -6,8 +6,6 @@ import { assert } from 'chai';
 import { ChildProcess } from 'child_process';
 import * as fs from 'fs-extra';
 import { injectable } from 'inversify';
-// tslint:disable-next-line: no-require-imports
-import escape = require('lodash/escape');
 import * as os from 'os';
 import * as path from 'path';
 import { SemVer } from 'semver';
@@ -1031,7 +1029,7 @@ a`,
                     mimeType: 'text/plain',
                     cellType: 'code',
                     result: `<a href=f>`,
-                    verifyValue: (d) => assert.ok(d.includes(escape(`<a href=f>`)), 'XML not escaped')
+                    verifyValue: (d) => assert.ok(d.includes(`<a href=f>`), 'Should not escape at the notebook level')
                 },
                 {
                     markdownRegEx: undefined,
@@ -1043,7 +1041,7 @@ df.head()`,
                     cellType: 'error',
                     // tslint:disable-next-line:quotemark
                     verifyValue: (d) =>
-                        assert.ok((d as string).includes(escape("has no attribute 'read'")), 'Unexpected error result')
+                        assert.ok((d as string).includes("has no attribute 'read'"), 'Unexpected error result')
                 },
                 {
                     markdownRegEx: undefined,

--- a/src/test/datascience/testHelpers.tsx
+++ b/src/test/datascience/testHelpers.tsx
@@ -7,7 +7,6 @@ import { min } from 'lodash';
 import * as path from 'path';
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import { isString } from 'util';
 import { CancellationToken } from 'vscode';
 
 import { EXTENSION_ROOT_DIR } from '../../client/common/constants';
@@ -273,7 +272,7 @@ export function verifyHtmlOnCell(
         output = targetCell!.find('div.markdown-cell-output');
     }
     const outputHtml = output.length > 0 ? output.html() : undefined;
-    if (html && isString(html)) {
+    if (html && typeof html === 'string') {
         // Extract only the first 100 chars from the input string
         const sliced = html.substr(0, min([html.length, 100]));
         assert.ok(output.length > 0, 'No output cell found');


### PR DESCRIPTION
For #14182

The original fix I did for escaping broke the data stored in the ipynb. It should not be escaped there. The escaping should be happening in the UI.

I also added a test for round tripping to make sure this doesn't happen again (or for other reasons).

That test found some other spots where we were changing stuff unnecessarily.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
