### PR TITLE
debuggerDataViewer experiment

### DIFF
--- a/src/client/common/experiments/debuggerDataViewerExperimentEnabler.ts
+++ b/src/client/common/experiments/debuggerDataViewerExperimentEnabler.ts
@@ -1,0 +1,26 @@
+import { inject, injectable } from 'inversify';
+import { IExtensionSingleActivationService } from '../../activation/types';
+import { ICommandManager } from '../../common/application/types';
+import { ContextKey } from '../../common/contextKey';
+import { traceError } from '../../common/logger';
+import { IExperimentService } from '../../common/types';
+
+@injectable()
+export class DebuggerDataViewerExperimentEnabler implements IExtensionSingleActivationService {
+    constructor(
+        @inject(ICommandManager) private readonly commandManager: ICommandManager,
+        @inject(IExperimentService) private readonly experimentService: IExperimentService
+    ) { }
+    public async activate() {
+        this.activateInternal().catch(traceError.bind('Failed to activate debuggerDataViewerExperimentEnabler'));
+    }
+    private async activateInternal() {
+        // This context key controls the visibility of the 'View Variable in Data Viewer'
+        // context menu item from the variable window context menu during a debugging session
+        const isDataViewerExperimentEnabled = new ContextKey(
+            'python.isDebuggerDataViewerExperimentEnabled',
+            this.commandManager
+        );
+        await isDataViewerExperimentEnabled.set(await this.experimentService.inExperiment('debuggerDataViewer'));
+    }
+}

--- a/src/client/common/experiments/debuggerDataViewerExperimentEnabler.ts
+++ b/src/client/common/experiments/debuggerDataViewerExperimentEnabler.ts
@@ -10,7 +10,7 @@ export class DebuggerDataViewerExperimentEnabler implements IExtensionSingleActi
     constructor(
         @inject(ICommandManager) private readonly commandManager: ICommandManager,
         @inject(IExperimentService) private readonly experimentService: IExperimentService
-    ) { }
+    ) {}
     public async activate() {
         this.activateInternal().catch(traceError.bind('Failed to activate debuggerDataViewerExperimentEnabler'));
     }

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -38,6 +38,7 @@ import { AsyncDisposableRegistry } from './asyncDisposableRegistry';
 import { ConfigurationService } from './configuration/service';
 import { CryptoUtils } from './crypto';
 import { EditorUtils } from './editor';
+import { DebuggerDataViewerExperimentEnabler } from './experiments/debuggerDataViewerExperimentEnabler';
 import { ExperimentsManager } from './experiments/manager';
 import { ExperimentService } from './experiments/service';
 import { FeatureDeprecationManager } from './featureDeprecationManager';
@@ -199,6 +200,10 @@ export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         ReloadVSCodeCommandHandler
+    );
+    serviceManager.addSingleton<IExtensionSingleActivationService>(
+        IExtensionSingleActivationService,
+        DebuggerDataViewerExperimentEnabler
     );
     serviceManager.addSingleton<IExtensionChannelService>(IExtensionChannelService, ExtensionChannelService);
     serviceManager.addSingleton<IExtensionChannelRule>(


### PR DESCRIPTION
#14447 removed this code, which controls the visibility of the debugger data viewer integration based on whether the user is in the debuggerDataViewer experiment.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
