### PR TITLE
Statusbar no interpreter color use default

### DIFF
--- a/news/1 Enhancements/14859.md
+++ b/news/1 Enhancements/14859.md
@@ -1,0 +1,1 @@
+Use default color for "Select Python interpreter" on the status bar. (thanks [danielfrg](https://github.com/danielfrg)!)

--- a/src/client/interpreter/display/index.ts
+++ b/src/client/interpreter/display/index.ts
@@ -102,7 +102,7 @@ export class InterpreterDisplay implements IInterpreterDisplay {
             this.currentlySelectedInterpreterPath = interpreter.path;
         } else {
             this.statusBar.tooltip = '';
-            this.statusBar.color = 'yellow';
+            this.statusBar.color = '';
             this.statusBar.text = '$(alert) Select Python Interpreter';
             this.currentlySelectedInterpreterPath = undefined;
         }

--- a/src/test/interpreters/display.unit.test.ts
+++ b/src/test/interpreters/display.unit.test.ts
@@ -234,7 +234,7 @@ suite('Interpreters Display', () => {
 
         await interpreterDisplay.refresh(resource);
 
-        statusBar.verify((s) => (s.color = TypeMoq.It.isValue('yellow')), TypeMoq.Times.once());
+        statusBar.verify((s) => (s.color = TypeMoq.It.isValue('')), TypeMoq.Times.once());
         statusBar.verify(
             (s) => (s.text = TypeMoq.It.isValue('$(alert) Select Python Interpreter')),
             TypeMoq.Times.once()


### PR DESCRIPTION
The yellow default works fine with vscode default theme but its not ideal in other not-dark-mode themes, with this at least is possible to customize it on the vs code settings.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).~
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~

