### PR TITLE
Make data viewer openable from the variables window while debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -929,7 +929,7 @@
             },
             {
                 "command": "python.datascience.showDataViewer",
-                "title": "View Tensor in Data Viewer",
+                "title": "%python.command.python.datascience.showDataViewer.title%",
                 "category": "Python"
             },
             {
@@ -1665,8 +1665,7 @@
                 {
                     "command": "python.datascience.showDataViewer",
                     "group": "1_view",
-                    "title": "View Tensor in Data Viewer",
-                    "when": "debugProtocolVariableMenuContext == 'Tensor'"
+                    "when": "debugProtocolVariableMenuContext == 'viewableInDataViewer'"
                 }
             ]
         },

--- a/package.json
+++ b/package.json
@@ -928,6 +928,11 @@
                 "category": "Python"
             },
             {
+                "command": "python.datascience.showDataViewer",
+                "title": "View Tensor in Data Viewer",
+                "category": "Python"
+            },
+            {
                 "command": "python.analysis.restartLanguageServer",
                 "title": "%python.command.python.analysis.restartLanguageServer.title%",
                 "category": "Python"
@@ -1654,6 +1659,14 @@
                     "command": "python.runTestNode",
                     "when": "view == python_tests && viewItem == suite && !busyTests",
                     "group": "inline@0"
+                }
+            ],
+            "debug/variables/context": [
+                {
+                    "command": "python.datascience.showDataViewer",
+                    "group": "1_view",
+                    "title": "View Tensor in Data Viewer",
+                    "when": "debugProtocolVariableMenuContext == 'Tensor'"
                 }
             ]
         },

--- a/package.nls.json
+++ b/package.nls.json
@@ -120,6 +120,7 @@
     "Datascience.currentlySelectedJupyterInterpreterForPlaceholder": "current: {0}",
     "python.command.python.analysis.clearCache.title": "Clear Module Analysis Cache",
     "python.command.python.analysis.restartLanguageServer.title": "Restart Language Server",
+    "python.command.python.datascience.showDataViewer.title": "View Value in Data Viewer",
     "python.snippet.launch.standard.label": "Python: Current File",
     "python.snippet.launch.module.label": "Python: Module",
     "python.snippet.launch.module.default": "enter-your-module-name",

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -3,7 +3,14 @@
 
 'use strict';
 
-import { CancellationToken, Position, TextDocument, Uri } from 'vscode';
+import {
+    CancellationToken,
+    DebugProtocolVariable,
+    DebugProtocolVariableContainer,
+    Position,
+    TextDocument,
+    Uri
+} from 'vscode';
 import { Commands as LSCommands } from '../../activation/commands';
 import { Commands as DSCommands } from '../../datascience/constants';
 import { KernelConnectionMetadata } from '../../datascience/jupyter/kernels/types';
@@ -204,4 +211,7 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.TrustNotebook]: [undefined | never | Uri];
     [DSCommands.NotebookEditorExpandAllCells]: [];
     [DSCommands.NotebookEditorCollapseAllCells]: [];
+    [DSCommands.ShowDataViewer]: [
+        { container: DebugProtocolVariableContainer | undefined; variable: DebugProtocolVariable }
+    ];
 }

--- a/src/client/common/application/commands.ts
+++ b/src/client/common/application/commands.ts
@@ -3,16 +3,10 @@
 
 'use strict';
 
-import {
-    CancellationToken,
-    DebugProtocolVariable,
-    DebugProtocolVariableContainer,
-    Position,
-    TextDocument,
-    Uri
-} from 'vscode';
+import { CancellationToken, Position, TextDocument, Uri } from 'vscode';
 import { Commands as LSCommands } from '../../activation/commands';
 import { Commands as DSCommands } from '../../datascience/constants';
+import { IShowDataViewerFromVariablePanel } from '../../datascience/interactive-common/interactiveWindowTypes';
 import { KernelConnectionMetadata } from '../../datascience/jupyter/kernels/types';
 import { INotebookModel, ISwitchKernelOptions } from '../../datascience/types';
 import { CommandSource } from '../../testing/common/constants';
@@ -211,7 +205,5 @@ export interface ICommandNameArgumentTypeMapping extends ICommandNameWithoutArgu
     [DSCommands.TrustNotebook]: [undefined | never | Uri];
     [DSCommands.NotebookEditorExpandAllCells]: [];
     [DSCommands.NotebookEditorCollapseAllCells]: [];
-    [DSCommands.ShowDataViewer]: [
-        { container: DebugProtocolVariableContainer | undefined; variable: DebugProtocolVariable }
-    ];
+    [DSCommands.ShowDataViewer]: [IShowDataViewerFromVariablePanel];
 }

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -111,6 +111,7 @@ export namespace Commands {
         'python.datascience.enableLoadingWidgetScriptsFromThirdPartySource';
     export const NotebookEditorExpandAllCells = 'python.datascience.notebookeditor.expandallcells';
     export const NotebookEditorCollapseAllCells = 'python.datascience.notebookeditor.collapseallcells';
+    export const ShowDataViewer = 'python.datascience.showDataViewer';;
 }
 
 export namespace CodeLensCommands {

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -111,7 +111,7 @@ export namespace Commands {
         'python.datascience.enableLoadingWidgetScriptsFromThirdPartySource';
     export const NotebookEditorExpandAllCells = 'python.datascience.notebookeditor.expandallcells';
     export const NotebookEditorCollapseAllCells = 'python.datascience.notebookeditor.collapseallcells';
-    export const ShowDataViewer = 'python.datascience.showDataViewer';;
+    export const ShowDataViewer = 'python.datascience.showDataViewer';
 }
 
 export namespace CodeLensCommands {

--- a/src/client/datascience/data-viewing/jupyterVariableDataProvider.ts
+++ b/src/client/datascience/data-viewing/jupyterVariableDataProvider.ts
@@ -57,7 +57,7 @@ export class JupyterVariableDataProvider implements IJupyterVariableDataProvider
         return;
     }
 
-    public setDependencies(variable: IJupyterVariable, notebook: INotebook): void {
+    public setDependencies(variable: IJupyterVariable, notebook?: INotebook): void {
         this.notebook = notebook;
         this.variable = variable;
     }
@@ -65,7 +65,7 @@ export class JupyterVariableDataProvider implements IJupyterVariableDataProvider
     public async getDataFrameInfo(): Promise<IDataFrameInfo> {
         let dataFrameInfo: IDataFrameInfo = {};
         await this.ensureInitialized();
-        if (this.variable && this.notebook) {
+        if (this.variable) {
             dataFrameInfo = {
                 columns: this.variable.columns
                     ? JupyterVariableDataProvider.getNormalizedColumns(this.variable.columns)
@@ -80,12 +80,12 @@ export class JupyterVariableDataProvider implements IJupyterVariableDataProvider
     public async getAllRows() {
         let allRows: IRowsResponse = [];
         await this.ensureInitialized();
-        if (this.variable && this.variable.rowCount && this.notebook) {
+        if (this.variable && this.variable.rowCount) {
             const dataFrameRows = await this.variableManager.getDataFrameRows(
                 this.variable,
-                this.notebook,
                 0,
-                this.variable.rowCount
+                this.variable.rowCount,
+                this.notebook
             );
             allRows = dataFrameRows && dataFrameRows.data ? (dataFrameRows.data as IRowsResponse) : [];
         }
@@ -95,8 +95,8 @@ export class JupyterVariableDataProvider implements IJupyterVariableDataProvider
     public async getRows(start: number, end: number) {
         let rows: IRowsResponse = [];
         await this.ensureInitialized();
-        if (this.variable && this.variable.rowCount && this.notebook) {
-            const dataFrameRows = await this.variableManager.getDataFrameRows(this.variable, this.notebook, start, end);
+        if (this.variable && this.variable.rowCount) {
+            const dataFrameRows = await this.variableManager.getDataFrameRows(this.variable, start, end, this.notebook);
             rows = dataFrameRows && dataFrameRows.data ? (dataFrameRows.data as IRowsResponse) : [];
         }
         return rows;
@@ -104,9 +104,9 @@ export class JupyterVariableDataProvider implements IJupyterVariableDataProvider
 
     private async ensureInitialized(): Promise<void> {
         // Postpone pre-req and variable initialization until data is requested.
-        if (!this.initialized && this.variable && this.notebook) {
+        if (!this.initialized && this.variable) {
             this.initialized = true;
-            await this.dependencyService.checkAndInstallMissingDependencies(this.notebook.getMatchingInterpreter());
+            await this.dependencyService.checkAndInstallMissingDependencies(this.notebook?.getMatchingInterpreter());
             this.variable = await this.variableManager.getDataFrameInfo(this.variable, this.notebook);
         }
     }

--- a/src/client/datascience/data-viewing/jupyterVariableDataProviderFactory.ts
+++ b/src/client/datascience/data-viewing/jupyterVariableDataProviderFactory.ts
@@ -15,9 +15,9 @@ import {
 
 @injectable()
 export class JupyterVariableDataProviderFactory implements IJupyterVariableDataProviderFactory {
-    constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) {}
+    constructor(@inject(IServiceContainer) private serviceContainer: IServiceContainer) { }
 
-    public async create(variable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariableDataProvider> {
+    public async create(variable: IJupyterVariable, notebook?: INotebook): Promise<IJupyterVariableDataProvider> {
         const jupyterVariableDataProvider = this.serviceContainer.get<IJupyterVariableDataProvider>(
             IJupyterVariableDataProvider
         );

--- a/src/client/datascience/editor-integration/hoverProvider.ts
+++ b/src/client/datascience/editor-integration/hoverProvider.ts
@@ -109,7 +109,7 @@ export class HoverProvider implements INotebookExecutionLogger, vscode.HoverProv
                     if (notebooks && notebooks.length) {
                         // Just use the first one to reply if more than one.
                         const match = await Promise.race(
-                            notebooks.map((n) => this.variableProvider.getMatchingVariable(n, word, t))
+                            notebooks.map((n) => this.variableProvider.getMatchingVariable(word, n, t))
                         );
                         if (match) {
                             return {

--- a/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
+++ b/src/client/datascience/interactive-common/intellisense/intellisenseProvider.ts
@@ -938,7 +938,7 @@ export class IntellisenseProvider implements IInteractiveWindowListener {
             const notebook = await this.getNotebook(token);
             if (notebook) {
                 try {
-                    const value = await this.variableProvider.getMatchingVariable(notebook, wordAtPosition, token);
+                    const value = await this.variableProvider.getMatchingVariable(wordAtPosition, notebook, token);
                     if (value) {
                         return {
                             contents: [`${wordAtPosition}: ${value.type} = ${value.value}`]

--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -889,7 +889,7 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
         if (
             !serverConnection &&
             this.configService.getSettings(this.owningResource).datascience.jupyterServerURI !==
-            Settings.JupyterServerLocalLaunch &&
+                Settings.JupyterServerLocalLaunch &&
             !this.configService.getSettings(this.owningResource).datascience.disableJupyterAutoStart
         ) {
             serverConnection = await this.notebookProvider.connect({ disableUI: true });
@@ -1444,12 +1444,12 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
         const response: IJupyterVariablesResponse = this._notebook
             ? await this.jupyterVariables.getVariables(this._notebook, args)
             : {
-                totalCount: 0,
-                pageResponse: [],
-                pageStartIndex: args?.startIndex,
-                executionCount: args?.executionCount,
-                refreshCount: args?.refreshCount || 0
-            };
+                  totalCount: 0,
+                  pageResponse: [],
+                  pageStartIndex: args?.startIndex,
+                  executionCount: args?.executionCount,
+                  refreshCount: args?.refreshCount || 0
+              };
 
         this.postMessage(InteractiveWindowMessages.GetVariablesResponse, response).ignoreErrors();
         sendTelemetryEvent(Telemetry.VariableExplorerVariableCount, undefined, { variableCount: response.totalCount });

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
-import { Uri } from 'vscode';
+import { DebugProtocolVariable, DebugProtocolVariableContainer, Uri } from 'vscode';
 import { DebugState, IServerState } from '../../../datascience-ui/interactive-common/mainState';
 
 import type { KernelMessage } from '@jupyterlab/services';
@@ -332,6 +332,11 @@ export interface IInsertCell {
 export interface IShowDataViewer {
     variable: IJupyterVariable;
     columnSize: number;
+}
+
+export interface IShowDataViewerFromVariablePanel {
+    container: DebugProtocolVariableContainer | undefined;
+    variable: DebugProtocolVariable;
 }
 
 export interface IRefreshVariablesRequest {

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -322,23 +322,19 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
             });
 
         this.lastKnownVariables = allowedVariables.map((v) => {
-            return convertDebuggerVariableToIJupyterVariable(v);
+            return {
+                name: v.name,
+                type: v.type!,
+                count: 0,
+                shape: '',
+                size: 0,
+                supportsDataExplorer: DataViewableTypes.has(v.type || ''),
+                value: v.value,
+                truncated: true,
+                frameId: v.variablesReference
+            };
         });
 
         this.refreshEventEmitter.fire();
     }
-}
-
-export function convertDebuggerVariableToIJupyterVariable(debuggerVariable: DebugProtocol.Variable) {
-    return {
-        name: debuggerVariable.name,
-        type: debuggerVariable.type!,
-        count: 0,
-        shape: '',
-        size: 0,
-        supportsDataExplorer: DataViewableTypes.has(debuggerVariable.type || ''),
-        value: debuggerVariable.value,
-        truncated: true,
-        frameId: debuggerVariable.variablesReference
-    };
 }

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -19,7 +19,7 @@ import {
     INotebook
 } from '../types';
 
-const DataViewableTypes: Set<string> = new Set<string>(['DataFrame', 'list', 'dict', 'ndarray', 'Series']);
+const DataViewableTypes: Set<string> = new Set<string>(['DataFrame', 'list', 'dict', 'ndarray', 'Series', 'Tensor']);
 const KnownExcludedVariables = new Set<string>(['In', 'Out', 'exit', 'quit']);
 
 @injectable()
@@ -33,7 +33,7 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
     constructor(
         @inject(IJupyterDebugService) @named(Identifiers.MULTIPLEXING_DEBUGSERVICE) private debugService: IDebugService,
         @inject(IConfigurationService) private configService: IConfigurationService
-    ) {}
+    ) { }
 
     public get refreshRequired(): Event<void> {
         return this.refreshEventEmitter.event;
@@ -294,10 +294,10 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
                 return true;
             })
             .map((v) => {
-                return v.type === 'Tensor'
-                    ? // tslint:disable-next-line: no-object-literal-type-assertion
-                      ({ ...v, __vscodeVariableMenuContext: 'Tensor' } as DebugProtocol.Variable)
-                    : v;
+                if (v.type && DataViewableTypes.has(v.type)) {
+                    v.__vscodeVariableMenuContext = 'viewableInDataViewer';
+                }
+                return v;
             });
 
         this.lastKnownVariables = allowedVariables.map((v) => {

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -322,19 +322,23 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
             });
 
         this.lastKnownVariables = allowedVariables.map((v) => {
-            return {
-                name: v.name,
-                type: v.type!,
-                count: 0,
-                shape: '',
-                size: 0,
-                supportsDataExplorer: DataViewableTypes.has(v.type || ''),
-                value: v.value,
-                truncated: true,
-                frameId: v.variablesReference
-            };
+            return convertDebugProtocolVariableToIJupyterVariable(v);
         });
 
         this.refreshEventEmitter.fire();
     }
+}
+
+export function convertDebugProtocolVariableToIJupyterVariable(variable: DebugProtocol.Variable) {
+    return {
+        name: variable.name,
+        type: variable.type!,
+        count: 0,
+        shape: '',
+        size: 0,
+        supportsDataExplorer: DataViewableTypes.has(variable.type || ''),
+        value: variable.value,
+        truncated: true,
+        frameId: variable.variablesReference
+    };
 }

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -274,24 +274,31 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
             ? this.configService.getSettings().datascience.variableExplorerExclude?.split(';')
             : [];
 
-        const allowedVariables = variablesResponse.body.variables.filter((v) => {
-            if (!v.name || !v.type || !v.value) {
-                return false;
-            }
-            if (exclusionList && exclusionList.includes(v.type)) {
-                return false;
-            }
-            if (v.name.startsWith('_')) {
-                return false;
-            }
-            if (KnownExcludedVariables.has(v.name)) {
-                return false;
-            }
-            if (v.type === 'NoneType') {
-                return false;
-            }
-            return true;
-        });
+        const allowedVariables = variablesResponse.body.variables
+            .filter((v) => {
+                if (!v.name || !v.type || !v.value) {
+                    return false;
+                }
+                if (exclusionList && exclusionList.includes(v.type)) {
+                    return false;
+                }
+                if (v.name.startsWith('_')) {
+                    return false;
+                }
+                if (KnownExcludedVariables.has(v.name)) {
+                    return false;
+                }
+                if (v.type === 'NoneType') {
+                    return false;
+                }
+                return true;
+            })
+            .map((v) => {
+                return v.type === 'Tensor'
+                    ? // tslint:disable-next-line: no-object-literal-type-assertion
+                      ({ ...v, __vscodeVariableMenuContext: 'Tensor' } as DebugProtocol.Variable)
+                    : v;
+            });
 
         this.lastKnownVariables = allowedVariables.map((v) => {
             return {

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -302,19 +302,23 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
             });
 
         this.lastKnownVariables = allowedVariables.map((v) => {
-            return {
-                name: v.name,
-                type: v.type!,
-                count: 0,
-                shape: '',
-                size: 0,
-                supportsDataExplorer: DataViewableTypes.has(v.type || ''),
-                value: v.value,
-                truncated: true,
-                frameId: v.variablesReference
-            };
+            return convertDebuggerVariableToIJupyterVariable(v);
         });
 
         this.refreshEventEmitter.fire();
     }
+}
+
+export function convertDebuggerVariableToIJupyterVariable(debuggerVariable: DebugProtocol.Variable) {
+    return {
+        name: debuggerVariable.name,
+        type: debuggerVariable.type!,
+        count: 0,
+        shape: '',
+        size: 0,
+        supportsDataExplorer: DataViewableTypes.has(debuggerVariable.type || ''),
+        value: debuggerVariable.value,
+        truncated: true,
+        frameId: debuggerVariable.variablesReference
+    };
 }

--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -33,7 +33,7 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
     constructor(
         @inject(IJupyterDebugService) @named(Identifiers.MULTIPLEXING_DEBUGSERVICE) private debugService: IDebugService,
         @inject(IConfigurationService) private configService: IConfigurationService
-    ) { }
+    ) {}
 
     public get refreshRequired(): Event<void> {
         return this.refreshEventEmitter.event;
@@ -295,7 +295,8 @@ export class DebuggerVariables implements IConditionalJupyterVariables, DebugAda
             })
             .map((v) => {
                 if (v.type && DataViewableTypes.has(v.type)) {
-                    v.__vscodeVariableMenuContext = 'viewableInDataViewer';
+                    // tslint:disable-next-line: no-any
+                    (v as any).__vscodeVariableMenuContext = 'viewableInDataViewer';
                 }
                 return v;
             });

--- a/src/client/datascience/jupyter/jupyterVariables.ts
+++ b/src/client/datascience/jupyter/jupyterVariables.ts
@@ -48,34 +48,34 @@ export class JupyterVariables implements IJupyterVariables {
     // IJupyterVariables implementation
     @captureTelemetry(Telemetry.VariableExplorerFetchTime, undefined, true)
     public async getVariables(
-        notebook: INotebook,
-        request: IJupyterVariablesRequest
+        request: IJupyterVariablesRequest,
+        notebook?: INotebook
     ): Promise<IJupyterVariablesResponse> {
-        return this.getVariableHandler(notebook).getVariables(notebook, request);
+        return this.getVariableHandler(notebook).getVariables(request, notebook);
     }
 
-    public getMatchingVariable(notebook: INotebook, name: string): Promise<IJupyterVariable | undefined> {
-        return this.getVariableHandler(notebook).getMatchingVariable(notebook, name);
+    public getMatchingVariable(name: string, notebook?: INotebook): Promise<IJupyterVariable | undefined> {
+        return this.getVariableHandler(notebook).getMatchingVariable(name, notebook);
     }
 
-    public async getDataFrameInfo(targetVariable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariable> {
+    public async getDataFrameInfo(targetVariable: IJupyterVariable, notebook?: INotebook): Promise<IJupyterVariable> {
         return this.getVariableHandler(notebook).getDataFrameInfo(targetVariable, notebook);
     }
 
     public async getDataFrameRows(
         targetVariable: IJupyterVariable,
-        notebook: INotebook,
         start: number,
-        end: number
+        end: number,
+        notebook?: INotebook
     ): Promise<JSONObject> {
-        return this.getVariableHandler(notebook).getDataFrameRows(targetVariable, notebook, start, end);
+        return this.getVariableHandler(notebook).getDataFrameRows(targetVariable, start, end, notebook);
     }
 
-    private getVariableHandler(notebook: INotebook): IJupyterVariables {
+    private getVariableHandler(notebook?: INotebook): IJupyterVariables {
         if (!this.experimentsManager.inExperiment(RunByLine.experiment)) {
             return this.oldVariables;
         }
-        if (this.debuggerVariables.active && notebook.status === ServerStatus.Busy) {
+        if (this.debuggerVariables.active && (!notebook || notebook.status === ServerStatus.Busy)) {
             return this.debuggerVariables;
         }
 

--- a/src/client/datascience/jupyter/kernelVariables.ts
+++ b/src/client/datascience/jupyter/kernelVariables.ts
@@ -56,16 +56,16 @@ export class KernelVariables implements IJupyterVariables {
 
     // IJupyterVariables implementation
     public async getVariables(
-        notebook: INotebook,
-        request: IJupyterVariablesRequest
+        request: IJupyterVariablesRequest,
+        notebook: INotebook
     ): Promise<IJupyterVariablesResponse> {
         // Run the language appropriate variable fetch
         return this.getVariablesBasedOnKernel(notebook, request);
     }
 
     public async getMatchingVariable(
-        notebook: INotebook,
         name: string,
+        notebook: INotebook,
         token?: CancellationToken
     ): Promise<IJupyterVariable | undefined> {
         // See if in the cache
@@ -124,9 +124,9 @@ export class KernelVariables implements IJupyterVariables {
 
     public async getDataFrameRows(
         targetVariable: IJupyterVariable,
-        notebook: INotebook,
         start: number,
-        end: number
+        end: number,
+        notebook: INotebook
     ): Promise<{}> {
         // Import the data frame script directory if we haven't already
         await this.importDataFrameScripts(notebook);

--- a/src/client/datascience/jupyter/oldJupyterVariables.ts
+++ b/src/client/datascience/jupyter/oldJupyterVariables.ts
@@ -58,7 +58,7 @@ export class OldJupyterVariables implements IJupyterVariables {
     constructor(
         @inject(IDataScienceFileSystem) private fs: IDataScienceFileSystem,
         @inject(IConfigurationService) private configService: IConfigurationService
-    ) {}
+    ) { }
 
     public get refreshRequired(): Event<void> {
         return this.refreshEventEmitter.event;
@@ -66,14 +66,14 @@ export class OldJupyterVariables implements IJupyterVariables {
 
     // IJupyterVariables implementation
     public async getVariables(
-        notebook: INotebook,
-        request: IJupyterVariablesRequest
+        request: IJupyterVariablesRequest,
+        notebook: INotebook
     ): Promise<IJupyterVariablesResponse> {
         // Run the language appropriate variable fetch
         return this.getVariablesBasedOnKernel(notebook, request);
     }
 
-    public async getMatchingVariable(_notebook: INotebook, _name: string): Promise<IJupyterVariable | undefined> {
+    public async getMatchingVariable(_name: string, _notebook: INotebook): Promise<IJupyterVariable | undefined> {
         // Not supported with old method.
         return undefined;
     }
@@ -91,9 +91,9 @@ export class OldJupyterVariables implements IJupyterVariables {
 
     public async getDataFrameRows(
         targetVariable: IJupyterVariable,
-        notebook: INotebook,
         start: number,
-        end: number
+        end: number,
+        notebook: INotebook
     ): Promise<{}> {
         // Run the get dataframe rows script
         return this.runScript<{}>(notebook, targetVariable, {}, () => this.fetchDataFrameRowsScript, [
@@ -324,7 +324,7 @@ export class OldJupyterVariables implements IJupyterVariables {
             result.pageStartIndex = startPos;
 
             // Do one at a time. All at once doesn't work as they all have to wait for each other anyway
-            for (let i = startPos; i < startPos + chunkSize && i < list.variables.length; ) {
+            for (let i = startPos; i < startPos + chunkSize && i < list.variables.length;) {
                 const fullVariable = list.variables[i].value
                     ? list.variables[i]
                     : await this.getVariableValueFromKernel(list.variables[i], notebook);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -860,28 +860,28 @@ export interface IJupyterVariable {
 
 export const IJupyterVariableDataProvider = Symbol('IJupyterVariableDataProvider');
 export interface IJupyterVariableDataProvider extends IDataViewerDataProvider {
-    setDependencies(variable: IJupyterVariable, notebook: INotebook): void;
+    setDependencies(variable: IJupyterVariable, notebook?: INotebook): void;
 }
 
 export const IJupyterVariableDataProviderFactory = Symbol('IJupyterVariableDataProviderFactory');
 export interface IJupyterVariableDataProviderFactory {
-    create(variable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariableDataProvider>;
+    create(variable: IJupyterVariable, notebook?: INotebook): Promise<IJupyterVariableDataProvider>;
 }
 
 export const IJupyterVariables = Symbol('IJupyterVariables');
 export interface IJupyterVariables {
     readonly refreshRequired: Event<void>;
-    getVariables(notebook: INotebook, request: IJupyterVariablesRequest): Promise<IJupyterVariablesResponse>;
-    getDataFrameInfo(targetVariable: IJupyterVariable, notebook: INotebook): Promise<IJupyterVariable>;
+    getVariables(request: IJupyterVariablesRequest, notebook?: INotebook): Promise<IJupyterVariablesResponse>;
+    getDataFrameInfo(targetVariable: IJupyterVariable, notebook?: INotebook): Promise<IJupyterVariable>;
     getDataFrameRows(
         targetVariable: IJupyterVariable,
-        notebook: INotebook,
         start: number,
-        end: number
+        end: number,
+        notebook?: INotebook
     ): Promise<JSONObject>;
     getMatchingVariable(
-        notebook: INotebook,
         name: string,
+        notebook?: INotebook,
         cancelToken?: CancellationToken
     ): Promise<IJupyterVariable | undefined>;
 }

--- a/src/test/datascience/commands/commandRegistry.unit.test.ts
+++ b/src/test/datascience/commands/commandRegistry.unit.test.ts
@@ -14,6 +14,8 @@ import { ExportCommands } from '../../../client/datascience/commands/exportComma
 import { NotebookCommands } from '../../../client/datascience/commands/notebookCommands';
 import { JupyterServerSelectorCommand } from '../../../client/datascience/commands/serverSelector';
 import { Commands } from '../../../client/datascience/constants';
+import { DataViewerFactory } from '../../../client/datascience/data-viewing/dataViewerFactory';
+import { JupyterVariableDataProviderFactory } from '../../../client/datascience/data-viewing/jupyterVariableDataProviderFactory';
 import { DataScienceFileSystem } from '../../../client/datascience/dataScienceFileSystem';
 import { DataScienceCodeLensProvider } from '../../../client/datascience/editor-integration/codelensprovider';
 import { NativeEditorProvider } from '../../../client/datascience/notebookStorage/nativeEditorProvider';
@@ -40,6 +42,8 @@ suite('DataScience - Commands', () => {
         const appShell = mock(ApplicationShell);
         const startPage = mock(StartPage);
         const exportCommand = mock(ExportCommands);
+        const jupyterVariableDataProviderFactory = mock(JupyterVariableDataProviderFactory);
+        const dataViewerFactory = mock(DataViewerFactory);
         const fileSystem = mock(DataScienceFileSystem);
 
         commandRegistry = new CommandRegistry(
@@ -57,6 +61,8 @@ suite('DataScience - Commands', () => {
             new MockOutputChannel('Jupyter'),
             instance(startPage),
             instance(exportCommand),
+            instance(jupyterVariableDataProviderFactory),
+            instance(dataViewerFactory),
             instance(fileSystem)
         );
     });

--- a/src/test/datascience/variableTestHelpers.ts
+++ b/src/test/datascience/variableTestHelpers.ts
@@ -140,21 +140,24 @@ export async function verifyCanFetchData<T>(
         identity: getDefaultInteractiveIdentity()
     });
     expect(notebook).to.not.be.undefined;
-    const variableList = await variableFetcher.getVariables(notebook!, {
-        executionCount,
-        startIndex: 0,
-        pageSize: 100,
-        sortAscending: true,
-        sortColumn: 'INDEX',
-        refreshCount: 0
-    });
+    const variableList = await variableFetcher.getVariables(
+        {
+            executionCount,
+            startIndex: 0,
+            pageSize: 100,
+            sortAscending: true,
+            sortColumn: 'INDEX',
+            refreshCount: 0
+        },
+        notebook!
+    );
     expect(variableList.pageResponse.length).to.be.greaterThan(0, 'No variables returned');
     const variable = variableList.pageResponse.find((v) => v.name === name);
     expect(variable).to.not.be.undefined;
     expect(variable?.supportsDataExplorer).to.eq(true, `Variable ${name} does not support data explorer`);
     const withInfo = await variableFetcher.getDataFrameInfo(variable!, notebook!);
     expect(withInfo.count).to.eq(rows.length, 'Wrong number of rows for variable');
-    const fetchedRows = await variableFetcher.getDataFrameRows(withInfo!, notebook!, 0, rows.length);
+    const fetchedRows = await variableFetcher.getDataFrameRows(withInfo!, 0, rows.length, notebook!);
     expect(fetchedRows.data).to.have.length(rows.length, 'Fetched rows data is not the correct size');
     for (let i = 0; i < rows.length; i += 1) {
         const fetchedRow = (fetchedRows.data as any)[i];

--- a/types/vscode.proposed.d.ts
+++ b/types/vscode.proposed.d.ts
@@ -716,4 +716,23 @@ declare module 'vscode' {
             priority?: number
         ): NotebookCellStatusBarItem;
     }
+
+    //#region debug
+
+    /**
+     * A DebugProtocolVariableContainer is an opaque stand-in type for the intersection of the Scope and Variable types defined in the Debug Adapter Protocol.
+     * See https://microsoft.github.io/debug-adapter-protocol/specification#Types_Scope and https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable.
+     */
+    export interface DebugProtocolVariableContainer {
+        // Properties: the intersection of DAP's Scope and Variable types.
+    }
+
+    /**
+     * A DebugProtocolVariable is an opaque stand-in type for the Variable type defined in the Debug Adapter Protocol.
+     * See https://microsoft.github.io/debug-adapter-protocol/specification#Types_Variable.
+     */
+    export interface DebugProtocolVariable {
+        // Properties: see details [here](https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_Variable).
+    }
+    //#endregion
 }


### PR DESCRIPTION
Per @greazer, changing the scope of this PR to provide users with a way to open the data viewer for data-viewable types, i.e.:
* 'DataFrame'
* 'list'
* 'dict'
* 'ndarray'
* 'Series'

![dataframes](https://user-images.githubusercontent.com/30305945/95404383-b8fd7880-08c9-11eb-9d7c-e6eafc159371.gif)

TODO:
- [ ] Currently doesn't work unless RBL experiment is enabled due to reliance on `jupyterVariables.getMatchingVariable` which is not implemented for oldJupyterVariables
- [ ] Need integration test
