### PR TITLE
Fix #12462, #14674 for debugging

### DIFF
--- a/news/1 Enhancements/12462.md
+++ b/news/1 Enhancements/12462.md
@@ -1,0 +1,1 @@
+Replaced "pythonPath" debug configuration property with "python".

--- a/package.json
+++ b/package.json
@@ -1571,9 +1571,9 @@
                                 "description": "Absolute path to the program.",
                                 "default": "${file}"
                             },
-                            "pythonPath": {
+                            "python": {
                                 "type": "string",
-                                "description": "Path (fully qualified) to python executable. Defaults to the value in settings",
+                                "description": "Absolute path to the Python interpreter executable; overrides workspace configuration if set.",
                                 "default": "${command:python.interpreterPath}"
                             },
                             "pythonArgs": {

--- a/src/client/debugger/extension/adapter/factory.ts
+++ b/src/client/debugger/extension/adapter/factory.ts
@@ -27,6 +27,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
         @inject(IApplicationShell) private readonly appShell: IApplicationShell
     ) {}
+
     public async createDebugAdapterDescriptor(
         session: DebugSession,
         _executable: DebugAdapterExecutable | undefined
@@ -54,7 +55,7 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
             }
         }
 
-        const pythonPath = await this.getPythonPath(configuration, session.workspaceFolder);
+        const pythonPath = await this.getDebugAdapterPython(configuration, session.workspaceFolder);
         if (pythonPath.length !== 0) {
             if (configuration.request === 'attach' && configuration.processId !== undefined) {
                 sendTelemetryEvent(EventName.DEBUGGER_ATTACH_TO_LOCAL_PROCESS);
@@ -96,13 +97,16 @@ export class DebugAdapterDescriptorFactory implements IDebugAdapterDescriptorFac
      * @returns {Promise<string>} Path to the python interpreter for this workspace.
      * @memberof DebugAdapterDescriptorFactory
      */
-    private async getPythonPath(
+    private async getDebugAdapterPython(
         configuration: LaunchRequestArguments | AttachRequestArguments,
         workspaceFolder?: WorkspaceFolder
     ): Promise<string> {
-        if (configuration.pythonPath) {
+        if (configuration.debugAdapterPython !== undefined) {
+            return configuration.debugAdapterPython;
+        } else if (configuration.pythonPath) {
             return configuration.pythonPath;
         }
+
         const resourceUri = workspaceFolder ? workspaceFolder.uri : undefined;
         const interpreter = await this.interpreterService.getActiveInterpreter(resourceUri);
         if (interpreter) {

--- a/src/client/debugger/extension/configuration/debugConfigurationService.ts
+++ b/src/client/debugger/extension/configuration/debugConfigurationService.ts
@@ -29,6 +29,7 @@ export class PythonDebugConfigurationService implements IDebugConfigurationServi
         private readonly providerFactory: IDebugConfigurationProviderFactory,
         @inject(IMultiStepInputFactory) private readonly multiStepFactory: IMultiStepInputFactory
     ) {}
+
     public async provideDebugConfigurations(
         folder: WorkspaceFolder | undefined,
         token?: CancellationToken
@@ -46,6 +47,7 @@ export class PythonDebugConfigurationService implements IDebugConfigurationServi
             return [state.config as DebugConfiguration];
         }
     }
+
     public async resolveDebugConfiguration(
         folder: WorkspaceFolder | undefined,
         debugConfiguration: DebugConfiguration,
@@ -76,6 +78,18 @@ export class PythonDebugConfigurationService implements IDebugConfigurationServi
             );
         }
     }
+
+    public async resolveDebugConfigurationWithSubstitutedVariables(
+        folder: WorkspaceFolder | undefined,
+        debugConfiguration: DebugConfiguration,
+        token?: CancellationToken
+    ): Promise<DebugConfiguration | undefined> {
+        function resolve<T extends DebugConfiguration>(resolver: IDebugConfigurationResolver<T>) {
+            return resolver.resolveDebugConfigurationWithSubstitutedVariables(folder, debugConfiguration as T, token);
+        }
+        return debugConfiguration.request === 'attach' ? resolve(this.attachResolver) : resolve(this.launchResolver);
+    }
+
     protected async pickDebugConfiguration(
         input: IMultiStepInput<DebugConfigurationState>,
         state: DebugConfigurationState

--- a/src/client/debugger/extension/configuration/resolvers/attach.ts
+++ b/src/client/debugger/extension/configuration/resolvers/attach.ts
@@ -21,7 +21,8 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
     ) {
         super(workspaceService, documentManager, platformService, configurationService);
     }
-    public async resolveDebugConfiguration(
+
+    public async resolveDebugConfigurationWithSubstitutedVariables(
         folder: WorkspaceFolder | undefined,
         debugConfiguration: AttachRequestArguments,
         _token?: CancellationToken
@@ -38,6 +39,7 @@ export class AttachConfigurationResolver extends BaseConfigurationResolver<Attac
         }
         return debugConfiguration;
     }
+
     // tslint:disable-next-line:cyclomatic-complexity
     protected async provideAttachDefaults(
         workspaceFolder: Uri | undefined,

--- a/src/client/debugger/extension/configuration/types.ts
+++ b/src/client/debugger/extension/configuration/types.ts
@@ -13,6 +13,12 @@ export interface IDebugConfigurationResolver<T extends DebugConfiguration> {
         debugConfiguration: T,
         token?: CancellationToken
     ): Promise<T | undefined>;
+
+    resolveDebugConfigurationWithSubstitutedVariables(
+        folder: WorkspaceFolder | undefined,
+        debugConfiguration: T,
+        token?: CancellationToken
+    ): Promise<T | undefined>;
 }
 
 export const IDebugConfigurationProviderFactory = Symbol('IDebugConfigurationProviderFactory');

--- a/src/client/debugger/types.ts
+++ b/src/client/debugger/types.ts
@@ -70,19 +70,35 @@ export interface IKnownLaunchRequestArguments extends ICommonDebugArguments {
     // An absolute path to the program to debug.
     module?: string;
     program?: string;
-    pythonPath: string;
+    python?: string;
     // Automatically stop target after launch. If not specified, target does not stop.
     stopOnEntry?: boolean;
-    args: string[];
+    args?: string[];
     cwd?: string;
     debugOptions?: DebugOptions[];
     env?: Record<string, string | undefined>;
-    envFile: string;
+    envFile?: string;
     console?: ConsoleType;
 
-    // Internal field used to set custom python debug adapter (for testing)
+    // The following are all internal properties that are not publicly documented or
+    // exposed in launch.json schema for the extension.
+
+    // Python interpreter used by the extension to spawn the debug adapter.
+    debugAdapterPython?: string;
+
+    // Debug adapter to use in lieu of the one bundled with the extension.
+    // This must be a full path that is executable with "python <debugAdapterPath>";
+    // for debugpy, this is ".../src/debugpy/adapter".
     debugAdapterPath?: string;
+
+    // Python interpreter used by the debug adapter to spawn the debug launcher.
+    debugLauncherPython?: string;
+
+    // Legacy interpreter setting. Equivalent to setting "python", "debugAdapterPython",
+    // and "debugLauncherPython" all at once.
+    pythonPath?: string;
 }
+
 // tslint:disable-next-line:interface-name
 export interface LaunchRequestArguments
     extends DebugProtocol.LaunchRequestArguments,

--- a/src/client/testing/common/debugLauncher.ts
+++ b/src/client/testing/common/debugLauncher.ts
@@ -164,7 +164,7 @@ export class DebugLauncher implements ITestDebugLauncher {
         configArgs.args = args.slice(1);
         // We leave configArgs.request as "test" so it will be sent in telemetry.
 
-        const launchArgs = await this.launchResolver.resolveDebugConfiguration(
+        let launchArgs = await this.launchResolver.resolveDebugConfiguration(
             workspaceFolder,
             configArgs,
             options.token
@@ -172,9 +172,17 @@ export class DebugLauncher implements ITestDebugLauncher {
         if (!launchArgs) {
             throw Error(`Invalid debug config "${debugConfig.name}"`);
         }
+        launchArgs = await this.launchResolver.resolveDebugConfigurationWithSubstitutedVariables(
+            workspaceFolder,
+            launchArgs,
+            options.token
+        );
+        if (!launchArgs) {
+            throw Error(`Invalid debug config "${debugConfig.name}"`);
+        }
         launchArgs.request = 'launch';
 
-        return launchArgs!;
+        return launchArgs;
     }
 
     private fixArgs(args: string[], testProvider: TestProvider): string[] {

--- a/src/test/application/diagnostics/checks/invalidLaunchJsonDebugger.unit.test.ts
+++ b/src/test/application/diagnostics/checks/invalidLaunchJsonDebugger.unit.test.ts
@@ -496,9 +496,8 @@ suite('Application Diagnostics - Checks if launch.json is invalid', () => {
     });
 
     test('File launch.json is fixed correctly when code equals ConfigPythonPathDiagnostic ', async () => {
-        const launchJson = 'This string contains {config:python.pythonPath} & {config:python.interpreterPath}';
-        const correctedlaunchJson =
-            'This string contains {command:python.interpreterPath} & {command:python.interpreterPath}';
+        const launchJson = '"pythonPath": "{config:python.pythonPath}{config:python.interpreterPath}"';
+        const correctedlaunchJson = '"python": "{command:python.interpreterPath}{command:python.interpreterPath}"';
         workspaceService
             .setup((w) => w.hasWorkspaceFolders)
             .returns(() => true)

--- a/src/test/debugger/extension/adapter/factory.unit.test.ts
+++ b/src/test/debugger/extension/adapter/factory.unit.test.ts
@@ -237,10 +237,28 @@ suite('Debugging - Adapter Factory', () => {
         assert.ok(Reporter.eventNames.includes(EventName.DEBUG_ADAPTER_USING_WHEELS_PATH));
     });
 
-    test('Use custom debug adapter path when specified', async () => {
+    test('Use "debugAdapterPath" when specified', async () => {
         const customAdapterPath = 'custom/debug/adapter/path';
         const session = createSession({ debugAdapterPath: customAdapterPath });
         const debugExecutable = new DebugAdapterExecutable(pythonPath, [customAdapterPath]);
+
+        const descriptor = await factory.createDebugAdapterDescriptor(session, nodeExecutable);
+
+        assert.deepEqual(descriptor, debugExecutable);
+    });
+
+    test('Use "debugAdapterPython" when specified', async () => {
+        const session = createSession({ debugAdapterPython: '/bin/custompy' });
+        const debugExecutable = new DebugAdapterExecutable('/bin/custompy', [debugAdapterPath]);
+
+        const descriptor = await factory.createDebugAdapterDescriptor(session, nodeExecutable);
+
+        assert.deepEqual(descriptor, debugExecutable);
+    });
+
+    test('Do not use "python" to spawn the debug adapter', async () => {
+        const session = createSession({ python: '/bin/custompy' });
+        const debugExecutable = new DebugAdapterExecutable(pythonPath, [debugAdapterPath]);
 
         const descriptor = await factory.createDebugAdapterDescriptor(session, nodeExecutable);
 

--- a/src/test/debugger/extension/configuration/resolvers/base.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/base.unit.test.ts
@@ -31,24 +31,38 @@ suite('Debugging - Config Resolver', () => {
         ): Promise<AttachRequestArguments | LaunchRequestArguments | undefined> {
             throw new Error('Not Implemented');
         }
+
+        public resolveDebugConfigurationWithSubstitutedVariables(
+            _folder: WorkspaceFolder | undefined,
+            _debugConfiguration: DebugConfiguration,
+            _token?: CancellationToken
+        ): Promise<AttachRequestArguments | LaunchRequestArguments | undefined> {
+            throw new Error('Not Implemented');
+        }
+
         public getWorkspaceFolder(folder: WorkspaceFolder | undefined): Uri | undefined {
             return super.getWorkspaceFolder(folder);
         }
+
         public getProgram(): string | undefined {
             return super.getProgram();
         }
+
         public resolveAndUpdatePythonPath(
             workspaceFolder: Uri | undefined,
             debugConfiguration: LaunchRequestArguments
         ): void {
             return super.resolveAndUpdatePythonPath(workspaceFolder, debugConfiguration);
         }
+
         public debugOption(debugOptions: DebugOptions[], debugOption: DebugOptions) {
             return super.debugOption(debugOptions, debugOption);
         }
+
         public isLocalHost(hostName?: string) {
             return super.isLocalHost(hostName);
         }
+
         public isDebuggingFlask(debugConfiguration: Partial<LaunchRequestArguments & AttachRequestArguments>) {
             return super.isDebuggingFlask(debugConfiguration);
         }
@@ -185,7 +199,7 @@ suite('Debugging - Config Resolver', () => {
     test('Do nothing if debug configuration is undefined', () => {
         resolver.resolveAndUpdatePythonPath(undefined, undefined as any);
     });
-    test('Python path in debug config must point to pythonpath in settings if pythonPath in config is not set', () => {
+    test('pythonPath in debug config must point to pythonPath in settings if pythonPath in config is not set', () => {
         const config = {};
         const pythonPath = path.join('1', '2', '3');
 
@@ -195,7 +209,7 @@ suite('Debugging - Config Resolver', () => {
 
         expect(config).to.have.property('pythonPath', pythonPath);
     });
-    test('Python path in debug config must point to pythonpath in settings  if pythonPath in config is ${command:python.interpreterPath}', () => {
+    test('pythonPath in debug config must point to pythonPath in settings  if pythonPath in config is ${command:python.interpreterPath}', () => {
         const config = {
             pythonPath: '${command:python.interpreterPath}'
         };

--- a/src/test/testing/common/debugLauncher.unit.test.ts
+++ b/src/test/testing/common/debugLauncher.unit.test.ts
@@ -119,7 +119,6 @@ suite('Unit Tests - Debug Launcher', () => {
             .setup((d) => d.getEnvironmentVariables(TypeMoq.It.isAny()))
             .returns(() => Promise.resolve(expected.env));
 
-        //debugService.setup(d => d.startDebugging(TypeMoq.It.isValue(workspaceFolder), TypeMoq.It.isValue(expected)))
         debugService
             .setup((d) => d.startDebugging(TypeMoq.It.isValue(workspaceFolder), TypeMoq.It.isValue(expected)))
             .returns((_wspc: WorkspaceFolder, _expectedParam: DebugConfiguration) => {
@@ -207,8 +206,14 @@ suite('Unit Tests - Debug Launcher', () => {
         }
 
         // added by LaunchConfigurationResolver:
-        if (!expected.pythonPath) {
-            expected.pythonPath = 'python';
+        if (!expected.python) {
+            expected.python = 'python';
+        }
+        if (!expected.debugAdapterPython) {
+            expected.debugAdapterPython = 'python';
+        }
+        if (!expected.debugLauncherPython) {
+            expected.debugLauncherPython = 'python';
         }
         expected.workspaceFolder = workspaceFolders[0].uri.fsPath;
         expected.debugOptions = [];
@@ -324,7 +329,9 @@ suite('Unit Tests - Debug Launcher', () => {
             name: 'my tests',
             type: DebuggerTypeName,
             request: 'launch',
-            pythonPath: 'some/dir/bin/py3',
+            python: 'some/dir/bin/py3',
+            debugAdapterPython: 'some/dir/bin/py3',
+            debugLauncherPython: 'some/dir/bin/py3',
             stopOnEntry: true,
             showReturnValue: true,
             console: 'integratedTerminal',
@@ -345,7 +352,7 @@ suite('Unit Tests - Debug Launcher', () => {
                 name: 'my tests',
                 type: DebuggerTypeName,
                 request: 'test',
-                pythonPath: expected.pythonPath,
+                pythonPath: expected.python,
                 stopOnEntry: expected.stopOnEntry,
                 showReturnValue: expected.showReturnValue,
                 console: expected.console,


### PR DESCRIPTION
Fix #14674: Enable overriding "pythonPath" in the launcher

Fix #12462: Update launch.json schema to add "python" and remove "pythonPath"

Split the "pythonPath" debug property into "python", "debugAdapterPython", and "debugLauncherPython".

Properly register the python.interpreterPath command to expand the ${command:interpreterPath} debug configuration variable.

Do most debug config validation on fully expanded property values via resolveDebugConfigurationWithSubstitutedVariables().

Add fixups for legacy launch.json with "pythonPath" and/or "${command:python.interpreterPath}".

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [x] Has telemetry for enhancements.
-   [x] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
