### PR TITLE
Buffer() is deprecated (#15045)

### DIFF
--- a/news/2 Fixes/15045.md
+++ b/news/2 Fixes/15045.md
@@ -1,1 +1,1 @@
-Buffer() is deprecated ([#15045](https://github.com/microsoft/vscode-python/issues/15045))
+Remove the Buffer() is deprecated warning from Developer tools. ([#15045](https://github.com/microsoft/vscode-python/issues/15045))

--- a/news/2 Fixes/15045.md
+++ b/news/2 Fixes/15045.md
@@ -1,0 +1,1 @@
+Buffer() is deprecated ([#15045](https://github.com/microsoft/vscode-python/issues/15045))

--- a/src/client/common/net/socket/SocketStream.ts
+++ b/src/client/common/net/socket/SocketStream.ts
@@ -26,7 +26,7 @@ export class SocketStream {
         this.socket.write(buffer);
     }
     public WriteString(value: string) {
-        const stringBuffer = new Buffer(value, 'utf-8');
+        const stringBuffer = Buffer.from(value, 'utf-8');
         this.WriteInt32(stringBuffer.length);
         if (stringBuffer.length > 0) {
             this.socket.write(stringBuffer);
@@ -81,7 +81,7 @@ export class SocketStream {
             this.buffer = additionalData;
             return;
         }
-        const newBuffer = new Buffer(this.buffer.length + additionalData.length);
+        const newBuffer = Buffer.alloc(this.buffer.length + additionalData.length);
         this.buffer.copy(newBuffer);
         additionalData.copy(newBuffer, this.buffer.length);
         this.buffer = newBuffer;
@@ -119,7 +119,7 @@ export class SocketStream {
             throw new Error('IOException() - Socket.ReadString failed to read string type;');
         }
 
-        const type = new Buffer([byteRead]).toString();
+        const type = Buffer.from([byteRead]).toString();
         let isUnicode = false;
         switch (type) {
             case 'N': // null string

--- a/src/client/debugger/extension/helpers/protocolParser.ts
+++ b/src/client/debugger/extension/helpers/protocolParser.ts
@@ -25,7 +25,7 @@ type Listener = (...args: any[]) => void;
  */
 @injectable()
 export class ProtocolParser implements IProtocolParser {
-    private rawData = new Buffer(0);
+    private rawData = Buffer.alloc(0);
     private contentLength: number = -1;
     private disposed: boolean = false;
     private stream?: Readable;

--- a/src/test/common/socketCallbackHandler.test.ts
+++ b/src/test/common/socketCallbackHandler.test.ts
@@ -9,8 +9,8 @@ import { createDeferred, Deferred } from '../../client/common/utils/async';
 const uint64be = require('uint64be');
 
 class Commands {
-    public static ExitCommandBytes: Buffer = new Buffer('exit');
-    public static PingBytes: Buffer = new Buffer('ping');
+    public static ExitCommandBytes: Buffer = Buffer.from('exit');
+    public static PingBytes: Buffer = Buffer.from('ping');
 }
 
 namespace ResponseCommands {
@@ -33,9 +33,9 @@ class MockSocketCallbackHandler extends SocketCallbackHandler {
     public ping(message: string) {
         this.SendRawCommand(Commands.PingBytes);
 
-        const stringBuffer = new Buffer(message);
+        const stringBuffer = Buffer.from(message);
         const buffer = Buffer.concat([
-            Buffer.concat([new Buffer('U'), uint64be.encode(stringBuffer.byteLength)]),
+            Buffer.concat([Buffer.from('U'), uint64be.encode(stringBuffer.byteLength)]),
             stringBuffer,
         ]);
         this.stream.Write(buffer);
@@ -102,7 +102,7 @@ class MockSocketClient {
         if (this.socket === undefined || this.def === undefined) {
             throw Error('not started');
         }
-        this.socketStream = new SocketStream(this.socket, new Buffer(''));
+        this.socketStream = new SocketStream(this.socket, Buffer.from(''));
         this.def.resolve();
         this.socket.on('error', () => {});
         this.socket.on('data', (data: Buffer) => {
@@ -119,7 +119,7 @@ class MockSocketClient {
                     }
                     cmdIdBytes.push(byte);
                 }
-                const cmdId = new Buffer(cmdIdBytes).toString();
+                const cmdId = Buffer.from(cmdIdBytes).toString();
                 const message = this.SocketStream.ReadString();
                 if (typeof message !== 'string') {
                     this.SocketStream.RollBackTransaction();
@@ -129,32 +129,32 @@ class MockSocketClient {
                 this.SocketStream.EndTransaction();
 
                 if (cmdId !== 'ping') {
-                    this.SocketStream.Write(new Buffer(ResponseCommands.Error));
+                    this.SocketStream.Write(Buffer.from(ResponseCommands.Error));
 
                     const errorMessage = `Received unknown command '${cmdId}'`;
                     const errorBuffer = Buffer.concat([
-                        Buffer.concat([new Buffer('A'), uint64be.encode(errorMessage.length)]),
-                        new Buffer(errorMessage),
+                        Buffer.concat([Buffer.from('A'), uint64be.encode(errorMessage.length)]),
+                        Buffer.from(errorMessage),
                     ]);
                     this.SocketStream.Write(errorBuffer);
                     return;
                 }
 
-                this.SocketStream.Write(new Buffer(ResponseCommands.Pong));
+                this.SocketStream.Write(Buffer.from(ResponseCommands.Pong));
 
-                const messageBuffer = new Buffer(message);
+                const messageBuffer = Buffer.from(message);
                 const pongBuffer = Buffer.concat([
-                    Buffer.concat([new Buffer('U'), uint64be.encode(messageBuffer.byteLength)]),
+                    Buffer.concat([Buffer.from('U'), uint64be.encode(messageBuffer.byteLength)]),
                     messageBuffer,
                 ]);
                 this.SocketStream.Write(pongBuffer);
             } catch (ex) {
-                this.SocketStream.Write(new Buffer(ResponseCommands.Error));
+                this.SocketStream.Write(Buffer.from(ResponseCommands.Error));
 
                 const errorMessage = `Fatal error in handling data at socket client. Error: ${ex.message}`;
                 const errorBuffer = Buffer.concat([
-                    Buffer.concat([new Buffer('A'), uint64be.encode(errorMessage.length)]),
-                    new Buffer(errorMessage),
+                    Buffer.concat([Buffer.from('A'), uint64be.encode(errorMessage.length)]),
+                    Buffer.from(errorMessage),
                 ]);
                 this.SocketStream.Write(errorBuffer);
             }
@@ -210,7 +210,7 @@ suite('SocketCallbackHandler', () => {
         });
 
         // Client has connected, now send information to the callback handler via sockets
-        const guidBuffer = Buffer.concat([new Buffer('A'), uint64be.encode(GUID.length), new Buffer(GUID)]);
+        const guidBuffer = Buffer.concat([Buffer.from('A'), uint64be.encode(GUID.length), Buffer.from(GUID)]);
         socketClient.SocketStream.Write(guidBuffer);
         socketClient.SocketStream.WriteInt32(PID);
         await def.promise;
@@ -246,7 +246,7 @@ suite('SocketCallbackHandler', () => {
         });
 
         // Client has connected, now send information to the callback handler via sockets
-        const guidBuffer = Buffer.concat([new Buffer('A'), uint64be.encode(GUID.length), new Buffer(GUID)]);
+        const guidBuffer = Buffer.concat([Buffer.from('A'), uint64be.encode(GUID.length), Buffer.from(GUID)]);
         socketClient.SocketStream.Write(guidBuffer);
 
         // Send the wrong pid
@@ -281,7 +281,7 @@ suite('SocketCallbackHandler', () => {
         });
 
         // Client has connected, now send information to the callback handler via sockets
-        const guidBuffer = Buffer.concat([new Buffer('A'), uint64be.encode(GUID.length), new Buffer(GUID)]);
+        const guidBuffer = Buffer.concat([Buffer.from('A'), uint64be.encode(GUID.length), Buffer.from(GUID)]);
         socketClient.SocketStream.Write(guidBuffer);
 
         // Send the wrong pid
@@ -304,7 +304,7 @@ suite('SocketCallbackHandler', () => {
         });
 
         // Client has connected, now send information to the callback handler via sockets
-        const guidBuffer = Buffer.concat([new Buffer('A'), uint64be.encode(GUID.length), new Buffer(GUID)]);
+        const guidBuffer = Buffer.concat([Buffer.from('A'), uint64be.encode(GUID.length), Buffer.from(GUID)]);
         socketClient.SocketStream.Write(guidBuffer);
         socketClient.SocketStream.WriteInt32(PID);
         await def.promise;
@@ -330,7 +330,7 @@ suite('SocketCallbackHandler', () => {
         });
 
         // Client has connected, now send information to the callback handler via sockets
-        const guidBuffer = Buffer.concat([new Buffer('A'), uint64be.encode(GUID.length), new Buffer(GUID)]);
+        const guidBuffer = Buffer.concat([Buffer.from('A'), uint64be.encode(GUID.length), Buffer.from(GUID)]);
         socketClient.SocketStream.Write(guidBuffer);
         socketClient.SocketStream.WriteInt32(PID);
         await def.promise;

--- a/src/test/common/socketStream.test.ts
+++ b/src/test/common/socketStream.test.ts
@@ -38,7 +38,7 @@ class MockSocket {
 
 suite('SocketStream', () => {
     test('Read Byte', (done) => {
-        const buffer = new Buffer('X');
+        const buffer = Buffer.from('X');
         const byteValue = buffer[0];
         const socket = new MockSocket();
 
@@ -70,7 +70,7 @@ suite('SocketStream', () => {
     test('Read Ascii String', (done) => {
         const message = 'Hello World';
         const socket = new MockSocket();
-        const buffer = Buffer.concat([new Buffer('A'), uint64be.encode(message.length), new Buffer(message)]);
+        const buffer = Buffer.concat([Buffer.from('A'), uint64be.encode(message.length), Buffer.from(message)]);
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
 
@@ -80,9 +80,9 @@ suite('SocketStream', () => {
     test('Read Unicode String', (done) => {
         const message = 'Hello World - Функция проверки ИНН и КПП - 说明';
         const socket = new MockSocket();
-        const stringBuffer = new Buffer(message);
+        const stringBuffer = Buffer.from(message);
         const buffer = Buffer.concat([
-            Buffer.concat([new Buffer('U'), uint64be.encode(stringBuffer.byteLength)]),
+            Buffer.concat([Buffer.from('U'), uint64be.encode(stringBuffer.byteLength)]),
             stringBuffer,
         ]);
 
@@ -94,10 +94,10 @@ suite('SocketStream', () => {
     test('Read RollBackTransaction', (done) => {
         const message = 'Hello World';
         const socket = new MockSocket();
-        let buffer = Buffer.concat([new Buffer('A'), uint64be.encode(message.length), new Buffer(message)]);
+        let buffer = Buffer.concat([Buffer.from('A'), uint64be.encode(message.length), Buffer.from(message)]);
 
         // Write part of a second message
-        const partOfSecondMessage = Buffer.concat([new Buffer('A'), uint64be.encode(message.length)]);
+        const partOfSecondMessage = Buffer.concat([Buffer.from('A'), uint64be.encode(message.length)]);
         buffer = Buffer.concat([buffer, partOfSecondMessage]);
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
@@ -113,10 +113,10 @@ suite('SocketStream', () => {
     test('Read EndTransaction', (done) => {
         const message = 'Hello World';
         const socket = new MockSocket();
-        let buffer = Buffer.concat([new Buffer('A'), uint64be.encode(message.length), new Buffer(message)]);
+        let buffer = Buffer.concat([Buffer.from('A'), uint64be.encode(message.length), Buffer.from(message)]);
 
         // Write part of a second message
-        const partOfSecondMessage = Buffer.concat([new Buffer('A'), uint64be.encode(message.length)]);
+        const partOfSecondMessage = Buffer.concat([Buffer.from('A'), uint64be.encode(message.length)]);
         buffer = Buffer.concat([buffer, partOfSecondMessage]);
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
@@ -132,18 +132,18 @@ suite('SocketStream', () => {
     });
     test('Write Buffer', (done) => {
         const message = 'Hello World';
-        const buffer = new Buffer('');
+        const buffer = Buffer.from('');
         const socket = new MockSocket();
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
-        stream.Write(new Buffer(message));
+        stream.Write(Buffer.from(message));
 
         assert.equal(socket.dataWritten, message);
         done();
     });
     test('Write Int32', (done) => {
         const num = 1234;
-        const buffer = new Buffer('');
+        const buffer = Buffer.from('');
         const socket = new MockSocket();
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
@@ -154,7 +154,7 @@ suite('SocketStream', () => {
     });
     test('Write Int64', (done) => {
         const num = 9007199254740993;
-        const buffer = new Buffer('');
+        const buffer = Buffer.from('');
         const socket = new MockSocket();
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
@@ -165,7 +165,7 @@ suite('SocketStream', () => {
     });
     test('Write Ascii String', (done) => {
         const message = 'Hello World';
-        const buffer = new Buffer('');
+        const buffer = Buffer.from('');
         const socket = new MockSocket();
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);
@@ -176,7 +176,7 @@ suite('SocketStream', () => {
     });
     test('Write Unicode String', (done) => {
         const message = 'Hello World - Функция проверки ИНН и КПП - 说明';
-        const buffer = new Buffer('');
+        const buffer = Buffer.from('');
         const socket = new MockSocket();
 
         const stream = new SocketStream((socket as any) as net.Socket, buffer);


### PR DESCRIPTION
due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

For #15045 

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [ ] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
