### PR TITLE
Update other cells in cell execution

### DIFF
--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -68,9 +68,6 @@ export abstract class BaseJupyterSession implements IJupyterSession {
     public get isConnected(): boolean {
         return this.connected;
     }
-    public get onIoPubMessage() {
-        return this.ioPubEventEmitter.event;
-    }
     protected onStatusChangedEvent: EventEmitter<ServerStatus> = new EventEmitter<ServerStatus>();
     protected statusHandler: Slot<ISessionWithSocket, Kernel.Status>;
     protected connected: boolean = false;

--- a/src/client/datascience/jupyter/kernels/cellExecution.ts
+++ b/src/client/datascience/jupyter/kernels/cellExecution.ts
@@ -18,7 +18,11 @@ import { noop } from '../../../common/utils/misc';
 import { StopWatch } from '../../../common/utils/stopWatch';
 import { sendTelemetryEvent } from '../../../telemetry';
 import { Telemetry } from '../../constants';
-import { updateCellExecutionCount, updateCellWithErrorStatus } from '../../notebook/helpers/executionHelpers';
+import {
+    handleUpdateDisplayDataMessage,
+    updateCellExecutionCount,
+    updateCellWithErrorStatus
+} from '../../notebook/helpers/executionHelpers';
 import {
     cellOutputToVSCCellOutput,
     clearCellForExecution,
@@ -370,12 +374,12 @@ export class CellExecution {
                 await this.handleStreamMessage(msg as KernelMessage.IStreamMsg, clearState);
             } else if (jupyterLab.KernelMessage.isDisplayDataMsg(msg)) {
                 await this.handleDisplayData(msg as KernelMessage.IDisplayDataMsg, clearState);
+            } else if (jupyterLab.KernelMessage.isUpdateDisplayDataMsg(msg)) {
+                await handleUpdateDisplayDataMessage(msg, this.editor);
             } else if (jupyterLab.KernelMessage.isClearOutputMsg(msg)) {
                 await this.handleClearOutput(msg as KernelMessage.IClearOutputMsg, clearState);
             } else if (jupyterLab.KernelMessage.isErrorMsg(msg)) {
                 await this.handleError(msg as KernelMessage.IErrorMsg, clearState);
-            } else if (jupyterLab.KernelMessage.isUpdateDisplayDataMsg(msg)) {
-                // Noop.
             } else if (jupyterLab.KernelMessage.isCommOpenMsg(msg)) {
                 // Noop.
             } else if (jupyterLab.KernelMessage.isCommMsgMsg(msg)) {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -320,7 +320,6 @@ export interface IJupyterPasswordConnect {
 export const IJupyterSession = Symbol('IJupyterSession');
 export interface IJupyterSession extends IAsyncDisposable {
     onSessionStatusChanged: Event<ServerStatus>;
-    onIoPubMessage: Event<KernelMessage.IIOPubMessage>;
     readonly status: ServerStatus;
     readonly workingDirectory: string;
     readonly kernelSocket: Observable<KernelSocketInformation | undefined>;

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -25,9 +25,6 @@ export class MockJupyterSession implements IJupyterSession {
     private dict: Record<string, ICell>;
     private restartedEvent: EventEmitter<void> = new EventEmitter<void>();
     private onStatusChangedEvent: EventEmitter<ServerStatus> = new EventEmitter<ServerStatus>();
-    private onIoPubMessageEvent: EventEmitter<KernelMessage.IIOPubMessage> = new EventEmitter<
-        KernelMessage.IIOPubMessage
-    >();
     private timedelay: number;
     private executionCount: number = 0;
     private outstandingRequestTokenSources: CancellationTokenSource[] = [];
@@ -58,10 +55,6 @@ export class MockJupyterSession implements IJupyterSession {
         }
         return this.onStatusChangedEvent.event;
     }
-    public get onIoPubMessage(): Event<KernelMessage.IIOPubMessage> {
-        return this.onIoPubMessageEvent.event;
-    }
-
     public get status(): ServerStatus {
         return this._status;
     }

--- a/src/test/datascience/notebook/executionService.ds.test.ts
+++ b/src/test/datascience/notebook/executionService.ds.test.ts
@@ -25,7 +25,7 @@ import {
     deleteAllCellsAndWait,
     executeActiveDocument,
     executeCell,
-    insertPythonCellAndWait,
+    insertPythonCell,
     startJupyter,
     trustAllNotebooks
 } from './helper';
@@ -56,7 +56,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
     setup(deleteAllCellsAndWait);
     suiteTeardown(() => closeNotebooksAndCleanUpAfterTests(disposables));
     test('Execute cell using VSCode Kernel', async () => {
-        await insertPythonCellAndWait('print("Hello World")');
+        await insertPythonCell('print("Hello World")');
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeCell(cell);
@@ -69,7 +69,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         );
     });
     test('Executed events are triggered', async () => {
-        await insertPythonCellAndWait('print("Hello World")');
+        await insertPythonCell('print("Hello World")');
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         const executed = createEventHandler(editorProvider.activeEditor!, 'executed', disposables);
@@ -87,7 +87,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         await codeExecuted.assertFired(1_000);
     });
     test('Empty cell will not get executed', async () => {
-        await insertPythonCellAndWait('');
+        await insertPythonCell('');
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
         await executeCell(cell);
 
@@ -96,8 +96,8 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.isUndefined(cell?.metadata.runState);
     });
     test('Empty cells will not get executed when running whole document', async () => {
-        await insertPythonCellAndWait('');
-        await insertPythonCellAndWait('print("Hello World")');
+        await insertPythonCell('');
+        await insertPythonCell('print("Hello World")');
         const cells = vscodeNotebook.activeNotebookEditor?.document.cells!;
 
         await executeActiveDocument();
@@ -111,7 +111,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.isUndefined(cells[0].metadata.runState);
     });
     test('Verify Cell output, execution count and status', async () => {
-        await insertPythonCellAndWait('print("Hello World")');
+        await insertPythonCell('print("Hello World")');
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeActiveDocument();
@@ -130,8 +130,8 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.ok(cell.metadata.executionOrder, 'Execution count should be > 0');
     });
     test('Verify multiple cells get executed', async () => {
-        await insertPythonCellAndWait('print("Foo Bar")');
-        await insertPythonCellAndWait('print("Hello World")');
+        await insertPythonCell('print("Foo Bar")');
+        await insertPythonCell('print("Hello World")');
         const cells = vscodeNotebook.activeNotebookEditor?.document.cells!;
 
         await executeActiveDocument();
@@ -153,7 +153,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.equal(cells[1].metadata.executionOrder! - 1, cells[0].metadata.executionOrder!);
     });
     test('Verify metadata for successfully executed cell', async () => {
-        await insertPythonCellAndWait('print("Foo Bar")');
+        await insertPythonCell('print("Foo Bar")');
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeActiveDocument();
@@ -172,7 +172,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.equal(cell.metadata.statusMessage, '', 'Incorrect Status message');
     });
     test('Verify output & metadata for executed cell with errors', async () => {
-        await insertPythonCellAndWait('print(abcd)');
+        await insertPythonCell('print(abcd)');
         const cell = vscodeNotebook.activeNotebookEditor?.document.cells![0]!;
 
         await executeActiveDocument();
@@ -198,9 +198,9 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.include(cell.metadata.statusMessage!, 'abcd', 'Must contain error message');
     });
     test('Updating display data', async () => {
-        await insertPythonCellAndWait('from IPython.display import Markdown\n');
-        await insertPythonCellAndWait('dh = display(display_id=True)\n');
-        await insertPythonCellAndWait('dh.update(Markdown("foo"))\n');
+        await insertPythonCell('from IPython.display import Markdown\n');
+        await insertPythonCell('dh = display(display_id=True)\n');
+        await insertPythonCell('dh.update(Markdown("foo"))\n');
         const displayCell = vscodeNotebook.activeNotebookEditor?.document.cells![1]!;
         const updateCell = vscodeNotebook.activeNotebookEditor?.document.cells![2]!;
 
@@ -225,7 +225,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         // Assume you are executing a cell that prints numbers 1-100.
         // When printing number 50, you click clear.
         // Cell output should now start printing output from 51 onwards, & not 1.
-        await insertPythonCellAndWait(
+        await insertPythonCell(
             dedent`
                     print("Start")
                     import time
@@ -277,7 +277,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         // Assume you are executing a cell that prints numbers 1-100.
         // When printing number 50, you click clear.
         // Cell output should now start printing output from 51 onwards, & not 1.
-        await insertPythonCellAndWait(
+        await insertPythonCell(
             dedent`
                 from IPython.display import display, clear_output
                 import time
@@ -315,7 +315,7 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         // Assume you are executing a cell that prints numbers 1-100.
         // When printing number 50, you click clear.
         // Cell output should now start printing output from 51 onwards, & not 1.
-        await insertPythonCellAndWait(
+        await insertPythonCell(
             dedent`
                     print("Start")
                     import time
@@ -344,14 +344,14 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         );
     });
     test('Verify escaping of output', async () => {
-        await insertPythonCellAndWait('1');
-        await insertPythonCellAndWait(dedent`
+        await insertPythonCell('1');
+        await insertPythonCell(dedent`
                                             a="<a href=f>"
                                             a`);
-        await insertPythonCellAndWait(dedent`
+        await insertPythonCell(dedent`
                                             a="<a href=f>"
                                             print(a)`);
-        await insertPythonCellAndWait('raise Exception("<whatever>")');
+        await insertPythonCell('raise Exception("<whatever>")');
         const cells = vscodeNotebook.activeNotebookEditor?.document.cells!;
 
         await executeActiveDocument();
@@ -390,5 +390,45 @@ suite('DataScience - VSCode Notebook - (Execution) (slow)', function () {
         assert.equal(errorOutput.evalue, '<whatever>', 'Incorrect evalue'); // As status contains ename, we don't want this displayed again.
         assert.isNotEmpty(errorOutput.traceback, 'Incorrect traceback');
         assert.include(errorOutput.traceback.join(''), '<whatever>');
+    });
+    test('Verify display updates', async () => {
+        await insertPythonCell('from IPython.display import Markdown', 0);
+        await insertPythonCell('dh = display(Markdown("foo"), display_id=True)', 1);
+        let cells = vscodeNotebook.activeNotebookEditor?.document.cells!;
+
+        await executeActiveDocument();
+        await waitForCondition(
+            async () => assertHasExecutionCompletedSuccessfully(cells[1]),
+            15_000,
+            'Cell did not get executed'
+        );
+
+        assert.equal(cells[0].outputs.length, 0, 'Incorrect number of output');
+        assert.equal(cells[1].outputs.length, 1, 'Incorrect number of output');
+        assert.equal(cells[1].outputs[0].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output type');
+        assert.equal((cells[1].outputs[0] as CellDisplayOutput).data['text/markdown'], 'foo', 'Incorrect output value');
+        const displayId = (cells[1].outputs[0] as CellDisplayOutput).metadata?.custom?.transient?.display_id;
+        assert.ok(displayId, 'Display id not present in metadata');
+
+        await insertPythonCell(
+            dedent`
+                    dh.update(Markdown("bar"))
+                    print('hello')`,
+            2
+        );
+        await executeActiveDocument();
+        cells = vscodeNotebook.activeNotebookEditor?.document.cells!;
+        await waitForCondition(
+            async () => assertHasExecutionCompletedSuccessfully(cells[2]),
+            15_000,
+            'Cell did not get executed'
+        );
+
+        assert.equal(cells[0].outputs.length, 0, 'Incorrect number of output');
+        assert.equal(cells[1].outputs.length, 1, 'Incorrect number of output');
+        assert.equal(cells[2].outputs.length, 1, 'Incorrect number of output');
+        assert.equal(cells[1].outputs[0].outputKind, vscodeNotebookEnums.CellOutputKind.Rich, 'Incorrect output type');
+        assert.equal((cells[1].outputs[0] as CellDisplayOutput).data['text/markdown'], 'bar', 'Incorrect output value');
+        assertHasTextOutputInVSCode(cells[2], 'hello', 0, false);
     });
 });

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -90,12 +90,6 @@ export async function insertPythonCell(source: string, index?: number) {
         ])
     );
 }
-export async function insertPythonCellAndWait(source: string, index?: number) {
-    await insertPythonCell(source, index);
-}
-export async function insertMarkdownCellAndWait(source: string) {
-    await insertMarkdownCell(source);
-}
 export async function deleteCell(index: number = 0) {
     const { vscodeNotebook } = await getServices();
     const activeEditor = vscodeNotebook.activeNotebookEditor;

--- a/src/test/datascience/notebook/interrupRestart.ds.test.ts
+++ b/src/test/datascience/notebook/interrupRestart.ds.test.ts
@@ -22,7 +22,7 @@ import {
     closeNotebooks,
     closeNotebooksAndCleanUpAfterTests,
     executeActiveDocument,
-    insertPythonCellAndWait,
+    insertPythonCell,
     startJupyter,
     trustAllNotebooks,
     waitForTextOutputInVSCode
@@ -82,7 +82,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
     });
 
     test('Cancelling token will cancel cell execution', async () => {
-        await insertPythonCellAndWait('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)', 0);
+        await insertPythonCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)', 0);
         const cell = vscEditor.document.cells[0];
         const appShell = api.serviceContainer.get<IApplicationShell>(IApplicationShell);
         const showInformationMessage = sinon.stub(appShell, 'showInformationMessage');
@@ -116,7 +116,7 @@ suite('DataScience - VSCode Notebook - Restart/Interrupt/Cancel/Errors (slow)', 
         }
     });
     test('Restarting kernel will cancel cell execution & we can re-run a cell', async () => {
-        await insertPythonCellAndWait('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)', 0);
+        await insertPythonCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)', 0);
         const cell = vscEditor.document.cells[0];
 
         await executeActiveDocument();

--- a/src/test/datascience/notebook/notebookEditorProvider.ds.test.ts
+++ b/src/test/datascience/notebook/notebookEditorProvider.ds.test.ts
@@ -19,7 +19,7 @@ import {
     canRunTests,
     closeNotebooksAndCleanUpAfterTests,
     createTemporaryNotebook,
-    insertMarkdownCellAndWait,
+    insertMarkdownCell,
     trustAllNotebooks
 } from './helper';
 
@@ -147,7 +147,7 @@ suite('DataScience - VSCode Notebook (Editor Provider)', function () {
         const notebookClosed = createEventHandler(editorProvider, 'onDidCloseNotebookEditor', disposables);
 
         const notebookEditor = await editorProvider.open(testIPynb);
-        await insertMarkdownCellAndWait('1'); // Make the file dirty (so it gets pinned).
+        await insertMarkdownCell('1'); // Make the file dirty (so it gets pinned).
         await notebookOpened.assertFired();
         await activeNotebookChanged.assertFired();
         assert.equal(activeNotebookChanged.first, notebookEditor);
@@ -194,7 +194,7 @@ suite('DataScience - VSCode Notebook (Editor Provider)', function () {
         const notebookClosed = createEventHandler(editorProvider, 'onDidCloseNotebookEditor', disposables);
 
         const editor1 = await editorProvider.open(testIPynb);
-        await insertMarkdownCellAndWait('1'); // Make the file dirty (so it gets pinned).
+        await insertMarkdownCell('1'); // Make the file dirty (so it gets pinned).
         await notebookOpened.assertFired();
         await activeNotebookChanged.assertFired();
         assert.equal(activeNotebookChanged.first, editor1);
@@ -203,7 +203,7 @@ suite('DataScience - VSCode Notebook (Editor Provider)', function () {
         // Open another notebook.
         const testIPynb2 = Uri.file(await createTemporaryNotebook(templateIPynb, disposables));
         const editor2 = await editorProvider.open(testIPynb2);
-        await insertMarkdownCellAndWait('1'); // Make the file dirty (so it gets pinned).
+        await insertMarkdownCell('1'); // Make the file dirty (so it gets pinned).
 
         await notebookOpened.assertFiredExactly(2);
         await activeNotebookChanged.assertFiredAtLeast(2);

--- a/src/test/datascience/notebook/saving.ds.test.ts
+++ b/src/test/datascience/notebook/saving.ds.test.ts
@@ -31,7 +31,7 @@ import {
     closeNotebooksAndCleanUpAfterTests,
     createTemporaryNotebook,
     executeActiveDocument,
-    insertPythonCellAndWait,
+    insertPythonCell,
     saveActiveNotebook,
     startJupyter,
     trustAllNotebooks
@@ -135,10 +135,10 @@ suite('DataScience - VSCode Notebook - (Saving)', function () {
         const testIPynb = Uri.file(await createTemporaryNotebook(templateIPynb, disposables));
         await editorProvider.open(testIPynb);
 
-        await insertPythonCellAndWait('print(1)');
-        await insertPythonCellAndWait('print(a)');
-        await insertPythonCellAndWait('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)');
-        await insertPythonCellAndWait('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)');
+        await insertPythonCell('print(1)');
+        await insertPythonCell('print(a)');
+        await insertPythonCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)');
+        await insertPythonCell('import time\nfor i in range(10000):\n  print(i)\n  time.sleep(0.1)');
         let cell1: NotebookCell;
         let cell2: NotebookCell;
         let cell3: NotebookCell;


### PR DESCRIPTION
Current when we need to update output of another cell when using IPython.display, it doesnt work properly with native notebooks.
THis is because we await in cellExecution class for updates to the cells.
While the above updates are pending, the IOPub messages from kernel are handled elsewhere and we update other cells, hence we have multiple updates going on and in parallel. This results in output not getting displayed.

Moved the code to listen to iopub messages & handle display updates to the cell execution (we were already listening to those messages, just had to move the code to perform the updates).

Also found that the onIoPubMessage was not use anywhere else, hence removed it