### PR TITLE
Make sure DS extensibility is backwards compatible

### DIFF
--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import { noop } from 'lodash';
 import { Event, NotebookCell, Uri } from 'vscode';
 import { isTestExecution } from './common/constants';
 import { traceError } from './common/logger';
@@ -143,10 +144,19 @@ export function buildApi(
         // These are for backwards compatibility. Other extensions are using these APIs and we don't want
         // to force them to move to the jupyter extension ... yet.
         datascience: {
-            onKernelPostExecute: jupyterIntegration.onKernelPostExecute.bind(jupyterIntegration),
-            onKernelRestart: jupyterIntegration.onKernelRestart.bind(jupyterIntegration),
-            registerRemoteServerProvider: jupyterIntegration.registerRemoteServerProvider.bind(jupyterIntegration),
-            showDataViewer: jupyterIntegration.showDataViewer.bind(jupyterIntegration)
+            // tslint:disable:no-any
+            onKernelPostExecute: jupyterIntegration
+                ? jupyterIntegration.onKernelPostExecute.bind(jupyterIntegration)
+                : (noop as any),
+            onKernelRestart: jupyterIntegration
+                ? jupyterIntegration.onKernelRestart.bind(jupyterIntegration)
+                : (noop as any),
+            registerRemoteServerProvider: jupyterIntegration
+                ? jupyterIntegration.registerRemoteServerProvider.bind(jupyterIntegration)
+                : (noop as any),
+            showDataViewer: jupyterIntegration
+                ? jupyterIntegration.showDataViewer.bind(jupyterIntegration)
+                : (noop as any)
         }
     };
 

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -3,10 +3,11 @@
 
 'use strict';
 
-import { Event, Uri } from 'vscode';
+import { Event, NotebookCell, Uri } from 'vscode';
 import { isTestExecution } from './common/constants';
 import { traceError } from './common/logger';
 import { IConfigurationService, Resource } from './common/types';
+import { IDataViewerDataProvider, IJupyterUriProvider } from './datascience/types';
 import { getDebugpyLauncherArgs, getDebugpyPackagePath } from './debugger/extension/adapter/remoteLaunchers';
 import { IInterpreterService } from './interpreter/contracts';
 import { IServiceContainer, IServiceManager } from './ioc/types';
@@ -78,6 +79,22 @@ export interface IExtensionApi {
             execCommand: string[] | undefined;
         };
     };
+
+    datascience: {
+        readonly onKernelPostExecute: Event<NotebookCell>;
+        readonly onKernelRestart: Event<void>;
+        /**
+         * Launches Data Viewer component.
+         * @param {IDataViewerDataProvider} dataProvider Instance that will be used by the Data Viewer component to fetch data.
+         * @param {string} title Data Viewer title
+         */
+        showDataViewer(dataProvider: IDataViewerDataProvider, title: string): Promise<void>;
+        /**
+         * Registers a remote server provider component that's used to pick remote jupyter server URIs
+         * @param serverProvider object called back when picking jupyter server URI
+         */
+        registerRemoteServerProvider(serverProvider: IJupyterUriProvider): void;
+    };
 }
 
 export function buildApi(
@@ -122,6 +139,14 @@ export function buildApi(
                 // If pythonPath equals an empty string, no interpreter is set.
                 return { execCommand: pythonPath === '' ? undefined : [pythonPath] };
             }
+        },
+        // These are for backwards compatibility. Other extensions are using these APIs and we don't want
+        // to force them to move to the jupyter extension ... yet.
+        datascience: {
+            onKernelPostExecute: jupyterIntegration.onKernelPostExecute.bind(jupyterIntegration),
+            onKernelRestart: jupyterIntegration.onKernelRestart.bind(jupyterIntegration),
+            registerRemoteServerProvider: jupyterIntegration.registerRemoteServerProvider.bind(jupyterIntegration),
+            showDataViewer: jupyterIntegration.showDataViewer.bind(jupyterIntegration)
         }
     };
 

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+'use strict';
+
+import { QuickPickItem } from 'vscode';
+
+export interface IJupyterServerUri {
+    baseUrl: string;
+    token: string;
+    // tslint:disable-next-line: no-any
+    authorizationHeader: any; // JSON object for authorization header.
+    expiration?: Date; // Date/time when header expires and should be refreshed.
+    displayName: string;
+}
+
+export type JupyterServerUriHandle = string;
+
+export interface IJupyterUriProvider {
+    readonly id: string; // Should be a unique string (like a guid)
+    getQuickPickEntryItems(): QuickPickItem[];
+    handleQuickPick(item: QuickPickItem, backEnabled: boolean): Promise<JupyterServerUriHandle | 'back' | undefined>;
+    getServerUri(handle: JupyterServerUriHandle): Promise<IJupyterServerUri>;
+}
+
+export interface IDataFrameInfo {
+    columns?: { key: string; type: ColumnType }[];
+    indexColumn?: string;
+    rowCount?: number;
+}
+
+export interface IDataViewerDataProvider {
+    dispose(): void;
+    getDataFrameInfo(): Promise<IDataFrameInfo>;
+    getAllRows(): Promise<IRowsResponse>;
+    getRows(start: number, end: number): Promise<IRowsResponse>;
+}
+
+export enum ColumnType {
+    String = 'string',
+    Number = 'number',
+    Bool = 'bool'
+}
+
+// tslint:disable-next-line: no-any
+export type IRowsResponse = any[];


### PR DESCRIPTION
This is a recreation of this pr here:
https://github.com/microsoft/vscode-python/pull/14496

Essentially making sure any extension that depended upon our DS extensibility API continues to work after we ship (example: AML extension)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
