### PR TITLE
Put the new REPL normalization script behind an experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1042,6 +1042,7 @@
                             "tryPylance",
                             "jediLSP",
                             "debuggerDataViewer",
+                            "pythonSendEntireLineToREPL",
                             "All"
                         ]
                     },
@@ -1068,6 +1069,7 @@
                             "tryPylance",
                             "jediLSP",
                             "debuggerDataViewer",
+                            "pythonSendEntireLineToREPL",
                             "All"
                         ]
                     },

--- a/src/client/common/experiments/groups.ts
+++ b/src/client/common/experiments/groups.ts
@@ -75,3 +75,8 @@ export enum JoinMailingListPromptVariants {
     variant2 = 'pythonJoinMailingListVar2',
     variant3 = 'pythonJoinMailingListVar3'
 }
+
+// Experiment to use a different method for normalizing code to be sent to the REPL.
+export enum SendSelectionToREPL {
+    experiment = 'pythonSendEntireLineToREPL'
+}

--- a/src/client/common/process/internal/scripts/index.ts
+++ b/src/client/common/process/internal/scripts/index.ts
@@ -228,6 +228,21 @@ export function normalizeForInterpreter(code: string): [string[], (out: string) 
 }
 
 //============================
+// normalizeSelection.py
+
+export function normalizeSelection(code: string): [string[], (out: string) => string] {
+    const script = path.join(SCRIPTS_DIR, 'normalizeSelection.py');
+    const args = [ISOLATED, script, code];
+
+    function parse(out: string) {
+        // The text will be used as-is.
+        return out;
+    }
+
+    return [args, parse];
+}
+
+//============================
 // symbolProvider.py
 
 namespace _symbolProvider {

--- a/src/test/pythonFiles/terminalExec/sample1_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample1_normalized_selection.py
@@ -1,0 +1,22 @@
+def square(x):
+    return x**2
+
+print('hello')
+# Sample block 2
+
+a = 2
+if a < 2:
+    print('less than 2')
+else:
+    print('more than 2')
+
+print('hello')
+# Sample block 3
+
+for i in range(5):
+    print(i)
+    print(i)
+    print(i)
+    print(i)
+
+print('complete')

--- a/src/test/pythonFiles/terminalExec/sample2_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample2_normalized_selection.py
@@ -1,0 +1,7 @@
+def add(x, y):
+    """Adds x to y"""
+    # Some comment
+    return x + y
+
+v = add(1, 7)
+print(v)

--- a/src/test/pythonFiles/terminalExec/sample3_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample3_normalized_selection.py
@@ -1,0 +1,5 @@
+if True:
+    print(1)
+    print(2)
+
+print(3)

--- a/src/test/pythonFiles/terminalExec/sample4_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample4_normalized_selection.py
@@ -1,0 +1,7 @@
+class pc(object):
+    def __init__(self, pcname, model):
+        self.pcname = pcname
+        self.model = model
+    def print_name(self):
+        print('Workstation name is', self.pcname, 'model is', self.model)
+

--- a/src/test/pythonFiles/terminalExec/sample5_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample5_normalized_selection.py
@@ -1,0 +1,9 @@
+for i in range(10):
+    print('a')
+    for j in range(5):
+        print('b')
+        print('b2')
+        for k in range(2):
+            print('c')
+    print('done with first loop')
+

--- a/src/test/pythonFiles/terminalExec/sample6_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample6_normalized_selection.py
@@ -1,0 +1,15 @@
+if True:
+    print(1)
+else: print(2)
+
+print('🔨')
+print(3)
+print(3)
+if True:
+    print(1)
+else: print(2)
+
+if True:
+    print(1)
+else: print(2)
+

--- a/src/test/pythonFiles/terminalExec/sample7_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample7_normalized_selection.py
@@ -1,0 +1,8 @@
+if True:
+    print(1)
+    print(1)
+else:
+    print(2)
+    print(2)
+
+print(3)

--- a/src/test/pythonFiles/terminalExec/sample8_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample8_normalized_selection.py
@@ -1,0 +1,8 @@
+if True:
+    print(1)
+    print(1)
+else:
+    print(2)
+    print(2)
+
+print(3)

--- a/src/test/pythonFiles/terminalExec/sample_normalized_selection.py
+++ b/src/test/pythonFiles/terminalExec/sample_normalized_selection.py
@@ -1,0 +1,5 @@
+import sys
+print(sys.executable)
+print("1234")
+print(1)
+print(2)

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -138,8 +138,7 @@ suite('Terminal - Code Execution Helper', () => {
                 return actualProcessService.exec.apply(actualProcessService, [file, args, options]);
             });
         const normalizedZCode = await helper.normalizeLines(source);
-        // In case file has been saved with different line endings.
-        expectedSource = expectedSource.splitLines({ removeEmptyEntries: false, trim: false }).join(EOL);
+        
         expect(normalizedZCode).to.be.equal(expectedSource);
     }
 

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -239,11 +239,11 @@ suite('Terminal - Code Execution Helper', () => {
         ['', '1', '2', '3', '4', '5', '6', '7', '8'].forEach((fileNameSuffix) => {
             test(`Ensure code is normalized (Sample${fileNameSuffix})`, async () => {
                 const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
-                const expectedCode = await fs.readFile(
+                let expectedCode = await fs.readFile(
                     path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized_selection.py`),
                     'utf8'
                 );
-                expectedCode.replace(/\r\n/g, '\n');
+                expectedCode = expectedCode.replace(/\r\n/g, '\n');
                 await ensureCodeIsNormalized(code, expectedCode);
             });
         });

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -22,14 +22,14 @@ import {
     ObservableExecutionResult
 } from '../../../client/common/process/types';
 import { IExperimentService } from '../../../client/common/types';
-import { Architecture, OSType } from '../../../client/common/utils/platform';
+import { Architecture } from '../../../client/common/utils/platform';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 import { CodeExecutionHelper } from '../../../client/terminals/codeExecution/helper';
 import { ICodeExecutionHelper } from '../../../client/terminals/types';
-import { isOs, isPythonVersion, PYTHON_PATH } from '../../common';
+import { PYTHON_PATH } from '../../common';
 
 const TEST_FILES_PATH = path.join(EXTENSION_ROOT_DIR, 'src', 'test', 'pythonFiles', 'terminalExec');
 

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -12,10 +12,12 @@ import * as TypeMoq from 'typemoq';
 import { Position, Range, Selection, TextDocument, TextEditor, TextLine, Uri } from 'vscode';
 import { IApplicationShell, IDocumentManager } from '../../../client/common/application/types';
 import { EXTENSION_ROOT_DIR, PYTHON_LANGUAGE } from '../../../client/common/constants';
+import { SendSelectionToREPL } from '../../../client/common/experiments/groups';
 import '../../../client/common/extensions';
 import { BufferDecoder } from '../../../client/common/process/decoder';
 import { ProcessService } from '../../../client/common/process/proc';
 import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
+import { IExperimentService } from '../../../client/common/types';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
 import { IInterpreterService } from '../../../client/interpreter/contracts';
@@ -36,6 +38,7 @@ suite('Terminal - Code Execution Helper', () => {
     let editor: TypeMoq.IMock<TextEditor>;
     let processService: TypeMoq.IMock<IProcessService>;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
+    let experimentService: TypeMoq.IMock<IExperimentService>;
     const workingPython: PythonEnvironment = {
         path: PYTHON_PATH,
         version: new SemVer('3.6.6-final'),
@@ -53,6 +56,7 @@ suite('Terminal - Code Execution Helper', () => {
         const envVariablesProvider = TypeMoq.Mock.ofType<IEnvironmentVariablesProvider>();
         processService = TypeMoq.Mock.ofType<IProcessService>();
         interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
+        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
         // tslint:disable-next-line:no-any
         processService.setup((x: any) => x.then).returns(() => undefined);
         interpreterService
@@ -80,6 +84,9 @@ suite('Terminal - Code Execution Helper', () => {
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IEnvironmentVariablesProvider), TypeMoq.It.isAny()))
             .returns(() => envVariablesProvider.object);
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService), TypeMoq.It.isAny()))
+            .returns(() => experimentService.object);
         helper = new CodeExecutionHelper(serviceContainer.object);
 
         document = TypeMoq.Mock.ofType<TextDocument>();
@@ -87,7 +94,43 @@ suite('Terminal - Code Execution Helper', () => {
         editor.setup((e) => e.document).returns(() => document.object);
     });
 
-    async function ensureBlankLinesAreRemoved(source: string, expectedSource: string) {
+    test('normalizeLines should call normalizeSelection.py if in the SendSelectionToREPL experiment', async () => {
+        let execArgs = '';
+
+        experimentService
+            .setup((e) => e.inExperiment(SendSelectionToREPL.experiment))
+            .returns(() => Promise.resolve(true));
+        processService
+            .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns((_, args: string[]) => {
+                execArgs = args.join(' ');
+                return Promise.resolve({ stdout: 'print("hello")' });
+            });
+
+        await helper.normalizeLines('print("hello")');
+
+        expect(execArgs).to.contain('normalizeSelection.py');
+    });
+
+    test('normalizeLines should call normalizeForInterpreter.py if not in the SendSelectionToREPL experiment', async () => {
+        let execArgs = '';
+
+        experimentService
+            .setup((e) => e.inExperiment(SendSelectionToREPL.experiment))
+            .returns(() => Promise.resolve(false));
+        processService
+            .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .returns((_, args: string[]) => {
+                execArgs = args.join(' ');
+                return Promise.resolve({ stdout: 'print("hello")' });
+            });
+
+        await helper.normalizeLines('print("hello")');
+
+        expect(execArgs).to.contain('normalizeForInterpreter.py');
+    });
+
+    async function ensureCodeIsNormalized(source: string, expectedSource: string) {
         const actualProcessService = new ProcessService(new BufferDecoder());
         processService
             .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
@@ -99,101 +142,112 @@ suite('Terminal - Code Execution Helper', () => {
         expectedSource = expectedSource.splitLines({ removeEmptyEntries: false, trim: false }).join(EOL);
         expect(normalizedZCode).to.be.equal(expectedSource);
     }
-    test('Ensure blank lines are NOT removed when code is not indented (simple)', async function () {
-        // This test has not been working for many months in Python 2.7 under
-        // Windows.Tracked by #2544.
-        if (isOs(OSType.Windows) && (await isPythonVersion('2.7'))) {
-            // tslint:disable-next-line:no-invalid-this
-            return this.skip();
-        }
 
-        const code = [
-            'import sys',
-            '',
-            '',
-            '',
-            'print(sys.executable)',
-            '',
-            'print("1234")',
-            '',
-            '',
-            'print(1)',
-            'print(2)'
-        ];
-        const expectedCode = code.filter((line) => line.trim().length > 0).join(EOL);
-        await ensureBlankLinesAreRemoved(code.join(EOL), expectedCode);
-    });
-    test('Ensure there are no multiple-CR elements in the normalized code.', async () => {
-        const code = [
-            'import sys',
-            '',
-            '',
-            '',
-            'print(sys.executable)',
-            '',
-            'print("1234")',
-            '',
-            '',
-            'print(1)',
-            'print(2)'
-        ];
-        const actualProcessService = new ProcessService(new BufferDecoder());
-        processService
-            .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
-            .returns((_file, args, options) => {
-                return actualProcessService.exec.apply(actualProcessService, [PYTHON_PATH, args, options]);
+    suite('When using normalizeForIntepreter.py to normalize code', () => {
+        setup(() => {
+            experimentService
+                .setup((e) => e.inExperiment(SendSelectionToREPL.experiment))
+                .returns(() => Promise.resolve(false));
+        });
+
+        test('Ensure blank lines are NOT removed when code is not indented (simple)', async function () {
+            // This test has not been working for many months in Python 2.7 under
+            // Windows.Tracked by #2544.
+            if (isOs(OSType.Windows) && (await isPythonVersion('2.7'))) {
+                // tslint:disable-next-line:no-invalid-this
+                return this.skip();
+            }
+
+            const code = [
+                'import sys',
+                '',
+                '',
+                '',
+                'print(sys.executable)',
+                '',
+                'print("1234")',
+                '',
+                '',
+                'print(1)',
+                'print(2)'
+            ];
+            const expectedCode = code.filter((line) => line.trim().length > 0).join(EOL);
+            await ensureCodeIsNormalized(code.join(EOL), expectedCode);
+        });
+        test('Ensure there are no multiple-CR elements in the normalized code.', async () => {
+            const code = [
+                'import sys',
+                '',
+                '',
+                '',
+                'print(sys.executable)',
+                '',
+                'print("1234")',
+                '',
+                '',
+                'print(1)',
+                'print(2)'
+            ];
+            const actualProcessService = new ProcessService(new BufferDecoder());
+            processService
+                .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+                .returns((_file, args, options) => {
+                    return actualProcessService.exec.apply(actualProcessService, [PYTHON_PATH, args, options]);
+                });
+            const normalizedCode = await helper.normalizeLines(code.join(EOL));
+            const doubleCrIndex = normalizedCode.indexOf('\r\r');
+            expect(doubleCrIndex).to.be.equal(
+                -1,
+                'Double CR (CRCRLF) line endings detected in normalized code snippet.'
+            );
+        });
+        ['', '1', '2', '3', '4', '5', '6', '7', '8'].forEach((fileNameSuffix) => {
+            test(`Ensure blank lines are removed (Sample${fileNameSuffix})`, async () => {
+                const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
+                const expectedCode = await fs.readFile(
+                    path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`),
+                    'utf8'
+                );
+                await ensureCodeIsNormalized(code, expectedCode);
             });
-        const normalizedCode = await helper.normalizeLines(code.join(EOL));
-        const doubleCrIndex = normalizedCode.indexOf('\r\r');
-        expect(doubleCrIndex).to.be.equal(-1, 'Double CR (CRCRLF) line endings detected in normalized code snippet.');
-    });
-    ['', '1', '2', '3', '4', '5', '6', '7', '8'].forEach((fileNameSuffix) => {
-        test(`Ensure blank lines are removed (Sample${fileNameSuffix})`, async function () {
-            // This test has not been working for many months in Python 2.7 under
-            // Windows.Tracked by #2544.
-            if (isOs(OSType.Windows) && (await isPythonVersion('2.7'))) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-
-            const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
-            const expectedCode = await fs.readFile(
-                path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`),
-                'utf8'
-            );
-            await ensureBlankLinesAreRemoved(code, expectedCode);
-        });
-        test(`Ensure last two blank lines are preserved (Sample${fileNameSuffix})`, async function () {
-            // This test has not been working for many months in Python 2.7 under
-            // Windows.Tracked by #2544.
-            if (isOs(OSType.Windows) && (await isPythonVersion('2.7'))) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-
-            const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
-            const expectedCode = await fs.readFile(
-                path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`),
-                'utf8'
-            );
-            await ensureBlankLinesAreRemoved(code + EOL, expectedCode + EOL);
-        });
-        test(`Ensure last two blank lines are preserved even if we have more than 2 trailing blank lines (Sample${fileNameSuffix})`, async function () {
-            // This test has not been working for many months in Python 2.7 under
-            // Windows.Tracked by #2544.
-            if (isOs(OSType.Windows) && (await isPythonVersion('2.7'))) {
-                // tslint:disable-next-line:no-invalid-this
-                return this.skip();
-            }
-
-            const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
-            const expectedCode = await fs.readFile(
-                path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`),
-                'utf8'
-            );
-            await ensureBlankLinesAreRemoved(code + EOL + EOL + EOL + EOL, expectedCode + EOL);
+            test(`Ensure last two blank lines are preserved (Sample${fileNameSuffix})`, async () => {
+                const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
+                const expectedCode = await fs.readFile(
+                    path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`),
+                    'utf8'
+                );
+                await ensureCodeIsNormalized(code + EOL, expectedCode + EOL);
+            });
+            test(`Ensure last two blank lines are preserved even if we have more than 2 trailing blank lines (Sample${fileNameSuffix})`, async () => {
+                const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
+                const expectedCode = await fs.readFile(
+                    path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized.py`),
+                    'utf8'
+                );
+                await ensureCodeIsNormalized(code + EOL + EOL + EOL + EOL, expectedCode + EOL);
+            });
         });
     });
+
+    suite('When using normalizeSelection.py to normalize code', () => {
+        setup(() => {
+            experimentService
+                .setup((e) => e.inExperiment(SendSelectionToREPL.experiment))
+                .returns(() => Promise.resolve(true));
+        });
+
+        ['', '1', '2', '3', '4', '5', '6', '7', '8'].forEach((fileNameSuffix) => {
+            test(`Ensure code is normalized (Sample${fileNameSuffix})`, async () => {
+                const code = await fs.readFile(path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_raw.py`), 'utf8');
+                const expectedCode = await fs.readFile(
+                    path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized_selection.py`),
+                    'utf8'
+                );
+                await ensureCodeIsNormalized(code, expectedCode);
+            });
+        });
+    });
+
     test("Display message if there's no active file", async () => {
         documentManager.setup((doc) => doc.activeTextEditor).returns(() => undefined);
 

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -138,7 +138,7 @@ suite('Terminal - Code Execution Helper', () => {
                 return actualProcessService.exec.apply(actualProcessService, [file, args, options]);
             });
         const normalizedZCode = await helper.normalizeLines(source);
-        
+
         expect(normalizedZCode).to.be.equal(expectedSource);
     }
 

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -243,7 +243,7 @@ suite('Terminal - Code Execution Helper', () => {
                     path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized_selection.py`),
                     'utf8'
                 );
-                expectedCode.replace('\r\n', '\n');
+                expectedCode.replace(/\r\n/g, '\n');
                 await ensureCodeIsNormalized(code, expectedCode);
             });
         });

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -16,7 +16,11 @@ import { SendSelectionToREPL } from '../../../client/common/experiments/groups';
 import '../../../client/common/extensions';
 import { BufferDecoder } from '../../../client/common/process/decoder';
 import { ProcessService } from '../../../client/common/process/proc';
-import { IProcessService, IProcessServiceFactory } from '../../../client/common/process/types';
+import {
+    IProcessService,
+    IProcessServiceFactory,
+    ObservableExecutionResult
+} from '../../../client/common/process/types';
 import { IExperimentService } from '../../../client/common/types';
 import { Architecture, OSType } from '../../../client/common/utils/platform';
 import { IEnvironmentVariablesProvider } from '../../../client/common/variables/types';
@@ -101,10 +105,10 @@ suite('Terminal - Code Execution Helper', () => {
             .setup((e) => e.inExperiment(SendSelectionToREPL.experiment))
             .returns(() => Promise.resolve(true));
         processService
-            .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((p) => p.execObservable(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns((_, args: string[]) => {
                 execArgs = args.join(' ');
-                return Promise.resolve({ stdout: 'print("hello")' });
+                return ({} as unknown) as ObservableExecutionResult<string>;
             });
 
         await helper.normalizeLines('print("hello")');
@@ -119,10 +123,10 @@ suite('Terminal - Code Execution Helper', () => {
             .setup((e) => e.inExperiment(SendSelectionToREPL.experiment))
             .returns(() => Promise.resolve(false));
         processService
-            .setup((p) => p.exec(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
+            .setup((p) => p.execObservable(TypeMoq.It.isAny(), TypeMoq.It.isAny(), TypeMoq.It.isAny()))
             .returns((_, args: string[]) => {
                 execArgs = args.join(' ');
-                return Promise.resolve({ stdout: 'print("hello")' });
+                return ({} as unknown) as ObservableExecutionResult<string>;
             });
 
         await helper.normalizeLines('print("hello")');

--- a/src/test/terminals/codeExecution/helper.test.ts
+++ b/src/test/terminals/codeExecution/helper.test.ts
@@ -243,6 +243,7 @@ suite('Terminal - Code Execution Helper', () => {
                     path.join(TEST_FILES_PATH, `sample${fileNameSuffix}_normalized_selection.py`),
                     'utf8'
                 );
+                expectedCode.replace('\r\n', '\n');
                 await ensureCodeIsNormalized(code, expectedCode);
             });
         });


### PR DESCRIPTION
For #14048 

Some tests in `helper.test.ts` were being skipped but the reason was obsolete (#2544), so I unskipped them.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
