### PR TITLE
Only install bandit for python>=3.5

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -2,7 +2,7 @@
 # but flake8 has a tighter pinning.
 flake8
 autopep8
-bandit
+bandit ; python_version >= '3.5'
 black ; python_version > '2.7'
 yapf
 pylint


### PR DESCRIPTION
The `3.5` comes from `setup.py` in bandit: https://github.com/PyCQA/bandit/pull/615