### PR TITLE
Fixes to blowing away of kernel info & not using right startup info

### DIFF
--- a/build/ci/templates/test_phases.yml
+++ b/build/ci/templates/test_phases.yml
@@ -118,7 +118,7 @@ steps:
       python -c "import sys;print(sys.executable)"
     displayName: 'pip install functional requirements'
     condition: and(succeeded(), eq(variables['NeedsPythonFunctionalReqs'], 'true'))
-    
+
   # Add CONDA to the path so anaconda works
   #
   # This task will only run if variable `NeedsPythonFunctionalReqs` is true.
@@ -422,7 +422,7 @@ steps:
   # Upload the test results to Azure DevOps to facilitate test reporting in their UX.
   - task: PublishTestResults@2
     displayName: 'Publish functional tests results'
-    condition: or(contains(variables['TestsToRun'], 'testFunctional'), contains(variables['TestsToRun'], 'testParallelFunctional')) 
+    condition: or(contains(variables['TestsToRun'], 'testFunctional'), contains(variables['TestsToRun'], 'testParallelFunctional'))
     inputs:
       testResultsFiles: '$(Build.ArtifactStagingDirectory)/test-junit*.xml'
       testRunTitle: 'functional-$(Agent.Os)-Py$(pythonVersion)'
@@ -446,7 +446,7 @@ steps:
   - script: |
       npm run testDataScience
     continueOnError: true
-    displayName: 'Run DataScience Tests in VSCode Insiders'
+    displayName: 'Run Native Notebook Tests in VSCode Insiders'
     condition: and(succeeded(), contains(variables['TestsToRun'], 'testDataScience'), not(contains(variables['TestsToRun'], 'testDataScienceInVSCode')))
     env:
       DISPLAY: :10

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -53,7 +53,7 @@ stages:
             'Single Workspace':
               TestsToRun: 'testSingleWorkspace'
               NeedsPythonTestReqs: true
-            'DataScience':
+            'Native Notebook':
               TestsToRun: 'testDataScience'
               NeedsPythonTestReqs: true
               NeedsPythonFunctionalReqs: true

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -123,7 +123,7 @@ export abstract class BaseJupyterSession implements IJupyterSession {
         }
     }
     public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
-        if (!this.session){
+        if (!this.session) {
             throw new Error('Cannot request KernelInfo, Session not initialized.');
         }
         return this.session.kernel.requestKernelInfo();

--- a/src/client/datascience/baseJupyterSession.ts
+++ b/src/client/datascience/baseJupyterSession.ts
@@ -122,7 +122,12 @@ export abstract class BaseJupyterSession implements IJupyterSession {
             );
         }
     }
-
+    public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
+        if (!this.session){
+            throw new Error('Cannot request KernelInfo, Session not initialized.');
+        }
+        return this.session.kernel.requestKernelInfo();
+    }
     public async changeKernel(kernelConnection: KernelConnectionMetadata, timeoutMS: number): Promise<void> {
         let newSession: ISessionWithSocket | undefined;
 

--- a/src/client/datascience/constants.ts
+++ b/src/client/datascience/constants.ts
@@ -574,6 +574,7 @@ export namespace LiveShareCommands {
     export const getUsableJupyterPython = 'getUsableJupyterPython';
     export const executeObservable = 'executeObservable';
     export const getSysInfo = 'getSysInfo';
+    export const requestKernelInfo = 'requestKernelInfo';
     export const serverResponse = 'serverResponse';
     export const catchupRequest = 'catchupRequest';
     export const syncRequest = 'synchRequest';

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -241,7 +241,9 @@ export class JupyterNotebookBase implements INotebook {
             }
         }
     }
-
+    public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
+        return this.session.requestKernelInfo();
+    }
     public get onSessionStatusChanged(): Event<ServerStatus> {
         if (!this.onStatusChangedEvent) {
             this.onStatusChangedEvent = new EventEmitter<ServerStatus>();

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -19,7 +19,7 @@ import {
 } from 'vscode';
 import { ServerStatus } from '../../../../datascience-ui/interactive-common/mainState';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../common/application/types';
-import { traceError } from '../../../common/logger';
+import { traceError, traceWarning } from '../../../common/logger';
 import { IDisposableRegistry } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { noop } from '../../../common/utils/misc';
@@ -239,7 +239,7 @@ export class Kernel implements IKernel {
         await this.notebook
             .requestKernelInfo()
             .then((item) => (this._info = item.content))
-            .catch(noop);
+            .catch(traceWarning.bind('Failed to request KernelInfo'));
         await this.notebook.waitForIdle(this.launchTimeout);
     }
 

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -238,12 +238,7 @@ export class Kernel implements IKernel {
         }
         await this.notebook
             .requestKernelInfo()
-            .then((item) => {
-                this._info = item.content;
-            })
-            .catch((ex) => {
-                console.error('ooops', ex);
-            })
+            .then((item) => (this._info = item.content))
             .catch(noop);
         await this.notebook.waitForIdle(this.launchTimeout);
     }

--- a/src/client/datascience/jupyter/kernels/kernel.ts
+++ b/src/client/datascience/jupyter/kernels/kernel.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { nbformat } from '@jupyterlab/coreutils';
+import { KernelMessage } from '@jupyterlab/services';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import * as uuid from 'uuid/v4';
@@ -22,7 +23,6 @@ import { traceError } from '../../../common/logger';
 import { IDisposableRegistry } from '../../../common/types';
 import { createDeferred, Deferred } from '../../../common/utils/async';
 import { noop } from '../../../common/utils/misc';
-import { IInterpreterService } from '../../../interpreter/contracts';
 import { CodeSnippets } from '../../constants';
 import { getDefaultNotebookContent, updateNotebookMetadata } from '../../notebookStorage/baseModel';
 import {
@@ -50,6 +50,10 @@ export class Kernel implements IKernel {
     }
     get onDisposed(): Event<void> {
         return this._onDisposed.event;
+    }
+    private _info?: KernelMessage.IInfoReplyMsg['content'];
+    get info(): KernelMessage.IInfoReplyMsg['content'] | undefined {
+        return this._info;
     }
     get status(): ServerStatus {
         return this.notebook?.status ?? ServerStatus.NotStarted;
@@ -79,7 +83,6 @@ export class Kernel implements IKernel {
         private readonly disposables: IDisposableRegistry,
         private readonly launchTimeout: number,
         commandManager: ICommandManager,
-        interpreterService: IInterpreterService,
         private readonly errorHandler: IDataScienceErrorHandler,
         editorProvider: INotebookEditorProvider,
         private readonly kernelProvider: IKernelProvider,
@@ -90,12 +93,12 @@ export class Kernel implements IKernel {
         this.kernelExecution = new KernelExecution(
             kernelProvider,
             commandManager,
-            interpreterService,
             errorHandler,
             editorProvider,
             kernelSelectionUsage,
             appShell,
-            vscNotebook
+            vscNotebook,
+            metadata
         );
     }
     public async executeCell(cell: NotebookCell): Promise<void> {
@@ -124,8 +127,9 @@ export class Kernel implements IKernel {
         } else {
             await this.validate(this.uri);
             const metadata = ((getDefaultNotebookContent().metadata || {}) as unknown) as nbformat.INotebookMetadata;
+            // Create a dummy notebook metadata & update the metadata before starting the notebook (required to ensure we fetch & start the right kernel).
+            // Lower layers of code below getOrCreateNotebook searches for kernels again using the metadata.
             updateNotebookMetadata(metadata, this.metadata);
-
             this._notebookPromise = this.notebookProvider.getOrCreateNotebook({
                 identity: this.uri,
                 resource: this.uri,
@@ -232,6 +236,15 @@ export class Kernel implements IKernel {
         if (isPythonKernelConnection(this.metadata)) {
             await this.notebook.setLaunchingFile(this.uri.fsPath);
         }
+        await this.notebook
+            .requestKernelInfo()
+            .then((item) => {
+                this._info = item.content;
+            })
+            .catch((ex) => {
+                console.error('ooops', ex);
+            })
+            .catch(noop);
         await this.notebook.waitForIdle(this.launchTimeout);
     }
 

--- a/src/client/datascience/jupyter/kernels/kernelProvider.ts
+++ b/src/client/datascience/jupyter/kernels/kernelProvider.ts
@@ -9,7 +9,6 @@ import { Uri } from 'vscode';
 import { IApplicationShell, ICommandManager, IVSCodeNotebook } from '../../../common/application/types';
 import { traceInfo, traceWarning } from '../../../common/logger';
 import { IAsyncDisposableRegistry, IConfigurationService, IDisposableRegistry } from '../../../common/types';
-import { IInterpreterService } from '../../../interpreter/contracts';
 import { IDataScienceErrorHandler, INotebookEditorProvider, INotebookProvider } from '../../types';
 import { Kernel } from './kernel';
 import { KernelSelector } from './kernelSelector';
@@ -24,7 +23,6 @@ export class KernelProvider implements IKernelProvider {
         @inject(INotebookProvider) private notebookProvider: INotebookProvider,
         @inject(IConfigurationService) private configService: IConfigurationService,
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
-        @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IDataScienceErrorHandler) private readonly errorHandler: IDataScienceErrorHandler,
         @inject(INotebookEditorProvider) private readonly editorProvider: INotebookEditorProvider,
         @inject(KernelSelector) private readonly kernelSelectionUsage: IKernelSelectionUsage,
@@ -50,7 +48,6 @@ export class KernelProvider implements IKernelProvider {
             this.disposables,
             waitForIdleTimeout,
             this.commandManager,
-            this.interpreterService,
             this.errorHandler,
             this.editorProvider,
             this,

--- a/src/client/datascience/jupyter/kernels/types.ts
+++ b/src/client/datascience/jupyter/kernels/types.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import type { Session } from '@jupyterlab/services';
+import type { KernelMessage, Session } from '@jupyterlab/services';
 import type { Observable } from 'rxjs/Observable';
 import type { CancellationToken, Event, QuickPickItem, Uri } from 'vscode';
 import { NotebookCell, NotebookDocument } from '../../../../../types/vscode-proposed';
@@ -130,6 +130,11 @@ export interface IKernel extends IAsyncDisposable {
     readonly onRestarted: Event<void>;
     readonly status: ServerStatus;
     readonly disposed: boolean;
+    /**
+     * Kernel information, used to save in ipynb in the metadata.
+     * Crucial for non-python notebooks, else we save the incorrect information.
+     */
+    readonly info?: KernelMessage.IInfoReplyMsg['content'];
     readonly kernelSocket: Observable<KernelSocketInformation | undefined>;
     start(): Promise<void>;
     interrupt(): Promise<InterruptResult>;

--- a/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
@@ -206,7 +206,6 @@ export class GuestJupyterNotebook
     }
 
     public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
-
         // This is a special case. Ask the shared server
         const service = await this.waitForService();
         if (service) {

--- a/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
+++ b/src/client/datascience/jupyter/liveshare/guestJupyterNotebook.ts
@@ -205,6 +205,17 @@ export class GuestJupyterNotebook
         }
     }
 
+    public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
+
+        // This is a special case. Ask the shared server
+        const service = await this.waitForService();
+        if (service) {
+            return service.request(LiveShareCommands.getSysInfo, []);
+        } else {
+            throw new Error('No LiveShare service to get KernelInfo');
+        }
+    }
+
     public async getCompletion(
         _cellCode: string,
         _offsetInCode: number,

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -27,6 +27,7 @@ import { JupyterNotebookView } from '../constants';
 // tslint:disable-next-line: no-var-requires no-require-imports
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 // tslint:disable-next-line: no-require-imports
+import { KernelMessage } from '@jupyterlab/services';
 import cloneDeep = require('lodash/cloneDeep');
 import { isUntitledFile } from '../../../common/utils/misc';
 import { KernelConnectionMetadata } from '../../jupyter/kernels/types';
@@ -54,7 +55,10 @@ export function isJupyterNotebook(option: NotebookDocument | string) {
     }
 }
 
-const kernelInformationForNotebooks = new WeakMap<NotebookDocument, KernelConnectionMetadata | undefined>();
+const kernelInformationForNotebooks = new WeakMap<
+    NotebookDocument,
+    { metadata?: KernelConnectionMetadata | undefined; kernelInfo?: KernelMessage.IInfoReplyMsg['content'] }
+>();
 
 export function getNotebookMetadata(document: NotebookDocument): nbformat.INotebookMetadata | undefined {
     // tslint:disable-next-line: no-any
@@ -70,8 +74,9 @@ export function getNotebookMetadata(document: NotebookDocument): nbformat.INoteb
         notebookContent = { ...content, metadata: { ...metadata, language_info } } as any;
     }
     notebookContent = cloneDeep(notebookContent);
-    if (kernelInformationForNotebooks.has(document)) {
-        updateNotebookMetadata(notebookContent.metadata, kernelInformationForNotebooks.get(document));
+    const data = kernelInformationForNotebooks.get(document);
+    if (data && data.metadata) {
+        updateNotebookMetadata(notebookContent.metadata, data.metadata, data.kernelInfo);
     }
 
     return notebookContent.metadata;
@@ -88,7 +93,20 @@ export function updateKernelInNotebookMetadata(
     document: NotebookDocument,
     kernelConnection: KernelConnectionMetadata | undefined
 ) {
-    kernelInformationForNotebooks.set(document, kernelConnection);
+    const data = { ...(kernelInformationForNotebooks.get(document) || {}) };
+    data.metadata = kernelConnection;
+    kernelInformationForNotebooks.set(document, data);
+}
+export function updateKernelInfoInNotebookMetadata(
+    document: NotebookDocument,
+    kernelInfo: KernelMessage.IInfoReplyMsg['content']
+) {
+    if (kernelInformationForNotebooks.get(document)?.kernelInfo === kernelInfo) {
+        return;
+    }
+    const data = { ...(kernelInformationForNotebooks.get(document) || {}) };
+    data.kernelInfo = kernelInfo;
+    kernelInformationForNotebooks.set(document, data);
 }
 /**
  * Converts a NotebookModel into VSCode friendly format.

--- a/src/client/datascience/notebook/helpers/helpers.ts
+++ b/src/client/datascience/notebook/helpers/helpers.ts
@@ -28,6 +28,7 @@ import { JupyterNotebookView } from '../constants';
 const vscodeNotebookEnums = require('vscode') as typeof import('vscode-proposed');
 // tslint:disable-next-line: no-require-imports
 import { KernelMessage } from '@jupyterlab/services';
+// tslint:disable-next-line: no-require-imports
 import cloneDeep = require('lodash/cloneDeep');
 import { isUntitledFile } from '../../../common/utils/misc';
 import { KernelConnectionMetadata } from '../../jupyter/kernels/types';

--- a/src/client/datascience/notebookStorage/notebookStorageProvider.ts
+++ b/src/client/datascience/notebookStorage/notebookStorageProvider.ts
@@ -90,7 +90,12 @@ export class NotebookStorageProvider implements INotebookStorageProvider {
         const uri = this.getNextNewNotebookUri(forVSCodeNotebooks);
 
         // Always skip loading from the hot exit file. When creating a new file we want a new file.
-        return this.getOrCreateModel({ file: uri, possibleContents, skipLoadingDirtyContents: true });
+        return this.getOrCreateModel({
+            file: uri,
+            possibleContents,
+            skipLoadingDirtyContents: true,
+            isNative: forVSCodeNotebooks
+        });
     }
 
     private getNextNewNotebookUri(forVSCodeNotebooks?: boolean): Uri {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -203,6 +203,7 @@ export interface INotebook extends IAsyncDisposable {
     interruptKernel(timeoutInMs: number): Promise<InterruptResult>;
     setLaunchingFile(file: string): Promise<void>;
     getSysInfo(): Promise<ICell | undefined>;
+    requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg>;
     setMatplotLibStyle(useDark: boolean): Promise<void>;
     getMatchingInterpreter(): PythonEnvironment | undefined;
     /**
@@ -360,6 +361,7 @@ export interface IJupyterSession extends IAsyncDisposable {
         hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>
     ): void;
     removeMessageHook(msgId: string, hook: (msg: KernelMessage.IIOPubMessage) => boolean | PromiseLike<boolean>): void;
+    requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg>;
 }
 
 export type ISessionWithSocket = Session.ISession & {

--- a/src/test/datascience/mockJupyterNotebook.ts
+++ b/src/test/datascience/mockJupyterNotebook.ts
@@ -23,6 +23,8 @@ import { PythonEnvironment } from '../../client/pythonEnvironments/info';
 import { ServerStatus } from '../../datascience-ui/interactive-common/mainState';
 import { noop } from '../core';
 
+// tslint:disable: no-any
+
 export class MockJupyterNotebook implements INotebook {
     public get connection(): INotebookProviderConnection | undefined {
         return this.providerConnection;
@@ -60,6 +62,26 @@ export class MockJupyterNotebook implements INotebook {
 
     constructor(private providerConnection: INotebookProviderConnection | undefined) {
         noop();
+    }
+    public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
+        return {
+            channel: 'shell',
+            content: {
+                protocol_version: '',
+                banner: '',
+                language_info: {
+                    name: 'py',
+                    version: '3'
+                },
+                status: 'ok',
+                implementation: '',
+                implementation_version: '',
+                help_links: []
+            },
+            header: {} as any,
+            metadata: {} as any,
+            parent_header: {} as any
+        };
     }
     public registerIOPubListener(_listener: (msg: KernelMessage.IIOPubMessage, requestId: string) => void): void {
         noop();

--- a/src/test/datascience/mockJupyterSession.ts
+++ b/src/test/datascience/mockJupyterSession.ts
@@ -82,7 +82,26 @@ export class MockJupyterSession implements IJupyterSession {
         }
         return sleep(this.timedelay);
     }
-
+    public async requestKernelInfo(): Promise<KernelMessage.IInfoReplyMsg> {
+        return {
+            channel: 'shell',
+            content: {
+                protocol_version: '',
+                banner: '',
+                language_info: {
+                    name: 'py',
+                    version: '3'
+                },
+                status: 'ok',
+                implementation: '',
+                implementation_version: '',
+                help_links: []
+            },
+            header: {} as any,
+            metadata: {} as any,
+            parent_header: {} as any
+        };
+    }
     public prolongRestarts() {
         this.forceRestartTimeout = true;
     }

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -196,8 +196,7 @@ export async function startJupyter(closeInitialEditor: boolean) {
     const disposables: IDisposable[] = [];
     try {
         await editorProvider.createNew();
-        await deleteAllCellsAndWait();
-        await insertPythonCell('print("Hello World")');
+        await insertPythonCell('print("Hello World")', 0);
         const cell = vscodeNotebook.activeNotebookEditor!.document.cells[0]!;
         await executeActiveDocument();
         // Wait for Jupyter to start.


### PR DESCRIPTION
* When starting a kernel we're re-generating the kernel connection information
* We're blowing away language_info
* With non-python kernels we're storing python information in the notebook

**Here's what the metadata in ipynb looks like:**
```json
// Julia
 "metadata": {
  "kernelspec": {
   "display_name": "Julia 1.5.2",
   "name": "julia-1.5"
  },
  "language_info": {
   "file_extension": ".jl",
   "mimetype": "application/julia",
   "name": "julia",
   "version": "1.5.2"
  },
  "orig_nbformat": 2
 },

// C#
 "metadata": {
  "kernelspec": {
   "display_name": ".NET (C#)",
   "name": ".net-csharp"
  },
  "language_info": {
   "file_extension": ".cs",
   "mimetype": "text/x-csharp",
   "name": "C#",
   "pygments_lexer": "csharp",
   "version": "8.0"
  },

// Python
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3.8.2 64-bit ('venvDS': venv)",
   "name": "python38264bitvenvdsvenv6326db73e23e42c7a6a8df252feeb441"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 3
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": "3.8.2"
  },

```