### PR TITLE
Python side of hiding interpreter for native notebooks

### DIFF
--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -88,6 +88,7 @@ export interface IInterpreterService {
 export const IInterpreterDisplay = Symbol('IInterpreterDisplay');
 export interface IInterpreterDisplay {
     refresh(resource?: Uri): Promise<void>;
+    registerVisibilityFilter(filter: IInterpreterStatusbarVisibilityFilter): void;
 }
 
 export const IShebangCodeLensProvider = Symbol('IShebangCodeLensProvider');

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -47,11 +47,10 @@ import {
     IInterpreterHelper,
     IInterpreterLocatorProgressHandler,
     IInterpreterService,
-    IInterpreterStatusbarVisibilityFilter,
     IInterpreterVersionService,
     IShebangCodeLensProvider,
 } from './contracts';
-import { AlwaysDisplayStatusBar, InterpreterDisplay } from './display';
+import { InterpreterDisplay } from './display';
 import { InterpreterSelectionTip } from './display/interpreterSelectionTip';
 import { InterpreterLocatorProgressStatubarHandler } from './display/progressDisplay';
 import { ShebangCodeLensProvider } from './display/shebangCodeLensProvider';
@@ -163,10 +162,6 @@ export function registerInterpreterTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,
         PreWarmActivatedEnvironmentVariables,
-    );
-    serviceManager.addSingleton<IInterpreterStatusbarVisibilityFilter>(
-        IInterpreterStatusbarVisibilityFilter,
-        AlwaysDisplayStatusBar,
     );
 }
 

--- a/src/client/jupyter/jupyterIntegration.ts
+++ b/src/client/jupyter/jupyterIntegration.ts
@@ -194,7 +194,9 @@ export class JupyterExtensionIntegration {
                 }
                 return undefined;
             },
-            registerInterpreterStatusFilter: this.interpreterDisplay.registerVisibilityFilter,
+            registerInterpreterStatusFilter: this.interpreterDisplay.registerVisibilityFilter.bind(
+                this.interpreterDisplay,
+            ),
         });
         return undefined;
     }

--- a/src/client/jupyter/jupyterIntegration.ts
+++ b/src/client/jupyter/jupyterIntegration.ts
@@ -24,7 +24,11 @@ import { isResource } from '../common/utils/misc';
 import { getDebugpyPackagePath } from '../debugger/extension/adapter/remoteLaunchers';
 import { IEnvironmentActivationService } from '../interpreter/activation/types';
 import { IInterpreterQuickPickItem, IInterpreterSelector } from '../interpreter/configuration/types';
-import { IInterpreterService } from '../interpreter/contracts';
+import {
+    IInterpreterDisplay,
+    IInterpreterService,
+    IInterpreterStatusbarVisibilityFilter,
+} from '../interpreter/contracts';
 import { IWindowsStoreInterpreter } from '../interpreter/locators/types';
 import { WindowsStoreInterpreter } from '../pythonEnvironments/discovery/locators/services/windowsStoreInterpreter';
 import { PythonEnvironment } from '../pythonEnvironments/info';
@@ -109,6 +113,10 @@ type PythonApiForJupyterExtension = {
      * @param resource file that determines which connection to return
      */
     getLanguageServer(resource?: InterpreterUri): Promise<ILanguageServer | undefined>;
+    /**
+     * Registers a visibility filter for the interpreter status bar.
+     */
+    registerInterpreterStatusFilter(filter: IInterpreterStatusbarVisibilityFilter): void;
 };
 
 export type JupyterExtensionApi = {
@@ -143,6 +151,7 @@ export class JupyterExtensionIntegration {
         @inject(IEnvironmentActivationService) private readonly envActivation: IEnvironmentActivationService,
         @inject(ILanguageServerCache) private readonly languageServerCache: ILanguageServerCache,
         @inject(IMemento) @named(GLOBAL_MEMENTO) private globalState: Memento,
+        @inject(IInterpreterDisplay) private interpreterDisplay: IInterpreterDisplay,
     ) {}
 
     public registerApi(jupyterExtensionApi: JupyterExtensionApi): JupyterExtensionApi | undefined {
@@ -185,6 +194,7 @@ export class JupyterExtensionIntegration {
                 }
                 return undefined;
             },
+            registerInterpreterStatusFilter: this.interpreterDisplay.registerVisibilityFilter,
         });
         return undefined;
     }

--- a/src/test/interpreters/display.unit.test.ts
+++ b/src/test/interpreters/display.unit.test.ts
@@ -117,7 +117,8 @@ suite('Interpreters Display', () => {
         createInterpreterDisplay();
     });
     function createInterpreterDisplay(filters: IInterpreterStatusbarVisibilityFilter[] = []) {
-        interpreterDisplay = new InterpreterDisplay(serviceContainer.object, filters);
+        interpreterDisplay = new InterpreterDisplay(serviceContainer.object);
+        filters.forEach((f) => interpreterDisplay.registerVisibilityFilter(f));
     }
     function setupWorkspaceFolder(resource: Uri, workspaceFolder?: Uri) {
         if (workspaceFolder) {


### PR DESCRIPTION
For #https://github.com/microsoft/vscode-jupyter/issues/3979

Give the jupyter extension the capability to hide the python interpreter

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->

-   [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR).
-   [x] Title summarizes what is changing.
-   [x] Appropriate comments and documentation strings in the code.
-   [x] Has sufficient logging.
-   [ ] Has telemetry for enhancements.
-   [ ] The wiki is updated with any design decisions/details.

Corresponding PR in jupyter is here:
https://github.com/microsoft/vscode-jupyter/pull/4391