### PR TITLE
Ensure workspace environments are autoselected when a workspace is opened for the first time

### DIFF
--- a/src/client/interpreter/autoSelection/rules/workspaceEnv.ts
+++ b/src/client/interpreter/autoSelection/rules/workspaceEnv.ts
@@ -67,7 +67,7 @@ export class WorkspaceVirtualEnvInterpretersAutoSelectionRule extends BaseRuleSe
         const interpreters = (await inDiscoveryExperiment(this.experimentService))
             ? // The cache may not have the workspace environments for this workspace, so ignore cache and query for fresh envs
               await this.pyenvs.getWorkspaceVirtualEnvInterpreters(workspacePath.folderUri, { ignoreCache: true })
-            : await this.getWorkspaceVirtualEnvInterpreters(workspacePath.folderUri, { ignoreCache: true });
+            : await this.getWorkspaceVirtualEnvInterpreters(workspacePath.folderUri);
         const bestInterpreter =
             Array.isArray(interpreters) && interpreters.length > 0
                 ? this.helper.getBestInterpreter(interpreters)
@@ -86,10 +86,7 @@ export class WorkspaceVirtualEnvInterpretersAutoSelectionRule extends BaseRuleSe
         return NextAction.runNextRule;
     }
 
-    protected async getWorkspaceVirtualEnvInterpreters(
-        resource: Resource,
-        options: { ignoreCache: boolean },
-    ): Promise<PythonEnvironment[] | undefined> {
+    protected async getWorkspaceVirtualEnvInterpreters(resource: Resource): Promise<PythonEnvironment[] | undefined> {
         if (!resource) {
             return undefined;
         }
@@ -102,7 +99,9 @@ export class WorkspaceVirtualEnvInterpretersAutoSelectionRule extends BaseRuleSe
             IInterpreterLocatorService,
             WORKSPACE_VIRTUAL_ENV_SERVICE,
         );
-        const interpreters = await workspaceVirtualEnvInterpreterLocator.getInterpreters(resource, options);
+        const interpreters = await workspaceVirtualEnvInterpreterLocator.getInterpreters(resource, {
+            ignoreCache: true,
+        });
         const workspacePath =
             this.platform.osType === OSType.Windows
                 ? workspaceFolder.uri.fsPath.toUpperCase()

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -39,7 +39,7 @@ export interface IComponentAdapter {
     // WorkspaceVirtualEnvInterpretersAutoSelectionRule
     getWorkspaceVirtualEnvInterpreters(
         resource: Uri,
-        options?: GetInterpreterLocatorOptions,
+        options?: { ignoreCache?: boolean },
     ): Promise<PythonEnvironment[] | undefined>;
     // IInterpreterService
     getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;

--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -37,7 +37,10 @@ export interface IComponentAdapter {
     hasInterpreters: Promise<boolean | undefined>;
     getInterpreters(resource?: Uri): Promise<PythonEnvironment[] | undefined>;
     // WorkspaceVirtualEnvInterpretersAutoSelectionRule
-    getWorkspaceVirtualEnvInterpreters(resource: Uri): Promise<PythonEnvironment[] | undefined>;
+    getWorkspaceVirtualEnvInterpreters(
+        resource: Uri,
+        options?: GetInterpreterLocatorOptions,
+    ): Promise<PythonEnvironment[] | undefined>;
     // IInterpreterService
     getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;
     // IInterpreterHelper

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -13,6 +13,7 @@ import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
+    GetInterpreterLocatorOptions,
     GetInterpreterOptions,
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
@@ -366,7 +367,10 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
         return envs.map(convertEnvInfo);
     }
 
-    public async getWorkspaceVirtualEnvInterpreters(resource: vscode.Uri): Promise<PythonEnvironment[] | undefined> {
+    public async getWorkspaceVirtualEnvInterpreters(
+        resource: vscode.Uri,
+        options?: GetInterpreterLocatorOptions,
+    ): Promise<PythonEnvironment[] | undefined> {
         if (!this.enabled) {
             return undefined;
         }
@@ -378,6 +382,7 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
             searchLocations: {
                 roots: [workspaceFolder.uri],
             },
+            ignoreCache: options?.ignoreCache,
         };
         const iterator = this.api.iterEnvs(query);
         const envs = await getEnvs(iterator);

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -13,7 +13,6 @@ import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
-    GetInterpreterLocatorOptions,
     GetInterpreterOptions,
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
@@ -369,7 +368,7 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
 
     public async getWorkspaceVirtualEnvInterpreters(
         resource: vscode.Uri,
-        options?: GetInterpreterLocatorOptions,
+        options?: { ignoreCache?: boolean },
     ): Promise<PythonEnvironment[] | undefined> {
         if (!this.enabled) {
             return undefined;

--- a/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
@@ -77,7 +77,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         }
 
         public async getWorkspaceVirtualEnvInterpreters(resource: Resource): Promise<PythonEnvironment[] | undefined> {
-            return super.getWorkspaceVirtualEnvInterpreters(resource, { ignoreCache: true });
+            return super.getWorkspaceVirtualEnvInterpreters(resource);
         }
     }
     setup(() => {

--- a/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/workspaceEnv.unit.test.ts
@@ -77,7 +77,7 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
         }
 
         public async getWorkspaceVirtualEnvInterpreters(resource: Resource): Promise<PythonEnvironment[] | undefined> {
-            return super.getWorkspaceVirtualEnvInterpreters(resource);
+            return super.getWorkspaceVirtualEnvInterpreters(resource, { ignoreCache: true });
         }
     }
     setup(() => {
@@ -368,10 +368,9 @@ suite('Interpreters - Auto Selection - Workspace Virtual Envs Rule', () => {
 
         const resource = Uri.file('x');
         // Return interpreters using the component adapter instead
-        when(componentAdapter.getWorkspaceVirtualEnvInterpreters(folderUri)).thenResolve([
-            interpreter2,
-            interpreter3,
-        ] as any);
+        when(
+            componentAdapter.getWorkspaceVirtualEnvInterpreters(folderUri, deepEqual({ ignoreCache: true })),
+        ).thenResolve([interpreter2, interpreter3] as any);
         const manager = mock(InterpreterAutoSelectionService);
         const nextInvoked = createDeferred();
         rule.next = () => Promise.resolve(nextInvoked.resolve());


### PR DESCRIPTION
We didn't have the ability to ignoreCache before so we couldn't replicate the old implementation exactly. We do now...