### PR TITLE
Scale down TensorBoard UI within iframe

### DIFF
--- a/src/client/tensorBoard/tensorBoardSession.ts
+++ b/src/client/tensorBoard/tensorBoardSession.ts
@@ -258,20 +258,44 @@ export class TensorBoardSession {
         if (this.webviewPanel) {
             this.webviewPanel.webview.html = `<!DOCTYPE html>
             <html lang="en">
-            <head>
-                <meta charset="UTF-8">
-                <meta http-equiv="Content-Security-Policy" content="default-src 'unsafe-inline'; frame-src ${this.url};">
-                <iframe
-                    width="100%"
-                    height="800"
-                    sandbox="allow-scripts allow-forms allow-same-origin allow-pointer-lock"
-                    src="${this.url}"
-                    frameborder="0"
-                    allowfullscreen
-                ></iframe>
-                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                <title>TensorBoard</title>
-            </head>
+                <head>
+                    <meta charset="UTF-8">
+                    <meta http-equiv="Content-Security-Policy" content="default-src 'unsafe-inline'; frame-src ${this.url};">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>TensorBoard</title>
+                </head>
+                <body>
+                    <script type="text/javascript">
+                        function resizeFrame() {
+                            var f = window.document.getElementById('vscode-tensorboard-iframe');
+                            if (f) {
+                                f.style.height = window.innerHeight / 0.7 + "px";
+                                f.style.width = window.innerWidth / 0.7 + "px";
+                            }
+                        }
+                        window.addEventListener('resize', resizeFrame);
+                    </script>
+                    <iframe
+                        id="vscode-tensorboard-iframe"
+                        class="responsive-iframe"
+                        sandbox="allow-scripts allow-forms allow-same-origin allow-pointer-lock"
+                        src="${this.url}"
+                        frameborder="0"
+                        border="0"
+                        allowfullscreen
+                    ></iframe>
+                    <style>
+                        .responsive-iframe {
+                            transform: scale(0.7);
+                            transform-origin: 0 0;
+                            position: absolute;
+                            top: 0;
+                            left: 0;
+                            overflow: hidden;
+                            display: block;
+                        }
+                    </style>
+                </body>
             </html>`;
         }
     }


### PR DESCRIPTION
Today the TensorBoard UI looks somewhat misplaced within VSCode because it appears more zoomed in than the rest of the VSCode UI and doesn't pick up VSCode's font sizes. To address this, this PR does the following:
1. Scales the contents of the iframe that the TensorBoard UI is hosted in down; since we don't own the TensorBoard UI we can't directly style it. However, this shrinks the entire iframe and not just its contents, so this PR also 
2. Sets the iframe width and height attributes whenever the window is resized and hides scrollbars from overflow so that the TensorBoard UI fills all available space in the window.

![image](https://user-images.githubusercontent.com/30305945/102399858-ffd8b000-3f95-11eb-8494-12e217250b19.png)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).~
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [ ] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
