### PR TITLE
expandWorkingDir falls back to os.tmpdir

### DIFF
--- a/src/client/datascience/jupyter/jupyterUtils.ts
+++ b/src/client/datascience/jupyter/jupyterUtils.ts
@@ -4,6 +4,7 @@
 import '../../common/extensions';
 
 import * as fs from 'fs-extra';
+import * as os from 'os';
 import * as path from 'path';
 import { Uri } from 'vscode';
 
@@ -13,6 +14,16 @@ import { noop } from '../../common/utils/misc';
 import { SystemVariables } from '../../common/variables/systemVariables';
 import { getJupyterConnectionDisplayName } from '../jupyter/jupyterConnection';
 import { IJupyterConnection, IJupyterServerUri } from '../types';
+
+function is_writable(directory: string): boolean {
+    try {
+        // const trialNotebook = path.join(directory, `${uuid()}.ipynb`);
+        fs.accessSync(directory, fs.constants.W_OK);
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
 
 export function expandWorkingDir(
     workingDir: string | undefined,
@@ -39,7 +50,13 @@ export function expandWorkingDir(
         return workspaceFolder.uri.fsPath;
     }
 
-    return process.cwd();
+    // check if we can write to the directory where vscode was launched
+    const launchingDirectory = process.cwd();
+    if (is_writable(launchingDirectory)) {
+        return launchingDirectory;
+    }
+
+    return os.tmpdir();
 }
 
 export function createRemoteConnectionInfo(


### PR DESCRIPTION
* added check that process.cwd is writable
* included tests

For #

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
