### PR TITLE
Support moving/adding/deleting cells in notebook intellisense

### DIFF
--- a/src/test/initialize.ts
+++ b/src/test/initialize.ts
@@ -86,7 +86,7 @@ async function closeWindowsInteral() {
         // Lets not waste too much time.
         const timer = setTimeout(() => {
             reject(new Error("Command 'workbench.action.closeAllEditors' timed out"));
-        }, 15000);
+        }, 2000);
         vscode.commands.executeCommand('workbench.action.closeAllEditors').then(
             () => {
                 clearTimeout(timer);

--- a/src/test/insiders/languageServer.insiders.test.ts
+++ b/src/test/insiders/languageServer.insiders.test.ts
@@ -7,6 +7,7 @@ import * as assert from 'assert';
 import { expect } from 'chai';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { PYTHON_LANGUAGE } from '../../client/common/constants';
 import { updateSetting } from '../common';
 import { EXTENSION_ROOT_DIR_FOR_TESTS } from '../constants';
 import { sleep } from '../core';
@@ -95,6 +96,31 @@ suite('Insiders Test: Language Server', () => {
             if (locations && locations.length > 0) {
                 expect(locations![0].uri.fsPath).to.contain(path.basename(notebookDefinitions));
                 tested = true;
+
+                // Insert a new cell
+                const activeEditor = vscode.notebook.activeNotebookEditor;
+                expect(activeEditor).not.to.be.equal(undefined, 'Active editor not found in notebook');
+                await activeEditor!.edit((edit) => {
+                    edit.replaceCells(0, 0, [
+                        {
+                            cellKind: vscode.CellKind.Code,
+                            language: PYTHON_LANGUAGE,
+                            source: 'x = 4',
+                            metadata: {
+                                hasExecutionOrder: false,
+                            },
+                            outputs: [],
+                        },
+                    ]);
+                });
+
+                // Wait a bit to get diagnostics
+                await sleep(1_000);
+
+                // Make sure no error diagnostics
+                const diagnostics = vscode.languages.getDiagnostics(activeEditor!.document.uri);
+                expect(diagnostics).to.have.lengthOf(0, 'Diagnostics found when shouldnt be');
+
                 break;
             } else {
                 // Wait for LS to start.


### PR DESCRIPTION
For #https://github.com/microsoft/vscode-jupyter/issues/4300

The concat of a notebook into a single python file works fine if the user edits cells. However when adding new cells, no changes were being made to the file. Nor when deleting or moving cells.

This change introduces change events when deleting/adding/moving cells as if the user typed the new cells out.