### PR TITLE
Add completion metric to jedi completion event

### DIFF
--- a/src/client/providers/completionProvider.ts
+++ b/src/client/providers/completionProvider.ts
@@ -18,7 +18,14 @@ export class PythonCompletionItemProvider implements vscode.CompletionItemProvid
         this.configService = serviceContainer.get<IConfigurationService>(IConfigurationService);
     }
 
-    @captureTelemetry(EventName.COMPLETION)
+    @captureTelemetry(
+        EventName.COMPLETION,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        PythonCompletionItemProvider.completionMeasure,
+    )
     public async provideCompletionItems(
         document: vscode.TextDocument,
         position: vscode.Position,
@@ -31,6 +38,13 @@ export class PythonCompletionItemProvider implements vscode.CompletionItemProvid
             }
         }
         return items;
+    }
+
+    private static completionMeasure(
+        _this: PythonCompletionItemProvider,
+        result: vscode.CompletionItem[] | undefined,
+    ): Record<string, number> {
+        return { resultLength: result?.length ?? 0 };
     }
 
     public async resolveCompletionItem(


### PR DESCRIPTION
This adds a new measure to the completion event, which counts the number of completion items offered.

Most of the PR is mirroring the work I did previously with `lazyProperties` to also add `lazyMeasures` (more stuf to deal with these decorators), however I'm a bit surprised that measures other than `duration` are only used in one other place, and that numbers are getting sent as string-based properties more often.

@brettcannon Do you have an opinion about me trying to use measures here rather than properties, or would you rather I drop most of this change and just put the new value into properties? In MPLS and Pylance I've tried to ensure that we only stick strings in properties and numbers always go into measures, but things seem to be less strict here after reading the event-property mapping. Maybe it doesn't matter at query time.