### PR TITLE
Added VSCode settings class to be used inside discovery component

### DIFF
--- a/src/client/common/utils/resourceLifecycle.ts
+++ b/src/client/common/utils/resourceLifecycle.ts
@@ -38,7 +38,7 @@ export async function disposeAll(disposables: IDisposable[]): Promise<void> {
  * A list of disposables.
  */
 export class Disposables implements IDisposables {
-    private disposables: IDisposable[] = [];
+    protected disposables: IDisposable[] = [];
 
     constructor(...disposables: IDisposable[]) {
         this.disposables.push(...disposables);

--- a/src/client/pythonEnvironments/pythonSettings.ts
+++ b/src/client/pythonEnvironments/pythonSettings.ts
@@ -17,8 +17,6 @@ interface IPythonSettings {
 }
 
 class PythonSettings extends Disposables implements IPythonSettings {
-    public static pythonSettings: PythonSettings | undefined;
-
     protected readonly changed = new vscode.EventEmitter<void>();
 
     constructor() {
@@ -32,13 +30,6 @@ class PythonSettings extends Disposables implements IPythonSettings {
         );
     }
 
-    public static getInstance(): PythonSettings {
-        if (!PythonSettings.pythonSettings) {
-            PythonSettings.pythonSettings = new PythonSettings();
-        }
-        return PythonSettings.pythonSettings;
-    }
-
     // eslint-disable-next-line class-methods-use-this
     public get<T>(name: string): T | undefined {
         return vscode.workspace.getConfiguration('python').get(name);
@@ -49,6 +40,10 @@ class PythonSettings extends Disposables implements IPythonSettings {
     }
 }
 
+let pythonSettings: (IPythonSettings & IDisposable) | undefined;
 export function getPythonSettingsInstance() : IPythonSettings & IDisposable {
-    return PythonSettings.getInstance();
+    if (pythonSettings === undefined) {
+        pythonSettings = new PythonSettings();
+    }
+    return pythonSettings;
 }

--- a/src/client/pythonEnvironments/pythonSettings.ts
+++ b/src/client/pythonEnvironments/pythonSettings.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from 'vscode';
+import { Disposables, IDisposable } from '../common/utils/resourceLifecycle';
+
+interface IPythonSettings {
+    /**
+     * An event that is emitted when a setting changes.
+     */
+    readonly onDidChange: vscode.Event<void>;
+    /**
+     * Returns the value for setting `python.<name>`.
+     * @param name The name of the setting
+     */
+    get<T>(name: string): T | undefined;
+}
+
+class PythonSettings extends Disposables implements IPythonSettings {
+    public static pythonSettings: PythonSettings | undefined;
+
+    protected readonly changed = new vscode.EventEmitter<void>();
+
+    constructor() {
+        super();
+        this.disposables.push(
+            vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) => {
+                if (event.affectsConfiguration('python')) {
+                    this.changed.fire();
+                }
+            }),
+        );
+    }
+
+    public static getInstance(): PythonSettings {
+        if (!PythonSettings.pythonSettings) {
+            PythonSettings.pythonSettings = new PythonSettings();
+        }
+        return PythonSettings.pythonSettings;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    public get<T>(name: string): T | undefined {
+        return vscode.workspace.getConfiguration('python').get(name);
+    }
+
+    public get onDidChange(): vscode.Event<void> {
+        return this.changed.event;
+    }
+}
+
+export function getPythonSettingsInstance() : IPythonSettings & IDisposable {
+    return PythonSettings.getInstance();
+}


### PR DESCRIPTION
I plan to add another class similarly for security: interpreterinfo.py stuff.