### PR TITLE
Ignore mypy lint errors for other files

### DIFF
--- a/src/client/linters/baseLinter.ts
+++ b/src/client/linters/baseLinter.ts
@@ -20,6 +20,7 @@ const namedRegexp = require('named-js-regexp');
 const REGEX = '(?<line>\\d+),(?<column>-?\\d+),(?<type>\\w+),(?<code>\\w+\\d+):(?<message>.*)\\r?(\\n|$)';
 
 export interface IRegexGroup {
+    file: string;
     line: number;
     column: number;
     code: string;
@@ -53,6 +54,7 @@ export function parseLine(
     match.column = Number(<any>match.column);
 
     return {
+        file: match.file,
         code: match.code,
         message: match.message,
         column: isNaN(match.column) || match.column <= 0 ? 0 : match.column - colOffset,

--- a/src/client/linters/mypy.ts
+++ b/src/client/linters/mypy.ts
@@ -1,5 +1,6 @@
 import { CancellationToken, OutputChannel, TextDocument } from 'vscode';
 import '../common/extensions';
+import * as path from 'path';
 import { Product } from '../common/types';
 import { IServiceContainer } from '../ioc/types';
 import { BaseLinter } from './baseLinter';
@@ -14,10 +15,19 @@ export class MyPy extends BaseLinter {
 
     protected async runLinter(document: TextDocument, cancellation: CancellationToken): Promise<ILintMessage[]> {
         const messages = await this.run([document.uri.fsPath], document, cancellation, REGEX);
+        const filteredMessages: ILintMessage[] = [];
         messages.forEach((msg) => {
+            if (msg.file == null) {
+                return;
+            }
+            const messageFilePath = path.join(this.getWorkspaceRootPath(document), msg.file);
+            if (messageFilePath !== document.uri.fsPath) {
+                return;
+            }
             msg.severity = this.parseMessagesSeverity(msg.type, this.pythonSettings.linting.mypyCategorySeverity);
             msg.code = msg.type;
+            filteredMessages.push(msg);
         });
-        return messages;
+        return filteredMessages;
     }
 }

--- a/src/client/linters/types.ts
+++ b/src/client/linters/types.ts
@@ -63,6 +63,7 @@ export interface ILinterManager {
 }
 
 export interface ILintMessage {
+    file?: string;
     line: number;
     column: number;
     code: string | undefined;


### PR DESCRIPTION
mypy sometimes returns errors for files that aren't the same as the file
it was called against.

This PR adds some filtering based on the current file name.

fixes https://github.com/microsoft/vscode-python/issues/10190