### PR TITLE
Ensure windows store locator only returns unique executables

### DIFF
--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -3,10 +3,6 @@
 
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
-import { Architecture } from '../../../common/utils/platform';
-import { arePathsSame } from '../../common/externalDependencies';
-import { areEqualVersions, areEquivalentVersions } from './pythonVersion';
-
 import {
     FileInfo,
     PythonDistroInfo,
@@ -15,6 +11,9 @@ import {
     PythonReleaseLevel,
     PythonVersion,
 } from '.';
+import { Architecture } from '../../../common/utils/platform';
+import { arePathsSame } from '../../common/externalDependencies';
+import { areEqualVersions, areEquivalentVersions } from './pythonVersion';
 
 /**
  * Create a new info object with all values empty.
@@ -26,17 +25,20 @@ export function buildEnvInfo(init?: {
     executable?: string;
     location?: string;
     version?: PythonVersion;
+    org?: string;
+    arch?: Architecture;
+    fileInfo?: {ctime:number, mtime:number}
 }): PythonEnvInfo {
     const env = {
+        name: '',
+        location: '',
         kind: PythonEnvKind.Unknown,
         executable: {
             filename: '',
             sysPrefix: '',
-            ctime: -1,
-            mtime: -1,
+            ctime: init?.fileInfo?.ctime ?? -1,
+            mtime: init?.fileInfo?.mtime ?? -1,
         },
-        name: '',
-        location: '',
         searchLocation: undefined,
         defaultDisplayName: undefined,
         version: {
@@ -48,9 +50,9 @@ export function buildEnvInfo(init?: {
                 serial: 0,
             },
         },
-        arch: Architecture.Unknown,
+        arch: init?.arch ?? Architecture.Unknown,
         distro: {
-            org: '',
+            org: init?.org ?? '',
         },
     };
     if (init !== undefined) {

--- a/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -1,9 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import * as path from 'path';
+import { PythonReleaseLevel, PythonVersion, UNKNOWN_PYTHON_VERSION } from '.';
+import { traceError } from '../../../common/logger';
 import { EMPTY_VERSION, parseBasicVersionInfo } from '../../../common/utils/version';
 
-import { PythonReleaseLevel, PythonVersion } from '.';
+export function getPythonVersionFromPath(exe:string): PythonVersion {
+    let version = UNKNOWN_PYTHON_VERSION;
+    try {
+        version = parseVersion(path.basename(exe));
+    } catch (ex) {
+        traceError(`Failed to parse version from path: ${exe}`, ex);
+    }
+    return version;
+}
 
 /**
  * Convert the given string into the corresponding Python version object.

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -6,13 +6,12 @@ import * as path from 'path';
 import { traceError, traceWarning } from '../../../../common/logger';
 import { Architecture, getEnvironmentVariable } from '../../../../common/utils/platform';
 import {
-    PythonEnvInfo, PythonEnvKind, PythonReleaseLevel, PythonVersion,
+    PythonEnvInfo, PythonEnvKind, PythonVersion, UNKNOWN_PYTHON_VERSION
 } from '../../../base/info';
+import { buildEnvInfo } from '../../../base/info/env';
 import { parseVersion } from '../../../base/info/pythonVersion';
-import { ILocator, IPythonEnvsIterator } from '../../../base/locator';
-import { PythonEnvsWatcher } from '../../../base/watcher';
+import { IPythonEnvsIterator, Locator } from '../../../base/locator';
 import { getFileInfo } from '../../../common/externalDependencies';
-import { isWindowsPythonExe } from '../../../common/windowsUtils';
 
 /**
  * Gets path to the Windows Apps directory.
@@ -89,6 +88,28 @@ export async function isWindowsStoreEnvironment(interpreterPath: string): Promis
 }
 
 /**
+ * Checks if a given path ends with python3.*.exe. Not all python executables are matched as
+ * we do not want to return duplicate executables.
+ * @param {string} interpreterPath : Path to python interpreter.
+ * @returns {boolean} : Returns true if the path matches pattern for windows python executable.
+ */
+export function isWindowsStorePythonExe(interpreterPath:string): boolean {
+    /**
+     * This Reg-ex matches following file names:
+     * python3.8.exe
+     * python3.9.exe
+     * This Reg-ex does not match:
+     * python.exe
+     * python2.7.exe
+     * python3.exe
+     * python38.exe
+     */
+    const windowsPythonExes = /^python(3(.\d+))\.exe$/;
+
+    return windowsPythonExes.test(path.basename(interpreterPath));
+}
+
+/**
  * Gets paths to the Python executable under Windows Store apps.
  * @returns: Returns python*.exe for the windows store app root directory.
  *
@@ -111,55 +132,49 @@ export async function getWindowsStorePythonExes(): Promise<string[]> {
     const files = await fsapi.readdir(windowsAppsRoot);
     return files
         .map((filename:string) => path.join(windowsAppsRoot, filename))
-        .filter(isWindowsPythonExe);
+        .filter(isWindowsStorePythonExe);
 }
 
-export class WindowsStoreLocator extends PythonEnvsWatcher implements ILocator {
+export class WindowsStoreLocator extends Locator {
     private readonly kind:PythonEnvKind = PythonEnvKind.WindowsStore;
 
     public iterEnvs(): IPythonEnvsIterator {
-        const buildEnvInfo = (exe:string) => this.buildEnvInfo(exe);
-        const iterator = async function* () {
+        const iterator = async function* (kind: PythonEnvKind) {
             const exes = await getWindowsStorePythonExes();
-            yield* exes.map(buildEnvInfo);
+            yield* exes.map(async (executable:string) => buildEnvInfo({
+                kind,
+                executable,
+                version: getPythonVersion(executable),
+                org: 'Microsoft',
+                arch: Architecture.x64,
+                fileInfo: await getFileInfo(executable),
+            }));
         };
-        return iterator();
+        return iterator(this.kind);
     }
 
     public async resolveEnv(env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
         const executablePath = typeof env === 'string' ? env : env.executable.filename;
         if (await isWindowsStoreEnvironment(executablePath)) {
-            return this.buildEnvInfo(executablePath);
+            return buildEnvInfo({
+                kind: this.kind,
+                executable: executablePath,
+                version: getPythonVersion(executablePath),
+                org: 'Microsoft',
+                arch: Architecture.x64,
+                fileInfo: await getFileInfo(executablePath),
+            });
         }
         return undefined;
     }
+}
 
-    private async buildEnvInfo(exe:string): Promise<PythonEnvInfo> {
-        let version:PythonVersion;
-        try {
-            version = parseVersion(path.basename(exe));
-        } catch (ex) {
-            traceError(`Failed to parse version from path: ${exe}`, ex);
-            version = {
-                major: 3,
-                minor: -1,
-                micro: -1,
-                release: { level: PythonReleaseLevel.Final, serial: -1 },
-                sysVersion: undefined,
-            };
-        }
-        return {
-            name: '',
-            location: '',
-            kind: this.kind,
-            executable: {
-                filename: exe,
-                sysPrefix: '',
-                ...(await getFileInfo(exe)),
-            },
-            version,
-            arch: Architecture.x64,
-            distro: { org: 'Microsoft' },
-        };
+function getPythonVersion(exe:string): PythonVersion {
+    let version = UNKNOWN_PYTHON_VERSION;
+    try {
+        version = parseVersion(path.basename(exe));
+    } catch (ex) {
+        traceError(`Failed to parse version from path: ${exe}`, ex);
     }
+    return version;
 }

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -3,13 +3,13 @@
 
 import * as fsapi from 'fs-extra';
 import * as path from 'path';
-import { traceError, traceWarning } from '../../../../common/logger';
+import { traceWarning } from '../../../../common/logger';
 import { Architecture, getEnvironmentVariable } from '../../../../common/utils/platform';
 import {
-    PythonEnvInfo, PythonEnvKind, PythonVersion, UNKNOWN_PYTHON_VERSION
+    PythonEnvInfo, PythonEnvKind,
 } from '../../../base/info';
 import { buildEnvInfo } from '../../../base/info/env';
-import { parseVersion } from '../../../base/info/pythonVersion';
+import { getPythonVersionFromPath } from '../../../base/info/pythonVersion';
 import { IPythonEnvsIterator, Locator } from '../../../base/locator';
 import { getFileInfo } from '../../../common/externalDependencies';
 
@@ -144,7 +144,7 @@ export class WindowsStoreLocator extends Locator {
             yield* exes.map(async (executable:string) => buildEnvInfo({
                 kind,
                 executable,
-                version: getPythonVersion(executable),
+                version: getPythonVersionFromPath(executable),
                 org: 'Microsoft',
                 arch: Architecture.x64,
                 fileInfo: await getFileInfo(executable),
@@ -159,7 +159,7 @@ export class WindowsStoreLocator extends Locator {
             return buildEnvInfo({
                 kind: this.kind,
                 executable: executablePath,
-                version: getPythonVersion(executablePath),
+                version: getPythonVersionFromPath(executablePath),
                 org: 'Microsoft',
                 arch: Architecture.x64,
                 fileInfo: await getFileInfo(executablePath),
@@ -167,14 +167,4 @@ export class WindowsStoreLocator extends Locator {
         }
         return undefined;
     }
-}
-
-function getPythonVersion(exe:string): PythonVersion {
-    let version = UNKNOWN_PYTHON_VERSION;
-    try {
-        version = parseVersion(path.basename(exe));
-    } catch (ex) {
-        traceError(`Failed to parse version from path: ${exe}`, ex);
-    }
-    return version;
 }

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
@@ -7,7 +7,7 @@ import * as sinon from 'sinon';
 import { ExecutionResult } from '../../../../client/common/process/types';
 import * as platformApis from '../../../../client/common/utils/platform';
 import {
-    PythonEnvInfo, PythonEnvKind, PythonReleaseLevel, PythonVersion,
+    PythonEnvInfo, PythonEnvKind, PythonReleaseLevel, PythonVersion, UNKNOWN_PYTHON_VERSION,
 } from '../../../../client/pythonEnvironments/base/info';
 import { InterpreterInformation } from '../../../../client/pythonEnvironments/base/info/interpreter';
 import { parseVersion } from '../../../../client/pythonEnvironments/base/info/pythonVersion';
@@ -34,10 +34,8 @@ suite('Windows Store', () => {
 
         test('Store Python Interpreters', async () => {
             const expected = [
-                path.join(testStoreAppRoot, 'python.exe'),
                 path.join(testStoreAppRoot, 'python3.7.exe'),
                 path.join(testStoreAppRoot, 'python3.8.exe'),
-                path.join(testStoreAppRoot, 'python3.exe'),
             ];
 
             const actual = await getWindowsStorePythonExes();
@@ -72,8 +70,6 @@ suite('Windows Store', () => {
             is64Bit: true,
         };
 
-        pathToData.set(path.join(testStoreAppRoot, 'python.exe'), python383data);
-        pathToData.set(path.join(testStoreAppRoot, 'python3.exe'), python383data);
         pathToData.set(path.join(testStoreAppRoot, 'python3.8.exe'), python383data);
         pathToData.set(path.join(testStoreAppRoot, 'python3.7.exe'), python379data);
 
@@ -90,13 +86,7 @@ suite('Windows Store', () => {
                     version.sysVersion = sysVersion;
                 }
             } catch (e) {
-                version = {
-                    major: 3,
-                    minor: -1,
-                    micro: -1,
-                    release: { level: PythonReleaseLevel.Final, serial: -1 },
-                    sysVersion,
-                };
+                version = UNKNOWN_PYTHON_VERSION;
             }
             return {
                 version,
@@ -138,7 +128,8 @@ suite('Windows Store', () => {
                     const data = pathToData.get(k);
                     if (data) {
                         return {
-
+                            defaultDisplayName: undefined,
+                            searchLocation: undefined,
                             name: '',
                             location: '',
                             kind: PythonEnvKind.WindowsStore,
@@ -160,7 +151,8 @@ suite('Windows Store', () => {
         test('resolveEnv(string)', async () => {
             const python38path = path.join(testStoreAppRoot, 'python3.8.exe');
             const expected = {
-
+                defaultDisplayName: undefined,
+                searchLocation: undefined,
                 name: '',
                 location: '',
                 kind: PythonEnvKind.WindowsStore,
@@ -177,7 +169,8 @@ suite('Windows Store', () => {
         test('resolveEnv(PythonEnvInfo)', async () => {
             const python38path = path.join(testStoreAppRoot, 'python3.8.exe');
             const expected = {
-
+                defaultDisplayName: undefined,
+                searchLocation: undefined,
                 name: '',
                 location: '',
                 kind: PythonEnvKind.WindowsStore,
@@ -189,6 +182,8 @@ suite('Windows Store', () => {
             const input:PythonEnvInfo = {
                 name: '',
                 location: '',
+                defaultDisplayName: undefined,
+                searchLocation: undefined,
                 kind: PythonEnvKind.WindowsStore,
                 distro: { org: 'Microsoft' },
                 arch: platformApis.Architecture.x64,
@@ -214,7 +209,8 @@ suite('Windows Store', () => {
         test('resolveEnv(string): forbidden path', async () => {
             const python38path = path.join(testLocalAppData, 'Program Files', 'WindowsApps', 'python3.8.exe');
             const expected = {
-
+                defaultDisplayName: undefined,
+                searchLocation: undefined,
                 name: '',
                 location: '',
                 kind: PythonEnvKind.WindowsStore,


### PR DESCRIPTION
- Cleanup stuff around `buildEnvInfo`. Used existing method and updated tests.
- `python.exe`, `python3.exe`, and `python3.8.exe` may all point to the same executable, only return `python3.*.exe`s.