### PR TITLE
Bind function to correct this for workspace syms

### DIFF
--- a/news/2 Fixes/14727.md
+++ b/news/2 Fixes/14727.md
@@ -1,0 +1,1 @@
+Fix workspace symbol searching always returning empty.

--- a/src/client/jupyter/languageserver/notebookConverter.ts
+++ b/src/client/jupyter/languageserver/notebookConverter.ts
@@ -129,7 +129,7 @@ export class NotebookConverter implements Disposable {
 
     public toIncomingWorkspaceSymbols(symbols: SymbolInformation[] | null | undefined) {
         if (Array.isArray(symbols)) {
-            return symbols.map((s) => this.toIncomingWorkspaceSymbol(s));
+            return symbols.map(this.toIncomingWorkspaceSymbol.bind(this));
         }
         return symbols;
     }

--- a/src/client/jupyter/languageserver/notebookConverter.ts
+++ b/src/client/jupyter/languageserver/notebookConverter.ts
@@ -129,7 +129,7 @@ export class NotebookConverter implements Disposable {
 
     public toIncomingWorkspaceSymbols(symbols: SymbolInformation[] | null | undefined) {
         if (Array.isArray(symbols)) {
-            return symbols.map(this.toIncomingWorkspaceSymbol.bind(this));
+            return symbols.map((s) => this.toIncomingWorkspaceSymbol(s));
         }
         return symbols;
     }

--- a/src/client/jupyter/languageserver/notebookMiddlewareAddon.ts
+++ b/src/client/jupyter/languageserver/notebookMiddlewareAddon.ts
@@ -294,7 +294,7 @@ export class NotebookMiddlewareAddon implements Middleware, Disposable {
     ): ProviderResult<SymbolInformation[]> {
         const result = next(query, token);
         if (isThenable(result)) {
-            return result.then(this.converter.toIncomingWorkspaceSymbols.bind(this));
+            return result.then(this.converter.toIncomingWorkspaceSymbols.bind(this.converter));
         }
         return this.converter.toIncomingWorkspaceSymbols(result);
     }


### PR DESCRIPTION
For #14727

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] ~Appropriate comments and documentation strings in the code.~
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] ~Unit tests & system/integration tests are added/updated.~
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
