### PR TITLE
Add more logging to figure out why raw kernel did not start

### DIFF
--- a/src/client/datascience/interactive-common/interactiveBase.ts
+++ b/src/client/datascience/interactive-common/interactiveBase.ts
@@ -943,6 +943,7 @@ export abstract class InteractiveBase extends WebviewPanelHost<IInteractiveWindo
                 await this.ensureNotebook(serverConnection);
             }
         } catch (exc) {
+            traceError(`Exception attempting to start notebook: `, exc);
             // We should dispose ourselves if the load fails. Othewise the user
             // updates their install and we just fail again because the load promise is the same.
             await this.closeBecauseOfFailure(exc);

--- a/src/client/datascience/jupyter/jupyterNotebook.ts
+++ b/src/client/datascience/jupyter/jupyterNotebook.ts
@@ -277,6 +277,8 @@ export class JupyterNotebookBase implements INotebook {
         this.ranInitialSetup = true;
         this._workingDirectory = undefined;
 
+        traceInfo(`Initial setup for ${this.identity.toString()} starting ...`);
+
         try {
             // When we start our notebook initial, change to our workspace or user specified root directory
             await this.updateWorkingDirectoryAndPath();

--- a/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
+++ b/src/client/datascience/raw-kernel/liveshare/hostRawNotebookProvider.ts
@@ -136,6 +136,7 @@ export class HostRawNotebookProvider
         notebookMetadata?: nbformat.INotebookMetadata,
         cancelToken?: CancellationToken
     ): Promise<INotebook> {
+        traceInfo(`Creating raw notebook for ${identity.toString()}`);
         const notebookPromise = createDeferred<INotebook>();
         this.setNotebook(identity, notebookPromise.promise);
 
@@ -143,6 +144,7 @@ export class HostRawNotebookProvider
             ? this.progressReporter.createProgressIndicator(localize.DataScience.connectingIPyKernel())
             : undefined;
 
+        traceInfo(`Computing working directory ${identity.toString()}`);
         const workingDirectory = await computeWorkingDirectory(resource, this.workspaceService);
 
         const rawSession = new RawJupyterSession(
@@ -155,6 +157,8 @@ export class HostRawNotebookProvider
         );
         try {
             const launchTimeout = this.configService.getSettings().datascience.jupyterLaunchTimeout;
+
+            traceInfo(`Getting preferred kernel for ${identity.toString()}`);
 
             // We need to locate kernelspec and possible interpreter for this launch based on resource and notebook metadata
             const kernelConnectionMetadata = await this.kernelSelector.getPreferredKernelForLocalConnection(
@@ -173,6 +177,7 @@ export class HostRawNotebookProvider
             ) {
                 notebookPromise.reject('Failed to find a kernelspec to use for ipykernel launch');
             } else {
+                traceInfo(`Connecting to raw session for ${identity.toString()}`);
                 await rawSession.connect(kernelConnectionMetadata, launchTimeout, cancelToken);
 
                 // Get the execution info for our notebook


### PR DESCRIPTION
In this run here, it looks like the ipywidget test failed for a legitimate reason - the kernel wouldn't start:

https://github.com/microsoft/vscode-python/pull/14360/checks?check_run_id=1236347273

I'm adding some more logging to see if we can figure out why.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
