### PR TITLE
Do not access or register PipenvService and related classes when in experiment

### DIFF
--- a/src/client/common/configuration/executionSettings/pipEnvExecution.ts
+++ b/src/client/common/configuration/executionSettings/pipEnvExecution.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+'use strict';
+
+import { injectable, inject } from 'inversify';
+import { IConfigurationService, IToolExecutionPath } from '../../types';
+
+@injectable()
+export class PipEnvExecutionPath implements IToolExecutionPath {
+    constructor(@inject(IConfigurationService) private readonly configService: IConfigurationService) {}
+
+    public get executable(): string {
+        return this.configService.getSettings().pipenvPath;
+    }
+}

--- a/src/client/common/serviceRegistry.ts
+++ b/src/client/common/serviceRegistry.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IExtensionSingleActivationService } from '../activation/types';
-import { IExperimentService, IFileDownloader, IHttpClient, IInterpreterPathService } from '../common/types';
+import {
+    IExperimentService,
+    IFileDownloader,
+    IHttpClient,
+    IInterpreterPathService,
+    IToolExecutionPath,
+    ToolExecutionPath,
+} from '../common/types';
 import { IServiceManager } from '../ioc/types';
 import { JupyterExtensionDependencyManager } from '../jupyter/jupyterExtensionDependencyManager';
 import { ImportTracker } from '../telemetry/importTracker';
@@ -38,6 +45,7 @@ import {
 import { WorkspaceService } from './application/workspace';
 import { AsyncDisposableRegistry } from './asyncDisposableRegistry';
 import { ConfigurationService } from './configuration/service';
+import { PipEnvExecutionPath } from './configuration/executionSettings/pipEnvExecution';
 import { CryptoUtils } from './crypto';
 import { EditorUtils } from './editor';
 import { DebuggerDataViewerExperimentEnabler } from './experiments/debuggerDataViewerExperimentEnabler';
@@ -184,6 +192,7 @@ export function registerTypes(serviceManager: IServiceManager) {
         PipEnvActivationCommandProvider,
         TerminalActivationProviders.pipenv,
     );
+    serviceManager.addSingleton<IToolExecutionPath>(IToolExecutionPath, PipEnvExecutionPath, ToolExecutionPath.pipenv);
     serviceManager.addSingleton<IFeatureDeprecationManager>(IFeatureDeprecationManager, FeatureDeprecationManager);
 
     serviceManager.addSingleton<IAsyncDisposableRegistry>(IAsyncDisposableRegistry, AsyncDisposableRegistry);

--- a/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
@@ -3,27 +3,22 @@
 
 'use strict';
 
-import { inject, injectable, named } from 'inversify';
+import { inject, injectable } from 'inversify';
 import { Uri } from 'vscode';
 import '../../../common/extensions';
-import {
-    IInterpreterLocatorService,
-    IInterpreterService,
-    IPipEnvService,
-    PIPENV_SERVICE,
-} from '../../../interpreter/contracts';
+import { IInterpreterService } from '../../../interpreter/contracts';
 import { EnvironmentType } from '../../../pythonEnvironments/info';
 import { IWorkspaceService } from '../../application/types';
 import { IFileSystem } from '../../platform/types';
+import { IConfigurationService } from '../../types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
 
 @injectable()
 export class PipEnvActivationCommandProvider implements ITerminalActivationCommandProvider {
     constructor(
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IInterpreterLocatorService)
-        @named(PIPENV_SERVICE)
-        private readonly pipenvService: IPipEnvService,
+        @inject(IConfigurationService)
+        private readonly configService: IConfigurationService,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IFileSystem) private readonly fs: IFileSystem,
     ) {}
@@ -46,7 +41,7 @@ export class PipEnvActivationCommandProvider implements ITerminalActivationComma
         ) {
             return;
         }
-        const execName = this.pipenvService.executable;
+        const execName = this.configService.getSettings().pipenvPath;
         return [`${execName.fileToCommandArgument()} shell`];
     }
 
@@ -59,7 +54,7 @@ export class PipEnvActivationCommandProvider implements ITerminalActivationComma
             return;
         }
 
-        const execName = this.pipenvService.executable;
+        const execName = this.configService.getSettings().pipenvPath;
         return [`${execName.fileToCommandArgument()} shell`];
     }
 }

--- a/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
+++ b/src/client/common/terminal/environmentActivationProviders/pipEnvActivationProvider.ts
@@ -3,22 +3,23 @@
 
 'use strict';
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, named } from 'inversify';
 import { Uri } from 'vscode';
 import '../../../common/extensions';
 import { IInterpreterService } from '../../../interpreter/contracts';
 import { EnvironmentType } from '../../../pythonEnvironments/info';
 import { IWorkspaceService } from '../../application/types';
 import { IFileSystem } from '../../platform/types';
-import { IConfigurationService } from '../../types';
+import { IToolExecutionPath, ToolExecutionPath } from '../../types';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../types';
 
 @injectable()
 export class PipEnvActivationCommandProvider implements ITerminalActivationCommandProvider {
     constructor(
         @inject(IInterpreterService) private readonly interpreterService: IInterpreterService,
-        @inject(IConfigurationService)
-        private readonly configService: IConfigurationService,
+        @inject(IToolExecutionPath)
+        @named(ToolExecutionPath.pipenv)
+        private readonly pipEnvExecution: IToolExecutionPath,
         @inject(IWorkspaceService) private readonly workspaceService: IWorkspaceService,
         @inject(IFileSystem) private readonly fs: IFileSystem,
     ) {}
@@ -41,7 +42,7 @@ export class PipEnvActivationCommandProvider implements ITerminalActivationComma
         ) {
             return;
         }
-        const execName = this.configService.getSettings().pipenvPath;
+        const execName = this.pipEnvExecution.executable;
         return [`${execName.fileToCommandArgument()} shell`];
     }
 
@@ -54,7 +55,7 @@ export class PipEnvActivationCommandProvider implements ITerminalActivationComma
             return;
         }
 
-        const execName = this.configService.getSettings().pipenvPath;
+        const execName = this.pipEnvExecution.executable;
         return [`${execName.fileToCommandArgument()} shell`];
     }
 }

--- a/src/client/common/types.ts
+++ b/src/client/common/types.ts
@@ -368,6 +368,20 @@ export interface IConfigurationService {
     ): Promise<void>;
 }
 
+/**
+ * Carries various tool execution path settings. For eg. pipenvPath, condaPath, pytestPath etc. These can be
+ * potentially used in discovery, autoselection, activation, installers, execution etc. And so should be a
+ * common interface to all the components.
+ */
+export const IToolExecutionPath = Symbol('IToolExecutionPath');
+export interface IToolExecutionPath {
+    readonly executable: string;
+}
+export enum ToolExecutionPath {
+    pipenv = 'pipenv',
+    // Gradually populate this list with tools as they come up.
+}
+
 export const ISocketServer = Symbol('ISocketServer');
 export interface ISocketServer extends Disposable {
     readonly client: Promise<Socket>;

--- a/src/client/interpreter/interpreterService.ts
+++ b/src/client/interpreter/interpreterService.ts
@@ -349,7 +349,14 @@ export class InterpreterService implements Disposable, IInterpreterService {
         if (info.architecture) {
             displayNameParts.push(getArchitectureDisplayName(info.architecture));
         }
-        if (!info.envName && info.path && info.envType && info.envType === EnvironmentType.Pipenv) {
+        if (
+            !info.envName &&
+            info.path &&
+            info.envType &&
+            info.envType === EnvironmentType.Pipenv &&
+            // We cannot access 'IVirtualEnvironmentManager' while in experiment.
+            !(await inDiscoveryExperiment(this.experimentService))
+        ) {
             // If we do not have the name of the environment, then try to get it again.
             // This can happen based on the context (i.e. resource).
             // I.e. we can determine if an environment is PipEnv only when giving it the right workspace path (i.e. resource).

--- a/src/client/interpreter/serviceRegistry.ts
+++ b/src/client/interpreter/serviceRegistry.ts
@@ -57,8 +57,6 @@ import { InterpreterHelper } from './helpers';
 import { InterpreterService } from './interpreterService';
 import { InterpreterVersionService } from './interpreterVersion';
 import { CondaInheritEnvPrompt } from './virtualEnvs/condaInheritEnvPrompt';
-import { VirtualEnvironmentManager } from './virtualEnvs/index';
-import { IVirtualEnvironmentManager } from './virtualEnvs/types';
 import { VirtualEnvironmentPrompt } from './virtualEnvs/virtualEnvPrompt';
 
 /**
@@ -89,7 +87,6 @@ export function registerInterpreterTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IInterpreterSecurityStorage>(IInterpreterSecurityStorage, InterpreterSecurityStorage);
     serviceManager.addSingleton<IInterpreterSecurityService>(IInterpreterSecurityService, InterpreterSecurityService);
 
-    serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
     serviceManager.addSingleton<IExtensionActivationService>(IExtensionActivationService, VirtualEnvironmentPrompt);
     serviceManager.addSingleton<IExtensionSingleActivationService>(
         IExtensionSingleActivationService,

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -443,8 +443,12 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             WINDOWS_REGISTRY_SERVICE,
         );
         serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
+        serviceManager.addSingleton<IInterpreterLocatorService>(
+            IInterpreterLocatorService,
+            PipEnvService,
+            PIPENV_SERVICE,
+        );
     }
-    serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
 
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
     serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -448,10 +448,10 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             PipEnvService,
             PIPENV_SERVICE,
         );
+        serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
     }
 
     serviceManager.addSingleton<ICondaService>(ICondaService, CondaService);
-    serviceManager.addSingleton<IPipEnvServiceHelper>(IPipEnvServiceHelper, PipEnvServiceHelper);
 }
 
 export function registerNewDiscoveryForIOC(

--- a/src/client/pythonEnvironments/legacyIOC.ts
+++ b/src/client/pythonEnvironments/legacyIOC.ts
@@ -32,6 +32,8 @@ import {
     WORKSPACE_VIRTUAL_ENV_SERVICE,
 } from '../interpreter/contracts';
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../interpreter/locators/types';
+import { VirtualEnvironmentManager } from '../interpreter/virtualEnvs';
+import { IVirtualEnvironmentManager } from '../interpreter/virtualEnvs/types';
 import { IServiceManager } from '../ioc/types';
 import { PythonEnvInfo, PythonEnvKind, PythonEnvSource, PythonReleaseLevel } from './base/info';
 import { buildEnvInfo } from './base/info/env';
@@ -440,6 +442,7 @@ export async function registerLegacyDiscoveryForIOC(serviceManager: IServiceMana
             WindowsRegistryService,
             WINDOWS_REGISTRY_SERVICE,
         );
+        serviceManager.addSingleton<IVirtualEnvironmentManager>(IVirtualEnvironmentManager, VirtualEnvironmentManager);
     }
     serviceManager.addSingleton<IInterpreterLocatorService>(IInterpreterLocatorService, PipEnvService, PIPENV_SERVICE);
 

--- a/src/test/common/installer/pipEnvInstaller.unit.test.ts
+++ b/src/test/common/installer/pipEnvInstaller.unit.test.ts
@@ -6,18 +6,36 @@
 import { expect } from 'chai';
 import * as TypeMoq from 'typemoq';
 import { Uri } from 'vscode';
+import { DiscoveryVariants } from '../../../client/common/experiments/groups';
 import { PipEnvInstaller } from '../../../client/common/installer/pipEnvInstaller';
-import { IInterpreterLocatorService, PIPENV_SERVICE } from '../../../client/interpreter/contracts';
+import { IExperimentService } from '../../../client/common/types';
+import { IComponentAdapter, IInterpreterLocatorService, PIPENV_SERVICE } from '../../../client/interpreter/contracts';
 import { IServiceContainer } from '../../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../../client/pythonEnvironments/info';
 
 suite('PipEnv installer', async () => {
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let locatorService: TypeMoq.IMock<IInterpreterLocatorService>;
+    let experimentService: TypeMoq.IMock<IExperimentService>;
+    let componentAdapter: TypeMoq.IMock<IComponentAdapter>;
     let pipEnvInstaller: PipEnvInstaller;
     setup(() => {
         serviceContainer = TypeMoq.Mock.ofType<IServiceContainer>();
         locatorService = TypeMoq.Mock.ofType<IInterpreterLocatorService>();
+        experimentService = TypeMoq.Mock.ofType<IExperimentService>();
+        componentAdapter = TypeMoq.Mock.ofType<IComponentAdapter>();
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(PIPENV_SERVICE)))
+            .returns(() => locatorService.object);
+        experimentService
+            .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
+            .returns(() => Promise.resolve(false));
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IExperimentService)))
+            .returns(() => experimentService.object);
+        serviceContainer
+            .setup((c) => c.get(TypeMoq.It.isValue(IComponentAdapter)))
+            .returns(() => componentAdapter.object);
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterLocatorService), TypeMoq.It.isValue(PIPENV_SERVICE)))
             .returns(() => locatorService.object);
@@ -59,6 +77,21 @@ suite('PipEnv installer', async () => {
                     TypeMoq.Mock.ofType<PythonEnvironment>().object,
                     TypeMoq.Mock.ofType<PythonEnvironment>().object,
                 ]),
+            );
+        const result = await pipEnvInstaller.isSupported(resource);
+        expect(result).to.equal(true, 'Should be true');
+    });
+
+    test('When in experiment, if InterpreterUri is Resource, and if resource contains pipEnv interpreters, return true', async () => {
+        const resource = Uri.parse('a');
+        experimentService.reset();
+        experimentService
+            .setup((e) => e.inExperiment(DiscoveryVariants.discoverWithFileWatching))
+            .returns(() => Promise.resolve(true));
+        componentAdapter
+            .setup((p) => p.getInterpreters(resource))
+            .returns(() =>
+                Promise.resolve([{ envType: EnvironmentType.Conda }, { envType: EnvironmentType.Pipenv }] as any),
             );
         const result = await pipEnvInstaller.isSupported(resource);
         expect(result).to.equal(true, 'Should be true');

--- a/src/test/common/serviceRegistry.unit.test.ts
+++ b/src/test/common/serviceRegistry.unit.test.ts
@@ -29,6 +29,7 @@ import {
 import { WorkspaceService } from '../../client/common/application/workspace';
 import { AsyncDisposableRegistry } from '../../client/common/asyncDisposableRegistry';
 import { ConfigurationService } from '../../client/common/configuration/service';
+import { PipEnvExecutionPath } from '../../client/common/configuration/executionSettings/pipEnvExecution';
 import { CryptoUtils } from '../../client/common/crypto';
 import { EditorUtils } from '../../client/common/editor';
 import { ExperimentsManager } from '../../client/common/experiments/manager';
@@ -95,6 +96,8 @@ import {
     IPathUtils,
     IPersistentStateFactory,
     IRandom,
+    IToolExecutionPath,
+    ToolExecutionPath,
 } from '../../client/common/types';
 import { IMultiStepInputFactory, MultiStepInputFactory } from '../../client/common/utils/multiStepInput';
 import { Random } from '../../client/common/utils/random';
@@ -141,6 +144,7 @@ suite('Common - Service Registry', () => {
                 CommandPromptAndPowerShell,
                 TerminalActivationProviders.commandPromptAndPowerShell,
             ],
+            [IToolExecutionPath, PipEnvExecutionPath, ToolExecutionPath.pipenv],
             [ITerminalActivationCommandProvider, CondaActivationCommandProvider, TerminalActivationProviders.conda],
             [ITerminalActivationCommandProvider, PipEnvActivationCommandProvider, TerminalActivationProviders.pipenv],
             [IFeatureDeprecationManager, FeatureDeprecationManager],

--- a/src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
+++ b/src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
@@ -13,8 +13,9 @@ import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { PipEnvActivationCommandProvider } from '../../../../client/common/terminal/environmentActivationProviders/pipEnvActivationProvider';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../../../../client/common/terminal/types';
+import { IConfigurationService } from '../../../../client/common/types';
 import { getNamesAndValues } from '../../../../client/common/utils/enum';
-import { IInterpreterService, IPipEnvService } from '../../../../client/interpreter/contracts';
+import { IInterpreterService } from '../../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../../client/interpreter/interpreterService';
 import { EnvironmentType } from '../../../../client/pythonEnvironments/info';
 
@@ -24,7 +25,7 @@ suite('Terminals Activation - Pipenv', () => {
             let pipenvExecFile = 'pipenv';
             let activationProvider: ITerminalActivationCommandProvider;
             let interpreterService: IInterpreterService;
-            let pipenvService: TypeMoq.IMock<IPipEnvService>;
+            let configService: TypeMoq.IMock<IConfigurationService>;
             let workspaceService: IWorkspaceService;
             let fs: IFileSystem;
             setup(() => {
@@ -32,15 +33,15 @@ suite('Terminals Activation - Pipenv', () => {
                 fs = mock(FileSystem);
                 workspaceService = mock(WorkspaceService);
                 interpreterService = mock(InterpreterService);
-                pipenvService = TypeMoq.Mock.ofType<IPipEnvService>();
+                configService = TypeMoq.Mock.ofType<IConfigurationService>();
                 activationProvider = new PipEnvActivationCommandProvider(
                     instance(interpreterService),
-                    pipenvService.object,
+                    configService.object,
                     instance(workspaceService),
                     instance(fs),
                 );
 
-                pipenvService.setup((p) => p.executable).returns(() => pipenvExecFile);
+                configService.setup((p) => p.getSettings()).returns(() => ({ pipenvPath: pipenvExecFile } as any));
             });
 
             test('No commands for no interpreter', async () => {

--- a/src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
+++ b/src/test/common/terminals/environmentActivationProviders/pipEnvActivationProvider.unit.test.ts
@@ -13,7 +13,7 @@ import { FileSystem } from '../../../../client/common/platform/fileSystem';
 import { IFileSystem } from '../../../../client/common/platform/types';
 import { PipEnvActivationCommandProvider } from '../../../../client/common/terminal/environmentActivationProviders/pipEnvActivationProvider';
 import { ITerminalActivationCommandProvider, TerminalShellType } from '../../../../client/common/terminal/types';
-import { IConfigurationService } from '../../../../client/common/types';
+import { IToolExecutionPath } from '../../../../client/common/types';
 import { getNamesAndValues } from '../../../../client/common/utils/enum';
 import { IInterpreterService } from '../../../../client/interpreter/contracts';
 import { InterpreterService } from '../../../../client/interpreter/interpreterService';
@@ -25,7 +25,7 @@ suite('Terminals Activation - Pipenv', () => {
             let pipenvExecFile = 'pipenv';
             let activationProvider: ITerminalActivationCommandProvider;
             let interpreterService: IInterpreterService;
-            let configService: TypeMoq.IMock<IConfigurationService>;
+            let pipEnvExecution: TypeMoq.IMock<IToolExecutionPath>;
             let workspaceService: IWorkspaceService;
             let fs: IFileSystem;
             setup(() => {
@@ -33,15 +33,15 @@ suite('Terminals Activation - Pipenv', () => {
                 fs = mock(FileSystem);
                 workspaceService = mock(WorkspaceService);
                 interpreterService = mock(InterpreterService);
-                configService = TypeMoq.Mock.ofType<IConfigurationService>();
+                pipEnvExecution = TypeMoq.Mock.ofType<IToolExecutionPath>();
                 activationProvider = new PipEnvActivationCommandProvider(
                     instance(interpreterService),
-                    configService.object,
+                    pipEnvExecution.object,
                     instance(workspaceService),
                     instance(fs),
                 );
 
-                configService.setup((p) => p.getSettings()).returns(() => ({ pipenvPath: pipenvExecFile } as any));
+                pipEnvExecution.setup((p) => p.executable).returns(() => pipenvExecFile);
             });
 
             test('No commands for no interpreter', async () => {

--- a/src/test/interpreters/display.unit.test.ts
+++ b/src/test/interpreters/display.unit.test.ts
@@ -34,7 +34,6 @@ import {
     IInterpreterStatusbarVisibilityFilter,
 } from '../../client/interpreter/contracts';
 import { InterpreterDisplay } from '../../client/interpreter/display';
-import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
 import { IServiceContainer } from '../../client/ioc/types';
 import { EnvironmentType, PythonEnvironment } from '../../client/pythonEnvironments/info';
 
@@ -55,7 +54,6 @@ suite('Interpreters Display', () => {
     let workspaceService: TypeMoq.IMock<IWorkspaceService>;
     let serviceContainer: TypeMoq.IMock<IServiceContainer>;
     let interpreterService: TypeMoq.IMock<IInterpreterService>;
-    let virtualEnvMgr: TypeMoq.IMock<IVirtualEnvironmentManager>;
     let fileSystem: TypeMoq.IMock<IFileSystem>;
     let disposableRegistry: Disposable[];
     let statusBar: TypeMoq.IMock<StatusBarItem>;
@@ -71,7 +69,6 @@ suite('Interpreters Display', () => {
         workspaceService = TypeMoq.Mock.ofType<IWorkspaceService>();
         applicationShell = TypeMoq.Mock.ofType<IApplicationShell>();
         interpreterService = TypeMoq.Mock.ofType<IInterpreterService>();
-        virtualEnvMgr = TypeMoq.Mock.ofType<IVirtualEnvironmentManager>();
         fileSystem = TypeMoq.Mock.ofType<IFileSystem>();
         interpreterHelper = TypeMoq.Mock.ofType<IInterpreterHelper>();
         disposableRegistry = [];
@@ -94,9 +91,6 @@ suite('Interpreters Display', () => {
         serviceContainer
             .setup((c) => c.get(TypeMoq.It.isValue(IInterpreterService)))
             .returns(() => interpreterService.object);
-        serviceContainer
-            .setup((c) => c.get(TypeMoq.It.isValue(IVirtualEnvironmentManager)))
-            .returns(() => virtualEnvMgr.object);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IFileSystem))).returns(() => fileSystem.object);
         serviceContainer.setup((c) => c.get(TypeMoq.It.isValue(IDisposableRegistry))).returns(() => disposableRegistry);
         serviceContainer
@@ -227,9 +221,6 @@ suite('Interpreters Display', () => {
         interpreterHelper
             .setup((v) => v.getInterpreterInformation(TypeMoq.It.isValue(pythonPath)))
             .returns(() => Promise.resolve(undefined));
-        virtualEnvMgr
-            .setup((v) => v.getEnvironmentName(TypeMoq.It.isValue(pythonPath)))
-            .returns(() => Promise.resolve(''));
 
         await interpreterDisplay.refresh(resource);
 
@@ -251,9 +242,6 @@ suite('Interpreters Display', () => {
             path: pythonPath,
         };
         fileSystem.setup((fs) => fs.fileExists(TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
-        virtualEnvMgr
-            .setup((v) => v.getEnvironmentName(TypeMoq.It.isValue(pythonPath)))
-            .returns(() => Promise.resolve(''));
         interpreterService
             .setup((i) => i.getActiveInterpreter(TypeMoq.It.isValue(resource)))
             .returns(() => Promise.resolve(activeInterpreter))

--- a/src/test/interpreters/serviceRegistry.unit.test.ts
+++ b/src/test/interpreters/serviceRegistry.unit.test.ts
@@ -56,9 +56,7 @@ import { InterpreterHelper } from '../../client/interpreter/helpers';
 import { InterpreterService } from '../../client/interpreter/interpreterService';
 import { InterpreterVersionService } from '../../client/interpreter/interpreterVersion';
 import { registerTypes } from '../../client/interpreter/serviceRegistry';
-import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
 import { CondaInheritEnvPrompt } from '../../client/interpreter/virtualEnvs/condaInheritEnvPrompt';
-import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
 import { VirtualEnvironmentPrompt } from '../../client/interpreter/virtualEnvs/virtualEnvPrompt';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 
@@ -76,7 +74,6 @@ suite('Interpreters - Service Registry', () => {
             [IInterpreterSecurityStorage, InterpreterSecurityStorage],
             [IInterpreterSecurityService, InterpreterSecurityService],
 
-            [IVirtualEnvironmentManager, VirtualEnvironmentManager],
             [IExtensionActivationService, VirtualEnvironmentPrompt],
             [IExtensionSingleActivationService, InterpreterSelectionTip],
 

--- a/src/test/pythonEnvironments/legacyIOC.unit.test.ts
+++ b/src/test/pythonEnvironments/legacyIOC.unit.test.ts
@@ -28,6 +28,8 @@ import {
     WORKSPACE_VIRTUAL_ENV_SERVICE,
 } from '../../client/interpreter/contracts';
 import { IPipEnvServiceHelper, IPythonInPathCommandProvider } from '../../client/interpreter/locators/types';
+import { VirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs';
+import { IVirtualEnvironmentManager } from '../../client/interpreter/virtualEnvs/types';
 import { ServiceContainer } from '../../client/ioc/container';
 import { ServiceManager } from '../../client/ioc/serviceManager';
 import { initializeExternalDependencies } from '../../client/pythonEnvironments/common/externalDependencies';
@@ -88,6 +90,12 @@ suite('Interpreters - Service Registry', () => {
                 IInterpreterLocatorService,
                 CondaEnvFileService,
                 CONDA_ENV_FILE_SERVICE,
+            ),
+        ).once();
+        verify(
+            serviceManager.addSingleton<IVirtualEnvironmentManager>(
+                IVirtualEnvironmentManager,
+                VirtualEnvironmentManager,
             ),
         ).once();
         verify(


### PR DESCRIPTION
Reviewing commit by commit maybe easier. Summary,
- Decoupled PipenvService and PipEnvActivationCommandProvider 
- Do not register or use VirtualEnvironmentManager when in experiment; which in turns says we don't use PipenvService via VirtualEnvironmentManager when in experiment
- Access PipenvService only when not in experiment in PipenvInstaller
- Do not register PipenvService when in experiment.