### PR TITLE
Fix some warnings from Sonar

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -611,7 +611,6 @@ src/client/formatters/baseFormatter.ts
 
 src/client/language/languageConfiguration.ts
 src/client/language/characters.ts
-src/client/language/textRangeCollection.ts
 src/client/language/tokenizer.ts
 src/client/language/characterStream.ts
 src/client/language/textIterator.ts
@@ -670,7 +669,6 @@ src/client/testing/common/constants.ts
 src/client/testing/common/testUtils.ts
 src/client/testing/common/xUnitParser.ts
 src/client/testing/common/updateTestSettings.ts
-src/client/testing/common/testVisitors/visitor.ts
 src/client/testing/common/testVisitors/flatteningVisitor.ts
 src/client/testing/common/testVisitors/resultResetVisitor.ts
 src/client/testing/common/runner.ts
@@ -744,7 +742,6 @@ src/client/common/terminal/environmentActivationProviders/pyenvActivationProvide
 src/client/common/utils/decorators.ts
 src/client/common/utils/enum.ts
 src/client/common/utils/async.ts
-src/client/common/utils/text.ts
 src/client/common/utils/localize.ts
 src/client/common/utils/regexp.ts
 src/client/common/utils/platform.ts
@@ -937,7 +934,6 @@ src/client/application/diagnostics/checks/macPythonInterpreter.ts
 src/client/application/diagnostics/checks/invalidPythonPathInDebugger.ts
 src/client/application/diagnostics/checks/pythonInterpreter.ts
 src/client/application/diagnostics/promptHandler.ts
-src/client/application/diagnostics/types.ts
 src/client/application/diagnostics/constants.ts
 src/client/application/diagnostics/commands/base.ts
 src/client/application/diagnostics/commands/ignore.ts

--- a/src/client/application/diagnostics/base.ts
+++ b/src/client/application/diagnostics/base.ts
@@ -34,7 +34,7 @@ export abstract class BaseDiagnosticsService implements IDiagnosticsService, IDi
         @unmanaged() private readonly supportedDiagnosticCodes: string[],
         @unmanaged() protected serviceContainer: IServiceContainer,
         @unmanaged() disposableRegistry: IDisposableRegistry,
-        @unmanaged() public readonly runInBackground: Boolean = false
+        @unmanaged() public readonly runInBackground: boolean = false
     ) {
         this.filterService = serviceContainer.get<IDiagnosticFilterService>(IDiagnosticFilterService);
         disposableRegistry.push(this);

--- a/src/client/application/diagnostics/types.ts
+++ b/src/client/application/diagnostics/types.ts
@@ -31,7 +31,7 @@ export interface IDiagnostic {
 export const IDiagnosticsService = Symbol('IDiagnosticsService');
 
 export interface IDiagnosticsService {
-    readonly runInBackground: Boolean;
+    readonly runInBackground: boolean;
     diagnose(resource: Resource): Promise<IDiagnostic[]>;
     canHandle(diagnostic: IDiagnostic): Promise<boolean>;
     handle(diagnostics: IDiagnostic[]): Promise<void>;

--- a/src/client/common/installer/productPath.ts
+++ b/src/client/common/installer/productPath.ts
@@ -24,7 +24,7 @@ export abstract class BaseProductPathsService implements IProductPathService {
         this.productInstaller = serviceContainer.get<IInstaller>(IInstaller);
     }
     public abstract getExecutableNameFromSettings(product: Product, resource?: Uri): string;
-    public isExecutableAModule(product: Product, resource?: Uri): Boolean {
+    public isExecutableAModule(product: Product, resource?: Uri): boolean {
         let moduleName: string | undefined;
         try {
             moduleName = this.productInstaller.translateProductToModuleName(product, ModuleNamePurpose.run);

--- a/src/client/common/installer/types.ts
+++ b/src/client/common/installer/types.ts
@@ -45,7 +45,7 @@ export interface IProductService {
 export const IProductPathService = Symbol('IProductPathService');
 export interface IProductPathService {
     getExecutableNameFromSettings(product: Product, resource?: Uri): string;
-    isExecutableAModule(product: Product, resource?: Uri): Boolean;
+    isExecutableAModule(product: Product, resource?: Uri): boolean;
 }
 
 export const INSIDERS_INSTALLER = 'INSIDERS_INSTALLER';

--- a/src/client/common/startPage/themeFinder.ts
+++ b/src/client/common/startPage/themeFinder.ts
@@ -59,7 +59,7 @@ export class ThemeFinder implements IThemeFinder {
     public async findLanguageConfiguration(language: string): Promise<LanguageConfiguration> {
         if (language === PYTHON_LANGUAGE) {
             // Custom for python. Some of these are required by monaco.
-            const config: any = {
+            const config: unknown = {
                 comments: {
                     lineComment: '#',
                     blockComment: ['"""', '"""']

--- a/src/client/common/startPage/themeFinder.ts
+++ b/src/client/common/startPage/themeFinder.ts
@@ -91,7 +91,7 @@ export class ThemeFinder implements IThemeFinder {
                     }
                 },
                 ...getLanguageConfiguration()
-            } as any; // NOSONAR
+            } as LanguageConfiguration;
         }
         return this.findMatchingLanguageConfiguration(language);
     }

--- a/src/client/common/startPage/themeFinder.ts
+++ b/src/client/common/startPage/themeFinder.ts
@@ -59,7 +59,7 @@ export class ThemeFinder implements IThemeFinder {
     public async findLanguageConfiguration(language: string): Promise<LanguageConfiguration> {
         if (language === PYTHON_LANGUAGE) {
             // Custom for python. Some of these are required by monaco.
-            return {
+            const config: any = {
                 comments: {
                     lineComment: '#',
                     blockComment: ['"""', '"""']
@@ -91,7 +91,9 @@ export class ThemeFinder implements IThemeFinder {
                     }
                 },
                 ...getLanguageConfiguration()
-            } as LanguageConfiguration;
+            };
+
+            return config as LanguageConfiguration;
         }
         return this.findMatchingLanguageConfiguration(language);
     }

--- a/src/client/common/utils/text.ts
+++ b/src/client/common/utils/text.ts
@@ -6,8 +6,8 @@
 import { Position, Range, TextDocument } from 'vscode';
 import { isNumber } from './sysTypes';
 
-export function getWindowsLineEndingCount(document: TextDocument, offset: Number) {
-    //const eolPattern = new RegExp('\r\n', 'g');
+export function getWindowsLineEndingCount(document: TextDocument, offset: number): number {
+    // const eolPattern = new RegExp('\r\n', 'g');
     const eolPattern = /\r\n/g;
     const readBlock = 1024;
     let count = 0;

--- a/src/client/interpreter/autoSelection/rules/workspaceEnv.ts
+++ b/src/client/interpreter/autoSelection/rules/workspaceEnv.ts
@@ -63,7 +63,7 @@ export class WorkspaceVirtualEnvInterpretersAutoSelectionRule extends BaseRuleSe
 
         if (bestInterpreter && manager) {
             await super.cacheSelectedInterpreter(workspacePath.folderUri, bestInterpreter);
-            await manager.setWorkspaceInterpreter(workspacePath.folderUri!, bestInterpreter);
+            await manager.setWorkspaceInterpreter(workspacePath.folderUri, bestInterpreter);
         }
 
         traceVerbose(

--- a/src/client/language/textRangeCollection.ts
+++ b/src/client/language/textRangeCollection.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 'use strict';
 
 import { ITextRange, ITextRangeCollection } from './types';
@@ -27,7 +28,7 @@ export class TextRangeCollection<T extends ITextRange> implements ITextRangeColl
         return this.items.length;
     }
 
-    public contains(position: number) {
+    public contains(position: number): boolean {
         return position >= this.start && position < this.end;
     }
 

--- a/src/client/language/textRangeCollection.ts
+++ b/src/client/language/textRangeCollection.ts
@@ -35,7 +35,7 @@ export class TextRangeCollection<T extends ITextRange> implements ITextRangeColl
         if (index < 0 || index >= this.items.length) {
             throw new Error('index is out of range');
         }
-        return this.items[index] as T;
+        return this.items[index];
     }
 
     public getItemAtPosition(position: number): number {

--- a/src/client/testing/common/services/unitTestDiagnosticService.ts
+++ b/src/client/testing/common/services/unitTestDiagnosticService.ts
@@ -31,7 +31,7 @@ export class UnitTestDiagnosticService implements ITestDiagnosticService {
     }
     public getMessagePrefix(status: TestStatus): string | undefined {
         const msgType = this.MessageTypes.get(status);
-        return msgType !== undefined ? this.MessagePrefixes.get(msgType!) : undefined;
+        return msgType !== undefined ? this.MessagePrefixes.get(msgType) : undefined;
     }
     public getSeverity(unitTestSeverity: PythonTestMessageSeverity): DiagnosticSeverity | undefined {
         return this.MessageSeverities.get(unitTestSeverity);

--- a/src/client/testing/common/testUtils.ts
+++ b/src/client/testing/common/testUtils.ts
@@ -165,7 +165,7 @@ export class TestsHelper implements ITestsHelper {
                     };
                     folderMap.set(newPath, testFolder);
                     if (parentFolder) {
-                        parentFolder!.folders.push(testFolder);
+                        parentFolder.folders.push(testFolder);
                     } else {
                         tests.rootTestFolders.push(testFolder);
                     }

--- a/src/client/testing/common/testVisitors/visitor.ts
+++ b/src/client/testing/common/testVisitors/visitor.ts
@@ -28,7 +28,7 @@ export function visitRecursive(tests: Tests, visitor: Visitor): void;
  */
 export function visitRecursive(tests: Tests, start: TestDataItem, visitor: Visitor): void;
 export function visitRecursive(tests: Tests, arg1: TestDataItem | Visitor, arg2?: Visitor): void {
-    const startItem = typeof arg1 === 'function' ? undefined : (arg1 as TestDataItem);
+    const startItem = typeof arg1 === 'function' ? undefined : arg1;
     const visitor = startItem ? arg2! : (arg1 as Visitor);
     let children: TestDataItem[] = [];
     if (startItem) {


### PR DESCRIPTION
Fixing either:
- Using a type wrapper unnecessarily.
- Unnecessary type conversions.
- Missing return types.

Also took some files out of `.eslintignore` which now pass cleanly.