### PR TITLE
Fix LS handlers being registered too late in startup

### DIFF
--- a/news/2 Fixes/14893.md
+++ b/news/2 Fixes/14893.md
@@ -1,0 +1,1 @@
+Fix custom language server message handlers being registered too late in startup.

--- a/src/client/activation/node/analysisOptions.ts
+++ b/src/client/activation/node/analysisOptions.ts
@@ -14,4 +14,10 @@ export class NodeLanguageServerAnalysisOptions extends LanguageServerAnalysisOpt
     ) {
         super(envVarsProvider, lsOutputChannel);
     }
+
+    protected async getInitializationOptions() {
+        return {
+            experimentationSupport: true
+        };
+    }
 }

--- a/src/client/activation/node/languageServerProxy.ts
+++ b/src/client/activation/node/languageServerProxy.ts
@@ -7,7 +7,8 @@ import {
     DidChangeConfigurationNotification,
     Disposable,
     LanguageClient,
-    LanguageClientOptions
+    LanguageClientOptions,
+    State
 } from 'vscode-languageclient/node';
 
 import { DeprecatePythonPath } from '../../common/experiments/groups';
@@ -94,46 +95,24 @@ export class NodeLanguageServerProxy implements ILanguageServerProxy {
             options.connectionOptions = { cancellationStrategy: this.cancellationStrategy };
 
             this.languageClient = await this.factory.createLanguageClient(resource, interpreter, options);
-            this.disposables.push(this.languageClient!.start());
+
+            this.languageClient.onDidChangeState((e) => {
+                // The client's on* methods must be called after the client has started, but if called too
+                // late the server may have already sent a message (which leads to failures). Register
+                // these on the state change to running to ensure they are ready soon enough.
+                if (e.newState === State.Running) {
+                    this.registerHandlers(resource);
+                }
+            });
+
+            this.disposables.push(this.languageClient.start());
             await this.serverReady();
+
             if (this.disposed) {
                 // Check if it got disposed in the interim.
                 return;
             }
-            const progressReporting = new ProgressReporting(this.languageClient!);
-            this.disposables.push(progressReporting);
 
-            if (this.experiments.inExperiment(DeprecatePythonPath.experiment)) {
-                this.disposables.push(
-                    this.interpreterPathService.onDidChange(() => {
-                        // Manually send didChangeConfiguration in order to get the server to requery
-                        // the workspace configurations (to then pick up pythonPath set in the middleware).
-                        // This is needed as interpreter changes via the interpreter path service happen
-                        // outside of VS Code's settings (which would mean VS Code sends the config updates itself).
-                        this.languageClient!.sendNotification(DidChangeConfigurationNotification.type, {
-                            settings: null
-                        });
-                    })
-                );
-            }
-
-            const settings = this.configurationService.getSettings(resource);
-            if (settings.downloadLanguageServer) {
-                this.languageClient.onTelemetry((telemetryEvent) => {
-                    const eventName = telemetryEvent.EventName || EventName.LANGUAGE_SERVER_TELEMETRY;
-                    const formattedProperties = {
-                        ...telemetryEvent.Properties,
-                        // Replace all slashes in the method name so it doesn't get scrubbed by vscode-extension-telemetry.
-                        method: telemetryEvent.Properties.method?.replace(/\//g, '.')
-                    };
-                    sendTelemetryEvent(
-                        eventName,
-                        telemetryEvent.Measurements,
-                        formattedProperties,
-                        telemetryEvent.Exception
-                    );
-                });
-            }
             await this.registerTestServices();
         } else {
             await this.startupCompleted.promise;
@@ -166,5 +145,47 @@ export class NodeLanguageServerProxy implements ILanguageServerProxy {
             throw new Error('languageClient not initialized');
         }
         await this.testManager.activate(new LanguageServerSymbolProvider(this.languageClient!));
+    }
+
+    private registerHandlers(resource: Resource) {
+        if (this.disposed) {
+            // Check if it got disposed in the interim.
+            return;
+        }
+
+        const progressReporting = new ProgressReporting(this.languageClient!);
+        this.disposables.push(progressReporting);
+
+        if (this.experiments.inExperiment(DeprecatePythonPath.experiment)) {
+            this.disposables.push(
+                this.interpreterPathService.onDidChange(() => {
+                    // Manually send didChangeConfiguration in order to get the server to requery
+                    // the workspace configurations (to then pick up pythonPath set in the middleware).
+                    // This is needed as interpreter changes via the interpreter path service happen
+                    // outside of VS Code's settings (which would mean VS Code sends the config updates itself).
+                    this.languageClient!.sendNotification(DidChangeConfigurationNotification.type, {
+                        settings: null
+                    });
+                })
+            );
+        }
+
+        const settings = this.configurationService.getSettings(resource);
+        if (settings.downloadLanguageServer) {
+            this.languageClient!.onTelemetry((telemetryEvent) => {
+                const eventName = telemetryEvent.EventName || EventName.LANGUAGE_SERVER_TELEMETRY;
+                const formattedProperties = {
+                    ...telemetryEvent.Properties,
+                    // Replace all slashes in the method name so it doesn't get scrubbed by vscode-extension-telemetry.
+                    method: telemetryEvent.Properties.method?.replace(/\//g, '.')
+                };
+                sendTelemetryEvent(
+                    eventName,
+                    telemetryEvent.Measurements,
+                    formattedProperties,
+                    telemetryEvent.Exception
+                );
+            });
+        }
     }
 }


### PR DESCRIPTION
For #14893

This is all a little duplicated, but the expectation is that most of this will end up being deleted anyway in the LS client refactor.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] ~Has sufficient logging.~
-   [x] ~Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   [x] ~[Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   [x] ~[`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   [x] ~The wiki is updated with any design decisions/details.~
