### PR TITLE
Ask debug adapter for raw strings

### DIFF
--- a/src/client/datascience/jupyter/debuggerVariables.ts
+++ b/src/client/datascience/jupyter/debuggerVariables.ts
@@ -118,7 +118,7 @@ export class DebuggerVariables extends DebugLocationTracker
         return results
             ? {
                   ...targetVariable,
-                  ...JSON.parse(results.result.slice(1, -1))
+                  ...JSON.parse(results.result)
               }
             : targetVariable;
     }
@@ -158,7 +158,7 @@ export class DebuggerVariables extends DebugLocationTracker
                 // tslint:disable-next-line: no-any
                 (targetVariable as any).frameId
             );
-            const chunkResults = JSON.parse(results.result.slice(1, -1));
+            const chunkResults = JSON.parse(results.result);
             if (output && output.data) {
                 output = {
                     ...output,
@@ -225,7 +225,8 @@ export class DebuggerVariables extends DebugLocationTracker
             const results = await this.debugService.activeDebugSession.customRequest('evaluate', {
                 expression: code,
                 frameId: this.topMostFrameId || frameId,
-                context: 'repl'
+                context: 'repl',
+                format: { rawString: true }
             });
             if (results && results.result !== 'None') {
                 return results;
@@ -268,7 +269,7 @@ export class DebuggerVariables extends DebugLocationTracker
             return {
                 ...variable,
                 truncated: false,
-                ...JSON.parse(results.result.slice(1, -1))
+                ...JSON.parse(results.result)
             };
         } else {
             // If no results, just return current value. Better than nothing.


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/14441

With our previous custom evaluate request, debugpy was returning the result of calling `repr()` on our variable value, which is what caused the extra backslashes. By sending "format": "rawString" with our request (implemented as a VS extension: https://github.com/microsoft/VSDebugAdapterHost/wiki/Stack-Trace-and-Value-Formatting), debugpy returns us the raw stringified JSON object, which we can then parse as JSON. The alternative would've been to parse Python string literals ourselves. 

![escapebugfix](https://user-images.githubusercontent.com/30305945/97060524-72a24d80-1548-11eb-8f55-c9d51c44ee32.gif)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
