### PR TITLE
Ignore formatting in ipynb when dealing with trust

### DIFF
--- a/src/client/datascience/notebookStorage/vscNotebookModel.ts
+++ b/src/client/datascience/notebookStorage/vscNotebookModel.ts
@@ -18,7 +18,7 @@ import { BaseNotebookModel } from './baseModel';
 
 // https://github.com/microsoft/vscode-python/issues/13155
 // tslint:disable-next-line: no-any
-function sortObjectPropertiesRecursively(obj: any): any {
+export function sortObjectPropertiesRecursively(obj: any): any {
     if (Array.isArray(obj)) {
         return obj.map(sortObjectPropertiesRecursively);
     }


### PR DESCRIPTION
The ipynb generated by native notebooks, Standard notebooks & Jupyter can differ.
One of the main reason is indentation & sorting of properties in the JSON.

When trusting a notebook, we aren't trusting the raw bytes of the notebook, instead the contents.
I.e. if we have 2 white spaces or 4 white spaces in JSON, its still the same content, JSON is identical.

This PR ensures we trust the contents (JSON) of the IPYNB, instead of trusting the string representation of IPYNB.

Required for Native Notebooks, something I spoke to @rchiodo  about. Cannot find the issue where we had this discussion (possibly on teams).
