### PR TITLE
Ensure workspace envs are displayed in the second session

### DIFF
--- a/src/client/pythonEnvironments/base/locators/composite/cachingLocator.ts
+++ b/src/client/pythonEnvironments/base/locators/composite/cachingLocator.ts
@@ -85,6 +85,11 @@ export class CachingLocator extends LazyResourceBasedLocator {
         // it again in here is not a problem.
         if (this.cache.getAllEnvs() === undefined) {
             await this.ensureRecentRefresh(looper);
+        } else {
+            // Cache only contains complete envs, so not all envs maybe added to cache
+            // But we need to show them eventually, so trigger a refresh in background
+            // but do not block on it as we already have most envs in cache.
+            this.ensureRecentRefresh(looper).ignoreErrors();
         }
     }
 


### PR DESCRIPTION
Workspace envs are considered unsafe by default, and so are not run until user manually triggers discovery. Hence they're not stored in cache, as they're considered incomplete.

From the second session onwards, we completely rely on the cache, so they were not displayed. This code changes to trigger a refresh in background, which will populate the cache with workspace envs at start of the second session.

To test whether it's run in background or not, without stubbing internal entities does not seem to be possible, and it's not very imp. So skipping that part.