### PR TITLE
Show prompt, code action and lens for tensorboardX

### DIFF
--- a/src/client/tensorBoard/helpers.ts
+++ b/src/client/tensorBoard/helpers.ts
@@ -27,8 +27,9 @@ export function containsTensorBoardImport(lines: (string | undefined)[]): boolea
                     // import package1, package2, ...
                     componentsToCheck = matches.groups.importImport.split(',');
                 }
-                for (const component of componentsToCheck) {
-                    if (component && component.trim() === 'tensorboard') {
+                for (let component of componentsToCheck) {
+                    component = component?.trim();
+                    if (component === 'tensorboard' || component === 'tensorboardX') {
                         return true;
                     }
                 }

--- a/src/test/tensorBoard/tensorBoardCodeActionProvider.unit.test.ts
+++ b/src/test/tensorBoard/tensorBoardCodeActionProvider.unit.test.ts
@@ -20,26 +20,35 @@ suite('TensorBoard code action provider', () => {
         codeActionProvider = new TensorBoardCodeActionProvider(experimentService, []);
     });
 
-    test('Provides code action for Python files', () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const document = new MockDocument('import foo\nimport tensorboard', 'foo.py', async (_doc) => true);
-        selection = TypeMoq.Mock.ofType<Selection>();
-        selection.setup((s) => s.active).returns(() => new Position(1, 0));
-        const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
-        assert.ok(
-            codeActions.length > 0,
-            'Failed to provide code action for Python file containing tensorboard import',
-        );
-    });
-    test('Provides code action for Python ipynbs', () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const document = new MockDocument('import tensorboard', 'foo.ipynb', async (_doc) => true);
-        selection.setup((s) => s.active).returns(() => new Position(0, 0));
-        const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
-        assert.ok(
-            codeActions.length > 0,
-            'Failed to provide code action for Python ipynb containing tensorboard import',
-        );
+    ['tensorboard', 'tensorboardX'].forEach((name) => {
+        test(`Provides code action for ${name} in Python files`, () => {
+            const document = new MockDocument(`import foo\nimport ${name}`, 'foo.py', async () => true);
+            selection = TypeMoq.Mock.ofType<Selection>();
+            selection.setup((s) => s.active).returns(() => new Position(1, 0));
+            const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
+            assert.ok(
+                codeActions.length > 0,
+                `Failed to provide code action for Python file containing ${name} import`,
+            );
+        });
+        test(`Provides code action for ${name} in Python ipynbs`, () => {
+            const document = new MockDocument(`import ${name}`, 'foo.ipynb', async () => true);
+            selection.setup((s) => s.active).returns(() => new Position(0, 0));
+            const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
+            assert.ok(
+                codeActions.length > 0,
+                `Failed to provide code action for Python ipynb containing ${name} import`,
+            );
+        });
+        test(`Does not provide code action if cursor is not on line containing ${name} import`, () => {
+            const document = new MockDocument(`import foo\nimport ${name}`, 'foo.py', async () => true);
+            selection.setup((s) => s.active).returns(() => new Position(0, 0));
+            const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
+            assert.ok(
+                codeActions.length === 0,
+                'Provided code action for file even though cursor was not on line containing import',
+            );
+        });
     });
     test('Does not provide code action if no matching import', () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -47,15 +56,5 @@ suite('TensorBoard code action provider', () => {
         selection.setup((s) => s.active).returns(() => new Position(0, 0));
         const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
         assert.ok(codeActions.length === 0, 'Provided code action for file without tensorboard import');
-    });
-    test('Does not provide code action if cursor is not on line containing tensorboard import', () => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const document = new MockDocument('import foo\nimport tensorboard', 'foo.py', async (_doc) => true);
-        selection.setup((s) => s.active).returns(() => new Position(0, 0));
-        const codeActions = codeActionProvider.provideCodeActions(document, selection.object);
-        assert.ok(
-            codeActions.length === 0,
-            'Provided code action for file even though cursor was not on line containing import',
-        );
     });
 });

--- a/src/test/tensorBoard/tensorBoardImportCodeLensProvider.unit.test.ts
+++ b/src/test/tensorBoard/tensorBoardImportCodeLensProvider.unit.test.ts
@@ -16,16 +16,17 @@ suite('TensorBoard import code lens provider', () => {
         experimentService = mock(ExperimentService);
         codeLensProvider = new TensorBoardImportCodeLensProvider(experimentService, []);
     });
-
-    test('Provides code lens for Python files', () => {
-        const document = new MockDocument('import tensorboard', 'foo.py', async () => true);
-        const codeActions = codeLensProvider.provideCodeLenses(document);
-        assert.ok(codeActions.length > 0, 'Failed to provide code lens for file containing tensorboard import');
-    });
-    test('Provides code lens for Python ipynbs', () => {
-        const document = new MockDocument('import tensorboard', 'foo.ipynb', async () => true);
-        const codeActions = codeLensProvider.provideCodeLenses(document);
-        assert.ok(codeActions.length > 0, 'Failed to provide code lens for ipynb containing tensorboard import');
+    ['tensorboard', 'tensorboardX'].forEach((name) => {
+        test(`Provides code lens for Python files importing ${name}`, () => {
+            const document = new MockDocument(`import ${name}`, 'foo.py', async () => true);
+            const codeActions = codeLensProvider.provideCodeLenses(document);
+            assert.ok(codeActions.length > 0, `Failed to provide code lens for file containing ${name} import`);
+        });
+        test(`Provides code lens for Python ipynbs importing ${name}`, () => {
+            const document = new MockDocument(`import ${name}`, 'foo.ipynb', async () => true);
+            const codeActions = codeLensProvider.provideCodeLenses(document);
+            assert.ok(codeActions.length > 0, `Failed to provide code lens for ipynb containing ${name} import`);
+        });
     });
     test('Does not provide code lens if no matching import', () => {
         const document = new MockDocument('import foo', 'foo.ipynb', async () => true);

--- a/src/test/tensorBoard/tensorBoardUsageTracker.unit.test.ts
+++ b/src/test/tensorBoard/tensorBoardUsageTracker.unit.test.ts
@@ -24,6 +24,12 @@ suite('TensorBoard usage tracker', () => {
         await tensorBoardImportTracker.activate();
         assert.ok(showNativeTensorBoardPrompt.calledOnce);
     });
+    test('Simple tensorboardX import in Python file', async () => {
+        const document = documentManager.addDocument('import tensorboardX', 'foo.py');
+        await documentManager.showTextDocument(document);
+        await tensorBoardImportTracker.activate();
+        assert.ok(showNativeTensorBoardPrompt.calledOnce);
+    });
     test('Simple tensorboard import in Python ipynb', async () => {
         const document = documentManager.addDocument('import tensorboard', 'foo.ipynb');
         await documentManager.showTextDocument(document);
@@ -38,6 +44,12 @@ suite('TensorBoard usage tracker', () => {
     });
     test('`from x.y import tensorboard` import', async () => {
         const document = documentManager.addDocument('from torch.utils import tensorboard', 'foo.py');
+        await documentManager.showTextDocument(document);
+        await tensorBoardImportTracker.activate();
+        assert.ok(showNativeTensorBoardPrompt.calledOnce);
+    });
+    test('`from tensorboardX import x` import', async () => {
+        const document = documentManager.addDocument('from tensorboardX import SummaryWriter', 'foo.py');
         await documentManager.showTextDocument(document);
         await tensorBoardImportTracker.activate();
         assert.ok(showNativeTensorBoardPrompt.calledOnce);


### PR DESCRIPTION
New requirement from @jmew: `tensorboardX` is a package used for creating tf event files during runs e.g. `from tensorboardX import SummaryWriter`. Show all of our existing import detection entrypoints for `tensorboardX` as well as `tensorboard`. 

Note that we will still install `tensorboard` and not `tensorboardX` for the user to launch an integrated TensorBoard session, as even with `tensorboardX` installed users will still require `tensorboard` to visualize their log data.