### PR TITLE
Remove files from .eslintignore that don't need to be there

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -27,13 +27,11 @@ src/test/ciConstants.ts
 src/test/common.ts
 src/test/constants.ts
 src/test/core.ts
-src/test/debuggerTest.ts
 src/test/extension-version.functional.test.ts
 src/test/fixtures.ts
 src/test/index.ts
 src/test/initialize.ts
 src/test/mockClasses.ts
-src/test/multiRootTest.ts
 src/test/performanceTest.ts
 src/test/proc.ts
 src/test/serviceRegistry.ts
@@ -55,7 +53,6 @@ src/test/interpreters/virtualEnvs/index.unit.test.ts
 src/test/interpreters/virtualEnvs/condaInheritEnvPrompt.unit.test.ts
 src/test/interpreters/virtualEnvs/virtualEnvPrompt.unit.test.ts
 src/test/interpreters/autoSelection/proxy.unit.test.ts
-src/test/interpreters/autoSelection/interpreterSecurity/interpreterSecurityStorage.unit.test.ts
 src/test/interpreters/autoSelection/interpreterSecurity/interpreterEvaluation.unit.test.ts
 src/test/interpreters/autoSelection/interpreterSecurity/interpreterSecurityService.unit.test.ts
 src/test/interpreters/autoSelection/index.unit.test.ts
@@ -71,8 +68,6 @@ src/test/interpreters/pythonPathUpdaterFactory.unit.test.ts
 src/test/interpreters/interpreterService.unit.test.ts
 src/test/interpreters/activation/service.unit.test.ts
 src/test/interpreters/activation/wrapperEnvironmentActivationService.unit.test.ts
-src/test/interpreters/activation/preWarmVariables.unit.test.ts
-src/test/interpreters/activation/terminalEnvironmentActivationService.unit.test.ts
 src/test/interpreters/helpers.unit.test.ts
 src/test/interpreters/serviceRegistry.unit.test.ts
 src/test/interpreters/currentPathService.unit.test.ts
@@ -81,7 +76,6 @@ src/test/interpreters/display/interpreterSelectionTip.unit.test.ts
 src/test/interpreters/display.unit.test.ts
 
 src/test/configuration/interpreterSelector/interpreterSelector.unit.test.ts
-src/test/configuration/interpreterSelector/commands/resetInterpreter.unit.test.ts
 src/test/configuration/interpreterSelector/commands/setInterpreter.unit.test.ts
 
 src/test/install/channelManager.channels.test.ts
@@ -94,7 +88,6 @@ src/test/terminals/codeExecution/helper.test.ts
 src/test/terminals/codeExecution/codeExecutionManager.unit.test.ts
 src/test/terminals/codeExecution/djangoShellCodeExect.unit.test.ts
 
-src/test/markdown/restTextConverter.test.ts
 
 src/test/languageServers/jedi/autocomplete/base.test.ts
 src/test/languageServers/jedi/autocomplete/pep526.test.ts
@@ -104,45 +97,32 @@ src/test/languageServers/jedi/completionSource.unit.test.ts
 src/test/languageServers/jedi/symbolProvider.unit.test.ts
 src/test/languageServers/jedi/pythonSignatureProvider.unit.test.ts
 src/test/languageServers/jedi/definitions/parallel.jedi.test.ts
-src/test/languageServers/jedi/definitions/navigation.test.ts
 src/test/languageServers/jedi/definitions/hover.jedi.test.ts
 
-src/test/providers/foldingProvider.test.ts
 src/test/providers/importSortProvider.unit.test.ts
 src/test/providers/terminal.unit.test.ts
 src/test/providers/repl.unit.test.ts
 src/test/providers/codeActionProvider/main.unit.test.ts
-src/test/providers/codeActionProvider/pythonCodeActionsProvider.unit.test.ts
-src/test/providers/codeActionProvider/launchJsonCodeActionProvider.unit.test.ts
 src/test/providers/shebangCodeLenseProvider.unit.test.ts
-src/test/providers/serviceRegistry.unit.test.ts
 
-src/test/activation/aaTesting.unit.test.ts
 src/test/activation/activationService.unit.test.ts
 src/test/activation/languageServer/downloadChannelRules.unit.test.ts
-src/test/activation/languageServer/platformData.unit.test.ts
 src/test/activation/languageServer/languageServer.unit.test.ts
 src/test/activation/languageServer/languageServerFolderService.unit.test.ts
 src/test/activation/languageServer/languageServerPackageRepository.unit.test.ts
-src/test/activation/languageServer/languageServerPackageService.test.ts
 src/test/activation/languageServer/manager.unit.test.ts
 src/test/activation/languageServer/analysisOptions.unit.test.ts
-src/test/activation/languageServer/languageServerCompatibilityService.unit.test.ts
-src/test/activation/languageServer/activator.unit.test.ts
 src/test/activation/languageServer/downloader.unit.test.ts
 src/test/activation/languageServer/languageServerExtension.unit.test.ts
 src/test/activation/languageServer/languageClientFactory.unit.test.ts
 src/test/activation/languageServer/outputChannel.unit.test.ts
 src/test/activation/languageServer/languageServerPackageService.unit.test.ts
 src/test/activation/activeResource.unit.test.ts
-src/test/activation/serviceRegistry.unit.test.ts
-src/test/activation/node/languageServerFolderService.unit.test.ts
 src/test/activation/node/languageServerChangeHandler.unit.test.ts
 src/test/activation/node/activator.unit.test.ts
 src/test/activation/extensionSurvey.unit.test.ts
 src/test/activation/activationManager.unit.test.ts
 
-src/test/utils/interpreters.ts
 src/test/utils/fs.ts
 
 src/test/language/braceCounter.unit.test.ts
@@ -162,37 +142,29 @@ src/test/testing/debugger.test.ts
 src/test/testing/serviceRegistry.ts
 src/test/testing/unittest/unittest.test.ts
 src/test/testing/unittest/unittest.discovery.unit.test.ts
-src/test/testing/unittest/unittest.diagnosticService.unit.test.ts
 src/test/testing/unittest/unittest.discovery.test.ts
 src/test/testing/unittest/unittest.run.test.ts
-src/test/testing/unittest/unittest.argsService.unit.test.ts
 src/test/testing/unittest/unittest.unit.test.ts
 src/test/testing/codeLenses/testFiles.unit.test.ts
 src/test/testing/nosetest/nosetest.test.ts
-src/test/testing/nosetest/nosetest.discovery.unit.test.ts
 src/test/testing/nosetest/nosetest.disovery.test.ts
-src/test/testing/nosetest/nosetest.argsService.unit.test.ts
 src/test/testing/nosetest/nosetest.run.test.ts
 src/test/testing/pytest/pytest.testMessageService.test.ts
 src/test/testing/pytest/pytest_unittest_parser_data.ts
 src/test/testing/pytest/pytest.discovery.test.ts
 src/test/testing/pytest/pytest.test.ts
 src/test/testing/pytest/pytest_run_tests_data.ts
-src/test/testing/pytest/pytest.argsService.unit.test.ts
 src/test/testing/pytest/pytest.run.test.ts
 src/test/testing/pytest/services/discoveryService.unit.test.ts
-src/test/testing/configurationFactory.unit.test.ts
 src/test/testing/rediscover.test.ts
 src/test/testing/helper.ts
 src/test/testing/navigation/fileNavigator.unit.test.ts
 src/test/testing/navigation/functionNavigator.unit.test.ts
 src/test/testing/navigation/suiteNavigator.unit.test.ts
-src/test/testing/navigation/serviceRegistry.unit.test.ts
 src/test/testing/navigation/commandHandlers.unit.test.ts
 src/test/testing/navigation/helper.unit.test.ts
 src/test/testing/navigation/symbolNavigator.unit.test.ts
 src/test/testing/configuration.unit.test.ts
-src/test/testing/explorer/testTreeViewItem.unit.test.ts
 src/test/testing/explorer/treeView.unit.test.ts
 src/test/testing/explorer/testExplorerCommandHandler.unit.test.ts
 src/test/testing/explorer/failedTestHandler.unit.test.ts
@@ -205,7 +177,6 @@ src/test/testing/common/trackEnablement.unit.test.ts
 src/test/testing/common/debugLauncher.unit.test.ts
 src/test/testing/common/managers/baseTestManager.unit.test.ts
 src/test/testing/common/managers/testConfigurationManager.unit.test.ts
-src/test/testing/common/xUnitParser.unit.test.ts
 src/test/testing/common/testUtils.unit.test.ts
 src/test/testing/common/testVisitors/resultResetVisitor.unit.test.ts
 src/test/testing/common/services/discoveredTestParser.unit.test.ts
@@ -215,7 +186,6 @@ src/test/testing/common/services/testResultsService.unit.test.ts
 src/test/testing/common/services/discovery.unit.test.ts
 src/test/testing/common/services/configSettingService.unit.test.ts
 src/test/testing/common/services/contextService.unit.test.ts
-src/test/testing/main.unit.test.ts
 src/test/testing/results.ts
 src/test/testing/display/picker.functional.test.ts
 src/test/testing/display/main.unit.test.ts
@@ -223,88 +193,56 @@ src/test/testing/display/picker.unit.test.ts
 
 src/test/common/exitCIAfterTestReporter.ts
 src/test/common/crypto.unit.test.ts
-src/test/common/configuration/service.test.ts
 src/test/common/configuration/service.unit.test.ts
 src/test/common/net/fileDownloader.unit.test.ts
 src/test/common/net/httpClient.unit.test.ts
 src/test/common/moduleInstaller.test.ts
 src/test/common/terminals/activator/index.unit.test.ts
 src/test/common/terminals/activator/base.unit.test.ts
-src/test/common/terminals/activator/powerShellFailedHandler.unit.test.ts
 src/test/common/terminals/activation.conda.unit.test.ts
 src/test/common/terminals/shellDetector.unit.test.ts
-src/test/common/terminals/activation.bash.unit.test.ts
-src/test/common/terminals/commandPrompt.unit.test.ts
 src/test/common/terminals/service.unit.test.ts
-src/test/common/terminals/synchronousTerminalService.unit.test.ts
-src/test/common/terminals/serviceRegistry.unit.test.ts
 src/test/common/terminals/helper.unit.test.ts
-src/test/common/terminals/activation.commandPrompt.unit.test.ts
-src/test/common/terminals/factory.unit.test.ts
-src/test/common/terminals/pyenvActivationProvider.unit.test.ts
 src/test/common/terminals/activation.unit.test.ts
 src/test/common/terminals/shellDetectors/shellDetectors.unit.test.ts
 src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
 src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
-src/test/common/misc.test.ts
 src/test/common/socketStream.test.ts
 src/test/common/configSettings.test.ts
 src/test/common/experiments/service.unit.test.ts
 src/test/common/experiments/manager.unit.test.ts
 src/test/common/experiments/telemetry.unit.test.ts
 src/test/common/platform/filesystem.unit.test.ts
-src/test/common/platform/pathUtils.functional.test.ts
 src/test/common/platform/errors.unit.test.ts
 src/test/common/platform/platformService.test.ts
 src/test/common/platform/utils.ts
 src/test/common/platform/fs-temp.unit.test.ts
 src/test/common/platform/fs-temp.functional.test.ts
-src/test/common/platform/serviceRegistry.unit.test.ts
 src/test/common/platform/filesystem.functional.test.ts
-src/test/common/platform/fs-paths.unit.test.ts
-src/test/common/platform/fs-paths.functional.test.ts
 src/test/common/platform/filesystem.test.ts
 src/test/common/utils/async.unit.test.ts
-src/test/common/utils/text.unit.test.ts
-src/test/common/utils/regexp.unit.test.ts
 src/test/common/utils/cacheUtils.unit.test.ts
 src/test/common/utils/decorators.unit.test.ts
 src/test/common/utils/localize.functional.test.ts
 src/test/common/utils/version.unit.test.ts
-src/test/common/utils/workerPool.functional.test.ts
 src/test/common/configSettings/configSettings.pythonPath.unit.test.ts
 src/test/common/configSettings/configSettings.unit.test.ts
 src/test/common/featureDeprecationManager.unit.test.ts
-src/test/common/dotnet/compatibilityService.unit.test.ts
-src/test/common/dotnet/serviceRegistry.unit.test.ts
-src/test/common/dotnet/services/linuxCompatibilityService.unit.test.ts
-src/test/common/dotnet/services/winCompatibilityService.unit.test.ts
-src/test/common/dotnet/services/unknownOsCompatibilityService.unit.test.ts
-src/test/common/dotnet/services/macCompatibilityService.unit.test.ts
 src/test/common/serviceRegistry.unit.test.ts
 src/test/common/extensions.unit.test.ts
-src/test/common/variables/envVarsService.functional.test.ts
-src/test/common/variables/envVarsService.test.ts
 src/test/common/variables/envVarsService.unit.test.ts
-src/test/common/variables/serviceRegistry.unit.test.ts
 src/test/common/variables/environmentVariablesProvider.unit.test.ts
 src/test/common/variables/envVarsProvider.multiroot.test.ts
-src/test/common/nuget/nugetService.unit.test.ts
-src/test/common/nuget/azureBobStoreRepository.functional.test.ts
-src/test/common/nuget/nugetRepository.unit.test.ts
 src/test/common/nuget/azureBobStoreRepository.unit.test.ts
 src/test/common/helpers.test.ts
 src/test/common/application/commands/reloadCommand.unit.test.ts
 src/test/common/installer/channelManager.unit.test.ts
-src/test/common/installer/condaInstaller.unit.test.ts
 src/test/common/installer/installer.unit.test.ts
 src/test/common/installer/pipInstaller.unit.test.ts
 src/test/common/installer/installer.invalidPath.unit.test.ts
 src/test/common/installer/moduleInstaller.unit.test.ts
 src/test/common/installer/pipEnvInstaller.unit.test.ts
 src/test/common/installer/productPath.unit.test.ts
-src/test/common/installer/serviceRegistry.unit.test.ts
-src/test/common/installer/poetryInstaller.unit.test.ts
 src/test/common/installer/extensionBuildInstaller.unit.test.ts
 src/test/common/socketCallbackHandler.test.ts
 src/test/common/installer.test.ts
@@ -313,11 +251,8 @@ src/test/common/process/pythonDaemonPool.unit.test.ts
 src/test/common/process/processFactory.unit.test.ts
 src/test/common/process/pythonToolService.unit.test.ts
 src/test/common/process/proc.observable.test.ts
-src/test/common/process/currentProcess.test.ts
-src/test/common/process/serviceRegistry.unit.test.ts
 src/test/common/process/pythonProc.simple.multiroot.test.ts
 src/test/common/process/execFactory.test.ts
-src/test/common/process/pythonEnvironment.unit.test.ts
 src/test/common/process/logger.unit.test.ts
 src/test/common/process/pythonDaemonPool.functional.test.ts
 src/test/common/process/proc.exec.test.ts
@@ -327,31 +262,23 @@ src/test/common/process/pythonExecutionFactory.unit.test.ts
 src/test/common/process/proc.unit.test.ts
 src/test/common/asyncDump.ts
 src/test/common/interpreterPathService.unit.test.ts
-src/test/common/insidersBuild/downloadChannelRules.unit.test.ts
 src/test/common/insidersBuild/insidersExtensionPrompt.unit.test.ts
 src/test/common/insidersBuild/downloadChannelService.unit.test.ts
 src/test/common/insidersBuild/insidersExtensionService.unit.test.ts
 
 src/test/pythonFiles/formatting/dummy.ts
 
-src/test/format/extension.dispatch.test.ts
 src/test/format/extension.format.native.vscode.test.ts
 src/test/format/extension.onTypeFormat.test.ts
 src/test/format/extension.lineFormatter.test.ts
 src/test/format/extension.sort.test.ts
 src/test/format/extension.onEnterFormat.test.ts
 src/test/format/extension.format.test.ts
-src/test/format/format.helper.test.ts
 src/test/format/formatter.unit.test.ts
 
 src/test/debugger/extension/configuration/debugConfigurationService.unit.test.ts
-src/test/debugger/extension/configuration/providers/moduleLaunch.unit.test.ts
-src/test/debugger/extension/configuration/providers/pyramidLaunch.unit.test.ts
-src/test/debugger/extension/configuration/providers/flaskLaunch.unit.test.ts
 src/test/debugger/extension/configuration/providers/fileLaunch.unit.test.ts
-src/test/debugger/extension/configuration/providers/djangoLaunch.unit.test.ts
 src/test/debugger/extension/configuration/providers/providerFactory.unit.test.ts
-src/test/debugger/extension/configuration/providers/remoteAttach.unit.test.ts
 src/test/debugger/extension/configuration/providers/pidAttach.unit.test.ts
 src/test/debugger/extension/configuration/resolvers/base.unit.test.ts
 src/test/debugger/extension/configuration/resolvers/common.ts
@@ -363,19 +290,12 @@ src/test/debugger/extension/configuration/launch.json/interpreterPathCommand.uni
 src/test/debugger/extension/banner.unit.test.ts
 src/test/debugger/extension/adapter/adapter.test.ts
 src/test/debugger/extension/adapter/outdatedDebuggerPrompt.unit.test.ts
-src/test/debugger/extension/adapter/remoteLaunchers.unit.test.ts
 src/test/debugger/extension/adapter/factory.unit.test.ts
 src/test/debugger/extension/adapter/activator.unit.test.ts
 src/test/debugger/extension/adapter/logging.unit.test.ts
-src/test/debugger/extension/serviceRegistry.unit.test.ts
 src/test/debugger/extension/hooks/childProcessAttachHandler.unit.test.ts
 src/test/debugger/extension/hooks/childProcessAttachService.unit.test.ts
-src/test/debugger/extension/attachQuickPick/provider.unit.test.ts
-src/test/debugger/extension/attachQuickPick/wmicProcessParser.unit.test.ts
-src/test/debugger/extension/attachQuickPick/factory.unit.test.ts
-src/test/debugger/extension/attachQuickPick/psProcessParser.unit.test.ts
 src/test/debugger/utils.ts
-src/test/debugger/common/constants.ts
 src/test/debugger/common/protocolparser.test.ts
 src/test/debugger/envVars.test.ts
 
@@ -385,10 +305,8 @@ src/test/startPage/startPage.functional.test.tsx
 src/test/telemetry/index.unit.test.ts
 src/test/telemetry/importTracker.unit.test.ts
 src/test/telemetry/envFileTelemetry.unit.test.ts
-src/test/telemetry/extensionInstallTelemetry.unit.test.ts
 
 src/test/linters/pylint.unit.test.ts
-src/test/linters/mypy.unit.test.ts
 src/test/linters/lint.provider.test.ts
 src/test/linters/lint.unit.test.ts
 src/test/linters/linter.availability.unit.test.ts
@@ -397,14 +315,12 @@ src/test/linters/lintengine.test.ts
 src/test/linters/lint.multilinter.test.ts
 src/test/linters/lint.test.ts
 src/test/linters/linterinfo.unit.test.ts
-src/test/linters/serviceRegistry.unit.test.ts
 src/test/linters/pylint.test.ts
 src/test/linters/lint.manager.unit.test.ts
 src/test/linters/lint.args.test.ts
 src/test/linters/linterCommands.unit.test.ts
 src/test/linters/lint.functional.test.ts
 src/test/linters/linterManager.unit.test.ts
-src/test/linters/lint.multiroot.test.ts
 
 src/test/application/diagnostics/checks/macPythonInterpreter.unit.test.ts
 src/test/application/diagnostics/checks/upgradeCodeRunner.unit.test.ts
@@ -419,12 +335,7 @@ src/test/application/diagnostics/checks/lsNotSupported.unit.test.ts
 src/test/application/diagnostics/applicationDiagnostics.unit.test.ts
 src/test/application/diagnostics/promptHandler.unit.test.ts
 src/test/application/diagnostics/sourceMapSupportService.unit.test.ts
-src/test/application/diagnostics/serviceRegistry.unit.test.ts
-src/test/application/diagnostics/filter.unit.test.ts
 src/test/application/diagnostics/commands/ignore.unit.test.ts
-src/test/application/diagnostics/commands/launchBrowser.unit.test.ts
-src/test/application/diagnostics/commands/execVSCCommands.unit.test.ts
-src/test/application/diagnostics/commands/factory.unit.test.ts
 src/test/application/misc/joinMailingListPrompt.unit.test.ts
 
 src/test/performance/load.perf.test.ts
@@ -447,7 +358,6 @@ src/client/interpreter/configuration/interpreterSelector/commands/setShebangInte
 src/client/interpreter/configuration/interpreterSelector/interpreterSelector.ts
 src/client/interpreter/configuration/pythonPathUpdaterService.ts
 src/client/interpreter/configuration/pythonPathUpdaterServiceFactory.ts
-src/client/interpreter/configuration/types.ts
 src/client/interpreter/configuration/services/globalUpdaterService.ts
 src/client/interpreter/configuration/services/workspaceUpdaterService.ts
 src/client/interpreter/configuration/services/workspaceFolderUpdaterService.ts
@@ -460,8 +370,6 @@ src/client/interpreter/virtualEnvs/index.ts
 src/client/interpreter/autoSelection/interpreterSecurity/interpreterSecurityStorage.ts
 src/client/interpreter/autoSelection/interpreterSecurity/interpreterEvaluation.ts
 src/client/interpreter/autoSelection/interpreterSecurity/interpreterSecurityService.ts
-src/client/interpreter/autoSelection/types.ts
-src/client/interpreter/autoSelection/constants.ts
 src/client/interpreter/autoSelection/proxy.ts
 src/client/interpreter/autoSelection/rules/baseRule.ts
 src/client/interpreter/autoSelection/rules/winRegistry.ts
@@ -471,24 +379,18 @@ src/client/interpreter/autoSelection/rules/cached.ts
 src/client/interpreter/autoSelection/rules/workspaceEnv.ts
 src/client/interpreter/autoSelection/rules/system.ts
 src/client/interpreter/autoSelection/index.ts
-src/client/interpreter/interpreterVersion.ts
-src/client/interpreter/contracts.ts
 src/client/interpreter/activation/wrapperEnvironmentActivationService.ts
 src/client/interpreter/activation/terminalEnvironmentActivationService.ts
 src/client/interpreter/activation/preWarmVariables.ts
-src/client/interpreter/activation/types.ts
 src/client/interpreter/activation/service.ts
-src/client/interpreter/locators/types.ts
 src/client/interpreter/display/shebangCodeLensProvider.ts
 src/client/interpreter/display/index.ts
 src/client/interpreter/display/progressDisplay.ts
 src/client/interpreter/display/interpreterSelectionTip.ts
 
 src/client/api.ts
-src/client/constants.ts
 src/client/extension.ts
 src/client/extensionActivation.ts
-src/client/extensionInit.ts
 src/client/sourceMapSupport.ts
 src/client/startupTelemetry.ts
 
@@ -500,10 +402,7 @@ src/client/typeFormatters/dispatcher.ts
 
 src/client/terminals/serviceRegistry.ts
 src/client/terminals/activation.ts
-src/client/terminals/types.ts
 src/client/terminals/codeExecution/helper.ts
-src/client/terminals/codeExecution/djangoShellCodeExecution.ts
-src/client/terminals/codeExecution/repl.ts
 src/client/terminals/codeExecution/terminalCodeExecution.ts
 src/client/terminals/codeExecution/codeExecutionManager.ts
 src/client/terminals/codeExecution/djangoContext.ts
@@ -521,10 +420,8 @@ src/client/providers/replProvider.ts
 src/client/providers/codeActionProvider/main.ts
 src/client/providers/codeActionProvider/launchJsonCodeActionProvider.ts
 src/client/providers/codeActionProvider/pythonCodeActionProvider.ts
-src/client/providers/types.ts
 src/client/providers/docStringFoldingProvider.ts
 src/client/providers/linterProvider.ts
-src/client/providers/providerUtilities.ts
 src/client/providers/simpleRefactorProvider.ts
 src/client/providers/completionProvider.ts
 src/client/providers/jediProxy.ts
@@ -559,7 +456,6 @@ src/client/activation/common/downloader.ts
 src/client/activation/common/packageRepository.ts
 src/client/activation/common/analysisOptions.ts
 src/client/activation/common/downloadChannelRules.ts
-src/client/activation/aaTesting.ts
 src/client/activation/refCountedLanguageServer.ts
 src/client/activation/jedi.ts
 src/client/activation/languageClientMiddleware.ts
@@ -575,14 +471,10 @@ src/client/activation/node/analysisOptions.ts
 src/client/activation/node/activator.ts
 src/client/activation/none/activator.ts
 
-src/client/formatters/blackFormatter.ts
 src/client/formatters/serviceRegistry.ts
 src/client/formatters/helper.ts
 src/client/formatters/dummyFormatter.ts
-src/client/formatters/autoPep8Formatter.ts
 src/client/formatters/lineFormatter.ts
-src/client/formatters/types.ts
-src/client/formatters/yapfFormatter.ts
 src/client/formatters/baseFormatter.ts
 
 src/client/language/languageConfiguration.ts
@@ -626,7 +518,6 @@ src/client/testing/navigation/symbolProvider.ts
 src/client/testing/navigation/helper.ts
 src/client/testing/navigation/commandHandler.ts
 src/client/testing/navigation/suiteNavigator.ts
-src/client/testing/navigation/types.ts
 src/client/testing/navigation/functionNavigator.ts
 src/client/testing/navigation/fileNavigator.ts
 src/client/testing/explorer/testTreeViewItem.ts
@@ -678,7 +569,6 @@ src/client/common/contextKey.ts
 src/client/common/markdown/restTextConverter.ts
 src/client/common/featureDeprecationManager.ts
 src/client/common/experiments/manager.ts
-src/client/common/experiments/groups.ts
 src/client/common/experiments/telemetry.ts
 src/client/common/experiments/service.ts
 src/client/common/refBool.ts
@@ -689,7 +579,6 @@ src/client/common/platform/fs-temp.ts
 src/client/common/platform/fs-paths.ts
 src/client/common/platform/platformService.ts
 src/client/common/platform/types.ts
-src/client/common/platform/constants.ts
 src/client/common/platform/fileSystem.ts
 src/client/common/platform/registry.ts
 src/client/common/platform/pathUtils.ts
@@ -700,7 +589,6 @@ src/client/common/terminal/activator/index.ts
 src/client/common/terminal/helper.ts
 src/client/common/terminal/syncTerminalService.ts
 src/client/common/terminal/factory.ts
-src/client/common/terminal/types.ts
 src/client/common/terminal/commandPrompt.ts
 src/client/common/terminal/service.ts
 src/client/common/terminal/shellDetector.ts
@@ -719,13 +607,11 @@ src/client/common/utils/decorators.ts
 src/client/common/utils/enum.ts
 src/client/common/utils/async.ts
 src/client/common/utils/localize.ts
-src/client/common/utils/regexp.ts
 src/client/common/utils/platform.ts
 src/client/common/utils/multiStepInput.ts
 src/client/common/utils/stopWatch.ts
 src/client/common/utils/random.ts
 src/client/common/utils/serializers.ts
-src/client/common/utils/icons.ts
 src/client/common/utils/sysTypes.ts
 src/client/common/utils/version.ts
 src/client/common/utils/misc.ts
@@ -736,7 +622,6 @@ src/client/common/crypto.ts
 src/client/common/extensions.ts
 src/client/common/dotnet/compatibilityService.ts
 src/client/common/dotnet/serviceRegistry.ts
-src/client/common/dotnet/types.ts
 src/client/common/dotnet/services/unknownOsCompatibilityService.ts
 src/client/common/dotnet/services/macCompatibilityService.ts
 src/client/common/dotnet/services/linuxCompatibilityService.ts
@@ -770,7 +655,6 @@ src/client/common/application/workspace.ts
 src/client/common/application/debugSessionTelemetry.ts
 src/client/common/application/extensions.ts
 src/client/common/application/types.ts
-src/client/common/application/activeResource.ts
 src/client/common/application/commandManager.ts
 src/client/common/application/documentManager.ts
 src/client/common/application/webPanels/webPanelProvider.ts
@@ -780,9 +664,7 @@ src/client/common/application/commands/reloadCommand.ts
 src/client/common/application/terminalManager.ts
 src/client/common/application/applicationEnvironment.ts
 src/client/common/errors/errorUtils.ts
-src/client/common/errors/moduleNotInstalledError.ts
 src/client/common/installer/serviceRegistry.ts
-src/client/common/installer/productNames.ts
 src/client/common/installer/condaInstaller.ts
 src/client/common/installer/extensionBuildInstaller.ts
 src/client/common/installer/productInstaller.ts
@@ -807,7 +689,6 @@ src/client/common/process/pythonDaemonFactory.ts
 src/client/common/process/types.ts
 src/client/common/process/logger.ts
 src/client/common/process/baseDaemon.ts
-src/client/common/process/constants.ts
 src/client/common/process/pythonProcess.ts
 src/client/common/process/proc.ts
 src/client/common/process/pythonEnvironment.ts
@@ -832,7 +713,6 @@ src/client/debugger/extension/configuration/resolvers/base.ts
 src/client/debugger/extension/configuration/resolvers/helper.ts
 src/client/debugger/extension/configuration/resolvers/launch.ts
 src/client/debugger/extension/configuration/resolvers/attach.ts
-src/client/debugger/extension/configuration/types.ts
 src/client/debugger/extension/configuration/debugConfigurationService.ts
 src/client/debugger/extension/configuration/launch.json/updaterService.ts
 src/client/debugger/extension/configuration/launch.json/interpreterPathCommand.ts
@@ -842,24 +722,16 @@ src/client/debugger/extension/serviceRegistry.ts
 src/client/debugger/extension/adapter/remoteLaunchers.ts
 src/client/debugger/extension/adapter/outdatedDebuggerPrompt.ts
 src/client/debugger/extension/adapter/factory.ts
-src/client/debugger/extension/adapter/types.ts
 src/client/debugger/extension/adapter/activator.ts
 src/client/debugger/extension/adapter/logging.ts
 src/client/debugger/extension/types.ts
 src/client/debugger/extension/hooks/eventHandlerDispatcher.ts
-src/client/debugger/extension/hooks/types.ts
-src/client/debugger/extension/hooks/constants.ts
-src/client/debugger/extension/hooks/childProcessAttachHandler.ts
 src/client/debugger/extension/hooks/childProcessAttachService.ts
 src/client/debugger/extension/attachQuickPick/wmicProcessParser.ts
 src/client/debugger/extension/attachQuickPick/factory.ts
-src/client/debugger/extension/attachQuickPick/types.ts
 src/client/debugger/extension/attachQuickPick/psProcessParser.ts
-src/client/debugger/extension/attachQuickPick/provider.ts
 src/client/debugger/extension/attachQuickPick/picker.ts
 src/client/debugger/extension/helpers/protocolParser.ts
-src/client/debugger/types.ts
-src/client/debugger/constants.ts
 
 src/client/languageServices/jediProxyFactory.ts
 src/client/languageServices/proposeLanguageServerBanner.ts
@@ -869,39 +741,29 @@ src/client/linters/serviceRegistry.ts
 src/client/linters/linterAvailability.ts
 src/client/linters/lintingEngine.ts
 src/client/linters/prospector.ts
-src/client/linters/pycodestyle.ts
 src/client/linters/linterInfo.ts
-src/client/linters/bandit.ts
 src/client/linters/linterCommands.ts
-src/client/linters/flake8.ts
 src/client/linters/errorHandlers/baseErrorHandler.ts
 src/client/linters/errorHandlers/errorHandler.ts
 src/client/linters/errorHandlers/notInstalled.ts
 src/client/linters/errorHandlers/standard.ts
 src/client/linters/types.ts
-src/client/linters/mypy.ts
 src/client/linters/baseLinter.ts
-src/client/linters/constants.ts
 src/client/linters/linterManager.ts
-src/client/linters/pylama.ts
 src/client/linters/pylint.ts
 
 src/client/application/serviceRegistry.ts
-src/client/application/types.ts
 src/client/application/diagnostics/surceMapSupportService.ts
 src/client/application/diagnostics/base.ts
 src/client/application/diagnostics/applicationDiagnostics.ts
 src/client/application/diagnostics/serviceRegistry.ts
 src/client/application/diagnostics/filter.ts
 src/client/application/diagnostics/promptHandler.ts
-src/client/application/diagnostics/constants.ts
 src/client/application/diagnostics/commands/base.ts
 src/client/application/diagnostics/commands/ignore.ts
 src/client/application/diagnostics/commands/factory.ts
 src/client/application/diagnostics/commands/execVSCCommand.ts
-src/client/application/diagnostics/commands/types.ts
 src/client/application/diagnostics/commands/launchBrowser.ts
-src/client/application/misc/joinMailingListPrompt.ts
 
 src/client/logging/levels.ts
 src/client/logging/transports.ts
@@ -914,13 +776,11 @@ src/client/logging/trace.ts
 
 src/client/refactor/proxy.ts
 src/client/workspaceSymbols/main.ts
-src/client/workspaceSymbols/contracts.ts
 src/client/workspaceSymbols/generator.ts
 src/client/workspaceSymbols/parser.ts
 src/client/workspaceSymbols/provider.ts
 
 src/client/common/startPage/codeCssGenerator.ts
-src/client/common/startPage/constants.ts
 src/client/common/startPage/themeFinder.ts
 src/client/common/startPage/webviewHost.ts
 src/client/common/startPage/webviewPanelHost.ts


### PR DESCRIPTION
Drop 140 files from `.eslintignore` which pass ESLint cleanly.