### PR TITLE
Fix multiprocessing problems with setting __file__

### DIFF
--- a/news/2 Fixes/12530.md
+++ b/news/2 Fixes/12530.md
@@ -1,0 +1,1 @@
+Only set ```__file__``` when not already set or is different.

--- a/news/2 Fixes/12530.md
+++ b/news/2 Fixes/12530.md
@@ -1,1 +1,1 @@
-Only set ```__file__``` when not already set or is different.
+Make sure not to set ```__file__``` unless necessary as this can mess up some modules (like multiprocessing)

--- a/src/client/datascience/interactive-ipynb/nativeEditor.ts
+++ b/src/client/datascience/interactive-ipynb/nativeEditor.ts
@@ -579,6 +579,10 @@ export class NativeEditor extends InteractiveBase implements INotebookEditor {
         // Actually don't close, just let the error bubble out
     }
 
+    protected async setFileInKernel(_file: string, _cancelToken: CancellationToken | undefined): Promise<void> {
+        // Native editor doesn't set this as the ipython file should be set for a notebook.
+    }
+
     protected async close(): Promise<void> {
         // Fire our event
         this.closedEvent.fire(this);


### PR DESCRIPTION
For #12530 

We were setting the ```__file__``` on every execution. This slows things down and actually can break the case as described in the bug. Since this was rather simple and the user in the bug is stuck on a specific version I sent him, figured I'd just fix this.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
