### PR TITLE
Specify the retention length for artifacts

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           name: ${{env.ARTIFACT_NAME_VSIX}}
           path: ${{env.VSIX_NAME}}
+          retention-days: 7
 
   lint:
     name: Lint
@@ -298,10 +299,11 @@ jobs:
 
       # Upload unit test coverage reports for later use in the "reports" job.
       - name: Upload unit test coverage reports
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: ${{runner.os}}-${{env.COVERAGE_REPORTS}}
           path: ${{ env.special-working-directory }}/.nyc_output
+          retention-days: 1
         if: matrix.test-suite == 'ts-unit' && startsWith(matrix.python, 3.)
 
       # Run the Python and IPython tests in our codebase.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           name: ${{ env.ARTIFACT_NAME_VSIX }}
           path: ${{ env.VSIX_NAME }}
+          retention-days: 14
 
   lint:
     # Unlike for the insiders build, we skip linting file formatting as that


### PR DESCRIPTION
As discussed with Kim and Karthik:

- 14 days for release branches (to cover time from cutting the branch to doing a release)
- 7 days for `main` (to cover time between commits and potential consecutive failures preventing uploading to Azure Blob Storage)
- 1 day for code coverage (as the workflow will upload to Codecov)