### PR TITLE
Fix markdown cell marker formatting for export to Python

### DIFF
--- a/news/2 Fixes/14359.md
+++ b/news/2 Fixes/14359.md
@@ -1,0 +1,1 @@
+Fix markdown cell marker when exporting a notebook to a Python script.

--- a/src/client/datascience/jupyter/jupyterImporter.ts
+++ b/src/client/datascience/jupyter/jupyterImporter.ts
@@ -36,7 +36,7 @@ export class JupyterImporter implements INotebookImporter {
 {% endblock codecell %}
 {% block in_prompt %}{% endblock in_prompt %}
 {% block input %}{{ cell.source | ipython2python }}{% endblock input %}
-{% block markdowncell scoped %}{0} [markdown]
+{% block markdowncell scoped %}{1} [markdown]
 {{ cell.source | comment_lines }}
 {% endblock markdowncell %}`;
     private readonly nbconvert5Null = 'null.tpl';
@@ -53,7 +53,7 @@ export class JupyterImporter implements INotebookImporter {
         @inject(INbConvertInterpreterDependencyChecker)
         private readonly nbConvertDependencyChecker: INbConvertInterpreterDependencyChecker,
         @inject(INbConvertExportToPythonService) private readonly exportToPythonService: INbConvertExportToPythonService
-    ) {}
+    ) { }
 
     public async importFromFile(sourceFile: Uri, interpreter: PythonEnvironment): Promise<string> {
         // If the user has requested it, add a cd command to the imported file so that relative paths still work

--- a/src/client/datascience/jupyter/jupyterImporter.ts
+++ b/src/client/datascience/jupyter/jupyterImporter.ts
@@ -53,7 +53,7 @@ export class JupyterImporter implements INotebookImporter {
         @inject(INbConvertInterpreterDependencyChecker)
         private readonly nbConvertDependencyChecker: INbConvertInterpreterDependencyChecker,
         @inject(INbConvertExportToPythonService) private readonly exportToPythonService: INbConvertExportToPythonService
-    ) { }
+    ) {}
 
     public async importFromFile(sourceFile: Uri, interpreter: PythonEnvironment): Promise<string> {
         // If the user has requested it, add a cd command to the imported file so that relative paths still work

--- a/src/test/datascience/notebook.functional.test.ts
+++ b/src/test/datascience/notebook.functional.test.ts
@@ -676,6 +676,7 @@ suite('DataScience notebook tests', () => {
 
                     // Make sure we have a cell in our results
                     assert.ok(/#\s*%%/.test(results), 'No cells in returned import');
+                    assert.ok(!results.includes('tpl'), 'Formatted template with wrong arguments');
                 } finally {
                     try {
                         importer.dispose();


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/14359

We changed how we format `nbconvertBaseTemplateFormat`, the template itself also needed updating:

https://github.com/microsoft/vscode-python/blob/74253efac697778e4a5b9969d97ec2d9b14d6a10/src/client/datascience/jupyter/jupyterImporter.ts#L39

and

https://github.com/microsoft/vscode-python/blob/74253efac697778e4a5b9969d97ec2d9b14d6a10/src/client/datascience/jupyter/jupyterImporter.ts#L183-L185

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
