### PR TITLE
Raise minimum VS Code version to 1.51

### DIFF
--- a/news/3 Code Health/15237.md
+++ b/news/3 Code Health/15237.md
@@ -1,0 +1,1 @@
+Raised the minimum required VS Code version to 1.51.

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,9 +936,9 @@
             }
         },
         "@types/vscode": {
-            "version": "1.48.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.48.0.tgz",
-            "integrity": "sha512-sZJKzsJz1gSoFXcOJWw3fnKl2sseUgZmvB4AJZS+Fea+bC/jfGPVhmFL/FfQHld/TKtukVONsmoD3Pkyx9iadg==",
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.51.0.tgz",
+            "integrity": "sha512-C/jZ35OT5k/rsJyAK8mS1kM++vMcm89oSWegkzxRCvHllIq0cToZAkIDs6eCY4SKrvik3nrhELizyLcM0onbQA==",
             "dev": true
         },
         "@types/webpack": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "theme": "dark"
     },
     "engines": {
-        "vscode": "^1.49.0"
+        "vscode": "^1.51.0"
     },
     "keywords": [
         "python",
@@ -2082,7 +2082,7 @@
         "@types/tmp": "0.0.33",
         "@types/untildify": "^3.0.0",
         "@types/uuid": "^3.4.3",
-        "@types/vscode": "^1.47.0",
+        "@types/vscode": "~1.51.0",
         "@types/webpack-bundle-analyzer": "^2.13.0",
         "@types/winreg": "^1.2.30",
         "@types/xml2js": "^0.4.2",

--- a/src/test/debugger/extension/adapter/factory.unit.test.ts
+++ b/src/test/debugger/extension/adapter/factory.unit.test.ts
@@ -96,6 +96,7 @@ suite('Debugging - Adapter Factory', () => {
             type: 'python',
             workspaceFolder,
             customRequest: () => Promise.resolve(),
+            getDebugProtocolBreakpoint: () => Promise.resolve(undefined),
         };
     }
 

--- a/src/test/debugger/extension/adapter/logging.unit.test.ts
+++ b/src/test/debugger/extension/adapter/logging.unit.test.ts
@@ -48,6 +48,7 @@ suite('Debugging - Session Logging', () => {
             type: 'python',
             workspaceFolder,
             customRequest: () => Promise.resolve(),
+            getDebugProtocolBreakpoint: () => Promise.resolve(undefined),
         };
     }
 

--- a/src/test/debugger/extension/adapter/outdatedDebuggerPrompt.unit.test.ts
+++ b/src/test/debugger/extension/adapter/outdatedDebuggerPrompt.unit.test.ts
@@ -63,6 +63,7 @@ suite('Debugging - Outdated Debugger Prompt tests.', () => {
             type: 'python',
             workspaceFolder,
             customRequest: () => Promise.resolve(),
+            getDebugProtocolBreakpoint: () => Promise.resolve(undefined),
         };
     }
 

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -7,7 +7,7 @@
 // import * as crypto from 'crypto';
 
 import { relative } from 'path';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import { vscMockHtmlContent } from './htmlContent';
 import { vscMockStrings } from './strings';
 import { vscUri } from './uri';
@@ -2166,6 +2166,6 @@ export namespace vscMockExtHostedTypes {
     }
 
     export class QuickInputButtons {
-        static readonly Back: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('back') };
+        static readonly Back: vscode.QuickInputButton = { iconPath: vscUri.URI.file('back') };
     }
 }

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -2166,6 +2166,6 @@ export namespace vscMockExtHostedTypes {
     }
 
     export class QuickInputButtons {
-        static readonly Back: vscode.QuickInputButton = { iconPath: 'back' };
+        static readonly Back: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('back') };
     }
 }

--- a/src/test/startPage/startPage.unit.test.ts
+++ b/src/test/startPage/startPage.unit.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as typemoq from 'typemoq';
-import { Memento, ExtensionContext } from 'vscode';
+import { ExtensionContext } from 'vscode';
 import {
     IApplicationEnvironment,
     IApplicationShell,
@@ -67,7 +67,7 @@ suite('StartPage tests', () => {
         appShell = typemoq.Mock.ofType<IApplicationShell>();
         context = typemoq.Mock.ofType<IExtensionContext>();
         appEnvironment = typemoq.Mock.ofType<IApplicationEnvironment>();
-        memento = typemoq.Mock.ofType<Memento>();
+        memento = typemoq.Mock.ofType<ExtensionContext['globalState']>();
 
         configuration.setup((cs) => cs.getSettings(undefined)).returns(() => dummySettings);
 

--- a/src/test/startPage/startPage.unit.test.ts
+++ b/src/test/startPage/startPage.unit.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import * as typemoq from 'typemoq';
-import { Memento } from 'vscode';
+import { Memento, ExtensionContext } from 'vscode';
 import {
     IApplicationEnvironment,
     IApplicationShell,
@@ -34,7 +34,7 @@ suite('StartPage tests', () => {
     let appShell: typemoq.IMock<IApplicationShell>;
     let context: typemoq.IMock<IExtensionContext>;
     let appEnvironment: typemoq.IMock<IApplicationEnvironment>;
-    let memento: typemoq.IMock<Memento>;
+    let memento: typemoq.IMock<ExtensionContext['globalState']>;
     const dummySettings = new PythonSettings(undefined, new MockAutoSelectionService());
 
     function setupVersions(savedVersion: string, actualVersion: string) {


### PR DESCRIPTION
For #15237.

I switched `@types/vscode` to a `~` dep; using a `^` means that an npm install may pick a newer version than written, which for `@types/vscode` is bad because you may end up seeing newer types (with potentially new API elements) that turn out to crash at runtime in older editors that you previously specified are supported.

I could also just jump ahead and bump the minimum to 1.52, if that's acceptable for the next release.