### PR TITLE
Update IJupyterKernelSpec to reflect that language may be undefined

### DIFF
--- a/src/client/datascience/jupyter/kernels/kernelService.ts
+++ b/src/client/datascience/jupyter/kernels/kernelService.ts
@@ -111,7 +111,7 @@ export class KernelService {
         const specs = await this.getKernelSpecs(sessionManager, cancelToken);
         if (isInterpreter(option)) {
             return specs.find((item) => {
-                if (item.language.toLowerCase() !== PYTHON_LANGUAGE.toLowerCase()) {
+                if (item.language?.toLowerCase() !== PYTHON_LANGUAGE.toLowerCase()) {
                     return false;
                 }
                 return (

--- a/src/client/datascience/kernel-launcher/kernelFinder.ts
+++ b/src/client/datascience/kernel-launcher/kernelFinder.ts
@@ -144,7 +144,7 @@ export class KernelFinder implements IKernelFinder {
 
     private async findKernelSpecBasedOnLanguage(resource: Resource, language: string) {
         const specs = await this.listKernelSpecs(resource);
-        return specs.find((item) => item.language.toLowerCase() === language.toLowerCase());
+        return specs.find((item) => item.language?.toLowerCase() === language.toLowerCase());
     }
 
     private async findResourceKernelSpecs(resource: Resource): Promise<IJupyterKernelSpec[]> {

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -412,9 +412,9 @@ export interface IJupyterKernelSpec {
      */
     id?: string;
     name: string;
-    language: string;
+    language?: string;
     path: string;
-    env: NodeJS.ProcessEnv | undefined;
+    env?: NodeJS.ProcessEnv | undefined;
     /**
      * Kernel display name.
      *

--- a/src/test/datascience/notebook/helper.ts
+++ b/src/test/datascience/notebook/helper.ts
@@ -197,7 +197,7 @@ export async function waitForKernelToGetAutoSelected(expectedLanguage?: string) 
         if (vscodeNotebook.activeNotebookEditor.kernel instanceof VSCodeNotebookKernelMetadata) {
             if (vscodeNotebook.activeNotebookEditor.kernel.selection.kind === 'startUsingKernelSpec') {
                 return (
-                    vscodeNotebook.activeNotebookEditor.kernel.selection.kernelSpec.language.toLowerCase() ===
+                    vscodeNotebook.activeNotebookEditor.kernel.selection.kernelSpec.language?.toLowerCase() ===
                     expectedLanguage.toLowerCase()
                 );
             }


### PR DESCRIPTION
Not all kernelspecs have the language property set. Prevents errors like this:

![image](https://user-images.githubusercontent.com/30305945/96310464-3c028b00-0fbc-11eb-8958-438d4714d44c.png)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
