### PR TITLE
Add data science product installers

### DIFF
--- a/build/ci/vscode-python-ci.yaml
+++ b/build/ci/vscode-python-ci.yaml
@@ -66,10 +66,6 @@ stages:
             'Debugger':
               TestsToRun: 'testDebugger'
               NeedsPythonTestReqs: true
-            'DataScience in VSCode':
-              TestsToRun: 'testDataScienceInVSCode'
-              NeedsPythonTestReqs: true
-              NeedsPythonFunctionalReqs: true
             'Smoke':
               TestsToRun: 'testSmoke'
               NeedsPythonTestReqs: true
@@ -138,10 +134,6 @@ stages:
             'Debugger':
               TestsToRun: 'testDebugger'
               NeedsPythonTestReqs: true
-            'DataScience in VSCode':
-              TestsToRun: 'testDataScienceInVSCode'
-              NeedsPythonTestReqs: true
-              NeedsPythonFunctionalReqs: true
             'Smoke':
               TestsToRun: 'testSmoke'
               NeedsPythonTestReqs: true

--- a/build/ci/vscode-python-pr-validation.yaml
+++ b/build/ci/vscode-python-pr-validation.yaml
@@ -57,10 +57,6 @@ stages:
               TestsToRun: 'testDataScience'
               NeedsPythonTestReqs: true
               NeedsPythonFunctionalReqs: true
-            'DataScience in VSCode':
-              TestsToRun: 'testDataScienceInVSCode'
-              NeedsPythonTestReqs: true
-              NeedsPythonFunctionalReqs: true
             'Smoke':
               TestsToRun: 'testSmoke'
               NeedsPythonTestReqs: true

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "author": {
         "name": "Microsoft Corporation"
     },
-    "extensionDependencies": [
-        "ms-toolsai.jupyter"
-    ],
     "license": "MIT",
     "homepage": "https://github.com/Microsoft/vscode-python",
     "repository": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -104,6 +104,8 @@
     "Installer.noCondaOrPipInstaller": "There is no Conda or Pip installer available in the selected environment.",
     "Installer.noPipInstaller": "There is no Pip installer available in the selected environment.",
     "Installer.searchForHelp": "Search for help",
+    "Installer.couldNotInstallLibrary":
+        "Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.",
     "diagnostics.removedPythonPathFromSettings": "We removed the \"python.pythonPath\" setting from your settings.json file as the setting is no longer used by the Python extension. You can get the path of your selected interpreter in the Python output channel. [Learn more](https://aka.ms/AA7jfor).",
     "diagnostics.warnSourceMaps": "Source map support is enabled in the Python Extension, this will adversely impact performance of the extension.",
     "diagnostics.disableSourceMaps": "Disable Source Map Support",

--- a/src/client/common/installer/productService.ts
+++ b/src/client/common/installer/productService.ts
@@ -28,6 +28,12 @@ export class ProductService implements IProductService {
         this.ProductTypes.set(Product.black, ProductType.Formatter);
         this.ProductTypes.set(Product.yapf, ProductType.Formatter);
         this.ProductTypes.set(Product.rope, ProductType.RefactoringLibrary);
+        this.ProductTypes.set(Product.jupyter, ProductType.DataScience);
+        this.ProductTypes.set(Product.notebook, ProductType.DataScience);
+        this.ProductTypes.set(Product.ipykernel, ProductType.DataScience);
+        this.ProductTypes.set(Product.nbconvert, ProductType.DataScience);
+        this.ProductTypes.set(Product.kernelspec, ProductType.DataScience);
+        this.ProductTypes.set(Product.pandas, ProductType.DataScience);
     }
     public getProductType(product: Product): ProductType {
         return this.ProductTypes.get(product)!;

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -77,7 +77,8 @@ export enum ProductType {
     Formatter = 'Formatter',
     TestFramework = 'TestFramework',
     RefactoringLibrary = 'RefactoringLibrary',
-    WorkspaceSymbols = 'WorkspaceSymbols'
+    WorkspaceSymbols = 'WorkspaceSymbols',
+    DataScience = 'DataScience'
 }
 
 export enum Product {
@@ -97,7 +98,13 @@ export enum Product {
     rope = 14,
     isort = 15,
     black = 16,
-    bandit = 17
+    bandit = 17,
+    jupyter = 18,
+    ipykernel = 19,
+    notebook = 20,
+    kernelspec = 21,
+    nbconvert = 22,
+    pandas = 23
 }
 
 export enum ModuleNamePurpose {

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -297,6 +297,10 @@ export namespace Installer {
         'There is no Pip installer available in the selected environment.'
     );
     export const searchForHelp = localize('Installer.searchForHelp', 'Search for help');
+    export const couldNotInstallLibrary = localize(
+        'Installer.couldNotInstallLibrary',
+        'Could not install {0}. If pip is not available, please use the package manager of your choice to manually install this library into your Python environment.'
+    );
 }
 
 export namespace ExtensionSurveyBanner {

--- a/src/test/common/installer.test.ts
+++ b/src/test/common/installer.test.ts
@@ -324,7 +324,11 @@ suite('Installer', () => {
         await checkInstalledDef.promise;
     }
     getNamesAndValues<Product>(Product).forEach((prod) => {
-        test(`Ensure isInstalled for Product: '${prod.name}' executes the right command`, async () => {
+        test(`Ensure isInstalled for Product: '${prod.name}' executes the right command`, async function () {
+            if (new ProductService().getProductType(prod.value) === ProductType.DataScience) {
+                // tslint:disable-next-line: no-invalid-this
+                return this.skip();
+            }
             ioc.serviceManager.addSingletonInstance<IModuleInstaller>(
                 IModuleInstaller,
                 new MockModuleInstaller('one', false)
@@ -357,7 +361,11 @@ suite('Installer', () => {
         await checkInstalledDef.promise;
     }
     getNamesAndValues<Product>(Product).forEach((prod) => {
-        test(`Ensure install for Product: '${prod.name}' executes the right command in IModuleInstaller`, async () => {
+        test(`Ensure install for Product: '${prod.name}' executes the right command in IModuleInstaller`, async function () {
+            if (new ProductService().getProductType(prod.value) === ProductType.DataScience) {
+                // tslint:disable-next-line: no-invalid-this
+                return this.skip();
+            }
             ioc.serviceManager.addSingletonInstance<IModuleInstaller>(
                 IModuleInstaller,
                 new MockModuleInstaller('one', false)

--- a/src/test/common/installer/installer.invalidPath.unit.test.ts
+++ b/src/test/common/installer/installer.invalidPath.unit.test.ts
@@ -13,7 +13,7 @@ import '../../../client/common/extensions';
 import { ProductInstaller } from '../../../client/common/installer/productInstaller';
 import { ProductService } from '../../../client/common/installer/productService';
 import { IProductPathService, IProductService } from '../../../client/common/installer/types';
-import { IPersistentState, IPersistentStateFactory, Product } from '../../../client/common/types';
+import { IPersistentState, IPersistentStateFactory, Product, ProductType } from '../../../client/common/types';
 import { getNamesAndValues } from '../../../client/common/utils/enum';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
@@ -35,7 +35,11 @@ suite('Module Installer - Invalid Paths', () => {
                 let productPathService: TypeMoq.IMock<IProductPathService>;
                 let persistentState: TypeMoq.IMock<IPersistentStateFactory>;
 
-                setup(() => {
+                setup(function () {
+                    if (new ProductService().getProductType(product.value) === ProductType.DataScience) {
+                        // tslint:disable-next-line: no-invalid-this
+                        return this.skip();
+                    }
                     serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
                     const outputChannel = TypeMoq.Mock.ofType<OutputChannel>();
 

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -61,7 +61,7 @@ import { sleep } from '../../common';
 
 use(chaiAsPromised);
 
-suite('Module Installer only', () => {
+suite('Module Installer onlyxxx', () => {
     [undefined, Uri.file('resource')].forEach((resource) => {
         // tslint:disable-next-line: cyclomatic-complexity
         getNamesAndValues<Product>(Product)
@@ -149,6 +149,10 @@ suite('Module Installer only', () => {
                     installer = new ProductInstaller(serviceContainer.object, outputChannel.object);
                 });
                 teardown(() => {
+                    if (new ProductService().getProductType(product.value) === ProductType.DataScience) {
+                        sinon.restore();
+                        return;
+                    }
                     // This must be resolved, else all subsequent tests will fail (as this same promise will be used for other tests).
                     promptDeferred.resolve();
                     disposables.forEach((disposable) => {

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -65,7 +65,7 @@ suite('Module Installer only', () => {
     [undefined, Uri.file('resource')].forEach((resource) => {
         // tslint:disable-next-line: cyclomatic-complexity
         getNamesAndValues<Product>(Product)
-            .concat([{ name: 'Unkown product', value: 404 }])
+            .concat([{ name: 'Unknown product', value: 404 }])
             // tslint:disable-next-line: cyclomatic-complexity
             .forEach((product) => {
                 let disposables: Disposable[] = [];
@@ -83,6 +83,9 @@ suite('Module Installer only', () => {
                 const productService = new ProductService();
 
                 setup(function () {
+                    if (new ProductService().getProductType(product.value) === ProductType.DataScience) {
+                        return this.skip();
+                    }
                     promptDeferred = createDeferred<string>();
                     serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
                     outputChannel = TypeMoq.Mock.ofType<OutputChannel>();

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -61,7 +61,7 @@ import { sleep } from '../../common';
 
 use(chaiAsPromised);
 
-suite('Module Installer onlyxxx', () => {
+suite('Module Installer only', () => {
     [undefined, Uri.file('resource')].forEach((resource) => {
         // tslint:disable-next-line: cyclomatic-complexity
         getNamesAndValues<Product>(Product)
@@ -74,7 +74,7 @@ suite('Module Installer onlyxxx', () => {
                 let moduleInstaller: TypeMoq.IMock<IModuleInstaller>;
                 let serviceContainer: TypeMoq.IMock<IServiceContainer>;
                 let app: TypeMoq.IMock<IApplicationShell>;
-                let promptDeferred: Deferred<string>;
+                let promptDeferred: Deferred<string> | undefined;
                 let workspaceService: TypeMoq.IMock<IWorkspaceService>;
                 let persistentStore: TypeMoq.IMock<IPersistentStateFactory>;
                 let outputChannel: TypeMoq.IMock<OutputChannel>;
@@ -154,7 +154,9 @@ suite('Module Installer onlyxxx', () => {
                         return;
                     }
                     // This must be resolved, else all subsequent tests will fail (as this same promise will be used for other tests).
-                    promptDeferred.resolve();
+                    if (promptDeferred) {
+                        promptDeferred.resolve();
+                    }
                     disposables.forEach((disposable) => {
                         if (disposable) {
                             disposable.dispose();
@@ -330,7 +332,7 @@ suite('Module Installer onlyxxx', () => {
                                     )
                                 )
                                     .returns(() => {
-                                        return promptDeferred.promise;
+                                        return promptDeferred!.promise;
                                     })
                                     .verifiable(TypeMoq.Times.once());
                                 const persistVal = TypeMoq.Mock.ofType<IPersistentState<boolean>>();

--- a/src/test/common/installer/installer.unit.test.ts
+++ b/src/test/common/installer/installer.unit.test.ts
@@ -82,11 +82,13 @@ suite('Module Installer only', () => {
                 let interpreterService: TypeMoq.IMock<IInterpreterService>;
                 const productService = new ProductService();
 
-                setup(() => {
+                setup(function () {
                     promptDeferred = createDeferred<string>();
                     serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
                     outputChannel = TypeMoq.Mock.ofType<OutputChannel>();
-
+                    if (new ProductService().getProductType(product.value) === ProductType.DataScience) {
+                        return this.skip();
+                    }
                     disposables = [];
                     serviceContainer
                         .setup((c) => c.get(TypeMoq.It.isValue(IDisposableRegistry), TypeMoq.It.isAny()))

--- a/src/test/common/installer/productPath.unit.test.ts
+++ b/src/test/common/installer/productPath.unit.test.ts
@@ -55,7 +55,10 @@ suite('Product Path', () => {
             let workspaceSymnbolSettings: TypeMoq.IMock<IWorkspaceSymbolSettings>;
             let configService: TypeMoq.IMock<IConfigurationService>;
             let productInstaller: ProductInstaller;
-            setup(() => {
+            setup(function () {
+                if (new ProductService().getProductType(product.value) === ProductType.DataScience) {
+                    return this.skip();
+                }
                 serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
                 configService = TypeMoq.Mock.ofType<IConfigurationService>();
                 formattingSettings = TypeMoq.Mock.ofType<IFormattingSettings>();


### PR DESCRIPTION
We need to bring back the installers.
Python extension is responsible for installing python packages (these were deleted, but required).
