### PR TITLE
Do not add to env cache if already present

### DIFF
--- a/src/client/pythonEnvironments/base/locators/composite/cachingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/cachingLocator.ts
@@ -34,42 +34,40 @@ export class CachingLocator extends LazyResourceBasedLocator {
     }
 
     protected async doResolveEnv(env: string | PythonEnvInfo): Promise<PythonEnvInfo | undefined> {
-        // If necessary we could be more aggressive about invalidating
-        // the cached value.
-        const query = getMinimalPartialInfo(env);
-        if (query === undefined) {
-            return undefined;
-        }
-        const candidates = this.cache.filterEnvs(query);
-        if (candidates === undefined) {
-            return undefined;
-        }
-        if (candidates.length > 0) {
-            return pickBestEnv(candidates);
+        let matchingEnvs = this.filterMatchingEnvsFromCache(env);
+        if (matchingEnvs.length > 0) {
+            return pickBestEnv(matchingEnvs);
         }
         // Fall back to the underlying locator.
         const resolved = await this.locator.resolveEnv(env);
         if (resolved !== undefined) {
-            await this.addEnvToCache(resolved);
+            // Add resolved env to cache if it doesn't already exist in cache
+            // The cache may have changed, query again for matching envs
+            matchingEnvs = this.filterMatchingEnvsFromCache(resolved);
+            if (matchingEnvs.length === 0) {
+                const envs = this.cache.getAllEnvs();
+                if (envs !== undefined) {
+                    envs.push(resolved);
+                    await this.updateCache(envs);
+                }
+            }
         }
         return resolved;
     }
 
-    private async addEnvToCache(env: PythonEnvInfo): Promise<void> {
+    /**
+     * If the cache has been activated, return environment info objects that match a env.
+     * If none of the environments in the cache match the env, return an empty array.
+     */
+    private filterMatchingEnvsFromCache(env: string | PythonEnvInfo): PythonEnvInfo[] {
+        // If necessary we could be more aggressive about invalidating
+        // the cached value.
         const query = getMinimalPartialInfo(env);
         if (query === undefined) {
-            return;
+            return [];
         }
         const candidates = this.cache.filterEnvs(query);
-        if (candidates !== undefined && candidates.length > 0) {
-            // Don't add to cache if already in cache
-            return;
-        }
-        const envs = this.cache.getAllEnvs();
-        if (envs !== undefined) {
-            envs.push(env);
-            await this.updateCache(envs);
-        }
+        return candidates !== undefined && candidates.length > 0 ? candidates : [];
     }
 
     protected async initResources(): Promise<void> {

--- a/src/client/pythonEnvironments/base/locators/composite/cachingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/cachingLocator.ts
@@ -50,12 +50,12 @@ export class CachingLocator extends LazyResourceBasedLocator {
         // Fall back to the underlying locator.
         const resolved = await this.locator.resolveEnv(env);
         if (resolved !== undefined) {
-            this.addEnvToCache(resolved);
+            await this.addEnvToCache(resolved);
         }
         return resolved;
     }
 
-    private addEnvToCache(env: PythonEnvInfo): void {
+    private async addEnvToCache(env: PythonEnvInfo): Promise<void> {
         const query = getMinimalPartialInfo(env);
         if (query === undefined) {
             return;
@@ -68,7 +68,7 @@ export class CachingLocator extends LazyResourceBasedLocator {
         const envs = this.cache.getAllEnvs();
         if (envs !== undefined) {
             envs.push(env);
-            this.updateCache(envs).ignoreErrors();
+            await this.updateCache(envs);
         }
     }
 


### PR DESCRIPTION
For: Dups envs showing up when creating env in workspace on Windows

Environment was being added to cache list midway, and then was again pushed to list. So duplicate entries for the same env were showing up.

Linting errors not related to the PR.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] The wiki is updated with any design decisions/details.
