### PR TITLE
Bump plotly.js-dist v1.57.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19561,9 +19561,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.56.0",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.56.0.tgz",
-            "integrity": "sha512-vkNePImh00Ka8zm8/2bkhL5XyIf9vjNKojSQqHd45UIgrvv1k9io31SFK+gUgz+KLYki8/QN4Qz6abifKVcu9Q==",
+            "version": "1.57.0",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.0.tgz",
+            "integrity": "sha512-PE9uO+cORryPgDhfyoEhb150wuJYpl/mZFPuWhKvSV8zRLmlQkBeetTU9JW3dwzblUElSHQ7A5GiyulwWPlDZQ==",
             "dev": true
         },
         "plugin-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19561,9 +19561,9 @@
             }
         },
         "plotly.js-dist": {
-            "version": "1.57.0",
-            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.0.tgz",
-            "integrity": "sha512-PE9uO+cORryPgDhfyoEhb150wuJYpl/mZFPuWhKvSV8zRLmlQkBeetTU9JW3dwzblUElSHQ7A5GiyulwWPlDZQ==",
+            "version": "1.57.1",
+            "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.1.tgz",
+            "integrity": "sha512-tOOFxNc6PvdDkOUgWCSYc+CcxQULTpaGTROxrtmmF8NuZghcT3EInsToEzhPH3PcGM6bu61fKo73ZiFqxwYtlg==",
             "dev": true
         },
         "plugin-error": {

--- a/package.json
+++ b/package.json
@@ -3724,7 +3724,7 @@
         "node-html-parser": "^1.1.13",
         "nyc": "^15.0.0",
         "playwright-chromium": "^0.13.0",
-        "plotly.js-dist": "^1.56.0",
+        "plotly.js-dist": "^1.57.0",
         "postcss": "^7.0.27",
         "postcss-cssnext": "^3.1.0",
         "postcss-import": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -3724,7 +3724,7 @@
         "node-html-parser": "^1.1.13",
         "nyc": "^15.0.0",
         "playwright-chromium": "^0.13.0",
-        "plotly.js-dist": "^1.57.0",
+        "plotly.js-dist": "^1.57.1",
         "postcss": "^7.0.27",
         "postcss-cssnext": "^3.1.0",
         "postcss-import": "^12.0.1",


### PR DESCRIPTION
Bumping `plotly.js-dist` module now that `plotly.js` `v1.57.1` is out 
https://github.com/plotly/plotly.js/releases/tag/v1.57.0
https://github.com/plotly/plotly.js/releases/tag/v1.57.1

-   [x] skip news
-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).

Similar to PR #14183
Also FYI a PR is submitted to https://github.com/nteract/outputs/pull/24 and https://github.com/nteract/outputs/pull/28.

@rchiodo
cc: @nicolaskruchten 
