### PR TITLE
Use Node 12.15 on all Insiders and Release GitHub Actions jobs

### DIFF
--- a/.github/workflows/insiders.yml
+++ b/.github/workflows/insiders.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
+
       - name: Install dependencies (npm ci)
         run: npm ci --prefer-offline
 
@@ -123,6 +128,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{env.special-working-directory-relative}}
+
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
 
       - name: Install dependencies (npm ci)
         run: npm ci
@@ -325,6 +335,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
+
       - name: Use Python ${{matrix.python}}
         uses: actions/setup-python@v2
         with:
@@ -395,6 +410,11 @@ jobs:
       # Need the source to have the tests available.
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
 
       - name: Use Python ${{matrix.python}}
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
+
       - name: Install dependencies (npm ci)
         run: npm ci --prefer-offline
 
@@ -110,6 +115,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{env.special-working-directory-relative}}
+
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
 
       - name: Install dependencies (npm ci)
         run: npm ci
@@ -302,6 +312,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
+
       - name: Use Python ${{matrix.python}}
         uses: actions/setup-python@v2
         with:
@@ -372,6 +387,11 @@ jobs:
       # Need the source to have the tests available.
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Use Node ${{env.NODE_VERSION}}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{env.NODE_VERSION}}
 
       - name: Use Python ${{matrix.python}}
         uses: actions/setup-python@v2


### PR DESCRIPTION
Looks like https://github.com/microsoft/vscode-python/pull/14641 fixed the Build VSIX job: https://github.com/microsoft/vscode-python/runs/1361560138 This PR applies the same fix to all jobs

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
