### PR TITLE
Ignore false positives when scraping environment variables

### DIFF
--- a/news/2 Fixes/14812.md
+++ b/news/2 Fixes/14812.md
@@ -1,0 +1,1 @@
+Ignore false positives when scraping environment variables.

--- a/src/client/interpreter/activation/service.ts
+++ b/src/client/interpreter/activation/service.ts
@@ -7,7 +7,7 @@ import { inject, injectable } from 'inversify';
 
 import { IWorkspaceService } from '../../common/application/types';
 import { PYTHON_WARNINGS } from '../../common/constants';
-import { LogOptions, traceDecorators, traceError, traceInfo, traceVerbose } from '../../common/logger';
+import { LogOptions, traceDecorators, traceError, traceInfo, traceVerbose, traceWarning } from '../../common/logger';
 import { IPlatformService } from '../../common/platform/types';
 import * as internalScripts from '../../common/process/internal/scripts';
 import { ExecutionResult, IProcessServiceFactory } from '../../common/process/types';
@@ -195,6 +195,7 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
             // This happens on AzDo machines a bunch when using Conda (and we can't dictate the conda version in order to get the fix)
             let result: ExecutionResult<string> | undefined;
             let tryCount = 1;
+            let returnedEnv: NodeJS.ProcessEnv | undefined;
             while (!result) {
                 try {
                     result = await processService.shellExec(command, {
@@ -204,8 +205,19 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
                         maxBuffer: 1000 * 1000,
                         throwOnStdErr: false,
                     });
-                    if (result.stderr && result.stderr.length > 0) {
-                        throw new Error(`StdErr from ShellExec, ${result.stderr} for ${command}`);
+                    try {
+                        returnedEnv = this.parseEnvironmentOutput(result.stdout, parse);
+                    } catch (ex) {
+                        if (!result.stderr) {
+                            throw ex;
+                        }
+                    }
+                    if (result.stderr) {
+                        if (returnedEnv) {
+                            traceWarning('Got env variables but with errors', result.stderr);
+                        } else {
+                            throw new Error(`StdErr from ShellExec, ${result.stderr} for ${command}`);
+                        }
                     }
                 } catch (exc) {
                     // Special case. Conda for some versions will state a file is in use. If
@@ -221,7 +233,6 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
                     }
                 }
             }
-            const returnedEnv = this.parseEnvironmentOutput(result.stdout, parse);
 
             // Put back the PYTHONWARNINGS value
             if (oldWarnings && returnedEnv) {

--- a/src/client/interpreter/activation/service.ts
+++ b/src/client/interpreter/activation/service.ts
@@ -205,7 +205,10 @@ export class EnvironmentActivationService implements IEnvironmentActivationServi
                         maxBuffer: 1000 * 1000,
                         throwOnStdErr: false,
                     });
+
                     try {
+                        // Try to parse the output, even if we have errors in stderr, its possible they are false positives.
+                        // If variables are available, then ignore errors (but log them).
                         returnedEnv = this.parseEnvironmentOutput(result.stdout, parse);
                     } catch (ex) {
                         if (!result.stderr) {


### PR DESCRIPTION
For #14812

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Has a [news entry](https://github.com/Microsoft/vscode-python/tree/main/news) file (remember to thank yourself!).
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [n/a] Has telemetry for enhancements.
-   [n/a] Unit tests & system/integration tests are added/updated.
-   [n/a] [Test plan](https://github.com/Microsoft/vscode-python/blob/main/.github/test_plan.md) is updated as appropriate.
-   [n/a] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/main/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed).
-   [n/a] The wiki is updated with any design decisions/details.
