### PR TITLE
Add more helpers for Python executable info.

### DIFF
--- a/src/client/pythonEnvironments/base/envsCache.ts
+++ b/src/client/pythonEnvironments/base/envsCache.ts
@@ -5,7 +5,8 @@
 
 import { cloneDeep } from 'lodash';
 import { PythonEnvInfo } from './info';
-import { areSameEnv, getEnvExecutable, haveSameExecutables } from './info/env';
+import { areSameEnv } from './info/env';
+import { getEnvExecutable, haveSameExecutables } from './info/executable';
 
 /**
  * A simple in-memory store of Python envs.

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -8,7 +8,7 @@ import { normalizeFilename } from '../../../common/utils/filesystem';
 import { Architecture } from '../../../common/utils/platform';
 import { arePathsSame } from '../../common/externalDependencies';
 import { getKindDisplayName, getPrioritizedEnvKinds } from './envKind';
-import { parseVersionFromExecutable } from './executable';
+import { parseExeVersion } from './executable';
 import { areIdenticalVersion, areSimilarVersions, getVersionDisplayString, isVersionEmpty } from './pythonVersion';
 
 import {
@@ -207,7 +207,7 @@ export function getFastEnvInfo(kind: PythonEnvKind, executable: string): PythonE
     const env = buildEnvInfo({ kind, executable });
 
     try {
-        env.version = parseVersionFromExecutable(env.executable.filename);
+        env.version = parseExeVersion(env.executable.filename);
     } catch {
         // It didn't have version info in it.
         // We could probably walk up the directory tree trying dirnames
@@ -243,7 +243,7 @@ export async function getMaxDerivedEnvInfo(minimal: PythonEnvInfo): Promise<Pyth
 
     if (isVersionEmpty(env.version)) {
         try {
-            env.version = parseVersionFromExecutable(env.executable.filename);
+            env.version = parseExeVersion(env.executable.filename);
         } catch {
             // It didn't have version info in it.
             // We could probably walk up the directory tree trying dirnames

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -4,11 +4,10 @@
 import { cloneDeep, uniq } from 'lodash';
 import * as path from 'path';
 import { getArchitectureDisplayName } from '../../../common/platform/registry';
-import { normalizeFilename } from '../../../common/utils/filesystem';
 import { Architecture } from '../../../common/utils/platform';
 import { arePathsSame } from '../../common/externalDependencies';
 import { getKindDisplayName, getPrioritizedEnvKinds } from './envKind';
-import { parseExeVersion } from './executable';
+import { getEnvExecutable, parseExeVersion } from './executable';
 import { areIdenticalVersion, areSimilarVersions, getVersionDisplayString, isVersionEmpty } from './pythonVersion';
 
 import {
@@ -156,17 +155,6 @@ function buildEnvDisplayString(env: PythonEnvInfo): string {
 }
 
 /**
- * Determine the corresponding Python executable filename, if any.
- */
-export function getEnvExecutable(env: string | Partial<PythonEnvInfo>): string {
-    const executable = typeof env === 'string' ? env : env.executable?.filename || '';
-    if (executable === '') {
-        return '';
-    }
-    return normalizeFilename(executable);
-}
-
-/**
  * For the given data, build a normalized partial info object.
  *
  * If insufficient data is provided to generate a minimal object, such
@@ -279,21 +267,6 @@ export function getEnvMatcher(query: string | Partial<PythonEnvInfo>): (env: Pyt
         return arePathsSame(executable, candidate.executable.filename);
     }
     return matchEnv;
-}
-
-/**
- * Decide if the two sets of executables for the given envs are the same.
- */
-export function haveSameExecutables(envs1: PythonEnvInfo[], envs2: PythonEnvInfo[]): boolean {
-    if (envs1.length !== envs2.length) {
-        return false;
-    }
-    const executables1 = envs1.map(getEnvExecutable);
-    const executables2 = envs2.map(getEnvExecutable);
-    if (!executables2.every((e) => executables1.includes(e))) {
-        return false;
-    }
-    return true;
 }
 
 /**

--- a/src/client/pythonEnvironments/base/info/executable.ts
+++ b/src/client/pythonEnvironments/base/info/executable.ts
@@ -16,20 +16,16 @@ import {
     parseVersion,
 } from './pythonVersion';
 
-import {
-    FileInfo,
-    PythonEnvInfo,
-    PythonExecutableInfo,
-    PythonVersion,
-} from '.';
+import { FileInfo, PythonEnvInfo, PythonExecutableInfo, PythonVersion } from '.';
 
 /**
  * Determine the corresponding Python executable filename, if any.
  */
 export function getEnvExecutable(env: string | Partial<PythonEnvInfo>): string {
-    const executable = typeof env === 'string'
-        ? env
-        : env.executable?.filename || '';
+    let executable = env as string;
+    if (typeof env !== 'string') {
+        executable = env.executable?.filename || '';
+    }
     if (executable === '') {
         return '';
     }
@@ -185,6 +181,7 @@ function walkExecutablePath(filename: string): PythonVersion {
  * Decide if the two sets of executables for the given envs are the same.
  */
 export function haveSameExecutables(
+    // These are the sets of envs to compare.
     envs1: PythonEnvInfo[],
     envs2: PythonEnvInfo[],
 ): boolean {
@@ -203,7 +200,9 @@ export function haveSameExecutables(
  * Make a copy of "executable" and fill in empty properties using "other."
  */
 export function mergeExecutables(
+    // This is the info.
     executable: PythonExecutableInfo,
+    // This is used to fill in missing info.
     other: PythonExecutableInfo,
 ): PythonExecutableInfo {
     const merged: PythonExecutableInfo = {

--- a/src/client/pythonEnvironments/base/info/executable.ts
+++ b/src/client/pythonEnvironments/base/info/executable.ts
@@ -10,6 +10,7 @@ import {
     areSimilarVersions,
     compareVersions,
     getEmptyVersion,
+    isVersionEmpty,
     parseBasicVersion,
     parseRelease,
     parseVersion,
@@ -155,12 +156,19 @@ function walkExecutablePath(filename: string): PythonVersion {
         if (current !== undefined && isPythonDirectory(basename, after)) {
             [current.release] = parseRelease(after);
 
-            if (!areSimilarVersions(current, best)) {
+            if (isVersionEmpty(best)) {
+                best = current;
+                if (current.release !== undefined) {
+                    // It can't get better.
+                    break;
+                }
+            } else if (isVersionEmpty(current)) {
+                // Skip it!
+            } else if (!areSimilarVersions(current, best, { allowMajorOnly: true })) {
                 // We treat the right-most version in the filename
                 // as authoritative in this case.
                 break;
-            }
-            if (compareVersions(current, best) < 0) {
+            } else if (compareVersions(current, best) < 0) {
                 best = current;
                 if (current.release !== undefined) {
                     // It can't get better.

--- a/src/client/pythonEnvironments/base/info/executable.ts
+++ b/src/client/pythonEnvironments/base/info/executable.ts
@@ -2,37 +2,238 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
+import { traceError } from '../../../common/logger';
+import { normalizeFilename } from '../../../common/utils/filesystem';
 import { getOSType, OSType } from '../../../common/utils/platform';
-import { getEmptyVersion, parseVersion } from './pythonVersion';
+import {
+    areSimilarVersions,
+    compareVersions,
+    getEmptyVersion,
+    parseBasicVersion,
+    parseRelease,
+    parseVersion,
+} from './pythonVersion';
 
-import { PythonVersion } from '.';
+import {
+    FileInfo,
+    PythonEnvInfo,
+    PythonExecutableInfo,
+    PythonVersion,
+} from '.';
+
+/**
+ * Determine the corresponding Python executable filename, if any.
+ */
+export function getEnvExecutable(env: string | Partial<PythonEnvInfo>): string {
+    const executable = typeof env === 'string'
+        ? env
+        : env.executable?.filename || '';
+    if (executable === '') {
+        return '';
+    }
+    return normalizeFilename(executable);
+}
+
+/**
+ * Make an as-is (deep) copy of the given info.
+ */
+export function copyExecutable(info: PythonExecutableInfo): PythonExecutableInfo {
+    return { ...info };
+}
+
+/**
+ * Make a copy and set all the properties properly.
+ */
+export function normalizeExecutable(info: PythonExecutableInfo): PythonExecutableInfo {
+    const norm = { ...info };
+    if (!norm.filename) {
+        norm.filename = '';
+    }
+    if (!norm.sysPrefix) {
+        norm.sysPrefix = '';
+    }
+    return norm;
+}
+
+/**
+ * Fail if any properties are not set properly.
+ *
+ * Optional properties that are not set are ignored.
+ *
+ * This assumes that the info has already been normalized.
+ */
+export function validateExecutable(info: PythonExecutableInfo): void {
+    if (info.filename === '') {
+        throw Error('missing executable filename');
+    }
+    // info.sysPrefix can be empty.
+}
 
 /**
  * Determine a best-effort Python version based on the given filename.
  */
-export function parseVersionFromExecutable(filename: string): PythonVersion {
-    const version = parseBasename(path.basename(filename));
+export function parseExeVersion( // AKA "inferFromExecutable"
+    filename: string,
+    opts: {
+        ignoreErrors?: boolean;
+    } = {},
+): PythonVersion {
+    let version: PythonVersion;
+    try {
+        version = walkExecutablePath(filename);
+    } catch (err) {
+        if (opts.ignoreErrors) {
+            traceError(`failed to parse version from "${filename}"`, err);
+            return getEmptyVersion();
+        }
+        throw err; // re-throw
+    }
 
-    if (version.major === 2 && version.minor === -1) {
-        version.minor = 7;
+    if (version.major === -1 && getOSType() !== OSType.Windows) {
+        // We can assume it is 2.7.  (See PEP 394.)
+        return parseVersion('2.7');
+    }
+
+    if (version.minor === -1) {
+        if (version.major === 2) {
+            version.minor = 7;
+        }
     }
 
     return version;
 }
 
 function parseBasename(basename: string): PythonVersion {
+    basename = basename.toLowerCase();
     if (getOSType() === OSType.Windows) {
         if (basename === 'python.exe') {
             // On Windows we can't assume it is 2.7.
             return getEmptyVersion();
         }
+        if (!basename.endsWith('.exe')) {
+            throw Error(`expected .exe suffix, got "${basename}")`);
+        }
     } else if (basename === 'python') {
-        // We can assume it is 2.7.  (See PEP 394.)
-        return parseVersion('2.7');
+        // We can assume 2.7 if a version doesn't show up elsewhere
+        // in the full executable filename.
+        return getEmptyVersion();
     }
     if (!basename.startsWith('python')) {
         throw Error(`not a Python executable (expected "python..", got "${basename}")`);
     }
     // If we reach here then we expect it to have a version in the name.
     return parseVersion(basename);
+}
+
+function isPythonDirectory(basename: string, after: string): boolean {
+    if (/^\d/.test(basename)) {
+        if (after !== '') {
+            return false;
+        }
+    } else if (!basename.startsWith('python')) {
+        return false;
+    }
+    return true;
+}
+
+function walkExecutablePath(filename: string): PythonVersion {
+    let best = parseBasename(path.basename(filename));
+    if (best.release !== undefined) {
+        return best;
+    }
+
+    let prev = '';
+    let dirname = path.dirname(filename).toLowerCase();
+    while (dirname !== '' && dirname !== prev) {
+        prev = dirname;
+        const basename = path.basename(dirname);
+        dirname = path.dirname(dirname);
+
+        let current: PythonVersion | undefined;
+        let after = '';
+        try {
+            [current, after] = parseBasicVersion(basename);
+        } catch {
+            // The path segment did not look like a version.
+        }
+        // We could move the prefix checks to parseBasicVersion().
+        if (current !== undefined && isPythonDirectory(basename, after)) {
+            [current.release] = parseRelease(after);
+
+            if (!areSimilarVersions(current, best)) {
+                // We treat the right-most version in the filename
+                // as authoritative in this case.
+                break;
+            }
+            if (compareVersions(current, best) < 0) {
+                best = current;
+                if (current.release !== undefined) {
+                    // It can't get better.
+                    break;
+                }
+            }
+        }
+    }
+
+    return best;
+}
+
+/**
+ * Decide if the two sets of executables for the given envs are the same.
+ */
+export function haveSameExecutables(
+    envs1: PythonEnvInfo[],
+    envs2: PythonEnvInfo[],
+): boolean {
+    if (envs1.length !== envs2.length) {
+        return false;
+    }
+    const executables1 = envs1.map(getEnvExecutable);
+    const executables2 = envs2.map(getEnvExecutable);
+    if (!executables2.every((e) => executables1.includes(e))) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Make a copy of "executable" and fill in empty properties using "other."
+ */
+export function mergeExecutables(
+    executable: PythonExecutableInfo,
+    other: PythonExecutableInfo,
+): PythonExecutableInfo {
+    const merged: PythonExecutableInfo = {
+        ...mergeFileInfo(executable, other),
+        sysPrefix: executable.sysPrefix,
+    };
+
+    if (executable.sysPrefix === '') {
+        merged.sysPrefix = other.sysPrefix;
+    }
+
+    return merged;
+}
+
+function mergeFileInfo(file: FileInfo, other: FileInfo): FileInfo {
+    const merged: FileInfo = {
+        filename: file.filename,
+        ctime: file.ctime,
+        mtime: file.mtime,
+    };
+
+    if (file.filename === '') {
+        merged.filename = other.filename;
+    }
+
+    if (merged.filename === other.filename || other.filename === '') {
+        if (file.ctime < 0 && other.ctime > -1) {
+            merged.ctime = other.ctime;
+        }
+        if (file.mtime < 0 && other.mtime > -1) {
+            merged.mtime = other.mtime;
+        }
+    }
+
+    return merged;
 }

--- a/src/client/pythonEnvironments/base/info/executable.ts
+++ b/src/client/pythonEnvironments/base/info/executable.ts
@@ -20,14 +20,31 @@ import { FileInfo, PythonEnvInfo, PythonExecutableInfo, PythonVersion } from '.'
 
 /**
  * Determine the corresponding Python executable filename, if any.
+ *
+ * The filename is resolved to its canonical absolute form.
+ *
+ * @param opts.preserveCase - on Windows, do not force a uniform case
+ *     for all filenames.  If this is `false` (the default) then the
+ *     resulting filename will be a unique representation, suitable
+ *     for comparison.
  */
-export function getEnvExecutable(env: string | Partial<PythonEnvInfo>): string {
+export function getEnvExecutable(
+    env: string | Partial<PythonEnvInfo>,
+    opts: {
+        preserveCase: boolean;
+    } = {
+        preserveCase: false,
+    },
+): string {
     let executable = env as string;
     if (typeof env !== 'string') {
         executable = env.executable?.filename || '';
     }
     if (executable === '') {
         return '';
+    }
+    if (opts.preserveCase) {
+        return path.resolve(executable);
     }
     return normalizeFilename(executable);
 }
@@ -188,8 +205,8 @@ export function haveSameExecutables(
     if (envs1.length !== envs2.length) {
         return false;
     }
-    const executables1 = envs1.map(getEnvExecutable);
-    const executables2 = envs2.map(getEnvExecutable);
+    const executables1 = envs1.map((env) => getEnvExecutable(env));
+    const executables2 = envs2.map((env) => getEnvExecutable(env));
     if (!executables2.every((e) => executables1.includes(e))) {
         return false;
     }

--- a/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -283,6 +283,14 @@ export function areSimilarVersions(left: PythonVersion, right: PythonVersion): b
     return left.minor > -1 && right.minor > -1;
 }
 
+/**
+ * Determine if the first version is less-than (-1), equal (0), or greater-than (1).
+ */
+export function compareVersions(left: PythonVersion, right: PythonVersion): number {
+    const [compared] = basic.compareVersions(left, right, compareVersionRelease);
+    return compared;
+}
+
 function compareVersionRelease(left: PythonVersion, right: PythonVersion): [number, string] {
     if (left.release === undefined) {
         if (right.release === undefined) {

--- a/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -2,23 +2,9 @@
 // Licensed under the MIT License.
 
 import { cloneDeep } from 'lodash';
-import * as path from 'path';
-import { traceError } from '../../../common/logger';
 import * as basic from '../../../common/utils/version';
 
-import { PythonReleaseLevel, PythonVersion, PythonVersionRelease, UNKNOWN_PYTHON_VERSION } from '.';
-
-// XXX getPythonVersionFromPath() should go away in favor of parseVersionFromExecutable().
-
-export function getPythonVersionFromPath(exe: string): PythonVersion {
-    let version = UNKNOWN_PYTHON_VERSION;
-    try {
-        version = parseVersion(path.basename(exe));
-    } catch (ex) {
-        traceError(`Failed to parse version from path: ${exe}`, ex);
-    }
-    return version;
-}
+import { PythonReleaseLevel, PythonVersion, PythonVersionRelease } from '.';
 
 /**
  * Convert the given string into the corresponding Python version object.

--- a/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -259,14 +259,23 @@ export function areIdenticalVersion(left: PythonVersion, right: PythonVersion): 
  * For Python 3+, at least the minor version must be set. `(2, -1, -1)`
  * implies 2.7, so in that case only the major version must be set (to 2).
  */
-export function areSimilarVersions(left: PythonVersion, right: PythonVersion): boolean {
+export function areSimilarVersions(
+    left: PythonVersion,
+    right: PythonVersion,
+    opts: {
+        allowMajorOnly?: boolean;
+    } = {},
+): boolean {
     if (!basic.areSimilarVersions(left, right, compareVersionRelease)) {
         return false;
     }
-    if (left.major === 2) {
-        return true;
+    if (!opts.allowMajorOnly) {
+        if (left.major === 2) {
+            return true;
+        }
+        return left.minor > -1 && right.minor > -1;
     }
-    return left.minor > -1 && right.minor > -1;
+    return true;
 }
 
 /**

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsStoreLocator.ts
@@ -8,7 +8,7 @@ import { traceWarning } from '../../../../common/logger';
 import { Architecture, getEnvironmentVariable } from '../../../../common/utils/platform';
 import { PythonEnvInfo, PythonEnvKind, PythonEnvSource } from '../../../base/info';
 import { buildEnvInfo } from '../../../base/info/env';
-import { getPythonVersionFromPath } from '../../../base/info/pythonVersion';
+import { parseExeVersion } from '../../../base/info/executable';
 import { IPythonEnvsIterator } from '../../../base/locator';
 import { FSWatchingLocator } from '../../../base/locators/lowLevel/fsWatchingLocator';
 import { getFileInfo, pathExists } from '../../../common/externalDependencies';
@@ -203,7 +203,7 @@ export class WindowsStoreLocator extends FSWatchingLocator {
                 buildEnvInfo({
                     kind,
                     executable,
-                    version: getPythonVersionFromPath(executable),
+                    version: parseExeVersion(executable),
                     org: 'Microsoft',
                     arch: Architecture.x64,
                     fileInfo: await getFileInfo(executable),
@@ -222,7 +222,7 @@ export class WindowsStoreLocator extends FSWatchingLocator {
             return buildEnvInfo({
                 kind: this.kind,
                 executable: executablePath,
-                version: getPythonVersionFromPath(executablePath),
+                version: parseExeVersion(executablePath),
                 org: 'Microsoft',
                 arch: Architecture.x64,
                 fileInfo: await getFileInfo(executablePath),

--- a/src/test/pythonEnvironments/base/info/executable.unit.test.ts
+++ b/src/test/pythonEnvironments/base/info/executable.unit.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+
+import { Disposables } from '../../../../client/common/utils/resourceLifecycle';
+import { parseExeVersion } from '../../../../client/pythonEnvironments/base/info/executable';
+import { getEmptyVersion } from '../../../../client/pythonEnvironments/base/info/pythonVersion';
+import * as osUtils from '../../../utils/os';
+import { ver } from './pythonVersion.unit.test';
+
+suite('pyenvs info - parseExeVersion', () => {
+    const disposables = new Disposables();
+
+    teardown(async () => {
+        await disposables.dispose();
+    });
+
+    function setNonWindows() {
+        disposables.push({ dispose: osUtils.setNonWindows() });
+    }
+    function setWindows() {
+        disposables.push({ dispose: osUtils.setWindows() });
+    }
+
+    suite('infer version from basename', () => {
+        const EXECUTABLES: [string, number, number | undefined][] = [
+            ['python27', 2, 7],
+            ['python2.7', 2, 7],
+            ['python-27', 2, 7],
+            ['python-2.7', 2, 7],
+            ['python35', 3, 5],
+            // case doesn't matter
+            ['Python27', 2, 7],
+            ['PYTHON27', 2, 7],
+            // implied values
+            ['python2', 2, 7],
+            ['python3', 3, undefined],
+            // directory does not match
+            ['/x/y/z/python2/bin/python3', 3, undefined],
+        ];
+        for (const info of EXECUTABLES) {
+            const [text, major, minor] = info;
+            const textExe = `${text}.exe`;
+            const expected = ver(major, minor, undefined);
+
+            test(`executable filename has version (${text}, non-Windows)`, () => {
+                setNonWindows();
+
+                const version = parseExeVersion(text);
+
+                assert.deepEqual(version, expected);
+            });
+
+            test(`executable filename has version (${textExe}, Windows)`, () => {
+                setWindows();
+
+                const version = parseExeVersion(textExe);
+
+                assert.deepEqual(version, expected);
+            });
+        }
+    });
+
+    suite('infer version from directory', () => {
+        const EXECUTABLES: [string, number, number | undefined][] = [
+            ['/x/y/z/python3.7/bin/python', 3, 7],
+            ['/x/y/z/python/3.7/bin/python', 3, 7],
+            ['/x/y/z/python37/bin/python3', 3, 7],
+            ['/x/y/z/python3/python', 3, undefined],
+        ];
+        for (const info of EXECUTABLES) {
+            const [text, major, minor] = info;
+            const textExe = `${text}.exe`;
+            const expected = ver(major, minor, undefined);
+
+            test(`executable filename has version (${text}, non-Windows)`, () => {
+                setNonWindows();
+
+                const version = parseExeVersion(text);
+
+                assert.deepEqual(version, expected);
+            });
+
+            test(`executable filename has version (${textExe}, Windows)`, () => {
+                setWindows();
+
+                const version = parseExeVersion(textExe);
+
+                assert.deepEqual(version, expected);
+            });
+        }
+    });
+
+    suite('infer version from "python" basename', () => {
+        [
+            'python',
+            // random numbers in directory are ignored
+            '/x/y/z/Miniconda3/python',
+        ].forEach((text) => {
+            const textExe = `${text}.exe`;
+
+            test(`executable filename has version (${text}, non-Windows)`, () => {
+                const expected = ver(2, 7, undefined);
+                setNonWindows();
+
+                const version = parseExeVersion(text);
+
+                assert.deepEqual(version, expected);
+            });
+
+            test(`executable filename has version (${textExe}, Windows)`, () => {
+                const expected = getEmptyVersion();
+                setWindows();
+
+                const version = parseExeVersion(textExe);
+
+                assert.deepEqual(version, expected);
+            });
+        });
+    });
+
+    suite('could not infer version', () => {
+        const BOGUS_EXECUTABLES = [
+            // almost okay
+            'py',
+            'py2',
+            'py27',
+            'py2.7',
+            'py-2.7',
+            'foo27',
+            'foo2.7',
+            '27',
+            '2.7',
+            'foopython27',
+            '/x/y/z/python27/exe',
+            // clearly no version
+            'foo',
+            'foo7x',
+            'foo7',
+            '',
+        ];
+        const expected = getEmptyVersion();
+        for (const info of BOGUS_EXECUTABLES) {
+            const executable = info;
+            test(`executable filename does not have version (${executable})`, () => {
+                const version = parseExeVersion(executable, { ignoreErrors: true });
+
+                assert.deepEqual(version, expected);
+            });
+        }
+    });
+});

--- a/src/test/utils/os.ts
+++ b/src/test/utils/os.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as sinon from 'sinon';
+import * as platformAPI from '../../client/common/utils/platform';
+
+type CleanupFunc = () => void;
+
+export function setOSType(osType: platformAPI.OSType): CleanupFunc {
+    if (platformAPI.getOSType() === osType) {
+        return () => undefined;
+    }
+    const stub = sinon.stub(platformAPI, 'getOSType');
+    stub.returns(osType);
+    return () => stub.restore();
+}
+
+export function setWindows(): CleanupFunc {
+    return setOSType(platformAPI.OSType.Windows);
+}
+
+export function setNonWindows(): CleanupFunc {
+    return setOSType(platformAPI.OSType.Unknown);
+}


### PR DESCRIPTION
This PR fills in some of the gaps in the executable-related info helpers and brings more consistency (both between the existing helpers and across the various info helpers).

(This PR is based on https://github.com/microsoft/vscode-python/pull/14910.)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[ ] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).~
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   [x] Unit tests & system/integration tests are added/updated.
-   ~[ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.~
-   ~[ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).~
-   ~[ ] The wiki is updated with any design decisions/details.~
