### PR TITLE
Fix two issues caused by the escape fix

### DIFF
--- a/news/2 Fixes/14212.md
+++ b/news/2 Fixes/14212.md
@@ -1,0 +1,1 @@
+Fix interactive debugging starting (trimQuotes error).

--- a/news/2 Fixes/14216.md
+++ b/news/2 Fixes/14216.md
@@ -1,0 +1,1 @@
+Fix latex output not showing up without a 'display' call.

--- a/src/client/datascience/jupyter/jupyterDebugger.ts
+++ b/src/client/datascience/jupyter/jupyterDebugger.ts
@@ -474,7 +474,7 @@ export class JupyterDebugger implements IJupyterDebugger, ICellHashListener {
                 const data = outputs[0].data;
                 if (data && data.hasOwnProperty('text/plain')) {
                     // tslint:disable-next-line:no-any
-                    return (data as any)['text/plain'];
+                    return concatMultilineString((data as any)['text/plain']);
                 }
                 if (outputs[0].output_type === 'stream') {
                     const stream = outputs[0] as nbformat.IStream;

--- a/src/datascience-ui/interactive-common/cellOutput.tsx
+++ b/src/datascience-ui/interactive-common/cellOutput.tsx
@@ -316,22 +316,6 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             input = JSON.stringify(output.data);
             renderWithScrollbars = true;
             isText = true;
-        } else if (
-            output.output_type === 'execute_result' &&
-            input &&
-            input.hasOwnProperty('text/plain') &&
-            !input.hasOwnProperty('text/html')
-        ) {
-            // Plain text should actually be shown as html so that escaped HTML shows up correctly
-            mimeType = 'text/html';
-            isText = true;
-            isError = false;
-            renderWithScrollbars = true;
-            // tslint:disable-next-line: no-any
-            const text = (input as any)['text/plain'];
-            input = {
-                'text/html': lodashEscape(concatMultilineString(text))
-            };
         } else if (output.output_type === 'stream') {
             mimeType = 'text/html';
             isText = true;
@@ -341,7 +325,7 @@ export class CellOutput extends React.Component<ICellOutputProps> {
             const stream = output as nbformat.IStream; // NOSONAR
             const concatted = lodashEscape(concatMultilineString(stream.text));
             input = {
-                'text/html': concatted // XML tags should have already been escaped.
+                'text/html': concatted
             };
 
             // Output may have ascii colorization chars in it.
@@ -399,12 +383,6 @@ export class CellOutput extends React.Component<ICellOutputProps> {
         // Fixup latex to make sure it has the requisite $$ around it
         if (mimeType === 'text/latex') {
             data = fixMarkdown(concatMultilineString(data as nbformat.MultilineString, true), true);
-        }
-
-        // Make sure text output is escaped (nteract texttransform won't)
-        if (mimeType === 'text/plain' && data) {
-            data = lodashEscape(data.toString());
-            mimeType = 'text/html';
         }
 
         return {


### PR DESCRIPTION
For #14212, #14216

Debugger problem was caused by text still being an array.
Latex problem was us forcing the mime type to text/html when there's actually a better (text/latex in this case) to display. It also seems the nteract text transform handles escaping itself so we don't need to do the escaping for text/plain

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
