### PR TITLE
Only force background envs refresh if the component is enabled.

### DIFF
--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -58,7 +58,7 @@ import { registerTypes as unitTestsRegisterTypes } from './testing/serviceRegist
 import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
 
 // components
-// import * as pythonEnvironments from './pythonEnvironments';
+import * as pythonEnvironments from './pythonEnvironments';
 
 import { ActivationResult, ExtensionState } from './components';
 import { Components } from './extensionInit';
@@ -66,8 +66,7 @@ import { Components } from './extensionInit';
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
     ext: ExtensionState,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _components: Components,
+    components: Components,
 ): Promise<ActivationResult[]> {
     // Note that each activation returns a promise that resolves
     // when that activation completes.  However, it might have started
@@ -79,12 +78,7 @@ export async function activateComponents(
     // activation resolves `ActivationResult`, which can safely wrap
     // the "inner" promise.
     const promises: Promise<ActivationResult>[] = [
-        // TODO: For now the extension should only interact with the component via the component adapter,
-        // which takes care of putting the component behind the experiment flag. It already activates the
-        // component among other things, hence the following is not needed.
-        // pythonEnvironments.activate(components.pythonEnvs),
-        // If we need to activate, we need to use the adapter:
-        // https://github.com/microsoft/vscode-python/issues/14984
+        pythonEnvironments.activate(components.pythonEnvs),
         // These will go away eventually.
         activateLegacy(ext),
     ];

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -26,7 +26,7 @@ import { PyenvLocator } from './discovery/locators/services/pyenvLocator';
 import { WindowsRegistryLocator } from './discovery/locators/services/windowsRegistryLocator';
 import { WindowsStoreLocator } from './discovery/locators/services/windowsStoreLocator';
 import { EnvironmentInfoService } from './info/environmentInfoService';
-import { registerLegacyDiscoveryForIOC, registerNewDiscoveryForIOC } from './legacyIOC';
+import { isComponentEnabled, registerLegacyDiscoveryForIOC, registerNewDiscoveryForIOC } from './legacyIOC';
 import { EnvironmentsSecurity, IEnvironmentsSecurity } from './security';
 
 /**
@@ -60,10 +60,12 @@ export async function initialize(ext: ExtensionState): Promise<PythonEnvironment
  * Make use of the component (e.g. register with VS Code).
  */
 export async function activate(api: PythonEnvironments): Promise<ActivationResult> {
-    // Force an initial background refresh of the environments.
-    getEnvs(api.iterEnvs())
-        // Don't wait for it to finish.
-        .ignoreErrors();
+    if (await isComponentEnabled()) {
+        // Force an initial background refresh of the environments.
+        getEnvs(api.iterEnvs())
+            // Don't wait for it to finish.
+            .ignoreErrors();
+    }
 
     // Registration with VS Code will go here.
 

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -60,12 +60,16 @@ export async function initialize(ext: ExtensionState): Promise<PythonEnvironment
  * Make use of the component (e.g. register with VS Code).
  */
 export async function activate(api: PythonEnvironments): Promise<ActivationResult> {
-    if (await isComponentEnabled()) {
-        // Force an initial background refresh of the environments.
-        getEnvs(api.iterEnvs())
-            // Don't wait for it to finish.
-            .ignoreErrors();
+    if (!(await isComponentEnabled())) {
+        return {
+            fullyReady: Promise.resolve(),
+        };
     }
+
+    // Force an initial background refresh of the environments.
+    getEnvs(api.iterEnvs())
+        // Don't wait for it to finish.
+        .ignoreErrors();
 
     // Registration with VS Code will go here.
 

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -132,8 +132,7 @@ function convertEnvInfo(info: PythonEnvInfo): PythonEnvironment {
     return env;
 }
 
-// Shouldn't be used outside of the discovery component.
-async function inDiscoveryExperiment(): Promise<boolean> {
+export async function isComponentEnabled(): Promise<boolean> {
     const results = await Promise.all([
         inExperiment(DiscoveryVariants.discoverWithFileWatching),
         inExperiment(DiscoveryVariants.discoveryWithoutFileWatching),
@@ -359,7 +358,7 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
 }
 
 export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceManager): Promise<void> {
-    const inExp = await inDiscoveryExperiment().catch((ex) => {
+    const inExp = await isComponentEnabled().catch((ex) => {
         // This is mainly to support old tests, where IExperimentService was registered
         // out of sequence / or not registered, so this throws an error. But we do not
         // care about that error as we don't care about IExperimentService in old tests.


### PR DESCRIPTION
(for #14984)

This ensures that the component is not used at all if not in the relevant experiments.

(FYI, this is a branch I had lying around so I figured I'd move it along.)

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   ~[ ] Has sufficient logging.~
-   ~[ ] Has telemetry for enhancements.~
-   ~[ ] The wiki is updated with any design decisions/details.~
