### PR TITLE
Do not show 'No interpreter is selected' when pythonPath in debug configuration is invalid

### DIFF
--- a/news/2 Fixes/14814.md
+++ b/news/2 Fixes/14814.md
@@ -1,0 +1,1 @@
+Do not show "You need to select a Python interpreter before you start debugging" when "python" in debug configuration is invalid.

--- a/src/client/debugger/extension/configuration/resolvers/launch.ts
+++ b/src/client/debugger/extension/configuration/resolvers/launch.ts
@@ -12,6 +12,7 @@ import { IPlatformService } from '../../../../common/platform/types';
 import { IConfigurationService } from '../../../../common/types';
 import { DebuggerTypeName } from '../../../constants';
 import { DebugOptions, LaunchRequestArguments } from '../../../types';
+import { PythonPathSource } from '../../types';
 import { BaseConfigurationResolver } from './base';
 import { IDebugEnvironmentVariablesService } from './helper';
 
@@ -184,15 +185,25 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
     ): Promise<boolean> {
         const diagnosticService = this.invalidPythonPathInDebuggerService;
         return (
-            diagnosticService.validatePythonPath(debugConfiguration.python, this.pythonPathSource, folder?.uri) &&
-            diagnosticService.validatePythonPath(
-                debugConfiguration.debugAdapterPython,
-                this.pythonPathSource,
+            (await diagnosticService.validatePythonPath(
+                debugConfiguration.python,
+                debugConfiguration.python === debugConfiguration.pythonPath
+                    ? this.pythonPathSource
+                    : PythonPathSource.launchJson,
                 folder?.uri
-            ) &&
+            )) &&
+            (await diagnosticService.validatePythonPath(
+                debugConfiguration.debugAdapterPython,
+                debugConfiguration.debugAdapterPython === debugConfiguration.pythonPath
+                    ? this.pythonPathSource
+                    : PythonPathSource.launchJson,
+                folder?.uri
+            )) &&
             diagnosticService.validatePythonPath(
                 debugConfiguration.debugLauncherPython,
-                this.pythonPathSource,
+                debugConfiguration.debugAdapterPython === debugConfiguration.pythonPath
+                    ? this.pythonPathSource
+                    : PythonPathSource.launchJson,
                 folder?.uri
             )
         );

--- a/src/client/debugger/extension/configuration/resolvers/launch.ts
+++ b/src/client/debugger/extension/configuration/resolvers/launch.ts
@@ -184,28 +184,17 @@ export class LaunchConfigurationResolver extends BaseConfigurationResolver<Launc
         debugConfiguration: LaunchRequestArguments
     ): Promise<boolean> {
         const diagnosticService = this.invalidPythonPathInDebuggerService;
-        return (
-            (await diagnosticService.validatePythonPath(
-                debugConfiguration.python,
-                debugConfiguration.python === debugConfiguration.pythonPath
-                    ? this.pythonPathSource
-                    : PythonPathSource.launchJson,
-                folder?.uri
-            )) &&
-            (await diagnosticService.validatePythonPath(
-                debugConfiguration.debugAdapterPython,
-                debugConfiguration.debugAdapterPython === debugConfiguration.pythonPath
-                    ? this.pythonPathSource
-                    : PythonPathSource.launchJson,
-                folder?.uri
-            )) &&
-            diagnosticService.validatePythonPath(
-                debugConfiguration.debugLauncherPython,
-                debugConfiguration.debugAdapterPython === debugConfiguration.pythonPath
-                    ? this.pythonPathSource
-                    : PythonPathSource.launchJson,
-                folder?.uri
-            )
-        );
+        for (const executable of [
+            debugConfiguration.python,
+            debugConfiguration.debugAdapterPython,
+            debugConfiguration.debugLauncherPython
+        ]) {
+            const source =
+                executable === debugConfiguration.pythonPath ? this.pythonPathSource : PythonPathSource.launchJson;
+            if (!(await diagnosticService.validatePythonPath(executable, source, folder?.uri))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
+++ b/src/test/debugger/extension/configuration/resolvers/launch.unit.test.ts
@@ -18,6 +18,7 @@ import { OSType } from '../../../../../client/common/utils/platform';
 import { DebuggerTypeName } from '../../../../../client/debugger/constants';
 import { IDebugEnvironmentVariablesService } from '../../../../../client/debugger/extension/configuration/resolvers/helper';
 import { LaunchConfigurationResolver } from '../../../../../client/debugger/extension/configuration/resolvers/launch';
+import { PythonPathSource } from '../../../../../client/debugger/extension/types';
 import { DebugOptions, LaunchRequestArguments } from '../../../../../client/debugger/types';
 import { IInterpreterHelper } from '../../../../../client/interpreter/contracts';
 import { getOSType } from '../../../../common';
@@ -928,6 +929,8 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
 
         test('Test validation of Python Path when launching debugger (with invalid "python")', async () => {
             const pythonPath = `PythonPath_${new Date().toString()}`;
+            const debugLauncherPython = `DebugLauncherPythonPath_${new Date().toString()}`;
+            const debugAdapterPython = `DebugAdapterPythonPath_${new Date().toString()}`;
             const workspaceFolder = createMoqWorkspaceFolder(__dirname);
             const pythonFile = 'xyz.py';
             setupIoc(pythonPath);
@@ -936,22 +939,148 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
             diagnosticsService.reset();
             diagnosticsService
                 .setup((h) =>
-                    h.validatePythonPath(TypeMoq.It.isValue(pythonPath), TypeMoq.It.isAny(), TypeMoq.It.isAny())
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(pythonPath),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
                 )
-                .returns(() => Promise.resolve(false))
-                .verifiable(TypeMoq.Times.atLeastOnce());
+                // Invalid
+                .returns(() => Promise.resolve(false));
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(debugLauncherPython),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                .returns(() => Promise.resolve(true));
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(debugAdapterPython),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                .returns(() => Promise.resolve(true));
 
             const debugConfig = await resolveDebugConfiguration(workspaceFolder, {
                 ...launch,
                 redirectOutput: false,
-                python: pythonPath
+                python: pythonPath,
+                debugLauncherPython,
+                debugAdapterPython
             });
 
             diagnosticsService.verifyAll();
             expect(debugConfig).to.be.equal(undefined, 'Not undefined');
         });
 
-        test('Test validation of Python Path when launching debugger (with valid "python")', async () => {
+        test('Test validation of Python Path when launching debugger (with invalid "debugLauncherPython")', async () => {
+            const pythonPath = `PythonPath_${new Date().toString()}`;
+            const debugLauncherPython = `DebugLauncherPythonPath_${new Date().toString()}`;
+            const debugAdapterPython = `DebugAdapterPythonPath_${new Date().toString()}`;
+            const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+            const pythonFile = 'xyz.py';
+            setupIoc(pythonPath);
+            setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
+
+            diagnosticsService.reset();
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(pythonPath),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                .returns(() => Promise.resolve(true));
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(debugLauncherPython),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                // Invalid
+                .returns(() => Promise.resolve(false));
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(debugAdapterPython),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                .returns(() => Promise.resolve(true));
+
+            const debugConfig = await resolveDebugConfiguration(workspaceFolder, {
+                ...launch,
+                redirectOutput: false,
+                python: pythonPath,
+                debugLauncherPython,
+                debugAdapterPython
+            });
+
+            diagnosticsService.verifyAll();
+            expect(debugConfig).to.be.equal(undefined, 'Not undefined');
+        });
+
+        test('Test validation of Python Path when launching debugger (with invalid "debugAdapterPython")', async () => {
+            const pythonPath = `PythonPath_${new Date().toString()}`;
+            const debugLauncherPython = `DebugLauncherPythonPath_${new Date().toString()}`;
+            const debugAdapterPython = `DebugAdapterPythonPath_${new Date().toString()}`;
+            const workspaceFolder = createMoqWorkspaceFolder(__dirname);
+            const pythonFile = 'xyz.py';
+            setupIoc(pythonPath);
+            setupActiveEditor(pythonFile, PYTHON_LANGUAGE);
+
+            diagnosticsService.reset();
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(pythonPath),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                .returns(() => Promise.resolve(true));
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(debugLauncherPython),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                .returns(() => Promise.resolve(true));
+            diagnosticsService
+                .setup((h) =>
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(debugAdapterPython),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
+                )
+                // Invalid
+                .returns(() => Promise.resolve(false));
+
+            const debugConfig = await resolveDebugConfiguration(workspaceFolder, {
+                ...launch,
+                redirectOutput: false,
+                python: pythonPath,
+                debugLauncherPython,
+                debugAdapterPython
+            });
+
+            diagnosticsService.verifyAll();
+            expect(debugConfig).to.be.equal(undefined, 'Not undefined');
+        });
+
+        test('Test validation of Python Path when launching debugger (with valid "python/debugAdapterPython/debugLauncherPython")', async () => {
             const pythonPath = `PythonPath_${new Date().toString()}`;
             const workspaceFolder = createMoqWorkspaceFolder(__dirname);
             const pythonFile = 'xyz.py';
@@ -961,7 +1090,11 @@ getInfoPerOS().forEach(([osName, osType, path]) => {
             diagnosticsService.reset();
             diagnosticsService
                 .setup((h) =>
-                    h.validatePythonPath(TypeMoq.It.isValue(pythonPath), TypeMoq.It.isAny(), TypeMoq.It.isAny())
+                    h.validatePythonPath(
+                        TypeMoq.It.isValue(pythonPath),
+                        PythonPathSource.launchJson,
+                        TypeMoq.It.isAny()
+                    )
                 )
                 .returns(() => Promise.resolve(true))
                 .verifiable(TypeMoq.Times.atLeastOnce());


### PR DESCRIPTION
For #14814

Python path source was being calculated incorrectly. We decided that calculating source correctly is not worth the hassle, and assume source is always launch.json for new properties if they're not derived from the old ones.
 
PR is marked as draft so reviewers are assigned correctly, but it's ready for review. @ericsnowcurrently 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
