### PR TITLE
Fix unittest discovery when using VS Code Insiders by using Inversify's `skipBaseClassChecks` option.

### DIFF
--- a/news/2 Fixes/14962.md
+++ b/news/2 Fixes/14962.md
@@ -1,0 +1,1 @@
+Fix unittest discovery when using VS Code Insiders by using Inversify's `skipBaseClassChecks` option.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6873,15 +6873,6 @@
                 }
             }
         },
-        "eslint-plugin-prettier": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.0.tgz",
-            "integrity": "sha512-tMTwO8iUWlSRZIwS9k7/E4vrTsfvsrcM5p1eftyuqWH25nKsz/o6/54I7jwQ/3zobISyC7wMy9ZsFwgTxOcOpQ==",
-            "dev": true,
-            "requires": {
-                "prettier-linter-helpers": "^1.0.0"
-            }
-        },
         "eslint-plugin-react": {
             "version": "7.20.6",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
@@ -7466,12 +7457,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "fast-diff": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-            "dev": true
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -9819,9 +9804,9 @@
             }
         },
         "inversify": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.13.0.tgz",
-            "integrity": "sha512-O5d8y7gKtyRwrvTLZzYET3kdFjqUy58sGpBYMARF13mzqDobpfBXVOPLH7HmnD2VR6Q+1HzZtslGvsdQfeb0SA=="
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.5.tgz",
+            "integrity": "sha512-60QsfPz8NAU/GZqXu8hJ+BhNf/C/c+Hp0eDc6XMIJTxBiP36AQyyQKpBkOVTLWBFDQWYVHpbbEuIsHu9dLuJDA=="
         },
         "invert-kv": {
             "version": "1.0.0",
@@ -15093,15 +15078,6 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
             "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
             "dev": true
-        },
-        "prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "dev": true,
-            "requires": {
-                "fast-diff": "^1.1.2"
-            }
         },
         "pretty-error": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1997,7 +1997,7 @@
         "glob": "^7.1.2",
         "hash.js": "^1.1.7",
         "iconv-lite": "^0.4.21",
-        "inversify": "^4.11.1",
+        "inversify": "^5.0.4",
         "jsonc-parser": "^2.0.3",
         "line-by-line": "^0.1.6",
         "lodash": "^4.17.19",

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -24,7 +24,7 @@ export function initializeGlobals(
     // This is stored in ExtensionState.
     context: IExtensionContext,
 ): ExtensionState {
-    const cont = new Container();
+    const cont = new Container({ skipBaseClassChecks: true });
     const serviceManager = new ServiceManager(cont);
     const serviceContainer = new ServiceContainer(cont);
     const disposables: IDisposableRegistry = context.subscriptions;


### PR DESCRIPTION
For #14962 

What `skipBaseClassCheck` does: https://github.com/inversify/InversifyJS/blob/master/wiki/container_api.md#skipbaseclasschecks

> You can use this to skip checking base classes for the @injectable property, which is especially useful if any of your @injectable classes extend classes that you don't control (third party classes). By default, this value is `false`.

`UnitTestSocketServer` (which is causing the issue) extends from `EventEmitter`, a Node class we don't control.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] Unit tests & system/integration tests are added/updated.
-   [ ] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [ ] The wiki is updated with any design decisions/details.
