### PR TITLE
fix: formatting .pyi files with black

### DIFF
--- a/news/2 Fixes/13341.md
+++ b/news/2 Fixes/13341.md
@@ -1,0 +1,1 @@
+Format `.pyi` files correctly when using Black.

--- a/news/2 Fixes/13341.md
+++ b/news/2 Fixes/13341.md
@@ -1,1 +1,2 @@
 Format `.pyi` files correctly when using Black.
+(thanks [Steve Dignam](https://github.com/sbdchd))

--- a/src/client/formatters/blackFormatter.ts
+++ b/src/client/formatters/blackFormatter.ts
@@ -40,6 +40,11 @@ export class BlackFormatter extends BaseFormatter {
         }
 
         const blackArgs = ['--diff', '--quiet'];
+
+        if (document.fileName.endsWith('.pyi')) {
+            blackArgs.push('--pyi');
+        }
+
         const promise = super.provideDocumentFormattingEdits(document, options, token, blackArgs);
         sendTelemetryWhenDone(EventName.FORMAT, promise, stopWatch, { tool: 'black', hasCustomArgs, formatSelection });
         return promise;

--- a/src/client/formatters/blackFormatter.ts
+++ b/src/client/formatters/blackFormatter.ts
@@ -3,6 +3,7 @@
 
 'use strict';
 
+import * as path from 'path';
 import * as vscode from 'vscode';
 import { IApplicationShell } from '../common/application/types';
 import { Product } from '../common/installer/productInstaller';
@@ -41,7 +42,7 @@ export class BlackFormatter extends BaseFormatter {
 
         const blackArgs = ['--diff', '--quiet'];
 
-        if (document.fileName.endsWith('.pyi')) {
+        if (path.extname(document.fileName) === '.pyi') {
             blackArgs.push('--pyi');
         }
 


### PR DESCRIPTION
Black has different formatting depending on the file ending.

When formatting a modified buffer or saving a file black will be run
against a temp file that looks roughly like:

```
./.venv/bin/black --diff --quiet ./queryset.pyi.26c0667c29728299036ec32a0f6f7729.tmp
```

The problem with this is that the ending is lost so black will default
to using the `.py` formatting, even when it's a `.pyi` file.

partially fixes https://github.com/microsoft/vscode-python/issues/13341

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] ~~Appropriate comments and documentation strings in the code.~~
-   [x] ~~Has sufficient logging.~~
-   [x] ~~Has telemetry for enhancements.~~
- [x] ~~Unit tests & system/integration tests are added/updated.~~
    Seems the integration suite isn't being run currently: https://github.com/microsoft/vscode-python/blob/2a62cf7d52be39907adf32eb364112123ae3b91f/src/test/format/extension.format.test.ts#L43-L47

-   [x] ~~[Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~~
-   [x] ~~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~~
-   [x] ~~The wiki is updated with any design decisions/details.~~
