### PR TITLE
Replace prompt with quickpick

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -221,10 +221,15 @@
     "StartPage.folderDesc": "- Open a <div class=\"link\" role=\"button\" onclick={0}>Folder</div><br /> - Open a <div class=\"link\" role=\"button\" onclick={1}>Workspace</div>",
     "StartPage.badWebPanelFormatString": "<html><body><h1>{0} is not a valid file name</h1></body></html>",
     "Jupyter.extensionRequired": "The Jupyter extension is required to perform that task. Click Yes to open the Jupyter extension installation page.",
-    "TensorBoard.logDirectoryPrompt" : "Please select a log directory to start TensorBoard with.",
+    "TensorBoard.useCurrentWorkingDirectory": "Use current working directory",
+    "TensorBoard.currentDirectory": "Current: {0}",
+    "TensorBoard.logDirectoryPrompt" : "Select a log directory to start TensorBoard with",
     "TensorBoard.progressMessage" : "Starting TensorBoard session...",
 	"TensorBoard.failedToStartSessionError" : "We failed to start a TensorBoard session due to the following error: {0}",
-    "TensorBoard.nativeTensorBoardPrompt" : "VS Code now has native TensorBoard support. Would you like to launch TensorBoard?",
-    "TensorBoard.usingCurrentWorkspaceFolder": "We are using the current workspace folder as the log directory for your TensorBoard session.",
-    "TensorBoard.selectAFolder": "Select a folder"
+    "TensorBoard.nativeTensorBoardPrompt" : "VS Code now has native TensorBoard support. Would you like to launch TensorBoard? (Tip: Launch TensorBoard anytime by opening the command palette and searching for \"Launch TensorBoard\".)",
+    "TensorBoard.selectAFolder": "Select a folder",
+    "TensorBoard.selectAnotherFolder": "Select another folder",
+    "TensorBoard.selectAFolderDetail": "Select a log directory containing tfevent files",
+    "TensorBoard.selectAnotherFolderDetail": "Use the file picker dialog to select another folder",
+    "TensorBoard.useCurrentWorkingDirectoryDetail": "TensorBoard will pick up tfevent files in subdirectories"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -230,6 +230,6 @@
     "TensorBoard.selectAFolder": "Select a folder",
     "TensorBoard.selectAnotherFolder": "Select another folder",
     "TensorBoard.selectAFolderDetail": "Select a log directory containing tfevent files",
-    "TensorBoard.selectAnotherFolderDetail": "Use the file picker dialog to select another folder",
-    "TensorBoard.useCurrentWorkingDirectoryDetail": "TensorBoard will pick up tfevent files in subdirectories"
+    "TensorBoard.selectAnotherFolderDetail": "Use the file explorer to select another folder",
+    "TensorBoard.useCurrentWorkingDirectoryDetail": "TensorBoard will search for tfevent files in all subdirectories of the current working directory"
 }

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -136,7 +136,7 @@ export namespace Jupyter {
 export namespace TensorBoard {
     export const useCurrentWorkingDirectoryDetail = localize(
         'TensorBoard.useCurrentWorkingDirectoryDetail',
-        'TensorBoard will pick up tfevent files in subdirectories'
+        'TensorBoard will search for tfevent files in all subdirectories of the current working directory'
     );
     export const useCurrentWorkingDirectory = localize(
         'TensorBoard.useCurrentWorkingDirectory',
@@ -164,7 +164,7 @@ export namespace TensorBoard {
     export const selectAnotherFolder = localize('TensorBoard.selectAnotherFolder', 'Select another folder');
     export const selectAnotherFolderDetail = localize(
         'TensorBoard.selectAnotherFolderDetail',
-        'Use the file picker dialog to select another folder'
+        'Use the file explorer to select another folder'
     );
 }
 

--- a/src/client/common/utils/localize.ts
+++ b/src/client/common/utils/localize.ts
@@ -134,9 +134,18 @@ export namespace Jupyter {
 }
 
 export namespace TensorBoard {
+    export const useCurrentWorkingDirectoryDetail = localize(
+        'TensorBoard.useCurrentWorkingDirectoryDetail',
+        'TensorBoard will pick up tfevent files in subdirectories'
+    );
+    export const useCurrentWorkingDirectory = localize(
+        'TensorBoard.useCurrentWorkingDirectory',
+        'Use current working directory'
+    );
+    export const currentDirectory = localize('TensorBoard.currentDirectory', 'Current: {0}');
     export const logDirectoryPrompt = localize(
         'TensorBoard.logDirectoryPrompt',
-        'Please select a log directory to start TensorBoard with.'
+        'Select a log directory to start TensorBoard with'
     );
     export const progressMessage = localize('TensorBoard.progressMessage', 'Starting TensorBoard session...');
     export const failedToStartSessionError = localize(
@@ -145,13 +154,18 @@ export namespace TensorBoard {
     );
     export const nativeTensorBoardPrompt = localize(
         'TensorBoard.nativeTensorBoardPrompt',
-        'VS Code now has native TensorBoard support. Would you like to launch TensorBoard?'
-    );
-    export const usingCurrentWorkspaceFolder = localize(
-        'TensorBoard.usingCurrentWorkspaceFolder',
-        'We are using the current workspace folder as the log directory for your TensorBoard session.'
+        'VS Code now has native TensorBoard support. Would you like to launch TensorBoard?  (Tip: Launch TensorBoard anytime by opening the command palette and searching for "Launch TensorBoard".)'
     );
     export const selectAFolder = localize('TensorBoard.selectAFolder', 'Select a folder');
+    export const selectAFolderDetail = localize(
+        'TensorBoard.selectAFolderDetail',
+        'Select a log directory containing tfevent files'
+    );
+    export const selectAnotherFolder = localize('TensorBoard.selectAnotherFolder', 'Select another folder');
+    export const selectAnotherFolderDetail = localize(
+        'TensorBoard.selectAnotherFolderDetail',
+        'Use the file picker dialog to select another folder'
+    );
 }
 
 export namespace LanguageService {


### PR DESCRIPTION
Addressing UX feedback from yesterday's PyTorch tooling sync. Change the logdir request flow to use a quickpick instead of a prompt, as it's likely that users will miss the prompt (which they must currently acknowledge before we proceed to start a session).

![image](https://user-images.githubusercontent.com/30305945/101117075-18f75f00-359b-11eb-94d0-1955b189dc02.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [ ] Title summarizes what is changing.
-   [ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
