### PR TITLE
Fix dependency cycle with windows store and hash provider factory

### DIFF
--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -2,7 +2,6 @@ import { SemVer } from 'semver';
 import { CodeLensProvider, ConfigurationTarget, Disposable, Event, TextDocument, Uri } from 'vscode';
 import { Resource } from '../common/types';
 import { CondaEnvironmentInfo, CondaInfo } from '../pythonEnvironments/discovery/locators/services/conda';
-import { GetInterpreterLocatorOptions } from '../pythonEnvironments/discovery/locators/types';
 import { EnvironmentType, PythonEnvironment } from '../pythonEnvironments/info';
 
 export const INTERPRETER_LOCATOR_SERVICE = 'IInterpreterLocatorService';
@@ -153,3 +152,5 @@ export type WorkspacePythonPath = {
 export type GetInterpreterOptions = {
     onSuggestion?: boolean;
 };
+
+export type GetInterpreterLocatorOptions = GetInterpreterOptions & { ignoreCache?: boolean };

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -4,7 +4,6 @@ import { Resource } from '../common/types';
 import { CondaEnvironmentInfo, CondaInfo } from '../pythonEnvironments/discovery/locators/services/conda';
 import { GetInterpreterLocatorOptions } from '../pythonEnvironments/discovery/locators/types';
 import { EnvironmentType, PythonEnvironment } from '../pythonEnvironments/info';
-import { GetInterpreterOptions } from './interpreterService';
 
 export const INTERPRETER_LOCATOR_SERVICE = 'IInterpreterLocatorService';
 export const WINDOWS_REGISTRY_SERVICE = 'WindowsRegistryService';
@@ -149,4 +148,8 @@ export interface IInterpreterStatusbarVisibilityFilter {
 export type WorkspacePythonPath = {
     folderUri: Uri;
     configTarget: ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder;
+};
+
+export type GetInterpreterOptions = {
+    onSuggestion?: boolean;
 };

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -1,10 +1,9 @@
 import { SemVer } from 'semver';
-import { CodeLensProvider, Disposable, Event, TextDocument, Uri } from 'vscode';
+import { CodeLensProvider, ConfigurationTarget, Disposable, Event, TextDocument, Uri } from 'vscode';
 import { Resource } from '../common/types';
 import { CondaEnvironmentInfo, CondaInfo } from '../pythonEnvironments/discovery/locators/services/conda';
 import { GetInterpreterLocatorOptions } from '../pythonEnvironments/discovery/locators/types';
 import { EnvironmentType, PythonEnvironment } from '../pythonEnvironments/info';
-import { WorkspacePythonPath } from './helpers';
 import { GetInterpreterOptions } from './interpreterService';
 
 export const INTERPRETER_LOCATOR_SERVICE = 'IInterpreterLocatorService';
@@ -146,3 +145,8 @@ export interface IInterpreterStatusbarVisibilityFilter {
     readonly changed?: Event<void>;
     readonly hidden: boolean;
 }
+
+export type WorkspacePythonPath = {
+    folderUri: Uri;
+    configTarget: ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder;
+};

--- a/src/client/interpreter/helpers.ts
+++ b/src/client/interpreter/helpers.ts
@@ -15,16 +15,11 @@ import {
     PythonEnvironment,
     sortInterpreters
 } from '../pythonEnvironments/info';
-import { IComponentAdapter, IInterpreterHelper } from './contracts';
+import { IComponentAdapter, IInterpreterHelper, WorkspacePythonPath } from './contracts';
 import { IInterpreterHashProviderFactory } from './locators/types';
 
 const EXPITY_DURATION = 24 * 60 * 60 * 1000;
 type CachedPythonInterpreter = Partial<PythonEnvironment> & { fileHash: string };
-
-export type WorkspacePythonPath = {
-    folderUri: Uri;
-    configTarget: ConfigurationTarget.Workspace | ConfigurationTarget.WorkspaceFolder;
-};
 
 export function getFirstNonEmptyLineFromMultilineString(stdout: string) {
     if (!stdout) {

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -25,6 +25,7 @@ import { EnvironmentType, PythonEnvironment } from '../pythonEnvironments/info';
 import { captureTelemetry } from '../telemetry';
 import { EventName } from '../telemetry/constants';
 import {
+    GetInterpreterOptions,
     IComponentAdapter,
     IInterpreterDisplay,
     IInterpreterHelper,
@@ -36,10 +37,6 @@ import { IInterpreterHashProviderFactory } from './locators/types';
 import { IVirtualEnvironmentManager } from './virtualEnvs/types';
 
 const EXPITY_DURATION = 24 * 60 * 60 * 1000;
-
-export type GetInterpreterOptions = {
-    onSuggestion?: boolean;
-};
 
 // The parts of IComponentAdapter used here.
 interface IComponent {

--- a/src/client/pythonEnvironments/discovery/locators/index.ts
+++ b/src/client/pythonEnvironments/discovery/locators/index.ts
@@ -17,6 +17,7 @@ import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
+    GetInterpreterLocatorOptions,
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
     IInterpreterLocatorHelper,
@@ -41,7 +42,6 @@ import {
 import { LazyResourceBasedLocator } from '../../base/locators/common/resourceBasedLocator';
 import { PythonEnvironment } from '../../info';
 import { isHiddenInterpreter } from './services/interpreterFilter';
-import { GetInterpreterLocatorOptions } from './types';
 
 /**
  * A wrapper around all locators used by the extension.

--- a/src/client/pythonEnvironments/discovery/locators/services/cacheableLocatorService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/cacheableLocatorService.ts
@@ -15,12 +15,11 @@ import { traceDecorators, traceVerbose } from '../../../../common/logger';
 import { IDisposableRegistry, IPersistentStateFactory } from '../../../../common/types';
 import { createDeferred, Deferred } from '../../../../common/utils/async';
 import { StopWatch } from '../../../../common/utils/stopWatch';
-import { IInterpreterLocatorService, IInterpreterWatcher } from '../../../../interpreter/contracts';
+import { GetInterpreterLocatorOptions, IInterpreterLocatorService, IInterpreterWatcher } from '../../../../interpreter/contracts';
 import { IServiceContainer } from '../../../../ioc/types';
 import { sendTelemetryEvent } from '../../../../telemetry';
 import { EventName } from '../../../../telemetry/constants';
 import { PythonEnvironment } from '../../../info';
-import { GetInterpreterLocatorOptions } from '../types';
 
 /**
  * This class exists so that the interpreter fetching can be cached in between tests. Normally

--- a/src/client/pythonEnvironments/discovery/locators/services/pipEnvService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/pipEnvService.ts
@@ -10,13 +10,12 @@ import { IFileSystem, IPlatformService } from '../../../../common/platform/types
 import { IProcessServiceFactory } from '../../../../common/process/types';
 import { IConfigurationService, ICurrentProcess } from '../../../../common/types';
 import { StopWatch } from '../../../../common/utils/stopWatch';
-import { IInterpreterHelper, IPipEnvService } from '../../../../interpreter/contracts';
+import { GetInterpreterLocatorOptions, IInterpreterHelper, IPipEnvService } from '../../../../interpreter/contracts';
 import { IPipEnvServiceHelper } from '../../../../interpreter/locators/types';
 import { IServiceContainer } from '../../../../ioc/types';
 import { sendTelemetryEvent } from '../../../../telemetry';
 import { EventName } from '../../../../telemetry/constants';
 import { EnvironmentType, PythonEnvironment } from '../../../info';
-import { GetInterpreterLocatorOptions } from '../types';
 import { CacheableLocatorService } from './cacheableLocatorService';
 
 const pipEnvFileNameVariable = 'PIPENV_PIPFILE';

--- a/src/client/pythonEnvironments/discovery/locators/types.ts
+++ b/src/client/pythonEnvironments/discovery/locators/types.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-import type { GetInterpreterOptions } from '../../../interpreter/interpreterService';
-
-export type GetInterpreterLocatorOptions = GetInterpreterOptions & { ignoreCache?: boolean };

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -11,6 +11,7 @@ import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
+    GetInterpreterOptions,
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
     ICondaService,
@@ -27,7 +28,6 @@ import {
     WINDOWS_REGISTRY_SERVICE,
     WORKSPACE_VIRTUAL_ENV_SERVICE,
 } from '../interpreter/contracts';
-import { GetInterpreterOptions } from '../interpreter/interpreterService';
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../interpreter/locators/types';
 import { IServiceManager } from '../ioc/types';
 import { PythonEnvInfo, PythonEnvKind, PythonReleaseLevel } from './base/info';


### PR DESCRIPTION
Broke dependency cycles by moving type declaration to a central types file. The types were being used outside the scope of where they were declared.