### PR TITLE
Add API for Python binaries watcher

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,6 @@ gulp.task('checkNativeDependencies', (done) => {
     done();
 });
 
-
 const webpackEnv = { NODE_OPTIONS: '--max_old_space_size=9096' };
 
 gulp.task('compile-viewers', async () => {
@@ -378,7 +377,7 @@ function hasNativeDependencies() {
     const jsonProperties = Object.keys(flat.flatten(dependencies));
     nativeDependencies = _.flatMap(nativeDependencies, (item) => path.dirname(item.substring(item.indexOf('node_modules') + 'node_modules'.length)).split(path.sep))
         .filter((item) => item.length > 0)
-        .filter((item) => !item.includes('zeromq')) // This is a known native. Allow this one for now
+        .filter((item) => !item.includes('zeromq') && item !== 'fsevents') // This is a known native. Allow this one for now
         .filter(
             (item) => jsonProperties.findIndex((flattenedDependency) => flattenedDependency.endsWith(`dependencies.${item}.version`)) >= 0,
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2785,20 +2785,9 @@
             "dev": true
         },
         "binary-extensions": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
-            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-            "dev": true
-        },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+            "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
         },
         "bl": {
             "version": "1.2.3",
@@ -3573,23 +3562,66 @@
             }
         },
         "chokidar": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
-            "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
-            "dev": true,
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
             "requires": {
-                "anymatch": "^2.0.0",
-                "async-each": "^1.0.1",
-                "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
-                "glob-parent": "^3.1.0",
-                "inherits": "^2.0.3",
-                "is-binary-path": "^1.0.0",
-                "is-glob": "^4.0.0",
-                "normalize-path": "^3.0.0",
-                "path-is-absolute": "^1.0.0",
-                "readdirp": "^2.2.1",
-                "upath": "^1.1.1"
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+                    "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
             }
         },
         "chownr": {
@@ -7626,13 +7658,6 @@
             "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
             "dev": true
         },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-            "dev": true,
-            "optional": true
-        },
         "filemanager-webpack-plugin-fixed": {
             "version": "2.0.9",
             "resolved": "https://registry.npmjs.org/filemanager-webpack-plugin-fixed/-/filemanager-webpack-plugin-fixed-2.0.9.tgz",
@@ -8203,555 +8228,10 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "1.2.12",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
-            "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "bindings": "^1.5.0",
-                "nan": "^2.12.1",
-                "node-pre-gyp": "*"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aproba": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "balanced-match": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "chownr": {
-                    "version": "1.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "code-point-at": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "console-control-strings": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "core-util-is": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "debug": {
-                    "version": "3.2.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "deep-extend": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "delegates": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "detect-libc": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "fs-minipass": {
-                    "version": "1.2.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.6.0"
-                    }
-                },
-                "fs.realpath": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "glob": {
-                    "version": "7.1.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "has-unicode": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "ignore-walk": {
-                    "version": "3.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "inflight": {
-                    "version": "1.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "ini": {
-                    "version": "1.3.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "minipass": {
-                    "version": "2.9.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.3.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minipass": "^2.9.0"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimist": "^1.2.5"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "needle": {
-                    "version": "2.3.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "debug": "^3.2.6",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.14.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.1",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4.4.2"
-                    }
-                },
-                "nopt": {
-                    "version": "4.0.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
-                    }
-                },
-                "npm-bundled": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "npm-normalize-package-bin": "^1.0.1"
-                    }
-                },
-                "npm-normalize-package-bin": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "npm-packlist": {
-                    "version": "1.4.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1",
-                        "npm-normalize-package-bin": "^1.0.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "number-is-nan": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "object-assign": {
-                    "version": "4.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "once": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "wrappy": "1"
-                    }
-                },
-                "os-homedir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "os-tmpdir": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "osenv": {
-                    "version": "0.1.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
-                    }
-                },
-                "path-is-absolute": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "process-nextick-args": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "rc": {
-                    "version": "1.2.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "deep-extend": "^0.6.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "rimraf": {
-                    "version": "2.7.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "sax": {
-                    "version": "1.2.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "semver": {
-                    "version": "5.7.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "set-blocking": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "signal-exit": {
-                    "version": "3.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "tar": {
-                    "version": "4.4.13",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.8.6",
-                        "minizlib": "^1.2.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.3"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "wide-align": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "string-width": "^1.0.2 || 2"
-                    }
-                },
-                "wrappy": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                }
-            }
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+            "optional": true
         },
         "fstream": {
             "version": "1.0.12",
@@ -8985,6 +8465,94 @@
                 "is-negated-glob": "^1.0.0",
                 "just-debounce": "^1.0.0",
                 "object.defaults": "^1.1.0"
+            },
+            "dependencies": {
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+                    "dev": true
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "nan": "^2.12.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "glob2base": {
@@ -10350,12 +9918,11 @@
             "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         },
         "is-binary-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-            "dev": true,
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "requires": {
-                "binary-extensions": "^1.0.0"
+                "binary-extensions": "^2.0.0"
             }
         },
         "is-boolean-object": {
@@ -10444,8 +10011,7 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-            "dev": true
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
         },
         "is-fullwidth-code-point": {
             "version": "1.0.0",
@@ -10460,7 +10026,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -13269,8 +12834,7 @@
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "normalize-range": {
             "version": "0.1.2",
@@ -14433,8 +13997,7 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-            "dev": true
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
         "pidusage": {
             "version": "1.2.0",
@@ -16186,46 +15749,11 @@
             }
         },
         "readdirp": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-            "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-            "dev": true,
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "micromatch": "^3.1.10",
-                "readable-stream": "^2.0.2"
-            },
-            "dependencies": {
-                "process-nextick-args": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
+                "picomatch": "^2.2.1"
             }
         },
         "rechoir": {
@@ -19894,9 +19422,9 @@
             "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
         },
         "upath": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-            "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true
         },
         "upper-case": {
@@ -20411,6 +19939,94 @@
                 "chokidar": "^2.1.8",
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0"
+            },
+            "dependencies": {
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+                    "dev": true
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "nan": "^2.12.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
             }
         },
         "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2789,6 +2789,16 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
             "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bl": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -7658,6 +7668,13 @@
             "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ==",
             "dev": true
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
+        },
         "filemanager-webpack-plugin-fixed": {
             "version": "2.0.9",
             "resolved": "https://registry.npmjs.org/filemanager-webpack-plugin-fixed/-/filemanager-webpack-plugin-fixed-2.0.9.tgz",
@@ -8500,6 +8517,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },
@@ -19974,6 +19992,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
+                        "bindings": "^1.5.0",
                         "nan": "^2.12.1"
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -1970,6 +1970,7 @@
     "dependencies": {
         "arch": "^2.1.0",
         "azure-storage": "^2.10.3",
+        "chokidar": "^3.4.3",
         "diff-match-patch": "^1.0.0",
         "fs-extra": "^4.0.3",
         "fuzzy": "^0.1.3",

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -8,12 +8,10 @@ import { createHash } from 'crypto';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import { injectable } from 'inversify';
-import * as path from 'path';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
 import '../../common/extensions';
 import { traceError } from '../logger';
-import { getOSType, OSType } from '../utils/platform';
 import { createDirNotEmptyError, isFileExistsError, isFileNotFoundError, isNoPermissionsError } from './errors';
 import { FileSystemPaths, FileSystemPathUtils } from './fs-paths';
 import { TemporaryFileSystem } from './fs-temp';
@@ -587,8 +585,4 @@ export class FileSystem implements IFileSystem {
     public async isDirReadonly(dirname: string): Promise<boolean> {
         return this.utils.isDirReadonly(dirname);
     }
-}
-
-export function normCasePath(filePath: string): string {
-    return getOSType() === OSType.Windows ? path.normalize(filePath).toUpperCase() : path.normalize(filePath);
 }

--- a/src/client/common/platform/fileSystem.ts
+++ b/src/client/common/platform/fileSystem.ts
@@ -8,10 +8,12 @@ import { createHash } from 'crypto';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
 import { injectable } from 'inversify';
+import * as path from 'path';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
 import '../../common/extensions';
 import { traceError } from '../logger';
+import { getOSType, OSType } from '../utils/platform';
 import { createDirNotEmptyError, isFileExistsError, isFileNotFoundError, isNoPermissionsError } from './errors';
 import { FileSystemPaths, FileSystemPathUtils } from './fs-paths';
 import { TemporaryFileSystem } from './fs-temp';
@@ -585,4 +587,8 @@ export class FileSystem implements IFileSystem {
     public async isDirReadonly(dirname: string): Promise<boolean> {
         return this.utils.isDirReadonly(dirname);
     }
+}
+
+export function normCasePath(filePath: string): string {
+    return getOSType() === OSType.Windows ? path.normalize(filePath).toUpperCase() : path.normalize(filePath);
 }

--- a/src/client/common/platform/fileSystemWatcher.ts
+++ b/src/client/common/platform/fileSystemWatcher.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as chokidar from 'chokidar';
+import * as path from 'path';
+import { RelativePattern, workspace } from 'vscode';
+import { normCasePath } from '../../pythonEnvironments/common/externalDependencies';
+import { traceError, traceVerbose, traceWarning } from '../logger';
+
+/**
+ * Enumeration of file change types.
+ */
+export enum FileChangeType {
+    /**
+     * The contents or metadata of a file have changed.
+     */
+    Changed = 1,
+
+    /**
+     * A file has been created.
+     */
+    Created = 2,
+
+    /**
+     * A file has been deleted.
+     */
+    Deleted = 3
+}
+const POLLING_INTERVAL = 5000;
+
+export function watchLocationForPattern(
+    baseDir: string,
+    pattern: string,
+    callback: (type: FileChangeType, absPath: string) => void
+): void {
+    // Use VSCode API iff base directory to exists within the current workspace folders
+    const found = workspace.workspaceFolders?.find((e) => normCasePath(baseDir).startsWith(normCasePath(e.uri.fsPath)));
+    if (found) {
+        watchLocationUsingVSCodeAPI(baseDir, pattern, callback);
+    } else {
+        // Fallback to chokidar as base directory to lookup doesn't exist within the current workspace folders
+        watchLocationUsingChokidar(baseDir, pattern, callback);
+    }
+}
+
+function watchLocationUsingVSCodeAPI(
+    baseDir: string,
+    pattern: string,
+    callback: (type: FileChangeType, absPath: string) => void
+) {
+    const globPattern = new RelativePattern(baseDir, pattern);
+    traceVerbose(`Start watching: ${baseDir} with pattern ${pattern} using VSCode API`);
+    const watcher = workspace.createFileSystemWatcher(globPattern);
+    watcher.onDidCreate((e) => callback(FileChangeType.Created, e.fsPath));
+    watcher.onDidChange((e) => callback(FileChangeType.Changed, e.fsPath));
+    watcher.onDidDelete((e) => callback(FileChangeType.Deleted, e.fsPath));
+}
+
+function watchLocationUsingChokidar(
+    baseDir: string,
+    pattern: string,
+    callback: (type: FileChangeType, absPath: string) => void
+) {
+    const watcherOpts: chokidar.WatchOptions = {
+        cwd: baseDir,
+        ignoreInitial: true,
+        ignorePermissionErrors: true,
+        // While not used in normal cases, if any error causes chokidar to fallback to polling, increase its intervals
+        interval: POLLING_INTERVAL,
+        binaryInterval: POLLING_INTERVAL,
+        // 'depth' doesn't matter rn given regex restricts the depth to 2, same goes for other properties below
+        // But using them just to be safe in case it's misused
+        depth: 2,
+        ignored: ['**/Lib/**'],
+        followSymlinks: false
+    };
+    traceVerbose(`Start watching: ${baseDir} with pattern ${pattern} using chokidar`);
+    let watcher: chokidar.FSWatcher | null = chokidar.watch(pattern, watcherOpts);
+    watcher.on('all', (type: string, e: string) => {
+        const absPath = path.join(baseDir, e);
+        let eventType: FileChangeType;
+        switch (type) {
+            case 'change':
+                eventType = FileChangeType.Changed;
+                break;
+            case 'add':
+            case 'addDir':
+                eventType = FileChangeType.Created;
+                break;
+            case 'unlink':
+            case 'unlinkDir':
+                eventType = FileChangeType.Deleted;
+                break;
+            default:
+                return;
+        }
+        callback(eventType, absPath);
+    });
+
+    watcher.on('error', async (error: NodeJS.ErrnoException) => {
+        if (error) {
+            // Specially handle ENOSPC errors that can happen when
+            // the watcher consumes so many file descriptors that
+            // we are running into a limit. We only want to warn
+            // once in this case to avoid log spam.
+            // See https://github.com/Microsoft/vscode/issues/7950
+            if (error.code === 'ENOSPC') {
+                traceError('Inotify limit reached (ENOSPC)');
+                if (watcher) {
+                    await watcher.close();
+                    watcher = null;
+                }
+            } else {
+                traceWarning(error.toString());
+            }
+        }
+    });
+}

--- a/src/client/common/platform/fileSystemWatcher.ts
+++ b/src/client/common/platform/fileSystemWatcher.ts
@@ -6,8 +6,8 @@
 import * as chokidar from 'chokidar';
 import * as path from 'path';
 import { RelativePattern, workspace } from 'vscode';
-import { normCasePath } from '../../pythonEnvironments/common/externalDependencies';
 import { traceError, traceVerbose, traceWarning } from '../logger';
+import { normCasePath } from './fileSystem';
 
 /**
  * Enumeration of file change types.
@@ -17,12 +17,10 @@ export enum FileChangeType {
      * The contents or metadata of a file have changed.
      */
     Changed = 1,
-
     /**
      * A file has been created.
      */
     Created = 2,
-
     /**
      * A file has been deleted.
      */

--- a/src/client/common/platform/fileSystemWatcher.ts
+++ b/src/client/common/platform/fileSystemWatcher.ts
@@ -7,7 +7,7 @@ import * as chokidar from 'chokidar';
 import * as path from 'path';
 import { RelativePattern, workspace } from 'vscode';
 import { traceError, traceVerbose, traceWarning } from '../logger';
-import { normCasePath } from './fileSystem';
+import { normCasePath } from './fs-paths';
 
 /**
  * Enumeration of file change types.

--- a/src/client/common/platform/fs-paths.ts
+++ b/src/client/common/platform/fs-paths.ts
@@ -142,3 +142,7 @@ export class FileSystemPathUtils implements IFileSystemPathUtils {
         }
     }
 }
+
+export function normCasePath(filePath: string): string {
+    return getOSType() === OSType.Windows ? nodepath.normalize(filePath).toUpperCase() : nodepath.normalize(filePath);
+}

--- a/src/client/pythonEnvironments/common/externalDependencies.ts
+++ b/src/client/pythonEnvironments/common/externalDependencies.ts
@@ -30,13 +30,12 @@ export function readFile(filePath: string): Promise<string> {
     return fsapi.readFile(filePath, 'utf-8');
 }
 
+export function normCasePath(filePath: string): string {
+    return getOSType() === OSType.Windows ? path.normalize(filePath).toUpperCase() : path.normalize(filePath);
+}
+
 export function arePathsSame(path1: string, path2: string): boolean {
-    path1 = path.normalize(path1);
-    path2 = path.normalize(path2);
-    if (getOSType() === OSType.Windows) {
-        return path1.toUpperCase() === path2.toUpperCase();
-    }
-    return path1 === path2;
+    return normCasePath(path1) === normCasePath(path2);
 }
 
 function getPersistentStateFactory(): IPersistentStateFactory {

--- a/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
+++ b/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import * as chokidar from 'chokidar';
+import * as path from 'path';
+import { FileChangeType, RelativePattern, workspace } from 'vscode';
+import { traceError, traceVerbose, traceWarning } from '../../common/logger';
+import { getOSType, OSType } from '../../common/utils/platform';
+import { normCasePath } from './externalDependencies';
+
+const POLLING_INTERVAL = 5000;
+const os = getOSType();
+const [executable, binName] = os === OSType.Windows ? ['python.exe', 'Scripts'] : ['python', 'bin'];
+const patterns = [executable, `*/${executable}`, `*/${binName}/${executable}`];
+
+export function watchLocationForPythonBinaries(
+    baseDir: string,
+    callback: (type: FileChangeType, absPath: string) => void,
+): void {
+    traceVerbose(`Start watching: ${baseDir} for Python binaries`);
+    // Use VSCode API if base directory to exists within the current workspace folders
+    const folders = workspace.workspaceFolders;
+    if (folders) {
+        const found = folders.find((folder) => normCasePath(baseDir).startsWith(normCasePath(folder.uri.fsPath)));
+        if (found) {
+            watchLocationUsingVSCodeAPI(baseDir, callback);
+        }
+    }
+    // Fallback to chokidar if base directory to lookup doesn't exist within the current workspace folders
+    watchLocationUsingChokidar(baseDir, callback);
+}
+
+function watchLocationUsingVSCodeAPI(baseDir: string, callback: (type: FileChangeType, absPath: string) => void) {
+    for (const pattern of patterns) {
+        const globPattern = new RelativePattern(baseDir, pattern);
+        const watcher = workspace.createFileSystemWatcher(globPattern);
+        watcher.onDidCreate((e) => callback(FileChangeType.Created, e.fsPath));
+        watcher.onDidChange((e) => callback(FileChangeType.Changed, e.fsPath));
+        watcher.onDidDelete((e) => callback(FileChangeType.Deleted, e.fsPath));
+    }
+}
+
+function watchLocationUsingChokidar(baseDir: string, callback: (type: FileChangeType, absPath: string) => void) {
+    const watcherOpts: chokidar.WatchOptions = {
+        cwd: baseDir,
+        ignoreInitial: true,
+        ignorePermissionErrors: true,
+        // While not used in normal cases, if any error causes chokidar to fallback to polling, increase its intervals
+        interval: POLLING_INTERVAL,
+        binaryInterval: POLLING_INTERVAL,
+        // 'depth' doesn't matter rn given regex already restricts the depth to 2, same goes for other properties below
+        // But using them just to be safe in case regex is modified
+        depth: 2,
+        ignored: ['**/Lib/**'],
+        followSymlinks: false,
+    };
+    for (const pattern of patterns) {
+        let watcher: chokidar.FSWatcher | null = chokidar.watch(pattern, watcherOpts);
+        watcher.on('all', (type: string, e: string) => {
+            if (!e.endsWith(executable)) {
+                // When deleting the file for some reason path to all directories leading up to python are reported
+                // Skip those events
+                return;
+            }
+            const absPath = path.join(baseDir, e);
+            let eventType: FileChangeType;
+            switch (type) {
+                case 'change':
+                    eventType = FileChangeType.Changed;
+                    break;
+                case 'add':
+                case 'addDir':
+                    eventType = FileChangeType.Created;
+                    break;
+                case 'unlink':
+                case 'unlinkDir':
+                    eventType = FileChangeType.Deleted;
+                    break;
+                default:
+                    return;
+            }
+            callback(eventType, absPath);
+        });
+
+        watcher.on('error', async (error: NodeJS.ErrnoException) => {
+            if (error) {
+                // Specially handle ENOSPC errors that can happen when
+                // the watcher consumes so many file descriptors that
+                // we are running into a limit. We only want to warn
+                // once in this case to avoid log spam.
+                // See https://github.com/Microsoft/vscode/issues/7950
+                if (error.code === 'ENOSPC') {
+                    traceError('Inotify limit reached (ENOSPC)');
+                    if (watcher) {
+                        await watcher.close();
+                        watcher = null;
+                    }
+                } else {
+                    traceWarning(error.toString());
+                }
+            }
+        });
+    }
+}

--- a/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
+++ b/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
@@ -3,14 +3,9 @@
 
 'use strict';
 
-import * as chokidar from 'chokidar';
-import * as path from 'path';
-import { FileChangeType, RelativePattern, workspace } from 'vscode';
-import { traceError, traceVerbose, traceWarning } from '../../common/logger';
+import { FileChangeType, watchLocationForPattern } from '../../common/platform/fileSystemWatcher';
 import { getOSType, OSType } from '../../common/utils/platform';
-import { normCasePath } from './externalDependencies';
 
-const POLLING_INTERVAL = 5000;
 const os = getOSType();
 const [executable, binName] = os === OSType.Windows ? ['python.exe', 'Scripts'] : ['python', 'bin'];
 const patterns = [executable, `*/${executable}`, `*/${binName}/${executable}`];
@@ -19,88 +14,14 @@ export function watchLocationForPythonBinaries(
     baseDir: string,
     callback: (type: FileChangeType, absPath: string) => void,
 ): void {
-    traceVerbose(`Start watching: ${baseDir} for Python binaries`);
-    // Use VSCode API if base directory to exists within the current workspace folders
-    const folders = workspace.workspaceFolders;
-    if (folders) {
-        const found = folders.find((folder) => normCasePath(baseDir).startsWith(normCasePath(folder.uri.fsPath)));
-        if (found) {
-            watchLocationUsingVSCodeAPI(baseDir, callback);
-        }
-    }
-    // Fallback to chokidar if base directory to lookup doesn't exist within the current workspace folders
-    watchLocationUsingChokidar(baseDir, callback);
-}
-
-function watchLocationUsingVSCodeAPI(baseDir: string, callback: (type: FileChangeType, absPath: string) => void) {
     for (const pattern of patterns) {
-        const globPattern = new RelativePattern(baseDir, pattern);
-        const watcher = workspace.createFileSystemWatcher(globPattern);
-        watcher.onDidCreate((e) => callback(FileChangeType.Created, e.fsPath));
-        watcher.onDidChange((e) => callback(FileChangeType.Changed, e.fsPath));
-        watcher.onDidDelete((e) => callback(FileChangeType.Deleted, e.fsPath));
-    }
-}
-
-function watchLocationUsingChokidar(baseDir: string, callback: (type: FileChangeType, absPath: string) => void) {
-    const watcherOpts: chokidar.WatchOptions = {
-        cwd: baseDir,
-        ignoreInitial: true,
-        ignorePermissionErrors: true,
-        // While not used in normal cases, if any error causes chokidar to fallback to polling, increase its intervals
-        interval: POLLING_INTERVAL,
-        binaryInterval: POLLING_INTERVAL,
-        // 'depth' doesn't matter rn given regex already restricts the depth to 2, same goes for other properties below
-        // But using them just to be safe in case regex is modified
-        depth: 2,
-        ignored: ['**/Lib/**'],
-        followSymlinks: false,
-    };
-    for (const pattern of patterns) {
-        let watcher: chokidar.FSWatcher | null = chokidar.watch(pattern, watcherOpts);
-        watcher.on('all', (type: string, e: string) => {
+        watchLocationForPattern(baseDir, pattern, (type: FileChangeType, e: string) => {
             if (!e.endsWith(executable)) {
                 // When deleting the file for some reason path to all directories leading up to python are reported
                 // Skip those events
                 return;
             }
-            const absPath = path.join(baseDir, e);
-            let eventType: FileChangeType;
-            switch (type) {
-                case 'change':
-                    eventType = FileChangeType.Changed;
-                    break;
-                case 'add':
-                case 'addDir':
-                    eventType = FileChangeType.Created;
-                    break;
-                case 'unlink':
-                case 'unlinkDir':
-                    eventType = FileChangeType.Deleted;
-                    break;
-                default:
-                    return;
-            }
-            callback(eventType, absPath);
-        });
-
-        watcher.on('error', async (error: NodeJS.ErrnoException) => {
-            if (error) {
-                // Specially handle ENOSPC errors that can happen when
-                // the watcher consumes so many file descriptors that
-                // we are running into a limit. We only want to warn
-                // once in this case to avoid log spam.
-                // See https://github.com/Microsoft/vscode/issues/7950
-                if (error.code === 'ENOSPC') {
-                    traceError('Inotify limit reached (ENOSPC)');
-                    if (watcher) {
-                        await watcher.close();
-                        watcher = null;
-                    }
-                } else {
-                    traceWarning(error.toString());
-                }
-            }
+            callback(type, e);
         });
     }
 }

--- a/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
+++ b/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
@@ -6,8 +6,7 @@
 import { FileChangeType, watchLocationForPattern } from '../../common/platform/fileSystemWatcher';
 import { getOSType, OSType } from '../../common/utils/platform';
 
-const os = getOSType();
-const [executable, binName] = os === OSType.Windows ? ['python.exe', 'Scripts'] : ['python', 'bin'];
+const [executable, binName] = getOSType() === OSType.Windows ? ['python.exe', 'Scripts'] : ['python', 'bin'];
 const patterns = [executable, `*/${executable}`, `*/${binName}/${executable}`];
 
 export function watchLocationForPythonBinaries(


### PR DESCRIPTION
The tests will be added along with the locators. Note VSCode API is more efficient but can only watch files within the current workspace folders. The options are chosen based on the spike.