### PR TITLE
Move the codecov configuration to a place where it will be found

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  strict_yaml_branch: 'main'
   notify:
     require_ci_to_pass: yes
 
@@ -8,7 +9,10 @@ coverage:
   range: '70...100'
 
   status:
-    project: yes
+    project:
+      default:
+        informational: true
+        only_pulls: true
     patch: yes
     changes: no
 
@@ -21,7 +25,7 @@ parsers:
       macro: no
 
 comment:
-  branch: !release*
-  layout: 'header, diff, files'
+  branches: ['main']
+  layout: 'diff, files'
   behavior: default
   require_changes: no


### PR DESCRIPTION
Closes #14652

Validated via `curl --data-binary @.github/codecov.yml https://codecov.io/validate`.