### PR TITLE
Upgrade to vsc 1.49 and fix nyc compile error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4169,9 +4169,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.48.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
-            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.50.0.tgz",
+            "integrity": "sha512-QnIeyi4L2DiD9M2bAQKRzT/EQvc80qP9UL6JD5TiLlNRL1khIDg4ej4mDSRbtFrDAsRntFI1RhMvdomUThMsqg==",
             "dev": true
         },
         "@types/vscode-notebook-renderer": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.48.0"
+        "vscode": "^1.49.0"
     },
     "keywords": [
         "python",
@@ -3654,7 +3654,7 @@
         "@types/tmp": "0.0.33",
         "@types/untildify": "^3.0.0",
         "@types/uuid": "^3.4.3",
-        "@types/vscode": "^1.47.0",
+        "@types/vscode": "^1.49.0",
         "@types/vscode-notebook-renderer": "^1.48.0",
         "@types/webpack-bundle-analyzer": "^2.13.0",
         "@types/winreg": "^1.2.30",

--- a/src/client/datascience/interactive-common/interactiveWindowTypes.ts
+++ b/src/client/datascience/interactive-common/interactiveWindowTypes.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 'use strict';
 import * as monacoEditor from 'monaco-editor/esm/vs/editor/editor.api';
-import { DebugProtocolVariable, DebugProtocolVariableContainer, Uri } from 'vscode';
+import { Uri } from 'vscode';
+import { DebugProtocolVariable, DebugProtocolVariableContainer } from '../../../../types/vscode-proposed';
 import { DebugState, IServerState } from '../../../datascience-ui/interactive-common/mainState';
 
 import type { KernelMessage } from '@jupyterlab/services';

--- a/src/client/datascience/jupyterDebugService.ts
+++ b/src/client/datascience/jupyterDebugService.ts
@@ -12,6 +12,7 @@ import {
     DebugConfiguration,
     DebugConfigurationProvider,
     DebugConsole,
+    DebugProtocolBreakpoint,
     DebugSession,
     DebugSessionCustomEvent,
     Disposable,
@@ -62,6 +63,9 @@ class JupyterDebugSession implements DebugSession {
     }
     public customRequest(command: string, args?: any): Thenable<any> {
         return this.customRequestHandler(command, args);
+    }
+    public getDebugProtocolBreakpoint(_breakpoint: Breakpoint): Thenable<DebugProtocolBreakpoint | undefined> {
+        return Promise.resolve(undefined);
     }
 }
 

--- a/src/test/debugger/extension/adapter/factory.unit.test.ts
+++ b/src/test/debugger/extension/adapter/factory.unit.test.ts
@@ -97,7 +97,8 @@ suite('Debugging - Adapter Factory', () => {
             name: 'python',
             type: 'python',
             workspaceFolder,
-            customRequest: () => Promise.resolve()
+            customRequest: () => Promise.resolve(),
+            getDebugProtocolBreakpoint: () => Promise.resolve({})
         };
     }
 

--- a/src/test/debugger/extension/adapter/logging.unit.test.ts
+++ b/src/test/debugger/extension/adapter/logging.unit.test.ts
@@ -48,7 +48,8 @@ suite('Debugging - Session Logging', () => {
             name: 'python',
             type: 'python',
             workspaceFolder,
-            customRequest: () => Promise.resolve()
+            customRequest: () => Promise.resolve(),
+            getDebugProtocolBreakpoint: () => Promise.resolve({})
         };
     }
 

--- a/src/test/debugger/extension/adapter/outdatedDebuggerPrompt.unit.test.ts
+++ b/src/test/debugger/extension/adapter/outdatedDebuggerPrompt.unit.test.ts
@@ -64,7 +64,8 @@ suite('Debugging - Outdated Debugger Prompt tests.', () => {
             name: 'python',
             type: 'python',
             workspaceFolder,
-            customRequest: () => Promise.resolve()
+            customRequest: () => Promise.resolve(),
+            getDebugProtocolBreakpoint: () => Promise.resolve({})
         };
     }
 

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -16,6 +16,10 @@ import { vscUri } from './uri';
 import { generateUuid } from './uuid';
 
 export namespace vscMockExtHostedTypes {
+    export class DebugProtocolVariable { }
+
+    export class DebugProtocolVariableContainer { }
+
     export enum CellKind {
         Markdown = 1,
         Code = 2
@@ -1046,7 +1050,7 @@ export namespace vscMockExtHostedTypes {
         public static readonly Source = CodeActionKind.Empty.append('source');
         public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 
-        constructor(public readonly value: string) {}
+        constructor(public readonly value: string) { }
 
         public append(parts: string): CodeActionKind {
             return new CodeActionKind(this.value ? this.value + CodeActionKind.sep + parts : parts);

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -1050,7 +1050,7 @@ export namespace vscMockExtHostedTypes {
         public static readonly Source = CodeActionKind.Empty.append('source');
         public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 
-        constructor(public readonly value: string) { }
+        constructor(public readonly value: string) {}
 
         public append(parts: string): CodeActionKind {
             return new CodeActionKind(this.value ? this.value + CodeActionKind.sep + parts : parts);

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -16,9 +16,9 @@ import { vscUri } from './uri';
 import { generateUuid } from './uuid';
 
 export namespace vscMockExtHostedTypes {
-    export class DebugProtocolVariable { }
+    export class DebugProtocolVariable {}
 
-    export class DebugProtocolVariableContainer { }
+    export class DebugProtocolVariableContainer {}
 
     export enum CellKind {
         Markdown = 1,

--- a/src/test/vscode-mock.ts
+++ b/src/test/vscode-mock.ts
@@ -108,6 +108,8 @@ mockedVSCode.FileSystemError = vscodeMocks.vscMockExtHostedTypes.FileSystemError
 (mockedVSCode as any).CellKind = vscodeMocks.vscMockExtHostedTypes.CellKind;
 (mockedVSCode as any).CellOutputKind = vscodeMocks.vscMockExtHostedTypes.CellOutputKind;
 (mockedVSCode as any).NotebookCellRunState = vscodeMocks.vscMockExtHostedTypes.NotebookCellRunState;
+(mockedVSCode as any).DebugProtocolVariable = vscodeMocks.vscMockExtHostedTypes.DebugProtocolVariable;
+(mockedVSCode as any).DebugProtocolVariableContainer = vscodeMocks.vscMockExtHostedTypes.DebugProtocolVariableContainer;
 
 // This API is used in src/client/telemetry/telemetry.ts
 const extensions = TypeMoq.Mock.ofType<typeof vscode.extensions>();

--- a/types/vscode-proposed/index.d.ts
+++ b/types/vscode-proposed/index.d.ts
@@ -82,6 +82,10 @@ export interface CellDisplayOutput {
     readonly metadata?: NotebookCellOutputMetadata;
 }
 
+export interface DebugProtocolVariable { }
+
+export interface DebugProtocolVariableContainer { }
+
 export type CellOutput = CellStreamOutput | CellErrorOutput | CellDisplayOutput;
 
 export enum NotebookCellRunState {

--- a/typings/vscode-proposed/index.d.ts
+++ b/typings/vscode-proposed/index.d.ts
@@ -82,6 +82,10 @@ export interface CellDisplayOutput {
     readonly metadata?: NotebookCellOutputMetadata;
 }
 
+export interface DebugProtocolVariable { }
+
+export interface DebugProtocolVariableContainer { }
+
 export type CellOutput = CellStreamOutput | CellErrorOutput | CellDisplayOutput;
 
 export enum NotebookCellRunState {


### PR DESCRIPTION
#14406 introduced a nyc compiler error resulting from importing two proposed API interfaces from 'vscode' instead of 'vscode.proposed.d.ts'. Additionally, the proposed API for contributing to the debug context menu was introduced in https://code.visualstudio.com/updates/v1_49#_contributable-context-menu-for-variables-view.


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
