### PR TITLE
Ensure experiment framework is registered along with platform classes before we initialize components

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -34,7 +34,7 @@ import { IAsyncDisposableRegistry, IExtensionContext } from './common/types';
 import { createDeferred } from './common/utils/async';
 import { Common } from './common/utils/localize';
 import { activateComponents } from './extensionActivation';
-import { initializeCommon, initializeComponents, initializeGlobals } from './extensionInit';
+import { initializeStandard, initializeComponents, initializeGlobals } from './extensionInit';
 import { IServiceContainer } from './ioc/types';
 import { sendErrorTelemetry, sendStartupTelemetry } from './startupTelemetry';
 
@@ -99,7 +99,9 @@ async function activateUnsafe(
     // First we initialize.
     const ext = initializeGlobals(context);
     activatedServiceContainer = ext.legacyIOC.serviceContainer;
-    initializeCommon(ext);
+    // Note standard utils especially experiment and platform code are fundamental to the extension
+    // and should be available before we activate anything else.Hence register them first.
+    initializeStandard(ext);
     const components = initializeComponents(ext);
 
     // Then we finish activating.

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -34,7 +34,7 @@ import { IAsyncDisposableRegistry, IExtensionContext } from './common/types';
 import { createDeferred } from './common/utils/async';
 import { Common } from './common/utils/localize';
 import { activateComponents } from './extensionActivation';
-import { initializeCommon, initializeComponents, initializeGlobals } from './extensionInit';
+import { initializeComponents, initializeGlobals, initializeLegacy } from './extensionInit';
 import { IServiceContainer } from './ioc/types';
 import { sendErrorTelemetry, sendStartupTelemetry } from './startupTelemetry';
 
@@ -99,7 +99,10 @@ async function activateUnsafe(
     // First we initialize.
     const ext = initializeGlobals(context);
     activatedServiceContainer = ext.legacyIOC.serviceContainer;
-    initializeCommon(ext);
+    initializeLegacy(ext);
+
+    // IMPORTANT: Note initializeComponents expect utils like the experiment framework and all its dependencies
+    // to be initialized already, so this initialization comes after all legacy initializations.
     const components = initializeComponents(ext);
 
     // Then we finish activating.

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -34,7 +34,7 @@ import { IAsyncDisposableRegistry, IExtensionContext } from './common/types';
 import { createDeferred } from './common/utils/async';
 import { Common } from './common/utils/localize';
 import { activateComponents } from './extensionActivation';
-import { initializeComponents, initializeGlobals, initializeLegacy } from './extensionInit';
+import { initializeCommon, initializeComponents, initializeGlobals } from './extensionInit';
 import { IServiceContainer } from './ioc/types';
 import { sendErrorTelemetry, sendStartupTelemetry } from './startupTelemetry';
 
@@ -99,10 +99,7 @@ async function activateUnsafe(
     // First we initialize.
     const ext = initializeGlobals(context);
     activatedServiceContainer = ext.legacyIOC.serviceContainer;
-    initializeLegacy(ext);
-
-    // IMPORTANT: Note initializeComponents expect utils like the experiment framework and all its dependencies
-    // to be initialized already, so this initialization comes after all legacy initializations.
+    initializeCommon(ext);
     const components = initializeComponents(ext);
 
     // Then we finish activating.

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -18,9 +18,7 @@ import { IApplicationEnvironment, ICommandManager, IWorkspaceService } from './c
 import { Commands, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL, UseProposedApi } from './common/constants';
 import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
 import { traceError } from './common/logger';
-import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
 import { IFileSystem } from './common/platform/types';
-import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { StartPage } from './common/startPage/startPage';
 import { IStartPage } from './common/startPage/types';
 import {
@@ -119,10 +117,6 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
     serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
-
-    // Core registrations (non-feature specific).
-    platformRegisterTypes(serviceManager);
-    processRegisterTypes(serviceManager);
 
     // We need to setup this property before any telemetry is sent
     const fs = serviceManager.get<IFileSystem>(IFileSystem);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -5,16 +5,22 @@
 
 import { CodeActionKind, debug, DebugConfigurationProvider, languages, OutputChannel, window } from 'vscode';
 
+import { registerTypes as activationRegisterTypes } from './activation/serviceRegistry';
 import {
     IExtensionActivationManager,
     IExtensionSingleActivationService,
     ILanguageServerExtension,
 } from './activation/types';
+import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { IApplicationDiagnostics } from './application/types';
 import { DebugService } from './common/application/debugService';
 import { IApplicationEnvironment, ICommandManager, IWorkspaceService } from './common/application/types';
-import { Commands, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL } from './common/constants';
+import { Commands, PYTHON, PYTHON_LANGUAGE, STANDARD_OUTPUT_CHANNEL, UseProposedApi } from './common/constants';
+import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
 import { traceError } from './common/logger';
+import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
+import { IFileSystem } from './common/platform/types';
+import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { StartPage } from './common/startPage/startPage';
 import { IStartPage } from './common/startPage/types';
 import {
@@ -26,36 +32,45 @@ import {
 } from './common/types';
 import { OutputChannelNames } from './common/utils/localize';
 import { noop } from './common/utils/misc';
+import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
 import { DebuggerTypeName } from './debugger/constants';
 import { DebugSessionEventDispatcher } from './debugger/extension/hooks/eventHandlerDispatcher';
 import { IDebugSessionEventHandlers } from './debugger/extension/hooks/types';
+import { registerTypes as debugConfigurationRegisterTypes } from './debugger/extension/serviceRegistry';
 import { IDebugConfigurationService, IDebuggerBanner } from './debugger/extension/types';
+import { registerTypes as formattersRegisterTypes } from './formatters/serviceRegistry';
 import {
     IComponentAdapter,
     IInterpreterLocatorProgressHandler,
     IInterpreterLocatorProgressService,
     IInterpreterService,
 } from './interpreter/contracts';
+import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
 import { getLanguageConfiguration } from './language/languageConfiguration';
 import { LinterCommands } from './linters/linterCommands';
-import { setLoggingLevel } from './logging';
+import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
+import { addOutputChannelLogging, setLoggingLevel } from './logging';
 import { PythonCodeActionProvider } from './providers/codeActionProvider/pythonCodeActionProvider';
 import { PythonFormattingEditProvider } from './providers/formatProvider';
 import { ReplProvider } from './providers/replProvider';
+import { registerTypes as providersRegisterTypes } from './providers/serviceRegistry';
 import { activateSimplePythonRefactorProvider } from './providers/simpleRefactorProvider';
 import { TerminalProvider } from './providers/terminalProvider';
 import { ISortImportsEditingProvider } from './providers/types';
+import { setExtensionInstallTelemetryProperties } from './telemetry/extensionInstallTelemetry';
+import { registerTypes as tensorBoardRegisterTypes } from './tensorBoard/serviceRegistry';
+import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionManager, ITerminalAutoActivation } from './terminals/types';
+import { TEST_OUTPUT_CHANNEL } from './testing/common/constants';
 import { ITestContextService } from './testing/common/types';
 import { ITestCodeNavigatorCommandHandler, ITestExplorerCommandHandler } from './testing/navigation/types';
+import { registerTypes as unitTestsRegisterTypes } from './testing/serviceRegistry';
 
 // components
 // import * as pythonEnvironments from './pythonEnvironments';
 
 import { ActivationResult, ExtensionState } from './components';
 import { Components } from './extensionInit';
-import { setExtensionInstallTelemetryProperties } from './telemetry/extensionInstallTelemetry';
-import { IFileSystem } from './common/platform/types';
 
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
@@ -97,9 +112,35 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     const { context, legacyIOC } = ext;
     const { serviceManager, serviceContainer } = legacyIOC;
 
+    // register "services"
+
+    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    addOutputChannelLogging(standardOutputChannel);
+    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
+
+    // Core registrations (non-feature specific).
+    platformRegisterTypes(serviceManager);
+    processRegisterTypes(serviceManager);
+
     // We need to setup this property before any telemetry is sent
     const fs = serviceManager.get<IFileSystem>(IFileSystem);
     await setExtensionInstallTelemetryProperties(fs);
+
+    const applicationEnv = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
+    const enableProposedApi = applicationEnv.packageJson.enableProposedApi;
+    serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
+    // Feature specific registrations.
+    variableRegisterTypes(serviceManager);
+    unitTestsRegisterTypes(serviceManager);
+    lintersRegisterTypes(serviceManager);
+    interpretersRegisterTypes(serviceManager);
+    formattersRegisterTypes(serviceManager);
+    installerRegisterTypes(serviceManager);
+    commonRegisterTerminalTypes(serviceManager);
+    debugConfigurationRegisterTypes(serviceManager);
+    tensorBoardRegisterTypes(serviceManager);
 
     const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
     // We should start logging using the log level as soon as possible, so set it as soon as we can access the level.
@@ -109,6 +150,13 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
 
     const abExperiments = serviceContainer.get<IExperimentsManager>(IExperimentsManager);
     await abExperiments.activate();
+
+    const languageServerType = configuration.getSettings().languageServer;
+
+    // Language feature registrations.
+    appRegisterTypes(serviceManager, languageServerType);
+    providersRegisterTypes(serviceManager);
+    activationRegisterTypes(serviceManager, languageServerType);
 
     // "initialize" "services"
 
@@ -130,7 +178,6 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     disposables.push(cmdManager.registerCommand(Commands.ViewOutput, () => outputChannel.show()));
     const startPage = serviceManager.get<StartPage>(IStartPage);
     cmdManager.registerCommand(Commands.OpenStartPage, () => startPage.open());
-    const applicationEnv = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
     cmdManager.executeCommand('setContext', 'python.vscode.channel', applicationEnv.channel).then(noop, noop);
 
     // Display progress of interpreter refreshes only after extension has activated.
@@ -151,7 +198,6 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     serviceManager.get<ITerminalAutoActivation>(ITerminalAutoActivation).register();
     const pythonSettings = configuration.getSettings();
 
-    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
     activateSimplePythonRefactorProvider(context, standardOutputChannel, serviceContainer);
 
     const sortImports = serviceContainer.get<ISortImportsEditingProvider>(ISortImportsEditingProvider);

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -6,6 +6,8 @@
 import { Container } from 'inversify';
 import { Disposable, Memento } from 'vscode';
 
+import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
+import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
 import { GLOBAL_MEMENTO, IDisposableRegistry, IExtensionContext, IMemento, WORKSPACE_MEMENTO } from './common/types';
 import { ExtensionState } from './components';
@@ -44,9 +46,12 @@ export function initializeGlobals(
     };
 }
 
-export function initializeCommon(ext: ExtensionState): void {
+export function initializeStandard(ext: ExtensionState): void {
+    const { serviceManager } = ext.legacyIOC;
     // Core registrations (non-feature specific).
-    commonRegisterTypes(ext.legacyIOC.serviceManager);
+    commonRegisterTypes(serviceManager);
+    platformRegisterTypes(serviceManager);
+    processRegisterTypes(serviceManager);
 
     // We will be pulling other code over from activateLegacy().
 }

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -4,16 +4,43 @@
 'use strict';
 
 import { Container } from 'inversify';
-import { Disposable, Memento } from 'vscode';
+import { Disposable, Memento, OutputChannel, window } from 'vscode';
 
+import { IApplicationEnvironment } from './common/application/types';
+import { registerTypes as activationRegisterTypes } from './activation/serviceRegistry';
+import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
-import { GLOBAL_MEMENTO, IDisposableRegistry, IExtensionContext, IMemento, WORKSPACE_MEMENTO } from './common/types';
+import {
+    GLOBAL_MEMENTO,
+    IDisposableRegistry,
+    IConfigurationService,
+    IExtensionContext,
+    IOutputChannel,
+    IMemento,
+    WORKSPACE_MEMENTO,
+} from './common/types';
 import { ExtensionState } from './components';
 import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
 import * as pythonEnvironments from './pythonEnvironments';
 import { PythonEnvironments } from './pythonEnvironments/api';
+import { OutputChannelNames } from './common/utils/localize';
+import { registerTypes as providersRegisterTypes } from './providers/serviceRegistry';
+import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
+import { registerTypes as debugConfigurationRegisterTypes } from './debugger/extension/serviceRegistry';
+import { registerTypes as formattersRegisterTypes } from './formatters/serviceRegistry';
+import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
+import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
+import { registerTypes as tensorBoardRegisterTypes } from './tensorBoard/serviceRegistry';
+import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
+import { TEST_OUTPUT_CHANNEL } from './testing/common/constants';
+import { registerTypes as unitTestsRegisterTypes } from './testing/serviceRegistry';
+import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
+import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
+import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
+import { addOutputChannelLogging } from './logging';
+import { STANDARD_OUTPUT_CHANNEL, UseProposedApi } from './common/constants';
 
 // The code in this module should do nothing more complex than register
 // objects to DI and simple init (e.g. no side effects).  That implies
@@ -44,11 +71,48 @@ export function initializeGlobals(
     };
 }
 
-export function initializeCommon(ext: ExtensionState): void {
+/**
+ * TODO: As we start refactoring things into components, gradually move simple initialization
+ * and DI registration currently in this function over to initializeComponents().
+ * See https://github.com/microsoft/vscode-python/issues/10454.
+ */
+export function initializeLegacy(ext: ExtensionState): void {
+    const { serviceManager } = ext.legacyIOC;
+
     // Core registrations (non-feature specific).
     commonRegisterTypes(ext.legacyIOC.serviceManager);
+    platformRegisterTypes(serviceManager);
+    processRegisterTypes(serviceManager);
 
-    // We will be pulling other code over from activateLegacy().
+    // register "services"
+
+    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    addOutputChannelLogging(standardOutputChannel);
+    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
+
+    const applicationEnv = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
+    const { enableProposedApi } = applicationEnv.packageJson;
+    serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
+    // Feature specific registrations.
+    variableRegisterTypes(serviceManager);
+    unitTestsRegisterTypes(serviceManager);
+    lintersRegisterTypes(serviceManager);
+    interpretersRegisterTypes(serviceManager);
+    formattersRegisterTypes(serviceManager);
+    installerRegisterTypes(serviceManager);
+    commonRegisterTerminalTypes(serviceManager);
+    debugConfigurationRegisterTypes(serviceManager);
+    tensorBoardRegisterTypes(serviceManager);
+
+    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
+    const languageServerType = configuration.getSettings().languageServer;
+
+    // Language feature registrations.
+    appRegisterTypes(serviceManager, languageServerType);
+    providersRegisterTypes(serviceManager);
+    activationRegisterTypes(serviceManager, languageServerType);
 }
 
 /**

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -46,6 +46,9 @@ export function initializeGlobals(
     };
 }
 
+/**
+ * Registers standard utils like experiment and platform code which are fundamental to the extension.
+ */
 export function initializeStandard(ext: ExtensionState): void {
     const { serviceManager } = ext.legacyIOC;
     // Core registrations (non-feature specific).

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -4,43 +4,16 @@
 'use strict';
 
 import { Container } from 'inversify';
-import { Disposable, Memento, OutputChannel, window } from 'vscode';
+import { Disposable, Memento } from 'vscode';
 
-import { IApplicationEnvironment } from './common/application/types';
-import { registerTypes as activationRegisterTypes } from './activation/serviceRegistry';
-import { registerTypes as appRegisterTypes } from './application/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
-import {
-    GLOBAL_MEMENTO,
-    IDisposableRegistry,
-    IConfigurationService,
-    IExtensionContext,
-    IOutputChannel,
-    IMemento,
-    WORKSPACE_MEMENTO,
-} from './common/types';
+import { GLOBAL_MEMENTO, IDisposableRegistry, IExtensionContext, IMemento, WORKSPACE_MEMENTO } from './common/types';
 import { ExtensionState } from './components';
 import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
 import * as pythonEnvironments from './pythonEnvironments';
 import { PythonEnvironments } from './pythonEnvironments/api';
-import { OutputChannelNames } from './common/utils/localize';
-import { registerTypes as providersRegisterTypes } from './providers/serviceRegistry';
-import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
-import { registerTypes as debugConfigurationRegisterTypes } from './debugger/extension/serviceRegistry';
-import { registerTypes as formattersRegisterTypes } from './formatters/serviceRegistry';
-import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
-import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
-import { registerTypes as tensorBoardRegisterTypes } from './tensorBoard/serviceRegistry';
-import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
-import { TEST_OUTPUT_CHANNEL } from './testing/common/constants';
-import { registerTypes as unitTestsRegisterTypes } from './testing/serviceRegistry';
-import { registerTypes as installerRegisterTypes } from './common/installer/serviceRegistry';
-import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
-import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
-import { addOutputChannelLogging } from './logging';
-import { STANDARD_OUTPUT_CHANNEL, UseProposedApi } from './common/constants';
 
 // The code in this module should do nothing more complex than register
 // objects to DI and simple init (e.g. no side effects).  That implies
@@ -71,48 +44,11 @@ export function initializeGlobals(
     };
 }
 
-/**
- * TODO: As we start refactoring things into components, gradually move simple initialization
- * and DI registration currently in this function over to initializeComponents().
- * See https://github.com/microsoft/vscode-python/issues/10454.
- */
-export function initializeLegacy(ext: ExtensionState): void {
-    const { serviceManager } = ext.legacyIOC;
-
+export function initializeCommon(ext: ExtensionState): void {
     // Core registrations (non-feature specific).
     commonRegisterTypes(ext.legacyIOC.serviceManager);
-    platformRegisterTypes(serviceManager);
-    processRegisterTypes(serviceManager);
 
-    // register "services"
-
-    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
-    addOutputChannelLogging(standardOutputChannel);
-    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
-    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
-    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
-
-    const applicationEnv = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
-    const { enableProposedApi } = applicationEnv.packageJson;
-    serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
-    // Feature specific registrations.
-    variableRegisterTypes(serviceManager);
-    unitTestsRegisterTypes(serviceManager);
-    lintersRegisterTypes(serviceManager);
-    interpretersRegisterTypes(serviceManager);
-    formattersRegisterTypes(serviceManager);
-    installerRegisterTypes(serviceManager);
-    commonRegisterTerminalTypes(serviceManager);
-    debugConfigurationRegisterTypes(serviceManager);
-    tensorBoardRegisterTypes(serviceManager);
-
-    const configuration = serviceManager.get<IConfigurationService>(IConfigurationService);
-    const languageServerType = configuration.getSettings().languageServer;
-
-    // Language feature registrations.
-    appRegisterTypes(serviceManager, languageServerType);
-    providersRegisterTypes(serviceManager);
-    activationRegisterTypes(serviceManager, languageServerType);
+    // We will be pulling other code over from activateLegacy().
 }
 
 /**


### PR DESCRIPTION
We needed to ensure experiment framework is registered along with platform classes are available before initializing components. Related https://github.com/microsoft/vscode-python/issues/10454.