### PR TITLE
Leverage ComponentAdapter.getInterpreterInformation in PythonPathUpdaterService

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -340,7 +340,6 @@ src/client/interpreter/configuration/interpreterSelector/commands/setInterpreter
 src/client/interpreter/configuration/interpreterSelector/commands/resetInterpreter.ts
 src/client/interpreter/configuration/interpreterSelector/commands/setShebangInterpreter.ts
 src/client/interpreter/configuration/interpreterSelector/interpreterSelector.ts
-src/client/interpreter/configuration/pythonPathUpdaterService.ts
 src/client/interpreter/configuration/pythonPathUpdaterServiceFactory.ts
 src/client/interpreter/configuration/services/globalUpdaterService.ts
 src/client/interpreter/configuration/services/workspaceUpdaterService.ts

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -9,7 +9,7 @@ import { InterpreterInformation } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { PythonInterpreterTelemetry } from '../../telemetry/types';
-import { IInterpreterVersionService } from '../contracts';
+import { IComponentAdapter, IInterpreterVersionService } from '../contracts';
 import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from './types';
 
 @injectable()
@@ -20,12 +20,15 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
 
     private readonly executionFactory: IPythonExecutionFactory;
 
+    private readonly componentAdapter: IComponentAdapter;
+
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.pythonPathSettingsUpdaterFactory = serviceContainer.get<IPythonPathUpdaterServiceFactory>(
             IPythonPathUpdaterServiceFactory,
         );
         this.interpreterVersionService = serviceContainer.get<IInterpreterVersionService>(IInterpreterVersionService);
         this.executionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
+        this.componentAdapter = serviceContainer.get<IComponentAdapter>(IComponentAdapter);
     }
 
     public async updatePythonPath(
@@ -63,25 +66,31 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
             trigger,
         };
         if (!failed && pythonPath) {
-            const processService = await this.executionFactory.create({ pythonPath });
-            const infoPromise = processService
-                .getInterpreterInformation()
-                .catch<InterpreterInformation | undefined>(() => undefined);
-            const pipVersionPromise = this.interpreterVersionService
-                .getPipVersion(pythonPath)
-                .then((value) => (value.length === 0 ? undefined : value))
-                .catch<string>(() => '');
-            const [info, pipVersion] = await Promise.all([infoPromise, pipVersionPromise]);
-            if (info) {
-                telemetryProperties.architecture = info.architecture;
-                if (info.version) {
+            // Ask for info using the new discovery code first.
+            // If it returns undefined, fallback on the old code.
+            const interpreterInfo = await this.componentAdapter.getInterpreterInformation(pythonPath);
+            if (interpreterInfo && interpreterInfo.version) {
+                telemetryProperties.pythonVersion = interpreterInfo.version.raw;
+            } else {
+                const processService = await this.executionFactory.create({ pythonPath });
+                const info = await processService
+                    .getInterpreterInformation()
+                    .catch<InterpreterInformation | undefined>(() => undefined);
+
+                if (info && info.version) {
                     telemetryProperties.pythonVersion = info.version.raw;
                 }
             }
+
+            const pipVersion = await this.interpreterVersionService
+                .getPipVersion(pythonPath)
+                .then((value) => (value.length === 0 ? undefined : value))
+                .catch<string>(() => '');
             if (pipVersion) {
                 telemetryProperties.pipVersion = pipVersion;
             }
         }
+
         sendTelemetryEvent(EventName.PYTHON_INTERPRETER, duration, telemetryProperties);
     }
 

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -15,8 +15,11 @@ import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } fr
 @injectable()
 export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManager {
     private readonly pythonPathSettingsUpdaterFactory: IPythonPathUpdaterServiceFactory;
+
     private readonly interpreterVersionService: IInterpreterVersionService;
+
     private readonly executionFactory: IPythonExecutionFactory;
+
     constructor(@inject(IServiceContainer) serviceContainer: IServiceContainer) {
         this.pythonPathSettingsUpdaterFactory = serviceContainer.get<IPythonPathUpdaterServiceFactory>(
             IPythonPathUpdaterServiceFactory,
@@ -24,6 +27,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         this.interpreterVersionService = serviceContainer.get<IInterpreterVersionService>(IInterpreterVersionService);
         this.executionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
     }
+
     public async updatePythonPath(
         pythonPath: string | undefined,
         configTarget: ConfigurationTarget,
@@ -47,6 +51,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
             traceError('Python Extension: sendTelemetry', ex),
         );
     }
+
     private async sendTelemetry(
         duration: number,
         failed: boolean,
@@ -79,6 +84,7 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         }
         sendTelemetryEvent(EventName.PYTHON_INTERPRETER, duration, telemetryProperties);
     }
+
     private getPythonUpdaterService(configTarget: ConfigurationTarget, wkspace?: Uri) {
         switch (configTarget) {
             case ConfigurationTarget.Global: {

--- a/src/client/interpreter/configuration/pythonPathUpdaterService.ts
+++ b/src/client/interpreter/configuration/pythonPathUpdaterService.ts
@@ -9,14 +9,12 @@ import { InterpreterInformation } from '../../pythonEnvironments/info';
 import { sendTelemetryEvent } from '../../telemetry';
 import { EventName } from '../../telemetry/constants';
 import { PythonInterpreterTelemetry } from '../../telemetry/types';
-import { IComponentAdapter, IInterpreterVersionService } from '../contracts';
+import { IComponentAdapter } from '../contracts';
 import { IPythonPathUpdaterServiceFactory, IPythonPathUpdaterServiceManager } from './types';
 
 @injectable()
 export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManager {
     private readonly pythonPathSettingsUpdaterFactory: IPythonPathUpdaterServiceFactory;
-
-    private readonly interpreterVersionService: IInterpreterVersionService;
 
     private readonly executionFactory: IPythonExecutionFactory;
 
@@ -26,7 +24,6 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
         this.pythonPathSettingsUpdaterFactory = serviceContainer.get<IPythonPathUpdaterServiceFactory>(
             IPythonPathUpdaterServiceFactory,
         );
-        this.interpreterVersionService = serviceContainer.get<IInterpreterVersionService>(IInterpreterVersionService);
         this.executionFactory = serviceContainer.get<IPythonExecutionFactory>(IPythonExecutionFactory);
         this.componentAdapter = serviceContainer.get<IComponentAdapter>(IComponentAdapter);
     }
@@ -80,14 +77,6 @@ export class PythonPathUpdaterService implements IPythonPathUpdaterServiceManage
                 if (info && info.version) {
                     telemetryProperties.pythonVersion = info.version.raw;
                 }
-            }
-
-            const pipVersion = await this.interpreterVersionService
-                .getPipVersion(pythonPath)
-                .then((value) => (value.length === 0 ? undefined : value))
-                .catch<string>(() => '');
-            if (pipVersion) {
-                telemetryProperties.pipVersion = pipVersion;
             }
         }
 

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -11,7 +11,6 @@ import { AppinsightsKey, isTestExecution, isUnitTestExecution, PVSC_EXTENSION_ID
 import { traceError, traceInfo } from '../common/logger';
 import { Telemetry } from '../common/startPage/constants';
 import type { TerminalShellType } from '../common/terminal/types';
-import { Architecture } from '../common/utils/platform';
 import { StopWatch } from '../common/utils/stopWatch';
 import { DebugConfigurationType } from '../debugger/extension/types';
 import { ConsoleType, TriggerType } from '../debugger/types';
@@ -939,12 +938,6 @@ export interface IEventNamePropertyMapping {
          * @type {string}
          */
         pipVersion?: string;
-        /**
-         * The bit-ness of the python interpreter represented using architecture.
-         *
-         * @type {Architecture}
-         */
-        architecture?: Architecture;
     };
     [EventName.PYTHON_INTERPRETER_ACTIVATION_ENVIRONMENT_VARIABLES]: {
         /**

--- a/src/client/telemetry/index.ts
+++ b/src/client/telemetry/index.ts
@@ -932,12 +932,6 @@ export interface IEventNamePropertyMapping {
          * @type {string}
          */
         pythonVersion?: string;
-        /**
-         * The version of pip module installed in the python interpreter
-         *
-         * @type {string}
-         */
-        pipVersion?: string;
     };
     [EventName.PYTHON_INTERPRETER_ACTIVATION_ENVIRONMENT_VARIABLES]: {
         /**


### PR DESCRIPTION
For #12020 

Outcome from discussion with Luciana:

> I believe we added that to establish a baseline for what our users had. But we can ditch the architecture value with the updates we're making, so we don't need to run anything to discover the bitness.

and 

> As for the pipversion, do we know if there's a performance implication? 
> actually I don't remember using this info anywhere anyway, so let's ditch pipversion too

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [ ] Appropriate comments and documentation strings in the code.
-   [ ] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] The wiki is updated with any design decisions/details.
