### PR TITLE
Ensure bitness and additional info for workspace envs is eventually shown

### DIFF
--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -43,7 +43,7 @@ const EXPIRY_DURATION = 24 * 60 * 60 * 1000;
 interface IComponent {
     hasInterpreters: Promise<boolean | undefined>;
     getInterpreterDetails(pythonPath: string): Promise<undefined | PythonEnvironment>;
-    getInterpreters(resource?: Uri): Promise<PythonEnvironment[] | undefined>;
+    getInterpreters(resource?: Uri, options?: GetInterpreterOptions): Promise<PythonEnvironment[] | undefined>;
 }
 
 @injectable()
@@ -146,7 +146,7 @@ export class InterpreterService implements Disposable, IInterpreterService {
     public async getInterpreters(resource?: Uri, options?: GetInterpreterOptions): Promise<PythonEnvironment[]> {
         let environments: PythonEnvironment[] = [];
         if (await inDiscoveryExperiment(this.experimentService)) {
-            environments = (await this.pyenvs.getInterpreters(resource)) ?? [];
+            environments = (await this.pyenvs.getInterpreters(resource, options)) ?? [];
         } else {
             const locator = this.serviceContainer.get<IInterpreterLocatorService>(
                 IInterpreterLocatorService,

--- a/src/client/pythonEnvironments/index.ts
+++ b/src/client/pythonEnvironments/index.ts
@@ -96,7 +96,8 @@ async function createLocators(
         locators,
         // These are shared.
         envInfoService,
-        environmentsSecurity.isEnvSafe,
+        // Class methods may depend on other properties which belong to the class, so bind the correct context.
+        environmentsSecurity.isEnvSafe.bind(environmentsSecurity),
     );
     const caching = await createCachingLocator(
         ext,

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -14,7 +14,7 @@ import {
     CONDA_ENV_FILE_SERVICE,
     CONDA_ENV_SERVICE,
     CURRENT_PATH_SERVICE,
-    GetInterpreterOptions,
+    GetInterpreterLocatorOptions,
     GLOBAL_VIRTUAL_ENV_SERVICE,
     IComponentAdapter,
     ICondaService,
@@ -311,7 +311,7 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
     // A result of `undefined` means "Fall back to the old code!"
     public async getInterpreters(
         resource?: vscode.Uri,
-        options?: GetInterpreterOptions,
+        options?: GetInterpreterLocatorOptions,
         // Currently we have no plans to support GetInterpreterLocatorOptions:
         // {
         //     ignoreCache?: boolean
@@ -338,7 +338,7 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
 
     private async getInterpretersViaAPI(
         resource?: vscode.Uri,
-        options?: GetInterpreterOptions,
+        options?: GetInterpreterLocatorOptions,
         // Currently we have no plans to support GetInterpreterLocatorOptions:
         // {
         //     ignoreCache?: boolean
@@ -346,12 +346,15 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
         // }
         source?: PythonEnvSource[],
     ): Promise<PythonEnvironment[]> {
-        if (options?.onSuggestion) {
+        if (options?.onSuggestion && !this.environmentsSecurity.allEnvsSafe) {
             // For now, until we have the concept of trusted workspaces, we assume all interpreters as safe
             // to run once user has triggered discovery, i.e interacted with the extension.
             this.environmentsSecurity.markAllEnvsAsSafe();
+            // We can now run certain executables to collect more information than what is currently in
+            // cache, so trigger discovery for fresh envs in background.
+            getEnvs(this.api.iterEnvs({ ignoreCache: true })).ignoreErrors();
         }
-        const query: PythonLocatorQuery = {};
+        const query: PythonLocatorQuery = { ignoreCache: options?.ignoreCache };
         if (resource !== undefined) {
             const wsFolder = vscode.workspace.getWorkspaceFolder(resource);
             if (wsFolder !== undefined) {

--- a/src/client/pythonEnvironments/security.ts
+++ b/src/client/pythonEnvironments/security.ts
@@ -10,10 +10,6 @@ import { isParentPath } from './common/externalDependencies';
  */
 export interface IEnvironmentsSecurity {
     /**
-     * Returns `true` if all environments are safe to execute, `false` otherwise.
-     */
-    readonly allEnvsSafe: boolean;
-    /**
      * Returns `true` the environment is safe to execute, `false` otherwise.
      */
     isEnvSafe(env: PythonEnvInfo): boolean;
@@ -30,10 +26,10 @@ export class EnvironmentsSecurity implements IEnvironmentsSecurity {
     /**
      * Carries `true` if it's secure to run all environment executables, `false` otherwise.
      */
-    public allEnvsSafe = false;
+    private areAllEnvsSafe = false;
 
     public isEnvSafe(env: PythonEnvInfo): boolean {
-        if (this.allEnvsSafe) {
+        if (this.areAllEnvsSafe) {
             return true;
         }
         const folders = vscode.workspace.workspaceFolders;
@@ -52,6 +48,6 @@ export class EnvironmentsSecurity implements IEnvironmentsSecurity {
     }
 
     public markAllEnvsAsSafe(): void {
-        this.allEnvsSafe = true;
+        this.areAllEnvsSafe = true;
     }
 }

--- a/src/client/pythonEnvironments/security.ts
+++ b/src/client/pythonEnvironments/security.ts
@@ -10,11 +10,15 @@ import { isParentPath } from './common/externalDependencies';
  */
 export interface IEnvironmentsSecurity {
     /**
+     * Returns `true` if all environments are safe to execute, `false` otherwise.
+     */
+    readonly allEnvsSafe: boolean;
+    /**
      * Returns `true` the environment is safe to execute, `false` otherwise.
      */
     isEnvSafe(env: PythonEnvInfo): boolean;
     /**
-     * Mark all environments to be safe.
+     * Mark all environments to be safe to execute.
      */
     markAllEnvsAsSafe(): void;
 }
@@ -26,7 +30,7 @@ export class EnvironmentsSecurity implements IEnvironmentsSecurity {
     /**
      * Carries `true` if it's secure to run all environment executables, `false` otherwise.
      */
-    private allEnvsSafe = false;
+    public allEnvsSafe = false;
 
     public isEnvSafe(env: PythonEnvInfo): boolean {
         if (this.allEnvsSafe) {


### PR DESCRIPTION
**Context:** `interpreterInfo.py` is not run for workspace envs until `Select interpreter` button is clicked. Hence workspace envs with incomplete info was being stored in cache.

Once we have the permission to run again, we ignore cache and trigger all of discovery again to get full info.