### PR TITLE
Fix for interpreter selection

### DIFF
--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -203,7 +203,7 @@ export class PythonSettings implements IPythonSettings {
         const keys = Object.entries(settings);
         keys.forEach((e) => {
             const [k, v] = e;
-            if (!k.includes('Manager') && !k.includes('Service') && !k.includes('onDid') && !k.includes('to')) {
+            if (!k.includes('Manager') && !k.includes('Service') && !k.includes('onDid')) {
                 clone[k] = v;
             }
         });

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -196,6 +196,21 @@ export class PythonSettings implements IPythonSettings {
         PythonSettings.pythonSettings.forEach((item) => item && item.dispose());
         PythonSettings.pythonSettings.clear();
     }
+
+    public static toSerializable(settings: IPythonSettings): IPythonSettings {
+        // tslint:disable-next-line: no-any
+        const clone: any = {};
+        const keys = Object.entries(settings);
+        keys.forEach((e) => {
+            const [k, v] = e;
+            if (!k.includes('Manager') && !k.includes('Service') && !k.includes('onDid') && !k.includes('to')) {
+                clone[k] = v;
+            }
+        });
+
+        return clone as IPythonSettings;
+    }
+
     public dispose() {
         // tslint:disable-next-line:no-unsafe-any
         this.disposables.forEach((disposable) => disposable && disposable.dispose());
@@ -681,7 +696,18 @@ function getPythonExecutable(pythonPath: string): string {
     }
     // Keep python right on top, for backwards compatibility.
     // tslint:disable-next-line:variable-name
-    const KnownPythonExecutables = ['python', 'python4', 'python3.6', 'python3.5', 'python3', 'python2.7', 'python2', 'python3.7', 'python3.8', 'python3.9'];
+    const KnownPythonExecutables = [
+        'python',
+        'python4',
+        'python3.6',
+        'python3.5',
+        'python3',
+        'python2.7',
+        'python2',
+        'python3.7',
+        'python3.8',
+        'python3.9'
+    ];
 
     for (let executableName of KnownPythonExecutables) {
         // Suffix with 'python' for linux and 'osx', and 'python.exe' for 'windows'.

--- a/src/client/common/startPage/webviewHost.ts
+++ b/src/client/common/startPage/webviewHost.ts
@@ -15,10 +15,10 @@ import * as localize from '../utils/localize';
 import { DefaultTheme, Telemetry } from './constants';
 import { ICodeCssGenerator, IThemeFinder } from './types';
 
+import { PythonSettings } from '../configSettings';
 import { isTestExecution } from '../constants';
 import { IConfigurationService, IDisposable, IPythonSettings, Resource } from '../types';
 import { CssMessages, IGetCssRequest, IGetMonacoThemeRequest, SharedMessages } from './messages';
-import { PythonSettings } from '../configSettings';
 
 @injectable() // For some reason this is necessary to get the class hierarchy to work.
 export abstract class WebviewHost<IMapping> implements IDisposable {

--- a/src/client/common/startPage/webviewHost.ts
+++ b/src/client/common/startPage/webviewHost.ts
@@ -18,6 +18,7 @@ import { ICodeCssGenerator, IThemeFinder } from './types';
 import { isTestExecution } from '../constants';
 import { IConfigurationService, IDisposable, IPythonSettings, Resource } from '../types';
 import { CssMessages, IGetCssRequest, IGetMonacoThemeRequest, SharedMessages } from './messages';
+import { PythonSettings } from '../configSettings';
 
 @injectable() // For some reason this is necessary to get the class hierarchy to work.
 export abstract class WebviewHost<IMapping> implements IDisposable {
@@ -104,18 +105,8 @@ export abstract class WebviewHost<IMapping> implements IDisposable {
     }
 
     protected async generateExtraSettings(): Promise<IPythonSettings> {
-        const resource = this.owningResource;
-        // tslint:disable-next-line: no-any
-        const prunedSettings = this.configService.getSettings(resource) as any;
-
-        // Remove keys that aren't serializable
-        const keys = Object.keys(prunedSettings);
-        keys.forEach((k) => {
-            if (k.includes('Manager') || k.includes('Service') || k.includes('onDid')) {
-                delete prunedSettings[k];
-            }
-        });
-        return prunedSettings;
+        const settings = this.configService.getSettings(this.owningResource);
+        return PythonSettings.toSerializable(settings);
     }
 
     protected async sendLocStrings() {


### PR DESCRIPTION
For https://github.com/microsoft/vscode-python/issues/14645

Removing properties from python settings instance caused python path experiment to fail. We should never be removing properties from an instance that could be referenced somewhere else. So shallow-cloning the settings with non-serializable properties removed for the startpage.