### PR TITLE
Fix failing global virtual env watcher tests

### DIFF
--- a/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
+++ b/src/client/pythonEnvironments/common/pythonBinariesWatcher.ts
@@ -29,7 +29,7 @@ export function watchLocationForPythonBinaries(
     const disposables = new DisposableRegistry();
     for (const pattern of patterns) {
         disposables.push(watchLocationForPattern(baseDir, pattern, (type: FileChangeType, e: string) => {
-            const isMatch = minimatch(e, path.join('**', executableBaseGlob), { nocase: getOSType() === OSType.Windows });
+            const isMatch = minimatch(path.basename(e), executableBaseGlob, { nocase: getOSType() === OSType.Windows });
             if (!isMatch) {
                 // When deleting the file for some reason path to all directories leading up to python are reported
                 // Skip those events

--- a/src/test/pythonEnvironments/discovery/locators/globalVirtualEnvironmentLocator.testvirtualenvs.ts
+++ b/src/test/pythonEnvironments/discovery/locators/globalVirtualEnvironmentLocator.testvirtualenvs.ts
@@ -62,6 +62,7 @@ suite('GlobalVirtualEnvironment Locator', async () => {
     setup(async () => {
         process.env.WORKON_HOME = testWorkOnHomePath;
         locator = new GlobalVirtualEnvironmentLocator();
+        await locator.initialize();
         // Wait for watchers to get ready
         await sleep(1000);
     });


### PR DESCRIPTION
For #14618 

Only the last commit is relevant. The rest of the PR is based on https://github.com/microsoft/vscode-python/pull/14605. P.S I'll only merge this one after that one.