### PR TITLE
Dont run DS full test on insider's push yet

### DIFF
--- a/.github/workflows/pr_datascience.yml
+++ b/.github/workflows/pr_datascience.yml
@@ -1,9 +1,6 @@
 name: Pull Request DataScience
 
 on:
-  push: 
-    branches: 
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Insider's builds are failing strangely. Looks like 'push' to main is the insider's condition for running so having it in two spots doesn't make any sense.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
