### PR TITLE
Retain webview context

### DIFF
--- a/src/client/tensorBoard/tensorBoardSession.ts
+++ b/src/client/tensorBoard/tensorBoardSession.ts
@@ -287,6 +287,7 @@ export class TensorBoardSession {
     private createPanel() {
         const webviewPanel = window.createWebviewPanel('tensorBoardSession', 'TensorBoard', ViewColumn.Two, {
             enableScripts: true,
+            retainContextWhenHidden: true,
         });
         webviewPanel.webview.html = `<!DOCTYPE html>
         <html lang="en">


### PR DESCRIPTION
Currently when the TensorBoard webview is backgrounded and then foregrounded, the webview's context is lost, and there's also a perceptible delay of ~2-3 seconds while the entire TensorBoard UI is reloaded. @jmew asked me to look into improving this experience.

To solve this problem, we should create the webview with `retainContextWhenHidden`. While this option is more memory intensive (according to the documentation), the other options that the [webview API documentation](https://code.visualstudio.com/api/extension-guides/webview#persistence) suggests for persisting the UI state do not apply to our scenario, since we don't directly control the contents of the iframe and cannot use `getState` and `setState` to save off the webview contents.

Before this change (note that the active TensorBoard tab resets and the webview is briefly blank):

![before](https://user-images.githubusercontent.com/30305945/104254345-76e55500-542b-11eb-85a9-1b0c32b07c67.gif)


With this change:

![after](https://user-images.githubusercontent.com/30305945/104254562-f5da8d80-542b-11eb-9de4-e76fce26c216.gif)


<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   ~[ ] Appropriate comments and documentation strings in the code.~
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] The wiki is updated with any design decisions/details.~
