### PR TITLE
Don't exclude startPage files in .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,6 @@
 **/*.map
 **/*.analyzer.html
-!out/startPage-ui/viewers/commons.initial.bundle.js.map
+!out/startPage-ui/viewers/
 *.vsix
 .appveyor.yml
 .editorconfig
@@ -69,10 +69,6 @@ obj/**
 out/**/*.stats.json
 out/client/**/*.analyzer.html
 out/coverconfig.json
-out/startPage-ui/common/**
-out/startPage-ui/startPage/**
-out/startPage-ui/react-common/**
-out/startPage-ui/viewers/**
 out/pythonFiles/**
 out/src/**
 out/test/**

--- a/build/webpack/webpack.startPage-ui.config.js
+++ b/build/webpack/webpack.startPage-ui.config.js
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-'use strict';
-
-const builder = require('./webpack.startPage-ui.config.builder');
-module.exports = [builder.viewers];

--- a/package.json
+++ b/package.json
@@ -1949,7 +1949,7 @@
         "compile": "tsc -watch -p ./",
         "compiled": "deemon npm run compile",
         "kill-compiled": "deemon --kill npm run compile",
-        "compile-webviews-watch": "cross-env NODE_OPTIONS=--max_old_space_size=9096 webpack --config ./build/webpack/webpack.startPage-ui.config.js --watch",
+        "compile-webviews-watch": "cross-env NODE_OPTIONS=--max_old_space_size=9096 webpack --config ./build/webpack/webpack.startPage-ui-viewers.config.js --watch",
         "compile-webviews-watchd": "deemon npm run compile-webviews-watch",
         "kill-compile-webviews-watchd": "deemon --kill npm run compile-webviews-watch",
         "checkDependencies": "gulp checkDependencies",

--- a/src/test/common/moduleInstaller.test.ts
+++ b/src/test/common/moduleInstaller.test.ts
@@ -28,6 +28,7 @@ import {
     ICustomEditorService,
     IDebugService,
     IDocumentManager,
+    IJupyterExtensionDependencyManager,
     IWorkspaceService
 } from '../../client/common/application/types';
 import { WorkspaceService } from '../../client/common/application/workspace';
@@ -125,6 +126,7 @@ import {
     PIPENV_SERVICE
 } from '../../client/interpreter/contracts';
 import { IServiceContainer } from '../../client/ioc/types';
+import { JupyterExtensionDependencyManager } from '../../client/jupyter/jupyterExtensionDependencyManager';
 import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironments/info';
 import { ImportTracker } from '../../client/telemetry/importTracker';
 import { IImportTracker } from '../../client/telemetry/types';
@@ -234,6 +236,10 @@ suite('Module Installer', () => {
             ioc.serviceManager.addSingleton<IDocumentManager>(IDocumentManager, DocumentManager);
             ioc.serviceManager.addSingleton<IDebugService>(IDebugService, DebugService);
             ioc.serviceManager.addSingleton<IApplicationEnvironment>(IApplicationEnvironment, ApplicationEnvironment);
+            ioc.serviceManager.addSingleton<IJupyterExtensionDependencyManager>(
+                IJupyterExtensionDependencyManager,
+                JupyterExtensionDependencyManager
+            );
             ioc.serviceManager.addSingleton<IBrowserService>(IBrowserService, BrowserService);
             ioc.serviceManager.addSingleton<IHttpClient>(IHttpClient, HttpClient);
             ioc.serviceManager.addSingleton<IFileDownloader>(IFileDownloader, FileDownloader);


### PR DESCRIPTION
Spent all morning debugging our gulp tasks and eventually found that [files that are excluded in .vscodeignore will also be excluded by `vsce package`](https://github.com/Microsoft/vscode-vsce/issues/266). The prePublishBundle and prePublishNonBundle tasks worked perfectly, but the common bundle js and startpage.js files were being dropped at the packaging stage because of those four lines in .vscodeignore.

Also deleting webpack.startPage-ui.config.js in WIP/NoDS because it's already gone in main and is identical to webpack.startPage-ui-viewers.config.js.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
