### PR TITLE
Tests for prompting to install missing ipykernel

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -178,6 +178,35 @@
             "skipFiles": ["<node_internals>/**"]
         },
         {
+            "name": "DataScience tests in VS Code (*.vscode.ts)",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "${workspaceFolder}/src/test/datascience",
+                "--disable-extensions",
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test"
+            ],
+            "env": {
+                "VSC_PYTHON_CI_TEST_GREP": "", // Modify this to run a subset of the single workspace tests
+                "VSC_PYTHON_CI_TEST_INVERT_GREP": "", // Initialize this to invert the grep (exclude tests with value defined in grep).
+                "CI_PYTHON_PATH": "<PythonPath>", // Initialize this to invert the grep (exclude tests with value defined in grep).
+                "VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE": "true",
+                "TEST_FILES_SUFFIX": "vscode.test"
+            },
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceFolder}/out/**/*.js",
+                "!${workspaceFolder}/**/node_modules**/*"
+            ],
+            "preLaunchTask": "Compile",
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        },
+        {
             "name": "Tests (Multiroot, VS Code, *.test.ts)",
             "type": "extensionHost",
             "request": "launch",

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -373,6 +373,23 @@ steps:
       buildPlatform: '$(Agent.Os)-Py$(pythonVersion)'
       buildConfiguration: 'SystemTests'
 
+
+  # Slow DataScience tests with VS Code
+  # Create a venv & register it as a kernel.
+  # These tests are slow hence will only run on linux.
+  # This env will be used to install ipykernel & test for prompts if ipykernel is missing & similar tests.
+  # Ensure this is registered as a kernel.
+  - bash: |
+      python -m venv .venvnokernel
+      source .venvnokernel/bin/activate
+
+      python -m pip install ipykernel
+      python -m ipykernel install --user --name .venvnokernel --display-name .venvnokernel
+      python -m pip uninstall ipykernel --yes
+    displayName: 'Prepare Virtual Env for Kernel Tests'
+    workingDirectory: $(Build.SourcesDirectory)/src/test/datascience
+    condition: and(succeeded(), contains(variables['TestsToRun'], 'testDataScienceInVSCode'))
+
   # Set the CI_PYTHON_PATH variable that forces VS Code system tests to use
   # the specified Python interpreter.
   #
@@ -438,7 +455,7 @@ steps:
     env:
       DISPLAY: :10
 
-  # Run the single workspace tests in VS Code Insiders.
+  # Run the single workspace tests for DS in VS Code Insiders.
   - script: |
       npm run testDataScience
     continueOnError: true
@@ -449,6 +466,18 @@ steps:
       VSC_PYTHON_CI_TEST_VSC_CHANNEL: 'insiders'
       VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE: 'true'
       TEST_FILES_SUFFIX: 'ds.test'
+
+  # Run the single workspace tests for DS in VS Code Stable.
+  - script: |
+      npm run testDataScienceInVSCode
+    continueOnError: true
+    displayName: 'Run DataScience Tests in VSCode Stable'
+    condition: and(succeeded(), contains(variables['TestsToRun'], 'testDataScienceInVSCode'))
+    env:
+      DISPLAY: :10
+      VSC_PYTHON_CI_TEST_VSC_CHANNEL: 'stable'
+      VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE: 'true'
+      TEST_FILES_SUFFIX: 'vscode.test'
 
   # Upload the test results to Azure DevOps to facilitate test reporting in their UX.
   - task: PublishTestResults@2

--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -460,7 +460,7 @@ steps:
       npm run testDataScience
     continueOnError: true
     displayName: 'Run DataScience Tests in VSCode Insiders'
-    condition: and(succeeded(), contains(variables['TestsToRun'], 'testDataScience'))
+    condition: and(succeeded(), contains(variables['TestsToRun'], 'testDataScience'), not(contains(variables['TestsToRun'], 'testDataScienceInVSCode')))
     env:
       DISPLAY: :10
       VSC_PYTHON_CI_TEST_VSC_CHANNEL: 'insiders'
@@ -470,7 +470,6 @@ steps:
   # Run the single workspace tests for DS in VS Code Stable.
   - script: |
       npm run testDataScienceInVSCode
-    continueOnError: true
     displayName: 'Run DataScience Tests in VSCode Stable'
     condition: and(succeeded(), contains(variables['TestsToRun'], 'testDataScienceInVSCode'))
     env:

--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -66,6 +66,10 @@ stages:
             'Debugger':
               TestsToRun: 'testDebugger'
               NeedsPythonTestReqs: true
+            'DataScience in VSCode':
+              TestsToRun: 'testDataScienceInVSCode'
+              NeedsPythonTestReqs: true
+              NeedsPythonFunctionalReqs: true
             'Smoke':
               TestsToRun: 'testSmoke'
               NeedsPythonTestReqs: true

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -58,6 +58,10 @@ stages:
               TestsToRun: 'testDataScience'
               NeedsPythonTestReqs: true
               NeedsPythonFunctionalReqs: true
+            'DataScience in VSCode':
+              TestsToRun: 'testDataScienceInVSCode'
+              NeedsPythonTestReqs: true
+              NeedsPythonFunctionalReqs: true
             'Smoke':
               TestsToRun: 'testSmoke'
               NeedsPythonTestReqs: true

--- a/package.json
+++ b/package.json
@@ -3472,6 +3472,8 @@
         "testJediLSP": "node ./out/test/languageServers/jedi/lspSetup.js && cross-env CODE_TESTS_WORKSPACE=src/test VSC_PYTHON_CI_TEST_GREP='Language Server:' node ./out/test/testBootstrap.js ./out/test/standardTest.js && node ./out/test/languageServers/jedi/lspTeardown.js",
         "pretestDataScience": "node ./out/test/datascience/dsTestSetup.js",
         "testDataScience": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_PYTHON_CI_TEST_VSC_CHANNEL=insiders TEST_FILES_SUFFIX=ds.test VSC_PYTHON_FORCE_LOGGING=1 VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
+        "pretestDataScienceInVSCode": "node ./out/test/datascience/dsTestSetup.js",
+        "testDataScienceInVSCode": "cross-env CODE_TESTS_WORKSPACE=src/test/datascience VSC_PYTHON_CI_TEST_VSC_CHANNEL=stable TEST_FILES_SUFFIX=vscode.test VSC_PYTHON_FORCE_LOGGING=1 VSC_PYTHON_LOAD_EXPERIMENTS_FROM_FILE=true node ./out/test/testBootstrap.js ./out/test/standardTest.js",
         "testMultiWorkspace": "node ./out/test/testBootstrap.js ./out/test/multiRootTest.js",
         "testPerformance": "node ./out/test/testBootstrap.js ./out/test/performanceTest.js",
         "testSmoke": "node ./out/test/smokeTest.js",

--- a/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditorOldWebView.ts
@@ -51,7 +51,7 @@ import {
 import { NativeEditor } from './nativeEditor';
 import { NativeEditorSynchronizer } from './nativeEditorSynchronizer';
 
-enum AskForSaveResult {
+export enum AskForSaveResult {
     Yes,
     No,
     Cancel

--- a/src/test/datascience/.vscode/settings.json
+++ b/src/test/datascience/.vscode/settings.json
@@ -13,7 +13,6 @@
     "python.formatting.provider": "yapf",
     "python.pythonPath": "python",
     "python.experiments.optInto": [
-        "LocalZMQKernel - experiment",
         "NativeNotebook - experiment"
     ],
     // Do not set this to "Microsoft", else it will result in LS being downloaded on CI
@@ -22,8 +21,11 @@
     "python.languageServer": "Jedi",
     // Ensure auto save is off.
     "files.autoSave": "off",
+    //If enabled, ensure we save immediately.
+    "files.autoSaveDelay": 1,
     // We don't want jupyter to start when testing (DS functionality or anything else).
     "python.dataScience.disableJupyterAutoStart": true,
     "python.logging.level": "debug",
-    "python.dataScience.alwaysTrustNotebooks": true // In UI tests we don't want prompts for `Do you want to trust thie nb...`
+    "python.dataScience.alwaysTrustNotebooks": true, // In UI tests we don't want prompts for `Do you want to trust thie nb...`
+    "python.dataScience.useNotebookEditor": true
 }

--- a/src/test/datascience/dsTestSetup.ts
+++ b/src/test/datascience/dsTestSetup.ts
@@ -2,64 +2,77 @@
 // Licensed under the MIT License.
 
 import * as fs from 'fs-extra';
+import { applyEdits, ModificationOptions, modify } from 'jsonc-parser';
 import * as path from 'path';
+import { IS_CI_SERVER } from '../ciConstants';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
-/**
- * Modify package.json to ensure VSC Notebooks have been setup so tests can run.
- * This is required because we modify package.json during runtime, hence we need to do the same thing for tests.
- */
 
-const packageJsonFile = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'package.json');
-const content = JSON.parse(fs.readFileSync(packageJsonFile).toString());
+const settingsFile = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.vscode/settings.json');
 
-// This code is temporary.
-if (
-    !content.enableProposedApi ||
-    !Array.isArray(content.contributes.notebookOutputRenderer) ||
-    !Array.isArray(content.contributes.notebookProvider)
-) {
-    content.enableProposedApi = true;
-    content.contributes.notebookOutputRenderer = [
-        {
-            viewType: 'jupyter-notebook-renderer',
-            displayName: 'Jupyter Notebook Renderer',
-            mimeTypes: [
-                'application/geo+json',
-                'application/vdom.v1+json',
-                'application/vnd.dataresource+json',
-                'application/vnd.plotly.v1+json',
-                'application/vnd.vega.v2+json',
-                'application/vnd.vega.v3+json',
-                'application/vnd.vega.v4+json',
-                'application/vnd.vega.v5+json',
-                'application/vnd.vegalite.v1+json',
-                'application/vnd.vegalite.v2+json',
-                'application/vnd.vegalite.v3+json',
-                'application/vnd.vegalite.v4+json',
-                'application/x-nteract-model-debug+json',
-                'image/gif',
-                'image/png',
-                'image/jpeg',
-                'text/latex',
-                'text/vnd.plotly.v1+html'
-            ]
-        }
-    ];
-    content.contributes.notebookProvider = [
-        {
-            viewType: 'jupyter-notebook',
-            displayName: 'Jupyter Notebook',
-            selector: [
-                {
-                    filenamePattern: '*.ipynb'
-                }
-            ]
-        }
-    ];
+function updateTestsForNativeNotebooks() {
+    /**
+     * Modify package.json to ensure VSC Notebooks have been setup so tests can run.
+     * This is required because we modify package.json during runtime, hence we need to do the same thing for tests.
+     */
+    const packageJsonFile = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'package.json');
+    const content = JSON.parse(fs.readFileSync(packageJsonFile).toString());
+
+    // This code is temporary.
+    if (
+        !content.enableProposedApi ||
+        !Array.isArray(content.contributes.notebookOutputRenderer) ||
+        !Array.isArray(content.contributes.notebookProvider)
+    ) {
+        content.enableProposedApi = true;
+        content.contributes.notebookProvider = [
+            {
+                viewType: 'jupyter-notebook',
+                displayName: 'Jupyter Notebook',
+                selector: [
+                    {
+                        filenamePattern: '*.ipynb'
+                    }
+                ]
+            }
+        ];
+    }
+
+    // Update package.json to pick experiments from our custom settings.json file.
+    content.contributes.configuration.properties['python.experiments.optInto'].scope = 'resource';
+    content.contributes.configuration.properties['python.logging.level'].scope = 'resource';
+
+    fs.writeFileSync(packageJsonFile, JSON.stringify(content, undefined, 4));
+
+    updateSettings(true);
 }
 
-// Update package.json to pick experiments from our custom settings.json file.
-content.contributes.configuration.properties['python.experiments.optInto'].scope = 'resource';
-content.contributes.configuration.properties['python.logging.level'].scope = 'resource';
+function updateSettings(useNativeNotebooks: boolean) {
+    const modificationOptions: ModificationOptions = {
+        formattingOptions: {
+            tabSize: 4,
+            insertSpaces: true
+        }
+    };
+    let settingsJson = fs.readFileSync(settingsFile).toString();
+    const experiments = useNativeNotebooks ? ['NativeNotebook - experiment'] : [];
+    const autoSave = useNativeNotebooks ? 'off' : 'afterDelay';
 
-fs.writeFileSync(packageJsonFile, JSON.stringify(content, undefined, 4));
+    settingsJson = applyEdits(
+        settingsJson,
+        modify(settingsJson, ['python.experiments.optInto'], experiments, modificationOptions)
+    );
+    settingsJson = applyEdits(settingsJson, modify(settingsJson, ['files.autoSave'], autoSave, modificationOptions));
+
+    fs.writeFileSync(settingsFile, settingsJson);
+}
+function updateTestsForOldNotebooks() {
+    updateSettings(false);
+}
+
+if (!IS_CI_SERVER) {
+    // Noop.
+} else if (process.env.VSC_PYTHON_CI_TEST_VSC_CHANNEL === 'insiders') {
+    updateTestsForNativeNotebooks();
+} else {
+    updateTestsForOldNotebooks();
+}

--- a/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
+++ b/src/test/datascience/jupyter/kernels/installationPrompts.vscode.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { assert } from 'chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { IApplicationShell } from '../../../../client/common/application/types';
+import { ProductNames } from '../../../../client/common/installer/productNames';
+import { BufferDecoder } from '../../../../client/common/process/decoder';
+import { ProcessService } from '../../../../client/common/process/proc';
+import { IInstaller, InstallerResponse, Product } from '../../../../client/common/types';
+import { createDeferred } from '../../../../client/common/utils/async';
+import { Common, DataScience } from '../../../../client/common/utils/localize';
+import { INotebookEditorProvider } from '../../../../client/datascience/types';
+import { IS_CI_SERVER } from '../../../ciConstants';
+import { getOSType, IExtensionTestApi, OSType, waitForCondition } from '../../../common';
+import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../../../constants';
+import { closeActiveWindows, initialize } from '../../../initialize';
+import { openNotebook } from '../../helpers';
+import { closeNotebooksAndCleanUpAfterTests } from '../../notebook/helper';
+
+// tslint:disable: no-invalid-this max-func-body-length no-function-expression no-any
+suite('DataScience Install IPyKernel (slow) (install)', () => {
+    const nbFile = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/jupyter/kernels/nbWithKernel.ipynb');
+    const executable = getOSType() === OSType.Windows ? 'Scripts/python.exe' : 'bin/python'; // If running locally on Windows box.
+    const venvPythonPath = path.join(EXTENSION_ROOT_DIR_FOR_TESTS, 'src/test/datascience/.venvnokernel', executable);
+    const expectedPromptMessageSuffix = `requires ${ProductNames.get(Product.ipykernel)!} to be installed.`;
+
+    let api: IExtensionTestApi;
+    let editorProvider: INotebookEditorProvider;
+    let appShell: IApplicationShell;
+    let installer: IInstaller;
+    const delayForUITest = 30_000;
+    /*
+    This test requires a virtual environment to be created & registered as a kernel.
+    It also needs to have ipykernel installed in it.
+    */
+    suiteSetup(async function () {
+        this.timeout(60_000); // Slow test, we need to uninstall/install ipykernel.
+
+        // These are slow tests, hence lets run only on linux on CI.
+        if ((IS_CI_SERVER && getOSType() !== OSType.Linux) || !fs.pathExistsSync(venvPythonPath)) {
+            // Virtual env does not exist.
+            return this.skip();
+        }
+        api = await initialize();
+        appShell = api.serviceContainer.get<IApplicationShell>(IApplicationShell);
+        installer = api.serviceContainer.get<IInstaller>(IInstaller);
+        editorProvider = api.serviceContainer.get<INotebookEditorProvider>(INotebookEditorProvider);
+
+        // Uninstall ipykernel from the virtual env.
+        const proc = new ProcessService(new BufferDecoder());
+        await proc.exec(venvPythonPath, ['-m', 'pip', 'uninstall', 'ipykernel', '--yes']);
+    });
+
+    setup(closeActiveWindows);
+    teardown(closeNotebooksAndCleanUpAfterTests);
+
+    test('Test Install IPyKernel prompt message', async () => {
+        // Confirm the message has not changed.
+        assert.ok(
+            DataScience.libraryRequiredToLaunchJupyterKernelNotInstalledInterpreter()
+                .format('', ProductNames.get(Product.ipykernel)!)
+                .endsWith(expectedPromptMessageSuffix),
+            'Message has changed, please update this test'
+        );
+    });
+
+    test('Ensure prompt is displayed when ipykernel module is not found and it gets installed', async () => {
+        const promptDisplayed = createDeferred();
+        const installed = createDeferred();
+
+        // Confirm it is installed.
+        sinon.stub(installer, 'install').callsFake(async function (product: Product) {
+            // Call original method
+            const result: InstallerResponse = await ((installer.install as any).wrappedMethod.apply(
+                installer,
+                arguments
+            ) as Promise<InstallerResponse>);
+            if (product === Product.ipykernel && result === InstallerResponse.Installed) {
+                installed.resolve();
+            }
+            return result;
+        });
+
+        // Confirm message is displayed & we click 'Install` button.
+        sinon.stub(appShell, 'showErrorMessage').callsFake(function (message: string) {
+            if (message.endsWith(expectedPromptMessageSuffix)) {
+                promptDisplayed.resolve();
+                // User clicked ok to install it.
+                return Common.install();
+            }
+            return (appShell.showErrorMessage as any).wrappedMethod.apply(appShell, arguments);
+        });
+
+        await openNotebook(api.serviceContainer, nbFile);
+
+        // Run all cells
+        editorProvider.activeEditor!.runAllCells();
+
+        // The prompt should be displayed & ipykernel should get installed.
+        await waitForCondition(
+            async () => {
+                await Promise.all([promptDisplayed.promise, installed.promise]);
+                return true;
+            },
+            delayForUITest,
+            'Prompt not displayed or not installed successfully'
+        );
+    });
+});

--- a/src/test/datascience/jupyter/kernels/nbWithKernel.ipynb
+++ b/src/test/datascience/jupyter/kernels/nbWithKernel.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "1\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": ".venvnokernel",
+   "display_name": ".venvnokernel"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2-final"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -149,7 +149,20 @@ export async function run(): Promise<void> {
     }
 
     // Ignore `ds.test.js` test files when running other tests.
-    const ignoreGlob = options.testFilesSuffix.toLowerCase() === 'ds.test' ? [] : ['**/**.ds.test.js'];
+    const ignoreGlob: string[] = [];
+    switch (options.testFilesSuffix.toLowerCase()) {
+        case 'ds.test': {
+            ignoreGlob.push('**/**.vscode.test.js');
+            break;
+        }
+        case 'vscode.test': {
+            ignoreGlob.push('**/**.ds.test.js');
+            break;
+        }
+        default: {
+            ignoreGlob.push('**/**.vscode.test.js', '**/**.ds.test.js');
+        }
+    }
     const testFiles = await new Promise<string[]>((resolve, reject) => {
         glob(
             `**/**.${options.testFilesSuffix}.js`,


### PR DESCRIPTION
For #13970

**Basically as discussed in our other branch,** 
* Create `*.vscode.test.ts` tests to run in VSCode
* This is an end to end VS Code test
* Plan is to move the existing old (*.ds.test.ts) into this so that we run Native Notebooks using same way (i.e. drop `ds.test.ts` as we've decided to do in other branch - probably already done).


I need to commit a few other changes, but that's related to setting up of the tests (changes to `scripts` in package & the like).
Let me know what your initial thoughts are.