### PR TITLE
GitHub bot should ignore epics when assigning data science issues

### DIFF
--- a/.github/workflows/assignIssue.yml
+++ b/.github/workflows/assignIssue.yml
@@ -22,7 +22,7 @@ jobs:
             ISSUE_ASSIGNEES: ${{toJson(github.event.issue.assignees)}}
             ISSUE_IS_INTERNAL: ${{steps.internal.outputs.result}}
         run: |
-          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('Epic') == 0).length === 1 ? 1 : 0")
+          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('Epic') == -1).length === 1 ? 1 : 0")
         shell: bash
       - uses: actions/checkout@v2
         if: steps.proceed.outputs.result == 1

--- a/.github/workflows/assignIssue.yml
+++ b/.github/workflows/assignIssue.yml
@@ -22,7 +22,7 @@ jobs:
             ISSUE_ASSIGNEES: ${{toJson(github.event.issue.assignees)}}
             ISSUE_IS_INTERNAL: ${{steps.internal.outputs.result}}
         run: |
-          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('Epic') == -1).length === 1 ? 1 : 0")
+          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('Epic') === -1).length === 1 ? 1 : 0")
         shell: bash
       - uses: actions/checkout@v2
         if: steps.proceed.outputs.result == 1

--- a/.github/workflows/assignIssue.yml
+++ b/.github/workflows/assignIssue.yml
@@ -22,7 +22,7 @@ jobs:
             ISSUE_ASSIGNEES: ${{toJson(github.event.issue.assignees)}}
             ISSUE_IS_INTERNAL: ${{steps.internal.outputs.result}}
         run: |
-          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0).length === 1 ? 1 : 0")
+          echo ::set-output name=result::$(node -p -e "process.env.ISSUE_IS_INTERNAL === '0' && JSON.parse(process.env.ISSUE_ASSIGNEES).length === 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('data science') >= 0 && JSON.parse(process.env.ISSUE_LABELS).filter(item => item.name.indexOf('Epic') == 0).length === 1 ? 1 : 0")
         shell: bash
       - uses: actions/checkout@v2
         if: steps.proceed.outputs.result == 1


### PR DESCRIPTION
Noticed that https://github.com/microsoft/vscode-python/issues/14208 got auto assigned to Don

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
