### PR TITLE
Drop PythonEnvInfo.defaultDisplayName.

### DIFF
--- a/src/client/pythonEnvironments/base/info/env.ts
+++ b/src/client/pythonEnvironments/base/info/env.ts
@@ -36,7 +36,7 @@ export function buildEnvInfo(init?: {
     arch?: Architecture;
     fileInfo?: { ctime: number; mtime: number };
     source?: PythonEnvSource[];
-    defaultDisplayName?: string;
+    display?: string;
 }): PythonEnvInfo {
     const env = {
         name: init?.name ?? '',
@@ -49,7 +49,7 @@ export function buildEnvInfo(init?: {
             mtime: init?.fileInfo?.mtime ?? -1,
         },
         searchLocation: undefined,
-        defaultDisplayName: init?.defaultDisplayName,
+        display: init?.display,
         version: {
             major: -1,
             minor: -1,
@@ -122,12 +122,7 @@ function updateEnv(
  */
 export function getEnvDisplayString(env: PythonEnvInfo): string {
     if (env.display === undefined || env.display === '') {
-        if (env.defaultDisplayName !== undefined && env.defaultDisplayName !== '') {
-            // XXX Normalize it?
-            env.display = env.defaultDisplayName;
-        } else {
-            env.display = buildEnvDisplayString(env);
-        }
+        env.display = buildEnvDisplayString(env);
     }
     return env.display;
 }
@@ -481,7 +476,7 @@ export function mergeEnvironments(target: PythonEnvInfo, other: PythonEnvInfo): 
     );
 
     merged.arch = merged.arch === Architecture.Unknown ? other.arch : target.arch;
-    merged.defaultDisplayName = merged.defaultDisplayName ?? other.defaultDisplayName;
+    merged.display = merged.display ?? other.display;
     merged.distro = distro;
     merged.executable = executable;
 

--- a/src/client/pythonEnvironments/base/info/index.ts
+++ b/src/client/pythonEnvironments/base/info/index.ts
@@ -176,13 +176,12 @@ type _PythonEnvInfo = PythonEnvBaseInfo & PythonBuildInfo;
  * they will usually be able to provide the version as well.
  *
  * @prop distro - the installed Python distro that this env is using or belongs to
- * @prop defaultDisplayName - the text to use when showing the env to users
+ * @prop display - the text to use when showing the env to users
  * @prop searchLocation - the root under which a locator found this env, if any
  */
 export type PythonEnvInfo = _PythonEnvInfo & {
     distro: PythonDistroInfo;
     display?: string;
-    defaultDisplayName?: string;
     searchLocation?: Uri;
 };
 

--- a/src/client/pythonEnvironments/common/windowsUtils.ts
+++ b/src/client/pythonEnvironments/common/windowsUtils.ts
@@ -39,7 +39,7 @@ export interface IRegistryInterpreterData {
     versionStr?: string;
     sysVersionStr?: string;
     bitnessStr?: string;
-    displayName?: string;
+    companyDisplayName?: string;
     distroOrgName?: string;
 }
 
@@ -65,7 +65,7 @@ async function getInterpreterDataFromKey(
                 result.versionStr = value.value;
                 break;
             case 'DisplayName':
-                result.displayName = value.value;
+                result.companyDisplayName = value.value;
                 break;
             default:
                 break;

--- a/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/pyenvLocator.ts
@@ -279,7 +279,7 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
             // `pyenv local|global <env-name>` or `pyenv shell <env-name>`
             //
             // For the display name we are going to treat these as `pyenv` environments.
-            const defaultDisplayName = `${subDir}:pyenv`;
+            const display = `${subDir}:pyenv`;
 
             const org = versionStrings && versionStrings.distro ? versionStrings.distro : '';
 
@@ -291,7 +291,7 @@ async function* getPyenvEnvironments(): AsyncIterableIterator<PythonEnvInfo> {
                 location: envDir,
                 version: pythonVersion,
                 source: [PythonEnvSource.Pyenv],
-                defaultDisplayName,
+                display,
                 org,
                 fileInfo,
             });
@@ -329,7 +329,7 @@ export class PyenvLocator extends FSWatchingLocator {
                 executable: executablePath,
                 source,
                 location,
-                defaultDisplayName: `${name}:pyenv`,
+                display: `${name}:pyenv`,
                 version: await getPythonVersionFromPath(executablePath, versionStrings?.pythonVer),
                 org: versionStrings && versionStrings.distro ? versionStrings.distro : '',
                 fileInfo: await getFileInfo(executablePath),

--- a/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/windowsRegistryLocator.ts
@@ -60,15 +60,16 @@ export class WindowsRegistryLocator extends Locator {
             traceVerbose(`Failed to parse version: ${versionStr}`, ex);
         }
 
-        return buildEnvInfo({
+        const env = buildEnvInfo({
             kind: this.kind,
             executable: data.interpreterPath,
             fileInfo: await getFileInfo(data.interpreterPath),
             version,
             arch: getArchitecture(data),
             org: data.distroOrgName,
-            defaultDisplayName: data.displayName,
             source: [PythonEnvSource.WindowsRegistry],
         });
+        env.distro.defaultDisplayName = data.companyDisplayName;
+        return env;
     }
 }

--- a/src/test/pythonEnvironments/base/envsCache.unit.test.ts
+++ b/src/test/pythonEnvironments/base/envsCache.unit.test.ts
@@ -142,7 +142,7 @@ suite('Environment Info cache', () => {
         const otherEnv = {
             kind: PythonEnvKind.OtherGlobal,
             executable: { filename: 'my-other-env' },
-            defaultDisplayName: 'other-env',
+            display: 'other-env',
         };
         const updatedEnvInfoArray = [
             otherEnv,
@@ -151,7 +151,7 @@ suite('Environment Info cache', () => {
         const expected = [otherEnv];
         const envsCache = await getPersistentCache(
             getGlobalPersistentStore(),
-            (env) => env.defaultDisplayName !== undefined,
+            (env) => env.display !== undefined,
         );
 
         envsCache.setAllEnvs(updatedEnvInfoArray);

--- a/src/test/pythonEnvironments/base/envsCache.unit.test.ts
+++ b/src/test/pythonEnvironments/base/envsCache.unit.test.ts
@@ -149,10 +149,7 @@ suite('Environment Info cache', () => {
             { kind: PythonEnvKind.System, executable: { filename: 'my-system-env' } },
         ] as PythonEnvInfo[];
         const expected = [otherEnv];
-        const envsCache = await getPersistentCache(
-            getGlobalPersistentStore(),
-            (env) => env.display !== undefined,
-        );
+        const envsCache = await getPersistentCache(getGlobalPersistentStore(), (env) => env.display !== undefined);
 
         envsCache.setAllEnvs(updatedEnvInfoArray);
         await envsCache.flush();

--- a/src/test/pythonEnvironments/base/info/env.unit.test.ts
+++ b/src/test/pythonEnvironments/base/info/env.unit.test.ts
@@ -16,7 +16,6 @@ suite('pyenvs info - getEnvDisplayString()', () => {
         kind?: PythonEnvKind;
         distro?: PythonDistroInfo;
         display?: string;
-        defaultDisplayName?: string;
         location?: string;
     }): PythonEnvInfo {
         const env = createLocatedEnv(
@@ -29,63 +28,27 @@ suite('pyenvs info - getEnvDisplayString()', () => {
         env.name = info.name || '';
         env.arch = info.arch || Architecture.Unknown;
         env.display = info.display;
-        env.defaultDisplayName = info.defaultDisplayName;
         return env;
     }
 
-    suite('cached', () => {
-        suite('already resolved', () => {
-            [
-                'Python', // built: absolute minimal
-                'Python 3.7.x x64 (my-env: venv)', // built: full
-                'spam',
-                'some env',
-                // corner cases
-                '---',
-                '  ',
-            ].forEach((display: string) => {
-                test(`"${display}"`, () => {
-                    const expected = display;
-                    const env = getEnv({ display });
-
-                    const result = getEnvDisplayString(env);
-
-                    assert.equal(result, expected);
-                });
-            });
-        });
-
-        suite('has default', () => {
-            const defaultDisplayName = 'my-env (some-kind)';
-
-            test('without "display"', () => {
-                const expected = defaultDisplayName;
-                const env = getEnv({ defaultDisplayName });
+    suite('already set', () => {
+        [
+            'Python', // built: absolute minimal
+            'Python 3.7.x x64 (my-env: venv)', // built: full
+            'spam',
+            'some env',
+            // corner cases
+            '---',
+            '  ',
+        ].forEach((display: string) => {
+            test(`"${display}"`, () => {
+                const expected = display;
+                const env = getEnv({ display });
 
                 const result = getEnvDisplayString(env);
 
                 assert.equal(result, expected);
             });
-
-            test('with empty "display"', () => {
-                const expected = defaultDisplayName;
-                const env = getEnv({ defaultDisplayName, display: '' });
-
-                const result = getEnvDisplayString(env);
-
-                assert.equal(result, expected);
-            });
-        });
-
-        test('both', () => {
-            const display = 'Python 3.7.3 (system)';
-            const defaultDisplayName = 'my-env (some-kind)';
-            const expected = display;
-            const env = getEnv({ display, defaultDisplayName });
-
-            const result = getEnvDisplayString(env);
-
-            assert.equal(result, expected);
         });
     });
 

--- a/src/test/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/base/locators/lowLevel/workspaceVirtualEnvLocator.unit.test.ts
@@ -43,7 +43,7 @@ suite('WorkspaceVirtualEnvironment Locator', () => {
                 ctime: -1,
                 mtime: -1,
             },
-            defaultDisplayName: undefined,
+            display: undefined,
             version,
             arch: platformUtils.Architecture.Unknown,
             distro: { org: '' },

--- a/src/test/pythonEnvironments/discovery/locators/condaHelper.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaHelper.unit.test.ts
@@ -635,7 +635,7 @@ suite('Conda and its environments are located correctly', () => {
                     name,
                     kind: PythonEnvKind.Conda,
                     arch: platform.Architecture.Unknown,
-                    defaultDisplayName: undefined,
+                    display: undefined,
                     searchLocation: undefined,
                     distro: { org: AnacondaCompanyName },
                     version: { major: -1, minor: -1, micro: -1, release: { level: 'final', serial: 0 } },

--- a/src/test/pythonEnvironments/discovery/locators/customVirtualEnvLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/customVirtualEnvLocator.unit.test.ts
@@ -53,7 +53,7 @@ suite('CustomVirtualEnvironment Locator', () => {
                 ctime: -1,
                 mtime: -1,
             },
-            defaultDisplayName: undefined,
+            display: undefined,
             version,
             arch: platformUtils.Architecture.Unknown,
             distro: { org: '' },

--- a/src/test/pythonEnvironments/discovery/locators/globalVirtualEnvironmentLocator.functional.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/globalVirtualEnvironmentLocator.functional.test.ts
@@ -47,7 +47,7 @@ suite('GlobalVirtualEnvironment Locator', () => {
                 ctime: -1,
                 mtime: -1,
             },
-            defaultDisplayName: undefined,
+            display: undefined,
             version,
             arch: platformUtils.Architecture.Unknown,
             distro: { org: '' },

--- a/src/test/pythonEnvironments/discovery/locators/pyenvLocator.functional.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/pyenvLocator.functional.test.ts
@@ -56,7 +56,7 @@ suite('Pyenv Locator Tests', () => {
                 },
                 source: [PythonEnvSource.Pyenv],
             });
-            envInfo.defaultDisplayName = '3.9.0:pyenv';
+            envInfo.display = '3.9.0:pyenv';
             envInfo.location = path.join(testPyenvVersionsDir, '3.9.0');
             envInfo.name = '3.9.0';
             return envInfo;
@@ -73,7 +73,7 @@ suite('Pyenv Locator Tests', () => {
                 },
                 source: [PythonEnvSource.Pyenv],
             });
-            envInfo.defaultDisplayName = 'conda1:pyenv';
+            envInfo.display = 'conda1:pyenv';
             envInfo.location = path.join(testPyenvVersionsDir, 'conda1');
             envInfo.name = 'conda1';
             return envInfo;
@@ -90,7 +90,7 @@ suite('Pyenv Locator Tests', () => {
                 },
                 source: [PythonEnvSource.Pyenv],
             });
-            envInfo.defaultDisplayName = 'miniconda3-4.7.12:pyenv';
+            envInfo.display = 'miniconda3-4.7.12:pyenv';
             envInfo.location = path.join(testPyenvVersionsDir, 'miniconda3-4.7.12');
             envInfo.name = 'miniconda3-4.7.12';
             envInfo.distro.org = 'miniconda3';
@@ -108,7 +108,7 @@ suite('Pyenv Locator Tests', () => {
                 },
                 source: [PythonEnvSource.Pyenv],
             });
-            envInfo.defaultDisplayName = 'venv1:pyenv';
+            envInfo.display = 'venv1:pyenv';
             envInfo.location = path.join(testPyenvVersionsDir, 'venv1');
             envInfo.name = 'venv1';
             return envInfo;

--- a/src/test/pythonEnvironments/discovery/locators/windowsRegistryLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsRegistryLocator.unit.test.ts
@@ -224,7 +224,7 @@ suite('Windows Registry', () => {
             versionStr: data.find((x) => x.name === 'Version')?.value,
             sysVersionStr: data.find((x) => x.name === 'SysVersion')?.value,
             bitnessStr: data.find((x) => x.name === 'SysArchitecture')?.value,
-            displayName: data.find((x) => x.name === 'DisplayName')?.value,
+            companyDisplayName: data.find((x) => x.name === 'DisplayName')?.value,
             distroOrgName: org,
         });
     }
@@ -238,16 +238,17 @@ suite('Windows Registry', () => {
             version = UNKNOWN_PYTHON_VERSION;
         }
 
-        return buildEnvInfo({
+        const env = buildEnvInfo({
             location: '',
             kind: PythonEnvKind.OtherGlobal,
             executable: data.interpreterPath,
             version,
             arch: data.bitnessStr === '32bit' ? Architecture.x86 : Architecture.x64,
             org: data.distroOrgName ?? '',
-            defaultDisplayName: data.displayName,
             source: [PythonEnvSource.WindowsRegistry],
         });
+        env.distro.defaultDisplayName = data.companyDisplayName;
+        return env;
     }
 
     async function getExpectedDataFromKey({ arch, hive, key }: winreg.Options, org: string): Promise<PythonEnvInfo> {

--- a/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/windowsStoreLocator.unit.test.ts
@@ -153,7 +153,7 @@ suite('Windows Store', () => {
                     const data = pathToData.get(k);
                     if (data) {
                         return {
-                            defaultDisplayName: undefined,
+                            display: undefined,
                             searchLocation: undefined,
                             name: '',
                             location: '',
@@ -177,7 +177,7 @@ suite('Windows Store', () => {
         test('resolveEnv(string)', async () => {
             const python38path = path.join(testStoreAppRoot, 'python3.8.exe');
             const expected = {
-                defaultDisplayName: undefined,
+                display: undefined,
                 searchLocation: undefined,
                 name: '',
                 location: '',
@@ -195,7 +195,7 @@ suite('Windows Store', () => {
         test('resolveEnv(PythonEnvInfo)', async () => {
             const python38path = path.join(testStoreAppRoot, 'python3.8.exe');
             const expected = {
-                defaultDisplayName: undefined,
+                display: undefined,
                 searchLocation: undefined,
                 name: '',
                 location: '',
@@ -209,7 +209,7 @@ suite('Windows Store', () => {
             const input: PythonEnvInfo = {
                 name: '',
                 location: '',
-                defaultDisplayName: undefined,
+                display: undefined,
                 searchLocation: undefined,
                 kind: PythonEnvKind.WindowsStore,
                 distro: { org: 'Microsoft' },
@@ -236,7 +236,7 @@ suite('Windows Store', () => {
         test('resolveEnv(string): forbidden path', async () => {
             const python38path = path.join(testLocalAppData, 'Program Files', 'WindowsApps', 'python3.8.exe');
             const expected = {
-                defaultDisplayName: undefined,
+                display: undefined,
                 searchLocation: undefined,
                 name: '',
                 location: '',


### PR DESCRIPTION
The property became irrelevant with #15130, so we should have dropped it there.  We're dropping it here after the fact instead. 
 (See https://github.com/microsoft/vscode-python/pull/15130#discussion_r562694272.)

Note that this PR also corrects a bug in the Windows registry locator that I found while dropping `PythonEnvInfo.defaultDisplayName`.  The "display name" found in the registry was getting set to `PythonEnvInfo.defaultDisplayName` when it should have been set to `PythonEnvInfo.distro.defaultDisplayName`.