### PR TITLE
Set display name for the component if it's not set

### DIFF
--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -170,7 +170,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
         const info = await this.pyenvs.getInterpreterDetails(pythonPath);
         if (info !== undefined) {
             if (!info.displayName) {
-                // Set display name for the component if it's not set (this should eventually go away)
+                // Set display name for the environment returned by component if it's not set (this should eventually go away)
                 info.displayName = await this.getDisplayName(info, resource);
             }
             return info;

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -169,6 +169,10 @@ export class InterpreterService implements Disposable, IInterpreterService {
     public async getInterpreterDetails(pythonPath: string, resource?: Uri): Promise<PythonEnvironment | undefined> {
         const info = await this.pyenvs.getInterpreterDetails(pythonPath);
         if (info !== undefined) {
+            if (!info.displayName) {
+                // Set display name for the component if it's not set (this should eventually go away)
+                info.displayName = await this.getDisplayName(info, resource);
+            }
             return info;
         }
 


### PR DESCRIPTION
Status bar is not shown if `statusBar.text` is not set, aka the display name is not set.