### PR TITLE
Ensure experiment framework can be created using standard utils

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -200,7 +200,6 @@ src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvide
 src/test/common/terminals/environmentActivationProviders/terminalActivation.testvirtualenvs.ts
 src/test/common/socketStream.test.ts
 src/test/common/configSettings.test.ts
-src/test/common/experiments/service.unit.test.ts
 src/test/common/experiments/manager.unit.test.ts
 src/test/common/experiments/telemetry.unit.test.ts
 src/test/common/platform/filesystem.unit.test.ts
@@ -373,7 +372,6 @@ src/client/interpreter/display/interpreterSelectionTip.ts
 
 src/client/api.ts
 src/client/extension.ts
-src/client/extensionActivation.ts
 src/client/sourceMapSupport.ts
 src/client/startupTelemetry.ts
 
@@ -553,7 +551,6 @@ src/client/common/markdown/restTextConverter.ts
 src/client/common/featureDeprecationManager.ts
 src/client/common/experiments/manager.ts
 src/client/common/experiments/telemetry.ts
-src/client/common/experiments/service.ts
 src/client/common/refBool.ts
 src/client/common/open.ts
 src/client/common/platform/serviceRegistry.ts
@@ -611,7 +608,6 @@ src/client/common/dotnet/services/linuxCompatibilityService.ts
 src/client/common/dotnet/services/windowsCompatibilityService.ts
 src/client/common/types.ts
 src/client/common/logger.ts
-src/client/common/configSettings.ts
 src/client/common/constants.ts
 src/client/common/variables/serviceRegistry.ts
 src/client/common/variables/environment.ts

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -520,6 +520,8 @@ export class PythonSettings implements IPythonSettings {
         } else {
             this.experiments = experiments;
         }
+        // Note we directly access experiment settings using workspace service in ExperimentService class.
+        // Any changes here specific to these settings here should propogate their as well.
         this.experiments = this.experiments
             ? this.experiments
             : {

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+// eslint-disable-next-line camelcase
 import * as child_process from 'child_process';
 import * as path from 'path';
 import {
@@ -13,7 +14,7 @@ import {
     WorkspaceConfiguration,
 } from 'vscode';
 import { LanguageServerType } from '../activation/types';
-import '../common/extensions';
+import './extensions';
 import { IInterpreterAutoSeletionProxyService, IInterpreterSecurityService } from '../interpreter/autoSelection/types';
 import { LogLevel } from '../logging/levels';
 import { sendTelemetryEvent } from '../telemetry';
@@ -56,6 +57,7 @@ export class PythonSettings implements IPythonSettings {
     public get pythonPath(): string {
         return this._pythonPath;
     }
+
     public set pythonPath(value: string) {
         if (this._pythonPath === value) {
             return;
@@ -72,6 +74,7 @@ export class PythonSettings implements IPythonSettings {
     public get defaultInterpreterPath(): string {
         return this._defaultInterpreterPath;
     }
+
     public set defaultInterpreterPath(value: string) {
         if (this._defaultInterpreterPath === value) {
             return;
@@ -84,41 +87,73 @@ export class PythonSettings implements IPythonSettings {
             this._defaultInterpreterPath = value;
         }
     }
+
     private static pythonSettings: Map<string, PythonSettings> = new Map<string, PythonSettings>();
+
     public showStartPage = true;
+
     public downloadLanguageServer = true;
+
     public jediPath = '';
+
     public jediMemoryLimit = 1024;
+
     public envFile = '';
+
     public venvPath = '';
+
     public venvFolders: string[] = [];
+
     public condaPath = '';
+
     public pipenvPath = '';
+
     public poetryPath = '';
+
     public devOptions: string[] = [];
+
     public linting!: ILintingSettings;
+
     public formatting!: IFormattingSettings;
+
     public autoComplete!: IAutoCompleteSettings;
+
     public testing!: ITestingSettings;
+
     public terminal!: ITerminalSettings;
+
     public sortImports!: ISortImportSettings;
+
     public workspaceSymbols!: IWorkspaceSymbolSettings;
+
     public disableInstallationChecks = false;
+
     public globalModuleInstallation = false;
+
     public analysis!: IAnalysisSettings;
-    public autoUpdateLanguageServer: boolean = true;
+
+    public autoUpdateLanguageServer = true;
+
     public insidersChannel!: ExtensionChannels;
+
     public experiments!: IExperiments;
+
     public languageServer: LanguageServerType = LanguageServerType.Microsoft;
+
     public logging: ILoggingSettings = { level: LogLevel.Error };
-    public useIsolation: boolean = true;
+
+    public useIsolation = true;
 
     protected readonly changed = new EventEmitter<void>();
+
     private workspaceRoot: Resource;
+
     private disposables: Disposable[] = [];
 
     private _pythonPath = '';
+
     private _defaultInterpreterPath = '';
+
     private readonly workspace: IWorkspaceService;
 
     constructor(
@@ -158,7 +193,8 @@ export class PythonSettings implements IPythonSettings {
             PythonSettings.pythonSettings.set(workspaceFolderKey, settings);
             // Pass null to avoid VSC from complaining about not passing in a value.
 
-            const config = workspace.getConfiguration('editor', resource ? resource : (null as any));
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const config = workspace.getConfiguration('editor', resource || (null as any));
             const formatOnType = config ? config.get('formatOnType', false) : false;
             sendTelemetryEvent(EventName.COMPLETION_ADD_BRACKETS, undefined, {
                 enabled: settings.autoComplete ? settings.autoComplete.addBrackets : false,
@@ -185,7 +221,7 @@ export class PythonSettings implements IPythonSettings {
         return { uri: workspaceFolderUri, target };
     }
 
-    public static dispose() {
+    public static dispose(): void {
         if (!isTestExecution()) {
             throw new Error('Dispose can only be called from unit tests');
         }
@@ -195,6 +231,7 @@ export class PythonSettings implements IPythonSettings {
     }
 
     public static toSerializable(settings: IPythonSettings): IPythonSettings {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const clone: any = {};
         const keys = Object.entries(settings);
         keys.forEach((e) => {
@@ -207,19 +244,19 @@ export class PythonSettings implements IPythonSettings {
         return clone as IPythonSettings;
     }
 
-    public dispose() {
+    public dispose(): void {
         this.disposables.forEach((disposable) => disposable && disposable.dispose());
         this.disposables = [];
     }
 
-    protected update(pythonSettings: WorkspaceConfiguration) {
+    protected update(pythonSettings: WorkspaceConfiguration): void {
         const workspaceRoot = this.workspaceRoot?.fsPath;
         const systemVariables: SystemVariables = new SystemVariables(undefined, workspaceRoot, this.workspace);
 
         this.pythonPath = this.getPythonPath(pythonSettings, systemVariables, workspaceRoot);
 
         const defaultInterpreterPath = systemVariables.resolveAny(pythonSettings.get<string>('defaultInterpreterPath'));
-        this.defaultInterpreterPath = defaultInterpreterPath ? defaultInterpreterPath : DEFAULT_INTERPRETER_SETTING;
+        this.defaultInterpreterPath = defaultInterpreterPath || DEFAULT_INTERPRETER_SETTING;
         this.defaultInterpreterPath = getAbsolutePath(this.defaultInterpreterPath, workspaceRoot);
 
         this.venvPath = systemVariables.resolveAny(pythonSettings.get<string>('venvPath'))!;
@@ -259,9 +296,11 @@ export class PythonSettings implements IPythonSettings {
         this.envFile = systemVariables.resolveAny(envFileSetting)!;
         sendSettingTelemetry(this.workspace, envFileSetting);
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.devOptions = systemVariables.resolveAny(pythonSettings.get<any[]>('devOptions'))!;
         this.devOptions = Array.isArray(this.devOptions) ? this.devOptions : [];
 
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const loggingSettings = systemVariables.resolveAny(pythonSettings.get<any>('logging'))!;
         loggingSettings.level = convertSettingTypeToLogLevel(loggingSettings.level);
         if (this.logging) {
@@ -538,11 +577,13 @@ export class PythonSettings implements IPythonSettings {
         this.insidersChannel = pythonSettings.get<ExtensionChannels>('insidersChannel')!;
     }
 
-    protected getPythonExecutable(pythonPath: string) {
+    // eslint-disable-next-line class-methods-use-this
+    protected getPythonExecutable(pythonPath: string): string {
         return getPythonExecutable(pythonPath);
     }
-    protected onWorkspaceFoldersChanged() {
-        //If an activated workspace folder was removed, delete its key
+
+    protected onWorkspaceFoldersChanged(): void {
+        // If an activated workspace folder was removed, delete its key
         const workspaceKeys = this.workspace.workspaceFolders!.map((workspaceFolder) => workspaceFolder.uri.fsPath);
         const activatedWkspcKeys = Array.from(PythonSettings.pythonSettings.keys());
         const activatedWkspcFoldersRemoved = activatedWkspcKeys.filter((item) => workspaceKeys.indexOf(item) < 0);
@@ -552,6 +593,7 @@ export class PythonSettings implements IPythonSettings {
             }
         }
     }
+
     protected initialize(): void {
         const onDidChange = () => {
             const currentConfig = this.workspace.getConfiguration('python', this.workspaceRoot);
@@ -584,8 +626,9 @@ export class PythonSettings implements IPythonSettings {
             this.update(initialConfig);
         }
     }
+
     @debounceSync(1)
-    protected debounceChangeNotification() {
+    protected debounceChangeNotification(): void {
         this.changed.fire();
     }
 
@@ -627,13 +670,11 @@ export class PythonSettings implements IPythonSettings {
                         .setWorkspaceInterpreter(this.workspaceRoot, autoSelectedPythonInterpreter)
                         .ignoreErrors();
                 }
-            } else {
-                if (autoSelectedPythonInterpreter && this.workspaceRoot) {
-                    this.pythonPath = autoSelectedPythonInterpreter.path;
-                    this.interpreterAutoSelectionService
-                        .setWorkspaceInterpreter(this.workspaceRoot, autoSelectedPythonInterpreter)
-                        .ignoreErrors();
-                }
+            } else if (autoSelectedPythonInterpreter && this.workspaceRoot) {
+                this.pythonPath = autoSelectedPythonInterpreter.path;
+                this.interpreterAutoSelectionService
+                    .setWorkspaceInterpreter(this.workspaceRoot, autoSelectedPythonInterpreter)
+                    .ignoreErrors();
             }
         }
         if (inExperiment && this.pythonPath === DEFAULT_INTERPRETER_SETTING) {

--- a/src/client/common/configSettings.ts
+++ b/src/client/common/configSettings.ts
@@ -521,7 +521,7 @@ export class PythonSettings implements IPythonSettings {
             this.experiments = experiments;
         }
         // Note we directly access experiment settings using workspace service in ExperimentService class.
-        // Any changes here specific to these settings here should propogate their as well.
+        // Any changes here specific to these settings should propogate their as well.
         this.experiments = this.experiments
             ? this.experiments
             : {

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -22,6 +22,7 @@ export class ExperimentService implements IExperimentService {
      * Experiments the user requested to opt into manually.
      */
     public _optInto: string[] = [];
+
     /**
      * Experiments the user requested to opt out from manually.
      */
@@ -100,7 +101,7 @@ export class ExperimentService implements IExperimentService {
 
     public async getExperimentValue<T extends boolean | number | string>(experiment: string): Promise<T | undefined> {
         if (!this.experimentationService || this._optOutFrom.includes('All') || this._optOutFrom.includes(experiment)) {
-            return;
+            return undefined;
         }
 
         return this.experimentationService.getTreatmentVariableAsync('vscode', experiment);

--- a/src/client/common/experiments/service.ts
+++ b/src/client/common/experiments/service.ts
@@ -116,7 +116,8 @@ export class ExperimentService implements IExperimentService {
             // short circuit and return. So, printing out additional experiment info might cause
             // confusion. So skip printing out any specific experiment details to the log.
             return;
-        } else if (this._optInto.includes('All')) {
+        }
+        if (this._optInto.includes('All')) {
             // Only if 'All' is not in optOut then check if it is in Opt In.
             this.output.appendLine(Experiments.inGroup().format('All'));
 

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -28,7 +28,6 @@ import {
     IFeatureDeprecationManager,
     IOutputChannel,
 } from './common/types';
-import { OutputChannelNames } from './common/utils/localize';
 import { noop } from './common/utils/misc';
 import { registerTypes as variableRegisterTypes } from './common/variables/serviceRegistry';
 import { DebuggerTypeName } from './debugger/constants';

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -71,6 +71,7 @@ import { Components } from './extensionInit';
 export async function activateComponents(
     // `ext` is passed to any extra activation funcs.
     ext: ExtensionState,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _components: Components,
 ): Promise<ActivationResult[]> {
     // Note that each activation returns a promise that resolves
@@ -95,7 +96,7 @@ export async function activateComponents(
     return Promise.all(promises);
 }
 
-/////////////////////////////
+/// //////////////////////////
 // old activation code
 
 // TODO: Gradually move simple initialization
@@ -117,7 +118,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     await setExtensionInstallTelemetryProperties(fs);
 
     const applicationEnv = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
-    const enableProposedApi = applicationEnv.packageJson.enableProposedApi;
+    const {enableProposedApi} = applicationEnv.packageJson;
     serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
     // Feature specific registrations.
     variableRegisterTypes(serviceManager);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -43,11 +43,10 @@ import {
     IInterpreterLocatorProgressService,
     IInterpreterService,
 } from './interpreter/contracts';
-import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
 import { getLanguageConfiguration } from './language/languageConfiguration';
 import { LinterCommands } from './linters/linterCommands';
 import { registerTypes as lintersRegisterTypes } from './linters/serviceRegistry';
-import { addOutputChannelLogging, setLoggingLevel } from './logging';
+import { setLoggingLevel } from './logging';
 import { PythonCodeActionProvider } from './providers/codeActionProvider/pythonCodeActionProvider';
 import { PythonFormattingEditProvider } from './providers/formatProvider';
 import { ReplProvider } from './providers/replProvider';
@@ -59,10 +58,10 @@ import { setExtensionInstallTelemetryProperties } from './telemetry/extensionIns
 import { registerTypes as tensorBoardRegisterTypes } from './tensorBoard/serviceRegistry';
 import { registerTypes as commonRegisterTerminalTypes } from './terminals/serviceRegistry';
 import { ICodeExecutionManager, ITerminalAutoActivation } from './terminals/types';
-import { TEST_OUTPUT_CHANNEL } from './testing/common/constants';
 import { ITestContextService } from './testing/common/types';
 import { ITestCodeNavigatorCommandHandler, ITestExplorerCommandHandler } from './testing/navigation/types';
 import { registerTypes as unitTestsRegisterTypes } from './testing/serviceRegistry';
+import { registerTypes as interpretersRegisterTypes } from './interpreter/serviceRegistry';
 
 // components
 // import * as pythonEnvironments from './pythonEnvironments';
@@ -113,10 +112,6 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     // register "services"
 
     const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
-    addOutputChannelLogging(standardOutputChannel);
-    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
-    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
-    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
 
     // We need to setup this property before any telemetry is sent
     const fs = serviceManager.get<IFileSystem>(IFileSystem);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -111,7 +111,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
 
     // register "services"
 
-    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    const standardOutputChannel = serviceManager.get<IOutputChannel>(IOutputChannel, STANDARD_OUTPUT_CHANNEL);
 
     // We need to setup this property before any telemetry is sent
     const fs = serviceManager.get<IFileSystem>(IFileSystem);

--- a/src/client/extensionActivation.ts
+++ b/src/client/extensionActivation.ts
@@ -118,7 +118,7 @@ async function activateLegacy(ext: ExtensionState): Promise<ActivationResult> {
     await setExtensionInstallTelemetryProperties(fs);
 
     const applicationEnv = serviceManager.get<IApplicationEnvironment>(IApplicationEnvironment);
-    const {enableProposedApi} = applicationEnv.packageJson;
+    const { enableProposedApi } = applicationEnv.packageJson;
     serviceManager.addSingletonInstance<boolean>(UseProposedApi, enableProposedApi);
     // Feature specific registrations.
     variableRegisterTypes(serviceManager);

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -4,18 +4,28 @@
 'use strict';
 
 import { Container } from 'inversify';
-import { Disposable, Memento } from 'vscode';
-
+import { Disposable, Memento, OutputChannel, window } from 'vscode';
+import { STANDARD_OUTPUT_CHANNEL } from './common/constants';
 import { registerTypes as platformRegisterTypes } from './common/platform/serviceRegistry';
 import { registerTypes as processRegisterTypes } from './common/process/serviceRegistry';
 import { registerTypes as commonRegisterTypes } from './common/serviceRegistry';
-import { GLOBAL_MEMENTO, IDisposableRegistry, IExtensionContext, IMemento, WORKSPACE_MEMENTO } from './common/types';
+import {
+    GLOBAL_MEMENTO,
+    IDisposableRegistry,
+    IExtensionContext,
+    IMemento,
+    IOutputChannel,
+    WORKSPACE_MEMENTO,
+} from './common/types';
+import { OutputChannelNames } from './common/utils/localize';
 import { ExtensionState } from './components';
 import { ServiceContainer } from './ioc/container';
 import { ServiceManager } from './ioc/serviceManager';
 import { IServiceContainer, IServiceManager } from './ioc/types';
+import { addOutputChannelLogging } from './logging';
 import * as pythonEnvironments from './pythonEnvironments';
 import { PythonEnvironments } from './pythonEnvironments/api';
+import { TEST_OUTPUT_CHANNEL } from './testing/common/constants';
 
 // The code in this module should do nothing more complex than register
 // objects to DI and simple init (e.g. no side effects).  That implies
@@ -55,6 +65,12 @@ export function initializeStandard(ext: ExtensionState): void {
     commonRegisterTypes(serviceManager);
     platformRegisterTypes(serviceManager);
     processRegisterTypes(serviceManager);
+
+    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    addOutputChannelLogging(standardOutputChannel);
+    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
 
     // We will be pulling other code over from activateLegacy().
 }

--- a/src/client/extensionInit.ts
+++ b/src/client/extensionInit.ts
@@ -49,6 +49,12 @@ export function initializeGlobals(
     serviceManager.addSingletonInstance<Memento>(IMemento, context.workspaceState, WORKSPACE_MEMENTO);
     serviceManager.addSingletonInstance<IExtensionContext>(IExtensionContext, context);
 
+    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
+    addOutputChannelLogging(standardOutputChannel);
+    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
+    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
+
     return {
         context,
         disposables,
@@ -65,12 +71,6 @@ export function initializeStandard(ext: ExtensionState): void {
     commonRegisterTypes(serviceManager);
     platformRegisterTypes(serviceManager);
     processRegisterTypes(serviceManager);
-
-    const standardOutputChannel = window.createOutputChannel(OutputChannelNames.python());
-    addOutputChannelLogging(standardOutputChannel);
-    const unitTestOutChannel = window.createOutputChannel(OutputChannelNames.pythonTest());
-    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, standardOutputChannel, STANDARD_OUTPUT_CHANNEL);
-    serviceManager.addSingletonInstance<OutputChannel>(IOutputChannel, unitTestOutChannel, TEST_OUTPUT_CHANNEL);
 
     // We will be pulling other code over from activateLegacy().
 }

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -8,7 +8,8 @@ import * as sinon from 'sinon';
 import { anything, instance, mock, when } from 'ts-mockito';
 import * as tasClient from 'vscode-tas-client';
 import { ApplicationEnvironment } from '../../../client/common/application/applicationEnvironment';
-import { Channel, IApplicationEnvironment } from '../../../client/common/application/types';
+import { Channel, IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
+import { WorkspaceService } from '../../../client/common/application/workspace';
 import { ConfigurationService } from '../../../client/common/configuration/service';
 import { ExperimentService } from '../../../client/common/experiments/service';
 import { IConfigurationService } from '../../../client/common/types';
@@ -23,6 +24,7 @@ suite('Experimentation service', () => {
     const extensionVersion = '1.2.3';
 
     let configurationService: IConfigurationService;
+    let workspaceService: IWorkspaceService;
     let appEnvironment: IApplicationEnvironment;
     let globalMemento: MockMemento;
     let outputChannel: MockOutputChannel;
@@ -30,6 +32,7 @@ suite('Experimentation service', () => {
     setup(() => {
         configurationService = mock(ConfigurationService);
         appEnvironment = mock(ApplicationEnvironment);
+        workspaceService = mock(WorkspaceService);
         globalMemento = new MockMemento();
         outputChannel = new MockOutputChannel('');
     });
@@ -47,6 +50,17 @@ suite('Experimentation service', () => {
                 optOutFrom,
             },
         } as any);
+        when(workspaceService.getConfiguration('python')).thenReturn({
+            get: (key: string) => {
+                if (key === 'experiments.enabled') {
+                    return enabled;
+                } else if (key === 'experiments.optInto') {
+                    return optInto;
+                } else if (key === 'experiments.optOutFrom') {
+                    return optOutFrom;
+                }
+            },
+        } as any);
     }
 
     function configureApplicationEnvironment(channel: Channel, version: string) {
@@ -62,12 +76,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
             configureApplicationEnvironment('stable', extensionVersion);
 
-            new ExperimentService(
-                instance(configurationService),
-                instance(appEnvironment),
-                globalMemento,
-                outputChannel,
-            );
+            new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento, outputChannel);
 
             sinon.assert.calledWithExactly(
                 getExperimentationServiceStub,
@@ -85,12 +94,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
             configureApplicationEnvironment('insiders', extensionVersion);
 
-            new ExperimentService(
-                instance(configurationService),
-                instance(appEnvironment),
-                globalMemento,
-                outputChannel,
-            );
+            new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento, outputChannel);
 
             sinon.assert.calledWithExactly(
                 getExperimentationServiceStub,
@@ -109,7 +113,7 @@ suite('Experimentation service', () => {
             configureApplicationEnvironment('stable', extensionVersion);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -124,7 +128,7 @@ suite('Experimentation service', () => {
             configureApplicationEnvironment('stable', extensionVersion);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -142,7 +146,7 @@ suite('Experimentation service', () => {
             when(globalMemento.get(anything(), anything())).thenReturn({ features: experiments } as any);
 
             new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 instance(globalMemento),
                 outputChannel,
@@ -183,7 +187,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -199,7 +203,7 @@ suite('Experimentation service', () => {
             configureSettings(false, [], []);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -215,7 +219,7 @@ suite('Experimentation service', () => {
             configureSettings(true, ['All'], []);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -235,7 +239,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [experiment], []);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -255,7 +259,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], ['All']);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -275,7 +279,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], [experiment]);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -309,7 +313,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -324,7 +328,7 @@ suite('Experimentation service', () => {
             configureSettings(false, [], []);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -339,7 +343,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], ['All']);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,
@@ -354,7 +358,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], [experiment]);
 
             const experimentService = new ExperimentService(
-                instance(configurationService),
+                instance(workspaceService),
                 instance(appEnvironment),
                 globalMemento,
                 outputChannel,

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -10,9 +10,7 @@ import * as tasClient from 'vscode-tas-client';
 import { ApplicationEnvironment } from '../../../client/common/application/applicationEnvironment';
 import { Channel, IApplicationEnvironment, IWorkspaceService } from '../../../client/common/application/types';
 import { WorkspaceService } from '../../../client/common/application/workspace';
-import { ConfigurationService } from '../../../client/common/configuration/service';
 import { ExperimentService } from '../../../client/common/experiments/service';
-import { IConfigurationService } from '../../../client/common/types';
 import { Experiments } from '../../../client/common/utils/localize';
 import * as Telemetry from '../../../client/telemetry';
 import { EventName } from '../../../client/telemetry/constants';
@@ -23,14 +21,12 @@ import { MockMemento } from '../../mocks/mementos';
 suite('Experimentation service', () => {
     const extensionVersion = '1.2.3';
 
-    let configurationService: IConfigurationService;
     let workspaceService: IWorkspaceService;
     let appEnvironment: IApplicationEnvironment;
     let globalMemento: MockMemento;
     let outputChannel: MockOutputChannel;
 
     setup(() => {
-        configurationService = mock(ConfigurationService);
         appEnvironment = mock(ApplicationEnvironment);
         workspaceService = mock(WorkspaceService);
         globalMemento = new MockMemento();
@@ -43,13 +39,6 @@ suite('Experimentation service', () => {
     });
 
     function configureSettings(enabled: boolean, optInto: string[], optOutFrom: string[]) {
-        when(configurationService.getSettings(undefined)).thenReturn({
-            experiments: {
-                enabled,
-                optInto,
-                optOutFrom,
-            },
-        } as any);
         when(workspaceService.getConfiguration('python')).thenReturn({
             get: (key: string) => {
                 if (key === 'experiments.enabled') {

--- a/src/test/common/experiments/service.unit.test.ts
+++ b/src/test/common/experiments/service.unit.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-new */
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -43,12 +44,16 @@ suite('Experimentation service', () => {
             get: (key: string) => {
                 if (key === 'experiments.enabled') {
                     return enabled;
-                } else if (key === 'experiments.optInto') {
+                }
+                if (key === 'experiments.optInto') {
                     return optInto;
-                } else if (key === 'experiments.optOutFrom') {
+                }
+                if (key === 'experiments.optOutFrom') {
                     return optOutFrom;
                 }
+                return undefined;
             },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any);
     }
 
@@ -65,6 +70,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
             configureApplicationEnvironment('stable', extensionVersion);
 
+            // eslint-disable-next-line no-new
             new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento, outputChannel);
 
             sinon.assert.calledWithExactly(
@@ -83,6 +89,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
             configureApplicationEnvironment('insiders', extensionVersion);
 
+            // eslint-disable-next-line no-new
             new ExperimentService(instance(workspaceService), instance(appEnvironment), globalMemento, outputChannel);
 
             sinon.assert.calledWithExactly(
@@ -132,6 +139,7 @@ suite('Experimentation service', () => {
             configureSettings(true, [], []);
             configureApplicationEnvironment('stable', extensionVersion);
 
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             when(globalMemento.get(anything(), anything())).thenReturn({ features: experiments } as any);
 
             new ExperimentService(
@@ -148,14 +156,14 @@ suite('Experimentation service', () => {
 
     suite('In-experiment check', () => {
         const experiment = 'Test Experiment - experiment';
-        let telemetryEvents: { eventName: string; properties: object }[] = [];
+        let telemetryEvents: { eventName: string; properties: Record<string, unknown> }[] = [];
         let isCachedFlightEnabledStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
 
         setup(() => {
             sendTelemetryEventStub = sinon
                 .stub(Telemetry, 'sendTelemetryEvent')
-                .callsFake((eventName: string, _, properties: object) => {
+                .callsFake((eventName: string, _, properties: Record<string, unknown>) => {
                     const telemetry = { eventName, properties };
                     telemetryEvents.push(telemetry);
                 });
@@ -163,7 +171,7 @@ suite('Experimentation service', () => {
             isCachedFlightEnabledStub = sinon.stub().returns(Promise.resolve(true));
             sinon.stub(tasClient, 'getExperimentationService').returns({
                 isCachedFlightEnabled: isCachedFlightEnabledStub,
-            } as any);
+            } as never);
 
             configureApplicationEnvironment('stable', extensionVersion);
         });
@@ -293,7 +301,7 @@ suite('Experimentation service', () => {
             getTreatmentVariableAsyncStub = sinon.stub().returns(Promise.resolve('value'));
             sinon.stub(tasClient, 'getExperimentationService').returns({
                 getTreatmentVariableAsync: getTreatmentVariableAsyncStub,
-            } as any);
+            } as never);
 
             configureApplicationEnvironment('stable', extensionVersion);
         });


### PR DESCRIPTION
Earlier experiment framework was dependent on config service, which was dependent on autoselection, which was dependent on all of legacy discovery code. This code changes experiment framework to use workspace service instead, which has no dependencies.

I have verified that I'm able to fetch experiment framework using service container just before we register legacy discovery classes.