### PR TITLE
Add utm source to join mailing list

### DIFF
--- a/src/client/application/misc/joinMailingListPrompt.ts
+++ b/src/client/application/misc/joinMailingListPrompt.ts
@@ -66,7 +66,8 @@ export class JoinMailingListPrompt implements IExtensionSingleActivationService 
         if (selection === Common.bannerLabelYes()) {
             sendTelemetryEvent(EventName.JOIN_MAILING_LIST_PROMPT, undefined, { selection: 'Yes' });
             const query = querystring.stringify({
-                m: encodeURIComponent(this.appEnvironment.sessionId)
+                m: encodeURIComponent(this.appEnvironment.sessionId),
+                utm_source: "vscode"
             });
             const url = `https://aka.ms/python-vscode-mailinglist?${query}`;
             this.browserService.launch(url);

--- a/src/client/application/misc/joinMailingListPrompt.ts
+++ b/src/client/application/misc/joinMailingListPrompt.ts
@@ -67,7 +67,7 @@ export class JoinMailingListPrompt implements IExtensionSingleActivationService 
             sendTelemetryEvent(EventName.JOIN_MAILING_LIST_PROMPT, undefined, { selection: 'Yes' });
             const query = querystring.stringify({
                 m: encodeURIComponent(this.appEnvironment.sessionId),
-                utm_source: "vscode"
+                utm_source: 'vscode'
             });
             const url = `https://aka.ms/python-vscode-mailinglist?${query}`;
             this.browserService.launch(url);

--- a/src/test/application/misc/joinMailingListPrompt.unit.test.ts
+++ b/src/test/application/misc/joinMailingListPrompt.unit.test.ts
@@ -113,7 +113,9 @@ suite('Interpreters - Interpreter Selection Tip', () => {
 
         await joinMailingList.activate();
 
-        verify(browserService.launch('https://aka.ms/python-vscode-mailinglist?m=test.sessionId&utm_source=vscode')).once();
+        verify(
+            browserService.launch('https://aka.ms/python-vscode-mailinglist?m=test.sessionId&utm_source=vscode')
+        ).once();
         verify(storage.updateValue(true)).once();
         assert.ok(
             sendTelemetryStub.calledWithExactly(EventName.JOIN_MAILING_LIST_PROMPT, undefined, { selection: 'Yes' })

--- a/src/test/application/misc/joinMailingListPrompt.unit.test.ts
+++ b/src/test/application/misc/joinMailingListPrompt.unit.test.ts
@@ -113,7 +113,7 @@ suite('Interpreters - Interpreter Selection Tip', () => {
 
         await joinMailingList.activate();
 
-        verify(browserService.launch('https://aka.ms/python-vscode-mailinglist?m=test.sessionId')).once();
+        verify(browserService.launch('https://aka.ms/python-vscode-mailinglist?m=test.sessionId&utm_source=vscode')).once();
         verify(storage.updateValue(true)).once();
         assert.ok(
             sendTelemetryStub.calledWithExactly(EventName.JOIN_MAILING_LIST_PROMPT, undefined, { selection: 'Yes' })


### PR DESCRIPTION
The goal is to send utm_source as "vscode" so we can capture that from Google Analytics, when querying to track interest on the mailing list survey.
 
<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
