### PR TITLE
Retrigger discovery in background if some env has changed

### DIFF
--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -54,6 +54,7 @@ export function initialize(ext: ExtensionState): PythonEnvironments {
         ext.legacyIOC.serviceManager,
         api,
         environmentsSecurity,
+        ext.disposables
     );
 
     return api;

--- a/src/test/pythonEnvironments/legacyIOC.ts
+++ b/src/test/pythonEnvironments/legacyIOC.ts
@@ -23,5 +23,6 @@ export function registerForIOC(
         serviceManager,
         instance(mock(PythonEnvironments)),
         instance(mock(EnvironmentsSecurity)),
+        []
     );
 }


### PR DESCRIPTION
Currently we're not making use of `api.onChanged` at all.