### PR TITLE
Fallback to the old mechanism to calculate displayName if not set by new discovery component

### DIFF
--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -144,15 +144,16 @@ export class InterpreterService implements Disposable, IInterpreterService {
 
     @captureTelemetry(EventName.PYTHON_INTERPRETER_DISCOVERY, { locator: 'all' }, true)
     public async getInterpreters(resource?: Uri, options?: GetInterpreterOptions): Promise<PythonEnvironment[]> {
+        let environments: PythonEnvironment[] = [];
         if (await inDiscoveryExperiment(this.experimentService)) {
-            return this.pyenvs.getInterpreters(resource) && Promise.resolve([]);
+            environments = (await this.pyenvs.getInterpreters(resource)) ?? [];
+        } else {
+            const locator = this.serviceContainer.get<IInterpreterLocatorService>(
+                IInterpreterLocatorService,
+                INTERPRETER_LOCATOR_SERVICE,
+            );
+            environments = await locator.getInterpreters(resource, options);
         }
-
-        const locator = this.serviceContainer.get<IInterpreterLocatorService>(
-            IInterpreterLocatorService,
-            INTERPRETER_LOCATOR_SERVICE,
-        );
-        const environments = await locator.getInterpreters(resource, options);
 
         await Promise.all(
             environments


### PR DESCRIPTION
No interpreters are displayed in the quickpick list. This is because displayname isn't set.

Right now most of the new locators don't set displayname. We need to use the old mechanism as a fallback atleast until we get to that item. Introduced with https://github.com/microsoft/vscode-python/pull/15203 where we removed all fallback on the old code.