### PR TITLE
Add the getEnvDisplayString() helper.

### DIFF
--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -3,12 +3,13 @@
 
 import { cloneDeep } from 'lodash';
 import * as path from 'path';
+import { getArchitectureDisplayName } from '../../../common/platform/registry';
 import { normalizeFilename } from '../../../common/utils/filesystem';
 import { Architecture } from '../../../common/utils/platform';
 import { arePathsSame } from '../../common/externalDependencies';
-import { getPrioritizedEnvKinds } from './envKind';
+import { getKindDisplayName, getPrioritizedEnvKinds } from './envKind';
 import { parseVersionFromExecutable } from './executable';
-import { areIdenticalVersion, areSimilarVersions, isVersionEmpty } from './pythonVersion';
+import { areIdenticalVersion, areSimilarVersions, getVersionDisplayString, isVersionEmpty } from './pythonVersion';
 
 import { FileInfo, PythonDistroInfo, PythonEnvInfo, PythonEnvKind, PythonReleaseLevel, PythonVersion } from '.';
 
@@ -99,6 +100,46 @@ function updateEnv(
     if (updates.version !== undefined) {
         env.version = updates.version;
     }
+}
+
+/**
+ * Convert the env info to a user-facing representation.
+ *
+ * The format is `Python <Version> <bitness> (<env name>: <env type>)`
+ * E.g. `Python 3.5.1 32-bit (myenv2: virtualenv)`
+ */
+export function getEnvDisplayString(env: PythonEnvInfo): string {
+    if (env.display === undefined || env.display === '') {
+        if (env.defaultDisplayName !== undefined && env.defaultDisplayName !== '') {
+            // XXX Normalize it?
+            env.display = env.defaultDisplayName;
+        } else {
+            env.display = buildEnvDisplayString(env);
+        }
+    }
+    return env.display;
+}
+
+function buildEnvDisplayString(env: PythonEnvInfo): string {
+    const displayNameParts: string[] = ['Python'];
+    const envSuffixParts: string[] = [];
+
+    if (!isVersionEmpty(env.version)) {
+        displayNameParts.push(getVersionDisplayString(env.version));
+    }
+    if (env.arch !== Architecture.Unknown) {
+        displayNameParts.push(getArchitectureDisplayName(env.arch));
+    }
+    if (env.name !== '') {
+        envSuffixParts.push(`'${env.name}'`);
+    }
+    const kindName = getKindDisplayName(env.kind);
+    if (kindName !== '') {
+        envSuffixParts.push(kindName);
+    }
+
+    const envSuffix = envSuffixParts.length === 0 ? '' : `(${envSuffixParts.join(': ')})`;
+    return `${displayNameParts.join(' ')} ${envSuffix}`.trim();
 }
 
 /**

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -131,6 +131,8 @@ function buildEnvDisplayString(env: PythonEnvInfo): string {
         displayNameParts.push(archName);
     }
 
+    // Note that currently we do not use env.distro in the display name.
+
     // "suffix"
     const envSuffixParts: string[] = [];
     if (env.name && env.name !== '') {

--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -121,24 +121,28 @@ export function getEnvDisplayString(env: PythonEnvInfo): string {
 }
 
 function buildEnvDisplayString(env: PythonEnvInfo): string {
+    // main parts
     const displayNameParts: string[] = ['Python'];
-    const envSuffixParts: string[] = [];
-
-    if (!isVersionEmpty(env.version)) {
+    if (env.version && !isVersionEmpty(env.version)) {
         displayNameParts.push(getVersionDisplayString(env.version));
     }
-    if (env.arch !== Architecture.Unknown) {
-        displayNameParts.push(getArchitectureDisplayName(env.arch));
+    const archName = getArchitectureDisplayName(env.arch);
+    if (archName !== '') {
+        displayNameParts.push(archName);
     }
-    if (env.name !== '') {
+
+    // "suffix"
+    const envSuffixParts: string[] = [];
+    if (env.name && env.name !== '') {
         envSuffixParts.push(`'${env.name}'`);
     }
     const kindName = getKindDisplayName(env.kind);
     if (kindName !== '') {
         envSuffixParts.push(kindName);
     }
-
     const envSuffix = envSuffixParts.length === 0 ? '' : `(${envSuffixParts.join(': ')})`;
+
+    // Pull it all together.
     return `${displayNameParts.join(' ')} ${envSuffix}`.trim();
 }
 

--- a/src/client/pythonEnvironments/base/info/index.ts
+++ b/src/client/pythonEnvironments/base/info/index.ts
@@ -147,6 +147,7 @@ type _PythonEnvInfo = PythonEnvBaseInfo & PythonBuildInfo;
  */
 export type PythonEnvInfo = _PythonEnvInfo & {
     distro: PythonDistroInfo;
+    display?: string;
     defaultDisplayName?: string;
     searchLocation?: Uri;
 };

--- a/src/client/pythonEnvironments/base/info/pythonVersion.ts
+++ b/src/client/pythonEnvironments/base/info/pythonVersion.ts
@@ -222,6 +222,19 @@ function validateRelease(info: PythonVersionRelease): void {
 }
 
 /**
+ * Convert the info to a user-facing representation.
+ */
+export function getVersionDisplayString(ver: PythonVersion): string {
+    if (isVersionEmpty(ver)) {
+        return '';
+    }
+    if (ver.micro !== -1) {
+        return getShortVersionString(ver);
+    }
+    return `${getShortVersionString(ver)}.x`;
+}
+
+/**
  * Convert the info to a simple string.
  */
 export function getShortVersionString(ver: PythonVersion): string {

--- a/src/test/pythonEnvironments/base/info/env.unit.test.ts
+++ b/src/test/pythonEnvironments/base/info/env.unit.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as assert from 'assert';
+import { Architecture } from '../../../../client/common/utils/platform';
+import { parseVersionInfo } from '../../../../client/common/utils/version';
+import { PythonEnvInfo, PythonDistroInfo, PythonEnvKind } from '../../../../client/pythonEnvironments/base/info';
+import { getEnvDisplayString } from '../../../../client/pythonEnvironments/base/info/env';
+import { createLocatedEnv } from '../common';
+
+suite('pyenvs info - getEnvDisplayString()', () => {
+    function getEnv(info: {
+        version?: string;
+        arch?: Architecture;
+        name?: string;
+        kind?: PythonEnvKind;
+        distro?: PythonDistroInfo;
+        display?: string;
+        defaultDisplayName?: string;
+        location?: string;
+    }): PythonEnvInfo {
+        const env = createLocatedEnv(
+            info.location || '',
+            info.version || '',
+            info.kind || PythonEnvKind.Unknown,
+            'python', // exec
+            info.distro,
+        );
+        env.name = info.name || '';
+        env.arch = info.arch || Architecture.Unknown;
+        env.display = info.display;
+        env.defaultDisplayName = info.defaultDisplayName;
+        return env;
+    }
+
+    suite('cached', () => {
+        suite('already resolved', () => {
+            [
+                'Python', // built: absolute minimal
+                'Python 3.7.x x64 (my-env: venv)', // built: full
+                'spam',
+                'some env',
+                // corner cases
+                '---',
+                '  ',
+            ].forEach((display: string) => {
+                test(`"${display}"`, () => {
+                    const expected = display;
+                    const env = getEnv({ display });
+
+                    const result = getEnvDisplayString(env);
+
+                    assert.equal(result, expected);
+                });
+            });
+        });
+
+        suite('has default', () => {
+            const defaultDisplayName = 'my-env (some-kind)';
+
+            test('without "display"', () => {
+                const expected = defaultDisplayName;
+                const env = getEnv({ defaultDisplayName });
+
+                const result = getEnvDisplayString(env);
+
+                assert.equal(result, expected);
+            });
+
+            test('with empty "display"', () => {
+                const expected = defaultDisplayName;
+                const env = getEnv({ defaultDisplayName, display: '' });
+
+                const result = getEnvDisplayString(env);
+
+                assert.equal(result, expected);
+            });
+        });
+
+        test('both', () => {
+            const display = 'Python 3.7.3 (system)';
+            const defaultDisplayName = 'my-env (some-kind)';
+            const expected = display;
+            const env = getEnv({ display, defaultDisplayName });
+
+            const result = getEnvDisplayString(env);
+
+            assert.equal(result, expected);
+        });
+    });
+
+    suite('built', () => {
+        const name = 'my-env';
+        const location = 'x/y/z/spam/';
+        const arch = Architecture.x64;
+        const version = '3.8.1';
+        const kind = PythonEnvKind.Venv;
+        const distro: PythonDistroInfo = {
+            org: 'Distro X',
+            defaultDisplayName: 'distroX 1.2',
+            version: parseVersionInfo('1.2.3')?.version,
+            binDir: 'distroX/bin',
+        };
+        const tests: [PythonEnvInfo, string][] = [
+            [getEnv({}), 'Python'],
+            [getEnv({ version, arch, name, kind, distro }), "Python 3.8.1 64-bit ('my-env': venv)"],
+            // without "suffix" info
+            [getEnv({ version }), 'Python 3.8.1'],
+            [getEnv({ arch }), 'Python 64-bit'],
+            [getEnv({ version, arch }), 'Python 3.8.1 64-bit'],
+            // with "suffix" info
+            [getEnv({ name }), "Python ('my-env')"],
+            [getEnv({ kind }), 'Python (venv)'],
+            [getEnv({ name, kind }), "Python ('my-env': venv)"],
+            // env.location is ignored.
+            [getEnv({ location }), 'Python'],
+            [getEnv({ name, location }), "Python ('my-env')"],
+        ];
+        tests.forEach(([env, expected]) => {
+            test(`"${expected}"`, () => {
+                const result = getEnvDisplayString(env);
+
+                assert.equal(result, expected);
+            });
+        });
+    });
+});


### PR DESCRIPTION
This change will allow code to get a uniform display name for an environment.  This may be used by locators to set `PythonEnvInfo.display` (or `PythonEnvInfo.defaultDisplayName`), as well as eventually in the env selection list.

Compare with similar code in src/client/interpreter/interpreterService.ts.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] The wiki is updated with any design decisions/details.~
