### PR TITLE
Use the component adapter to fetch Windows registry envs in legacy code.

### DIFF
--- a/src/client/interpreter/contracts.ts
+++ b/src/client/interpreter/contracts.ts
@@ -46,6 +46,8 @@ export interface IComponentAdapter {
         resource: Uri,
         options?: { ignoreCache?: boolean },
     ): Promise<PythonEnvironment[] | undefined>;
+    // IInterpreterLocatorService (for WINDOWS_REGISTRY_SERVICE)
+    getWinRegInterpreters(resource: Resource): Promise<PythonEnvironment[] | undefined>;
     // IInterpreterService
     getInterpreterDetails(pythonPath: string, _resource?: Uri): Promise<undefined | PythonEnvironment>;
     // IInterpreterHelper

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -428,7 +428,7 @@ export class CondaService implements ICondaService {
 
     private async getWinRegEnvs(): Promise<PythonEnvironment[] | undefined> {
         if (await inDiscoveryExperiment(this.experimentService)) {
-            return await this.pyenvs.getWinRegInterpreters(undefined);
+            return this.pyenvs.getWinRegInterpreters(undefined);
         }
         if (this.registryLookupForConda) {
             return this.registryLookupForConda.getInterpreters();

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -87,11 +87,11 @@ export class CondaService implements ICondaService {
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IComponentAdapter) private readonly pyenvs: IComponent,
+        @inject(IExperimentService) private readonly experimentService: IExperimentService,
         @inject(IInterpreterLocatorService)
         @named(WINDOWS_REGISTRY_SERVICE)
         @optional()
-        private registryLookupForConda: IInterpreterLocatorService | undefined,
-        @inject(IExperimentService) private readonly experimentService: IExperimentService,
+        private registryLookupForConda?: IInterpreterLocatorService,
     ) {
         this.addCondaPathChangedHandler();
     }

--- a/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
+++ b/src/client/pythonEnvironments/discovery/locators/services/condaService.ts
@@ -4,10 +4,17 @@ import { compare, parse, SemVer } from 'semver';
 import { ConfigurationChangeEvent, Uri } from 'vscode';
 
 import { IWorkspaceService } from '../../../../common/application/types';
+import { inDiscoveryExperiment } from '../../../../common/experiments/helpers';
 import { traceDecorators, traceError, traceVerbose, traceWarning } from '../../../../common/logger';
 import { IFileSystem, IPlatformService } from '../../../../common/platform/types';
 import { IProcessServiceFactory } from '../../../../common/process/types';
-import { IConfigurationService, IDisposableRegistry, IPersistentStateFactory } from '../../../../common/types';
+import {
+    IConfigurationService,
+    IDisposableRegistry,
+    IExperimentService,
+    IPersistentStateFactory,
+    Resource,
+} from '../../../../common/types';
 import { cache } from '../../../../common/utils/decorators';
 import {
     IComponentAdapter,
@@ -54,6 +61,7 @@ export const CondaGetEnvironmentPrefix = 'Outputting Environment Now...';
 interface IComponent {
     isCondaEnvironment(interpreterPath: string): Promise<boolean | undefined>;
     getCondaEnvironment(interpreterPath: string): Promise<CondaEnvironmentInfo | undefined>;
+    getWinRegInterpreters(resource: Resource): Promise<PythonEnvironment[] | undefined>;
 }
 
 /**
@@ -82,7 +90,8 @@ export class CondaService implements ICondaService {
         @inject(IInterpreterLocatorService)
         @named(WINDOWS_REGISTRY_SERVICE)
         @optional()
-        private registryLookupForConda?: IInterpreterLocatorService,
+        private registryLookupForConda: IInterpreterLocatorService | undefined,
+        @inject(IExperimentService) private readonly experimentService: IExperimentService,
     ) {
         this.addCondaPathChangedHandler();
     }
@@ -400,8 +409,8 @@ export class CondaService implements ICondaService {
         if (isAvailable) {
             return 'conda';
         }
-        if (this.platform.isWindows && this.registryLookupForConda) {
-            const interpreters = await this.registryLookupForConda.getInterpreters();
+        if (this.platform.isWindows) {
+            const interpreters: PythonEnvironment[] = (await this.getWinRegEnvs()) || [];
             const condaInterpreters = interpreters.filter(CondaService.detectCondaEnvironment);
             const condaInterpreter = CondaService.getLatestVersion(condaInterpreters);
             if (condaInterpreter) {
@@ -415,6 +424,16 @@ export class CondaService implements ICondaService {
             }
         }
         return this.getCondaFileFromKnownLocations();
+    }
+
+    private async getWinRegEnvs(): Promise<PythonEnvironment[] | undefined> {
+        if (await inDiscoveryExperiment(this.experimentService)) {
+            return await this.pyenvs.getWinRegInterpreters(undefined);
+        }
+        if (this.registryLookupForConda) {
+            return this.registryLookupForConda.getInterpreters();
+        }
+        return [];
     }
 
     /**

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -392,6 +392,12 @@ class ComponentAdapter implements IComponentAdapter, IExtensionSingleActivationS
         const envs = await getEnvs(iterator);
         return envs.map(convertEnvInfo);
     }
+
+    // Implements IInterpreterLocatorService (for WINDOWS_REGISTRY_SERVICE).
+
+    public async getWinRegInterpreters(resource: Resource): Promise<PythonEnvironment[] | undefined> {
+        return this.getInterpreters(resource, undefined, [PythonEnvSource.WindowsRegistry]);
+    }
 }
 
 export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceManager): Promise<void> {

--- a/src/test/interpreters/autoSelection/rules/winRegistry.unit.test.ts
+++ b/src/test/interpreters/autoSelection/rules/winRegistry.unit.test.ts
@@ -12,14 +12,18 @@ import { PersistentState, PersistentStateFactory } from '../../../../client/comm
 import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { PlatformService } from '../../../../client/common/platform/platformService';
 import { IFileSystem, IPlatformService } from '../../../../client/common/platform/types';
-import { IPersistentStateFactory, Resource } from '../../../../client/common/types';
+import { IExperimentService, IPersistentStateFactory, Resource } from '../../../../client/common/types';
 import { getNamesAndValues } from '../../../../client/common/utils/enum';
 import { OSType } from '../../../../client/common/utils/platform';
 import { InterpreterAutoSelectionService } from '../../../../client/interpreter/autoSelection';
 import { NextAction } from '../../../../client/interpreter/autoSelection/rules/baseRule';
 import { WindowsRegistryInterpretersAutoSelectionRule } from '../../../../client/interpreter/autoSelection/rules/winRegistry';
 import { IInterpreterAutoSelectionService } from '../../../../client/interpreter/autoSelection/types';
-import { IInterpreterHelper, IInterpreterLocatorService } from '../../../../client/interpreter/contracts';
+import {
+    IComponentAdapter,
+    IInterpreterHelper,
+    IInterpreterLocatorService,
+} from '../../../../client/interpreter/contracts';
 import { InterpreterHelper } from '../../../../client/interpreter/helpers';
 import { WindowsRegistryService } from '../../../../client/pythonEnvironments/discovery/locators/services/windowsRegistryService';
 import { PythonEnvironment } from '../../../../client/pythonEnvironments/info';
@@ -31,6 +35,8 @@ suite('Interpreters - Auto Selection - Windows Registry Rule', () => {
     let state: PersistentState<PythonEnvironment | undefined>;
     let locator: IInterpreterLocatorService;
     let platform: IPlatformService;
+    let discovery: IComponentAdapter;
+    let experiments: IExperimentService;
     let helper: IInterpreterHelper;
     class WindowsRegistryInterpretersAutoSelectionRuleTest extends WindowsRegistryInterpretersAutoSelectionRule {
         public async setGlobalInterpreter(
@@ -53,6 +59,8 @@ suite('Interpreters - Auto Selection - Windows Registry Rule', () => {
         helper = mock(InterpreterHelper);
         locator = mock(WindowsRegistryService);
         platform = mock(PlatformService);
+        discovery = mock<IComponentAdapter>();
+        experiments = mock<IExperimentService>();
 
         when(stateFactory.createGlobalPersistentState<PythonEnvironment | undefined>(anything(), undefined)).thenReturn(
             instance(state),
@@ -63,6 +71,8 @@ suite('Interpreters - Auto Selection - Windows Registry Rule', () => {
             instance(stateFactory),
             instance(platform),
             instance(locator),
+            instance(discovery),
+            instance(experiments),
         );
     });
 

--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -137,8 +137,8 @@ suite('Interpreters Conda Service', () => {
             disposableRegistry,
             workspaceService.object,
             pyenvs.object,
-            registryInterpreterLocatorService.object,
             experiments.object,
+            registryInterpreterLocatorService.object,
         );
     });
 
@@ -638,7 +638,6 @@ suite('Interpreters Conda Service', () => {
             disposableRegistry,
             workspaceService.object,
             pyenvs.object,
-            undefined,
             experiments.object,
         );
 

--- a/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
+++ b/src/test/pythonEnvironments/discovery/locators/condaService.unit.test.ts
@@ -11,7 +11,12 @@ import { FileSystemPaths, FileSystemPathUtils } from '../../../../client/common/
 import { IFileSystem, IPlatformService } from '../../../../client/common/platform/types';
 import { IProcessService, IProcessServiceFactory } from '../../../../client/common/process/types';
 import { ITerminalActivationCommandProvider } from '../../../../client/common/terminal/types';
-import { IConfigurationService, IPersistentStateFactory, IPythonSettings } from '../../../../client/common/types';
+import {
+    IConfigurationService,
+    IExperimentService,
+    IPersistentStateFactory,
+    IPythonSettings,
+} from '../../../../client/common/types';
 import { Architecture } from '../../../../client/common/utils/platform';
 import {
     IComponentAdapter,
@@ -54,6 +59,7 @@ suite('Interpreters Conda Service', () => {
     let disposableRegistry: Disposable[];
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
     let workspaceService: TypeMoq.IMock<IWorkspaceService>;
+    let experiments: TypeMoq.IMock<IExperimentService>;
     let mockState: MockState;
     let terminalProvider: TypeMoq.IMock<ITerminalActivationCommandProvider>;
     setup(async () => {
@@ -69,6 +75,7 @@ suite('Interpreters Conda Service', () => {
         config = TypeMoq.Mock.ofType<IConfigurationService>();
         settings = TypeMoq.Mock.ofType<IPythonSettings>();
         procServiceFactory = TypeMoq.Mock.ofType<IProcessServiceFactory>();
+        experiments = TypeMoq.Mock.ofType<IExperimentService>();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         processService.setup((x: any) => x.then).returns(() => undefined);
         procServiceFactory
@@ -131,6 +138,7 @@ suite('Interpreters Conda Service', () => {
             workspaceService.object,
             pyenvs.object,
             registryInterpreterLocatorService.object,
+            experiments.object,
         );
     });
 
@@ -630,6 +638,8 @@ suite('Interpreters Conda Service', () => {
             disposableRegistry,
             workspaceService.object,
             pyenvs.object,
+            undefined,
+            experiments.object,
         );
 
         const result = await condaSrv.getCondaFile();


### PR DESCRIPTION
This is part of the work to enable the discovery experiment.